### PR TITLE
Use unique_ptr, not auto_ptr, in HLT

### DIFF
--- a/HLTrigger/Egamma/src/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/src/HLTScoutingEgammaProducer.cc
@@ -147,8 +147,8 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event & iEvent, 
     }
 
     // Produce electrons and photons
-    std::auto_ptr<ScoutingElectronCollection> outElectrons(new ScoutingElectronCollection());
-    std::auto_ptr<ScoutingPhotonCollection> outPhotons(new ScoutingPhotonCollection());
+    std::unique_ptr<ScoutingElectronCollection> outElectrons(new ScoutingElectronCollection());
+    std::unique_ptr<ScoutingPhotonCollection> outPhotons(new ScoutingPhotonCollection());
     int index = 0;
     for (auto &candidate : *EgammaCandidateCollection) {
         reco::RecoEcalCandidateRef candidateRef = getRef(EgammaCandidateCollection, index);
@@ -200,8 +200,8 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event & iEvent, 
     }
 
     // Put output
-    iEvent.put(outElectrons);
-    iEvent.put(outPhotons);
+    iEvent.put(std::move(outElectrons));
+    iEvent.put(std::move(outPhotons));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
@@ -203,8 +203,8 @@ void HLTPrescaleRecorder::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   if (event_) {
     /// Writing to Event
-    auto_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
-    iEvent.put(product,"Event");
+    unique_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
+    iEvent.put(std::move(product),"Event");
   }
 
   return;
@@ -216,8 +216,8 @@ void HLTPrescaleRecorder::endLuminosityBlockProduce(edm::LuminosityBlock& iLumi,
 
   if (lumi_) {
     /// Writing to Lumi Block
-    auto_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
-    iLumi.put(product,"Lumi");
+    unique_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
+    iLumi.put(std::move(product),"Lumi");
   }
   return;
 }
@@ -273,7 +273,7 @@ void HLTPrescaleRecorder::endRun(edm::Run const& iRun, const edm::EventSetup& iS
 void HLTPrescaleRecorder::endRunProduce(edm::Run& iRun, const edm::EventSetup& iSetup) {
    if (run_) {
      /// Writing to Run Block
-     auto_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
-     iRun.put(product,"Run");
+     unique_ptr<HLTPrescaleTable> product (new HLTPrescaleTable(hlt_));
+     iRun.put(std::move(product),"Run");
    }
 }

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -299,7 +299,7 @@ TriggerSummaryProducerAOD::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
    ///
    /// construct single AOD product, reserving capacity
-   auto_ptr<TriggerEvent> product(new TriggerEvent(pn_,nk,no,nf));
+   unique_ptr<TriggerEvent> product(new TriggerEvent(pn_,nk,no,nf));
 
    /// fill trigger object collection
    product->addCollections(tags_,keys_);
@@ -339,7 +339,7 @@ TriggerSummaryProducerAOD::produce(edm::Event& iEvent, const edm::EventSetup& iS
      }
    }
 
-   OrphanHandle<TriggerEvent> ref = iEvent.put(product);
+   OrphanHandle<TriggerEvent> ref = iEvent.put(std::move(product));
    LogTrace("TriggerSummaryProducerAOD") << "Number of physics objects packed: " << ref->sizeObjects();
    LogTrace("TriggerSummaryProducerAOD") << "Number of filter  objects packed: " << ref->sizeFilters();
 

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -79,7 +79,7 @@ TriggerSummaryProducerRAW::produce(edm::Event& iEvent, const edm::EventSetup&)
    LogDebug("TriggerSummaryProducerRaw") << "Number of filter objects found: " << nfob;
 
    // construct single RAW product
-   auto_ptr<TriggerEventWithRefs> product(new TriggerEventWithRefs(pn_,nfob));
+   unique_ptr<TriggerEventWithRefs> product(new TriggerEventWithRefs(pn_,nfob));
    for (unsigned int ifob=0; ifob!=nfob; ++ifob) {
      const string& label    (fobs[ifob].provenance()->moduleLabel());
      const string& instance (fobs[ifob].provenance()->productInstanceName());
@@ -130,7 +130,7 @@ TriggerSummaryProducerRAW::produce(edm::Event& iEvent, const edm::EventSetup&)
    }
 
    // place product in Event
-   OrphanHandle<TriggerEventWithRefs> ref = iEvent.put(product);
+   OrphanHandle<TriggerEventWithRefs> ref = iEvent.put(std::move(product));
    LogTrace("TriggerSummaryProducerRaw") << "Number of filter objects packed: " << ref->size();
 
    return;

--- a/HLTrigger/HLTcore/src/HLTFilter.cc
+++ b/HLTrigger/HLTcore/src/HLTFilter.cc
@@ -34,13 +34,13 @@ HLTFilter::~HLTFilter()
 { }
 
 bool HLTFilter::filter(edm::StreamID, edm::Event & event, const edm::EventSetup & setup) const {
-  std::auto_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );
+  std::unique_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );
 
   // compute the result of the HLTFilter implementation
   bool result = hltFilter(event, setup, * filterproduct);
 
   // put filter object into the Event
-  event.put(filterproduct);
+  event.put(std::move(filterproduct));
 
   // retunr the result of the HLTFilter
   return result;

--- a/HLTrigger/HLTcore/src/HLTStreamFilter.cc
+++ b/HLTrigger/HLTcore/src/HLTStreamFilter.cc
@@ -34,13 +34,13 @@ HLTStreamFilter::~HLTStreamFilter()
 { }
 
 bool HLTStreamFilter::filter(edm::Event & event, const edm::EventSetup & setup) {
-  std::auto_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );
+  std::unique_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );
 
   // compute the result of the HLTStreamFilter implementation
   bool result = hltFilter(event, setup, * filterproduct);
 
   // put filter object into the Event
-  event.put(filterproduct);
+  event.put(std::move(filterproduct));
 
   // retunr the result of the HLTStreamFilter
   return result;

--- a/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
+++ b/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
@@ -111,8 +111,8 @@ TestBXVectorRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 {
    using namespace edm;
 
-   auto_ptr<vector<int>> jetMom ( new vector<int> );
-   auto_ptr<l1t::JetRefVector> jetRef ( new l1t::JetRefVector );
+   unique_ptr<vector<int>> jetMom ( new vector<int> );
+   unique_ptr<l1t::JetRefVector> jetRef ( new l1t::JetRefVector );
 
    // retrieve the tracks
    Handle<l1t::JetBxCollection> jets;
@@ -134,9 +134,9 @@ TestBXVectorRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
    } // end for 
 
-   iEvent.put(jetMom,"jetPt");
+   iEvent.put(std::move(jetMom),"jetPt");
    
-   if (doRefs_) iEvent.put(jetRef,"l1tJetRef");
+   if (doRefs_) iEvent.put(std::move(jetRef),"l1tJetRef");
 
    return;
  

--- a/HLTrigger/JetMET/interface/HLTJetsCleanedFromLeadingLeptons.h
+++ b/HLTrigger/JetMET/interface/HLTJetsCleanedFromLeadingLeptons.h
@@ -266,10 +266,10 @@ void HLTJetsCleanedFromLeadingLeptons<JetType>::produce(edm::Event &iEvent,
     
     
     // Store the collection in the event
-    std::auto_ptr<JetCollectionVector> product(new JetCollectionVector);
-    //^ Have to use the depricated auto_ptr here because this is what edm::Event::put expects
+    std::unique_ptr<JetCollectionVector> product(new JetCollectionVector);
+    //^ Have to use the depricated unique_ptr here because this is what edm::Event::put expects
     product->emplace_back(cleanedJetRefs);
-    iEvent.put(product);
+    iEvent.put(std::move(product));
 }
 
 #endif  // HLTJetsCleanedFromLeadingLeptons_h

--- a/HLTrigger/JetMET/interface/HLTRHemisphere.h
+++ b/HLTrigger/JetMET/interface/HLTRHemisphere.h
@@ -47,7 +47,7 @@ class HLTRHemisphere : public edm::stream::EDFilter<> {
       int max_NJ_;             // don't calculate R if event has more than NJ jets
       bool accNJJets_;         // accept or reject events with high NJ
 
-      void ComputeHemispheres(std::auto_ptr<std::vector<math::XYZTLorentzVector> >& hlist, const std::vector<math::XYZTLorentzVector>& JETS, std::vector<math::XYZTLorentzVector> *extraJets=0);
+      void ComputeHemispheres(std::unique_ptr<std::vector<math::XYZTLorentzVector> >& hlist, const std::vector<math::XYZTLorentzVector>& JETS, std::vector<math::XYZTLorentzVector> *extraJets=0);
 };
 
 #endif //HLTRHemisphere_h

--- a/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
@@ -185,14 +185,14 @@ HLTJetHbbFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,tr
 		filterproduct.addObject(triggerType_,ref2);
 	      
 		//create METCollection for storing csv tag1 and tag2 results
-		std::auto_ptr<reco::METCollection> csvObject(new reco::METCollection());
+		std::unique_ptr<reco::METCollection> csvObject(new reco::METCollection());
 		reco::MET::LorentzVector csvP4(tag1,tag2,0,0);
 		reco::MET::Point vtx(0,0,0);
 		reco::MET csvTags(csvP4, vtx);
 		csvObject->push_back(csvTags);
 		edm::RefProd<reco::METCollection > ref_before_put = event.getRefBeforePut<reco::METCollection >();
 		//put the METCollection into the event (necessary because of how addCollectionTag works...)
-		event.put(csvObject);
+		event.put(std::move(csvObject));
 		edm::Ref<reco::METCollection> csvRef(ref_before_put, 0);
 		if (saveTags()) filterproduct.addCollectionTag(edm::InputTag( *moduleLabel()));
 		filterproduct.addObject(trigger::TriggerMET, csvRef); //give it the ID of a MET object

--- a/HLTrigger/JetMET/plugins/HLTRFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTRFilter.cc
@@ -189,7 +189,7 @@ HLTRFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger
 void HLTRFilter::addObjects(edm::Event& iEvent, trigger::TriggerFilterObjectWithRefs & filterproduct, double MR, double Rsq) const{
     
     //create METCollection for storing MR and Rsq results
-    std::auto_ptr<reco::METCollection> razorObject(new reco::METCollection());
+    std::unique_ptr<reco::METCollection> razorObject(new reco::METCollection());
     
     reco::MET::LorentzVector mrRsqP4(MR,Rsq,0,0);
     reco::MET::Point vtx(0,0,0);
@@ -200,7 +200,7 @@ void HLTRFilter::addObjects(edm::Event& iEvent, trigger::TriggerFilterObjectWith
     edm::RefProd<reco::METCollection > ref_before_put = iEvent.getRefBeforePut<reco::METCollection >();
 
     //put the METCollection into the event (necessary because of how addCollectionTag works...)
-    iEvent.put(razorObject);
+    iEvent.put(std::move(razorObject));
     edm::Ref<reco::METCollection> mrRsqRef(ref_before_put, 0);
 
     //add it to the trigger object collection

--- a/HLTrigger/JetMET/plugins/HLTRHemisphere.cc
+++ b/HLTrigger/JetMET/plugins/HLTRHemisphere.cc
@@ -93,7 +93,7 @@ HLTRHemisphere::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    if(doMuonCorrection_) iEvent.getByToken( m_theMuonToken,muons );
 
    // The output Collection
-   std::auto_ptr<vector<math::XYZTLorentzVector> > Hemispheres(new vector<math::XYZTLorentzVector> );
+   std::unique_ptr<vector<math::XYZTLorentzVector> > Hemispheres(new vector<math::XYZTLorentzVector> );
 
    // look at all objects, check cuts and add to filter object
    int n(0);
@@ -106,7 +106,7 @@ HLTRHemisphere::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
 
   if(n>max_NJ_ && max_NJ_!=-1){
-    iEvent.put(Hemispheres);
+    iEvent.put(std::move(Hemispheres));
     return accNJJets_; // too many jets, accept for timing
   }
 
@@ -119,7 +119,7 @@ HLTRHemisphere::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
     for(muonIt = muons->begin(); muonIt!=muons->end(); muonIt++,index++){ 
       if(std::abs(muonIt->eta()) > muonEta_ || muonIt->pt() < min_Jet_Pt_) continue; // skip muons out of eta range or too low pT
       if(nPassMu >= 2){ // if we have already accepted two muons, accept the event
-	iEvent.put(Hemispheres); // too many muons, accept for timing      
+	iEvent.put(std::move(Hemispheres)); // too many muons, accept for timing      
 	return true;
       }
       muonIndex[nPassMu++] = index;    
@@ -151,12 +151,12 @@ HLTRHemisphere::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   // 0 muon: 2 hemispheres (2)
   // 1 muon: 2 hemisheress + leadMuP4 + 2 hemispheres (5)
   // 2 muon: 2 hemispheres + leadMuP4 + 2 hemispheres + 2ndMuP4 + 4 Hemispheres (10)
-  iEvent.put(Hemispheres);
+  iEvent.put(std::move(Hemispheres));
   return true;
 }
 
 void
-HLTRHemisphere::ComputeHemispheres(std::auto_ptr<std::vector<math::XYZTLorentzVector> >& hlist, const std::vector<math::XYZTLorentzVector>& JETS,
+HLTRHemisphere::ComputeHemispheres(std::unique_ptr<std::vector<math::XYZTLorentzVector> >& hlist, const std::vector<math::XYZTLorentzVector>& JETS,
 				   std::vector<math::XYZTLorentzVector>* extraJets){
   using namespace math;
   using namespace reco;

--- a/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
@@ -85,7 +85,7 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
 
     //get calo jets
     Handle<reco::CaloJetCollection> caloJetCollection;
-    std::auto_ptr<ScoutingCaloJetCollection> outCaloJets(new ScoutingCaloJetCollection());
+    std::unique_ptr<ScoutingCaloJetCollection> outCaloJets(new ScoutingCaloJetCollection());
     if(iEvent.getByToken(caloJetCollection_, caloJetCollection)){
         for(auto &jet : *caloJetCollection){
             if(jet.pt() > caloJetPtCut && fabs(jet.eta()) < caloJetEtaCut){
@@ -102,7 +102,7 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
 
     //get vertices
     Handle<reco::VertexCollection> vertexCollection;
-    std::auto_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
+    std::unique_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
     if(iEvent.getByToken(vertexCollection_, vertexCollection)){
         //produce vertices (only if present; otherwise return an empty collection)
         for(auto &vtx : *vertexCollection){
@@ -114,26 +114,26 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
 
     //get rho
     Handle<double>rho;
-    std::auto_ptr<double> outRho(new double(-999));
+    std::unique_ptr<double> outRho(new double(-999));
     if(iEvent.getByToken(rho_, rho)){
         outRho.reset(new double(*rho));
     }
 
     //get MET 
     Handle<reco::CaloMETCollection> metCollection;
-    std::auto_ptr<double> outMetPt(new double(-999));
-    std::auto_ptr<double> outMetPhi(new double(-999));
+    std::unique_ptr<double> outMetPt(new double(-999));
+    std::unique_ptr<double> outMetPhi(new double(-999));
     if(doMet && iEvent.getByToken(metCollection_, metCollection)){
         outMetPt.reset(new double(metCollection->front().pt()));
         outMetPhi.reset(new double(metCollection->front().phi()));
     }
 
     //put output
-    iEvent.put(outCaloJets);
-    iEvent.put(outVertices);
-    iEvent.put(outRho, "rho");
-    iEvent.put(outMetPt, "caloMetPt");
-    iEvent.put(outMetPhi, "caloMetPhi");
+    iEvent.put(std::move(outCaloJets));
+    iEvent.put(std::move(outVertices));
+    iEvent.put(std::move(outRho), "rho");
+    iEvent.put(std::move(outMetPt), "caloMetPt");
+    iEvent.put(std::move(outMetPhi), "caloMetPhi");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -101,7 +101,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm:
 
     //get vertices
     Handle<reco::VertexCollection> vertexCollection;
-    std::auto_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
+    std::unique_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
     if(iEvent.getByToken(vertexCollection_, vertexCollection)){
         for(auto &vtx : *vertexCollection){
             outVertices->emplace_back(
@@ -112,15 +112,15 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm:
 
     //get rho
     Handle<double> rho;
-    std::auto_ptr<double> outRho(new double(-999));
+    std::unique_ptr<double> outRho(new double(-999));
     if(iEvent.getByToken(rho_, rho)){
         outRho.reset(new double(*rho));
     }
 
     //get MET
     Handle<reco::METCollection> metCollection;
-    std::auto_ptr<double> outMetPt(new double(-999));
-    std::auto_ptr<double> outMetPhi(new double(-999));
+    std::unique_ptr<double> outMetPt(new double(-999));
+    std::unique_ptr<double> outMetPhi(new double(-999));
     if(doMet && iEvent.getByToken(metCollection_, metCollection)){
         outMetPt.reset(new double(metCollection->front().pt()));
         outMetPhi.reset(new double(metCollection->front().phi()));
@@ -128,7 +128,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm:
 
     //get PF candidates
     Handle<reco::PFCandidateCollection> pfCandidateCollection;
-    std::auto_ptr<ScoutingParticleCollection> outPFCandidates(new ScoutingParticleCollection());
+    std::unique_ptr<ScoutingParticleCollection> outPFCandidates(new ScoutingParticleCollection());
     if(doCandidates && iEvent.getByToken(pfCandidateCollection_, pfCandidateCollection)){
         for(auto &cand : *pfCandidateCollection){
             if(cand.pt() > pfCandidatePtCut){
@@ -155,7 +155,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm:
 
     //get PF jets
     Handle<reco::PFJetCollection> pfJetCollection;
-    std::auto_ptr<ScoutingPFJetCollection> outPFJets(new ScoutingPFJetCollection());
+    std::unique_ptr<ScoutingPFJetCollection> outPFJets(new ScoutingPFJetCollection());
     if(iEvent.getByToken(pfJetCollection_, pfJetCollection)){
         //get PF jet tags
         Handle<reco::JetTagCollection> pfJetTagCollection;
@@ -215,12 +215,12 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm:
     }
 
     //put output
-    iEvent.put(outVertices);
-    iEvent.put(outPFCandidates);
-    iEvent.put(outPFJets);
-    iEvent.put(outRho, "rho");
-    iEvent.put(outMetPt, "pfMetPt");
-    iEvent.put(outMetPhi, "pfMetPhi");
+    iEvent.put(std::move(outVertices));
+    iEvent.put(std::move(outPFCandidates));
+    iEvent.put(std::move(outPFJets));
+    iEvent.put(std::move(outRho), "rho");
+    iEvent.put(std::move(outMetPt), "pfMetPt");
+    iEvent.put(std::move(outMetPhi), "pfMetPhi");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/HLTrigger/JetMET/plugins/PixelJetPuId.cc
+++ b/HLTrigger/JetMET/plugins/PixelJetPuId.cc
@@ -142,8 +142,8 @@ PixelJetPuId::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 void PixelJetPuId::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   using namespace edm;
-  std::auto_ptr<std::vector<reco::CaloJet> > pOut(new std::vector<reco::CaloJet> );
-  std::auto_ptr<std::vector<reco::CaloJet> > pOut_PUjets(new std::vector<reco::CaloJet> );
+  std::unique_ptr<std::vector<reco::CaloJet> > pOut(new std::vector<reco::CaloJet> );
+  std::unique_ptr<std::vector<reco::CaloJet> > pOut_PUjets(new std::vector<reco::CaloJet> );
   
    //get tracks
   Handle<std::vector<reco::Track> > tracks;
@@ -212,8 +212,8 @@ void PixelJetPuId::produce(edm::StreamID sid, edm::Event& iEvent, const edm::Eve
 	  }
       }
     }
-  iEvent.put(pOut);
-  iEvent.put(pOut_PUjets,"PUjets");
+  iEvent.put(std::move(pOut));
+  iEvent.put(std::move(pOut_PUjets),"PUjets");
   
 }
 

--- a/HLTrigger/JetMET/src/AnyJetToCaloJetProducer.cc
+++ b/HLTrigger/JetMET/src/AnyJetToCaloJetProducer.cc
@@ -23,7 +23,7 @@ AnyJetToCaloJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
 
 void AnyJetToCaloJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 {
-  std::auto_ptr<reco::CaloJetCollection> newjets(new reco::CaloJetCollection());
+  std::unique_ptr<reco::CaloJetCollection> newjets(new reco::CaloJetCollection());
   
   edm::Handle<edm::View<reco::Jet> > jets;
   if(iEvent.getByToken(m_theGenericJetToken,jets)) {
@@ -33,7 +33,7 @@ void AnyJetToCaloJetProducer::produce(edm::Event& iEvent, const edm::EventSetup&
     }
   }
   
-  iEvent.put(newjets);
+  iEvent.put(std::move(newjets));
 }
 
 

--- a/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
@@ -57,7 +57,7 @@ void HLTCaloJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & des
 void HLTCaloJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::CaloJetCollection> result (new reco::CaloJetCollection());
+    std::unique_ptr<reco::CaloJetCollection> result (new reco::CaloJetCollection());
 
     edm::Handle<reco::CaloJetCollection> calojets;
     iEvent.getByToken(m_theCaloJetToken, calojets);
@@ -85,5 +85,5 @@ void HLTCaloJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     }
 
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
@@ -49,7 +49,7 @@ void HLTCaloTowerHtMhtProducer::fillDescriptions(edm::ConfigurationDescriptions 
 void HLTCaloTowerHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::METCollection> result(new reco::METCollection());
+    std::unique_ptr<reco::METCollection> result(new reco::METCollection());
 
     edm::Handle<CaloTowerCollection> towers;
     iEvent.getByToken(m_theTowersToken, towers);
@@ -81,5 +81,5 @@ void HLTCaloTowerHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetu
     result->push_back(htmht);
     
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
+++ b/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
@@ -147,7 +147,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
   using namespace reco;
 
   //output collection
-  std::auto_ptr<CaloMETCollection> CleanedMET(new CaloMETCollection);
+  std::unique_ptr<CaloMETCollection> CleanedMET(new CaloMETCollection);
 
   //get the calo MET / MHT
   edm::Handle<CaloMETCollection> met_h;
@@ -163,7 +163,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
   // in this case, do not filter anything
   if(severity_==0){
     CleanedMET->push_back(inCaloMet);
-    iEvent.put(CleanedMET);
+    iEvent.put(std::move(CleanedMET));
     return true;
   }
 
@@ -174,7 +174,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
     edm::LogError("DataNotFound") << "HLTHcalMETNoiseCleaner: Could not find HcalNoiseRBXCollection product named "
 				  << HcalNoiseRBXCollectionTag_ << "." << std::endl;
     CleanedMET->push_back(inCaloMet);
-    iEvent.put(CleanedMET);    
+    iEvent.put(std::move(CleanedMET));    
     return true; // no valid RBXs
   }
 
@@ -189,7 +189,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
   //if 0 RBXs are in the list, just accept
   if(data.size()<1){
     CleanedMET->push_back(inCaloMet);
-    iEvent.put(CleanedMET);
+    iEvent.put(std::move(CleanedMET));
     return true;
   }
   // data is now sorted by RBX energy
@@ -257,13 +257,13 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
     //-----------FOUND a SECOND NOISY RBX-------------------
     if(isNoise && cntr > 0){ 
 	CleanedMET->push_back(inCaloMet);
-	iEvent.put(CleanedMET);   	
+	iEvent.put(std::move(CleanedMET));   	
 	return accept2NoiseRBXEvents_; // don't try to clean these for the moment, just keep or throw away      
     }
     //----------LEADING RBX is NOT NOISY--------------------
     if(!isNoise && cntr == 0){ 
       CleanedMET->push_back(inCaloMet);
-      iEvent.put(CleanedMET);   	
+      iEvent.put(std::move(CleanedMET));   	
       return true; // don't reject the event if the leading RBX isn't noise
     }
     //-----------SUBLEADING RBX is NOT NOISY: STORE INFO----
@@ -283,7 +283,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
 
   if(noiseHPDVector.Mag()==0){
     CleanedMET->push_back(inCaloMet);
-    iEvent.put(CleanedMET);   	
+    iEvent.put(std::move(CleanedMET));   	
     return true; // don't reject the event if the leading RBX isn't noise
   }
 
@@ -325,7 +325,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
 
   reco::CaloMET corMet = BuildCaloMet(CorMetSumEt,CorMetPt,CorMetPhi);
   CleanedMET->push_back(corMet);
-  iEvent.put(CleanedMET);
+  iEvent.put(std::move(CleanedMET));
 
   return (corMet.pt() > CaloMetCut_);
 }

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleaner.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleaner.cc
@@ -234,7 +234,7 @@ void HLTHcalTowerNoiseCleaner::produce(edm::Event& iEvent, const edm::EventSetup
   }//if(severity_>0)
   
   //output collection
-  std::auto_ptr<CaloTowerCollection> OutputTowers(new CaloTowerCollection() );
+  std::unique_ptr<CaloTowerCollection> OutputTowers(new CaloTowerCollection() );
 
   CaloTowerCollection::const_iterator inTowersIt;
   
@@ -245,7 +245,7 @@ void HLTHcalTowerNoiseCleaner::produce(edm::Event& iEvent, const edm::EventSetup
       OutputTowers->push_back(*inTowersIt);
     }
   }
-  iEvent.put(OutputTowers);
+  iEvent.put(std::move(OutputTowers));
 
 }
 

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
@@ -247,7 +247,7 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
   }//if(severity_>0)
   
   //output collection
-  std::auto_ptr<CaloTowerCollection> OutputTowers(new CaloTowerCollection() );
+  std::unique_ptr<CaloTowerCollection> OutputTowers(new CaloTowerCollection() );
 
   CaloTowerCollection::const_iterator inTowersIt;
   
@@ -259,7 +259,7 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
       OutputTowers->push_back(*inTowersIt);
     }
   }
-  iEvent.put(OutputTowers);
+  iEvent.put(std::move(OutputTowers));
 
 }
 

--- a/HLTrigger/JetMET/src/HLTHtMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTHtMhtProducer.cc
@@ -57,7 +57,7 @@ void HLTHtMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descrip
 void HLTHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::METCollection> result(new reco::METCollection());
+    std::unique_ptr<reco::METCollection> result(new reco::METCollection());
 
     if (pfCandidatesLabel_.label() == "")
         excludePFMuons_ = false;
@@ -111,5 +111,5 @@ void HLTHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     result->push_back(htmht);
 
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
@@ -120,9 +120,9 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
  
   const TCollection & theJetCollection = *theJetCollectionHandle;
   
-  std::auto_ptr< TCollection >  theFilteredJetCollection(new TCollection);
+  std::unique_ptr< TCollection >  theFilteredJetCollection(new TCollection);
   
-  std::auto_ptr < TCollectionVector > allSelections(new TCollectionVector());
+  std::unique_ptr < TCollectionVector > allSelections(new TCollectionVector());
   
   bool foundSolution(false);
 
@@ -183,7 +183,7 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
     
   }
   
-  iEvent.put(theFilteredJetCollection);
+  iEvent.put(std::move(theFilteredJetCollection));
   
   return;
   

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForBoostedLeptonPlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForBoostedLeptonPlusJets.cc
@@ -102,8 +102,8 @@ HLTJetCollectionsForBoostedLeptonPlusJets<jetType>::produce(edm::Event& iEvent, 
   
   typename JetCollection::const_iterator jet;
   
-  auto_ptr<JetCollection> allSelections(new JetCollection);
-  auto_ptr<JetCollectionVector> product(new JetCollectionVector);
+  unique_ptr<JetCollection> allSelections(new JetCollection);
+  unique_ptr<JetCollectionVector> product(new JetCollectionVector);
 
   std::vector<size_t> usedCands;
 
@@ -194,7 +194,7 @@ HLTJetCollectionsForBoostedLeptonPlusJets<jetType>::produce(edm::Event& iEvent, 
   NumericSafeGreaterByPt<jetType> compJets;  
   // reorder cleaned jets
   std::sort (allSelections->begin(), allSelections->end(), compJets);
-  edm::OrphanHandle<JetCollection> cleanedJetHandle = iEvent.put(allSelections);
+  edm::OrphanHandle<JetCollection> cleanedJetHandle = iEvent.put(std::move(allSelections));
 
   JetCollection const & jets = *cleanedJetHandle;
 
@@ -205,7 +205,7 @@ HLTJetCollectionsForBoostedLeptonPlusJets<jetType>::produce(edm::Event& iEvent, 
   }
 
   product->emplace_back(cleanedJetRefs);
-  iEvent.put(product);
+  iEvent.put(std::move(product));
 
   return;
   

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
@@ -124,9 +124,9 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
   
   const TCollection & theJetCollection = *theJetCollectionHandle;
   
-  //std::auto_ptr< TCollection >  theFilteredJetCollection(new TCollection);
+  //std::unique_ptr< TCollection >  theFilteredJetCollection(new TCollection);
   
-  std::auto_ptr < TCollectionVector > allSelections(new TCollectionVector());
+  std::unique_ptr < TCollectionVector > allSelections(new TCollectionVector());
   
  //bool foundSolution(false);
 
@@ -146,8 +146,8 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
     allSelections->push_back(refVector);
     }
 
-    //iEvent.put(theFilteredJetCollection);
-    iEvent.put(allSelections);
+    //iEvent.put(std::move(theFilteredJetCollection));
+    iEvent.put(std::move(allSelections));
   
   return;
   

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
@@ -91,7 +91,7 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
   
   const JetCollection & theJetCollection = *theJetCollectionHandle;
   
-  auto_ptr < JetCollectionVector > allSelections(new JetCollectionVector());
+  unique_ptr < JetCollectionVector > allSelections(new JetCollectionVector());
   
  if(!clusCands.empty()){ // try trigger clusters
     for(size_t candNr=0;candNr<clusCands.size();candNr++){  
@@ -136,7 +136,7 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
 
 
 
- iEvent.put(allSelections);
+ iEvent.put(std::move(allSelections));
   
   return;
   

--- a/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
@@ -59,7 +59,7 @@ void HLTJetL1MatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup
   edm::Handle<TCollection> jets;
   iEvent.getByToken(m_theJetToken, jets);
 
-  std::auto_ptr<TCollection> result (new TCollection);
+  std::unique_ptr<TCollection> result (new TCollection);
 
 
   edm::Handle<l1extra::L1JetParticleCollection> l1TauJets;
@@ -104,7 +104,7 @@ void HLTJetL1MatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup
 
   } // jet_iter
 
-  iEvent.put( result);
+  iEvent.put(std::move(result));
 
 }
 

--- a/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
@@ -54,7 +54,7 @@ void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetu
   edm::Handle<TCollection> jets;
   iEvent.getByToken(m_theJetToken, jets);
 
-  std::auto_ptr<TCollection> result (new TCollection);
+  std::unique_ptr<TCollection> result (new TCollection);
 
 
   edm::Handle<l1t::JetBxCollection> l1Jets;
@@ -81,7 +81,7 @@ void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetu
     edm::LogWarning("MissingProduct") << "L1Upgrade l1Jets bx collection not found." << std::endl;
   }
 
-  iEvent.put( result);
+  iEvent.put(std::move(result));
 
 }
 

--- a/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
+++ b/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
@@ -43,7 +43,7 @@ void HLTMETCleanerUsingJetID::fillDescriptions(edm::ConfigurationDescriptions& d
 void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::CaloMETCollection> result(new reco::CaloMETCollection);
+    std::unique_ptr<reco::CaloMETCollection> result(new reco::CaloMETCollection);
 
     edm::Handle<reco::CaloMETCollection> met;
     edm::Handle<reco::CaloJetCollection> jets;
@@ -100,5 +100,5 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
         result->push_back(cleanmet);
     }
 
-    iEvent.put( result );
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTMhtProducer.cc
@@ -52,7 +52,7 @@ void HLTMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
 void HLTMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::METCollection> result(new reco::METCollection());
+    std::unique_ptr<reco::METCollection> result(new reco::METCollection());
 
     edm::Handle<reco::JetView> jets;
     iEvent.getByToken(m_theJetToken, jets);
@@ -98,5 +98,5 @@ void HLTMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
     result->push_back(mht);
 
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -53,7 +53,7 @@ void HLTPFJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descr
 void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::PFJetCollection> result (new reco::PFJetCollection());
+    std::unique_ptr<reco::PFJetCollection> result (new reco::PFJetCollection());
 
     edm::Handle<reco::PFJetCollection> pfjets;
     iEvent.getByToken(m_thePFJetToken, pfjets);
@@ -93,5 +93,5 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
     }
 
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTTrackMETProducer.cc
+++ b/HLTrigger/JetMET/src/HLTTrackMETProducer.cc
@@ -65,7 +65,7 @@ void HLTTrackMETProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
 void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Create a pointer to the products
-    std::auto_ptr<reco::METCollection> result(new reco::METCollection());
+    std::unique_ptr<reco::METCollection> result(new reco::METCollection());
 
     if (pfCandidatesLabel_.label() == "")
         excludePFMuons_ = false;
@@ -171,5 +171,5 @@ void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     result->push_back(mht);
 
     // Put the products into the Event
-    iEvent.put(result);
+    iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/PFJetsMatchedToFilteredCaloJetsProducer.cc
+++ b/HLTrigger/JetMET/src/PFJetsMatchedToFilteredCaloJetsProducer.cc
@@ -46,7 +46,7 @@ void PFJetsMatchedToFilteredCaloJetsProducer::produce(edm::Event& iEvent, const 
 	using namespace reco;
 	using namespace trigger;
 	
-	auto_ptr<PFJetCollection> pfjets(new PFJetCollection);
+	unique_ptr<PFJetCollection> pfjets(new PFJetCollection);
 	
 	//Getting HLT jets to be matched
 	edm::Handle<edm::View<reco::Candidate> > PFJets;
@@ -80,5 +80,5 @@ void PFJetsMatchedToFilteredCaloJetsProducer::produce(edm::Event& iEvent, const 
 	  }  
 			
 	// std::cout <<"Size of PF matched jets "<<pfjets->size()<<std::endl;
-	iEvent.put(pfjets);
+	iEvent.put(std::move(pfjets));
 }

--- a/HLTrigger/Muon/src/HLTL1MuonSelector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonSelector.cc
@@ -58,7 +58,7 @@ void HLTL1MuonSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
 {
   const std::string metname = "Muon|RecoMuon|HLTL1MuonSelector";
 
-  auto_ptr<L1MuonParticleCollection> output(new L1MuonParticleCollection());
+  unique_ptr<L1MuonParticleCollection> output(new L1MuonParticleCollection());
   
   // Muon particles 
   edm::Handle<L1MuonParticleCollection> muColl;
@@ -112,6 +112,6 @@ void HLTL1MuonSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     
   } // loop over L1MuonParticleCollection
   
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 

--- a/HLTrigger/Muon/src/HLTL1TMuonSelector.cc
+++ b/HLTrigger/Muon/src/HLTL1TMuonSelector.cc
@@ -60,7 +60,7 @@ void HLTL1TMuonSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 {
   const std::string metname = "Muon|RecoMuon|HLTL1TMuonSelector";
 
-  auto_ptr<MuonBxCollection> output(new MuonBxCollection());
+  unique_ptr<MuonBxCollection> output(new MuonBxCollection());
   
   // Muon particles 
   edm::Handle<MuonBxCollection> muColl;
@@ -99,6 +99,6 @@ void HLTL1TMuonSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::E
   }
 
 
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 

--- a/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
@@ -97,7 +97,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    // this HLT filter, and place it in the Event.
 
    //the decision map
-   std::auto_ptr<edm::ValueMap<bool> >
+   std::unique_ptr<edm::ValueMap<bool> >
      isoMap( new edm::ValueMap<bool> ());
 
    // get hold of trks
@@ -174,7 +174,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
        isoFiller.insert(mucands, isos.begin(), isos.end());
        isoFiller.fill();
      }
-     iEvent.put(isoMap);
+     iEvent.put(std::move(isoMap));
    }
 
    LogDebug("HLTMuonIsoFilter") << " >>>>> Result of HLTMuonIsoFilter is " << accept << ", number of muons passing isolation cuts= " << nIsolatedMu;

--- a/HLTrigger/Muon/src/HLTMuonPFIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonPFIsoFilter.cc
@@ -91,7 +91,7 @@ HLTMuonPFIsoFilter::fillDescriptions(edm::ConfigurationDescriptions& description
     // this HLT filter, and place it in the Event.
  
     //the decision map
-    std::auto_ptr<edm::ValueMap<bool> > PFisoMap( new edm::ValueMap<bool> ());
+    std::unique_ptr<edm::ValueMap<bool> > PFisoMap( new edm::ValueMap<bool> ());
  
     // get hold of trks
     Handle<RecoChargedCandidateCollection> mucands;
@@ -189,7 +189,7 @@ HLTMuonPFIsoFilter::fillDescriptions(edm::ConfigurationDescriptions& description
       isoFiller.fill();
     }
 
-    iEvent.put(PFisoMap);
+    iEvent.put(std::move(PFisoMap));
 
     LogDebug("HLTMuonPFIsoFilter") << " >>>>> Result of HLTMuonPFIsoFilter is " << accept << ", number of muons passing isolation cuts= " << nIsolatedMu; 
     return accept;

--- a/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
@@ -87,7 +87,7 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
     }
 
     // Produce muons
-    std::auto_ptr<ScoutingMuonCollection> outMuons(new ScoutingMuonCollection());
+    std::unique_ptr<ScoutingMuonCollection> outMuons(new ScoutingMuonCollection());
     int index = 0;
     for (auto &muon : *ChargedCandidateCollection) {
         reco::RecoChargedCandidateRef muonRef = getRef(ChargedCandidateCollection, index);
@@ -116,7 +116,7 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
     }
 
     // Put output
-    iEvent.put(outMuons);
+    iEvent.put(std::move(outMuons));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/HLTrigger/Timer/src/Timer.cc
+++ b/HLTrigger/Timer/src/Timer.cc
@@ -100,10 +100,10 @@ void Timer::newTimingMeasurement(const ModuleDescription& iMod, double iTime)
 void
 Timer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::auto_ptr<EventTime> out(new EventTime(timing));
+  std::unique_ptr<EventTime> out(new EventTime(timing));
   // reset data so that we can start from scratch for next event
    timing.reset();
    //
-   iEvent.put(out);
+   iEvent.put(std::move(out));
 }
 

--- a/HLTrigger/btau/src/ConeIsolation.cc
+++ b/HLTrigger/btau/src/ConeIsolation.cc
@@ -99,8 +99,8 @@ ConeIsolation::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    Handle<reco::JetTracksAssociationCollection> jetTracksAssociation;
    iEvent.getByToken(jetTrackToken,jetTracksAssociation);
 
-   std::auto_ptr<reco::JetTagCollection>             tagCollection;
-   std::auto_ptr<reco::IsolatedTauTagInfoCollection> extCollection( new reco::IsolatedTauTagInfoCollection() );
+   std::unique_ptr<reco::JetTagCollection>             tagCollection;
+   std::unique_ptr<reco::IsolatedTauTagInfoCollection> extCollection( new reco::IsolatedTauTagInfoCollection() );
    if (not jetTracksAssociation->empty()) {
      RefToBaseProd<reco::Jet> prod( edm::makeRefToBaseProdFrom(jetTracksAssociation->begin()->first, iEvent) );
      tagCollection.reset( new reco::JetTagCollection(prod) );
@@ -147,8 +147,8 @@ ConeIsolation::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
        extCollection->push_back(myPair.second);
      }
 
-   iEvent.put(extCollection);
-   iEvent.put(tagCollection);
+   iEvent.put(std::move(extCollection));
+   iEvent.put(std::move(tagCollection));
 
 }
 

--- a/HLTrigger/btau/src/HLTCollectionProducer.h
+++ b/HLTrigger/btau/src/HLTCollectionProducer.h
@@ -83,7 +83,7 @@ void
 HLTCollectionProducer<T>::produce(edm::StreamID iStreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
 
-  std::auto_ptr<std::vector<T> > collection ( new std::vector<T>() );
+  std::unique_ptr<std::vector<T> > collection ( new std::vector<T>() );
 
   // get hold of collection of TriggerFilterObjectsWithRefs
   edm::Handle<trigger::TriggerFilterObjectWithRefs> hltObject;
@@ -98,7 +98,7 @@ HLTCollectionProducer<T>::produce(edm::StreamID iStreamID, edm::Event& iEvent, c
     }
   }
   
-  iEvent.put(collection);
+  iEvent.put(std::move(collection));
 
 }
 

--- a/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.cc
@@ -95,7 +95,7 @@ void HLTDisplacedmumuVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 	edm::ESHandle<TransientTrackBuilder> theB;
 	iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
 
-	std::auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+	std::unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
 
 	// look at all mucands,  check cuts and make vertices
 	double e1,e2;
@@ -179,7 +179,7 @@ void HLTDisplacedmumuVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 			 vertexCollection->push_back(vertex);
 	       }
 	}
-   	iEvent.put(vertexCollection);
+   	iEvent.put(std::move(vertexCollection));
 }
 
 

--- a/HLTrigger/btau/src/HLTDisplacedmumumuVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuVtxProducer.cc
@@ -96,7 +96,7 @@ void HLTDisplacedmumumuVtxProducer::produce(edm::Event& iEvent, const edm::Event
   edm::ESHandle<TransientTrackBuilder> theB;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
   
-  std::auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+  std::unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
   
   // look at all mucands,  check cuts and make vertices
   double e1,e2,e3;
@@ -197,7 +197,7 @@ void HLTDisplacedmumumuVtxProducer::produce(edm::Event& iEvent, const edm::Event
       }
     }
   }
-  iEvent.put(vertexCollection);
+  iEvent.put(std::move(vertexCollection));
 }
 
 

--- a/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
@@ -103,7 +103,7 @@ void HLTDisplacedtktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 	edm::ESHandle<TransientTrackBuilder> theB;
 	iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
 
-	std::auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+	std::unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
 
 	// look at all trackcands,  check cuts and make vertices
 	double e1,e2;
@@ -192,7 +192,7 @@ void HLTDisplacedtktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 			 vertexCollection->push_back(vertex);
 	       }
 	}
-   	iEvent.put(vertexCollection);
+   	iEvent.put(std::move(vertexCollection));
 }
 
 

--- a/HLTrigger/btau/src/HLTmmkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkFilter.cc
@@ -102,8 +102,8 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   const double thirdTrackMass2(thirdTrackMass_*thirdTrackMass_);
 
-  auto_ptr<CandidateCollection> output(new CandidateCollection());
-  auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+  unique_ptr<CandidateCollection> output(new CandidateCollection());
+  unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
 
   //get the transient track builder:
   edm::ESHandle<TransientTrackBuilder> theB;
@@ -342,7 +342,7 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   LogDebug("HLTDisplacedMumukFilter") << " >>>>> Result of HLTDisplacedMumukFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter;
 
-  iEvent.put(vertexCollection);
+  iEvent.put(std::move(vertexCollection));
 
   return accept;
 }

--- a/HLTrigger/btau/src/HLTmmkkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkkFilter.cc
@@ -105,8 +105,8 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
   const double thirdTrackMass2(thirdTrackMass_*thirdTrackMass_);
   const double fourthTrackMass2(fourthTrackMass_*fourthTrackMass_);
 
-  auto_ptr<CandidateCollection> output(new CandidateCollection());
-  auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+  unique_ptr<CandidateCollection> output(new CandidateCollection());
+  unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
 
   //get the transient track builder:
   edm::ESHandle<TransientTrackBuilder> theB;
@@ -389,7 +389,7 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 
   LogDebug("HLTDisplacedMumukkFilter") << " >>>>> Result of HLTDisplacedMumukkFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter;
 
-  iEvent.put(vertexCollection);
+  iEvent.put(std::move(vertexCollection));
 
   return accept;
 }

--- a/HLTrigger/btau/src/HLTmumutkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTmumutkVtxProducer.cc
@@ -99,7 +99,7 @@ void HLTmumutkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
   Handle<RecoChargedCandidateCollection> trkcands;
   iEvent.getByToken(trkCandToken_,trkcands);
 
-  auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+  unique_ptr<VertexCollection> vertexCollection(new VertexCollection());
 
   // Ref to Candidate object to be recorded in filter object
   RecoChargedCandidateRef refMu1;
@@ -203,7 +203,7 @@ void HLTmumutkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       }
     }
   }
-  iEvent.put(vertexCollection);
+  iEvent.put(std::move(vertexCollection));
 }
 
 FreeTrajectoryState HLTmumutkVtxProducer::initialFreeState( const reco::Track& tk, const MagneticField* field)

--- a/HLTrigger/btau/src/HLTmumutktkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTmumutktkVtxProducer.cc
@@ -109,7 +109,7 @@ void HLTmumutktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   Handle<RecoChargedCandidateCollection> trkcands;
   iEvent.getByToken(trkCandToken_,trkcands);
 
-  auto_ptr<VertexCollection>      vertexCollection( new VertexCollection()   );
+  unique_ptr<VertexCollection>      vertexCollection( new VertexCollection()   );
 
   // Ref to Candidate object to be recorded in filter object
   RecoChargedCandidateRef refMu1 ;
@@ -249,7 +249,7 @@ void HLTmumutktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
       }
     }
   }
-  iEvent.put(vertexCollection);
+  iEvent.put(std::move(vertexCollection));
 }
 
 FreeTrajectoryState HLTmumutktkVtxProducer::initialFreeState( const reco::Track& tk, const MagneticField* field)

--- a/HLTrigger/special/src/HLTDummyCollections.cc
+++ b/HLTrigger/special/src/HLTDummyCollections.cc
@@ -216,99 +216,99 @@ HLTDummyCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   /*
   if (doEcal_) {
-    std::auto_ptr< edm::LazyGetter<EcalRecHit> > Ecalcollection( new edm::LazyGetter<EcalRecHit> );
-    iEvent.put(Ecalcollection);
+    std::unique_ptr< edm::LazyGetter<EcalRecHit> > Ecalcollection( new edm::LazyGetter<EcalRecHit> );
+    iEvent.put(std::move(Ecalcollection));
     } */
 
   if (doHcal_) {
-    std::auto_ptr<HBHEDigiCollection> hbhe_prod(new HBHEDigiCollection()); 
-    std::auto_ptr<HFDigiCollection> hf_prod(new HFDigiCollection());
-    std::auto_ptr<HODigiCollection> ho_prod(new HODigiCollection());
-    std::auto_ptr<HcalTrigPrimDigiCollection> htp_prod(new HcalTrigPrimDigiCollection());  
-    std::auto_ptr<HOTrigPrimDigiCollection> hotp_prod(new HOTrigPrimDigiCollection());  
-    iEvent.put(hbhe_prod);
-    iEvent.put(hf_prod);
-    iEvent.put(ho_prod);
-    iEvent.put(htp_prod);
-    iEvent.put(hotp_prod);
+    std::unique_ptr<HBHEDigiCollection> hbhe_prod(new HBHEDigiCollection()); 
+    std::unique_ptr<HFDigiCollection> hf_prod(new HFDigiCollection());
+    std::unique_ptr<HODigiCollection> ho_prod(new HODigiCollection());
+    std::unique_ptr<HcalTrigPrimDigiCollection> htp_prod(new HcalTrigPrimDigiCollection());  
+    std::unique_ptr<HOTrigPrimDigiCollection> hotp_prod(new HOTrigPrimDigiCollection());  
+    iEvent.put(std::move(hbhe_prod));
+    iEvent.put(std::move(hf_prod));
+    iEvent.put(std::move(ho_prod));
+    iEvent.put(std::move(htp_prod));
+    iEvent.put(std::move(hotp_prod));
     if (unpackZDC_) {
-      std::auto_ptr<ZDCDigiCollection> zdcprod(new ZDCDigiCollection());
-      iEvent.put(zdcprod);
+      std::unique_ptr<ZDCDigiCollection> zdcprod(new ZDCDigiCollection());
+      iEvent.put(std::move(zdcprod));
     }
   }
 
   if (doEcalPreshower_) {
-    std::auto_ptr<ESDigiCollection> productDigis(new ESDigiCollection);  
-    iEvent.put(productDigis, ESdigiCollection_);
+    std::unique_ptr<ESDigiCollection> productDigis(new ESDigiCollection);  
+    iEvent.put(std::move(productDigis), ESdigiCollection_);
   }
 
   if (doMuonDTDigis_) {
-    std::auto_ptr<DTDigiCollection> detectorProduct(new DTDigiCollection);
-    std::auto_ptr<DTLocalTriggerCollection> triggerProduct(new DTLocalTriggerCollection);
-    iEvent.put(detectorProduct);
-    iEvent.put(triggerProduct);
+    std::unique_ptr<DTDigiCollection> detectorProduct(new DTDigiCollection);
+    std::unique_ptr<DTLocalTriggerCollection> triggerProduct(new DTLocalTriggerCollection);
+    iEvent.put(std::move(detectorProduct));
+    iEvent.put(std::move(triggerProduct));
   }
 
   if (doMuonCSCDigis_) {
-    std::auto_ptr<CSCWireDigiCollection> wireProduct(new CSCWireDigiCollection);
-    std::auto_ptr<CSCStripDigiCollection> stripProduct(new CSCStripDigiCollection);
-    std::auto_ptr<CSCALCTDigiCollection> alctProduct(new CSCALCTDigiCollection);
-    std::auto_ptr<CSCCLCTDigiCollection> clctProduct(new CSCCLCTDigiCollection);
-    std::auto_ptr<CSCComparatorDigiCollection> comparatorProduct(new CSCComparatorDigiCollection);
-    std::auto_ptr<CSCRPCDigiCollection> rpcProduct(new CSCRPCDigiCollection);
-    std::auto_ptr<CSCCorrelatedLCTDigiCollection> corrlctProduct(new CSCCorrelatedLCTDigiCollection);
+    std::unique_ptr<CSCWireDigiCollection> wireProduct(new CSCWireDigiCollection);
+    std::unique_ptr<CSCStripDigiCollection> stripProduct(new CSCStripDigiCollection);
+    std::unique_ptr<CSCALCTDigiCollection> alctProduct(new CSCALCTDigiCollection);
+    std::unique_ptr<CSCCLCTDigiCollection> clctProduct(new CSCCLCTDigiCollection);
+    std::unique_ptr<CSCComparatorDigiCollection> comparatorProduct(new CSCComparatorDigiCollection);
+    std::unique_ptr<CSCRPCDigiCollection> rpcProduct(new CSCRPCDigiCollection);
+    std::unique_ptr<CSCCorrelatedLCTDigiCollection> corrlctProduct(new CSCCorrelatedLCTDigiCollection);
 
-    iEvent.put(wireProduct,"MuonCSCWireDigi");
-    iEvent.put(stripProduct,"MuonCSCStripDigi");
-    iEvent.put(alctProduct,"MuonCSCALCTDigi");
-    iEvent.put(clctProduct,"MuonCSCCLCTDigi");
-    iEvent.put(comparatorProduct,"MuonCSCComparatorDigi");
-    iEvent.put(rpcProduct,"MuonCSCRPCDigi");
-    iEvent.put(corrlctProduct,"MuonCSCCorrelatedLCTDigi");
+    iEvent.put(std::move(wireProduct),"MuonCSCWireDigi");
+    iEvent.put(std::move(stripProduct),"MuonCSCStripDigi");
+    iEvent.put(std::move(alctProduct),"MuonCSCALCTDigi");
+    iEvent.put(std::move(clctProduct),"MuonCSCCLCTDigi");
+    iEvent.put(std::move(comparatorProduct),"MuonCSCComparatorDigi");
+    iEvent.put(std::move(rpcProduct),"MuonCSCRPCDigi");
+    iEvent.put(std::move(corrlctProduct),"MuonCSCCorrelatedLCTDigi");
   }
 
   if (doSiPixelDigis_) {
-    std::auto_ptr< edm::DetSetVector<PixelDigi> > SiPicollection( new edm::DetSetVector<PixelDigi> );
-    iEvent.put(SiPicollection);
+    std::unique_ptr< edm::DetSetVector<PixelDigi> > SiPicollection( new edm::DetSetVector<PixelDigi> );
+    iEvent.put(std::move(SiPicollection));
   }
 
   if (doSiStrip_) {
-    std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > SiStripcollection( new edmNew::DetSetVector<SiStripCluster> );
-    iEvent.put(SiStripcollection);
+    std::unique_ptr< edmNew::DetSetVector<SiStripCluster> > SiStripcollection( new edmNew::DetSetVector<SiStripCluster> );
+    iEvent.put(std::move(SiStripcollection));
   }
 
   if (doGCT_) {
-    std::auto_ptr<L1GctEmCandCollection> m_gctIsoEm( new L1GctEmCandCollection) ;
-    std::auto_ptr<L1GctEmCandCollection> m_gctNonIsoEm(new L1GctEmCandCollection);
-    std::auto_ptr<L1GctJetCandCollection> m_gctCenJets(new L1GctJetCandCollection);
-    std::auto_ptr<L1GctJetCandCollection> m_gctForJets(new L1GctJetCandCollection);
-    std::auto_ptr<L1GctJetCandCollection> m_gctTauJets(new L1GctJetCandCollection);
-    std::auto_ptr<L1GctHFBitCountsCollection> m_gctHfBitCounts(new L1GctHFBitCountsCollection);
-    std::auto_ptr<L1GctHFRingEtSumsCollection> m_gctHfRingEtSums(new L1GctHFRingEtSumsCollection);
-    std::auto_ptr<L1GctEtTotalCollection> m_gctEtTot(new L1GctEtTotalCollection);
-    std::auto_ptr<L1GctEtHadCollection> m_gctEtHad(new L1GctEtHadCollection);
-    std::auto_ptr<L1GctEtMissCollection> m_gctEtMiss(new L1GctEtMissCollection);
-    std::auto_ptr<L1GctHtMissCollection> m_gctHtMiss(new L1GctHtMissCollection);
-    std::auto_ptr<L1GctJetCountsCollection> m_gctJetCounts(new L1GctJetCountsCollection);  // DEPRECATED
+    std::unique_ptr<L1GctEmCandCollection> m_gctIsoEm( new L1GctEmCandCollection) ;
+    std::unique_ptr<L1GctEmCandCollection> m_gctNonIsoEm(new L1GctEmCandCollection);
+    std::unique_ptr<L1GctJetCandCollection> m_gctCenJets(new L1GctJetCandCollection);
+    std::unique_ptr<L1GctJetCandCollection> m_gctForJets(new L1GctJetCandCollection);
+    std::unique_ptr<L1GctJetCandCollection> m_gctTauJets(new L1GctJetCandCollection);
+    std::unique_ptr<L1GctHFBitCountsCollection> m_gctHfBitCounts(new L1GctHFBitCountsCollection);
+    std::unique_ptr<L1GctHFRingEtSumsCollection> m_gctHfRingEtSums(new L1GctHFRingEtSumsCollection);
+    std::unique_ptr<L1GctEtTotalCollection> m_gctEtTot(new L1GctEtTotalCollection);
+    std::unique_ptr<L1GctEtHadCollection> m_gctEtHad(new L1GctEtHadCollection);
+    std::unique_ptr<L1GctEtMissCollection> m_gctEtMiss(new L1GctEtMissCollection);
+    std::unique_ptr<L1GctHtMissCollection> m_gctHtMiss(new L1GctHtMissCollection);
+    std::unique_ptr<L1GctJetCountsCollection> m_gctJetCounts(new L1GctJetCountsCollection);  // DEPRECATED
 
-    iEvent.put(m_gctIsoEm, "isoEm");
-    iEvent.put(m_gctNonIsoEm, "nonIsoEm");
-    iEvent.put(m_gctCenJets,"cenJets");
-    iEvent.put(m_gctForJets,"forJets");
-    iEvent.put(m_gctTauJets,"tauJets");
-    iEvent.put(m_gctHfBitCounts);
-    iEvent.put(m_gctHfRingEtSums);
-    iEvent.put(m_gctEtTot);
-    iEvent.put(m_gctEtHad);
-    iEvent.put(m_gctEtMiss);
-    iEvent.put(m_gctHtMiss);
-    iEvent.put(m_gctJetCounts);  // Deprecated (empty collection still needed by GT)
+    iEvent.put(std::move(m_gctIsoEm), "isoEm");
+    iEvent.put(std::move(m_gctNonIsoEm), "nonIsoEm");
+    iEvent.put(std::move(m_gctCenJets),"cenJets");
+    iEvent.put(std::move(m_gctForJets),"forJets");
+    iEvent.put(std::move(m_gctTauJets),"tauJets");
+    iEvent.put(std::move(m_gctHfBitCounts));
+    iEvent.put(std::move(m_gctHfRingEtSums));
+    iEvent.put(std::move(m_gctEtTot));
+    iEvent.put(std::move(m_gctEtHad));
+    iEvent.put(std::move(m_gctEtMiss));
+    iEvent.put(std::move(m_gctHtMiss));
+    iEvent.put(std::move(m_gctJetCounts));  // Deprecated (empty collection still needed by GT)
   }
 
   if (doObjectMap_) {
-    std::auto_ptr<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord(
+    std::unique_ptr<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord(
         new L1GlobalTriggerObjectMapRecord() );
-    iEvent.put(gtObjectMapRecord);
+    iEvent.put(std::move(gtObjectMapRecord));
   }
 
 }

--- a/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
@@ -101,8 +101,8 @@ HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event & event, const edm::EventS
   event.getByToken(endcapHitsToken_,endcapRecHitsHandle);
  
   //Create empty output collections
-  std::auto_ptr< EBDigiCollection > phiSymEBDigiCollection( new EBDigiCollection );
-  std::auto_ptr< EEDigiCollection > phiSymEEDigiCollection( new EEDigiCollection );
+  std::unique_ptr< EBDigiCollection > phiSymEBDigiCollection( new EBDigiCollection );
+  std::unique_ptr< EEDigiCollection > phiSymEEDigiCollection( new EEDigiCollection );
   
   const EBDigiCollection* EBDigis = barrelDigisHandle.product();
   const EEDigiCollection* EEDigis = endcapDigisHandle.product();
@@ -149,8 +149,8 @@ HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event & event, const edm::EventS
     return false;
 
   //Put selected information in the event
-  event.put( phiSymEBDigiCollection, phiSymBarrelDigis_);
-  event.put( phiSymEEDigiCollection, phiSymEndcapDigis_);
+  event.put(std::move(phiSymEBDigiCollection), phiSymBarrelDigis_);
+  event.put(std::move(phiSymEEDigiCollection), phiSymEndcapDigis_);
   
   return true;
 }

--- a/HLTrigger/special/src/HLTEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTEcalResonanceFilter.cc
@@ -212,9 +212,9 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
 {
    
   //Create empty output collections
-  std::auto_ptr< EBRecHitCollection > selEBRecHitCollection( new EBRecHitCollection );
+  std::unique_ptr< EBRecHitCollection > selEBRecHitCollection( new EBRecHitCollection );
   //Create empty output collections
-  std::auto_ptr< EERecHitCollection > selEERecHitCollection( new EERecHitCollection );
+  std::unique_ptr< EERecHitCollection > selEERecHitCollection( new EERecHitCollection );
   
   
   ////all selected..
@@ -358,7 +358,7 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
   // The set of used DetID's for a given event:
   m_used_strips.clear();
-  std::auto_ptr<ESRecHitCollection> selESRecHitCollection(new ESRecHitCollection );
+  std::unique_ptr<ESRecHitCollection> selESRecHitCollection(new ESRecHitCollection );
 
   Handle<EERecHitCollection> endcapRecHitsHandle;
   iEvent.getByToken(endcapHitsToken_,endcapRecHitsHandle);
@@ -472,12 +472,12 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   
   ////Now put into events selected rechits.
   if(doSelBarrel_){
-    iEvent.put( selEBRecHitCollection, BarrelHits_);
+    iEvent.put(std::move(selEBRecHitCollection), BarrelHits_);
   }  
   if(doSelEndcap_){
-    iEvent.put( selEERecHitCollection, EndcapHits_);
+    iEvent.put(std::move(selEERecHitCollection), EndcapHits_);
     if(storeRecHitES_){
-      iEvent.put( selESRecHitCollection, ESHits_);
+      iEvent.put(std::move(selESRecHitCollection), ESHits_);
     }
   }
   

--- a/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
@@ -60,9 +60,9 @@ HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
   iEvent.getByToken(HFHitsToken_,HFRecHitsH);
 
   //Create empty output collections
-  std::auto_ptr< HBHERecHitCollection > phiSymHBHERecHitCollection( new HBHERecHitCollection );
-  std::auto_ptr< HORecHitCollection > phiSymHORecHitCollection( new HORecHitCollection );
-  std::auto_ptr< HFRecHitCollection > phiSymHFRecHitCollection( new HFRecHitCollection );
+  std::unique_ptr< HBHERecHitCollection > phiSymHBHERecHitCollection( new HBHERecHitCollection );
+  std::unique_ptr< HORecHitCollection > phiSymHORecHitCollection( new HORecHitCollection );
+  std::unique_ptr< HFRecHitCollection > phiSymHFRecHitCollection( new HFRecHitCollection );
 
   //Select interesting HBHERecHits
   for (HBHERecHitCollection::const_iterator it=HBHERecHitsH->begin(); it!=HBHERecHitsH->end(); it++) {
@@ -92,9 +92,9 @@ HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
   if ((!phiSymHBHERecHitCollection->size() ) && (!phiSymHORecHitCollection->size()) && (!phiSymHFRecHitCollection->size())) return false;
 
   //Put selected information in the event
-  if (phiSymHBHERecHitCollection->size()>0) iEvent.put( phiSymHBHERecHitCollection, phiSymHBHEHits_);
-  if (phiSymHORecHitCollection->size()>0) iEvent.put( phiSymHORecHitCollection, phiSymHOHits_);
-  if (phiSymHFRecHitCollection->size()>0) iEvent.put( phiSymHFRecHitCollection, phiSymHFHits_);
+  if (phiSymHBHERecHitCollection->size()>0) iEvent.put(std::move(phiSymHBHERecHitCollection), phiSymHBHEHits_);
+  if (phiSymHORecHitCollection->size()>0) iEvent.put(std::move(phiSymHORecHitCollection), phiSymHOHits_);
+  if (phiSymHFRecHitCollection->size()>0) iEvent.put(std::move(phiSymHFRecHitCollection), phiSymHFHits_);
 
   return true;
 }

--- a/HLTrigger/special/src/HLTLogMonitorFilter.cc
+++ b/HLTrigger/special/src/HLTLogMonitorFilter.cc
@@ -179,11 +179,11 @@ bool HLTLogMonitorFilter::filter(edm::Event & event, const edm::EventSetup & set
   }
 
   // harvest the errors, but only if the filter will accept the event
-  std::auto_ptr<std::vector<edm::ErrorSummaryEntry> > errors(new std::vector<edm::ErrorSummaryEntry>());
+  std::unique_ptr<std::vector<edm::ErrorSummaryEntry> > errors(new std::vector<edm::ErrorSummaryEntry>());
   if (accept) {
     errors->swap(errorSummary);
   }
-  event.put(errors);
+  event.put(std::move(errors));
 
   return accept;
 }

--- a/HLTrigger/special/src/HLTRechitsToDigis.cc
+++ b/HLTrigger/special/src/HLTRechitsToDigis.cc
@@ -124,8 +124,8 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
   Handle<EEDigiCollection> digisEEHandle;
   
   // output collections
-  std::auto_ptr<EBDigiCollection> outputEBDigiCollection( new EBDigiCollection );
-  std::auto_ptr<EEDigiCollection> outputEEDigiCollection( new EEDigiCollection );
+  std::unique_ptr<EBDigiCollection> outputEBDigiCollection( new EBDigiCollection );
+  std::unique_ptr<EEDigiCollection> outputEEDigiCollection( new EEDigiCollection );
   
   // calibrated rechits
   Handle<EcalRecHitCollection> recHitsHandle;
@@ -148,7 +148,7 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
     }
 
     // add the built collection to the event 
-    iEvent.put( outputEBDigiCollection, digisOut_);     
+    iEvent.put(std::move(outputEBDigiCollection), digisOut_);     
     break;      
   }    
   case endcap: {
@@ -166,7 +166,7 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
     } // end loop over endcap rechits
 
     // add the built collection to the event     
-    iEvent.put(outputEEDigiCollection, digisOut_);     
+    iEvent.put(std::move(outputEEDigiCollection), digisOut_);     
     break;
   }
   case invalidRegion: {

--- a/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
@@ -288,9 +288,9 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
 {
    
   //Create empty output collections
-  std::auto_ptr< EBRecHitCollection > selEBRecHitCollection( new EBRecHitCollection );
+  std::unique_ptr< EBRecHitCollection > selEBRecHitCollection( new EBRecHitCollection );
   //Create empty output collections
-  std::auto_ptr< EERecHitCollection > selEERecHitCollection( new EERecHitCollection );
+  std::unique_ptr< EERecHitCollection > selEERecHitCollection( new EERecHitCollection );
   
   
   ////all selected..
@@ -436,7 +436,7 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
   }
   // The set of used DetID's for a given event:
   m_used_strips.clear();
-  std::auto_ptr<ESRecHitCollection> selESRecHitCollection(new ESRecHitCollection );
+  std::unique_ptr<ESRecHitCollection> selESRecHitCollection(new ESRecHitCollection );
 
   Handle<EERecHitCollection> endcapRecHitsHandle;
   iEvent.getByToken(endcapHitsToken_,endcapRecHitsHandle);
@@ -553,12 +553,12 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
   
   ////Now put into events selected rechits.
   if(doSelBarrel_){
-    iEvent.put( selEBRecHitCollection, BarrelHits_);
+    iEvent.put(std::move(selEBRecHitCollection), BarrelHits_);
   }  
   if(doSelEndcap_){
-    iEvent.put( selEERecHitCollection, EndcapHits_);
+    iEvent.put(std::move(selEERecHitCollection), EndcapHits_);
     if(storeRecHitES_){
-      iEvent.put( selESRecHitCollection, ESHits_);
+      iEvent.put(std::move(selESRecHitCollection), ESHits_);
     }
   }
   

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
@@ -217,7 +217,7 @@ void HLTRecHitInAllL1RegionsProducer<RecHitType>::produce(edm::Event& event, con
       continue;
     }
 
-    std::auto_ptr<RecHitCollectionType> filteredRecHits(new RecHitCollectionType);
+    std::unique_ptr<RecHitCollectionType> filteredRecHits(new RecHitCollectionType);
       
     if(!recHits->empty()){
       const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(recHits->front().id());
@@ -235,7 +235,7 @@ void HLTRecHitInAllL1RegionsProducer<RecHitType>::produce(edm::Event& event, con
       }//end check of empty regions
     }//end check of empty rec-hits
     //   std::cout <<"putting fileter coll in "<<filteredRecHits->size()<<std::endl;
-    event.put(filteredRecHits,productLabels_[recHitCollNr]);
+    event.put(std::move(filteredRecHits),productLabels_[recHitCollNr]);
   }//end loop over all rec hit collections
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/ESListOfFEDSProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/ESListOfFEDSProducer.cc
@@ -136,7 +136,7 @@ void ESListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSetup
     first_ = false;
   }                                                                                              
   
-  std::auto_ptr<ESListOfFEDS> productAddress(new ESListOfFEDS);
+  std::unique_ptr<ESListOfFEDS> productAddress(new ESListOfFEDS);
   std::vector<int> feds;		// the list of Ecal FEDS produced 
   
   ///
@@ -210,7 +210,7 @@ void ESListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSetup
   
   ///now push list of ES FEDs into event.
   productAddress.get() -> SetList(es_feds);
-  e.put(productAddress,OutputLabel_);
+  e.put(std::move(productAddress),OutputLabel_);
   
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/ESRecHitsMerger.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/ESRecHitsMerger.cc
@@ -72,7 +72,7 @@ void ESRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
  std::vector< edm::Handle<ESRecHitCollection> > EcalRecHits_done;
  e.getManyByType(EcalRecHits_done);
  
- std::auto_ptr<EcalRecHitCollection> ESMergedRecHits(new EcalRecHitCollection);
+ std::unique_ptr<EcalRecHitCollection> ESMergedRecHits(new EcalRecHitCollection);
  
  
  unsigned int nColl = EcalRecHits_done.size();
@@ -131,7 +131,7 @@ void ESRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
  
  
  // std::cout << " avant le put " << std::endl;
- e.put(ESMergedRecHits,OutputLabelES_);
+ e.put(std::move(ESMergedRecHits),OutputLabelES_);
  // std::cout << " apres le put " << std::endl;
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EcalListOfFEDSProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EcalListOfFEDSProducer.cc
@@ -133,7 +133,7 @@ void EcalListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSet
     first_ = false;
   }                                                                                              
   
-  std::auto_ptr<EcalListOfFEDS> productAddress(new EcalListOfFEDS);
+  std::unique_ptr<EcalListOfFEDS> productAddress(new EcalListOfFEDS);
   
   std::vector<int> feds;		// the list of FEDS produced by this module
   
@@ -188,7 +188,7 @@ void EcalListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSet
     std::cout << " Warning : no ECAL FED to unpack for Run " << e.id().run() << "  Event " << e.id().event() << std::endl;
   
   productAddress.get() -> SetList(feds);
-  e.put(productAddress,OutputLabel_);
+  e.put(std::move(productAddress),OutputLabel_);
 }
 
 void EcalListOfFEDSProducer::Egamma(edm::Event& e, const edm::EventSetup& es, std::vector<int>& done, std::vector<int>& FEDs ) {

--- a/RecoEgamma/EgammaHLTProducers/src/EcalRecHitsMerger.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EcalRecHitsMerger.cc
@@ -86,8 +86,8 @@ void EcalRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
  std::vector< edm::Handle<EcalRecHitCollection> > EcalRecHits_done;
  e.getManyByType(EcalRecHits_done);
 
- std::auto_ptr<EcalRecHitCollection> EBMergedRecHits(new EcalRecHitCollection);
- std::auto_ptr<EcalRecHitCollection> EEMergedRecHits(new EcalRecHitCollection);
+ std::unique_ptr<EcalRecHitCollection> EBMergedRecHits(new EcalRecHitCollection);
+ std::unique_ptr<EcalRecHitCollection> EEMergedRecHits(new EcalRecHitCollection);
 
  unsigned int nColl = EcalRecHits_done.size();
 
@@ -147,8 +147,8 @@ void EcalRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
 
 
  // std::cout << " avant le put " << std::endl;
- e.put(EBMergedRecHits,OutputLabelEB_);
- e.put(EEMergedRecHits,OutputLabelEE_);
+ e.put(std::move(EBMergedRecHits),OutputLabelEB_);
+ e.put(std::move(EEMergedRecHits),OutputLabelEE_);
  // std::cout << " apres le put " << std::endl;
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
@@ -135,6 +135,6 @@ void EgammaHLTBcHcalIsolationProducersRegional::produce(edm::Event& iEvent, cons
     isoMap.insert(recoEcalCandRef, isol);
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCaloTowerProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCaloTowerProducer.cc
@@ -57,7 +57,7 @@ void EgammaHLTCaloTowerProducer::produce(edm::StreamID, edm::Event & evt, edm::E
   evt.getByToken(l1isoseeds_, emIsolColl);
   edm::Handle<edm::View<reco::Candidate> > emNonIsolColl;
   evt.getByToken(l1nonisoseeds_, emNonIsolColl);
-  std::auto_ptr<CaloTowerCollection> cands(new CaloTowerCollection);
+  std::unique_ptr<CaloTowerCollection> cands(new CaloTowerCollection);
   cands->reserve(caloTowers->size());
 
   for (unsigned idx = 0; idx < caloTowers->size(); idx++) {
@@ -86,5 +86,5 @@ void EgammaHLTCaloTowerProducer::produce(edm::StreamID, edm::Event & evt, edm::E
     }
   }
 
-  evt.put( cands );  
+  evt.put(std::move(cands));  
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTClusterShapeProducer.cc
@@ -77,8 +77,8 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid, edm::Event& iEven
 
   
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> clushMap(new reco::RecoEcalCandidateIsolationMap(clshMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> clush5x5Map(new reco::RecoEcalCandidateIsolationMap(clsh5x5Map));
-  iEvent.put(clushMap);
-  iEvent.put(clush5x5Map,"sigmaIEtaIEta5x5");
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> clushMap(new reco::RecoEcalCandidateIsolationMap(clshMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> clush5x5Map(new reco::RecoEcalCandidateIsolationMap(clsh5x5Map));
+  iEvent.put(std::move(clushMap));
+  iEvent.put(std::move(clush5x5Map),"sigmaIEtaIEta5x5");
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCombinedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCombinedIsolationProducer.cc
@@ -78,8 +78,8 @@ EgammaHLTCombinedIsolationProducer::produce(edm::Event& iEvent, const edm::Event
     
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> Map(new reco::RecoEcalCandidateIsolationMap(TotalIsolMap));
-  iEvent.put(Map);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> Map(new reco::RecoEcalCandidateIsolationMap(TotalIsolMap));
+  iEvent.put(std::move(Map));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalIsolationProducersRegional.cc
@@ -101,7 +101,7 @@ void EgammaHLTEcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
 
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalRecIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalRecIsolationProducer.cc
@@ -176,8 +176,8 @@ void EgammaHLTEcalRecIsolationProducer::produce(edm::Event& iEvent, const edm::E
     isoMap.insert(recoecalcandref, isol);
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronCombinedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronCombinedIsolationProducer.cc
@@ -97,8 +97,8 @@ void EgammaHLTElectronCombinedIsolationProducer::produce(edm::Event& iEvent, con
     
   }
 
-  std::auto_ptr<reco::ElectronIsolationMap> isolMap(new reco::ElectronIsolationMap(TotalIsolMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::ElectronIsolationMap> isolMap(new reco::ElectronIsolationMap(TotalIsolMap));
+  iEvent.put(std::move(isolMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
@@ -103,18 +103,18 @@ void EgammaHLTElectronDetaDphiProducer::produce(edm::Event& iEvent, const edm::E
        dphiCandMap.insert(recoEcalCandRef, dEtaDPhi.second);
      }//end loop over reco ecal candidates
 
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> detaCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(detaCandMap));
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dphiCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(dphiCandMap));
-    iEvent.put(detaCandMapForEvent, "Deta" );
-    iEvent.put(dphiCandMapForEvent, "Dphi" );
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> detaCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(detaCandMap));
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dphiCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(dphiCandMap));
+    iEvent.put(std::move(detaCandMapForEvent), "Deta" );
+    iEvent.put(std::move(dphiCandMapForEvent), "Dphi" );
 
   }//end if between electrons or reco ecal candidates
 
   if(!useSCRefs_){
-    std::auto_ptr<reco::ElectronIsolationMap> detMap(new reco::ElectronIsolationMap(detaMap));
-    std::auto_ptr<reco::ElectronIsolationMap> dphMap(new reco::ElectronIsolationMap(dphiMap));
-    iEvent.put(detMap, "Deta" );
-    iEvent.put(dphMap, "Dphi" );
+    std::unique_ptr<reco::ElectronIsolationMap> detMap(new reco::ElectronIsolationMap(detaMap));
+    std::unique_ptr<reco::ElectronIsolationMap> dphMap(new reco::ElectronIsolationMap(dphiMap));
+    iEvent.put(std::move(detMap), "Deta" );
+    iEvent.put(std::move(dphMap), "Dphi" );
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronTrackIsolationProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronTrackIsolationProducers.cc
@@ -105,8 +105,8 @@ void EgammaHLTElectronTrackIsolationProducers::produce(edm::StreamID sid, edm::E
       recoEcalCandMap.insert(recoEcalCandRef,isol);
     }//end reco ecal candidate ref
 
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
+    iEvent.put(std::move(mapForEvent));
 
   }else{ //we are going to loop over electron instead
     for(reco::ElectronCollection::const_iterator iElectron = electronHandle->begin(); iElectron != electronHandle->end(); iElectron++){
@@ -116,8 +116,8 @@ void EgammaHLTElectronTrackIsolationProducers::produce(edm::StreamID sid, edm::E
       eleMap.insert(eleRef, isol);
     }
 
-    std::auto_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
+    iEvent.put(std::move(mapForEvent));
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -188,23 +188,23 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     chi2Map.insert(recoEcalCandRef, chi2Value);
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaSeedMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> missingHitsForEvent(new reco::RecoEcalCandidateIsolationMap(missingHitsMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> validHitsForEvent(new reco::RecoEcalCandidateIsolationMap(validHitsMap));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> chi2ForEvent(new reco::RecoEcalCandidateIsolationMap(chi2Map));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaSeedMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> missingHitsForEvent(new reco::RecoEcalCandidateIsolationMap(missingHitsMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> validHitsForEvent(new reco::RecoEcalCandidateIsolationMap(validHitsMap));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> chi2ForEvent(new reco::RecoEcalCandidateIsolationMap(chi2Map));
 
-  iEvent.put(dEtaMapForEvent, "Deta" );
-  iEvent.put(dEtaSeedMapForEvent, "DetaSeed" );
-  iEvent.put(dPhiMapForEvent, "Dphi" );
-  iEvent.put(oneOverESuperMinusOneOverPMapForEvent,"OneOESuperMinusOneOP");
-  iEvent.put(oneOverESeedMinusOneOverPMapForEvent,"OneOESeedMinusOneOP");
-  iEvent.put(missingHitsForEvent, "MissingHits");
-  iEvent.put(validHitsForEvent, "ValidHits");
-  iEvent.put(chi2ForEvent, "Chi2");
+  iEvent.put(std::move(dEtaMapForEvent), "Deta" );
+  iEvent.put(std::move(dEtaSeedMapForEvent), "DetaSeed" );
+  iEvent.put(std::move(dPhiMapForEvent), "Dphi" );
+  iEvent.put(std::move(oneOverESuperMinusOneOverPMapForEvent), "OneOESuperMinusOneOP");
+  iEvent.put(std::move(oneOverESeedMinusOneOverPMapForEvent), "OneOESeedMinusOneOP");
+  iEvent.put(std::move(missingHitsForEvent), "MissingHits");
+  iEvent.put(std::move(validHitsForEvent), "ValidHits");
+  iEvent.put(std::move(chi2ForEvent), "Chi2");
 }
 
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationDoubleConeProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationDoubleConeProducers.cc
@@ -79,7 +79,7 @@ void EgammaHLTHcalIsolationDoubleConeProducers::produce(edm::Event& iEvent, cons
     isoMap.insert(recoecalcandref, isol);
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
@@ -140,8 +140,8 @@ void EgammaHLTHcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
     isoMap.insert(recoEcalCandRef, isol);   
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
@@ -177,7 +177,7 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
   es.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
   const CaloSubdetectorGeometry *geometry_p;
-  std::auto_ptr<const CaloSubdetectorTopology> topology;
+  std::unique_ptr<const CaloSubdetectorTopology> topology;
 
   //edm::ESHandle<EcalChannelStatus> chStatus;
   //es.get<EcalChannelStatusRcd>().get(chStatus);
@@ -290,10 +290,10 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
   reco::BasicClusterCollection basicClusters;
   hybrid_p->makeClusters(hit_collection, geometry_p, basicClusters, sevLevel, true, regions);
   
-  // create an auto_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > basicclusters_p(new reco::BasicClusterCollection);
+  // create an unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
+  std::unique_ptr< reco::BasicClusterCollection > basicclusters_p(new reco::BasicClusterCollection);
   basicclusters_p->assign(basicClusters.begin(), basicClusters.end());
-  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(basicclusters_p, 
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(std::move(basicclusters_p),
                                                                        basicclusterCollection_);
   if (!(bccHandle.isValid())) {
     return;
@@ -307,9 +307,9 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
 
   reco::SuperClusterCollection superClusters = hybrid_p->makeSuperClusters(clusterRefVector);
 
-  std::auto_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
+  std::unique_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
   superclusters_p->assign(superClusters.begin(), superClusters.end());
-  evt.put(superclusters_p, superclusterCollection_);
+  evt.put(std::move(superclusters_p), superclusterCollection_);
 
 
   nEvt_++;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
@@ -293,14 +293,14 @@ void EgammaHLTIslandClusterProducer::clusterizeECALPart(edm::Event &evt, const e
   reco::BasicClusterCollection clusters;
   clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, ecalPart, true, regions);
 
-  // create an auto_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
+  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (ecalPart == IslandClusterAlgo::barrel) 
-    bccHandle = evt.put(clusters_p, barrelClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
-    bccHandle = evt.put(clusters_p, endcapClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
   delete topology_p;
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
@@ -301,14 +301,14 @@ void EgammaHLTMulti5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const
   reco::BasicClusterCollection clusters;
   clusters = Multi5x5_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, detector, true, regions);
 
-  // create an auto_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
+  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (detector == reco::CaloID::DET_ECAL_BARREL) 
-    bccHandle = evt.put(clusters_p, barrelClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
-    bccHandle = evt.put(clusters_p, endcapClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
   delete topology_p;
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -249,15 +249,15 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   
   
   //Create empty output collections
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
   clusters_p->assign(clusters.begin(), clusters.end());
   if (detector == reco::CaloID::DET_ECAL_BARREL){
     if(debug_>=1) LogDebug("")<<"nxnclusterProducer: "<<clusters_p->size() <<" made in barrel"<<std::endl;
-    evt.put(clusters_p, barrelClusterCollection_);
+    evt.put(std::move(clusters_p), barrelClusterCollection_);
   }
   else {
     if(debug_>=1) LogDebug("")<<"nxnclusterProducer: "<<clusters_p->size() <<" made in endcap"<<std::endl;
-    evt.put(clusters_p, endcapClusterCollection_);
+    evt.put(std::move(clusters_p), endcapClusterCollection_);
   }
   
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFChargedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFChargedIsolationProducer.cc
@@ -116,8 +116,8 @@ void EgammaHLTPFChargedIsolationProducer::produce(edm::Event& iEvent, const edm:
       
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
+    iEvent.put(std::move(mapForEvent));
 
   } else {
 
@@ -161,7 +161,7 @@ void EgammaHLTPFChargedIsolationProducer::produce(edm::Event& iEvent, const edm:
 
       eleMap.insert(eleRef, sum);
     }   
-    std::auto_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
+    iEvent.put(std::move(mapForEvent));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFNeutralIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFNeutralIsolationProducer.cc
@@ -161,8 +161,8 @@ void EgammaHLTPFNeutralIsolationProducer::produce(edm::Event& iEvent, const edm:
        
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
+    iEvent.put(std::move(mapForEvent));
     
   } else {
 
@@ -219,7 +219,7 @@ void EgammaHLTPFNeutralIsolationProducer::produce(edm::Event& iEvent, const edm:
  
       eleMap.insert(eleRef, sum);
     }   
-    std::auto_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
+    iEvent.put(std::move(mapForEvent));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFPhotonIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFPhotonIsolationProducer.cc
@@ -188,8 +188,8 @@ void EgammaHLTPFPhotonIsolationProducer::produce(edm::Event& iEvent, const edm::
       
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::auto_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
+    iEvent.put(std::move(mapForEvent));
     
   } else {
 
@@ -270,7 +270,7 @@ void EgammaHLTPFPhotonIsolationProducer::produce(edm::Event& iEvent, const edm::
 
       eleMap.insert(eleRef, sum);
     }   
-    std::auto_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(mapForEvent);
+    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
+    iEvent.put(std::move(mapForEvent));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPhotonTrackIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPhotonTrackIsolationProducersRegional.cc
@@ -85,7 +85,7 @@ EgammaHLTPhotonTrackIsolationProducersRegional::produce(edm::StreamID sid, edm::
 
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(isolMap);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
+  iEvent.put(std::move(isolMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
@@ -65,13 +65,13 @@ void EgammaHLTPixelMatchElectronProducers::produce(edm::StreamID sid, edm::Event
   algo_->setupES(iSetup);  
   
   // Create the output collections   
-  std::auto_ptr<ElectronCollection> pOutEle(new ElectronCollection);
+  std::unique_ptr<ElectronCollection> pOutEle(new ElectronCollection);
   
   // invoke algorithm
     algo_->run(e,*pOutEle);
 
   // put result into the Event
-    e.put(pOutEle);
+    e.put(std::move(pOutEle));
 }
 
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -126,10 +126,10 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
 
   if(!recoEcalCandHandle.isValid() || !pixelSeedsHandle.isValid()) return;
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhi1BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhi2BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dzBestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> s2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhi1BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhi2BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dzBestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> s2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
   
   for(unsigned int candNr = 0; candNr<recoEcalCandHandle->size(); candNr++) {
     
@@ -160,11 +160,11 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
     
   }
 
-  iEvent.put(s2Map,"s2");
+  iEvent.put(std::move(s2Map),"s2");
   if(productsToWrite_>=1){
-    iEvent.put(dPhi1BestS2Map,"dPhi1BestS2");
-    iEvent.put(dPhi2BestS2Map,"dPhi2BestS2");
-    iEvent.put(dzBestS2Map,"dzBestS2");
+    iEvent.put(std::move(dPhi1BestS2Map),"dPhi1BestS2");
+    iEvent.put(std::move(dPhi2BestS2Map),"dPhi2BestS2");
+    iEvent.put(std::move(dzBestS2Map),"dzBestS2");
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
@@ -70,11 +70,11 @@ void EgammaHLTR9IDProducer::produce(edm::StreamID sid, edm::Event& iEvent, const
     
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
-  iEvent.put(R9Map);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
+  iEvent.put(std::move(R9Map));
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> R95x5Map(new reco::RecoEcalCandidateIsolationMap(r95x5Map));
-  iEvent.put(R95x5Map,"r95x5");
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R95x5Map(new reco::RecoEcalCandidateIsolationMap(r95x5Map));
+  iEvent.put(std::move(R95x5Map),"r95x5");
 }
 
 //define this as a plug-in

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9Producer.cc
@@ -70,7 +70,7 @@ void EgammaHLTR9Producer::produce(edm::StreamID sid, edm::Event& iEvent, const e
     
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
-  iEvent.put(R9Map);
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
+  iEvent.put(std::move(R9Map));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRecoEcalCandidateProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRecoEcalCandidateProducers.cc
@@ -47,7 +47,7 @@ void EgammaHLTRecoEcalCandidateProducers::produce(edm::StreamID sid, edm::Event&
   //
 
   reco::RecoEcalCandidateCollection outputRecoEcalCandidateCollection;
-  std::auto_ptr< reco::RecoEcalCandidateCollection > outputRecoEcalCandidateCollection_p(new reco::RecoEcalCandidateCollection);
+  std::unique_ptr< reco::RecoEcalCandidateCollection > outputRecoEcalCandidateCollection_p(new reco::RecoEcalCandidateCollection);
 
   // Get the  Barrel Super Cluster collection
   Handle<reco::SuperClusterCollection> scBarrelHandle;
@@ -105,7 +105,7 @@ for(reco::SuperClusterCollection::const_iterator aClus = scEndcapHandle->begin()
 
   // put the product in the event
   outputRecoEcalCandidateCollection_p->assign(outputRecoEcalCandidateCollection.begin(),outputRecoEcalCandidateCollection.end());
-  theEvent.put( outputRecoEcalCandidateCollection_p, recoEcalCandidateCollection_);
+  theEvent.put(std::move(outputRecoEcalCandidateCollection_p), recoEcalCandidateCollection_);
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
@@ -115,7 +115,7 @@ void EgammaHLTRegionalPixelSeedGeneratorProducers::produce(edm::Event& iEvent, c
 {
 
   // resulting collection
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());    
+  std::unique_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());    
 
   // Get the recoEcalCandidates
   edm::Handle<reco::RecoEcalCandidateCollection> recoecalcands;
@@ -163,5 +163,5 @@ void EgammaHLTRegionalPixelSeedGeneratorProducers::produce(edm::Event& iEvent, c
     
   }
 
-    iEvent.put(output);
+    iEvent.put(std::move(output));
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRemoveDuplicatedSC.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRemoveDuplicatedSC.cc
@@ -55,7 +55,7 @@ EgammaHLTRemoveDuplicatedSC::produce(edm::Event& evt, const edm::EventSetup& es)
 
 
   // Define a collection of corrected SuperClusters to put back into the event
-  std::auto_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
+  std::unique_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
   
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;
@@ -78,7 +78,7 @@ EgammaHLTRemoveDuplicatedSC::produce(edm::Event& evt, const edm::EventSetup& es)
     }
 
   // Put collection of corrected SuperClusters into the event
-  evt.put(corrClusters, outputCollection_);   
+  evt.put(std::move(corrClusters), outputCollection_);
   
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTTimeCleanedRechitProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTTimeCleanedRechitProducer.cc
@@ -60,7 +60,7 @@ void EgammaHLTTimeCleanedRechitProducer::produce(edm::Event& evt, const edm::Eve
     
 
   for (unsigned int i=0; i<hitLabels.size(); i++) {
-    std::auto_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
+    std::unique_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
     
     evt.getByToken(hitTokens[i], rhcH[i]);  
     if (!(rhcH[i].isValid())) {
@@ -75,7 +75,7 @@ void EgammaHLTTimeCleanedRechitProducer::produce(edm::Event& evt, const edm::Eve
 	hits->push_back(*it);
     }
     
-    evt.put(hits, productLabels[i]);
+    evt.put(std::move(hits), productLabels[i]);
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
@@ -118,8 +118,8 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
     recoCandMap.insert(candRef, sum);
   }
   
-  std::auto_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
-  iEvent.put(mapForEvent);
+  std::unique_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
+  iEvent.put(std::move(mapForEvent));
 }
 
 typedef HLTEcalPFClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTEcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
@@ -132,8 +132,8 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid, edm::Even
     recoCandMap.insert(candRef, sum);
   }
   
-  std::auto_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
-  iEvent.put(mapForEvent);
+  std::unique_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
+  iEvent.put(std::move(mapForEvent));
 }
 
 typedef HLTHcalPFClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTHcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
@@ -104,7 +104,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
   es.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
   const CaloSubdetectorGeometry *geometry_p;
-  std::auto_ptr<const CaloSubdetectorTopology> topology;
+  std::unique_ptr<const CaloSubdetectorTopology> topology;
     
   //Get the L1 EM Particle Collection
   edm::Handle< T1Collection > emIsolColl ;
@@ -130,7 +130,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 
     edm::Handle<EcalUncalibratedRecHitCollection> urhcH[3];
     for (unsigned int i=0; i<hitLabels.size(); i++) {
-      std::auto_ptr<EcalUncalibratedRecHitCollection> uhits(new EcalUncalibratedRecHitCollection);
+      std::unique_ptr<EcalUncalibratedRecHitCollection> uhits(new EcalUncalibratedRecHitCollection);
       
       evt.getByToken(uncalibHitTokens[i], urhcH[i]);  
       if (!(urhcH[i].isValid())) {
@@ -167,7 +167,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 	  }
 	}
       }
-      evt.put(uhits, productLabels[i]);
+      evt.put(std::move(uhits), productLabels[i]);
 
     }
 
@@ -175,7 +175,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 
     edm::Handle<EcalRecHitCollection> rhcH[3];
     for (unsigned int i=0; i<hitLabels.size(); i++) {
-      std::auto_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
+      std::unique_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
     
       evt.getByToken(hitTokens[i], rhcH[i]);  
       if (!(rhcH[i].isValid())) {
@@ -211,7 +211,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 	  }
 	}
       }
-      evt.put(hits, productLabels[i]);
+      evt.put(std::move(hits), productLabels[i]);
 
     }
   }

--- a/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
@@ -42,7 +42,7 @@ void CaloTowerCreatorForTauHLT::produce( StreamID sid, Event& evt, const EventSe
   edm::Handle<L1JetParticleCollection> jetsgen;
   evt.getByToken( mTauTrigger_token, jetsgen);
 
-  std::auto_ptr<CaloTowerCollection> cands( new CaloTowerCollection );
+  std::unique_ptr<CaloTowerCollection> cands( new CaloTowerCollection );
   cands->reserve( caloTowers->size() );
   
   int idTau =0;
@@ -81,7 +81,7 @@ void CaloTowerCreatorForTauHLT::produce( StreamID sid, Event& evt, const EventSe
       idTau++;
     }
 
-  evt.put( cands );
+  evt.put(std::move(cands));
   
 }
 

--- a/RecoTauTag/HLTProducers/src/CaloTowerFromL1TCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerFromL1TCreatorForTauHLT.cc
@@ -42,7 +42,7 @@ void CaloTowerFromL1TCreatorForTauHLT::produce( StreamID sid, Event& evt, const 
   edm::Handle<l1t::TauBxCollection> jetsgen;
   evt.getByToken( mTauTrigger_token, jetsgen);
 
-  std::auto_ptr<CaloTowerCollection> cands( new CaloTowerCollection );
+  std::unique_ptr<CaloTowerCollection> cands( new CaloTowerCollection );
   cands->reserve( caloTowers->size() );
 
   int idTau = 0;
@@ -84,7 +84,7 @@ void CaloTowerFromL1TCreatorForTauHLT::produce( StreamID sid, Event& evt, const 
     edm::LogWarning("MissingProduct") << "L1Upgrade jet bx collection not found." << std::endl;
   }
   
-  evt.put( cands );
+  evt.put(std::move(cands));
   
 }
 

--- a/RecoTauTag/HLTProducers/src/DQMTauProducer.cc
+++ b/RecoTauTag/HLTProducers/src/DQMTauProducer.cc
@@ -64,9 +64,9 @@ void DQMTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
    }
  
    
-  std::auto_ptr<reco::HLTTauCollection> selectedTaus(jetCollection);
+  std::unique_ptr<reco::HLTTauCollection> selectedTaus(jetCollection);
   
-  iEvent.put(selectedTaus);
+  iEvent.put(std::move(selectedTaus));
   
 
 

--- a/RecoTauTag/HLTProducers/src/L1HLTJetsMatching.cc
+++ b/RecoTauTag/HLTProducers/src/L1HLTJetsMatching.cc
@@ -34,7 +34,7 @@ void L1HLTJetsMatching::produce(edm::Event& iEvent, const edm::EventSetup& iES)
   
   typedef std::vector<LeafCandidate> LeafCandidateCollection;
   
-  auto_ptr<CaloJetCollection> tauL2jets(new CaloJetCollection);
+  unique_ptr<CaloJetCollection> tauL2jets(new CaloJetCollection);
   
   double deltaR = 1.0;
   double matchingR = 0.5;
@@ -97,6 +97,6 @@ void L1HLTJetsMatching::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 
   //std::cout <<"Size of L1HLT matched jets "<<tauL2jets->size()<<std::endl;
 
-  iEvent.put(tauL2jets);
-  // iEvent.put(tauL2LC);
+  iEvent.put(std::move(tauL2jets));
+  // iEvent.put(std::move(tauL2LC));
 }

--- a/RecoTauTag/HLTProducers/src/L1HLTTauMatching.cc
+++ b/RecoTauTag/HLTProducers/src/L1HLTTauMatching.cc
@@ -32,7 +32,7 @@ void L1HLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const edm
   using namespace trigger;
   using namespace l1extra;
 	
-  auto_ptr<PFTauCollection> tauL2jets(new PFTauCollection);
+  unique_ptr<PFTauCollection> tauL2jets(new PFTauCollection);
 	
   double deltaR = 1.0;
   double matchingR = 0.5;
@@ -100,8 +100,8 @@ void L1HLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const edm
 
   //std::cout <<"Size of L1HLT matched jets "<<tauL2jets->size()<<std::endl;
 
-  iEvent.put(tauL2jets);
-  // iEvent.put(tauL2LC);
+  iEvent.put(std::move(tauL2jets));
+  // iEvent.put(std::move(tauL2LC));
 }
 
 void L1HLTTauMatching::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 

--- a/RecoTauTag/HLTProducers/src/L1THLTTauMatching.cc
+++ b/RecoTauTag/HLTProducers/src/L1THLTTauMatching.cc
@@ -24,7 +24,7 @@ L1THLTTauMatching::~L1THLTTauMatching(){ }
 void L1THLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
     
-  auto_ptr<PFTauCollection> tauL2jets(new PFTauCollection);
+  unique_ptr<PFTauCollection> tauL2jets(new PFTauCollection);
     
   double deltaR    = 1.0;
   double matchingR = 0.5;
@@ -59,7 +59,7 @@ void L1THLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const ed
     }
   }  
    
-  iEvent.put(tauL2jets);
+  iEvent.put(std::move(tauL2jets));
 }
 
 void L1THLTTauMatching::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 

--- a/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
@@ -51,7 +51,7 @@ void L2TauJetsMerger::produce(edm::StreamID iSId, edm::Event& iEvent, const edm:
    iL1Jet++;
  }
 
- std::auto_ptr<CaloJetCollection> tauL2jets(new CaloJetCollection); 
+ std::unique_ptr<CaloJetCollection> tauL2jets(new CaloJetCollection); 
 
  //Removing the collinear jets correctly!
  
@@ -72,7 +72,7 @@ void L2TauJetsMerger::produce(edm::StreamID iSId, edm::Event& iEvent, const edm:
  }
  
 
-  iEvent.put(tauL2jets);
+  iEvent.put(std::move(tauL2jets));
 
 }
 

--- a/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
@@ -52,7 +52,7 @@ void L2TauPixelIsoTagProducer::produce(edm::StreamID sid, edm::Event& ev, const 
 
 
   // define the product to store
-  auto_ptr<JetTagCollection> jetTagCollection;
+  unique_ptr<JetTagCollection> jetTagCollection;
   if (jets.empty())
   {
     jetTagCollection.reset( new JetTagCollection() );
@@ -106,7 +106,7 @@ void L2TauPixelIsoTagProducer::produce(edm::StreamID sid, edm::Event& ev, const 
     }
   }
 
-  ev.put(jetTagCollection);
+  ev.put(std::move(jetTagCollection));
 }
 
 void L2TauPixelIsoTagProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 

--- a/RecoTauTag/HLTProducers/src/L2TauPixelTrackMatch.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauPixelTrackMatch.cc
@@ -84,7 +84,7 @@ void L2TauPixelTrackMatch::produce(edm::Event& ev, const edm::EventSetup& es)
   // *** Match tau jets to intertesting tracks  and assign them new vertices ***
 
   // the new product
-  std::auto_ptr<CaloJetCollection> new_tau_jets(new CaloJetCollection);
+  std::unique_ptr<CaloJetCollection> new_tau_jets(new CaloJetCollection);
   int n_uniq = 0;
   if (good_tracks.size()) for (size_t i=0; i < n_jets; ++i)
   {
@@ -123,5 +123,5 @@ void L2TauPixelTrackMatch::produce(edm::Event& ev, const edm::EventSetup& es)
   DBG_PRINT(cout<<"n_uniq_matched_jets "<<n_uniq<<endl<<"storing njets "<<new_tau_jets->size()<<endl);
   
   // store the result
-  ev.put(new_tau_jets);
+  ev.put(std::move(new_tau_jets));
 }

--- a/RecoTauTag/HLTProducers/src/PFJetToCaloProducer.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetToCaloProducer.cc
@@ -22,7 +22,7 @@ void PFJetToCaloProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES
   using namespace edm;
   using namespace std;
   
-  std::auto_ptr<reco::CaloJetCollection> selectedTaus(new CaloJetCollection);
+  std::unique_ptr<reco::CaloJetCollection> selectedTaus(new CaloJetCollection);
 
   edm::Handle<PFJetCollection> tauJets;
   iEvent.getByToken( tauSrc_, tauJets );
@@ -34,5 +34,5 @@ void PFJetToCaloProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES
       selectedTaus->push_back(jet);
   }
 
-  iEvent.put(selectedTaus);
+  iEvent.put(std::move(selectedTaus));
 }

--- a/RecoTauTag/HLTProducers/src/PFTauToJetProducer.cc
+++ b/RecoTauTag/HLTProducers/src/PFTauToJetProducer.cc
@@ -38,8 +38,8 @@ void PFTauToJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 
   
 
-  auto_ptr<reco::CaloJetCollection> selectedTaus(jetCollectionTmp);
-  iEvent.put(selectedTaus);
+  unique_ptr<reco::CaloJetCollection> selectedTaus(jetCollectionTmp);
+  iEvent.put(std::move(selectedTaus));
 
 
 }

--- a/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
+++ b/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
@@ -40,7 +40,7 @@ TauJetSelectorForHLTTrackSeeding::~TauJetSelectorForHLTTrackSeeding()
 void
 TauJetSelectorForHLTTrackSeeding::produce(edm::StreamID iStreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-   std::auto_ptr< reco::TrackJetCollection > augmentedTrackJets (new reco::TrackJetCollection);
+   std::unique_ptr< reco::TrackJetCollection > augmentedTrackJets (new reco::TrackJetCollection);
 
    edm::Handle<reco::TrackJetCollection> trackjets;
    iEvent.getByToken(inputTrackJetToken_, trackjets);
@@ -136,7 +136,7 @@ TauJetSelectorForHLTTrackSeeding::produce(edm::StreamID iStreamID, edm::Event& i
      augmentedTrackJets->push_back(reco::TrackJet(p4,vertex));
    }
 
-   iEvent.put(augmentedTrackJets);
+   iEvent.put(std::move(augmentedTrackJets));
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -58,7 +58,7 @@ VertexFromTrackProducer::produce(edm::StreamID iStreamId, edm::Event& iEvent, co
 {
   using namespace edm;
 
-  std::auto_ptr<reco::VertexCollection> result(new reco::VertexCollection);
+  std::unique_ptr<reco::VertexCollection> result(new reco::VertexCollection);
   reco::VertexCollection vColl;
 
   math::XYZPoint vertexPoint;
@@ -203,7 +203,7 @@ VertexFromTrackProducer::produce(edm::StreamID iStreamId, edm::Event& iEvent, co
 
   
   *result = vColl;
-  iEvent.put(result);
+  iEvent.put(std::move(result));
   
 }
 


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in HLT to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in HLT may also have been changed to std::unique_ptr.
