### PR TITLE
Properly handle the case where there are more than 10 streams

### DIFF
--- a/FWCore/Concurrency/bin/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/bin/edmStreamStallGrapher.py
@@ -72,7 +72,8 @@ def readLogFile(fileName):
           delayed = False
           if l.find("finished:") != -1:
               trans = kFinished
-          stream = int( l[l.find("stream = ")+9])
+          streamIndex = l.find("stream = ")
+          stream = int( l[streamIndex+9:l.find(" ",streamIndex+10)])
           name = l.split("'")[1]
           if l.find("delayed") != -1:
               delayed = True


### PR DESCRIPTION
Previously log file parser only used the first character of the stream id when converting from a string to a number. This change makes sure to get all the digits.
