### PR TITLE
Consumes migration for triggerResultsByName

### DIFF
--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -109,7 +109,7 @@ namespace fwlite {
 
       virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
       void fillParameterSetRegistry() const;
-      virtual edm::TriggerResultsByName triggerResultsByName(std::string const& process) const;
+      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -150,7 +150,7 @@ namespace fwlite {
 
          virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
 
-         virtual edm::TriggerResultsByName triggerResultsByName(std::string const& process) const;
+         virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
 
          virtual edm::ProcessHistory const& processHistory() const {return history();}
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -123,7 +123,7 @@ class MultiChainEvent: public EventBase
       { return event2_->eventIndex(); }
 
       virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
-      virtual edm::TriggerResultsByName triggerResultsByName(std::string const& process) const;
+      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -326,8 +326,8 @@ ChainEvent::fillParameterSetRegistry() const
 }
 
 edm::TriggerResultsByName
-ChainEvent::triggerResultsByName(std::string const& process) const {
-  return event_->triggerResultsByName(process);
+ChainEvent::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
+  return event_->triggerResultsByName(triggerResults);
 }
 
 //

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -493,20 +493,14 @@ Event::fillParameterSetRegistry() const {
 }
 
 edm::TriggerResultsByName
-Event::triggerResultsByName(std::string const& process) const {
+Event::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
 
-  fwlite::Handle<edm::TriggerResults> hTriggerResults;
-  hTriggerResults.getByLabel(*this, "TriggerResults", "", process.c_str());
-  if (!hTriggerResults.isValid()) {
-    return edm::TriggerResultsByName(0,0);
-  }
-
-  edm::TriggerNames const* names = triggerNames_(*hTriggerResults);
+  edm::TriggerNames const* names = triggerNames_(triggerResults);
   if (names == nullptr && !parameterSetRegistryFilled_) {
     fillParameterSetRegistry();
-    names = triggerNames_(*hTriggerResults);
+    names = triggerNames_(triggerResults);
   }
-  return edm::TriggerResultsByName(hTriggerResults.product(), names);
+  return edm::TriggerResultsByName(&triggerResults, names);
 }
 
 //

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -459,28 +459,22 @@ MultiChainEvent::triggerNames(edm::TriggerResults const& triggerResults) const
 }
 
 edm::TriggerResultsByName
-MultiChainEvent::triggerResultsByName(std::string const& process) const {
+MultiChainEvent::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
 
-  fwlite::Handle<edm::TriggerResults> hTriggerResults;
-  hTriggerResults.getByLabel(*this,"TriggerResults","",process.c_str());
-  if (!hTriggerResults.isValid()) {
-    return edm::TriggerResultsByName(0,0);
-  }
-
-  edm::TriggerNames const* names = triggerNames_(*hTriggerResults);
+  edm::TriggerNames const* names = triggerNames_(triggerResults);
 
   if (names == nullptr) {
     event1_->fillParameterSetRegistry();
-    names = triggerNames_(*hTriggerResults);
+    names = triggerNames_(triggerResults);
   }
 
   if (names == nullptr) {
     event2_->to(event1_->id());
     event2_->fillParameterSetRegistry();
-    names = triggerNames_(*hTriggerResults);
+    names = triggerNames_(triggerResults);
   }
 
-  return edm::TriggerResultsByName(hTriggerResults.product(), names);
+  return edm::TriggerResultsByName(&triggerResults, names);
 }
 
 //

--- a/DataFormats/FWLite/test/triggerResultsByName_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_cint.C
@@ -30,23 +30,21 @@ void triggerResultsByName_cint()
   for (ev.toBegin(); ! ev.atEnd(); ++ev) {
 
     bool accept = false;
-    edm::TriggerResultsByName resultsByName = ev.triggerResultsByName("TEST");
-    if (resultsByName.isValid()) {
+
+    hTriggerResults.getByLabel(ev, "TriggerResults", "", "TEST");
+
+    if (hTriggerResults.isValid()) {
+      edm::TriggerResultsByName resultsByName = ev.triggerResultsByName(*hTriggerResults);
       std::cout << "From TriggerResultsByName, accept = "
                 << resultsByName.accept("p") << "\n";
       accept = resultsByName.accept("p");
+    } else {
+      std::cerr << "triggerResultsByName_cint.C, invalid TriggerResults handle" << std::endl;
+      abort();
     }
     if (iEvent < 4 && expectedValue[iEvent] != accept) {
       std::cerr << "triggerResultsByName_cint.C, trigger results do not match expected values" << std::endl;
       abort();
-    }
-
-    // Try again, but this time test what happens when the process does not
-    // exist, the object should not be valid
-    resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
-    if (resultsByName.isValid()) {
-      std::cout << "From TriggerResultsByName, accept = "
-                << resultsByName.accept("p") << "\n";
     }
     ++iEvent;
   }

--- a/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
@@ -32,23 +32,22 @@ void triggerResultsByName_multi_cint()
   int iEvent = 0;
   for (ev.toBegin(); ! ev.atEnd(); ++ev) {
     bool accept = false;
-    edm::TriggerResultsByName resultsByName = ev.triggerResultsByName("TEST");
-    if (resultsByName.isValid()) {
+
+    hTriggerResults.getByLabel(ev, "TriggerResults", "", "TEST");
+
+    if (hTriggerResults.isValid()) {
+
+      edm::TriggerResultsByName resultsByName = ev.triggerResultsByName(*hTriggerResults);
       std::cout << "From TriggerResultsByName, accept = "
                 << resultsByName.accept("p") << "\n";
       accept = resultsByName.accept("p");
+    } else {
+      std::cerr << "triggerResultsByName_multi_cint.C, invalid TriggerResults handle" << std::endl;
+      abort();
     }
     if (iEvent < 4 && expectedValue[iEvent] != accept) {
       std::cerr << "triggerResultsByName_cint.C, trigger results do not match expected values" << std::endl;
       abort();
-    }
-
-    // Try again, but this time test what happens when the process does not
-    // exist, the object should not be valid
-    resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
-    if (resultsByName.isValid()) {
-      std::cout << "From TriggerResultsByName, accept = "
-                << resultsByName.accept("p") << "\n";
     }
     ++iEvent;
   }

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -32,7 +32,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 // system include files
-#include <string>
 #include <typeinfo>
 
 namespace edm {
@@ -67,7 +66,7 @@ namespace edm {
       virtual edm::EventAuxiliary const& eventAuxiliary() const = 0;
 
       virtual TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const = 0;
-      virtual TriggerResultsByName triggerResultsByName(std::string const& process) const = 0;
+      virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const = 0;
       virtual ProcessHistory const& processHistory() const = 0;
 
    protected:

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -227,7 +227,7 @@ namespace edm {
     size_t size() const;
 
     virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
-    virtual TriggerResultsByName triggerResultsByName(std::string const& process) const;
+    virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -228,18 +228,9 @@ namespace edm {
   }
 
   TriggerResultsByName
-  Event::triggerResultsByName(std::string const& process) const {
+  Event::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
 
-    Handle<TriggerResults> hTriggerResults;
-    InputTag tag(std::string("TriggerResults"),
-                 std::string(""),
-                 process);
-
-    getByLabel(tag, hTriggerResults);
-    if(!hTriggerResults.isValid()) {
-      return TriggerResultsByName(0, 0);
-    }
-    edm::TriggerNames const* names = triggerNames_(*hTriggerResults);
-    return TriggerResultsByName(hTriggerResults.product(), names);
+    edm::TriggerNames const* names = triggerNames_(triggerResults);
+    return TriggerResultsByName(&triggerResults, names);
   }
 }

--- a/FWCore/Framework/test/stubs/TestTriggerNames.cc
+++ b/FWCore/Framework/test/stubs/TestTriggerNames.cc
@@ -224,12 +224,13 @@ namespace edmtest {
       }
     }
 
-    edm::TriggerResultsByName resultsByNameHLT = e.triggerResultsByName("HLT");
-    if(resultsByNameHLT.isValid() && expectedTriggerResultsHLT_.size() > 0) {
+    edm::InputTag tag("TriggerResults", "", "HLT");
+    edm::Handle<edm::TriggerResults> hTriggerResults;
+    e.getByLabel(tag, hTriggerResults);
 
-      edm::InputTag tag("TriggerResults", "", "HLT");
-      edm::Handle<edm::TriggerResults> hTriggerResults;
-      e.getByLabel(tag, hTriggerResults);
+    if(hTriggerResults.isValid() && expectedTriggerResultsHLT_.size() > 0) {
+
+      edm::TriggerResultsByName resultsByNameHLT = e.triggerResultsByName(*hTriggerResults);
 
       if(hTriggerResults->parameterSetID() != resultsByNameHLT.parameterSetID() ||
            hTriggerResults->wasrun() != resultsByNameHLT.wasrun() ||
@@ -269,7 +270,15 @@ namespace edmtest {
     }
 
     if(expectedTriggerResultsHLT_.size() > iEvent_) {
-      edm::TriggerResultsByName resultsByNameHLT = e.triggerResultsByName("HLT");
+
+      if(!hTriggerResults.isValid()) {
+        std::cerr << "TestTriggerNames: While testing TriggerResultsByName class\n"
+                  << "Invalid TriggerResults Handle for HLT" << std::endl;
+        abort();
+      }
+
+      edm::TriggerResultsByName resultsByNameHLT = e.triggerResultsByName(*hTriggerResults);
+
       if(!resultsByNameHLT.isValid()) {
         std::cerr << "TestTriggerNames: While testing TriggerResultsByName class\n"
                   << "Invalid object for HLT" << std::endl;
@@ -284,8 +293,19 @@ namespace edmtest {
                 << std::endl;
     }
 
+    edm::InputTag tagPROD("TriggerResults", "", "PROD");
+    edm::Handle<edm::TriggerResults> hTriggerResultsPROD;
+    e.getByLabel(tagPROD, hTriggerResultsPROD);
+
     if(expectedTriggerResultsPROD_.size() > iEvent_) {
-      edm::TriggerResultsByName resultsByNamePROD = e.triggerResultsByName("PROD");
+
+      if(!hTriggerResultsPROD.isValid()) {
+        std::cerr << "TestTriggerNames: While testing TriggerResultsByName class\n"
+                  << "Invalid TriggerResults Handle for PROD" << std::endl;
+        abort();
+      }
+
+      edm::TriggerResultsByName resultsByNamePROD = e.triggerResultsByName(*hTriggerResultsPROD);
       if(!resultsByNamePROD.isValid()) {
         std::cerr << "TestTriggerNames: While testing TriggerResultsByName class\n"
                   << "Invalid object for PROD" << std::endl;
@@ -297,13 +317,6 @@ namespace edmtest {
         abort();
       }
       std::cout << "Event " << iEvent_ << "  " << resultsByNamePROD.accept("p1") << std::endl;
-    }
-
-    edm::TriggerResultsByName resultsByNameNONE = e.triggerResultsByName("NONE");
-    if(resultsByNameNONE.isValid()) {
-      std::cerr << "TestTriggerNames: While testing TriggerResultsByName class\n"
-                << "Object is valid with nonexistent process name" << std::endl;
-      abort();
     }
     ++iEvent_;
   }

--- a/PhysicsTools/FWLite/interface/EventContainer.h
+++ b/PhysicsTools/FWLite/interface/EventContainer.h
@@ -100,8 +100,8 @@ namespace fwlite
          edm::TriggerNames const&  triggerNames(edm::TriggerResults const& triggerResults) const
          { return m_eventBasePtr->triggerNames(triggerResults); }
 
-         edm::TriggerResultsByName triggerResultsByName(std::string const& process) const
-         { return m_eventBasePtr->triggerResultsByName(process); }
+         edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const
+         { return m_eventBasePtr->triggerResultsByName(triggerResults); }
 
          Long64_t fileIndex()          const 
          { return m_eventBasePtr->fileIndex(); }

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPHLTFilter.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPHLTFilter.cc
@@ -35,6 +35,7 @@ class HSCPHLTFilter : public edm::EDFilter {
       bool IncreasedTreshold(const trigger::TriggerEvent& trEv, const edm::InputTag& InputPath, double NewThreshold, double etaCut, int NObjectAboveThreshold, bool averageThreshold);
 
       std::string TriggerProcess;
+      edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
       edm::EDGetTokenT< trigger::TriggerEvent > trEvToken;
       std::map<std::string, bool > DuplicateMap;
 
@@ -55,6 +56,8 @@ HSCPHLTFilter::HSCPHLTFilter(const edm::ParameterSet& iConfig)
    RemoveDuplicates      = iConfig.getParameter<bool>                ("RemoveDuplicates");
 
    TriggerProcess        = iConfig.getParameter<std::string>         ("TriggerProcess");
+   triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", TriggerProcess));
+
    trEvToken = consumes< trigger::TriggerEvent >( edm::InputTag( "hltTriggerSummaryAOD" ) );
    MuonTrigger1Mask      = iConfig.getParameter<int>                 ("MuonTrigger1Mask");
    PFMetTriggerMask      = iConfig.getParameter<int>                 ("PFMetTriggerMask");
@@ -91,7 +94,13 @@ bool HSCPHLTFilter::isDuplicate(unsigned int Run, unsigned int Event){
 /////////////////////////////////////////////////////////////////////////////////////
 bool HSCPHLTFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   edm::TriggerResultsByName tr = iEvent.triggerResultsByName(TriggerProcess);
+   edm::Handle<edm::TriggerResults> triggerResults;
+   iEvent.getByToken(triggerResultsToken_, triggerResults);
+
+   edm::TriggerResultsByName tr(nullptr, nullptr);
+   if (triggerResults.isValid()) {
+     tr = iEvent.triggerResultsByName(*triggerResults);
+   }
    if(!tr.isValid()){    printf("NoValidTrigger\n");  }
 
 

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.cc
@@ -107,6 +107,7 @@ HSCPValidator::HSCPValidator(const edm::ParameterSet& iConfig) :
   tkTracksToken_(consumes<reco::TrackCollection>(edm::InputTag("generalTracks"))),
   dEdxTrackToken_(consumes<edm::ValueMap<reco::DeDxData> >(edm::InputTag("dedxHarmonic2"))),
   rpcRecHitsToken_(consumes<RPCRecHitCollection>(edm::InputTag("rpcRecHits"))),
+  triggerResultsToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"))),
   particleIds_ (iConfig.getParameter< std::vector<int> >("particleIds")),
   particleStatus_ (iConfig.getUntrackedParameter<int>("particleStatus",1)),
   ebSimHitToken_ (consumes<edm::PCaloHitContainer>(iConfig.getParameter<edm::InputTag>("EBSimHitCollection"))),
@@ -378,12 +379,17 @@ void HSCPValidator::makeHLTPlots(const edm::Event& iEvent)
   using namespace edm;
   //get HLT infos
 
+   edm::Handle<edm::TriggerResults> triggerResults;
+   iEvent.getByToken(triggerResultsToken_, triggerResults);
 
-      edm::TriggerResultsByName tr = iEvent.triggerResultsByName("HLT");
+   edm::TriggerResultsByName tr(nullptr, nullptr);
+   if(triggerResults.isValid()) {
+     tr = iEvent.triggerResultsByName(*triggerResults);
+   }
 
-          if(!tr.isValid()){
-        std::cout<<"Tirgger Results not available"<<std::endl;
-      }
+   if(!tr.isValid()){
+      std::cout<<"Trigger Results not available"<<std::endl;
+   }
 
    edm::Handle< trigger::TriggerEvent > trEvHandle;
    iEvent.getByToken(trEvToken_, trEvHandle);

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.h
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.h
@@ -73,6 +73,7 @@ class HSCPValidator : public edm::EDAnalyzer {
       edm::EDGetTokenT<reco::TrackCollection> tkTracksToken_;
       edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > dEdxTrackToken_;
       edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitsToken_;
+      edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
       std::vector<int> particleIds_;
       int particleStatus_;
       std::map<int,int> particleIdsFoundMap_;

--- a/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/Analysis_Step234.C
+++ b/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/Analysis_Step234.C
@@ -293,7 +293,11 @@ bool hasGoodPtHat(const fwlite::ChainEvent& ev, const double& PtMax){
 
 bool PassTrigger(const fwlite::ChainEvent& ev)
 {
-      edm::TriggerResultsByName tr = ev.triggerResultsByName("MergeHLT");
+      fwlite::Handle<edm::TriggerResults> hTriggerResults;
+      hTriggerResults.getByLabel(ev, "TriggerResults", "", "MergeHLT");
+      if(!hTriggerResults.isValid()) return false;
+
+      edm::TriggerResultsByName tr = ev.triggerResultsByName(*hTriggerResults);
       if(!tr.isValid())return false;
 
       if(tr.accept(tr.triggerIndex("HscpPathSingleMu")))return true;

--- a/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/DumpInfo.C
+++ b/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/DumpInfo.C
@@ -385,7 +385,11 @@ void DumpCandidateInfo(const susybsm::HSCParticle& hscp, const fwlite::ChainEven
 
 bool PassTrigger(const fwlite::ChainEvent& ev)
 {
-      edm::TriggerResultsByName tr = ev.triggerResultsByName("Merge");
+      fwlite::Handle<edm::TriggerResults> hTriggerResults;
+      hTriggerResults.getByLabel(ev, "TriggerResults", "", "Merge");
+      if(!hTriggerResults.isValid()) return false;
+
+      edm::TriggerResultsByName tr = ev.triggerResultsByName(*hTriggerResults);
       if(!tr.isValid())return false;
       if(tr.accept(tr.triggerIndex("HscpPathMu")))return true;
       if(tr.accept(tr.triggerIndex("HscpPathMet")))return true;

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/StabilityCheck.C
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/StabilityCheck.C
@@ -121,7 +121,12 @@ bool PassPreselection(const susybsm::HSCParticle& hscp,  const reco::DeDxData& d
 
 
 bool PassingTrigger(const fwlite::ChainEvent& ev, const std::string& TriggerName){
-      edm::TriggerResultsByName tr = ev.triggerResultsByName("MergeHLT");
+
+      fwlite::Handle<edm::TriggerResults> hTriggerResults;
+      hTriggerResults.getByLabel(ev, "TriggerResults", "", "MergeHLT");
+      if(!hTriggerResults.isValid()) return false;
+
+      edm::TriggerResultsByName tr = ev.triggerResultsByName(*hTriggerResults);
       if(!tr.isValid())return false;
 
       bool Accept = false;

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/TriggerStudy/TriggerStudy.C
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/TriggerStudy/TriggerStudy.C
@@ -282,8 +282,23 @@ void TriggerStudy_Core(string SignalName, FILE* pFile, stPlot* plot)
       if(e%TreeStep==0){printf(".");fflush(stdout);}
       if(MaxEntry>0 && e>MaxEntry)break;
       ev.to(e);
-      edm::TriggerResultsByName tr = ev.triggerResultsByName("HLT"); 
-      if(simhitshifted) tr= ev.triggerResultsByName("HLTSIMHITSHIFTER");
+
+      fwlite::Handle<edm::TriggerResults> hTriggerResults;
+      hTriggerResults.getByLabel(ev, "TriggerResults", "", "HLT");
+      edm::TriggerResultsByName tr(nullptr, nullptr);
+      if(hTriggerResults.isValid()) {
+        tr = ev.triggerResultsByName(*hTriggerResults);
+      }
+
+      if(simhitshifted) {
+
+        fwlite::Handle<edm::TriggerResults> hTriggerResults1;
+        hTriggerResults1.getByLabel(ev, "TriggerResults", "", "HLTSIMHITSHIFTER");
+        tr = edm::TriggerResultsByName(nullptr, nullptr);
+        if(hTriggerResults1.isValid()) {
+          tr = ev.triggerResultsByName(*hTriggerResults1);
+        }
+      }
 //      edm::TriggerResultsByName tr = ev.triggerResultsByName("HLT");      if(!tr.isValid())continue;
       //    for(unsigned int i=0;i<tr.size();i++){
       //   printf("Path %3i %50s --> %1i\n",i, tr.triggerName(i).c_str(),tr.accept(i));


### PR DESCRIPTION
Note that SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.cc shows many lines changed only because the previous version had DOS line endings. Ignoring that, the changes in that file are almost the same as in  SUSYBSMAnalysis/HSCP/plugins/HSCPHLTFilter.cc.
