### PR TITLE
Tracking Fast cleaner during pattern recognition

### DIFF
--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -35,6 +35,9 @@
 // only included for RecHit comparison operator:
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
 
+#include "TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h"
+
+
 // for looper reconstruction
 #include "TrackingTools/GeomPropagators/interface/HelixBarrelCylinderCrossing.h"
 #include "TrackingTools/GeomPropagators/interface/HelixBarrelPlaneCrossingByCircle.h"
@@ -271,25 +274,16 @@ GroupedCkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed& seed,
   groupedLimitedCandidates(seed, startingTraj, regionalCondition, forwardPropagator(seed), inOut, work_);
   if ( work_.empty() )  return startingTraj;
 
-  /*  rebuilding is de-coupled from standard building
-  //
-  // try to additional hits in the seeding region
-  //
-  if ( theMinNrOfHitsForRebuild>0 ) {
-    // reverse direction
-    //thePropagator->setPropagationDirection(oppositeDirection(seed.direction()));
-    // rebuild part of the trajectory
-    rebuildSeedingRegion(startingTraj,work);
-  }
+  // cleaning now done here...
 
-  */
+  FastTrajectoryCleaner cleaner(theFoundHitBonus,theLostHitPenalty);
+
+  cleaner.clean(work_);
 
   boost::shared_ptr<const TrajectorySeed> pseed(new TrajectorySeed(seed));
-  result.reserve(work_.size());
-  for (TempTrajectoryContainer::const_iterator it = work_.begin(), ed = work_.end(); it != ed; ++it) {
-    result.push_back( it->toTrajectory() ); result.back().setSharedSeed(pseed);
+  for (auto const & it : work_) if (it.isValid()) {
+    result.push_back( it.toTrajectory() ); result.back().setSharedSeed(pseed);
   }
-
   work_.clear(); 
   if (work_.capacity() > work_MaxSize_) {  TempTrajectoryContainer().swap(work_); work_.reserve(work_MaxSize_/2); }
 

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -18,7 +18,7 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
     maxCand = cms.int32(5),
     intermediateCleaning = cms.bool(True),
     # Chi2 added to track candidate if no hit found in layer
-    lostHitPenalty = cms.double(30.0),
+    lostHitPenalty = cms.double(20.0),
     MeasurementTrackerName = cms.string(''),
     lockHits = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
+++ b/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
@@ -19,12 +19,20 @@ class FastTrajectoryCleaner final : public TrajectoryCleaner {
   using	TempTrajectoryContainer = TrajectoryCleaner::TempTrajectoryContainer;
 
   FastTrajectoryCleaner() :
-    validHitBonus_(5.0),
-    missingHitPenalty_(20.0),
+    validHitBonus_(0.5f*5.0f),
+    missingHitPenalty_(20.0f),
     dismissSeed_(true){}
 
+
+  FastTrajectoryCleaner(float bonus, float penalty, bool noSeed=true) :
+    validHitBonus_(0.5f*bonus),
+    missingHitPenalty_(penalty),
+    dismissSeed_(noSeed){}
+
+
+
   FastTrajectoryCleaner(const edm::ParameterSet & iConfig) :
-    validHitBonus_(iConfig.getParameter<double>("ValidHitBonus")),
+    validHitBonus_(0.5*iConfig.getParameter<double>("ValidHitBonus")),
     missingHitPenalty_(iConfig.getParameter<double>("MissingHitPenalty")),
     dismissSeed_(iConfig.getParameter<bool>("dismissSeed")){}
 
@@ -35,7 +43,7 @@ class FastTrajectoryCleaner final : public TrajectoryCleaner {
   void clean(TrajectoryPointerContainer&) const override;
 
  private:
-  float validHitBonus_;
+  float validHitBonus_; // here per dof
   float missingHitPenalty_;
   bool dismissSeed_;
 };

--- a/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
+++ b/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
@@ -1,0 +1,43 @@
+#ifndef TrajectoryCleaning_FastTrajectoryCleaner_h
+#define TrajectoryCleaning_FastTrajectoryCleaner_h
+
+#include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h"
+
+/** A concrete TrajectoryCleaner that assumes all trajectories
+ * coming from the same seed and therefore incompatible
+ *  The "best" trajectory of is kept, the others are invalidated.
+ *  The goodness of a track is defined in terms of Chi^2, number of
+ *  reconstructed hits, and number of lost hits.
+ *  As it can be used during PatternReco there is the option to not consider hits from the common seed
+ */
+
+
+class FastTrajectoryCleaner final : public TrajectoryCleaner {
+ public:
+
+  using TrajectoryPointerContainer = TrajectoryCleaner::TrajectoryPointerContainer;
+  using	TempTrajectoryContainer = TrajectoryCleaner::TempTrajectoryContainer;
+
+  FastTrajectoryCleaner() :
+    validHitBonus_(5.0),
+    missingHitPenalty_(20.0),
+    dismissSeed_(true){}
+
+  FastTrajectoryCleaner(const edm::ParameterSet & iConfig) :
+    validHitBonus_(iConfig.getParameter<double>("ValidHitBonus")),
+    missingHitPenalty_(iConfig.getParameter<double>("MissingHitPenalty")),
+    dismissSeed_(iConfig.getParameter<bool>("dismissSeed")){}
+
+  ~FastTrajectoryCleaner(){}
+
+  TrajectoryCleaner::clean;
+  void clean(TempTrajectoryContainer&) const override;
+  void clean(TrajectoryPointerContainer&) const override;
+
+ private:
+  float validHitBonus_;
+  float missingHitPenalty_;
+  bool dismissSeed_;
+};
+
+#endif

--- a/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
+++ b/TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h
@@ -38,7 +38,6 @@ class FastTrajectoryCleaner final : public TrajectoryCleaner {
 
   ~FastTrajectoryCleaner(){}
 
-  TrajectoryCleaner::clean;
   void clean(TempTrajectoryContainer&) const override;
   void clean(TrajectoryPointerContainer&) const override;
 

--- a/TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h
+++ b/TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h
@@ -2,6 +2,7 @@
 #define TrajectoryCleaning_TrajectoryCleaner_h
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TempTrajectory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 /** The component of track reconstruction that resolves ambiguities 
@@ -19,10 +20,15 @@ class TrajectoryCleaner {
   typedef TrajectoryContainer::iterator TrajectoryIterator;
   typedef TrajectoryPointerContainer::iterator TrajectoryPointerIterator;
 
-  TrajectoryCleaner(){};
-  TrajectoryCleaner(edm::ParameterSet & iConfig){};
-  virtual ~TrajectoryCleaner(){};
+  using   TempTrajectoryContainer = std::vector<TempTrajectory>;
 
+
+
+  TrajectoryCleaner(){}
+  TrajectoryCleaner(edm::ParameterSet & iConfig){}
+  virtual ~TrajectoryCleaner(){}
+
+  virtual void clean( TempTrajectoryContainer&) const;
   virtual void clean( TrajectoryContainer&) const;
   virtual void clean( TrajectoryPointerContainer&) const = 0;
 

--- a/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
@@ -17,7 +17,7 @@ void FastTrajectoryCleaner::clean( TempTrajectoryContainer & tc) const
     // count active degree of freedom
     int dof=0;
     for (auto const & im : pd) {
-      if(im.estimate()==0) continue;
+      if(dismissSeed_ & (im.estimate()==0)) continue;
       auto const & h = im.recHitR();
       if (!h.isValid()) continue;
       dof+=h.dimension();

--- a/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
@@ -28,7 +28,7 @@ void FastTrajectoryCleaner::clean( TempTrajectoryContainer & tc) const
      maxScore = score;
     }
   }
-  assert(bestTr);
+  
   for (auto & it : tc) {
    if ((&it)!=bestTr) it.invalidate();
   }

--- a/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
@@ -1,0 +1,48 @@
+#include "TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h"
+void FastTrajectoryCleaner::clean( TrajectoryPointerContainer & tc) const
+{
+  edm::LogError("FastTrajectoryCleaner") << "not implemented for Trajectory";
+  assert(false);
+}
+
+void FastTrajectoryCleaner::clean( TempTrajectoryContainer & tc) const
+{
+
+  if (tc.size() <= 1) return; // nothing to clean
+  float maxScore= -std::numeric_limits<float>::max();
+  TempTrajectory * bestTr = nullptr;
+  for (auto & it : tc) {
+    if (!it.isValid()) continue;
+    auto const & pd = it.measurements();
+    // count active degree of freedom
+    int dof=0;
+    for (auto const & im : pd) {
+      if(im.estimate()==0) continue;
+      auto const & h = im.recHitR();
+      if (!h.isValid()) continue;
+      dof+=h.dimension();
+    }
+    float score = validHitBonus_*dof - missingHitPenalty_*it.lostHits() - it.chiSquared();
+    if (score>=maxScore) {
+     bestTr = &it;
+     maxScore = score;
+    }
+  }
+  assert(bestTr);
+  for (auto & it : tc) {
+   if ((&it)!=bestTr) it.invalidate();
+  }
+
+
+}
+
+/*
+     auto score = [&](Trajectory const&t)->float {
+            // possible variant under study
+            // auto ns = t.foundHits()-t.trailingFoundHits();
+            //auto penalty =  0.8f*missingHitPenalty_;
+            // return validHitBonus_*(t.foundHits()-0.2f*t.cccBadHits())  - penalty*t.lostHits() - t.chiSquared();
+         // classical score
+         return validHitBonus_*t.foundHits()  - missingHitPenalty_*t.lostHits() - t.chiSquared();
+     };
+*/

--- a/TrackingTools/TrajectoryCleaning/src/TrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/TrajectoryCleaner.cc
@@ -1,7 +1,12 @@
 
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h"
+#include<cassert>
 
-#include "FWCore/Utilities/interface/typelookup.h"
+void TrajectoryCleaner::clean( TempTrajectoryContainer&) const
+{
+  edm::LogError("TrajectoryCleaner") << "not implemented for TempTrajectory";
+  assert(false);
+}
 
 void TrajectoryCleaner::clean( TrajectoryContainer& tc) const
 {
@@ -14,4 +19,6 @@ void TrajectoryCleaner::clean( TrajectoryContainer& tc) const
   clean(thePointerContainer);
 }
 
+
+#include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(TrajectoryCleaner);


### PR DESCRIPTION
This PR introduces a new implementation of the TrajectoryCleaner during pattern reco.
It is much faster of the previous one as it relies on the fact that all trajectories originate from the same seed.
More important it now counts degrees of freedom instead of hits to account for cases a mix of 1D,2D and 4D hits are used during pattern recognition.
It also allows not to count hits that do not contribute to the chi2 (such as seed-hits during in-out)

A small regression may be observed as the lostHitPenalty of the trajectory builder have been lowered to 20 (from 30) to make it consistent with the value used elsewhere.

For the time being it affects only reconstruction using the "GroupedCkfTrajectoryBuilder"
(so, no HLT, Muon )

In future we need to make a massive cleanup of all these "Cleaners"
