### PR TITLE
Fix use of std::unique_ptr in GeneratorFilter

### DIFF
--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -132,7 +132,7 @@ namespace edm
     //added for selecting/filtering gen events, in the case of hadronizer+externalDecayer
       
     bool passEvtGenSelector = false;
-    std::auto_ptr<HepMC::GenEvent> event(nullptr);
+    std::unique_ptr<HepMC::GenEvent> event(nullptr);
    
     while(!passEvtGenSelector)
       {
@@ -149,16 +149,19 @@ namespace edm
 	//
 	if ( !hadronizer_.decay() ) return false;
 	
-	event = std::auto_ptr<HepMC::GenEvent>(hadronizer_.getGenEvent());
+	event = std::unique_ptr<HepMC::GenEvent>(hadronizer_.getGenEvent());
 	if ( !event.get() ) return false; 
 	
 	// The external decay driver is being added to the system,
 	// it should be called here
 	//
 	if ( decayer_ ) 
-	  {
-	    event.reset( decayer_->decay( event.get() ) );
-	  }
+	{
+           auto t = decayer_->decay( event.get() );
+           if(t != event.get()) {
+             event.reset(t);
+           }
+	}
 	if ( !event.get() ) return false;
 	
 	passEvtGenSelector = hadronizer_.select( event.get() );


### PR DESCRIPTION
When the GeneratorFilter was changed to use unique_ptr from auto_ptr a
key difference between the two was missed. the method 'reset' on an auto_ptr
appears to check to see if the new value is the same as the old value and if it
is it does nothing. This does not appear to be the case for unique_ptr.
At the time, this difference was not yet understood, so the problem was "fixed" by reverting unique_ptr to auto_ptr. However, this is unsatisfactory in the long run, because if and when the deprecated auto-ptr is changed to unique_ptr, the problem will recur. This PR converts the auto_ptr to unique_ptr and changes the code to explicitly check for the case that caused the problem.
PR #14293 fixed the same problem in HadronizerFilter.
