### PR TITLE
Clang warnings clean up (April 25th)

### DIFF
--- a/Alignment/CocoaUtilities/interface/ALIUtils.h
+++ b/Alignment/CocoaUtilities/interface/ALIUtils.h
@@ -19,6 +19,7 @@
 #include <time.h>
 #include <fstream> 
 #include <iostream> 
+#include <cmath>
 
 class ALIUtils
 {
@@ -88,7 +89,7 @@ public:
   static ALIdouble val0( ALIdouble val ) {
     //-std::cout << val << " val " << ( (val <= 1.E-9) ? 0. : val) << std::endl; 
 //    return (abs(val) <= 1.E-9) ? 0. : val; }
-    if( fabs(val) <= 1.E-9) { return 0.;
+    if( std::fabs(val) <= 1.E-9) { return 0.;
     }else { return val; }; }
 
   static ALIstring subQuotes( const ALIstring& str );

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
@@ -45,7 +45,7 @@ private:
   container selected_;
   selector select_;
   RefAdder addRef_;
-  friend class reco::modules::SingleElementCollectionSelectorEventSetupInit<SingleElementCollectionSelector>;
+  friend struct reco::modules::SingleElementCollectionSelectorEventSetupInit<SingleElementCollectionSelector>;
 };
 
 #include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"

--- a/CommonTools/Utils/interface/AndSelector.h
+++ b/CommonTools/Utils/interface/AndSelector.h
@@ -29,7 +29,7 @@ struct AndSelector {
   }
 
 private:
-  friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, S5>;
+  friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, S5>;
   S1 s1_;
   S2 s2_;
   S3 s3_;
@@ -51,7 +51,7 @@ struct AndSelector<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, hel
     return s1_( t1 ) && s2_( t2 );
   }
 private:
-  friend class reco::modules::CombinedEventSetupInit<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>;
+  friend struct reco::modules::CombinedEventSetupInit<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>;
   S1 s1_;
   S2 s2_;
 };
@@ -69,7 +69,7 @@ struct AndSelector<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>
     return s1_( t1 ) && s2_( t2 ) && s3_( t3 );
   }
 private:
-  friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>;
+  friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>;
   S1 s1_;
   S2 s2_;
   S3 s3_;
@@ -88,7 +88,7 @@ struct AndSelector<S1, S2, S3, S4, helpers::NullAndOperand> {
     return s1_( t1 ) && s2_( t2 ) && s3_( t3 ) && s4_( t4 );
   }
 private:
-  friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, helpers::NullAndOperand>;
+  friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, helpers::NullAndOperand>;
   S1 s1_;
   S2 s2_;
   S3 s3_;

--- a/EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h
@@ -43,7 +43,7 @@ class HcalDCCHeader {
   /** Check the third bit of second Slink64 CDF word */
   inline bool thereIsAThirdCDFHeaderWord() const {return ((commondataformat2>>3) & 0x0001); }
   /** Get the Orbit Number from the CDF. */
-  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 && 0xF) << 28) + ( commondataformat2>>4) ); }
+  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 & 0xF) << 28) + ( commondataformat2>>4) ); }
   /** get the (undefined) 'Reserved' part of the second Slink64 CDF word */
   inline unsigned int getSlink64ReservedBits() const { return (  (commondataformat3>>4)&0x00FFFFFF ); }
   /** Get the Beginning Of Event bits.  If it's not the first or last CDF Slink64 word, the high 4 bits must be zero.*/

--- a/EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h
@@ -46,7 +46,7 @@ class HcalDTCHeader {
   /** Check the third bit of second Slink64 CDF word */
   inline bool thereIsAThirdCDFHeaderWord() const {return ((commondataformat2>>3) & 0x0001); }
   /** Get the Orbit Number from the CDF. */
-  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 && 0xF) << 28) + ( commondataformat2>>4) ); }
+  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 & 0xF) << 28) + ( commondataformat2>>4) ); }
   /** get the (undefined) 'Reserved' part of the second Slink64 CDF word */
   inline unsigned int getSlink64ReservedBits() const { return (  (commondataformat3>>4)&0x00FFFFFF ); }
   /** Get the Beginning Of Event bits.  If it's not the first or last CDF Slink64 word, the high 4 bits must be zero.*/

--- a/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.cc
@@ -1,4 +1,3 @@
-using namespace std;
 #include "EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -1,4 +1,3 @@
-using namespace std;
 #include "EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -1532,7 +1532,7 @@ std::vector<float> EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits( cons
         }
 	float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
         float weight = 0;
-        if(fabs(weightedPositionMethod)<0.0001){ //linear
+        if(std::abs(weightedPositionMethod)<0.0001){ //linear
             weight = rh_energy/energyTotal;
         }else{ //logrithmic
             weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));
@@ -1570,7 +1570,7 @@ std::vector<float> EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits( cons
         }
 	float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
         float weight = 0;
-        if(fabs(weightedPositionMethod) < 0.0001){ //linear
+        if(std::abs(weightedPositionMethod) < 0.0001){ //linear
             weight = rh_energy/energyTotal;
         }else{ //logrithmic
             weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterSeverityAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterSeverityAlgo.cc
@@ -231,7 +231,7 @@ void testEcalClusterSeverityAlgo::analyze(const edm::Event& ev, const edm::Event
 	    for ( HepMC::GenEvent::particle_const_iterator mcIter=myGenEvent->particles_begin(); mcIter != myGenEvent->particles_end(); mcIter++ ) {
 	      
 	      // select electrons
-	      if ( abs((*mcIter)->pdg_id()) == 11 )
+	      if ( std::abs((*mcIter)->pdg_id()) == 11 )
 		{
 		
 		  // single primary electrons or electrons from Zs or Ws
@@ -243,9 +243,9 @@ void testEcalClusterSeverityAlgo::analyze(const edm::Event& ev, const edm::Event
 		  }
 		  if ( (
 			(mother == 0) || 
-			((mother != 0) && (mother->pdg_id() == 23)) ||
-			((mother != 0) && (mother->pdg_id() == 32)) ||
-			((mother != 0) && (fabs(mother->pdg_id()) == 24))
+			((mother != 0) && (std::abs(mother->pdg_id()) == 23)) ||
+			((mother != 0) && (std::abs(mother->pdg_id()) == 32)) ||
+			((mother != 0) && (std::abs(mother->pdg_id()) == 24))
 			)
 		       ) 
 		    {


### PR DESCRIPTION
The following should resolve a few hundreds of warnings:

```
118 CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h:48:10: warning: class 'SingleElementCollectionSelectorEventSetupInit' was previously declared as a struct [-Wmismatched-tags]
108 RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h:1573:12: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
107 RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h:1535:12: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
1 RecoEcal/EgammaCoreTools/test/testEcalClusterSeverityAlgo.cc:248:23: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
63 EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h:46:77: warning: use of logical '&&' with constant operand [-Wconstant-logical-operand]
2 EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h:49:77: warning: use of logical '&&' with constant operand [-Wconstant-logical-operand]
1 EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc:1:17: warning: using directive refers to implicitly-defined namespace 'std'
1 EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.cc:1:17: warning: using directive refers to implicitly-defined namespace 'std'
54 Alignment/CocoaUtilities/interface/ALIUtils.h:91:9: warning: absolute value function 'fabs' given an argument of type 'ALIdouble' (aka 'long double') but has parameter of type 'double' which may cause truncation of value [-Wabsolute-value]
22 CommonTools/Utils/interface/AndSelector.h:54:10: warning: class 'CombinedEventSetupInit' was previously declared as a struct [-Wmismatched-tags]
```

There are still thousands left.
