### PR TITLE
TrackerMonitorTrack: Fix side for TID so that TID/MINUS histograms appear. (8_1_X)

### DIFF
--- a/DQM/TrackerMonitorTrack/README.md
+++ b/DQM/TrackerMonitorTrack/README.md
@@ -55,6 +55,9 @@ The data shown in the histograms is computed by the Alignment/OfflineValidation 
 * `SiStrip/MechanicalView/TID/PLUS/wheel_1/HitResiduals_TID__wheel__1`
 * `SiStrip/MechanicalView/TID/PLUS/wheel_2/HitResiduals_TID__wheel__2`
 * `SiStrip/MechanicalView/TID/PLUS/wheel_3/HitResiduals_TID__wheel__3`
+* `SiStrip/MechanicalView/TID/MINUS/wheel_1/HitResiduals_TID__wheel__1`
+* `SiStrip/MechanicalView/TID/MINUS/wheel_2/HitResiduals_TID__wheel__2`
+* `SiStrip/MechanicalView/TID/MINUS/wheel_3/HitResiduals_TID__wheel__3`
 * `SiStrip/MechanicalView/TOB/layer_1/HitResiduals_TOB__Layer__1`
 * `SiStrip/MechanicalView/TOB/layer_2/HitResiduals_TOB__Layer__2`
 * `SiStrip/MechanicalView/TOB/layer_3/HitResiduals_TOB__Layer__3`

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -69,7 +69,7 @@ std::pair<std::string, int32_t> MonitorTrackResidualsBase<pixel_or_strip>::findS
 	  break;
 	case 4:
 	  subdet = "TID";
-          layer = tTopo->tidWheel(id) * ( tTopo->tecSide(ModuleID)==1 ? -1 : +1);
+          layer = tTopo->tidWheel(id) * ( tTopo->tidSide(ModuleID)==1 ? -1 : +1);
 	  break;
 	case 5:
 	  subdet = "TOB";


### PR DESCRIPTION
8_1_X version of #14318.

The issue came up here: https://hypernews.cern.ch/HyperNews/CMS/get/trk-dqm/417/2/1.html

This fixes a bug introduced in #13240 .
