### PR TITLE
SCEnergyCorrectorSemiParm: don't cache ES objects the wrong way

### DIFF
--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -47,8 +47,6 @@ class SCEnergyCorrectorSemiParm {
   
   edm::ESHandle<CaloTopology> calotopo_;
   edm::ESHandle<CaloGeometry> calogeom_;
-  const CaloTopologyRecord* topo_record_;
-  const CaloGeometryRecord* geom_record_;    
   
   edm::EDGetTokenT<EcalRecHitCollection> tokenEBRecHits_;
   edm::EDGetTokenT<EcalRecHitCollection> tokenEERecHits_;

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -19,9 +19,7 @@ forestee_(0),
 forestsigmaeb_(0),
 forestsigmaee_(0),
 calotopo_(0),
-calogeom_(0),
-topo_record_(0),
-geom_record_(0)
+calogeom_(0)
 {}
 
 //--------------------------------------------------------------------------------------------------
@@ -49,19 +47,9 @@ void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet &iConfig, edm:
 
 //--------------------------------------------------------------------------------------------------
 void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup &es) {
-  
-  const CaloTopologyRecord& topofrom_es = es.get<CaloTopologyRecord>();
-  if( !topo_record_ ||
-      topofrom_es.cacheIdentifier() != topo_record_->cacheIdentifier() ) {
-    topo_record_ = &topofrom_es;
-    topo_record_->get(calotopo_);
-  }
-  const CaloGeometryRecord& geomfrom_es = es.get<CaloGeometryRecord>();
-  if( !geom_record_ ||
-      geomfrom_es.cacheIdentifier() != geom_record_->cacheIdentifier() ) {
-    geom_record_ = &geomfrom_es;
-    geom_record_->get(calogeom_);
-  }  
+
+  es.get<CaloTopologyRecord>().get(calotopo_);
+  es.get<CaloGeometryRecord>().get(calogeom_);
 
   edm::ESHandle<GBRForestD> readereb;
   edm::ESHandle<GBRForestD> readerebvar;


### PR DESCRIPTION
Remove the caching of calo topology and geometry that was causing crashes when reconstructing events from different runs in the same job.
Same as #14340 for 80X, the two branches point to the same commit but I gave them different names in case I may have to update the two PRs differently.
