### PR TITLE
SiPixelMonitorTrack invalid TSOS crash fix

### DIFF
--- a/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
+++ b/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
@@ -76,6 +76,7 @@ TrackerValidationVariables::fillHitQuantities(const Trajectory* trajectory, std:
     if (!itTraj->updatedState().isValid()) continue;
     
     TrajectoryStateOnSurface tsos = tsoscomb( itTraj->forwardPredictedState(), itTraj->backwardPredictedState() );
+    if(!tsos.isValid()) continue;
     TransientTrackingRecHit::ConstRecHitPointer hit = itTraj->recHit();
     
     if(!hit->isValid() || hit->geographicalId().det() != DetId::Tracker) continue;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -419,6 +419,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event& iEvent, const edm::Ev
       }
       //check if extrapolated hit to layer 1 one matches the original hit
       TrajectoryStateOnSurface chkPredTrajState=trajStateComb(tmeasIt->forwardPredictedState(), tmeasIt->backwardPredictedState());
+      if (!chkPredTrajState.isValid()) continue;
       float chkx=chkPredTrajState.globalPosition().x();
       float chky=chkPredTrajState.globalPosition().y();
       float chkz=chkPredTrajState.globalPosition().z();

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -952,6 +952,8 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 	if(! tmeasIt->updatedState().isValid()) continue; 
 	
 	TrajectoryStateOnSurface tsos = tsoscomb( tmeasIt->forwardPredictedState(), tmeasIt->backwardPredictedState() );
+        if (!tsos.isValid()) continue; // Happens rarely, due to singular matrix or similar
+
 	TransientTrackingRecHit::ConstRecHitPointer hit = tmeasIt->recHit();
 	if(! hit->isValid() || hit->geographicalId().det() != DetId::Tracker ) {
 	  continue; 


### PR DESCRIPTION
This should fix the issue of PromptReco crashes in DQM code [0].

Not really tested yet, just the change suggested in the thread.

[0] https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1440.html
