### PR TITLE
Use unique_ptr, not auto_ptr, in CommonTools

### DIFF
--- a/CommonTools/CandAlgos/interface/CandCombiner.h
+++ b/CommonTools/CandAlgos/interface/CandCombiner.h
@@ -154,7 +154,7 @@ namespace reco {
 	for(int i = 0; i < n; ++i)
 	  evt.getByToken(tokens_[i], colls[i]);
 
-	auto_ptr<OutputCollection> out = combiner_.combine(colls, names_.roles());
+	unique_ptr<OutputCollection> out = combiner_.combine(colls, names_.roles());
 	if(setLongLived_ || setMassConstraint_ || setPdgId_) {
 	  typename OutputCollection::iterator i = out->begin(), e = out->end();
 	  for(; i != e; ++i) {
@@ -164,7 +164,7 @@ namespace reco {
 	    if(setPdgId_) i->setPdgId(pdgId_);
 	  }
 	}
-	evt.put(out);
+	evt.put(std::move(out));
       }
       /// combiner utility
       ::CandCombiner<Selector, PairSelector, Cloner, OutputCollection, Setup> combiner_;

--- a/CommonTools/CandAlgos/interface/ShallowCloneProducer.h
+++ b/CommonTools/CandAlgos/interface/ShallowCloneProducer.h
@@ -46,14 +46,14 @@ ShallowCloneProducer<C>::~ShallowCloneProducer() {
 
 template<typename C>
 void ShallowCloneProducer<C>::produce( edm::Event& evt, const edm::EventSetup& ) {
-  std::auto_ptr<reco::CandidateCollection> coll( new reco::CandidateCollection );
+  std::unique_ptr<reco::CandidateCollection> coll( new reco::CandidateCollection );
   edm::Handle<C> masterCollection;
   evt.getByToken( srcToken_, masterCollection );
   for( size_t i = 0; i < masterCollection->size(); ++i ) {
     reco::CandidateBaseRef masterClone( edm::Ref<C>( masterCollection, i ) );
     coll->push_back( new reco::ShallowCloneCandidate( masterClone ) );
   }
-  evt.put( coll );
+  evt.put(std::move(coll));
 }
 
 #endif

--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -47,7 +47,7 @@ CandPtrProjector::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
   Handle<View<reco::Candidate> > vetos;
   iEvent.getByToken(vetoSrcToken_, vetos);
 
-  std::auto_ptr<PtrVector<reco::Candidate> > result(new PtrVector<reco::Candidate>());
+  std::unique_ptr<PtrVector<reco::Candidate> > result(new PtrVector<reco::Candidate>());
   std::set<reco::CandidatePtr> vetoedPtrs;
   for(size_t i = 0; i< vetos->size();  ++i) {
    for(size_t j=0,n=(*vetos)[i].numberOfSourceCandidatePtrs(); j<n;j++ )    {
@@ -61,7 +61,7 @@ CandPtrProjector::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
       result->push_back(c);
     }
   }
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 void CandPtrProjector::endJob()

--- a/CommonTools/CandAlgos/plugins/CandReducer.cc
+++ b/CommonTools/CandAlgos/plugins/CandReducer.cc
@@ -52,12 +52,12 @@ CandReducer::~CandReducer() {
 void CandReducer::produce( Event& evt, const EventSetup& ) {
   Handle<reco::CandidateView> cands;
   evt.getByToken( srcToken_, cands );
-  std::auto_ptr<CandidateCollection> comp( new CandidateCollection );
+  std::unique_ptr<CandidateCollection> comp( new CandidateCollection );
   for( reco::CandidateView::const_iterator c = cands->begin(); c != cands->end(); ++c ) {
-    std::auto_ptr<Candidate> cand( new LeafCandidate( * c ) );
+    std::unique_ptr<Candidate> cand( new LeafCandidate( * c ) );
     comp->push_back( cand.release() );
   }
-  evt.put( comp );
+  evt.put(std::move(comp));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
@@ -22,14 +22,14 @@ public:
   }
 private:
   void produce(edm::Event & evt, const edm::EventSetup &) override {
-    std::auto_ptr<std::vector<reco::CandidateBaseRef> > out(new std::vector<reco::CandidateBaseRef>);
+    std::unique_ptr<std::vector<reco::CandidateBaseRef> > out(new std::vector<reco::CandidateBaseRef>);
     for(std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator i = srcTokens_.begin(); i != srcTokens_.end(); ++i) {
       edm::Handle<reco::CandidateView> src;
       evt.getByToken(*i, src);
       for(size_t j = 0; j < src->size(); ++j)
 	out->push_back(src->refAt(j));
     }
-    evt.put(out);
+    evt.put(std::move(out));
   }
   std::vector<edm::EDGetTokenT<reco::CandidateView> > srcTokens_;
 };

--- a/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
+++ b/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
@@ -62,8 +62,8 @@ void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   edm::Handle<CandidateCollection> genCandidatesCollection;
   iEvent.getByToken(genCandidatesToken_, genCandidatesCollection);
 
-  auto_ptr<CandidateCollection> mothercands(new CandidateCollection);
-  auto_ptr<CandidateCollection> daughterscands(new CandidateCollection);
+  unique_ptr<CandidateCollection> mothercands(new CandidateCollection);
+  unique_ptr<CandidateCollection> daughterscands(new CandidateCollection);
   size_t daughtersize = daughtersPdgId_.size();
   for( CandidateCollection::const_iterator p = genCandidatesCollection->begin();p != genCandidatesCollection->end(); ++ p ) {
     if (p->pdgId() == motherPdgId_  && p->status() == 3){
@@ -79,13 +79,13 @@ void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     }
   }
 
-  iEvent.put(mothercands, decayChain_ + "Mother");
+  iEvent.put(std::move(mothercands), decayChain_ + "Mother");
   daughterscands->sort(GreaterByPt<reco::Candidate>());
 
   for (unsigned int row = 0; row < daughtersize; ++ row ){
-    auto_ptr<CandidateCollection> leptonscands_(new CandidateCollection);
+    unique_ptr<CandidateCollection> leptonscands_(new CandidateCollection);
     leptonscands_->push_back((daughterscands->begin()+row)->clone());
-    iEvent.put(leptonscands_, valias.at(row));
+    iEvent.put(std::move(leptonscands_), valias.at(row));
   }
 }
 

--- a/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.cc
+++ b/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.cc
@@ -49,7 +49,7 @@ DeltaBetaWeights::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   double sumNPU = .0;
   double sumPU =  .0;
 
-  std::auto_ptr<reco::PFCandidateCollection> out(new reco::PFCandidateCollection); 
+  std::unique_ptr<reco::PFCandidateCollection> out(new reco::PFCandidateCollection);
 
 
   for (const reco::Candidate & cand : *src) {
@@ -85,6 +85,6 @@ DeltaBetaWeights::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   }
 
-  iEvent.put(out);
+  iEvent.put(std::move(out));
  
 }

--- a/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
@@ -185,10 +185,10 @@ void PFCandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSe
   const IsoDepositMap & map = begin->map();
 
   if (map.size()==0) { // !!???
-        event.put(std::auto_ptr<CandDoubleMap>(new CandDoubleMap()));
+        event.put(std::unique_ptr<CandDoubleMap>(new CandDoubleMap()));
         return;
   }
-  std::auto_ptr<CandDoubleMap> ret(new CandDoubleMap());
+  std::unique_ptr<CandDoubleMap> ret(new CandDoubleMap());
   CandDoubleMap::Filler filler(*ret);
 
   typedef reco::IsoDepositMap::const_iterator iterator_i;
@@ -212,7 +212,7 @@ void PFCandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSe
     filler.insert(candH, retV.begin(), retV.end());
   }
   filler.fill();
-  event.put(ret);
+  event.put(std::move(ret));
 }
 
 DEFINE_FWK_MODULE( PFCandIsolatorFromDeposits );

--- a/CommonTools/ParticleFlow/plugins/PFMET.cc
+++ b/CommonTools/ParticleFlow/plugins/PFMET.cc
@@ -55,13 +55,13 @@ void PFMET::produce(Event& iEvent,
   Handle<PFCandidateCollection> pfCandidates;
   iEvent.getByToken( tokenPFCandidates_, pfCandidates);
 
-  auto_ptr< METCollection >
+  unique_ptr< METCollection >
     pOutput( new METCollection() );
 
 
 
   pOutput->push_back( pfMETAlgo_.produce( *pfCandidates ) );
-  iEvent.put( pOutput );
+  iEvent.put(std::move(pOutput));
 
   LogDebug("PFMET")<<"STOP event: "<<iEvent.id().event()
 		   <<" in run "<<iEvent.id().run()<<endl;

--- a/CommonTools/ParticleFlow/plugins/PFPileUp.cc
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.cc
@@ -61,10 +61,10 @@ void PFPileUp::produce(Event& iEvent,
 
   // get PFCandidates
 
-  auto_ptr< PFCollection >
+  unique_ptr< PFCollection >
     pOutput( new PFCollection );
 
-  auto_ptr< PFCollectionByValue >
+  unique_ptr< PFCollectionByValue >
     pOutputByValue ( new PFCollectionByValue );
 
   if(enable_) {
@@ -118,7 +118,7 @@ void PFPileUp::produce(Event& iEvent,
 
   } // end if enabled
   // outsize of the loop to fill the collection anyway even when disabled
-  iEvent.put( pOutput );
-  // iEvent.put( pOutputByValue );
+  iEvent.put(std::move(pOutput));
+  // iEvent.put(std::move(pOutputByValue));
 }
 

--- a/CommonTools/ParticleFlow/plugins/TopProjector.h
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.h
@@ -269,7 +269,7 @@ void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
 
   // output collection of FwdPtrs to objects,
   // selected from the Bottom collection
-  std::auto_ptr< BottomFwdPtrCollection >
+  std::unique_ptr< BottomFwdPtrCollection >
     pBottomFwdPtrOutput( new BottomFwdPtrCollection );
 
   LogDebug("TopProjection")<<" Remaining candidates in the bottom collection ------ ";
@@ -297,7 +297,7 @@ void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
     }
   }
 
-  iEvent.put( pBottomFwdPtrOutput );
+  iEvent.put(std::move(pBottomFwdPtrOutput));
 }
 
 

--- a/CommonTools/ParticleFlow/plugins/Type1PFMET.cc
+++ b/CommonTools/ParticleFlow/plugins/Type1PFMET.cc
@@ -36,11 +36,11 @@ Type1PFMET::~Type1PFMET() {}
   iEvent.getByToken( correctorToken, corrector );
   Handle<METCollection> inputUncorMet;                     //Define Inputs
   iEvent.getByToken( tokenUncorMet,  inputUncorMet );     //Get Inputs
-  std::auto_ptr<METCollection> output( new METCollection() );  //Create empty output
+  std::unique_ptr<METCollection> output( new METCollection() );  //Create empty output
   run( *(inputUncorMet.product()), *(corrector.product()), *(inputUncorJets.product()),
        jetPTthreshold, jetEMfracLimit, jetMufracLimit,
        &*output );                                         //Invoke the algorithm
-  iEvent.put( output );                                        //Put output into Event
+  iEvent.put(std::move(output));                                        //Put output into Event
 }
 
 void Type1PFMET::run(const METCollection& uncorMET,

--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
@@ -97,7 +97,7 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Get Weights
   edm::Handle<edm::ValueMap<float> > pupWeights; 
   iEvent.getByToken(tokenWeights_,pupWeights);
-  std::auto_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
+  std::unique_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
   LorentzVectorCollection puppiP4s;
   std::vector<reco::CandidatePtr> values(hPFProduct->size());
   int iPF = 0; 
@@ -156,16 +156,16 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     corrCandidates_->push_back(pCand);
   }
   //Fill it into the event
-  edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( corrCandidates_ );
+  edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put(std::move(corrCandidates_));
   for(unsigned int ic=0, nc = pupCol->size(); ic < nc; ++ic) {
       reco::CandidatePtr pkref( oh, ic );
       values[ic] = pkref;
   }  
-  std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
+  std::unique_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
   edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
   filler.insert(hPFProduct, values.begin(), values.end());
   filler.fill();
-  iEvent.put(pfMap_p);
+  iEvent.put(std::move(pfMap_p));
 }
 // ------------------------------------------------------------------------------------------
 bool PuppiPhoton::matchPFCandidate(const reco::Candidate *iPF,const reco::Candidate *iPho) { 

--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
@@ -41,7 +41,7 @@ private:
 	bool   usePhotonId_;
 	std::vector<double>  dRMatch_;
 	std::vector<int32_t> pdgIds_; 
-        std::auto_ptr< PFOutputCollection > corrCandidates_;
+        std::unique_ptr< PFOutputCollection > corrCandidates_;
 	double weight_;
 	bool   useValueMap_;
 };

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -213,7 +213,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
 
   //Fill it into the event
-  std::auto_ptr<edm::ValueMap<float> > lPupOut(new edm::ValueMap<float>());
+  std::unique_ptr<edm::ValueMap<float> > lPupOut(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler  lPupFiller(*lPupOut);
   lPupFiller.insert(hPFProduct,lWeights.begin(),lWeights.end());
   lPupFiller.fill();
@@ -229,7 +229,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // the input is set to have a four-vector of 0,0,0,0
   fPuppiCandidates.reset( new PFOutputCollection );
   fPackedPuppiCandidates.reset( new PackedOutputCollection );
-  std::auto_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
+  std::unique_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
   LorentzVectorCollection puppiP4s;
   std::vector<reco::CandidatePtr> values(hPFProduct->size());
 
@@ -276,26 +276,26 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   p4PupFiller.insert(hPFProduct,puppiP4s.begin(), puppiP4s.end() );
   p4PupFiller.fill();
   
-  iEvent.put(lPupOut);
-  iEvent.put(p4PupOut);
+  iEvent.put(std::move(lPupOut));
+  iEvent.put(std::move(p4PupOut));
   if (fUseExistingWeights || fClonePackedCands) {
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put( fPackedPuppiCandidates );
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(fPackedPuppiCandidates));
     for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
         reco::CandidatePtr pkref( oh, ic );
         values[ic] = pkref;
     }
   } else {
-    edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( fPuppiCandidates );
+    edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put(std::move(fPuppiCandidates));
     for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
         reco::CandidatePtr pkref( oh, ic );
         values[ic] = pkref;
     }
   }
-  std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
+  std::unique_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
   edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
   filler.insert(hPFProduct, values.begin(), values.end());
   filler.fill();
-  iEvent.put(pfMap_p);
+  iEvent.put(std::move(pfMap_p));
 
 
   //////////////////////////////////////////////
@@ -303,17 +303,17 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // all the different alphas per particle
     // THE alpha per particle
-    std::auto_ptr<std::vector<double> > theAlphas(new std::vector<double>(fPuppiContainer->puppiAlphas()));
-    std::auto_ptr<std::vector<double> > theAlphasMed(new std::vector<double>(fPuppiContainer->puppiAlphasMed()));
-    std::auto_ptr<std::vector<double> > theAlphasRms(new std::vector<double>(fPuppiContainer->puppiAlphasRMS()));
-    std::auto_ptr<std::vector<double> > alphas(new std::vector<double>(fPuppiContainer->puppiRawAlphas()));
-    std::auto_ptr<double> nalgos(new double(fPuppiContainer->puppiNAlgos()));
+    std::unique_ptr<std::vector<double> > theAlphas(new std::vector<double>(fPuppiContainer->puppiAlphas()));
+    std::unique_ptr<std::vector<double> > theAlphasMed(new std::vector<double>(fPuppiContainer->puppiAlphasMed()));
+    std::unique_ptr<std::vector<double> > theAlphasRms(new std::vector<double>(fPuppiContainer->puppiAlphasRMS()));
+    std::unique_ptr<std::vector<double> > alphas(new std::vector<double>(fPuppiContainer->puppiRawAlphas()));
+    std::unique_ptr<double> nalgos(new double(fPuppiContainer->puppiNAlgos()));
     
-    iEvent.put(alphas,"PuppiRawAlphas");
-    iEvent.put(nalgos,"PuppiNAlgos");
-    iEvent.put(theAlphas,"PuppiAlphas");
-    iEvent.put(theAlphasMed,"PuppiAlphasMed");
-    iEvent.put(theAlphasRms,"PuppiAlphasRms");
+    iEvent.put(std::move(alphas),"PuppiRawAlphas");
+    iEvent.put(std::move(nalgos),"PuppiNAlgos");
+    iEvent.put(std::move(theAlphas),"PuppiAlphas");
+    iEvent.put(std::move(theAlphasMed),"PuppiAlphasMed");
+    iEvent.put(std::move(theAlphasRms),"PuppiAlphasRms");
   }
   
 }

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -58,7 +58,7 @@ private:
 	double fVtxZCut;
 	std::unique_ptr<PuppiContainer> fPuppiContainer;
 	std::vector<RecoObj> fRecoObjCollection;
-        std::auto_ptr< PFOutputCollection >          fPuppiCandidates;
-	std::auto_ptr< PackedOutputCollection >      fPackedPuppiCandidates;
+        std::unique_ptr< PFOutputCollection >          fPuppiCandidates;
+	std::unique_ptr< PackedOutputCollection >      fPackedPuppiCandidates;
 };
 #endif

--- a/CommonTools/PileupAlgos/plugins/SoftKillerProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/SoftKillerProducer.cc
@@ -102,7 +102,7 @@ void
 SoftKillerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  std::auto_ptr< PFOutputCollection > pOutput( new PFOutputCollection );
+  std::unique_ptr< PFOutputCollection > pOutput( new PFOutputCollection );
 
   // get PF Candidates
   edm::Handle<reco::CandidateView> pfCandidates;
@@ -123,7 +123,7 @@ SoftKillerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   std::vector<fastjet::PseudoJet> soft_killed_event;
   soft_killer.apply(fjInputs, soft_killed_event, pt_threshold);
 
-  std::auto_ptr<edm::ValueMap<LorentzVector> > p4SKOut(new edm::ValueMap<LorentzVector>());
+  std::unique_ptr<edm::ValueMap<LorentzVector> > p4SKOut(new edm::ValueMap<LorentzVector>());
   LorentzVectorCollection skP4s;
 
   static const reco::PFCandidate dummySinceTranslateIsNotStatic;
@@ -154,8 +154,8 @@ SoftKillerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   p4SKFiller.insert(pfCandidates,skP4s.begin(), skP4s.end() );
   p4SKFiller.fill();
 
-  iEvent.put(p4SKOut,"SoftKillerP4s");
-  iEvent.put( pOutput );
+  iEvent.put(std::move(p4SKOut),"SoftKillerP4s");
+  iEvent.put(std::move(pOutput));
 
 }
 

--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -76,25 +76,25 @@ namespace helper {
     }
 
     edm::OrphanHandle<reco::GsfElectronCollection> put( edm::Event & evt ) {
-      edm::OrphanHandle<reco::GsfElectronCollection> h = evt.put( selElectrons_ );
-      evt.put( selElectronCores_ );
-      evt.put( selSuperClusters_ );
-      evt.put( selTracks_ );
-      evt.put( selTrackExtras_ );
-      evt.put( selGsfTrackExtras_ );
-      evt.put( selHits_ );
+      edm::OrphanHandle<reco::GsfElectronCollection> h = evt.put(std::move(selElectrons_));
+      evt.put(std::move(selElectronCores_ ));
+      evt.put(std::move(selSuperClusters_ ));
+      evt.put(std::move(selTracks_ ));
+      evt.put(std::move(selTrackExtras_ ));
+      evt.put(std::move(selGsfTrackExtras_ ));
+      evt.put(std::move(selHits_ ));
       return h;
     }
 
     size_t size() const { return selElectrons_->size(); }
   private:
-    std::auto_ptr<reco::GsfElectronCollection> selElectrons_;
-    std::auto_ptr<reco::GsfElectronCoreCollection> selElectronCores_;
-    std::auto_ptr<reco::SuperClusterCollection> selSuperClusters_;
-    std::auto_ptr<reco::GsfTrackCollection> selTracks_;
-    std::auto_ptr<reco::TrackExtraCollection> selTrackExtras_;
-    std::auto_ptr<reco::GsfTrackExtraCollection> selGsfTrackExtras_;
-    std::auto_ptr<TrackingRecHitCollection> selHits_;
+    std::unique_ptr<reco::GsfElectronCollection> selElectrons_;
+    std::unique_ptr<reco::GsfElectronCoreCollection> selElectronCores_;
+    std::unique_ptr<reco::SuperClusterCollection> selSuperClusters_;
+    std::unique_ptr<reco::GsfTrackCollection> selTracks_;
+    std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+    std::unique_ptr<reco::GsfTrackExtraCollection> selGsfTrackExtras_;
+    std::unique_ptr<TrackingRecHitCollection> selHits_;
   };
 
   class GsfElectronSelectorBase : public edm::EDFilter {

--- a/CommonTools/RecoAlgos/interface/MuonSelector.h
+++ b/CommonTools/RecoAlgos/interface/MuonSelector.h
@@ -61,18 +61,18 @@ namespace helper {
     
   private:
      //--- Collections to store:
-    std::auto_ptr<reco::MuonCollection> selMuons_;
-    std::auto_ptr<reco::TrackCollection> selTracks_;
-    std::auto_ptr<reco::TrackExtraCollection> selTracksExtras_;
-    std::auto_ptr<TrackingRecHitCollection> selTracksHits_;
-    std::auto_ptr<reco::TrackCollection> selGlobalMuonTracks_;
-    std::auto_ptr<reco::TrackExtraCollection> selGlobalMuonTracksExtras_;
-    std::auto_ptr<TrackingRecHitCollection> selGlobalMuonTracksHits_;
-    std::auto_ptr<reco::TrackCollection> selStandAloneTracks_;
-    std::auto_ptr<reco::TrackExtraCollection> selStandAloneTracksExtras_;
-    std::auto_ptr<TrackingRecHitCollection> selStandAloneTracksHits_;
-    std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >  selStripClusters_;
-    std::auto_ptr< edmNew::DetSetVector<SiPixelCluster> >  selPixelClusters_;
+    std::unique_ptr<reco::MuonCollection> selMuons_;
+    std::unique_ptr<reco::TrackCollection> selTracks_;
+    std::unique_ptr<reco::TrackExtraCollection> selTracksExtras_;
+    std::unique_ptr<TrackingRecHitCollection> selTracksHits_;
+    std::unique_ptr<reco::TrackCollection> selGlobalMuonTracks_;
+    std::unique_ptr<reco::TrackExtraCollection> selGlobalMuonTracksExtras_;
+    std::unique_ptr<TrackingRecHitCollection> selGlobalMuonTracksHits_;
+    std::unique_ptr<reco::TrackCollection> selStandAloneTracks_;
+    std::unique_ptr<reco::TrackExtraCollection> selStandAloneTracksExtras_;
+    std::unique_ptr<TrackingRecHitCollection> selStandAloneTracksHits_;
+    std::unique_ptr< edmNew::DetSetVector<SiStripCluster> >  selStripClusters_;
+    std::unique_ptr< edmNew::DetSetVector<SiPixelCluster> >  selPixelClusters_;
 
     reco::MuonRefProd rMuons_;      
     reco::TrackRefProd rTracks_;      

--- a/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
@@ -63,10 +63,10 @@ private:
       edm::Handle<reco::TrackCollection> hSrcTrack;
       evt.getByToken( hSrcTrackToken_, hSrcTrack );
 
-      selTracks_ = std::auto_ptr<reco::TrackCollection>(new reco::TrackCollection());
+      selTracks_ = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection());
       if (copyExtras_) {
-          selTrackExtras_ = std::auto_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
-          selHits_ = std::auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+          selTrackExtras_ = std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
+          selHits_ = std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
       }
 
       TrackRefProd rTracks = evt.template getRefBeforePut<TrackCollection>();
@@ -115,8 +115,8 @@ private:
           evt.getByToken(hTTAssToken_, hTTAss);
           evt.getByToken(hTrajToken_, hTraj);
           edm::RefProd< std::vector<Trajectory> > TrajRefProd = evt.template getRefBeforePut< std::vector<Trajectory> >();
-          selTrajs_ = std::auto_ptr< std::vector<Trajectory> >(new std::vector<Trajectory>());
-          selTTAss_ = std::auto_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection());
+          selTrajs_ = std::unique_ptr< std::vector<Trajectory> >(new std::vector<Trajectory>());
+          selTTAss_ = std::unique_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection());
           for (size_t i = 0, n = hTraj->size(); i < n; ++i) {
               edm::Ref< std::vector<Trajectory> > trajRef(hTraj, i);
               TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
@@ -134,13 +134,13 @@ private:
           }
       }
 
-      evt.put(selTracks_);
+      evt.put(std::move(selTracks_));
       if (copyExtras_) {
-            evt.put(selTrackExtras_);
-            evt.put(selHits_);
+            evt.put(std::move(selTrackExtras_));
+            evt.put(std::move(selHits_));
             if ( copyTrajectories_ ) {
-                evt.put(selTrajs_);
-                evt.put(selTTAss_);
+                evt.put(std::move(selTrajs_));
+                evt.put(std::move(selTTAss_));
             }
       }
   }
@@ -155,11 +155,11 @@ private:
   /// filter event
   Selector selector_;
   // some space
-  std::auto_ptr<reco::TrackCollection> selTracks_;
-  std::auto_ptr<reco::TrackExtraCollection> selTrackExtras_;
-  std::auto_ptr<TrackingRecHitCollection> selHits_;
-  std::auto_ptr< std::vector<Trajectory> > selTrajs_;
-  std::auto_ptr< TrajTrackAssociationCollection > selTTAss_;
+  std::unique_ptr<reco::TrackCollection> selTracks_;
+  std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+  std::unique_ptr<TrackingRecHitCollection> selHits_;
+  std::unique_ptr< std::vector<Trajectory> > selTrajs_;
+  std::unique_ptr< TrajTrackAssociationCollection > selTTAss_;
 };
 
 } }

--- a/CommonTools/RecoAlgos/interface/TrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/TrackSelector.h
@@ -68,11 +68,11 @@ namespace helper {
     
   private:
     //--- Collections to store:
-    std::auto_ptr<reco::TrackCollection>                   selTracks_;
-    std::auto_ptr<reco::TrackExtraCollection>              selTrackExtras_;
-    std::auto_ptr<TrackingRecHitCollection>                selHits_;
-    std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >  selStripClusters_;
-    std::auto_ptr< edmNew::DetSetVector<SiPixelCluster> >  selPixelClusters_;
+    std::unique_ptr<reco::TrackCollection>                   selTracks_;
+    std::unique_ptr<reco::TrackExtraCollection>              selTrackExtras_;
+    std::unique_ptr<TrackingRecHitCollection>                selHits_;
+    std::unique_ptr< edmNew::DetSetVector<SiStripCluster> >  selStripClusters_;
+    std::unique_ptr< edmNew::DetSetVector<SiPixelCluster> >  selPixelClusters_;
 
     //--- References to products (i.e. to collections):
     reco::TrackRefProd           rTracks_ ;

--- a/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
@@ -37,7 +37,7 @@ namespace reco {
       using namespace std;
       Handle<HitCollection> hits;
       evt.getByToken( srcToken_, hits );
-      auto_ptr<CandidateCollection> cands( new CandidateCollection );
+      unique_ptr<CandidateCollection> cands( new CandidateCollection );
       size_t size = hits->size();
       cands->reserve( size );
       for( size_t idx = 0; idx != size; ++ idx ) {
@@ -50,7 +50,7 @@ namespace reco {
 	c->setCaloRecHit( RefToBase<CaloRecHit>( Ref<HitCollection>( hits, idx ) ) );
 	cands->push_back( c );
       }
-      evt.put( cands );
+      evt.put(std::move(cands));
     }
 
   }

--- a/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
@@ -146,12 +146,12 @@ HBHENoiseFilterResultProducer::produce(edm::Event& iEvent, const edm::EventSetup
   decisionMap_["HBHENoiseFilterResultRun2Tight"] = failRun2Tight;
 
   // Write out the standard flags
-  std::auto_ptr<bool> pOut;
+  std::unique_ptr<bool> pOut;
   for (std::map<std::string, bool>::const_iterator it = decisionMap_.begin();
        it != decisionMap_.end(); ++it)
   {
-      pOut = std::auto_ptr<bool>(new bool(!it->second));
-      iEvent.put(pOut, it->first);
+      pOut = std::unique_ptr<bool>(new bool(!it->second));
+      iEvent.put(std::move(pOut), it->first);
   }
 
   // Overwrite defaultDecision_ dynamically based on bunchSpacingProducer
@@ -173,15 +173,15 @@ HBHENoiseFilterResultProducer::produce(edm::Event& iEvent, const edm::EventSetup
   std::map<std::string, bool>::const_iterator it = decisionMap_.find(defaultDecision_);
   if (it == decisionMap_.end())
       throw cms::Exception("Invalid HBHENoiseFilterResultProducer parameter \"defaultDecision\"");
-  pOut = std::auto_ptr<bool>(new bool(!it->second));
-  iEvent.put(pOut, "HBHENoiseFilterResult");
+  pOut = std::unique_ptr<bool>(new bool(!it->second));
+  iEvent.put(std::move(pOut), "HBHENoiseFilterResult");
 
   // Check isolation requirements
   const bool failIsolation = summary.numIsolatedNoiseChannels() >= minNumIsolatedNoiseChannels_ ||
                              summary.isolatedNoiseSumE() >= minIsolatedNoiseSumE_ ||
                              summary.isolatedNoiseSumEt() >= minIsolatedNoiseSumEt_;
-  pOut = std::auto_ptr<bool>(new bool(!failIsolation));
-  iEvent.put(pOut, "HBHEIsoNoiseFilterResult");
+  pOut = std::unique_ptr<bool>(new bool(!failIsolation));
+  iEvent.put(std::move(pOut), "HBHEIsoNoiseFilterResult");
   
   return;
 }

--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -53,8 +53,8 @@ public:
 
     virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
 
-      std::auto_ptr< JetsOutput > jets ( new std::vector<T>() );
-      std::auto_ptr< ConstituentsOutput > candsOut( new ConstituentsOutput  );
+      std::unique_ptr< JetsOutput > jets ( new std::vector<T>() );
+      std::unique_ptr< ConstituentsOutput > candsOut( new ConstituentsOutput  );
 
       edm::Handle< typename edm::View<T> > h_jets;
       iEvent.getByToken( srcToken_, h_jets );
@@ -76,8 +76,8 @@ public:
 
       // put  in Event
       bool pass = jets->size() > 0;
-      iEvent.put(jets);
-      iEvent.put(candsOut, "constituents");
+      iEvent.put(std::move(jets));
+      iEvent.put(std::move(candsOut), "constituents");
 
       if ( filter_ )
 	return pass;

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -59,7 +59,7 @@ private:
 
   virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
 
-    std::auto_ptr< TagInfosCollection > mappedTagInfos ( new TagInfosCollection() );
+    std::unique_ptr< TagInfosCollection > mappedTagInfos ( new TagInfosCollection() );
 
 
     edm::Handle< typename edm::View<T> > h_jets1;
@@ -123,7 +123,7 @@ private:
     
 
     // put  in Event
-    iEvent.put(mappedTagInfos);
+    iEvent.put(std::move(mappedTagInfos));
   }
 
   const edm::EDGetTokenT< typename edm::View<T> >  srcToken_;

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -130,27 +130,27 @@ private:
 
     if( value_!="" )
     {
-      std::auto_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
+      std::unique_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
 
       JetValueMap::Filler filler(*jetValueMap);
       filler.insert(h_jets1, values.begin(), values.end());
       filler.fill();
 
       // put in Event
-      iEvent.put(jetValueMap);
+      iEvent.put(std::move(jetValueMap));
     }
     if( multiValue_ )
     {
       for( size_t i=0; i<valueLabels_.size(); ++i)
       {
-        std::auto_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
+        std::unique_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
 
         JetValueMap::Filler filler(*jetValueMap);
         filler.insert(h_jets1, valuesMap.at(valueLabels_[i]).begin(), valuesMap.at(valueLabels_[i]).end());
         filler.fill();
 
         // put in Event
-        iEvent.put(jetValueMap, valueLabels_[i]);
+        iEvent.put(std::move(jetValueMap), valueLabels_[i]);
       }
     }
   }

--- a/CommonTools/RecoAlgos/plugins/ME0MuonTrackCollProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ME0MuonTrackCollProducer.cc
@@ -69,7 +69,7 @@ void ME0MuonTrackCollProducer::produce(edm::Event& iEvent, const edm::EventSetup
   iEvent.getByToken(OurMuonsToken_,OurMuons);
 
   
-  std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
  
   reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
   
@@ -90,6 +90,6 @@ void ME0MuonTrackCollProducer::produce(edm::Event& iEvent, const edm::EventSetup
       selectedTracks->push_back( *trk );
       //selectedTrackExtras->push_back( *newExtra );
   }
-  iEvent.put(selectedTracks);
+  iEvent.put(std::move(selectedTracks));
 
 }

--- a/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
+++ b/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
@@ -204,8 +204,8 @@ using namespace reco;
 
 
   if(produceOriginalMapping_){
-    auto_ptr< CandToVertex>  pfCandToOriginalVertexOutput( new CandToVertex(vertices) );
-    auto_ptr< CandToVertexQuality>  pfCandToOriginalVertexQualityOutput( new CandToVertexQuality() );
+    unique_ptr< CandToVertex>  pfCandToOriginalVertexOutput( new CandToVertex(vertices) );
+    unique_ptr< CandToVertexQuality>  pfCandToOriginalVertexQualityOutput( new CandToVertexQuality() );
     CandToVertex::Filler cand2VertexFiller(*pfCandToOriginalVertexOutput);
     CandToVertexQuality::Filler cand2VertexQualityFiller(*pfCandToOriginalVertexQualityOutput);
 
@@ -214,14 +214,14 @@ using namespace reco;
 
     cand2VertexFiller.fill();
     cand2VertexQualityFiller.fill();
-    iEvent.put( pfCandToOriginalVertexOutput ,"original");
-    iEvent.put( pfCandToOriginalVertexQualityOutput ,"original");
+    iEvent.put(std::move(pfCandToOriginalVertexOutput) ,"original");
+    iEvent.put(std::move(pfCandToOriginalVertexQualityOutput) ,"original");
 
-    auto_ptr< VertexScore>  vertexScoreOriginalOutput( new VertexScore );
+    unique_ptr< VertexScore>  vertexScoreOriginalOutput( new VertexScore );
     VertexScore::Filler vertexScoreOriginalFiller(*vertexScoreOriginalOutput);
     vertexScoreOriginalFiller.insert(vertices,vertexScoreOriginal.begin(),vertexScoreOriginal.end());
     vertexScoreOriginalFiller.fill();
-    iEvent.put( vertexScoreOriginalOutput ,"original");
+    iEvent.put(std::move(vertexScoreOriginalOutput) ,"original");
  
   }
 
@@ -233,13 +233,13 @@ using namespace reco;
 //        pfToSortedPVQualityVector.push_back(pfToPVQualityVector[i]); //same as old!
       }
 
-      auto_ptr< reco::VertexCollection>  sortedVerticesOutput( new reco::VertexCollection );
+      unique_ptr< reco::VertexCollection>  sortedVerticesOutput( new reco::VertexCollection );
       for(size_t i=0;i<vertices->size();i++){
          sortedVerticesOutput->push_back((*vertices)[newToOld[i]]); 
       }
-    edm::OrphanHandle<reco::VertexCollection> oh = iEvent.put( sortedVerticesOutput);
-    auto_ptr< CandToVertex>  pfCandToVertexOutput( new CandToVertex(oh) );
-    auto_ptr< CandToVertexQuality>  pfCandToVertexQualityOutput( new CandToVertexQuality() );
+    edm::OrphanHandle<reco::VertexCollection> oh = iEvent.put(std::move(sortedVerticesOutput));
+    unique_ptr< CandToVertex>  pfCandToVertexOutput( new CandToVertex(oh) );
+    unique_ptr< CandToVertexQuality>  pfCandToVertexQualityOutput( new CandToVertexQuality() );
     CandToVertex::Filler cand2VertexFiller(*pfCandToVertexOutput);
     CandToVertexQuality::Filler cand2VertexQualityFiller(*pfCandToVertexQualityOutput);
 
@@ -248,23 +248,23 @@ using namespace reco;
 
     cand2VertexFiller.fill();
     cand2VertexQualityFiller.fill();
-    iEvent.put( pfCandToVertexOutput );
-    iEvent.put( pfCandToVertexQualityOutput );
+    iEvent.put(std::move(pfCandToVertexOutput ));
+    iEvent.put(std::move(pfCandToVertexQualityOutput ));
 
-    auto_ptr< VertexScore>  vertexScoreOutput( new VertexScore );
+    unique_ptr< VertexScore>  vertexScoreOutput( new VertexScore );
     VertexScore::Filler vertexScoreFiller(*vertexScoreOutput);
     vertexScoreFiller.insert(oh,vertexScore.begin(),vertexScore.end());
     vertexScoreFiller.fill();
-    iEvent.put( vertexScoreOutput);
+    iEvent.put(std::move(vertexScoreOutput));
 
 
   }
 
 
-  auto_ptr< PFCollection >  pfCollectionNOPUOriginalOutput( new PFCollection );
-  auto_ptr< PFCollection >  pfCollectionNOPUOutput( new PFCollection );
-  auto_ptr< PFCollection >  pfCollectionPUOriginalOutput( new PFCollection );
-  auto_ptr< PFCollection >  pfCollectionPUOutput( new PFCollection );
+  unique_ptr< PFCollection >  pfCollectionNOPUOriginalOutput( new PFCollection );
+  unique_ptr< PFCollection >  pfCollectionNOPUOutput( new PFCollection );
+  unique_ptr< PFCollection >  pfCollectionPUOriginalOutput( new PFCollection );
+  unique_ptr< PFCollection >  pfCollectionPUOutput( new PFCollection );
 
   for(size_t i=0;i<particles.size();i++) {
     auto pv = pfToPVVector[i];
@@ -288,10 +288,10 @@ using namespace reco;
                    pfCollectionPUOriginalOutput->push_back(particles[i]);
 
   }              
-  if(producePFNoPileUp_ && produceSortedVertices_) iEvent.put(pfCollectionNOPUOutput,"NoPileUp" );
-  if(producePFPileUp_ && produceSortedVertices_) iEvent.put(pfCollectionPUOutput, "PileUp");
-  if(producePFNoPileUp_ && produceOriginalMapping_) iEvent.put(pfCollectionNOPUOriginalOutput,"originalNoPileUp" );
-  if(producePFPileUp_ && produceOriginalMapping_) iEvent.put(pfCollectionPUOriginalOutput,"originalPileUp" );
+  if(producePFNoPileUp_ && produceSortedVertices_) iEvent.put(std::move(pfCollectionNOPUOutput),"NoPileUp" );
+  if(producePFPileUp_ && produceSortedVertices_) iEvent.put(std::move(pfCollectionPUOutput), "PileUp");
+  if(producePFNoPileUp_ && produceOriginalMapping_) iEvent.put(std::move(pfCollectionNOPUOriginalOutput),"originalNoPileUp" );
+  if(producePFPileUp_ && produceOriginalMapping_) iEvent.put(std::move(pfCollectionPUOriginalOutput),"originalPileUp" );
   
 
 } 

--- a/CommonTools/RecoAlgos/src/CandidateProducer.h
+++ b/CommonTools/RecoAlgos/src/CandidateProducer.h
@@ -92,7 +92,7 @@ private:
     evt.getByToken(srcToken_, src);
     Init::init(selector_, evt, es);
     ::helper::MasterCollection<TColl> master(src, evt);
-    std::auto_ptr<CColl> cands(new CColl);
+    std::unique_ptr<CColl> cands(new CColl);
     if(src->size()!= 0) {
       size_t size = src->size();
       cands->reserve(size);
@@ -101,7 +101,7 @@ private:
 	  Creator::create(master.index(idx), *cands, master, converter_);
       }
     }
-    evt.put(cands);
+    evt.put(std::move(cands));
   }
   /// label of source collection and tag
   edm::EDGetTokenT<TColl> srcToken_;

--- a/CommonTools/RecoAlgos/src/MuonSelector.cc
+++ b/CommonTools/RecoAlgos/src/MuonSelector.cc
@@ -200,19 +200,19 @@ namespace helper
     MuonCollectionStoreManager::
     put( edm::Event & evt ) {
       edm::OrphanHandle<reco::MuonCollection> h;
-      h = evt.put( selMuons_ , "SelectedMuons");
-      evt.put( selTracks_ , "TrackerOnly");
-      evt.put( selTracksExtras_ , "TrackerOnly");
-      evt.put( selTracksHits_ ,"TrackerOnly");
-      evt.put( selGlobalMuonTracks_,"GlobalMuon" );
-      evt.put( selGlobalMuonTracksExtras_ ,"GlobalMuon");
-      evt.put( selGlobalMuonTracksHits_,"GlobalMuon" );
-      evt.put( selStandAloneTracks_ ,"StandAlone");
-      evt.put( selStandAloneTracksExtras_ ,"StandAlone");
-      evt.put( selStandAloneTracksHits_ ,"StandAlone");
+      h = evt.put(std::move(selMuons_), "SelectedMuons");
+      evt.put(std::move(selTracks_), "TrackerOnly");
+      evt.put(std::move(selTracksExtras_), "TrackerOnly");
+      evt.put(std::move(selTracksHits_),"TrackerOnly");
+      evt.put(std::move(selGlobalMuonTracks_),"GlobalMuon" );
+      evt.put(std::move(selGlobalMuonTracksExtras_),"GlobalMuon");
+      evt.put(std::move(selGlobalMuonTracksHits_),"GlobalMuon" );
+      evt.put(std::move(selStandAloneTracks_),"StandAlone");
+      evt.put(std::move(selStandAloneTracksExtras_),"StandAlone");
+      evt.put(std::move(selStandAloneTracksHits_),"StandAlone");
       if (cloneClusters()) {
-          evt.put( selStripClusters_ );
-          evt.put( selPixelClusters_ );
+          evt.put(std::move(selStripClusters_));
+          evt.put(std::move(selPixelClusters_));
       }
       return h; 
      

--- a/CommonTools/RecoAlgos/src/TrackSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackSelector.cc
@@ -64,11 +64,11 @@ namespace helper
   TrackCollectionStoreManager::
   put( edm::Event & evt ) {
     edm::OrphanHandle<reco::TrackCollection> 
-      h = evt.put( selTracks_ );
-    evt.put( selTrackExtras_ );
-    evt.put( selHits_ );
-    evt.put( selStripClusters_ );
-    evt.put( selPixelClusters_ );
+      h = evt.put(std::move(selTracks_));
+    evt.put(std::move(selTrackExtras_));
+    evt.put(std::move(selHits_));
+    evt.put(std::move(selStripClusters_));
+    evt.put(std::move(selPixelClusters_));
     return h; 
   }
   

--- a/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
@@ -54,7 +54,7 @@ class PFCand_AssoMapAlgos : public PF_PU_AssoMapAlgos  {
    std::auto_ptr<VertexToPFCandAssMap> CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
 
    //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
-   std::auto_ptr<PFCandToVertexAssMap> SortPFCandAssociationMap(PFCandToVertexAssMap*,
+   std::unique_ptr<PFCandToVertexAssMap> SortPFCandAssociationMap(PFCandToVertexAssMap*,
                                                                 edm::EDProductGetter const* getter);
 
  protected:

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -98,7 +98,7 @@ class PF_PU_AssoMapAlgos{
    std::auto_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
 
    //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
-   std::auto_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*);
+   std::unique_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*);
 
  protected:
   //protected functions

--- a/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
@@ -87,13 +87,13 @@ PFCand_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	PFCand_AssoMapAlgos::GetInputCollections(iEvent,iSetup);
 
 	if ( ( asstype == "PFCandsToVertex" ) || ( asstype == "Both" ) ) {
-  	  auto_ptr<PFCandToVertexAssMap> PFCand2Vertex = CreatePFCandToVertexMap(pfCandH, iSetup);
+	  unique_ptr<PFCandToVertexAssMap> PFCand2Vertex = CreatePFCandToVertexMap(pfCandH, iSetup);
 	  iEvent.put( SortPFCandAssociationMap( &(*PFCand2Vertex), &iEvent.productGetter() ) );
 	}
 
 	if ( ( asstype == "VertexToPFCands" ) || ( asstype == "Both" ) ) {
-  	  auto_ptr<VertexToPFCandAssMap> Vertex2PFCand = CreateVertexToPFCandMap(pfCandH, iSetup);
-  	  iEvent.put( Vertex2PFCand );
+	  unique_ptr<VertexToPFCandAssMap> Vertex2PFCand = CreateVertexToPFCandMap(pfCandH, iSetup);
+	  iEvent.put(std::move(Vertex2PFCand));
 	}
 
 }

--- a/CommonTools/RecoUtils/plugins/PFCand_NoPU_WithAM.cc
+++ b/CommonTools/RecoUtils/plugins/PFCand_NoPU_WithAM.cc
@@ -92,8 +92,8 @@ void
 PFCand_NoPU_WithAM::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-	auto_ptr<PFCandidateCollection> p2v_firstvertex(new PFCandidateCollection() );
-	auto_ptr<PFCandidateCollection> v2p_firstvertex(new PFCandidateCollection() );
+	unique_ptr<PFCandidateCollection> p2v_firstvertex(new PFCandidateCollection() );
+	unique_ptr<PFCandidateCollection> v2p_firstvertex(new PFCandidateCollection() );
 
 	bool p2vassmap = false;
 	bool v2passmap = false;
@@ -149,7 +149,7 @@ PFCand_NoPU_WithAM::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	  }
 
-          iEvent.put( p2v_firstvertex, "P2V" );
+          iEvent.put(std::move(p2v_firstvertex), "P2V" );
 
 	}
 
@@ -180,7 +180,7 @@ PFCand_NoPU_WithAM::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	  }
 
-          iEvent.put( v2p_firstvertex, "V2P" );
+          iEvent.put(std::move(v2p_firstvertex), "V2P" );
 
 	}
 }

--- a/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
@@ -86,13 +86,13 @@ PF_PU_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	PF_PU_AssoMapAlgos::GetInputCollections(iEvent,iSetup);
 
 	if ( ( asstype == "TracksToVertex" ) || ( asstype == "Both" ) ) {
-  	  auto_ptr<TrackToVertexAssMap> Track2Vertex = CreateTrackToVertexMap(trkcollH, iSetup);
+	  unique_ptr<TrackToVertexAssMap> Track2Vertex = CreateTrackToVertexMap(trkcollH, iSetup);
   	  iEvent.put( SortAssociationMap( &(*Track2Vertex) ) );
 	}
 
 	if ( ( asstype == "VertexToTracks" ) || ( asstype == "Both" ) ) {
-  	  auto_ptr<VertexToTrackAssMap> Vertex2Track = CreateVertexToTrackMap(trkcollH, iSetup);
-  	  iEvent.put( Vertex2Track );
+	  unique_ptr<VertexToTrackAssMap> Vertex2Track = CreateVertexToTrackMap(trkcollH, iSetup);
+	  iEvent.put(std::move(Vertex2Track));
 	}
 
 }

--- a/CommonTools/RecoUtils/plugins/PF_PU_FirstVertexTracks.cc
+++ b/CommonTools/RecoUtils/plugins/PF_PU_FirstVertexTracks.cc
@@ -104,8 +104,8 @@ void
 PF_PU_FirstVertexTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-	auto_ptr<TrackCollection> t2v_firstvertextracks(new TrackCollection() );
-	auto_ptr<TrackCollection> v2t_firstvertextracks(new TrackCollection() );
+	unique_ptr<TrackCollection> t2v_firstvertextracks(new TrackCollection() );
+	unique_ptr<TrackCollection> v2t_firstvertextracks(new TrackCollection() );
 
 	bool t2vassmap = false;
 	bool v2tassmap = false;
@@ -167,7 +167,7 @@ PF_PU_FirstVertexTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
 	  }
 
-          iEvent.put( t2v_firstvertextracks, "T2V" );
+          iEvent.put(std::move(t2v_firstvertextracks), "T2V" );
 
 	}
 
@@ -208,7 +208,7 @@ PF_PU_FirstVertexTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
 	  }
 
-          iEvent.put( v2t_firstvertextracks, "V2T" );
+          iEvent.put(std::move(v2t_firstvertextracks), "V2T" );
 
 	}
 

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -177,12 +177,12 @@ PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollec
 /* create the vertex to pf candidate association map                                 */
 /*************************************************************************************/
 
-std::auto_ptr<PFCandToVertexAssMap>
+std::unique_ptr<PFCandToVertexAssMap>
 PFCand_AssoMapAlgos::SortPFCandAssociationMap(PFCandToVertexAssMap* pfcvertexassInput,
                                               edm::EDProductGetter const* getter)
 {
 	//create a new PFCandVertexAssMap for the Output which will be sorted
-	auto_ptr<PFCandToVertexAssMap> pfcvertexassOutput(new PFCandToVertexAssMap(getter) );
+	unique_ptr<PFCandToVertexAssMap> pfcvertexassOutput(new PFCandToVertexAssMap(getter) );
 
 	//Create and fill a vector of pairs of vertex and the summed (pT)**2 of the pfcandidates associated to the vertex
 	VertexPtsumVector vertexptsumvector;

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -209,11 +209,11 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
 /* function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2  */
 /*****************************************************************************************/
 
-auto_ptr<TrackToVertexAssMap>
+unique_ptr<TrackToVertexAssMap>
 PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput)
 {
 	//create a new TrackVertexAssMap for the Output which will be sorted
-     	auto_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap() );
+	unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap() );
 
 	//Create and fill a vector of pairs of vertex and the summed (pT-pT_Error)**2 of the tracks associated to the vertex
 	VertexPtsumVector vertexptsumvector;

--- a/CommonTools/TriggerUtils/plugins/CandidateTriggerObjectProducer.cc
+++ b/CommonTools/TriggerUtils/plugins/CandidateTriggerObjectProducer.cc
@@ -64,7 +64,7 @@ CandidateTriggerObjectProducer::produce(edm::Event & iEvent, const edm::EventSet
   using namespace reco;
   using namespace trigger;
 
-  std::auto_ptr<reco::CandidateCollection> coll( new reco::CandidateCollection );
+  std::unique_ptr<reco::CandidateCollection> coll( new reco::CandidateCollection );
 
   // get event products
   iEvent.getByToken(triggerResultsToken_,triggerResultsHandle_);
@@ -168,7 +168,7 @@ CandidateTriggerObjectProducer::produce(edm::Event & iEvent, const edm::EventSet
     }
 
 
-  iEvent.put(coll);
+  iEvent.put(std::move(coll));
   return;
 }
 

--- a/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
+++ b/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
@@ -43,7 +43,7 @@ void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::Event& evt, co
   Handle<am_t> am;
   evt.getByToken(am_, am);
 
-  auto_ptr<as_t> as(new as_t);
+  unique_ptr<as_t> as(new as_t);
   typename as_t::Filler filler(*as);
   filler.fill();
   size_t size = am->size();
@@ -53,7 +53,7 @@ void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::Event& evt, co
     indices.push_back(i->val.key());
   }
   filler.insert(am->refProd().key, indices.begin(), indices.end());
-  evt.put(as);
+  evt.put(std::move(as));
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
@@ -44,7 +44,7 @@ void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::Event& evt, cons
   Handle<av_t> av;
   evt.getByToken(av_, av);
 
-  auto_ptr<vm_t> vm(new vm_t);
+  unique_ptr<vm_t> vm(new vm_t);
   typename vm_t::Filler filler(*vm);
   filler.fill();
   size_t size = av->size();
@@ -54,7 +54,7 @@ void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::Event& evt, cons
     values.push_back(i->second);
   }
   filler.insert(av->keyProduct(), values.begin(), values.end());
-  evt.put(vm);
+  evt.put(std::move(vm));
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
@@ -48,7 +48,7 @@ void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::prod
   using namespace std;
   Handle<association_t> association;
   evt.getByToken(associationToken_, association);
-  auto_ptr<collection_t> selected(new collection_t);
+  unique_ptr<collection_t> selected(new collection_t);
   vector<typename CVal::value_type> selectedValues;
   size_t size = association->size();
   selected->reserve(size);
@@ -65,12 +65,12 @@ void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::prod
   // new association must be created after the
   // selected collection is full because it uses the size
   KeyRefProd ref = evt.getRefBeforePut<collection_t>();
-  auto_ptr<association_t> selectedAssociation(new association_t(ref, selected.get()));
+  unique_ptr<association_t> selectedAssociation(new association_t(ref, selected.get()));
   size = selected->size();
-  OrphanHandle<collection_t> oh = evt.put(selected);
+  OrphanHandle<collection_t> oh = evt.put(std::move(selected));
   for(size_t i = 0; i != size; ++i)
     selectedAssociation->setValue(i, selectedValues[i]);
-  evt.put(selectedAssociation);
+  evt.put(std::move(selectedAssociation));
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/CollectionAdder.h
+++ b/CommonTools/UtilAlgos/interface/CollectionAdder.h
@@ -24,14 +24,14 @@ public:
 private:
   std::vector<edm::EDGetTokenT<collection>> srcTokens_;
   void produce(edm::Event & evt, const edm::EventSetup&) override {
-    std::auto_ptr<collection> coll(new collection);
+    std::unique_ptr<collection> coll(new collection);
     typename collection::Filler filler(*coll);
     for(size_t i = 0; i < srcTokens_.size(); ++i ) {
       edm::Handle<collection> src;
       evt.getByToken(srcTokens_[i], src);
       *coll += *src;
     }
-    evt.put(coll);
+    evt.put(std::move(coll));
   }
 };
 

--- a/CommonTools/UtilAlgos/interface/FwdPtrCollectionFilter.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrCollectionFilter.h
@@ -51,9 +51,9 @@ namespace edm {
 
     virtual bool filter(edm::Event & iEvent, const edm::EventSetup& iSetup){
 
-      std::auto_ptr< std::vector< edm::FwdPtr<T> > > pOutput ( new std::vector<edm::FwdPtr<T> > );
+      std::unique_ptr< std::vector< edm::FwdPtr<T> > > pOutput ( new std::vector<edm::FwdPtr<T> > );
 
-      std::auto_ptr< std::vector<T> > pClones ( new std::vector<T> );
+      std::unique_ptr< std::vector<T> > pClones ( new std::vector<T> );
 
 
       edm::Handle< std::vector< edm::FwdPtr<T> > > hSrcAsFwdPtr;
@@ -94,9 +94,9 @@ namespace edm {
       }
 
       bool pass = pOutput->size() > 0;
-      iEvent.put( pOutput );
+      iEvent.put(std::move(pOutput));
       if ( makeClones_ )
-	iEvent.put( pClones );
+	iEvent.put(std::move(pClones));
       if ( filter_ )
 	return pass;
       else

--- a/CommonTools/UtilAlgos/interface/FwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrProducer.h
@@ -39,7 +39,7 @@ namespace edm {
       edm::Handle< edm::View<T> > hSrc;
       iEvent.getByToken( srcToken_, hSrc );
 
-      std::auto_ptr< std::vector< edm::FwdPtr<T> > > pOutputFwdPtr ( new std::vector<edm::FwdPtr<T> > );
+      std::unique_ptr< std::vector< edm::FwdPtr<T> > > pOutputFwdPtr ( new std::vector<edm::FwdPtr<T> > );
 
       for ( typename edm::View<T>::const_iterator ibegin = hSrc->begin(),
 	      iend = hSrc->end(),
@@ -50,7 +50,7 @@ namespace edm {
       }
 
 
-      iEvent.put( pOutputFwdPtr );
+      iEvent.put(std::move(pOutputFwdPtr));
     }
 
   protected :

--- a/CommonTools/UtilAlgos/interface/Matcher.h
+++ b/CommonTools/UtilAlgos/interface/Matcher.h
@@ -94,7 +94,7 @@ namespace reco {
       typedef typename MatchMap::ref_type ref_type;
       typedef typename ref_type::key_type key_ref_type;
       typedef typename ref_type::value_type value_ref_type;
-      auto_ptr<MatchMap> matchMap( new MatchMap( ref_type( key_ref_type( cands ),
+      unique_ptr<MatchMap> matchMap( new MatchMap( ref_type( key_ref_type( cands ),
 							   value_ref_type( matched ) ) ) );
       for( size_t c = 0; c != cands->size(); ++ c ) {
 	const T1 & cand = (*cands)[ c ];
@@ -113,7 +113,7 @@ namespace reco {
 	  matchMap->insert( edm::getRef( cands, c ), edm::getRef( matched, mMin ) );
 	}
       }
-      evt.put( matchMap );
+      evt.put(std::move(matchMap));
     }
 
   }

--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -56,7 +56,7 @@ Merger<InputCollection, OutputCollection, P>::~Merger() {
 
 template<typename InputCollection, typename OutputCollection, typename P>
 void Merger<InputCollection, OutputCollection, P>::produce( edm::Event& evt, const edm::EventSetup&) {
-  std::auto_ptr<OutputCollection> coll( new OutputCollection );
+  std::unique_ptr<OutputCollection> coll( new OutputCollection );
   for( typename vtoken::const_iterator s = srcToken_.begin(); s != srcToken_.end(); ++ s ) {
     edm::Handle<InputCollection> h;
     evt.getByToken( * s, h );
@@ -64,7 +64,7 @@ void Merger<InputCollection, OutputCollection, P>::produce( edm::Event& evt, con
       coll->push_back( P::clone( * c ) );
     }
   }
-  evt.put( coll );
+  evt.put(std::move(coll));
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/NewMatcher.h
+++ b/CommonTools/UtilAlgos/interface/NewMatcher.h
@@ -74,7 +74,7 @@ namespace reco {
       evt.getByToken(matchedToken_, matched);
       Handle<C1> cands;
       evt.getByToken(srcToken_, cands);
-      auto_ptr<MatchMap> matchMap(new MatchMap(matched));
+      unique_ptr<MatchMap> matchMap(new MatchMap(matched));
       size_t size = cands->size();
       if( size != 0 ) {
 	typename MatchMap::Filler filler(*matchMap);
@@ -99,7 +99,7 @@ namespace reco {
 	filler.insert(master.get(), indices.begin(), indices.end());
 	filler.fill();
       }
-      evt.put(matchMap);
+      evt.put(std::move(matchMap));
     }
 
   }

--- a/CommonTools/UtilAlgos/interface/NtpProducer.h
+++ b/CommonTools/UtilAlgos/interface/NtpProducer.h
@@ -72,25 +72,25 @@ void NtpProducer<C>::produce( edm::Event& iEvent, const edm::EventSetup&) {
    edm::Handle<C> coll;
    iEvent.getByToken(srcToken_, coll);
    if(eventInfo_){
-     std::auto_ptr<edm::EventNumber_t> event( new edm::EventNumber_t );
-     std::auto_ptr<unsigned int> run( new unsigned int );
-     std::auto_ptr<unsigned int> lumi( new unsigned int );
+     std::unique_ptr<edm::EventNumber_t> event( new edm::EventNumber_t );
+     std::unique_ptr<unsigned int> run( new unsigned int );
+     std::unique_ptr<unsigned int> lumi( new unsigned int );
      *event = iEvent.id().event();
      *run = iEvent.id().run();
      *lumi = iEvent.luminosityBlock();
-     iEvent.put( event, prefix_ + "EventNumber" );
-     iEvent.put( run, prefix_ + "RunNumber" );
-     iEvent.put( lumi, prefix_ + "LumiBlock" );
+     iEvent.put(std::move(event), prefix_ + "EventNumber" );
+     iEvent.put(std::move(run), prefix_ + "RunNumber" );
+     iEvent.put(std::move(lumi), prefix_ + "LumiBlock" );
    }
    typename std::vector<std::pair<std::string, StringObjectFunction<typename C::value_type> > >::const_iterator
      q = tags_.begin(), end = tags_.end();
    for(;q!=end; ++q) {
-     std::auto_ptr<std::vector<float> > x(new std::vector<float>);
+     std::unique_ptr<std::vector<float> > x(new std::vector<float>);
      x->reserve(coll->size());
      for (typename C::const_iterator elem=coll->begin(); elem!=coll->end(); ++elem ) {
        x->push_back(q->second(*elem));
      }
-     iEvent.put(x, q->first);
+     iEvent.put(std::move(x), q->first);
    }
 }
 

--- a/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
+++ b/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
@@ -117,7 +117,7 @@ namespace reco {
     Handle<C1> cands;
     evt.getByToken(srcToken_, cands);
     // create product
-    auto_ptr<MatchMap> matchMap(new MatchMap(matched));
+    unique_ptr<MatchMap> matchMap(new MatchMap(matched));
     size_t size = cands->size();
     if( size != 0 ) {
       //
@@ -189,7 +189,7 @@ namespace reco {
       filler.insert(master.get(), indices.begin(), indices.end());
       filler.fill();
     }
-    evt.put(matchMap);
+    evt.put(std::move(matchMap));
   }
 
 }

--- a/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
@@ -40,7 +40,7 @@ namespace edm {
       edm::Handle< std::vector<edm::FwdPtr<T> > > hSrc;
       iEvent.getByToken( srcToken_, hSrc );
 
-      std::auto_ptr< std::vector<T> > pOutput ( new std::vector<T> );
+      std::unique_ptr< std::vector<T> > pOutput ( new std::vector<T> );
 
       for ( typename std::vector< edm::FwdPtr<T> >::const_iterator ibegin = hSrc->begin(),
 	      iend = hSrc->end(),
@@ -51,7 +51,7 @@ namespace edm {
       }
 
 
-      iEvent.put( pOutput );
+      iEvent.put(std::move(pOutput));
     }
 
   protected :

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -82,7 +82,7 @@ namespace helper {
       }
     }
     edm::OrphanHandle<collection> put( edm::Event & evt ) {
-      return evt.put( std::move(selected_) );
+      return evt.put(std::move(selected_));
     }
     size_t size() const { return selected_->size(); }
   private:

--- a/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
@@ -28,8 +28,8 @@ value_( cfg.getParameter<double>( "value" ) ){
 }
 
 void DoubleProducer::produce( Event & evt, const EventSetup & ) {
-  auto_ptr<double> value( new double( value_ ) );
-  evt.put( value );
+  unique_ptr<double> value( new double( value_ ) );
+  evt.put(std::move(value));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
@@ -81,9 +81,9 @@ void
 EventCountProducer::endLuminosityBlockProduce(LuminosityBlock & theLuminosityBlock, const EventSetup & theSetup) {
   LogTrace("EventCounting") << "endLumi: adding " << eventsProcessedInLumi_ << " events" << endl;
 
-  auto_ptr<edm::MergeableCounter> numEventsPtr(new edm::MergeableCounter);
+  unique_ptr<edm::MergeableCounter> numEventsPtr(new edm::MergeableCounter);
   numEventsPtr->value = eventsProcessedInLumi_;
-  theLuminosityBlock.put(numEventsPtr);
+  theLuminosityBlock.put(std::move(numEventsPtr));
 
   return;
 }


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in CommonTools (which is used by both reco and analysis)  to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in CommonTools may also have been changed to std::unique_ptr.
