### PR TITLE
Fix use of std::unique_ptr in HadronizerFilter

### DIFF
--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -222,7 +222,10 @@ namespace edm
       //
       if ( decayer_ ) 
       {
-        event.reset( decayer_->decay( event.get(),lheEvent ) );
+        auto t = decayer_->decay( event.get(),lheEvent );
+        if(t != event.get()) {
+          event.reset(t);
+        }
       }
 
       if ( !event.get() ) continue;


### PR DESCRIPTION
When the HadronizerFilter was changed to use unique_ptr from auto_ptr a
key difference between the two was missed. the method 'reset' on an auto_ptr
appears to check to see if the new value is the same as the old value and if it
is it does nothing. This does not appear to be the case for unique_ptr.
Changing the code to explicitly look for that case fixed the bug seen.
