### PR TITLE
Fix IB crashes due to BX range set improperly

### DIFF
--- a/DataFormats/L1Trigger/interface/BXVector.h
+++ b/DataFormats/L1Trigger/interface/BXVector.h
@@ -124,7 +124,7 @@ class BXVector  {
   // this method converts integer BX index into an unsigned index
   // used by the internal data representation
   unsigned indexFromBX(int bx) const;
-  unsigned numBX() const {return static_cast<const unsigned>(bxLast_) - bxFirst_; }
+  unsigned numBX() const {return 1 + static_cast<const unsigned>(bxLast_ - bxFirst_); }
 
  private:
 

--- a/DataFormats/L1Trigger/interface/BXVector.impl
+++ b/DataFormats/L1Trigger/interface/BXVector.impl
@@ -1,5 +1,6 @@
 #include <vector>
 #include <iostream>
+#include <cassert>
 using namespace std;
 
 template < class T >
@@ -7,12 +8,13 @@ BXVector<T>::BXVector( unsigned size,      // number of objects per BX
 		       int bxFirst,   // first BX stored
 		       int bxLast )  // last BX stored
   :
-  bxFirst_(bxFirst),
-  bxLast_(bxLast),
-  data_(std::vector<T>(size * (numBX()+1)))
+  bxFirst_(std::min(0,bxFirst)),
+  bxLast_(std::max(0,bxLast)),
+  data_(std::vector<T>(size * numBX()))
 {
+  assert(bxFirst_ <= bxLast_);
   itrs_.clear();
-  for (unsigned i=0; i<=numBX(); i++){ 
+  for (unsigned i=0; i<numBX(); i++){ 
     itrs_.push_back(i*size);
   }
 }
@@ -102,7 +104,8 @@ template < class T >
 typename BXVector<T>::const_iterator
 BXVector<T>::begin( int bx ) const
 {
-   return data_.begin()+itrs_[indexFromBX(bx)];
+  assert(itrs_.size() > 0);
+  return data_.begin()+itrs_[indexFromBX(bx)];
 }
 
 // iterator access by BX

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -438,6 +438,9 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
         m_emulateBxInEvent = m_totalBxInEvent;
     }
 
+    if (m_emulateBxInEvent < 1) m_emulateBxInEvent=1;
+    if (m_L1DataBxInEvent < 1) m_L1DataBxInEvent=1;
+
     int minEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - m_emulateBxInEvent;
     int maxEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - 1;
 

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -141,35 +141,36 @@ void l1t::L1TGlobalUtil::retrieveL1Event(const edm::Event& iEvent, const edm::Ev
      if(m_uGtAlgBlk.isValid()) {
        // get the GlabalAlgBlk (Stupid find better way) of BX=0
        std::vector<GlobalAlgBlk>::const_iterator algBlk = m_uGtAlgBlk->begin(0);     
-
-       // Grab the final OR from the AlgBlk,       
-       m_finalOR = algBlk->getFinalOR();
+       if (algBlk != m_uGtAlgBlk->end(0)){     
+	 // Grab the final OR from the AlgBlk,       
+	 m_finalOR = algBlk->getFinalOR();
        
-       // Make a map of the trigger name and whether it passed various stages (initial,prescale,final)
-       // Note: might be able to improve performance by not full remaking map with names each time
-       for (std::map<std::string, L1TUtmAlgorithm>::const_iterator itAlgo = m_algorithmMap->begin(); itAlgo != m_algorithmMap->end(); itAlgo++) {
+	 // Make a map of the trigger name and whether it passed various stages (initial,prescale,final)
+	 // Note: might be able to improve performance by not full remaking map with names each time
+	 for (std::map<std::string, L1TUtmAlgorithm>::const_iterator itAlgo = m_algorithmMap->begin(); itAlgo != m_algorithmMap->end(); itAlgo++) {
 
-	 // Get the algorithm name
-	 std::string algName = itAlgo->first;
-	 int algBit = (itAlgo->second).getIndex(); //algoBitNumber();
+	   // Get the algorithm name
+	   std::string algName = itAlgo->first;
+	   int algBit = (itAlgo->second).getIndex(); //algoBitNumber();
 
-	 bool decisionInitial   = algBlk->getAlgoDecisionInitial(algBit);
-	 (m_decisionsInitial[algBit]).first  = algName;
-	 (m_decisionsInitial[algBit]).second = decisionInitial;
-
-	 bool decisionPrescaled = algBlk->getAlgoDecisionPreScaled(algBit);
-	 (m_decisionsPrescaled[algBit]).first  = algName;
-	 (m_decisionsPrescaled[algBit]).second = decisionPrescaled;
-
-	 bool decisionFinal     = algBlk->getAlgoDecisionFinal(algBit);
-	 (m_decisionsFinal[algBit]).first  = algName;
-	 (m_decisionsFinal[algBit]).second = decisionFinal;
-      
+	   bool decisionInitial   = algBlk->getAlgoDecisionInitial(algBit);
+	   (m_decisionsInitial[algBit]).first  = algName;
+	   (m_decisionsInitial[algBit]).second = decisionInitial;
+	   
+	   bool decisionPrescaled = algBlk->getAlgoDecisionPreScaled(algBit);
+	   (m_decisionsPrescaled[algBit]).first  = algName;
+	   (m_decisionsPrescaled[algBit]).second = decisionPrescaled;
+	   
+	   bool decisionFinal     = algBlk->getAlgoDecisionFinal(algBit);
+	   (m_decisionsFinal[algBit]).first  = algName;
+	   (m_decisionsFinal[algBit]).second = decisionFinal;
+	   
+	 }
+       } else {
+	 //cout << "Error empty AlgBlk recovered.\n";
        }
      } else {
-
-       cout
-	 << "Error no valid uGT Algorithm Data with Token provided " << endl;
+       //cout<< "Error no valid uGT Algorithm Data with Token provided " << endl;
      }
     
 }

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -224,6 +224,12 @@ L1TMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       bxMin = std::max(bxMin, emtfMuons->getFirstBX());
       bxMax = std::min(bxMax, emtfMuons->getLastBX());
     }
+    if (bxMin > 0) {
+      bxMin = 0;
+    }
+    if (bxMax < 0){
+      bxMax = 0;
+    }
     if (bxMin > -1000) {
       m_bxMin = bxMin;
     } else {


### PR DESCRIPTION
Fixes crash in RelVal 135.9 found out to be due to a BXVector being configured with bxLast < bxFirst.  In addition to fixing calling code, at protection to BXVector.  

Also fixed potential problem with L1TGlobalUtils, discovered during bug hunt, which wasn't checking that size of bx=0 was nonzero before using content of begin(0).

Some assert statements are left in place to alert me if I am wrong, but the protections added should insure that these assertions do not fail. 
