### PR TITLE
Improve low-pT performance of "quadruplets by propagation", and use it in phase1 tracking instead of "triplet merging"

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
@@ -5,6 +5,11 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayers.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
 
 #include <utility>
 #include <vector>
@@ -28,10 +33,75 @@ public:
 private:
   std::unique_ptr<SeedComparitor> theComparitor;
 
-  const double extraHitRZtolerance;
-  const double extraHitRPhitolerance;
-  const double maxChi2;
-  const bool keepTriplets;
+  class QuantityDependsPtEval {
+  public:
+    QuantityDependsPtEval(float v1, float v2, float c1, float c2):
+      value1_(v1), value2_(v2), curvature1_(c1), curvature2_(c2)
+    {}
+
+    float value(float curvature) const {
+      if(value1_ == value2_) // not enabled
+        return value1_;
+
+      if(curvature1_ < curvature)
+        return value1_;
+      if(curvature2_ < curvature && curvature <= curvature1_)
+        return value2_ + (curvature-curvature2_)/(curvature1_-curvature2_) * (value1_-value2_);
+      return value2_;
+    }
+
+  private:
+    const float value1_;
+    const float value2_;
+    const float curvature1_;
+    const float curvature2_;
+  };
+
+  // Linear interpolation (in curvature) between value1 at pt1 and
+  // value2 at pt2. If disabled, value2 is given (the point is to
+  // allow larger/smaller values of the quantity at low pt, so it
+  // makes more sense to have the high-pt value as the default).
+  class QuantityDependsPt {
+  public:
+    explicit QuantityDependsPt(const edm::ParameterSet& pset):
+      value1_(pset.getParameter<double>("value1")),
+      value2_(pset.getParameter<double>("value2")),
+      pt1_(pset.getParameter<double>("pt1")),
+      pt2_(pset.getParameter<double>("pt2")),
+      enabled_(pset.getParameter<bool>("enabled"))
+    {
+      if(enabled_ && pt1_ >= pt2_)
+        throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
+      if(pt1_ <= 0)
+        throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 needs to be > 0; is " << pt1_;
+      if(pt2_ <= 0)
+        throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt2 needs to be > 0; is " << pt2_;
+    }
+
+    QuantityDependsPtEval evaluator(const edm::EventSetup& es) const {
+      if(enabled_) {
+        return QuantityDependsPtEval(value1_, value2_,
+                                     PixelRecoUtilities::curvature(1.f/pt1_, es),
+                                     PixelRecoUtilities::curvature(1.f/pt2_, es));
+      }
+      return QuantityDependsPtEval(value2_, value2_, 0.f, 0.f);
+    }
+
+  private:
+    const float value1_;
+    const float value2_;
+    const float pt1_;
+    const float pt2_;
+    const bool enabled_;
+  };
+
+  const float extraHitRZtolerance;
+  const float extraHitRPhitolerance;
+  const QuantityDependsPt extraPhiTolerance;
+  const QuantityDependsPt maxChi2;
+  const bool fitFastCircle;
+  const bool fitFastCircleChi2Cut;
+  const bool useBendingCorrection;
 };
 
 

--- a/RecoPixelVertexing/PixelTriplets/python/PixelQuadrupletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelQuadrupletGenerator_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+PixelQuadrupletGenerator = cms.PSet(
+    ComponentName = cms.string("PixelQuadrupletGenerator"),
+    extraHitRZtolerance = cms.double(0.1),
+    extraHitRPhitolerance = cms.double(0.1),
+    extraPhiTolerance = cms.PSet(
+        pt1    = cms.double(0.1) , pt2    = cms.double(0.1),
+        value1 = cms.double(999.), value2 = cms.double(0.15),
+        enabled = cms.bool(False),
+    ),
+    maxChi2 = cms.PSet(
+        pt1    = cms.double(0.2), pt2    = cms.double(1.5),
+        value1 = cms.double(500), value2 = cms.double(50),
+        enabled = cms.bool(True),
+    ),
+    fitFastCircle = cms.bool(False),
+    fitFastCircleChi2Cut = cms.bool(False),
+    useBendingCorrection = cms.bool(False),
+)

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -28,10 +28,15 @@ eras.trackingPhase1PU70.toReplaceWith(detachedQuadStepClusters, _detachedQuadSte
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 detachedQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
     BPix = dict(skipClusters = cms.InputTag('detachedQuadStepClusters')),
     FPix = dict(skipClusters = cms.InputTag('detachedQuadStepClusters'))
 )
+eras.trackingPhase1.toModify(detachedQuadStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
+
 
 # SEEDS
 from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
@@ -40,6 +45,7 @@ PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock as _RegionPsetFomBeamSpotBlock
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+from RecoPixelVertexing.PixelTriplets.PixelQuadrupletGenerator_cfi import PixelQuadrupletGenerator as _PixelQuadrupletGenerator
 detachedQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
     OrderedHitsFactoryPSet = dict(
         SeedingLayers = 'detachedQuadStepSeedLayers',
@@ -61,12 +67,30 @@ detachedQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     ),
-    SeedMergerPSet = cms.PSet(
-        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
-        addRemainingTriplets = cms.bool(False),
-        mergeTriplets = cms.bool(True),
-        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
-    )
+)
+eras.trackingPhase1.toModify(detachedQuadStepSeeds,
+    OrderedHitsFactoryPSet = cms.PSet(
+        ComponentName = cms.string("CombinedHitQuadrupletGenerator"),
+        GeneratorPSet = _PixelQuadrupletGenerator.clone(
+            extraHitRZtolerance = detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
+            extraHitRPhitolerance = detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = dict(
+                pt1    = 0.8, pt2    = 2,
+                value1 = 500, value2 = 100,
+                enabled = True,
+            ),
+            extraPhiTolerance = dict(
+                pt1    = 0.4, pt2    = 1,
+                value1 = 0.2, value2 = 0.05,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            fitFastCircle = True,
+            fitFastCircleChi2Cut = True,
+        ),
+        TripletGeneratorPSet = detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet,
+        SeedingLayers = detachedQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers,
+    ),
 )
 eras.trackingPhase1PU70.toModify(detachedQuadStepSeeds,
     RegionFactoryPSet = dict(
@@ -75,6 +99,12 @@ eras.trackingPhase1PU70.toModify(detachedQuadStepSeeds,
             originRadius = 0.5,
             nSigmaZ = 4.0
         )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+        addRemainingTriplets = cms.bool(False),
+        mergeTriplets = cms.bool(True),
+        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
     )
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -32,12 +32,19 @@ initialStepSeedsPreSplitting = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriple
     )
     )
 initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayersPreSplitting'
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
+initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
+initialStepSeedsPreSplitting.ClusterCheckPSet.PixelClusterCollectionLabel = 'siPixelClustersPreSplitting'
+
 eras.trackingPhase1.toModify(initialStepSeedsPreSplitting,
     OrderedHitsFactoryPSet = cms.PSet(
         ComponentName = cms.string("CombinedHitQuadrupletGenerator"),
         GeneratorPSet = _PixelQuadrupletGenerator.clone(
             extraHitRZtolerance = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
             extraHitRPhitolerance = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
+            SeedComparitorPSet = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet,
             maxChi2 = dict(
                 pt1    = 0.8, pt2    = 2,
                 value1 = 200, value2 = 100,
@@ -57,11 +64,6 @@ eras.trackingPhase1.toModify(initialStepSeedsPreSplitting,
     )
 )
 
-from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
-import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
-initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
-initialStepSeedsPreSplitting.ClusterCheckPSet.PixelClusterCollectionLabel = 'siPixelClustersPreSplitting'
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -9,12 +9,17 @@ from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
+eras.trackingPhase1.toModify(initialStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 
 
 # seeding
 from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+from RecoPixelVertexing.PixelTriplets.PixelQuadrupletGenerator_cfi import PixelQuadrupletGenerator as _PixelQuadrupletGenerator
 initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
     RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
     ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
@@ -32,7 +37,30 @@ _SeedMergerPSet = cms.PSet(
     mergeTriplets = cms.bool(True),
     ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
 )
-eras.trackingPhase1.toModify(initialStepSeeds, SeedMergerPSet = _SeedMergerPSet)
+eras.trackingPhase1.toModify(initialStepSeeds,
+    OrderedHitsFactoryPSet = cms.PSet(
+        ComponentName = cms.string("CombinedHitQuadrupletGenerator"),
+        GeneratorPSet = _PixelQuadrupletGenerator.clone(
+            extraHitRZtolerance = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
+            extraHitRPhitolerance = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = dict(
+                pt1    = 0.8, pt2    = 2,
+                value1 = 200, value2 = 100,
+                enabled = True,
+            ),
+            extraPhiTolerance = dict(
+                pt1    = 0.6, pt2    = 1,
+                value1 = 0.15, value2 = 0.1,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            fitFastCircle = True,
+            fitFastCircleChi2Cut = True,
+        ),
+        TripletGeneratorPSet = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet,
+        SeedingLayers = cms.InputTag('initialStepSeedLayers'),
+    )
+)
 eras.trackingPhase1PU70.toModify(initialStepSeeds,
     RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 0.7)),
     SeedMergerPSet = _SeedMergerPSet

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -31,6 +31,10 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
     )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
+
 _SeedMergerPSet = cms.PSet(
     layerList = cms.PSet(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
     addRemainingTriplets = cms.bool(False),
@@ -43,6 +47,7 @@ eras.trackingPhase1.toModify(initialStepSeeds,
         GeneratorPSet = _PixelQuadrupletGenerator.clone(
             extraHitRZtolerance = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
             extraHitRPhitolerance = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
+            SeedComparitorPSet = initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet,
             maxChi2 = dict(
                 pt1    = 0.8, pt2    = 2,
                 value1 = 200, value2 = 100,
@@ -67,9 +72,6 @@ eras.trackingPhase1PU70.toModify(initialStepSeeds,
 )
 
 
-from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
-import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
 eras.trackingLowPU.toModify(initialStepSeeds, OrderedHitsFactoryPSet = dict(GeneratorPSet = dict(maxElement = 100000)))
 
 # building

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -70,6 +70,7 @@ eras.trackingPhase1.toModify(lowPtQuadStepSeeds,
         GeneratorPSet = _PixelQuadrupletGenerator.clone(
             extraHitRZtolerance = lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
             extraHitRPhitolerance = lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
+            SeedComparitorPSet = lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet,
             maxChi2 = dict(
                 pt1    = 0.8  , pt2    = 2,
                 value1 = 2000, value2 = 100,

--- a/RecoTracker/TkSeedGenerator/interface/FastCircleFit.h
+++ b/RecoTracker/TkSeedGenerator/interface/FastCircleFit.h
@@ -1,0 +1,41 @@
+#ifndef RecoTracker_TkSeedGenerator_FastCircleFit_h
+#define RecoTracker_TkSeedGenerator_FastCircleFit_h
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+
+#include <vector>
+
+/**
+ * Same (almost) as FastCircle but with arbitrary number of hits. 
+ *
+ * Strandlie, Wroldsen, Frühwirth NIM A 488 (2002) 332-341.
+ * Frühwirth, Strandlie, Waltenberger NIM A 490 (2002) 366-378.
+ */
+class FastCircleFit {
+public:
+  // TODO: try to make the interface more generic than just vectors
+  FastCircleFit(const std::vector<GlobalPoint>& points, const std::vector<GlobalError>& errors):
+    FastCircleFit(points.data(), errors.data(), points.size()) {}
+  FastCircleFit(const DynArray<GlobalPoint>& points, const DynArray<GlobalError>& errors):
+    FastCircleFit(points.begin(), errors.begin(), points.size()) {}
+  FastCircleFit(const GlobalPoint *points, const GlobalError *errors, size_t size);
+  ~FastCircleFit() = default;
+
+  float x0() const { return x0_; }
+  float y0() const { return y0_; }
+  float rho() const { return rho_; }
+
+  // TODO: I'm not sure if the minimized square sum is chi2 distributed
+  float chi2() const { return chi2_; }
+
+private:
+  float x0_;
+  float y0_;
+  float rho_;
+  float chi2_;
+};
+
+
+#endif

--- a/RecoTracker/TkSeedGenerator/src/FastCircleFit.cc
+++ b/RecoTracker/TkSeedGenerator/src/FastCircleFit.cc
@@ -1,0 +1,148 @@
+#include "RecoTracker/TkSeedGenerator/interface/FastCircleFit.h"
+#include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+
+#include "TVectorD.h"
+#include "TMatrixDSym.h"
+#include "TMatrixDSymEigen.h"
+
+#ifdef MK_DEBUG
+#include <iostream>
+#define PRINT std::cout
+#else
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#define PRINT LogTrace("FastCircleFit")
+#endif
+
+namespace {
+  template<typename T>
+  T sqr(T t) { return t*t; }
+}
+
+FastCircleFit::FastCircleFit(const GlobalPoint *points, const GlobalError *errors, size_t size):
+  x0_(0), y0_(0), rho_(0),
+  chi2_(0)
+{
+  const auto N = size;
+  declareDynArray(float, N, x);
+  declareDynArray(float, N, y);
+  declareDynArray(float, N, z);
+  declareDynArray(float, N, weight); // 1/sigma^2
+
+  AlgebraicVector3 mean;
+
+  // transform
+  for(size_t i=0; i<N; ++i) {
+    const auto& point = points[i];
+    const auto p = point.basicVector();
+    x[i] = p.x();
+    y[i] = p.y();
+    z[i] = sqr(p.x()) + sqr(p.y());
+
+    // TODO: The following accounts only the hit uncertainty in phi.
+    // Albeit it "works nicely", should we account also the
+    // uncertainty in r in FPix (and the correlation between phi and r)?
+    const float phiErr2 = errors[i].phierr(point);
+    const float w = 1.f/(point.perp2()*phiErr2);
+    weight[i] = w;
+
+    PRINT << " point " << p.x()
+          << " " << p.y()
+          << " transformed " << x[i]
+          << " " << y[i]
+          << " " << z[i]
+          << " weight " << w
+          << std::endl;
+  }
+  const float invTotWeight = 1.f/std::accumulate(weight.begin(), weight.end(), 0.f);
+  PRINT << " invTotWeight " << invTotWeight;
+
+  for(size_t i=0; i<N; ++i) {
+    const float w = weight[i]*invTotWeight;
+    mean[0] += w*x[i];
+    mean[1] += w*y[i];
+    mean[2] += w*z[i];
+  }
+  PRINT << " mean " << mean[0] << " " << mean[1] << " " << mean[2] << std::endl;
+
+  // TODO: Using TMatrix for eigenvalues and eigenvectors of 3x3
+  // symmetrix matrix is an overkill. To be replaced with something
+  // lightweight.
+  TMatrixDSym A(3);
+  for(size_t i=0; i<N; ++i) {
+    const auto diff_x = x[i] - mean[0];
+    const auto diff_y = y[i] - mean[1];
+    const auto diff_z = z[i] - mean[2];
+    const auto w = weight[i];
+    A(0,0) += w * diff_x * diff_x;
+    A(0,1) += w * diff_x * diff_y;
+    A(0,2) += w * diff_x * diff_z;
+    A(1,0) += w * diff_y * diff_x;
+    A(1,1) += w * diff_y * diff_y;
+    A(1,2) += w * diff_y * diff_z;
+    A(2,0) += w * diff_z * diff_x;
+    A(2,1) += w * diff_z * diff_y;
+    A(2,2) += w * diff_z * diff_z;
+    PRINT << " i " << i << " A " << A(0,0) << " " << A(0,1) << " " << A(0,2) << std::endl
+          << "     " << A(1,0) << " " << A(1,1) << " " << A(1,2) << std::endl
+          << "     " << A(2,0) << " " << A(2,1) << " " << A(2,2) << std::endl;
+  }
+  A *= 1./static_cast<double>(N);
+
+  PRINT << " A " << A(0,0) << " " << A(0,1) << " " << A(0,2) << std::endl
+        << "   " << A(1,0) << " " << A(1,1) << " " << A(1,2) << std::endl
+        << "   " << A(2,0) << " " << A(2,1) << " " << A(2,2) << std::endl;
+
+  // find eigenvalues and vectors
+  TMatrixDSymEigen eigen(A);
+  TVectorD eigenValues = eigen.GetEigenValues();
+  TMatrixD eigenVectors = eigen.GetEigenVectors();
+
+  int smallest = 0;
+  if(eigenValues[1] < eigenValues[0]) smallest = 1;
+  if(eigenValues[2] < eigenValues[smallest]) smallest = 2;
+
+  PRINT << " eigenvalues " << eigenValues[0]
+        << " " << eigenValues[1]
+        << " " << eigenValues[2]
+        << " smallest " << smallest
+        << std::endl;
+
+  PRINT << " eigen " << eigenVectors(0,0) << " " << eigenVectors(0,1) << " " << eigenVectors(0,2) << std::endl
+        << "       " << eigenVectors(1,0) << " " << eigenVectors(1,1) << " " << eigenVectors(1,2) << std::endl
+        << "       " << eigenVectors(2,0) << " " << eigenVectors(2,1) << " " << eigenVectors(2,2) << std::endl;
+
+  AlgebraicVector3 n;
+  n[0] = eigenVectors(0, smallest);
+  n[1] = eigenVectors(1, smallest);
+  n[2] = eigenVectors(2, smallest);
+  PRINT << " n (copy) " << n[0] << " " << n[1] << " " << n[2] << std::endl;
+  n.Unit();
+  PRINT << " n (unit) " << n[0] << " " << n[1] << " " << n[2] << std::endl;
+
+  const float c = -1.f * (n[0]*mean[0] + n[1]*mean[1] + n[2]*mean[2]);
+
+  PRINT << " c " << c << std::endl;
+
+  // calculate fit parameters
+  const auto tmp = 0.5f * 1.f/n[2];
+  x0_ = -n[0]*tmp;
+  y0_ = -n[1]*tmp;
+  const float rho2 = (1 - sqr(n[2]) - 4*c*n[2]) * sqr(tmp);
+  rho_ = std::sqrt(rho2);
+
+  // calculate square sum
+  float S = 0;
+  for(size_t i=0; i<N; ++i) {
+    const float incr = sqr(c + n[0]*x[i] + n[1]*y[i] + n[2]*z[i]) * weight[i];
+#if defined(MK_DEBUG) || defined(EDM_ML_DEBUG)
+    const float distance = std::sqrt(sqr(x[i]-x0_) + sqr(y[i]-y0_)) - rho_;
+    PRINT << " i " << i
+          << " chi2 incr " << incr
+          << " d(hit, circle) " << distance
+          << " sigma " << 1.f/std::sqrt(weight[i])
+          << std::endl;
+#endif
+    S += incr;
+  }
+  chi2_ = S;
+}

--- a/RecoTracker/TkSeedGenerator/test/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/test/BuildFile.xml
@@ -1,2 +1,5 @@
 <use name="DataFormats/Math"/>
 <bin file="FastCircle_t.cpp"/>
+<bin file="FastCircleFit_t.cpp">
+  <use name="root"/>
+</bin>

--- a/RecoTracker/TkSeedGenerator/test/FastCircleFit_t.cpp
+++ b/RecoTracker/TkSeedGenerator/test/FastCircleFit_t.cpp
@@ -1,0 +1,111 @@
+//#define MK_DEBUG
+#include "RecoTracker/TkSeedGenerator/src/FastCircleFit.cc"
+
+#include <iostream>
+
+namespace {
+  void test(const std::vector<GlobalPoint>& points, const std::vector<GlobalError>& errors) {
+    FastCircleFit c(points, errors);
+
+    std::cout << "origin " << c.x0() << " " << c.y0()
+              << " radius " << c.rho()
+              << " chi2 " << c.chi2()
+              << std::endl;
+  };
+}
+
+int main() {
+  {
+    std::vector<GlobalPoint> points = {{
+        GlobalPoint( 0., -1.,0.),
+        GlobalPoint(-1.,  0.,0.),
+        GlobalPoint( 0.,  1.,0.)
+      }};
+    std::vector<GlobalError> errors = {{
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1),
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1),
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1)
+      }};
+                                       
+    test(points, errors);
+  }
+
+  {
+    std::vector<GlobalPoint> points = {{
+        GlobalPoint( 0.1, 0.,0.),
+        GlobalPoint(-0.9, 1.,0.),
+        GlobalPoint( 0.1, 2.,0.)
+      }};
+    std::vector<GlobalError> errors = {{
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1),
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1),
+        GlobalError(1,
+                    0, 1,
+                    0, 0, 1)
+      }};
+                                       
+    test(points, errors);
+  }
+
+  {
+    std::vector<GlobalPoint> points = {{
+        GlobalPoint(-3.18318,  0.0479436 ,0.),
+        GlobalPoint(-6.74696, -0.303678  ,0.),
+        GlobalPoint(-10.7557, -1.24485   ,0.),
+        GlobalPoint(-14.6143, -2.79196   ,0.)
+      }};
+    std::vector<GlobalError> errors = {{
+        GlobalError(2.37751e-07,
+                    8.873e-07, 3.31145e-06,
+                    0, 0, 5.22405e-06),
+        GlobalError(6.10596e-09,
+                    -5.41919e-08, 4.80966e-07,
+                    0, 0, 7.44661e-06),
+        GlobalError(6.41271e-09,
+                    -8.96614e-08, 1.25363e-06,
+                    0, 0, 4.73874e-06),
+        GlobalError(1.19665e-06,
+                    2.78201e-07, 2.80112e-07,
+                    0, 0, 2.78938e-08)
+      }};
+                                       
+    test(points, errors);
+  }
+  {
+    std::vector<GlobalPoint> points = {{
+        GlobalPoint(-3.18318,  0.0479436 ,0.),
+        GlobalPoint(-6.74696, -0.303678  ,0.),
+        GlobalPoint(-10.7557, -1.24485   ,0.),
+        GlobalPoint(-14.699,  -2.83295   ,0.)
+      }};
+    std::vector<GlobalError> errors = {{
+        GlobalError(2.37751e-07,
+                    8.873e-07, 3.31145e-06,
+                    0, 0, 5.22405e-06),
+        GlobalError(6.10596e-09,
+                    -5.41919e-08, 4.80966e-07,
+                    0, 0, 7.44661e-06),
+        GlobalError(6.41271e-09,
+                    -8.96614e-08, 1.25363e-06,
+                    0, 0, 4.73874e-06),
+        GlobalError(3.14525e-06,
+                    2.64413e-07, 4.33922e-07,
+                    0, 0, 5.69573e-08)
+      }};
+                                       
+    test(points, errors);
+  }
+
+
+  return 0;
+}


### PR DESCRIPTION
This PR makes significant improvements on the low-pT performance of `PixelQuadrupletGenerator` (almost) as described in Tracking POG meeting April 25 https://indico.cern.ch/event/524162/contributions/2147043/attachments/1263095/1868128/slides_phase1.pdf . The `PixelQuadrupletGenerator` is also switched as the default method for producing the quadruplet seeds from hit triplets (I left the `customiseForQuadrupletsByPropagation.py`, introduced in #13753, still there to remind us the recommended duplicate cleaning flag for PixelTrackProducer).

"Almost" means that while preparing the PR I noticed that the SeedComparitors were not used in InitialStepPreSplitting, InitialStep and DetachedQuadStep as I intended (= use the same SeedComparitor in triplet and quadruplet generation). The presented version is the second-to-last commit (28fddea), and the last commit (77ce974) shows the fix. Below is a link to MultiTrackValidator plots with 1000 events of TTbar+35PU with both "design" and "realistic" GTs
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre2_phase1/
(I think we should review the use of SeedComparitors at some point)

The code is still somewhat prototype quality, which will be addressed later. I marked the most important points with `// TODO`.

Tested in CMSSW_8_1_X_2016-04-29-2300. No changes are expected in 2016 workflows. 2017 workflows should show small changes here and there in tracking performance (see MTV link above), and iterative tracking should be roughly 10 % faster.

@rovere @VinInn 
