### PR TITLE
Jet ID and b-tag information for Scouting Calojets

### DIFF
--- a/DataFormats/Scouting/interface/ScoutingCaloJet.h
+++ b/DataFormats/Scouting/interface/ScoutingCaloJet.h
@@ -13,18 +13,18 @@ class ScoutingCaloJet
                 float jetArea, float maxEInEmTowers, float maxEInHadTowers,
                 float hadEnergyInHB, float hadEnergyInHE, float hadEnergyInHF,
                 float emEnergyInEB, float emEnergyInEE, float emEnergyInHF,
-                float towersArea, float mvaDiscriminator):
+                float towersArea, float mvaDiscriminator, float btagDiscriminator):
             pt_(pt), eta_(eta), phi_(phi), m_(m),
             jetArea_(jetArea), maxEInEmTowers_(maxEInEmTowers), maxEInHadTowers_(maxEInHadTowers), 
             hadEnergyInHB_(hadEnergyInHB), hadEnergyInHE_(hadEnergyInHE), hadEnergyInHF_(hadEnergyInHF),
             emEnergyInEB_(emEnergyInEB), emEnergyInEE_(emEnergyInEE), emEnergyInHF_(emEnergyInHF),
-            towersArea_(towersArea), mvaDiscriminator_(mvaDiscriminator){ }
+            towersArea_(towersArea), mvaDiscriminator_(mvaDiscriminator), btagDiscriminator_(btagDiscriminator) { }
         //default constructor
         ScoutingCaloJet():pt_(0), eta_(0), phi_(0), m_(0), 
         jetArea_(0), maxEInEmTowers_(0), maxEInHadTowers_(0), 
         hadEnergyInHB_(0), hadEnergyInHE_(0), hadEnergyInHF_(0),
         emEnergyInEB_(0), emEnergyInEE_(0), emEnergyInHF_(0),
-        towersArea_(0), mvaDiscriminator_(0) { }
+        towersArea_(0), mvaDiscriminator_(0), btagDiscriminator_(0) { }
 
         //accessor functions
         float pt() const { return pt_; }
@@ -42,6 +42,7 @@ class ScoutingCaloJet
         float emEnergyInHF() const { return emEnergyInHF_; }
         float towersArea() const { return towersArea_; }
         float mvaDiscriminator() const { return mvaDiscriminator_; }
+        float btagDiscriminator() const { return btagDiscriminator_; }
 
     private:
         float pt_;
@@ -59,6 +60,7 @@ class ScoutingCaloJet
         float emEnergyInHF_;
         float towersArea_;
         float mvaDiscriminator_;
+        float btagDiscriminator_;
 };
 
 typedef std::vector<ScoutingCaloJet> ScoutingCaloJetCollection;

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
-  <class name="ScoutingCaloJet" ClassVersion="2">
+  <class name="ScoutingCaloJet" ClassVersion="3">
       <version ClassVersion="2" checksum="2705685116"/>
+      <version ClassVersion="3" checksum="631496401"/>
   </class>
   <class name="ScoutingPFJet" ClassVersion="2">
       <version ClassVersion="2" checksum="2507658732"/>

--- a/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
@@ -29,9 +29,12 @@ Description: Producer for ScoutingCaloJets from reco::CaloJet objects
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
 
 #include "DataFormats/Scouting/interface/ScoutingCaloJet.h"
 #include "DataFormats/Scouting/interface/ScoutingVertex.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
 
 class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
     public:
@@ -44,6 +47,7 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
         virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
 
         const edm::EDGetTokenT<reco::CaloJetCollection> caloJetCollection_;
+        const edm::EDGetTokenT<reco::JetTagCollection> caloJetTagCollection_;
         const edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
         const edm::EDGetTokenT<reco::CaloMETCollection> metCollection_;
         const edm::EDGetTokenT<double> rho_;
@@ -52,6 +56,7 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
         const double caloJetEtaCut;
 
         const bool doMet;
+        const bool doJetTags;
 };
 
 //
@@ -59,12 +64,14 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
 //
 HLTScoutingCaloProducer::HLTScoutingCaloProducer(const edm::ParameterSet& iConfig):
     caloJetCollection_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("caloJetCollection"))),
+    caloJetTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("caloJetTagCollection"))),
     vertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
     metCollection_(consumes<reco::CaloMETCollection>(iConfig.getParameter<edm::InputTag>("metCollection"))),
     rho_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
     caloJetPtCut(iConfig.getParameter<double>("caloJetPtCut")),
     caloJetEtaCut(iConfig.getParameter<double>("caloJetEtaCut")),
-    doMet(iConfig.getParameter<bool>("doMet"))
+    doMet(iConfig.getParameter<bool>("doMet")),
+    doJetTags(iConfig.getParameter<bool>("doJetTags"))
 {
     //register products
     produces<ScoutingCaloJetCollection>();
@@ -87,14 +94,33 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
     Handle<reco::CaloJetCollection> caloJetCollection;
     std::auto_ptr<ScoutingCaloJetCollection> outCaloJets(new ScoutingCaloJetCollection());
     if(iEvent.getByToken(caloJetCollection_, caloJetCollection)){
+        //get jet tags
+        Handle<reco::JetTagCollection> caloJetTagCollection;
+        bool haveJetTags = false;
+        if(doJetTags && iEvent.getByToken(caloJetTagCollection_, caloJetTagCollection)){
+            haveJetTags = true;
+        }
+
         for(auto &jet : *caloJetCollection){
             if(jet.pt() > caloJetPtCut && fabs(jet.eta()) < caloJetEtaCut){
+                //find the jet tag corresponding to the jet
+                float tagValue = -20;
+                float minDR2 = 0.01;
+                if(haveJetTags){
+                    for(auto &tag : *caloJetTagCollection){
+                        float dR2 = reco::deltaR2(jet, *(tag.first));
+                        if(dR2 < minDR2){
+                            minDR2 = dR2;
+                            tagValue = tag.second;
+                        }
+                    }
+                }
                 outCaloJets->emplace_back(
                         jet.pt(), jet.eta(), jet.phi(), jet.mass(),
                         jet.jetArea(), jet.maxEInEmTowers(), jet.maxEInHadTowers(),
                         jet.hadEnergyInHB(), jet.hadEnergyInHE(), jet.hadEnergyInHF(),
                         jet.emEnergyInEB(), jet.emEnergyInEE(), jet.emEnergyInHF(),
-                        jet.towersArea(), 0.0
+                        jet.towersArea(), 0.0, tagValue
                         );
             }
         }
@@ -141,12 +167,14 @@ void
 HLTScoutingCaloProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("caloJetCollection",edm::InputTag("hltAK4CaloJets"));
+    desc.add<edm::InputTag>("caloJetTagCollection",edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
     desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
     desc.add<edm::InputTag>("metCollection", edm::InputTag("hltMet"));
     desc.add<edm::InputTag>("rho", edm::InputTag("hltFixedGridRhoFastjetAllCalo"));
     desc.add<double>("caloJetPtCut", 20.0);
     desc.add<double>("caloJetEtaCut", 3.0);
     desc.add<bool>("doMet", true);
+    desc.add<bool>("doJetTags", false);
     descriptions.add("hltScoutingCaloProducer", desc);
 }
 

--- a/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
@@ -47,7 +47,8 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
         virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
 
         const edm::EDGetTokenT<reco::CaloJetCollection> caloJetCollection_;
-        const edm::EDGetTokenT<reco::JetTagCollection> caloJetTagCollection_;
+        const edm::EDGetTokenT<reco::JetTagCollection> caloJetBTagCollection_;
+        const edm::EDGetTokenT<reco::JetTagCollection> caloJetIDTagCollection_;
         const edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
         const edm::EDGetTokenT<reco::CaloMETCollection> metCollection_;
         const edm::EDGetTokenT<double> rho_;
@@ -56,7 +57,8 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
         const double caloJetEtaCut;
 
         const bool doMet;
-        const bool doJetTags;
+        const bool doJetBTags;
+        const bool doJetIDTags;
 };
 
 //
@@ -64,14 +66,16 @@ class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
 //
 HLTScoutingCaloProducer::HLTScoutingCaloProducer(const edm::ParameterSet& iConfig):
     caloJetCollection_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("caloJetCollection"))),
-    caloJetTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("caloJetTagCollection"))),
+    caloJetBTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("caloJetBTagCollection"))),
+    caloJetIDTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("caloJetIDTagCollection"))),
     vertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
     metCollection_(consumes<reco::CaloMETCollection>(iConfig.getParameter<edm::InputTag>("metCollection"))),
     rho_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
     caloJetPtCut(iConfig.getParameter<double>("caloJetPtCut")),
     caloJetEtaCut(iConfig.getParameter<double>("caloJetEtaCut")),
     doMet(iConfig.getParameter<bool>("doMet")),
-    doJetTags(iConfig.getParameter<bool>("doJetTags"))
+    doJetBTags(iConfig.getParameter<bool>("doJetBTags")),
+    doJetIDTags(iConfig.getParameter<bool>("doJetIDTags"))
 {
     //register products
     produces<ScoutingCaloJetCollection>();
@@ -95,23 +99,39 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
     std::auto_ptr<ScoutingCaloJetCollection> outCaloJets(new ScoutingCaloJetCollection());
     if(iEvent.getByToken(caloJetCollection_, caloJetCollection)){
         //get jet tags
-        Handle<reco::JetTagCollection> caloJetTagCollection;
-        bool haveJetTags = false;
-        if(doJetTags && iEvent.getByToken(caloJetTagCollection_, caloJetTagCollection)){
-            haveJetTags = true;
+        Handle<reco::JetTagCollection> caloJetBTagCollection;
+        bool haveJetBTags = false;
+        if(doJetBTags && iEvent.getByToken(caloJetBTagCollection_, caloJetBTagCollection)){
+            haveJetBTags = true;
+        }
+        Handle<reco::JetTagCollection> caloJetIDTagCollection;
+        bool haveJetIDTags = false;
+        if(doJetIDTags && iEvent.getByToken(caloJetIDTagCollection_, caloJetIDTagCollection)){
+            haveJetIDTags = true;
         }
 
         for(auto &jet : *caloJetCollection){
             if(jet.pt() > caloJetPtCut && fabs(jet.eta()) < caloJetEtaCut){
-                //find the jet tag corresponding to the jet
-                float tagValue = -20;
-                float minDR2 = 0.01;
-                if(haveJetTags){
-                    for(auto &tag : *caloJetTagCollection){
+                //find the jet tag(s) corresponding to the jet
+                float bTagValue = -20;
+                float bTagMinDR2 = 0.01;
+                if(haveJetBTags){
+                    for(auto &tag : *caloJetBTagCollection){
                         float dR2 = reco::deltaR2(jet, *(tag.first));
-                        if(dR2 < minDR2){
-                            minDR2 = dR2;
-                            tagValue = tag.second;
+                        if(dR2 < bTagMinDR2){
+                            bTagMinDR2 = dR2;
+                            bTagValue = tag.second;
+                        }
+                    }
+                }
+                float idTagValue = -20;
+                float idTagMinDR2 = 0.01;
+                if(haveJetIDTags){
+                    for(auto &tag : *caloJetIDTagCollection){
+                        float dR2 = reco::deltaR2(jet, *(tag.first));
+                        if(dR2 < idTagMinDR2){
+                            idTagMinDR2 = dR2;
+                            idTagValue = tag.second;
                         }
                     }
                 }
@@ -120,7 +140,7 @@ HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::Ev
                         jet.jetArea(), jet.maxEInEmTowers(), jet.maxEInHadTowers(),
                         jet.hadEnergyInHB(), jet.hadEnergyInHE(), jet.hadEnergyInHF(),
                         jet.emEnergyInEB(), jet.emEnergyInEE(), jet.emEnergyInHF(),
-                        jet.towersArea(), 0.0, tagValue
+                        jet.towersArea(), idTagValue, bTagValue
                         );
             }
         }
@@ -167,14 +187,16 @@ void
 HLTScoutingCaloProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("caloJetCollection",edm::InputTag("hltAK4CaloJets"));
-    desc.add<edm::InputTag>("caloJetTagCollection",edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
+    desc.add<edm::InputTag>("caloJetBTagCollection",edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
+    desc.add<edm::InputTag>("caloJetIDTagCollection",edm::InputTag("hltCaloJetFromPV"));
     desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
     desc.add<edm::InputTag>("metCollection", edm::InputTag("hltMet"));
     desc.add<edm::InputTag>("rho", edm::InputTag("hltFixedGridRhoFastjetAllCalo"));
     desc.add<double>("caloJetPtCut", 20.0);
     desc.add<double>("caloJetEtaCut", 3.0);
     desc.add<bool>("doMet", true);
-    desc.add<bool>("doJetTags", false);
+    desc.add<bool>("doJetBTags", false);
+    desc.add<bool>("doJetIDTags", false);
     descriptions.add("hltScoutingCaloProducer", desc);
 }
 


### PR DESCRIPTION
This PR modifies HLTScoutingCaloProducer so that it can put b-tag and jet ID information (provided as JetTagCollections) into ScoutingCaloJet objects.

The change does not modify the current behavior of this producer in the HLT menu.  The new options (doJetBTags and doJetIDTags) are turned off by default.  

This is related to the PR from @silviodonato (https://github.com/cms-sw/cmssw/pull/14269), but the PRs can be merged independently of one another.  

When this looks ok, I will submit a backport PR for 80X.  
