### PR TITLE
fix to fill properly the rec-hits Tracker maps 81X

### DIFF
--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -218,7 +218,7 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
       // book module plots
       folder_organizer.setDetectorFolder(detid,tTopo);
       bookModMEs(ibooker , *detid_iter);
-    }//end loop on detectors detid
+   }//end loop on detectors detid
   } else {
     for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin(),detid_end=vdetId_.end();detid_iter!=detid_end;++detid_iter){  //loop on all the active detid
       uint32_t detid = *detid_iter;
@@ -663,15 +663,16 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
     TrajectoryStateOnSurface  updatedtsos=traj_mes_iterator->updatedState();
     ConstRecHitPointer ttrh=traj_mes_iterator->recHit();
 
-    if (TkHistoMap_On_ && (numTracks > 0)) {
+ 
+    if (TkHistoMap_On_ ) {
       uint32_t thedetid=ttrh->rawId();
-      if ( thedetid > 369120277-1 ) {
+      if ( SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) { //TIB/TID + TOB + TEC only
         if ( (ttrh->getType()==1) )
-          tkhisto_NumMissingHits->add(thedetid,static_cast<float>(1./numTracks));
+          tkhisto_NumMissingHits->add(thedetid,1.);
         if ( (ttrh->getType()==2) )
-          tkhisto_NumberInactiveHits->add(thedetid,static_cast<float>(1./numTracks));
+          tkhisto_NumberInactiveHits->add(thedetid,1.);
         if ( (ttrh->getType()==0) )
-          tkhisto_NumberValidHits->add(thedetid,static_cast<float>(1./numTracks));
+          tkhisto_NumberValidHits->add(thedetid,1.);
       }
     }
 
@@ -851,7 +852,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
   //  es.get<TransientTrackRecord>().get("TransientTrackBuilder",builder);
   //  const TransientTrackBuilder* transientTrackBuilder = builder.product();
   
-  numTracks = trackCollectionHandle->size();    
+  //numTracks = trackCollectionHandle->size();    
   reco::TrackCollection trackCollection = *trackCollectionHandle;
   for (reco::TrackCollection::const_iterator track = trackCollection.begin(), etrack = trackCollection.end(); 
        track!=etrack; ++track) {
@@ -862,15 +863,15 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
     for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
 	 hit!=ehit; ++hit) {
 
-      if (TkHistoMap_On_ && (numTracks > 0)) {
+      if (TkHistoMap_On_ ) {
         uint32_t thedetid=(*hit)->rawId();
-        if ( thedetid > 369120277-1 ) {
+        if ( SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) { //TIB/TID + TOB + TEC only
           if ( ((*hit)->getType()==1) )
-            tkhisto_NumMissingHits->add(thedetid,static_cast<float>(1./numTracks));
+            tkhisto_NumMissingHits->add(thedetid,1.);
           if ( ((*hit)->getType()==2) )
-            tkhisto_NumberInactiveHits->add(thedetid,static_cast<float>(1./numTracks));
+            tkhisto_NumberInactiveHits->add(thedetid,1.);
           if ( ((*hit)->getType()==0) )
-            tkhisto_NumberValidHits->add(thedetid,static_cast<float>(1./numTracks));
+            tkhisto_NumberValidHits->add(thedetid,1.);
         }
       }
 


### PR DESCRIPTION
This PR fix the filling of Tracker Maps relative to rec-hits, they where filled with the hit number normalized for the number of tracks, while what we want is the mean per event.
