### PR TITLE
remove unneeded EE geometry from EcalRecHitWorkerRecover

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
@@ -55,12 +55,10 @@ void EcalRecHitWorkerRecover::set(const edm::EventSetup& es)
         ecalMapping_ = pEcalMapping_.product();
         // geometry...
         es.get<EcalBarrelGeometryRecord>().get("EcalBarrel",pEBGeom_);
-        es.get<EcalEndcapGeometryRecord>().get("EcalEndcap",pEEGeom_);
 	es.get<CaloGeometryRecord>().get(caloGeometry_);
 	es.get<EcalChannelStatusRcd>().get(chStatus_);
         geo_ = caloGeometry_.product();
         ebGeom_ = pEBGeom_.product();
-        eeGeom_ = pEEGeom_.product();
         es.get<IdealGeometryRecord>().get(ttMap_);
         recoveredDetIds_EB_.clear();
         recoveredDetIds_EE_.clear();
@@ -321,7 +319,6 @@ EcalRecHitWorkerRecover::run( const edm::Event & evt,
 				  float energy = jt->energy(); // Correct conversion to Et
 				  float eta = geo_->getPosition(jt->id()).eta();
 				  float pf = 1.0/cosh(eta);
-				  //float theta = eeGeom_->getGeometry( *it )->getPosition().theta();
 				  // use Et instead of E, consistent with the Et estimation of the associated TT
 				  totE -= energy*pf;
                                 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.h
@@ -81,9 +81,7 @@ class EcalRecHitWorkerRecover : public EcalRecHitWorkerBaseClass {
                 edm::ESHandle<EcalTrigTowerConstituentsMap> ttMap_;
  
                 edm::ESHandle<CaloSubdetectorGeometry> pEBGeom_;
-                edm::ESHandle<CaloSubdetectorGeometry> pEEGeom_;
                 const CaloSubdetectorGeometry * ebGeom_;
-                const CaloSubdetectorGeometry * eeGeom_;
 		const CaloGeometry* geo_;
 
                 EcalRecHitSimpleAlgo * rechitMaker_;

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -81,14 +81,3 @@ ecalRecHit = cms.EDProducer("EcalRecHitProducer",
 
     )
 
-from Configuration.StandardSequences.Eras import eras
-# disable workerRecover_ which requires EcalEndcapGeometryRecord
-eras.phase2_common.toModify( ecalRecHit,
-    recoverEBIsolatedChannels = cms.bool(False), 
-    recoverEEIsolatedChannels = cms.bool(False), 
-    recoverEBVFE = cms.bool(False), 
-    recoverEEVFE = cms.bool(False), 
-    recoverEBFE = cms.bool(False), 
-    recoverEEFE = cms.bool(False), 
-    killDeadChannels = cms.bool(False)
-)


### PR DESCRIPTION
In #14165, I referenced an issue where `EcalRecHitWorkerRecover` could not run without the EE geometry, which is not present in Phase2 workflows. To avoid this at that time, I used a Python customization to turn off all options that might use this class.

However, upon further investigation, the only use of the EE geometry in this class was commented out in September 2010: ae80cb2e3811a990547e17ea6a06871c0f3712b6.

In this PR, I've taken the most expedient solution of simply deleting all references to the EE geometry from this class. If ECAL RECO experts object for some reason, please propose an alternative solution. (Not sure who should be tagged...)

Tested with:

```
runTheMatrix.py -w upgrade -l 11000.0
```

to make sure the Phase2 workflows still run, which they do.
