### PR TITLE
avoid redundant computations in StripCPE

### DIFF
--- a/DataFormats/Common/interface/DetSetNew.h
+++ b/DataFormats/Common/interface/DetSetNew.h
@@ -96,6 +96,9 @@ namespace edmNew {
       return edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>( handle.id(), ci, ci - &(container().front()) );
     }
 
+    unsigned int makeKeyOf(const_iterator ci) const {
+      return  ci - &(container().front());
+    }
     
   private:
 

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
@@ -13,6 +13,7 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 
+#include "CommonTools/Utils/interface/DynArray.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 
@@ -25,9 +26,15 @@
 class StripClusterParameterEstimator
 {
  public:
-  typedef std::pair<LocalPoint,LocalError>  LocalValues;
+  using LocalValues = std::pair<LocalPoint,LocalError>;
+  using ALocalValues = DynArray<LocalValues>;
+  using AClusters =  DynArray<SiStripCluster const *>;
   typedef std::vector<LocalValues> VLocalValues;
 
+  virtual void localParameters(AClusters const & clusters, ALocalValues & retValues, const GeomDetUnit& gd, const LocalTrajectoryParameters & ltp) const {
+  }
+
+  
   virtual LocalValues localParameters( const SiStripCluster&,const GeomDetUnit&) const {
       return std::make_pair(LocalPoint(), LocalError());
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
@@ -10,14 +10,15 @@
 #include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
-#include <ext/hash_map>
+
 class StripTopology;
 
 class StripCPE : public StripClusterParameterEstimator 
 {
 public:
+  using StripClusterParameterEstimator::localParameters;
 
-  StripClusterParameterEstimator::LocalValues localParameters( const SiStripCluster& cl, const GeomDetUnit&) const;
+  StripClusterParameterEstimator::LocalValues localParameters( const SiStripCluster& cl, const GeomDetUnit&) const override;
   
   StripCPE( edm::ParameterSet & conf, 
 	    const MagneticField&, 
@@ -28,6 +29,45 @@ public:
 	    const SiStripLatency&);    
   LocalVector driftDirection(const StripGeomDetUnit* det) const;
 
+ struct Param {
+    Param() : topology(nullptr) {}
+    StripTopology const * topology;
+    LocalVector drift;
+    float thickness, invThickness,pitch_rel_err2, maxLength;
+    int nstrips;
+    float backplanecorrection;
+    SiStripDetId::ModuleGeometry moduleGeom;
+    float coveredStrips(const LocalVector&, const LocalPoint&) const;
+  };
+
+  
+  struct AlgoParam {
+    Param const & p; const LocalTrajectoryParameters & ltp;
+    SiStripDetId::SubDetector loc; float afullProjection; float corr;
+  };
+
+
+  virtual StripClusterParameterEstimator::LocalValues
+  localParameters( const SiStripCluster& cl, AlgoParam const & ap) const {
+    return std::make_pair(LocalPoint(), LocalError());
+  }
+  
+  AlgoParam getAlgoParam(const GeomDetUnit& det, const LocalTrajectoryParameters & ltp) const {
+
+    StripCPE::Param const & p = param(det);
+    SiStripDetId::SubDetector loc = SiStripDetId( det.geographicalId() ).subDetector();  
+ 
+    LocalVector track = ltp.momentum();
+    track *= -p.thickness/track.z();
+
+    const float fullProjection = p.coveredStrips( track+p.drift, ltp.position());
+
+    auto const corr = -  0.5f*(1.f-p.backplanecorrection) * fullProjection
+      + 0.5f*p.coveredStrips(track, ltp.position());
+
+    return  AlgoParam{p,ltp,loc,std::abs(fullProjection),corr};
+  }
+  
  protected:  
 
   const bool peakMode_;
@@ -38,16 +78,6 @@ public:
   std::vector<float> xtalk1;
   std::vector<float> xtalk2;
 
-  struct Param {
-    Param() : topology(nullptr) {}
-    StripTopology const * topology;
-    LocalVector drift;
-    float thickness, invThickness,pitch_rel_err2, maxLength;
-    int nstrips;
-    float backplanecorrection;
-    SiStripDetId::ModuleGeometry moduleGeom;
-    float coveredStrips(const LocalVector&, const LocalPoint&) const;
-  };
   Param const & param(const GeomDetUnit& det) const {
     return m_Params[det.index()-m_off];
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -29,9 +29,18 @@ private:
   Algo m_algo;
 
 public:  
+  using AlgoParam = StripCPE::AlgoParam;
+  using AClusters = StripClusterParameterEstimator::AClusters;
+  using ALocalValues  = StripClusterParameterEstimator::ALocalValues;
+  
+  void localParameters(AClusters const & clusters, ALocalValues & retValues, const GeomDetUnit& gd, const LocalTrajectoryParameters &ltp) const override;
 
   StripClusterParameterEstimator::LocalValues
-  localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
+  localParameters( const SiStripCluster& cl, AlgoParam const & ap) const override;
+
+  
+  StripClusterParameterEstimator::LocalValues
+  localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
   
   float stripErrorSquared(const unsigned N, const float uProj, const SiStripDetId::SubDetector loc ) const ;
   float legacyStripErrorSquared(const unsigned N, const float uProj) const;

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -36,6 +36,7 @@ float StripCPEfromTrackAngle::stripErrorSquared(const unsigned N, const float uP
   return uerr*uerr;
 }
 
+
 float StripCPEfromTrackAngle::legacyStripErrorSquared(const unsigned N, const float uProj) const {
   if unlikely( (float(N)-uProj) > 3.5f )
     return float(N*N)/12.f;
@@ -56,7 +57,7 @@ void StripCPEfromTrackAngle::localParameters(AClusters const & clusters, ALocalV
   auto const & par = getAlgoParam(det,ltp);
   auto const & p = par.p;
   auto loc = par.loc;
-  auto corr = par.loc;
+  auto corr = par.corr;
   auto afp = par.afullProjection;
 
   auto fill = [&](unsigned int i, float uerr2) {
@@ -99,7 +100,7 @@ StripCPEfromTrackAngle::localParameters( const SiStripCluster& cluster, AlgoPara
   auto const & p = par.p;
   auto const & ltp = par.ltp;
   auto loc = par.loc;
-  auto corr = par.loc;
+  auto corr = par.corr;
   auto afp = par.afullProjection;
 
   float uerr2=0;

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -209,13 +209,14 @@ TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& ts, const 
 
     const detset & detSet = data.stripData().detSet(index());
     unInitDynArray(AClusters::value_type,detSet.size(),clusters);
+    assert(clusters.size()==0);
     for (auto const & ci : detSet) {
       if (isMasked(ci)) continue;
       if (accept(detSet.makeKeyOf(&ci), data.stripClustersToSkip()))
 	clusters.push_back(&ci);
       else LogDebug("TkStripMeasurementDet")<<"skipping this str from last iteration on"<<rawId()<<" key: "<<detSet.makeKeyOf(&ci);
     }
-    buildSimpleRecHits(clusters, data, detSet, ts,result);
+    if (!clusters.empty()) buildSimpleRecHits(clusters, data, detSet, ts,result);
  
 }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -65,7 +65,9 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
   auto oldSize = result.size();
   
   int utraj =  specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()).x();
-  const detset & detSet = data.stripData().detSet(index()); 
+  const detset & detSet = data.stripData().detSet(index());
+  auto const & cpepar = cpe()->getAlgoParam(specificGeomDet(),stateOnThisDet.localParameters());
+
   auto rightCluster = 
     std::find_if( detSet.begin(), detSet.end(), [utraj](const SiStripCluster& hit) { return hit.firstStrip() > utraj; });
   
@@ -76,14 +78,14 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
       SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
-      bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
+      bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
       if(!isCompatible) break; // exit loop on first incompatible hit
       for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();								
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
     SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
-    bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
+    bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
     if(!isCompatible) break; // exit loop on first incompatible hit
     for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
   }
@@ -102,7 +104,9 @@ bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& state
   auto oldSize = result.size();
 
   int utraj =  specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()).x();
-  const detset & detSet = data.stripData().detSet(index()); 
+  const detset & detSet = data.stripData().detSet(index());
+  auto const & cpepar = cpe()->getAlgoParam(specificGeomDet(),stateOnThisDet.localParameters());
+  
   auto rightCluster = 
     std::find_if( detSet.begin(), detSet.end(), [utraj](const SiStripCluster& hit) { return hit.firstStrip() > utraj; });
   
@@ -111,13 +115,13 @@ bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& state
     auto leftCluster = rightCluster;
     while ( --leftCluster >=  detSet.begin()) {
       SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
-      bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
+      bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), result);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
     SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
-    bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result);
+    bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), result);
     if(!isCompatible) break; // exit loop on first incompatible hit
   }
   

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -136,6 +136,7 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, 
   if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
 
   auto oldSize = result.size();
+  auto const & cpepar = cpe()->getAlgoParam(specificGeomDet(),stateOnThisDet.localParameters());
 
   int utraj =  specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()).x();
  
@@ -148,13 +149,13 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, 
       auto leftCluster = rightCluster;
       while ( --leftCluster >=  detSet.begin()) {
 	SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
-	bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result, diffs);
+	bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), result, diffs);
 	if(!isCompatible) break; // exit loop on first incompatible hit
       }
     }
     for ( ; rightCluster != detSet.end(); rightCluster++) {
       SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
-      bool isCompatible = filteredRecHits(clusterref, stateOnThisDet, est, data.stripClustersToSkip(), result,diffs);
+      bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), result,diffs);
       if(!isCompatible) break; // exit loop on first incompatible hit
     }
     

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -172,25 +172,21 @@ public:
   
 
   template<class ClusterRefT>
-  bool filteredRecHits( const ClusterRefT& cluster, const TrajectoryStateOnSurface& ltp,  const MeasurementEstimator& est, const std::vector<bool> & skipClusters,
+  bool filteredRecHits( const ClusterRefT& cluster, StripCPE::AlgoParam const& cpepar,
+			const TrajectoryStateOnSurface& ltp,  const MeasurementEstimator& est, const std::vector<bool> & skipClusters,
 			RecHitContainer & result, std::vector<float> & diffs) const {
     if (isMasked(*cluster)) return true;
-    const GeomDetUnit& gdu( specificGeomDet());
     if (!accept(cluster, skipClusters)) return true;
     if (!est.preFilter(ltp, ClusterFilterPayload(rawId(),&*cluster) )) return true;  // avoids shadow; consistent with previous statement...
-    VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
-    bool isCompatible(false);
-    for(auto vl : vlv) {
-      SiStripRecHit2D recHit(vl.first, vl.second, fastGeomDet(), cluster); // FIXME add cluster count in OmniRef
-      std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
-      LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
-      if ( diffEst.first ) {
-	result.push_back(std::move(std::make_shared<SiStripRecHit2D>(recHit)));
-	diffs.push_back(diffEst.second);
-	isCompatible = true;
-      }
+    auto const & vl = cpe()->localParameters( *cluster, cpepar);
+    SiStripRecHit2D recHit(vl.first, vl.second, fastGeomDet(), cluster); // FIXME add cluster count in OmniRef (and move again to multiple sub-clusters..)
+    std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
+    LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
+    if ( diffEst.first ) {
+      result.push_back(std::move(std::make_shared<SiStripRecHit2D>(recHit)));
+      diffs.push_back(diffEst.second);
     }
-    return isCompatible;
+    return diffEst.first;
   }
 
 
@@ -199,11 +195,10 @@ public:
 			  const TrajectoryStateOnSurface& ltp,  const MeasurementEstimator& est, const std::vector<bool> & skipClusters,
 			  std::vector<SiStripRecHit2D> & result) const {
     if (isMasked(*cluster)) return true;
-    const GeomDetUnit& gdu( specificGeomDet());
     if (!accept(cluster, skipClusters)) return true;
     if (!est.preFilter(ltp, ClusterFilterPayload(rawId(),&*cluster) )) return true;   // avoids shadow; consistent with previous statement...
     auto const & vl = cpe()->localParameters( *cluster, cpepar);
-    result.emplace_back( vl.first, vl.second, gdu, cluster);   // FIXME add cluster count in OmniRef
+    result.emplace_back( vl.first, vl.second, fastGeomDet(), cluster);   // FIXME add cluster count in OmniRef
     std::pair<bool,double> diffEst = est.estimate(ltp, result.back());
     LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
     if ( !diffEst.first ) result.pop_back();


### PR DESCRIPTION
Major speed up in the computation of Strip CPE during pattern-recognition by avoiding redundant computations depending on track and detector only.
The net result is about 10% speed up for tracking in TTBAR PU35

No regression expected.
