### PR TITLE
bug fix in the APV Killing procedure

### DIFF
--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -169,7 +169,7 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
 			    if(charge!=0 && isHadron){
 					if(CLHEP::RandFlat::shoot(engine) < APVSaturationProb){
                                                 int FirstAPV = localFirstChannel/128;
-				 		int LastAPV = localLastChannel/128;
+				 		int LastAPV = (localLastChannel-1)/128;
 						//std::cout << "-------------------HIP--------------" << std::endl;
 						//std::cout << "Killing APVs " << FirstAPV << " - " <<LastAPV << " " << detID <<std::endl;
 				 		for(int strip = FirstAPV*128; strip < LastAPV*128 +128; ++strip) {


### PR DESCRIPTION
This fix is required, assuming the definition of localLastChannel (from see https://github.com/cms-sw/cmssw/blob/0397259dd747cee94b68928f17976224c037057a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc#L249).  

Example: if there are 512 strips (4 APVs), and if it turns out that localLastChannel = 512, then without the fix, LastAPV = 4 instead of 3 (as 0->127 the APV count is 0, 128->255 is 1, 256->383 is 2, 384->511 is 3). 
