### PR TITLE
Filling the fillDescription method of CaloRecHitsBeamHaloCleaned and …

### DIFF
--- a/RecoMET/METProducers/python/CaloRecHitsBeamHaloCleaned_cfi.py
+++ b/RecoMET/METProducers/python/CaloRecHitsBeamHaloCleaned_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-CaloRecHitsBeamHaloCleaned = cms.EDProducer('CaloRecHitsBeamHaloCleaned',
-  EBRecHitsLabel = cms.InputTag('EcalRecHit', 'EcalRecHitsEB'),
-  EERecHitsLabel = cms.InputTag('EcalRecHit', 'EcalRecHitsEE'),
-  HBHERecHitsLabel = cms.InputTag('hbhereco'),
-  GlobalHaloDataLabel = cms.InputTag('GlobalHaloData'),
-  IsHLT = cms.bool(False)
-)

--- a/RecoMET/METProducers/python/CaloRecHitsBeamHaloCleaned_cfi.py
+++ b/RecoMET/METProducers/python/CaloRecHitsBeamHaloCleaned_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+CaloRecHitsBeamHaloCleaned = cms.EDProducer('CaloRecHitsBeamHaloCleaned',
+  EBRecHitsLabel = cms.InputTag('EcalRecHit', 'EcalRecHitsEB'),
+  EERecHitsLabel = cms.InputTag('EcalRecHit', 'EcalRecHitsEE'),
+  HBHERecHitsLabel = cms.InputTag('hbhereco'),
+  GlobalHaloDataLabel = cms.InputTag('GlobalHaloData'),
+  IsHLT = cms.bool(False)
+)

--- a/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
+++ b/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
@@ -209,7 +209,7 @@ CaloRecHitsBeamHaloCleaned::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("HBHERecHitsLabel", edm::InputTag("hbhereco"));
   desc.add<edm::InputTag>("GlobalHaloDataLabel", edm::InputTag("GlobalHaloData"));
   desc.add<bool>("IsHLT",false);
-  descriptions.add("CaloRecHitsBeamHaloCleaned",desc);
+  descriptions.add("caloRecHitsBeamHaloCleaned",desc);
 
 }
 

--- a/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
+++ b/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
@@ -27,6 +27,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include <vector>
@@ -200,11 +203,14 @@ CaloRecHitsBeamHaloCleaned::produce(edm::Event& iEvent, const edm::EventSetup& i
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void
 CaloRecHitsBeamHaloCleaned::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("EBRecHitsLabel", edm::InputTag("EcalRecHit","EcalRecHitsEB"));
+  desc.add<edm::InputTag>("EERecHitsLabel", edm::InputTag("EcalRecHit","EcalRecHitsEE"));
+  desc.add<edm::InputTag>("HBHERecHitsLabel", edm::InputTag("hbhereco"));
+  desc.add<edm::InputTag>("GlobalHaloDataLabel", edm::InputTag("GlobalHaloData"));
+  desc.add<bool>("IsHLT",false);
+  descriptions.add("CaloRecHitsBeamHaloCleaned",desc);
+
 }
 
 //define this as a plug-in


### PR DESCRIPTION
…adding the corresponding generated config file. 

The producer CaloRecHitsBeamHaloCleaned  is needed for the design of a new trigger path. The changes are required in order to parse theconfig in ConfDB. 
