### PR TITLE
Add new signal to ActivityRegistry around when a

### DIFF
--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -27,12 +27,11 @@ namespace edm {
   class DelayedReader {
   public:
     virtual ~DelayedReader();
-    std::unique_ptr<WrapperBase> getProduct(BranchKey const& k, EDProductGetter const* ep);
     std::unique_ptr<WrapperBase> getProduct(BranchKey const& k,
                                             EDProductGetter const* ep,
-                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& preReadFromSourceSignal,
-                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& postReadFromSourceSignal,
-                                            ModuleCallingContext const* mcc);
+                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preReadFromSourceSignal = nullptr,
+                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postReadFromSourceSignal = nullptr,
+                                            ModuleCallingContext const* mcc = nullptr);
 
     void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
     void reset() {reset_();}

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -13,14 +13,27 @@ uses input sources to retrieve EDProducts from external storage.
 #include <memory>
 
 namespace edm {
+
   class BranchKey;
   class EDProductGetter;
+  class ModuleCallingContext;
   class SharedResourcesAcquirer;
+  class StreamContext;
+
+  namespace signalslot {
+    template <typename T> class Signal;
+  }
+
   class DelayedReader {
   public:
     virtual ~DelayedReader();
-    virtual std::unique_ptr<WrapperBase> getProduct(BranchKey const& k, EDProductGetter const* ep);
-    
+    std::unique_ptr<WrapperBase> getProduct(BranchKey const& k, EDProductGetter const* ep);
+    std::unique_ptr<WrapperBase> getProduct(BranchKey const& k,
+                                            EDProductGetter const* ep,
+                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& preReadFromSourceSignal,
+                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& postReadFromSourceSignal,
+                                            ModuleCallingContext const* mcc);
+
     void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
     void reset() {reset_();}
     

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -173,11 +173,13 @@ namespace edm {
     }
 
     using Base::getProvenance;
-    
+
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preModuleDelayedGetSignal_;
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postModuleDelayedGetSignal_;
 
-    
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preReadFromSourceSignal_;
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postReadFromSourceSignal_;
+
   private:
 
     BranchID pidToBid(ProductID const& pid) const;

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -15,21 +15,11 @@
 namespace edm {
   DelayedReader::~DelayedReader() {}
 
-  std::unique_ptr<WrapperBase> 
-  DelayedReader::getProduct(BranchKey const& k, EDProductGetter const* ep) {
-    auto sr = sharedResources_();
-    std::unique_lock<SharedResourcesAcquirer> guard;
-    if(sr) {
-      guard =std::unique_lock<SharedResourcesAcquirer>(*sr);
-    }
-    return getProduct_(k, ep);
-  }
-
   std::unique_ptr<WrapperBase>
   DelayedReader::getProduct(BranchKey const& k,
                             EDProductGetter const* ep,
-                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& preReadFromSourceSignal,
-                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& postReadFromSourceSignal,
+                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preReadFromSourceSignal,
+                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postReadFromSourceSignal,
                             ModuleCallingContext const* mcc) {
 
     auto sr = sharedResources_();
@@ -39,11 +29,11 @@ namespace edm {
     }
 
     if(mcc) {
-      preReadFromSourceSignal.emit(*(mcc->getStreamContext()),*mcc);
+      preReadFromSourceSignal->emit(*(mcc->getStreamContext()),*mcc);
     }
     std::shared_ptr<void> guardForSignal(nullptr,[&postReadFromSourceSignal,mcc](const void*){
       if(mcc) {
-        postReadFromSourceSignal.emit(*(mcc->getStreamContext()),*mcc);
+        postReadFromSourceSignal->emit(*(mcc->getStreamContext()),*mcc);
       }
     });
 

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -1,5 +1,8 @@
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/Signal.h"
 
 #include <mutex>
 #include <cassert>
@@ -19,6 +22,31 @@ namespace edm {
     if(sr) {
       guard =std::unique_lock<SharedResourcesAcquirer>(*sr);
     }
+    return getProduct_(k, ep);
+  }
+
+  std::unique_ptr<WrapperBase>
+  DelayedReader::getProduct(BranchKey const& k,
+                            EDProductGetter const* ep,
+                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& preReadFromSourceSignal,
+                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const& postReadFromSourceSignal,
+                            ModuleCallingContext const* mcc) {
+
+    auto sr = sharedResources_();
+    std::unique_lock<SharedResourcesAcquirer> guard;
+    if(sr) {
+      guard =std::unique_lock<SharedResourcesAcquirer>(*sr);
+    }
+
+    if(mcc) {
+      preReadFromSourceSignal.emit(*(mcc->getStreamContext()),*mcc);
+    }
+    std::shared_ptr<void> guardForSignal(nullptr,[&postReadFromSourceSignal,mcc](const void*){
+      if(mcc) {
+        postReadFromSourceSignal.emit(*(mcc->getStreamContext()),*mcc);
+      }
+    });
+
     return getProduct_(k, ep);
   }
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -197,8 +197,8 @@ namespace edm {
         }
       });
       
-      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this));
-      
+      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, preReadFromSourceSignal_, postReadFromSourceSignal_, mcc));
+
       // Now fix up the ProductResolver
       phb.putProduct(std::move(edp));
     }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -197,7 +197,7 @@ namespace edm {
         }
       });
       
-      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, preReadFromSourceSignal_, postReadFromSourceSignal_, mcc));
+      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, &preReadFromSourceSignal_, &postReadFromSourceSignal_, mcc));
 
       // Now fix up the ProductResolver
       phb.putProduct(std::move(edp));

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -546,6 +546,8 @@ namespace edm {
            thinnedAssociationsHelper(), *processConfiguration_, historyAppender_.get(), index);
       ep->preModuleDelayedGetSignal_.connect(std::cref(actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
+      ep->preReadFromSourceSignal_.connect(std::cref(actReg_->preEventReadFromSourceSignal_));
+      ep->postReadFromSourceSignal_.connect(std::cref(actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);
     }
     // initialize the subprocesses, if there are any

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -172,6 +172,8 @@ namespace edm {
                                                  false /*not primary process*/);
       ep->preModuleDelayedGetSignal_.connect(std::cref(items.actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(items.actReg_->postModuleEventDelayedGetSignal_));
+      ep->preReadFromSourceSignal_.connect(std::cref(items.actReg_->preEventReadFromSourceSignal_));
+      ep->postReadFromSourceSignal_.connect(std::cref(items.actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);
     }
     if(hasSubProcesses) {

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -311,20 +311,32 @@ PathContext: pathName = e pathID = 0 (EndPath)
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
@@ -421,20 +433,32 @@ PathContext: pathName = e pathID = 0 (EndPath)
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
@@ -531,20 +555,32 @@ PathContext: pathName = e pathID = 0 (EndPath)
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -684,22 +684,38 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostModuleEvent)
 
-     /// signal is emitted after the module starts processing the Event and before a delayed get has started
-     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEventDelayedGet;
-     PreModuleEventDelayedGet preModuleEventDelayedGetSignal_;
-     void watchPreModuleEventDelayedGet(PreModuleEventDelayedGet::slot_type const& iSlot) {
-       preModuleEventDelayedGetSignal_.connect(iSlot);
-     }
-     AR_WATCH_USING_METHOD_2(watchPreModuleEventDelayedGet)
-     
-     /// signal is emitted after the module starts processing the Event and after a delayed get has finished
-     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleEventDelayedGet;
-     PostModuleEventDelayedGet postModuleEventDelayedGetSignal_;
-     void watchPostModuleEventDelayedGet(PostModuleEventDelayedGet::slot_type const& iSlot) {
-       postModuleEventDelayedGetSignal_.connect_front(iSlot);
-     }
-     AR_WATCH_USING_METHOD_2(watchPostModuleEventDelayedGet)
-     
+      /// signal is emitted after the module starts processing the Event and before a delayed get has started
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEventDelayedGet;
+      PreModuleEventDelayedGet preModuleEventDelayedGetSignal_;
+      void watchPreModuleEventDelayedGet(PreModuleEventDelayedGet::slot_type const& iSlot) {
+         preModuleEventDelayedGetSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleEventDelayedGet)
+
+      /// signal is emitted after the module starts processing the Event and after a delayed get has finished
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleEventDelayedGet;
+      PostModuleEventDelayedGet postModuleEventDelayedGetSignal_;
+      void watchPostModuleEventDelayedGet(PostModuleEventDelayedGet::slot_type const& iSlot) {
+         postModuleEventDelayedGetSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleEventDelayedGet)
+
+      /// signal is emitted after the module starts processing the Event, after a delayed get has started, and before a source read
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreEventReadFromSource;
+      PreEventReadFromSource preEventReadFromSourceSignal_;
+      void watchPreEventReadFromSource(PreEventReadFromSource::slot_type const& iSlot) {
+         preEventReadFromSourceSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreEventReadFromSource)
+
+      /// signal is emitted after the module starts processing the Event, after a delayed get has started, and after a source read
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostEventReadFromSource;
+      PostEventReadFromSource postEventReadFromSourceSignal_;
+      void watchPostEventReadFromSource(PostEventReadFromSource::slot_type const& iSlot) {
+         postEventReadFromSourceSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostEventReadFromSource)
+
       typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleStreamBeginRun;
       PreModuleStreamBeginRun preModuleStreamBeginRunSignal_;
       void watchPreModuleStreamBeginRun(PreModuleStreamBeginRun::slot_type const& iSlot) {

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -214,6 +214,8 @@ namespace edm {
      preModuleEventDelayedGetSignal_.connect(std::cref(iOther.preModuleEventDelayedGetSignal_));
      postModuleEventDelayedGetSignal_.connect(std::cref(iOther.postModuleEventDelayedGetSignal_));
 
+     preEventReadFromSourceSignal_.connect(std::cref(iOther.preEventReadFromSourceSignal_));
+     postEventReadFromSourceSignal_.connect(std::cref(iOther.postEventReadFromSourceSignal_));
 
      preModuleStreamBeginRunSignal_.connect(std::cref(iOther.preModuleStreamBeginRunSignal_));
      postModuleStreamBeginRunSignal_.connect(std::cref(iOther.postModuleStreamBeginRunSignal_));
@@ -377,6 +379,9 @@ namespace edm {
 
     copySlotsToFrom(preModuleEventDelayedGetSignal_, iOther.preModuleEventDelayedGetSignal_);
     copySlotsToFromReverse(postModuleEventDelayedGetSignal_, iOther.postModuleEventDelayedGetSignal_);
+
+    copySlotsToFrom(preEventReadFromSourceSignal_, iOther.preEventReadFromSourceSignal_);
+    copySlotsToFromReverse(postEventReadFromSourceSignal_, iOther.postEventReadFromSourceSignal_);
 
     copySlotsToFrom(preModuleStreamBeginRunSignal_, iOther.preModuleStreamBeginRunSignal_);
     copySlotsToFromReverse(postModuleStreamBeginRunSignal_, iOther.postModuleStreamBeginRunSignal_);

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -134,6 +134,8 @@ namespace edm {
       void postModuleEvent(StreamContext const&, ModuleCallingContext const&);
       void preModuleEventDelayedGet(StreamContext const&, ModuleCallingContext const&);
       void postModuleEventDelayedGet(StreamContext const&, ModuleCallingContext const&);
+      void preEventReadFromSource(StreamContext const&, ModuleCallingContext const&);
+      void postEventReadFromSource(StreamContext const&, ModuleCallingContext const&);
       
       void preModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
       void postModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
@@ -271,6 +273,8 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   iRegistry.watchPostModuleEvent(this, &Tracer::postModuleEvent);
   iRegistry.watchPreModuleEventDelayedGet(this, &Tracer::preModuleEventDelayedGet);
   iRegistry.watchPostModuleEventDelayedGet(this, &Tracer::postModuleEventDelayedGet);
+  iRegistry.watchPreEventReadFromSource(this, &Tracer::preEventReadFromSource);
+  iRegistry.watchPostEventReadFromSource(this, &Tracer::postEventReadFromSource);
 
   iRegistry.watchPreModuleStreamBeginRun(this, &Tracer::preModuleStreamBeginRun);
   iRegistry.watchPostModuleStreamBeginRun(this, &Tracer::postModuleStreamBeginRun);
@@ -904,6 +908,28 @@ Tracer::postModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext 
     out << "\n" << sc;
     out << mcc;
   }
+}
+
+void
+Tracer::preEventReadFromSource(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 5;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: event delayed read from source: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
+}
+
+void
+Tracer::postEventReadFromSource(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 5;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: event delayed read from source: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
 }
 
 


### PR DESCRIPTION
source is called during processing of an event
to get a product using DelayedRead. This should be
useful when measuring stall time in multithreaded processes.
