### PR TITLE
Bugfix Check L1T Global Scale Range

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -404,11 +404,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 {
 
 
-    int minEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - m_emulateBxInEvent;
-    int maxEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - 1;		   
 
-    int minL1DataBxInEvent = (m_L1DataBxInEvent + 1)/2 - m_L1DataBxInEvent;
-    int maxL1DataBxInEvent = (m_L1DataBxInEvent + 1)/2 - 1;
 
 
     // process event iEvent
@@ -443,7 +439,10 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 	// taus
         m_nrL1Tau= data->numberL1Tau();
 
-
+	if (m_L1DataBxInEvent < 1) m_L1DataBxInEvent=1;
+	int minL1DataBxInEvent = (m_L1DataBxInEvent + 1)/2 - m_L1DataBxInEvent;
+	int maxL1DataBxInEvent = (m_L1DataBxInEvent + 1)/2 - 1;
+	
         // Initialize Board
         m_uGtBrd->init(m_numberPhysTriggers, m_nrL1Mu, m_nrL1EG, m_nrL1Tau, m_nrL1Jet, minL1DataBxInEvent, maxL1DataBxInEvent );
 
@@ -452,8 +451,13 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
     }
 
-
-
+    if (m_emulateBxInEvent < 0) {
+      m_emulateBxInEvent = m_totalBxInEvent;
+    }
+    
+    if (m_emulateBxInEvent < 1) m_emulateBxInEvent=1;
+    int minEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - m_emulateBxInEvent;
+    int maxEmulBxInEvent = (m_emulateBxInEvent + 1)/2 - 1;		   
 
     // get / update the trigger menu from the EventSetup
     // local cache & check on cacheIdentifier

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -416,6 +416,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		if(etaBin0<0) etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0; //twos complement		
 //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
 		
+		int ssize = m_gtScales->getMUScales().etBins.size();
+		if (etIndex0 >= ssize){ 
+		  etIndex0 = ssize-1; 			  
+		  edm::LogWarning("L1TGlobal") 
+		    << "muon0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+		} 
+		
 		// Determine Floating Pt numbers for floating point caluclation
 		std::pair<double, double> binEdges = m_gtScales->getMUScales().phiBins.at(phiIndex0);
 		phi0Phy = 0.5*(binEdges.second + binEdges.first);
@@ -441,7 +448,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    etaBin0   = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getEGScales().etaBins.size() + etaBin0;
 //		    LogDebug("L1TGlobal") << "EG0 phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0 << " et " << etIndex0 << std::endl;
-		    
+
+		    int ssize = m_gtScales->getEGScales().etBins.size();
+		    if (etIndex0 >= ssize){ 
+		      etIndex0 = ssize-1; 			  
+		      edm::LogWarning("L1TGlobal") 
+			<< "EG0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+		    } 
+	    
 		    // Determine Floating Pt numbers for floating point caluclation
 		    std::pair<double, double> binEdges = m_gtScales->getEGScales().phiBins.at(phiIndex0);
 		    phi0Phy = 0.5*(binEdges.second + binEdges.first);					    
@@ -461,6 +475,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getJETScales().etaBins.size() + etaBin0;
 
+		    int ssize = m_gtScales->getJETScales().etBins.size();
+		    if (etIndex0 >= ssize){ 
+		      //edm::LogWarning("L1TGlobal") 
+		      //<< "jet0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+		      etIndex0 = ssize-1; 			  
+		    } 
 		    
 		    // Determine Floating Pt numbers for floating point caluclation
 		    std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex0);
@@ -479,6 +499,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getTAUScales().etaBins.size() + etaBin0;
+
+		    int ssize = m_gtScales->getTAUScales().etBins.size();
+		    if (etIndex0 >= ssize){ 		      
+		      etIndex0 = ssize-1; 			  
+		      edm::LogWarning("L1TGlobal") 
+			<< "tau0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+		    } 
 
 		    
 		    // Determine Floating Pt numbers for floating point caluclation
@@ -650,6 +677,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   if(etaBin1<0) etaBin1 = m_gtScales->getMUScales().etaBins.size() + etaBin1;	   
 //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
 		   
+		   int ssize = m_gtScales->getMUScales().etBins.size();
+		   if (etIndex1 >= ssize){ 
+		     edm::LogWarning("L1TGlobal") 
+		       << "muon2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
+		     etIndex1 = ssize-1; 			  
+		   } 
+
 		   // Determine Floating Pt numbers for floating point caluclation
 		   std::pair<double, double> binEdges = m_gtScales->getMUScales().phiBins.at(phiIndex1);
 		   phi1Phy = 0.5*(binEdges.second + binEdges.first);
@@ -669,6 +703,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1   =   etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getEGScales().etaBins.size() + etaBin1;
+
+			int ssize = m_gtScales->getEGScales().etBins.size();
+			if (etIndex1 >= ssize){ 
+			  edm::LogWarning("L1TGlobal") 
+			    << "EG1 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
+			  etIndex1 = ssize-1; 			  
+			} 
 			
 			// Determine Floating Pt numbers for floating point caluclation
 		   	std::pair<double, double> binEdges = m_gtScales->getEGScales().phiBins.at(phiIndex1);
@@ -687,12 +728,21 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getJETScales().etaBins.size() + etaBin1;
-			
+						
+			int ssize = m_gtScales->getJETScales().etBins.size();
+			assert(ssize);
+			if (etIndex1 >= ssize){ 			  
+			  //edm::LogWarning("L1TGlobal") 
+			  //<< "jet2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
+			  etIndex1 = ssize-1; 			  
+			} 
+
 			// Determine Floating Pt numbers for floating point caluclation
 		   	std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex1);
 		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
 			binEdges = m_gtScales->getJETScales().etaBins.at(etaBin1);
 			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
+			//CRASHES HERE:
 			binEdges = m_gtScales->getJETScales().etBins.at(etIndex1);
 			et1Phy = 0.5*(binEdges.second + binEdges.first);
 			lutObj1 = "JET";
@@ -705,6 +755,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getTAUScales().etaBins.size() + etaBin1;
+
+			int ssize = m_gtScales->getTAUScales().etBins.size();
+			if (etIndex1 >= ssize){ 
+			  edm::LogWarning("L1TGlobal") 
+			    << "tau2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
+			  etIndex1 = ssize-1; 			  
+			} 
 						
 			// Determine Floating Pt numbers for floating point caluclation
 		   	std::pair<double, double> binEdges = m_gtScales->getTAUScales().phiBins.at(phiIndex1);


### PR DESCRIPTION
This prevents a crash detected during relvals by truncating hardware ETs that are larger than the physical scale.

This requires further scrutiny by the subsystem experts to see if there is an underlying bug.  As this is a floating point calculation, it is likely already deprecated for the bitwise correct version...

I also added back some range checks that were missing after the merge of latest global.  Perhaps these have no effect, but they were present during my tests, so I am leaving in place for now.  They should be scrutinized as well.
