### PR TITLE
Fix condition loading in Castor DQM online client

### DIFF
--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -27,7 +27,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 #============================================
 # Castor Conditions: from Global Conditions Tag 
 #============================================
-process.load('Configuration.StandardSequences.CondDBESSource_cff')
+process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 #FIXME: they should use an official GT, not define custom records and conditions on their own!!!
 process.GlobalTag.toGet = cms.VPSet( cms.PSet( record = cms.string('CastorGainsRcd'),
                                                tag = cms.string('CastorGains_v2.1_hlt'), 


### PR DESCRIPTION
The Castor DQM online client in `DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py` should load all the conditions from the online GT provided by DQM configuration, and eventually customise them, not just define the Castor records on their own.

This commit reverts https://github.com/cms-sw/cmssw/commit/099ad01c0658185697b206f888124ed5f7206ff7 which is a regression, as it reintroduces the bug fixed when testing in the online playback by commit https://github.com/cms-sw/cmssw/commit/6943411fce8edfe2390bf400d63b359548d2904b#diff-3d9d457e24541d87ac089a37cc36fd1f
