### PR TITLE
Use unique_ptr, not auto_ptr, in Generators

### DIFF
--- a/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
+++ b/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
@@ -255,7 +255,7 @@ void AlpgenSource::beginRun(edm::Run &run)
   }
 
   // Build the final Run info object. Backwards-compatible order.
-  std::auto_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
+  std::unique_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
   runInfo->addHeader(comments);
   runInfo->addHeader(lheAlpgenUnwParHeader);
   if (writeAlpgenWgtFile)
@@ -265,7 +265,7 @@ void AlpgenSource::beginRun(edm::Run &run)
   runInfo->addHeader(slha);
   if(writeExtraHeader)
     runInfo->addHeader(extraHeader);
-  run.put(runInfo);
+  run.put(std::move(runInfo));
 
   // Open the .unw file in the heap, and set the global pointer to it.
   inputFile_.reset(new std::ifstream((fileName_ + ".unw").c_str()));
@@ -476,8 +476,8 @@ void AlpgenSource::produce(edm::Event &event)
   }
 
   // Create the LHEEventProduct and put it into the Event.
-  std::auto_ptr<LHEEventProduct> lheEvent(new LHEEventProduct(hepeup));
-  event.put(lheEvent);
+  std::unique_ptr<LHEEventProduct> lheEvent(new LHEEventProduct(hepeup));
+  event.put(std::move(lheEvent));
 
   hepeup_.reset();
 }

--- a/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
+++ b/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
@@ -119,7 +119,7 @@ void BeamHaloProducer::produce(Event & e, const EventSetup & es) {
 
 	// cout << "in produce " << endl;
 
-  //    	auto_ptr<HepMCProduct> bare_product(new HepMCProduct());
+  //    	unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
 
 	// cout << "apres autoptr " << endl;
 
@@ -155,12 +155,12 @@ void BeamHaloProducer::produce(Event & e, const EventSetup & es) {
 	HepMC::WeightContainer& weights = evt -> weights();
 	weights.push_back(weight);
 	//	evt->print();
-  std::auto_ptr<HepMCProduct> CMProduct(new HepMCProduct());
+  std::unique_ptr<HepMCProduct> CMProduct(new HepMCProduct());
   if (evt) CMProduct->addHepMCData(evt);
-  e.put(CMProduct, "unsmeared");
+  e.put(std::move(CMProduct), "unsmeared");
 
-  auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(evt));
-  e.put(genEventInfo);
+  unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(evt));
+  e.put(std::move(genEventInfo));
 }
 
 void BeamHaloProducer::endRunProduce( Run &run, const EventSetup& es )
@@ -168,8 +168,8 @@ void BeamHaloProducer::endRunProduce( Run &run, const EventSetup& es )
    // just create an empty product
    // to keep the EventContent definitions happy
    // later on we might put the info into the run info that this is a PGun
-   auto_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
-   run.put( genRunInfo );
+   unique_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
+   run.put(std::move(genRunInfo));
 }
 
 bool BeamHaloProducer::call_bh_set_parameters(int* ival, float* fval, const std::string cval_string) {

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -132,7 +132,7 @@ namespace edm
     //added for selecting/filtering gen events, in the case of hadronizer+externalDecayer
       
     bool passEvtGenSelector = false;
-    std::auto_ptr<HepMC::GenEvent> event(0);
+    std::auto_ptr<HepMC::GenEvent> event(nullptr);
    
     while(!passEvtGenSelector)
       {
@@ -186,18 +186,18 @@ namespace edm
     //
     // tutto bene - finally, form up EDM products !
     //
-    std::auto_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());
+    std::unique_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());
     if (!genEventInfo.get())
       { 
 	// create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
 	genEventInfo.reset(new GenEventInfoProduct(event.get()));
       }
       
-    ev.put(genEventInfo);
+    ev.put(std::move(genEventInfo));
    
-    std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());
+    std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
     bare_product->addHepMCData( event.release() );
-    ev.put(bare_product, "unsmeared");
+    ev.put(std::move(bare_product), "unsmeared");
     nEventsInLumiBlock_ ++;
     return true;
   }
@@ -215,8 +215,8 @@ namespace edm
     
     if ( decayer_ ) decayer_->statistics();
     
-    std::auto_ptr<GenRunInfoProduct> griproduct(new GenRunInfoProduct(hadronizer_.getGenRunInfo()));
-    r.put(griproduct);
+    std::unique_ptr<GenRunInfoProduct> griproduct(new GenRunInfoProduct(hadronizer_.getGenRunInfo()));
+    r.put(std::move(griproduct));
   }
 
   template <class HAD, class DEC>
@@ -261,8 +261,8 @@ namespace edm
 	 << hadronizer_.classname()
 	 << " for internal parton generation\n";
          
-    std::auto_ptr<GenLumiInfoHeader> genLumiInfoHeader(hadronizer_.getGenLumiInfoHeader());
-    lumi.put(genLumiInfoHeader);
+    std::unique_ptr<GenLumiInfoHeader> genLumiInfoHeader(hadronizer_.getGenLumiInfoHeader());
+    lumi.put(std::move(genLumiInfoHeader));
 
   }
 
@@ -297,11 +297,11 @@ namespace edm
     temp.setAcceptedBr(0,-1,-1);
     GenLumiProcess.push_back(temp);
 
-    std::auto_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
+    std::unique_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
     genLumiInfo->setHEPIDWTUP(-1);
     genLumiInfo->setProcessInfo( GenLumiProcess );
         
-    lumi.put(genLumiInfo);
+    lumi.put(std::move(genLumiInfo));
 
     nEventsInLumiBlock_ = 0;
 

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -189,8 +189,8 @@ namespace edm
     edm::Handle<LHEEventProduct> product;
     ev.getByToken(eventProductToken_, product);
     
-    std::auto_ptr<HepMC::GenEvent> finalEvent;
-    std::auto_ptr<GenEventInfoProduct> finalGenEventInfo;
+    std::unique_ptr<HepMC::GenEvent> finalEvent;
+    std::unique_ptr<GenEventInfoProduct> finalGenEventInfo;
     
     //sum of weights for events passing hadronization
     double waccept = 0;
@@ -214,7 +214,7 @@ namespace edm
       //
       if ( !hadronizer_.decay() ) continue;
       
-      std::auto_ptr<HepMC::GenEvent> event (hadronizer_.getGenEvent());
+      std::unique_ptr<HepMC::GenEvent> event (hadronizer_.getGenEvent());
       if( !event.get() ) continue; 
 
       // The external decay driver is being added to the system,
@@ -240,7 +240,7 @@ namespace edm
       
       event->set_event_number( ev.id().event() );
       
-      std::auto_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());      
+      std::unique_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());
       if (!genEventInfo.get())
       { 
         // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
@@ -274,11 +274,11 @@ namespace edm
       finalEvent->weights()[0] *= multihadweight;
     }
     
-    ev.put(finalGenEventInfo);
+    ev.put(std::move(finalGenEventInfo));
 
-    std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());
+    std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
     bare_product->addHepMCData( finalEvent.release() );
-    ev.put(bare_product, "unsmeared");
+    ev.put(std::move(bare_product), "unsmeared");
 
     return true;
   }
@@ -338,8 +338,8 @@ namespace edm
     if ( filter_ ) filter_->statistics();
     lheRunInfo->statistics();
 
-    std::auto_ptr<GenRunInfoProduct> griproduct( new GenRunInfoProduct(genRunInfo) );
-    r.put(griproduct);
+    std::unique_ptr<GenRunInfoProduct> griproduct( new GenRunInfoProduct(genRunInfo) );
+    r.put(std::move(griproduct));
   }
 
   template <class HAD, class DEC>
@@ -389,8 +389,8 @@ namespace edm
 	<< hadronizer_.classname()
 	<< " for external parton generation\n";
         
-    std::auto_ptr<GenLumiInfoHeader> genLumiInfoHeader(hadronizer_.getGenLumiInfoHeader());
-    lumi.put(genLumiInfoHeader);
+    std::unique_ptr<GenLumiInfoHeader> genLumiInfoHeader(hadronizer_.getGenLumiInfoHeader());
+    lumi.put(std::move(genLumiInfoHeader));
         
   }
 
@@ -425,17 +425,17 @@ namespace edm
       temp.setAcceptedBr(thisProcess.acceptedBr().n(), thisProcess.acceptedBr().sum(), thisProcess.acceptedBr().sum2());
       GenLumiProcess.push_back(temp);
     }
-    std::auto_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
+    std::unique_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
     genLumiInfo->setHEPIDWTUP(lheRunInfo->getHEPRUP()->IDWTUP);
     genLumiInfo->setProcessInfo( GenLumiProcess );
 
-    lumi.put(genLumiInfo);
+    lumi.put(std::move(genLumiInfo));
 
 
     // produce GenFilterInfo if HepMCFilter is called
     if (filter_) {
 
-      std::auto_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
+      std::unique_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
 								 filter_->numEventsPassPos(),
 								 filter_->numEventsPassNeg(),
 								 filter_->numEventsTotalPos(),
@@ -445,7 +445,7 @@ namespace edm
 								 filter_->sumtotal_w(),
 								 filter_->sumtotal_w2()
 								 ));
-      lumi.put(thisProduct);
+      lumi.put(std::move(thisProduct));
     }
       
 

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -119,7 +119,7 @@ GenFilterEfficiencyProducer::endLuminosityBlock(edm::LuminosityBlock const& iLum
 void
 GenFilterEfficiencyProducer::endLuminosityBlockProduce(edm::LuminosityBlock & iLumi, const edm::EventSetup&) {
 
-  std::auto_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
+  std::unique_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
 							     numEventsPassPos_,
 							     numEventsPassNeg_,
 							     numEventsTotalPos_,
@@ -129,5 +129,5 @@ GenFilterEfficiencyProducer::endLuminosityBlockProduce(edm::LuminosityBlock & iL
 							     sumtotal_w_,
 							     sumtotal_w2_
 							     ));
-  iLumi.put(thisProduct);
+  iLumi.put(std::move(thisProduct));
 }

--- a/GeneratorInterface/CosmicMuonGenerator/src/CosMuoGenProducer.cc
+++ b/GeneratorInterface/CosmicMuonGenerator/src/CosMuoGenProducer.cc
@@ -114,7 +114,7 @@ void edm::CosMuoGenProducer::beginLuminosityBlock(LuminosityBlock const& lumi, E
 
 void edm::CosMuoGenProducer::endRunProduce( Run &run, const EventSetup& es )
 {
-  std::auto_ptr<GenRunInfoProduct> genRunInfo(new GenRunInfoProduct());
+  std::unique_ptr<GenRunInfoProduct> genRunInfo(new GenRunInfoProduct());
 
   double cs = CosMuoGen->getRate(); // flux in Hz, not s^-1m^-2
   if (MultiMuon) genRunInfo->setInternalXSec(0.);
@@ -122,7 +122,7 @@ void edm::CosMuoGenProducer::endRunProduce( Run &run, const EventSetup& es )
   genRunInfo->setExternalXSecLO(extCrossSect);
   genRunInfo->setFilterEfficiency(extFilterEff);
 
-  run.put(genRunInfo);
+  run.put(std::move(genRunInfo));
 
   CosMuoGen->terminate();
 }
@@ -232,11 +232,11 @@ void edm::CosMuoGenProducer::produce(Event &e, const edm::EventSetup &es)
 
   if (cmVerbosity_) fEvt->print();
 
-  std::auto_ptr<HepMCProduct> CMProduct(new HepMCProduct());
+  std::unique_ptr<HepMCProduct> CMProduct(new HepMCProduct());
   CMProduct->addHepMCData( fEvt );
-  e.put(CMProduct, "unsmeared");
+  e.put(std::move(CMProduct), "unsmeared");
 
-  std::auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct( fEvt ));
-  e.put(genEventInfo);
+  std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct( fEvt ));
+  e.put(std::move(genEventInfo));
 
 }

--- a/GeneratorInterface/GenFilters/src/MCPdgIndexFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCPdgIndexFilter.cc
@@ -26,7 +26,7 @@ bool MCPdgIndexFilter::filter(edm::Event& evt, const edm::EventSetup&) {
   bool result = pass(evt);
   LogDebug("FilterResult") << (result?"Pass":"Fail");
   if (!taggingMode) return result;
-  evt.put( std::auto_ptr<bool>(new bool(result)), tag);
+  evt.put(std::move(std::unique_ptr<bool>(new bool(result))), tag);
   return true;
 }
 

--- a/GeneratorInterface/GenFilters/src/MCZll.cc
+++ b/GeneratorInterface/GenFilters/src/MCZll.cc
@@ -58,7 +58,7 @@ void MCZll::endJob()
 // ------------ method called to skim the data  ------------
 bool MCZll::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct()); 
+  std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
 
   nEvents_++;
   using namespace edm;
@@ -130,7 +130,7 @@ bool MCZll::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if(zEvent)  
 	bare_product->addHepMCData(zEvent);
       if (filter_)
-	iEvent.put(bare_product);
+	iEvent.put(std::move(bare_product));
       nAccepted_++;
       //      std::cout << "+++++++++++++++++++++++++++++++++++++++++++++++++"<< std::endl;
       LogDebug("MCZll") << "Event " << iEvent.id().event()  << " accepted" << std::endl; 

--- a/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
@@ -184,7 +184,7 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         meanPt /= nCharged;
     }
 
-    std::auto_ptr<edm::GenHIEvent> pGenHI(new edm::GenHIEvent(b,
+    std::unique_ptr<edm::GenHIEvent> pGenHI(new edm::GenHIEvent(b,
 							      npart,
 							      ncoll,
 							      nhard,
@@ -199,7 +199,7 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 							      nChargedPtCutMR
 							      ));
 
-    iEvent.put(pGenHI);
+    iEvent.put(std::move(pGenHI));
 
 }
 

--- a/GeneratorInterface/LHEInterface/interface/LHEReader.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEReader.h
@@ -39,10 +39,10 @@ class LHEReader {
 	unsigned int			curIndex;
 	std::vector<std::string>        weightsinconfig;
 
-	std::auto_ptr<Source>		curSource;
-	std::auto_ptr<XMLDocument>	curDoc;
+	std::unique_ptr<Source>		curSource;
+	std::unique_ptr<XMLDocument>	curDoc;
 	boost::shared_ptr<LHERunInfo>	curRunInfo;
-	std::auto_ptr<XMLHandler>	handler;
+	std::unique_ptr<XMLHandler>	handler;
 };
 
 } // namespace lhef

--- a/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
@@ -140,8 +140,8 @@ LHE2HepMCConverter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       v->add_particle_out(gp);
    } 
 
-   std::auto_ptr<HepMCProduct> pOut(new HepMCProduct(evt));
-   iEvent.put(pOut, "unsmeared");
+   std::unique_ptr<HepMCProduct> pOut(new HepMCProduct(evt));
+   iEvent.put(std::move(pOut), "unsmeared");
 
 }
 

--- a/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
@@ -140,9 +140,9 @@ void LHECOMWeightProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
       double weight = (newpdf1/oldpdf1)*(newpdf2/oldpdf2);
       std::vector<double> weights;
       weights.push_back(weight);
-      std::auto_ptr<GenEventInfoProduct> info(new GenEventInfoProduct());
+      std::unique_ptr<GenEventInfoProduct> info(new GenEventInfoProduct());
       info->setWeights(weights);
-      iEvent.put(info, _label);
+      iEvent.put(std::move(info), _label);
 }
 
 DEFINE_FWK_MODULE(LHECOMWeightProducer);

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -113,7 +113,7 @@ void MCatNLOSource::beginRun(edm::Run &run)
   heprup.PDFGUP.first = 0;
   heprup.PDFGUP.second = 0;
 
-  std::auto_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
+  std::unique_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
 
   LHERunInfoProduct::Header hw6header("herwig6header");
   hw6header.addLine("\n");
@@ -150,7 +150,7 @@ void MCatNLOSource::beginRun(edm::Run &run)
 
   runInfo->addHeader(hw6header);
 
-  run.put(runInfo);
+  run.put(std::move(runInfo));
 
   return;
 }
@@ -186,9 +186,9 @@ void MCatNLOSource::produce(edm::Event &event)
   lhef::CommonBlocks::readHEPRUP(&heprup);
   lhef::CommonBlocks::readHEPEUP(&hepeup);
   hepeup.IDPRUP = heprup.LPRUP[0];
-  std::auto_ptr<LHEEventProduct> lhEvent(new LHEEventProduct(hepeup,hepeup.XWGTUP));
+  std::unique_ptr<LHEEventProduct> lhEvent(new LHEEventProduct(hepeup,hepeup.XWGTUP));
   lhEvent->addComment(makeConfigLine("#IHPRO", ihpro));
-  event.put(lhEvent);
+  event.put(std::move(lhEvent));
 }
 
 bool MCatNLOSource::hwwarn(const std::string &fn, int code)

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.cc
@@ -230,11 +230,11 @@ void Pythia6Gun::produce( edm::Event& evt, const edm::EventSetup& )
 void Pythia6Gun::loadEvent( edm::Event& evt )
 {
 
-   std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());  
+   std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
    
    if(fEvt)  bare_product->addHepMCData( fEvt );
 
-   evt.put(bare_product, "unsmeared");
+   evt.put(std::move(bare_product), "unsmeared");
 
    
    return;

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -198,9 +198,9 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   // Finalize HepMC event record
   hepmc_event->set_signal_process_vertex(*(vertex1->vertices_begin()));
 
-  std::auto_ptr<edm::HepMCProduct> hepmc_product(new edm::HepMCProduct());
+  std::unique_ptr<edm::HepMCProduct> hepmc_product(new edm::HepMCProduct());
   hepmc_product->addHepMCData(hepmc_event);
-  event.put(hepmc_product, "unsmeared");
+  event.put(std::move(hepmc_product), "unsmeared");
 
 }
 

--- a/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
@@ -143,33 +143,33 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
   }
   bool isValid=true;
   if(!(0<=WT && WT<10)){isValid=false; WT=1.0; WTFlip=1.0;}
-  std::auto_ptr<bool> TauSpinnerWeightisValid(new bool);
+  std::unique_ptr<bool> TauSpinnerWeightisValid(new bool);
   *TauSpinnerWeightisValid =isValid;
-  e.put(TauSpinnerWeightisValid,"TauSpinnerWTisValid");
+  e.put(std::move(TauSpinnerWeightisValid),"TauSpinnerWTisValid");
 
   // regular weight
-  std::auto_ptr<double> TauSpinnerWeight(new double);
+  std::unique_ptr<double> TauSpinnerWeight(new double);
   *TauSpinnerWeight =WT;
-  e.put(TauSpinnerWeight,"TauSpinnerWT");
+  e.put(std::move(TauSpinnerWeight),"TauSpinnerWT");
   
   // flipped weight (ie Z->H or H->Z)
-  std::auto_ptr<double> TauSpinnerWeightFlip(new double);
+  std::unique_ptr<double> TauSpinnerWeightFlip(new double);
   *TauSpinnerWeightFlip =WTFlip;
-  e.put(TauSpinnerWeightFlip,"TauSpinnerWTFlip");
+  e.put(std::move(TauSpinnerWeightFlip),"TauSpinnerWTFlip");
   
   // h+ polarization
   double WThplus=WT;
   if(polSM<0.0 && polSM!=-999 && isValid) WThplus=0;
-  std::auto_ptr<double> TauSpinnerWeighthplus(new double);
+  std::unique_ptr<double> TauSpinnerWeighthplus(new double);
   *TauSpinnerWeighthplus = WThplus;
-  e.put(TauSpinnerWeighthplus,"TauSpinnerWThplus");
+  e.put(std::move(TauSpinnerWeighthplus),"TauSpinnerWThplus");
 
   // h- polarization
   double WThminus=WT;
   if(polSM>0.0&& polSM!=-999 && isValid) WThminus=0;
-  std::auto_ptr<double> TauSpinnerWeighthminus(new double);
+  std::unique_ptr<double> TauSpinnerWeighthminus(new double);
   *TauSpinnerWeighthminus = WThminus;
-  e.put(TauSpinnerWeighthminus,"TauSpinnerWThminus");
+  e.put(std::move(TauSpinnerWeighthminus),"TauSpinnerWThminus");
   return ;
 }
 

--- a/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
@@ -102,6 +102,6 @@ void BaseFlatGunProducer::endRunProduce(Run &run, const EventSetup& es )
    // just create an empty product
    // to keep the EventContent definitions happy
    // later on we might put the info into the run info that this is a PGun
-   auto_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
-   run.put( genRunInfo );
+   unique_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
+   run.put(std::move(genRunInfo));
 }

--- a/IOMC/ParticleGuns/src/ExpoRandomPGunProducer.cc
+++ b/IOMC/ParticleGuns/src/ExpoRandomPGunProducer.cc
@@ -142,12 +142,12 @@ void ExpoRandomPGunProducer::produce(Event &e, const EventSetup& es)
       fEvt->print() ;
    }
 
-   auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
    BProduct->addHepMCData( fEvt );
-   e.put(BProduct, "unsmeared");
+   e.put(std::move(BProduct), "unsmeared");
 
-   auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-   e.put(genEventInfo);
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
 
    if ( fVerbosity > 0 )
    {

--- a/IOMC/ParticleGuns/src/ExpoRandomPtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/ExpoRandomPtGunProducer.cc
@@ -134,12 +134,12 @@ void ExpoRandomPtGunProducer::produce(Event &e, const EventSetup& es)
       fEvt->print() ;  
    }
 
-   auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
    BProduct->addHepMCData( fEvt );
-   e.put(BProduct, "unsmeared");
+   e.put(std::move(BProduct), "unsmeared");
 
-   auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-   e.put(genEventInfo);
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
     
    if ( fVerbosity > 0 )
    {

--- a/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
@@ -134,12 +134,12 @@ void FileRandomKEThetaGunProducer::produce(edm::Event & e, const edm::EventSetup
     fEvt->print() ;  
   }  
 
-  std::auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+  std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
   BProduct->addHepMCData( fEvt );
-  e.put(BProduct, "unsmeared");
+  e.put(std::move(BProduct), "unsmeared");
 
-  std::auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-  e.put(genEventInfo);
+  std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+  e.put(std::move(genEventInfo));
 
   if ( fVerbosity > 0 ) 
     LogDebug("FlatThetaGun") << "FileRandomKEThetaGunProducer : Event Generation Done";

--- a/IOMC/ParticleGuns/src/FlatBaseThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatBaseThetaGunProducer.cc
@@ -58,6 +58,6 @@ void FlatBaseThetaGunProducer::endRunProduce(Run &run, const EventSetup& es )
    // just create an empty product
    // to keep the EventContent definitions happy
    // later on we might put the info into the run info that this is a PGun
-   std::auto_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
-   run.put( genRunInfo );
+   std::unique_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
+   run.put(std::move(genRunInfo));
 }

--- a/IOMC/ParticleGuns/src/FlatRandomEGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomEGunProducer.cc
@@ -131,12 +131,12 @@ void FlatRandomEGunProducer::produce(Event & e, const EventSetup& es)
       fEvt->print() ;  
    }  
 
-   auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
    BProduct->addHepMCData( fEvt );
-   e.put(BProduct, "unsmeared");
+   e.put(std::move(BProduct), "unsmeared");
 
-   auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-   e.put(genEventInfo);
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
     
    if ( fVerbosity > 0 )
    {

--- a/IOMC/ParticleGuns/src/FlatRandomEThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomEThetaGunProducer.cc
@@ -110,12 +110,12 @@ void FlatRandomEThetaGunProducer::produce(edm::Event & e, const edm::EventSetup&
     fEvt->print() ;  
   }  
 
-  std::auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+  std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
   BProduct->addHepMCData( fEvt );
-  e.put(BProduct, "unsmeared");
+  e.put(std::move(BProduct), "unsmeared");
 
-  std::auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-  e.put(genEventInfo);
+  std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+  e.put(std::move(genEventInfo));
 
   if ( fVerbosity > 0 ) {
     LogDebug("FlatThetaGun") << "FlatRandomEThetaGunProducer : Event Generation Done";

--- a/IOMC/ParticleGuns/src/FlatRandomOneOverPtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomOneOverPtGunProducer.cc
@@ -109,12 +109,12 @@ void FlatRandomOneOverPtGunProducer::produce(Event &e, const EventSetup& es) {
     fEvt->print() ;  
   }
 
-  std::auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+  std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
   BProduct->addHepMCData( fEvt );
-  e.put(BProduct, "unsmeared");
+  e.put(std::move(BProduct), "unsmeared");
 
-  std::auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-  e.put(genEventInfo);
+  std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+  e.put(std::move(genEventInfo));
     
   LogDebug("ParticleGun") << " FlatRandomOneOverPtGunProducer : Event Generation Done ";
 }

--- a/IOMC/ParticleGuns/src/FlatRandomPtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomPtGunProducer.cc
@@ -116,12 +116,12 @@ void FlatRandomPtGunProducer::produce(Event &e, const EventSetup& es)
       fEvt->print() ;  
    }
 
-   auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
    BProduct->addHepMCData( fEvt );
-   e.put(BProduct, "unsmeared");
+   e.put(std::move(BProduct), "unsmeared");
 
-   auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-   e.put(genEventInfo);
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
     
    if ( fVerbosity > 0 )
    {

--- a/IOMC/ParticleGuns/src/FlatRandomPtThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomPtThetaGunProducer.cc
@@ -107,12 +107,12 @@ void FlatRandomPtThetaGunProducer::produce(edm::Event &e, const EventSetup& es) 
     fEvt->print() ;  
   }
 
-  std::auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+  std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
   BProduct->addHepMCData( fEvt );
-  e.put(BProduct, "unsmeared");
+  e.put(std::move(BProduct), "unsmeared");
 
-  std::auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-  e.put(genEventInfo);
+  std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+  e.put(std::move(genEventInfo));
 
   if ( fVerbosity > 0 ) {
     LogDebug("FlatThetaGun") << "FlatRandomPtThetaGunProducer : Event Generation Done ";

--- a/IOMC/ParticleGuns/src/MultiParticleInConeGunProducer.cc
+++ b/IOMC/ParticleGuns/src/MultiParticleInConeGunProducer.cc
@@ -188,12 +188,12 @@ void MultiParticleInConeGunProducer::produce(Event &e, const EventSetup& es)
       fEvt->print() ;  
    }
 
-   auto_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
    BProduct->addHepMCData( fEvt );
-   e.put(BProduct, "unsmeared");
+   e.put(std::move(BProduct), "unsmeared");
 
-   auto_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
-   e.put(genEventInfo);
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
 
    if ( fVerbosity > 0 )
      {


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in generators to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in generators may also have been changed to std::unique_ptr.
