### PR TITLE
Update Global Tag for Collisions2016_v1 L1T menu and splitting Ecal Pedestal tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,33 +10,33 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v12',
+    'run2_design'       :   '80X_mcRun2_design_v13',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v12',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v13',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v12',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v13',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v11',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v12',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v8',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v13',
+    'run1_data'         :   '80X_dataRun2_v14',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v13',
+    'run2_data'         :   '80X_dataRun2_v14',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v11',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v9',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v10',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v11',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v12',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_v3',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '80X_dataRun2_relval_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v11',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v8',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v9',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v7',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '80X_upgrade2017_design_v11',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v13) as [80X_mcRun2_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v13/80X_mcRun2_design_v12): 
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v12) as [80X_mcRun2cosmics_startup_peak_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v12/80X_mcRun2cosmics_startup_peak_v11): 
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v13) as [80X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v13/80X_mcRun2_asymptotic_v12): 
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
- **RunII Startup scenario** : [80X_mcRun2_startup_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v13) as [80X_mcRun2_startup_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v13/80X_mcRun2_startup_v12): 
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
## RunII data
- **RunII HLTHI processing** : [80X_dataRun2_HLTHI_frozen_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v9) as [80X_dataRun2_HLTHI_frozen_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v9/80X_dataRun2_HLTHI_frozen_v7): 
  - new tag for DT and CSC Alignment errors (allow updates via append IOV with hlt synchronization)
  - updated AK4CaloHLT JEC with L2L3 residuals for [CMSHLT-518](https://its.cern.ch/jira/browse/CMSHLT-518)
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v12) as [80X_dataRun2_HLT_frozen_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v12/80X_dataRun2_HLT_frozen_v11): 
  -  new tag for DT and CSC Alignment errors (allow updates via append IOV with hlt synchronization)
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v10) as [80X_dataRun2_HLT_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v9/80X_dataRun2_HLT_relval_v8): 
  - new tag for DT and CSC Alignment errors (allow updates via append IOV with hlt synchronization)
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
- **RunII Offline processing** : [80X_dataRun2_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v14) as [80X_dataRun2_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v14/80X_dataRun2_v13): 
  - split Ecal pedestal tags as agreed in [AlCa meeting](https://indico.cern.ch/event/523683/contributions/2145029/attachments/1263035/1868225/AlCaDB-v12.pdf) to ease validation procedure
- **RunII Offline relval processing** : [80X_dataRun2_relval_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v11) as [80X_dataRun2_relval_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v11/80X_dataRun2_relval_v9): 
  - update uGT L1 menu to `L1Menu_Collisions2016_v1_xml`
  - split Ecal pedestal tags as agreed in [AlCa meeting](https://indico.cern.ch/event/523683/contributions/2145029/attachments/1263035/1868225/AlCaDB-v12.pdf) to ease validation procedure
