### PR TITLE
uMNio data skipping implemented

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -588,6 +588,8 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
     int nps=(amc13->AMCId(iamc)>>12)&0xF;
     
     HcalUHTRData uhtr(amc13->AMCPayload(iamc),amc13->AMCSize(iamc));
+    //Check to make sure uMNio is not unpacked here
+    if(uhtr.getFormatVersion() != 1) continue;
 #ifdef DebugLog
     //debug printouts
     int nwords=uhtr.getRawLengthBytes()/2;


### PR DESCRIPTION
This pull request incorporates the same changes as my other one for CMSSW_8_1_X (#14158).   In brief:  This patch allows for HCAL to operate its laser during the global operations by preventing the special laser position information from being unpacked with the regular data.
