### PR TITLE
define RecoFullLocal and use in Phase2 upgrade workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1609,6 +1609,16 @@ for k in upgradeKeys:
     if k2 in PUDataSets:
         upgradeStepDict['RecoFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFull'][k]])
 
+    upgradeStepDict['RecoFullLocal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:localreco',
+                                      '--conditions':gt,
+                                      '--datatier':'GEN-SIM-RECO',
+                                      '-n':'10',
+                                      '--eventcontent':'FEVTDEBUGHLT',
+                                      '--geometry' : geom
+                                      }
+    if cust!=None : upgradeStepDict['RecoFullLocal'][k]['--customise']=cust
+    if era is not None: upgradeStepDict['RecoFullLocal'][k]['--era']=era
+
     upgradeStepDict['RecoFullHGCAL'][k] = {'-s':'RAW2DIGI,L1Reco,RECO',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1563,16 +1563,6 @@ for k in upgradeKeys:
     if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFull'][k]['--era']=era
     
-    upgradeStepDict['DigiFulllocalreco'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,RAW2DIGI,L1Reco,RECO:localreco',
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
-    if cust!=None : upgradeStepDict['DigiFulllocalreco'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['DigiFulllocalreco'][k]['--era']=era
-    
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -98,15 +98,15 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
 # step5 is digi+l1tracktrigger
 # step6 is fastsim
 # step7 is fastsim harvesting
-upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','DigiFulllocalreco','RecoFull','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
+upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','DigiFulllocalreco','RecoFull','RecoFullLocal','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
 
 upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    #'2017':['GenSimFull'],
 		   '2017PU':['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],#full sequence
 		   '2023':['GenSimFull','DigiFull','RecoFull'],#full sequence
-		   '2023tilted':['GenSimFull','DigiFulllocalreco'],#dev scenario
+		   '2023tilted':['GenSimFull','DigiFull','RecoFullLocal'],#dev scenario
 		   '2023sim':['GenSimFull'],#sim scenario
-		   '2023LReco':['GenSimFull','DigiFulllocalreco'],#local reco scneario
+		   '2023LReco':['GenSimFull','DigiFull','RecoFullLocal'],#local reco scenario
 		   '2023Reco':['GenSimFull','DigiFull','RecoFull']#full reco scenario
                    }
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -98,7 +98,7 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
 # step5 is digi+l1tracktrigger
 # step6 is fastsim
 # step7 is fastsim harvesting
-upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','DigiFulllocalreco','RecoFull','RecoFullLocal','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
+upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','RecoFullLocal','RecoFull','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
 
 upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    #'2017':['GenSimFull'],

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -20,8 +20,8 @@ _phase2_hcalLocalRecoSequence.replace(hfreco,hfUpgradeReco)
 _phase2_hcalLocalRecoSequence.replace(hbheprereco,hbheUpgradeReco)
 
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_common.toModify( hbheprereco, digiLabel = cms.InputTag('simHcalDigis','HBHEUpgradeDigiCollection') )
+eras.phase2_common.toModify( hbheUpgradeReco, digiLabel = cms.InputTag('simHcalDigis','HBHEUpgradeDigiCollection') )
 eras.phase2_common.toModify( horeco, digiLabel = cms.InputTag('simHcalDigis') )
-eras.phase2_common.toModify( hfreco, digiLabel = cms.InputTag('simHcalDigis','HFUpgradeDigiCollection') )
+eras.phase2_common.toModify( hfUpgradeReco, digiLabel = cms.InputTag('simHcalDigis','HFUpgradeDigiCollection') )
 eras.phase2_common.toModify( zdcreco, digiLabel = cms.InputTag('simHcalUnsuppressedDigis'), digiLabelhcal = cms.InputTag('simHcalUnsuppressedDigis') )
 eras.phase2_common.toReplaceWith( hcalLocalRecoSequence, _phase2_hcalLocalRecoSequence )


### PR DESCRIPTION
Based on an email discussion with @VinInn, for Phase2 RECO development, it's better to have a separate step3 with (for the moment) RAW2DIGI, L1Reco, RECO:localreco.

Also, this PR fixes a small bug in the HCAL upgrade reco input settings, which wasn't noticeable with the previous workflows combining step2 and step3.
