### PR TITLE
Short term fix for number of HLT paths

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -419,7 +419,7 @@ TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBl
 {
   std::shared_ptr<trigJson::lumiVars> iSummary(new trigJson::lumiVars);
 
-  unsigned int MAXPATHS = 500;
+  unsigned int MAXPATHS = 1000;
 
   iSummary->processed = new HistoJ<unsigned int>(1, 1);
 


### PR DESCRIPTION
It was discovered during testing that the full-fledged HLT menu currently contains more paths than the old module can handle (especially if we need 1kHz of ZeroBias). Since there is a chance that we will not be able to switch to the new modules soon (it depends on the storage manager), this is a quick short-term fix to prevent the menu from crashing. The new modules will be modified to avoid the use of hard-coded numbers (it's a bit tricky because these are in static functions and thus do not have access to most class members).
