### PR TITLE
Add pixel-only seed extension

### DIFF
--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -544,6 +544,12 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 
       // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
       std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "NOT_STOPPED" };
+      if(StopReasonName.size() != static_cast<unsigned int>(StopReason::SIZE)) {
+        throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
+                                       << " but TrackAnalyzer has StopReasonName's only for "
+                                       << StopReasonName.size()
+                                       << ". Please update also TrackAnalyzer.cc near line " << __LINE__ << ".";
+      }
 
       histname = "stoppingSource_";
       stoppingSource = ibooker.book1D(histname+CategoryName, histname+CategoryName, StopReasonName.size(), 0., double(StopReasonName.size()));

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -543,7 +543,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       }
 
       // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
-      std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "NOT_STOPPED" };
+      std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "SEED_EXTENSION", "NOT_STOPPED" };
       if(StopReasonName.size() != static_cast<unsigned int>(StopReason::SIZE)) {
         throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
                                        << " but TrackAnalyzer has StopReasonName's only for "

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -208,6 +208,12 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker)
   if (doAllTCPlots || doStopSource) {
     // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
     std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "NOT_STOPPED" };
+    if(StopReasonName.size() != static_cast<unsigned int>(StopReason::SIZE)) {
+      throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
+                                     << " but TrackBuildingAnalyzer has StopReasonName's only for "
+                                     << StopReasonName.size()
+                                     << ". Please update also TrackBuildingAnalyzer.cc near line " << __LINE__ << ".";
+    }
     
     histname = "StoppingSource_"+seedProducer.label() + "_";
     stoppingSource = ibooker.book1D(histname+CatagoryName,

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -207,7 +207,7 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker)
 
   if (doAllTCPlots || doStopSource) {
     // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
-    std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "NOT_STOPPED" };
+    std::vector<std::string> StopReasonName = { "UNINITIALIZED", "MAX_HITS", "MAX_LOST_HITS", "MAX_CONSECUTIVE_LOST_HITS", "LOST_HIT_FRACTION", "MIN_PT", "CHARGE_SIGNIFICANCE", "LOOPER", "MAX_CCC_LOST_HITS", "NO_SEGMENTS_FOR_VALID_LAYERS", "SEED_EXTENSION", "NOT_STOPPED" };
     if(StopReasonName.size() != static_cast<unsigned int>(StopReason::SIZE)) {
       throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
                                      << " but TrackBuildingAnalyzer has StopReasonName's only for "

--- a/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
@@ -13,6 +13,7 @@ enum class StopReason {
   MAX_CCC_LOST_HITS = 8,
   NO_SEGMENTS_FOR_VALID_LAYERS = 9,
   SEED_EXTENSION = 10,
+  SIZE = 12, // This gives the number of the stopping reasons. The cound needs to be manually maintained, and should be 2 + the last value above .
   NOT_STOPPED = 255 // this is the max allowed since it will be streamed as type uint8_t
 };
 

--- a/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
@@ -12,6 +12,7 @@ enum class StopReason {
   LOOPER = 7,
   MAX_CCC_LOST_HITS = 8,
   NO_SEGMENTS_FOR_VALID_LAYERS = 9,
+  SEED_EXTENSION = 10,
   NOT_STOPPED = 255 // this is the max allowed since it will be streamed as type uint8_t
 };
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -62,6 +62,13 @@ def customiseFor14317(process):
                     pset.seedPairPenalty = cms.int32(0)
     return process
 
+# Add pixel seed extension (PR #14356)
+def customiseFor14356(process):
+    for name, pset in process.psets_().iteritems():
+        if hasattr(pset, "ComponentType") and pset.ComponentType.value() == "CkfBaseTrajectoryFilter" and not hasattr(pset, "pixelSeedExtension"):
+            pset.pixelSeedExtension = cms.bool(False)
+    return process
+
 #
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -73,6 +80,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor13753(process)
         process = customiseFor14282(process)
         process = customiseFor14317(process)
+        process = customiseFor14356(process)
 
     if cmsswVersion >= "CMSSW_8_0":
 #       process = customiseFor12718(process)

--- a/TrackingTools/PatternTools/interface/TempTrajectory.h
+++ b/TrackingTools/PatternTools/interface/TempTrajectory.h
@@ -76,6 +76,7 @@ public:
     theData(std::move(rh.theData)),
     theChiSquared(rh.theChiSquared), 
     theNumberOfFoundHits(rh.theNumberOfFoundHits),
+    theNumberOfFoundPixelHits(rh.theNumberOfFoundPixelHits),
     theNumberOfLostHits(rh.theNumberOfLostHits),
     theNumberOfTrailingFoundHits(rh.theNumberOfTrailingFoundHits),
     theNumberOfCCCBadHits_(rh.theNumberOfCCCBadHits_),
@@ -92,6 +93,7 @@ public:
     swap(theData,rh.theData);
     theChiSquared=rh.theChiSquared;
     theNumberOfFoundHits=rh.theNumberOfFoundHits;
+    theNumberOfFoundPixelHits=rh.theNumberOfFoundPixelHits;
     theNumberOfLostHits=rh.theNumberOfLostHits;
     theNumberOfTrailingFoundHits=rh.theNumberOfTrailingFoundHits;
     theNumberOfCCCBadHits_=rh.theNumberOfCCCBadHits_;
@@ -205,6 +207,10 @@ public:
    */
   int foundHits() const { return theNumberOfFoundHits;}
 
+  /** Number of valid pixel RecHits used to determine the trajectory.
+   */
+  int foundPixelHits() const { return theNumberOfFoundPixelHits;}
+
   /** Number of detector layers crossed without valid RecHits.
    *  Used mainly as a criteria for abandoning a trajectory candidate
    *  during trajectory building.
@@ -302,6 +308,7 @@ private:
   float theChiSquared=0;
 
   signed short theNumberOfFoundHits=0;
+  signed short theNumberOfFoundPixelHits=0;
   signed short theNumberOfLostHits=0;
   signed short theNumberOfTrailingFoundHits=0;
   signed short theNumberOfCCCBadHits_=0;

--- a/TrackingTools/PatternTools/interface/Trajectory.h
+++ b/TrackingTools/PatternTools/interface/Trajectory.h
@@ -107,6 +107,7 @@ public:
     theChiSquared(rh.theChiSquared),
     theChiSquaredBad(rh.theChiSquaredBad),
     theNumberOfFoundHits(rh.theNumberOfFoundHits),
+    theNumberOfFoundPixelHits(rh.theNumberOfFoundPixelHits),
     theNumberOfLostHits(rh.theNumberOfLostHits),
     theNumberOfTrailingFoundHits(rh.theNumberOfTrailingFoundHits),
     theNumberOfCCCBadHits_(rh.theNumberOfCCCBadHits_),
@@ -129,6 +130,7 @@ public:
     theCCCThreshold_=rh.theCCCThreshold_;
     theNLoops=rh.theNLoops;  
     theNumberOfFoundHits=rh.theNumberOfFoundHits;
+    theNumberOfFoundPixelHits=rh.theNumberOfFoundPixelHits;
     theNumberOfLostHits=rh.theNumberOfLostHits;
     theNumberOfTrailingFoundHits=rh.theNumberOfTrailingFoundHits;
     theNumberOfCCCBadHits_=rh.theNumberOfCCCBadHits_;
@@ -222,6 +224,10 @@ public:
 
   int foundHits() const { return theNumberOfFoundHits;}
 
+  /** Number of valid pixel RecHits used to determine the trajectory.
+   */
+  int foundPixelHits() const { return theNumberOfFoundPixelHits;}
+
   /** Number of detector layers crossed without valid RecHits.
    *  Used mainly as a criteria for abandoning a trajectory candidate
    *  during trajectory building.
@@ -294,6 +300,11 @@ public:
    */
   static bool isBad( const TrackingRecHit& hit);
 
+  /** Returns true if the hit type is TrackingRecHit::bad
+   *  Used in trajectory filtering
+   */
+  static bool pixel( const TrackingRecHit& hit);
+
   /// Redundant method, returns the layer of lastMeasurement() .
   const DetLayer* lastLayer() const {
     check();
@@ -357,6 +368,7 @@ private:
   float theChiSquaredBad=0;
 
   signed short theNumberOfFoundHits=0;
+  signed short theNumberOfFoundPixelHits=0;
   signed short theNumberOfLostHits=0;
   signed short theNumberOfTrailingFoundHits=0;
   signed short theNumberOfCCCBadHits_=0;

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -17,12 +18,12 @@ namespace {
     }
     return n;
   }
-
 }
 
 TempTrajectory::TempTrajectory(Trajectory && traj):
   theChiSquared(0),
   theNumberOfFoundHits(0),
+  theNumberOfFoundPixelHits(0),
   theNumberOfLostHits(0),
   theNumberOfCCCBadHits_(0),
   theDirection(traj.direction()),
@@ -45,6 +46,7 @@ void TempTrajectory::pop() {
     if (theData.back().recHit()->isValid()) {
         theNumberOfFoundHits--;
         if(badForCCC(theData.back())) theNumberOfCCCBadHits_--; 
+        if(Trajectory::pixel(*(theData.back().recHit()))) theNumberOfFoundPixelHits--;
     }
     else if(lost(* (theData.back().recHit()) )) {theNumberOfLostHits--;}
     theData.pop_back();
@@ -60,7 +62,8 @@ void TempTrajectory::pushAux(double chi2Increment) {
     theNumberOfFoundHits++;
     theNumberOfTrailingFoundHits++;
     if (badForCCC(tm)) theNumberOfCCCBadHits_++;
-   }
+    if(Trajectory::pixel(*(tm.recHit()))) theNumberOfFoundPixelHits++;
+  }
   //else if (lost( tm.recHit()) && !inactive(tm.recHit().det())) theNumberOfLostHits++;
   else if (lost( *(tm.recHit()) ) )   { theNumberOfLostHits++; theNumberOfTrailingFoundHits=0;}
 
@@ -80,6 +83,7 @@ void TempTrajectory::push(const TempTrajectory& segment) {
     tmp[i++] =&tm;
   while(i!=0) theData.push_back(*tmp[--i]);
   theNumberOfFoundHits+= segment.theNumberOfFoundHits;
+  theNumberOfFoundPixelHits+= segment.theNumberOfFoundPixelHits;
   theNumberOfLostHits += segment.theNumberOfLostHits;
   theNumberOfCCCBadHits_ += segment.theNumberOfCCCBadHits_;
   theNumberOfTrailingFoundHits=countTrailingValidHits(theData);
@@ -97,6 +101,7 @@ void TempTrajectory::join( TempTrajectory& segment) {
   } else {
     theData.join(segment.theData);
     theNumberOfFoundHits+= segment.theNumberOfFoundHits;
+    theNumberOfFoundPixelHits+= segment.theNumberOfFoundPixelHits;
     theNumberOfLostHits += segment.theNumberOfLostHits;
     theNumberOfCCCBadHits_ += segment.theNumberOfCCCBadHits_;
     theNumberOfTrailingFoundHits=countTrailingValidHits(theData);

--- a/TrackingTools/PatternTools/src/Trajectory.cc
+++ b/TrackingTools/PatternTools/src/Trajectory.cc
@@ -32,6 +32,7 @@ void Trajectory::pop() {
       theNumberOfFoundHits--;
       theChiSquared -= theData.back().estimate();
       if(badForCCC(theData.back())) theNumberOfCCCBadHits_--; 
+      if(pixel(*(theData.back().recHit()))) theNumberOfFoundPixelHits--;
     }
     else if(lost(* (theData.back().recHit()) )) {
       theNumberOfLostHits--;
@@ -73,6 +74,7 @@ void Trajectory::pushAux(double chi2Increment) {
     theNumberOfFoundHits++;
     theNumberOfTrailingFoundHits++;
     if (badForCCC(tm)) theNumberOfCCCBadHits_++;
+    if(pixel(*(tm.recHit())))  theNumberOfFoundPixelHits++;
   }
   // else if (lost( tm.recHit()) && !inactive(tm.recHit().det())) theNumberOfLostHits++;
   else if (lost( *(tm.recHit()) ) ) {
@@ -170,6 +172,13 @@ bool Trajectory::isBad( const TrackingRecHit& hit)
       return hit.getType() == TrackingRecHit::bad;
     }
   }
+}
+
+bool Trajectory::pixel(const TrackingRecHit& hit) {
+  if (trackerHitRTTI::isUndef(hit))
+    return false;
+  auto const * thit = static_cast<const BaseTrackerRecHit*>( hit.hit() );
+  return thit->isPixel();
 }
 
 bool Trajectory::badForCCC(const TrajectoryMeasurement &tm) {

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -67,6 +67,7 @@ public:
 protected:
 
   template <class T> bool QF(const T& traj) const{
+    if (!theSeedExtensionTrajectoryFilter->qualityFilter(traj)) return false;
     if (!theChargeSignificanceTrajectoryFilter->qualityFilter(traj)) return false;            
     if (!theMinHitsTrajectoryFilter->qualityFilter(traj)) return false;
     if (!theMinPtTrajectoryFilter->qualityFilter(traj)) return false;

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -12,8 +12,8 @@ public:
      theStrict(pset.getParameter<bool>("strictSeedExtension")),
      theExtension(pset.getParameter<int>("seedExtension")) {}
 
-  virtual bool qualityFilter( const Trajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
-  virtual bool qualityFilter( const TempTrajectory& traj) const { return TrajectoryFilter::qualityFilterIfNotContributing; }
+  virtual bool qualityFilter( const Trajectory& traj) const { return QF(traj); }
+  virtual bool qualityFilter( const TempTrajectory& traj) const { return QF(traj); }
 
   virtual bool toBeContinued( TempTrajectory& traj) const { return TBC<TempTrajectory>(traj);}
   virtual bool toBeContinued( Trajectory& traj) const{ return TBC<Trajectory>(traj);}
@@ -21,6 +21,9 @@ public:
   virtual std::string name() const{return "LostHitsFractionTrajectoryFilter";}
 
 private:
+  template<class T> bool QF(const T & traj) const {
+    return traj.stopReason() != StopReason::SEED_EXTENSION; // reject tracks killed by seed extension
+  }
 
   template<class T> bool TBC(T& traj) const {
     if(theExtension <= 0) return true; // skipping checks explicitly when intended to be disabled is the safest way

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -22,9 +22,11 @@ public:
 
 private:
 
-  template<class T> bool TBC(const T& traj) const {
-     if(theExtension <= 0) return true; // skipping checks explicitly when intended to be disabled is the safest way
-     return theStrict? strictTBC(traj) : looseTBC(traj);
+  template<class T> bool TBC(T& traj) const {
+    if(theExtension <= 0) return true; // skipping checks explicitly when intended to be disabled is the safest way
+    const bool ret =  theStrict? strictTBC(traj) : looseTBC(traj);
+    if(!ret) traj.setStopReason(StopReason::SEED_EXTENSION);
+    return ret;
   }
   template<class T> bool looseTBC(const T& traj) const;
   template<class T> bool strictTBC(const T& traj) const;

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -33,6 +33,7 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
 # Cut on the length of the seed extention (no lost hits allowed)
     seedExtension = cms.int32(0),
     strictSeedExtension = cms.bool(False),
+    pixelSeedExtension = cms.bool(False),
 
 # Cuts for looperTrajectoryFilter
     minNumberOfHitsForLoopers           = cms.int32(13),


### PR DESCRIPTION
This PR adds a "pixel-only" flavour of the SeedExtensionTrajectoryFilter (one of the explored pixel-quadruplet approaches for phase1). As a prerequisite, Trajectory and TempTrajectory are extended to count also found pixel hits (which may have other uses too). 

The SeedExtensionTrajectoryFilter is also extended to act as "qualityFilter()" in addition to "toBeContinued()". The point is that if seed extension decides that a propagation of a trajectory should be stopped, the trajectory should also be discarded (in my opinion). This way the assumption is enforced without relying on the value of `minimumNumberOfHits` (alternatively we would need `minimumNumberOfPixelHits`). The easiest way to communicate the "trajectory was stopped because of seed extension" from `toBeContinued()` to `qualityFilter()` was to use the existing `StoppingReason` enum, so I added a `SEED_EXTENSION` enumerator there.

I updated the tracking DQM for the new `StoppingReason` (*), also adding a run-time check in case new StoppingReasons are added. (Maybe we should eventually abstract the string representation of StoppingReasons similarly to TrackBase::TrackAlgorithm?)

(*) After the "qualityFilter()" change we expect to see zero tracks with `SEED_EXTENSION` stopping reason, so the DQM change serves mainly as a sanity check (seeing something there indicates a bug).

Tested in CMSSW_8_1_X_2016-05-01-2300 (rebased on top of ~~CMSSW_8_1_X_2016-05-09-2300~~ CMSSW_8_1_X_2016-05-16-2300), no changes expected in standard workflows (new functionality is added but not enabled; StopReason DQM plots show changes because of added bin).

@rovere @VinInn @mtosi 
