### PR TITLE
Added missing dictionaries related to BXVector

### DIFF
--- a/DataFormats/L1TCalorimeter/src/classes.h
+++ b/DataFormats/L1TCalorimeter/src/classes.h
@@ -20,6 +20,11 @@ namespace DataFormats_L1TCalorimeter {
     l1t::CaloTowerBxCollection   caloTowerBxColl;
     l1t::CaloClusterBxCollection caloClusterBxColl;
 
+    std::vector<l1t::CaloRegion>  v_aloRegionBx;
+    std::vector<l1t::CaloEmCand>  v_caloEmCandBx;
+    std::vector<l1t::CaloTower>   v_caloTowerBx;
+    std::vector<l1t::CaloCluster> v_caloClusterBx;
+
     edm::Wrapper<l1t::CaloRegionBxCollection>  w_caloRegionBxColl;
     edm::Wrapper<l1t::CaloEmCandBxCollection>  w_caloEmCandBxColl;
     edm::Wrapper<l1t::CaloTowerBxCollection>   w_caloTowerBxColl;

--- a/DataFormats/L1TCalorimeter/src/classes_def.xml
+++ b/DataFormats/L1TCalorimeter/src/classes_def.xml
@@ -1,17 +1,21 @@
 <lcgdict>
   <class name="l1t::CaloEmCand" />
+  <class name="std::vector<l1t::CaloEmCand>" />
   <class name="l1t::CaloEmCandBxCollection"/>
   <class name="edm::Wrapper<l1t::CaloEmCandBxCollection>"/>
 
   <class name="l1t::CaloRegion" />
+  <class name="std::vector<l1t::CaloRegion>" />
   <class name="l1t::CaloRegionBxCollection"/>
   <class name="edm::Wrapper<l1t::CaloRegionBxCollection>"/>
 
   <class name="l1t::CaloTower" />
+  <class name="std::vector<l1t::CaloTower>" />
   <class name="l1t::CaloTowerBxCollection"/>
   <class name="edm::Wrapper<l1t::CaloTowerBxCollection>"/>
 
   <class name="l1t::CaloCluster" />
+  <class name="std::vector<l1t::CaloCluster>" />
   <class name="l1t::CaloClusterBxCollection"/>
   <class name="edm::Wrapper<l1t::CaloClusterBxCollection>"/>
 

--- a/DataFormats/L1TGlobal/src/classes.h
+++ b/DataFormats/L1TGlobal/src/classes.h
@@ -1,6 +1,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include <vector>
 
 namespace DataFormats_L1TGlobal {
   struct dictionary {
@@ -10,5 +11,8 @@ namespace DataFormats_L1TGlobal {
 
     edm::Wrapper<GlobalAlgBlkBxCollection>    w_uGtAlgBxColl;
     edm::Wrapper<GlobalExtBlkBxCollection>    w_uGtExtBxColl;
+
+    std::vector<GlobalAlgBlk> v_uGtAlgBx;
+    std::vector<GlobalExtBlk> v_uGtExtBx;
   };
 }

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -7,6 +7,7 @@
   </class>
   <class name="GlobalAlgBlkBxCollection"/>
   <class name="edm::Wrapper<GlobalAlgBlkBxCollection>"/>
+  <class name="std::vector<GlobalAlgBlk>"/>
 
   <class name="GlobalExtBlk" ClassVersion="13">
    <version ClassVersion="13" checksum="3765126275"/>
@@ -16,6 +17,7 @@
   </class>
   <class name="GlobalExtBlkBxCollection"/>
   <class name="edm::Wrapper<GlobalExtBlkBxCollection>"/>
+  <class name="std::vector<GlobalExtBlk>"/>
 
 </lcgdict>
 

--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -11,9 +11,11 @@ namespace {
   struct dictionary {
     l1t::MuonCaloSumBxCollection caloSum;
     edm::Wrapper<l1t::MuonCaloSumBxCollection> caloSumWrap;
+    std::vector<l1t::MuonCaloSum> vCaloSum;
 
     l1t::RegionalMuonCandBxCollection regCand;
     edm::Wrapper<l1t::RegionalMuonCandBxCollection> regCandWrap;
+    std::vector<l1t::RegionalMuonCand> vRegCand;
    
     l1t::EMTFOutputCollection emtfOutput;
     edm::Wrapper<l1t::EMTFOutputCollection> emtfOutputWrap;

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -3,10 +3,12 @@
 
   <class name="l1t::RegionalMuonCand"/>
   <class name="l1t::RegionalMuonCandBxCollection"/>
+  <class name="std::vector<l1t::RegionalMuonCand>"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
   <class name="l1t::MuonCaloSum"/>
   <class name="l1t::MuonCaloSumBxCollection"/>
+  <class name="std::vector<l1t::MuonCaloSum>"/>
   <class name="edm::Wrapper<l1t::MuonCaloSumBxCollection>"/>
 
   <class name="l1t::EMTFOutput"/>

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -52,6 +52,15 @@ namespace DataFormats_L1Trigger {
     edm::Wrapper<l1t::CaloSpareBxCollection> w_caloSpareColl;
     edm::Wrapper<l1t::L1DataEmulResultBxCollection>   w_deResult;
 
+    std::vector<l1t::L1Candidate> v_l1CandidateBx;
+    std::vector<l1t::EGamma> v_eGammaBx;
+    std::vector<l1t::EtSum> v_etSumBx;
+    std::vector<l1t::Jet> v_jetBx;
+    std::vector<l1t::Muon> v_muonBx;
+    std::vector<l1t::Tau> v_tauBx;
+    std::vector<l1t::CaloSpare> v_caloSparseBx;
+    std::vector<l1t::L1DataEmulResult> v_deResult;
+
     l1t::L1CandidateRef   refL1Candidate_;
     l1t::L1CandidateRefVector   refVecL1Candidate_;
     l1t::L1CandidateVectorRef   vecRefL1Candidate_;

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -6,6 +6,7 @@
   </class>
   <class name="l1t::L1CandidateBxCollection"/>
   <class name="edm::Wrapper<l1t::L1CandidateBxCollection>"/>
+  <class name="std::vector<l1t::L1Candidate>"/>
   <class name="l1t::L1CandidateRef"/>
   <class name="edm::Wrapper<l1t::L1CandidateRef>"/>
   <class name="l1t::L1CandidateRefVector"/>
@@ -21,6 +22,7 @@
   </class>
   <class name="l1t::JetBxCollection"/>
   <class name="edm::Wrapper<l1t::JetBxCollection>"/>
+  <class name="std::vector<l1t::Jet>"/>
   <class name="l1t::JetRef"/>
   <class name="edm::Wrapper<l1t::JetRef>"/>
   <class name="l1t::JetRefVector"/>
@@ -36,6 +38,7 @@
    <version ClassVersion="10" checksum="130849840"/>
   </class>
   <class name="l1t::EGammaBxCollection"/>
+  <class name="std::vector<l1t::EGamma>"/>
   <class name="edm::Wrapper<l1t::EGammaBxCollection>"/>
   <class name="l1t::EGammaRef"/>
   <class name="edm::Wrapper<l1t::EGammaRef>"/>
@@ -51,6 +54,7 @@
    <version ClassVersion="10" checksum="3389025278"/>
   </class>
   <class name="l1t::EtSumBxCollection"/>
+  <class name="std::vector<l1t::EtSum>"/>
   <class name="edm::Wrapper<l1t::EtSumBxCollection>"/>
   <class name="l1t::EtSumRef"/>
   <class name="edm::Wrapper<l1t::EtSumRef>"/>
@@ -66,6 +70,7 @@
    <version ClassVersion="10" checksum="3214350964"/>
   </class>
   <class name="l1t::TauBxCollection"/>
+  <class name="std::vector<l1t::Tau>"/>
   <class name="edm::Wrapper<l1t::TauBxCollection>"/>
   <class name="l1t::TauRef"/>
   <class name="edm::Wrapper<l1t::TauRef>"/>
@@ -84,6 +89,7 @@
    <version ClassVersion="10" checksum="1956355507"/>
   </class>
   <class name="l1t::MuonBxCollection"/>
+  <class name="std::vector<l1t::Muon>"/>
   <class name="edm::Wrapper<l1t::MuonBxCollection>"/>
   <class name="l1t::MuonRef"/>
   <class name="edm::Wrapper<l1t::MuonRef>"/>
@@ -99,6 +105,7 @@
    <version ClassVersion="10" checksum="3477497140"/>
   </class>
   <class name="l1t::CaloSpareBxCollection"/>
+  <class name="std::vector<l1t::CaloSpare>"/>
   <class name="edm::Wrapper<l1t::CaloSpareBxCollection>"/>
 
   <class name="l1extra::L1EmParticle" ClassVersion="13">
@@ -206,6 +213,7 @@
     <version ClassVersion="10" checksum="604440326"/>
   </class>
   <class name="l1t::L1DataEmulResultBxCollection"/>
+  <class name="std::vector<l1t::L1DataEmulResult>"/>
   <class name="edm::Wrapper<l1t::L1DataEmulResultBxCollection>"/>
 
 


### PR DESCRIPTION
This solves the problem seen by the Tier 0 repacking jobs:
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3643.html
