### PR TITLE
Added names for hardcoded constants and added one TP plot

### DIFF
--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -43,6 +43,14 @@ namespace ecaldqm {
     nDCCMEM = 44,
     nEEDCCMEM = 8,
 
+    nTTOuter = 16,
+    nTTInner = 28,
+    // These lines set the number of TriggerTowers in "outer" and "inner" TCCs,
+    // where "outer" := closer to the barrel. These constants are used in
+    // setting the binning. There are 16 trigger towers per TCC for "outer" TCCs,
+    // and 24 per TCC for "inner" TCCs (but the numbering is from 0 to 27, so
+    // 28 bins are required).
+
     nTCC = 108,
     kEEmTCCLow = 0, kEEmTCCHigh = 35,
     kEEpTCCLow = 72, kEEpTCCHigh = 107,

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -68,9 +68,15 @@ namespace ecaldqm
           if(tccid <= 36 || tccid >= 73){ // EE
             unsigned bin(ttId(_id));
             bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
-            if(outer) bin += 56; // Sets bin number to increment by 56 for TTs in "outer" TCCs (closer to the barrel)
-            bin += (tccid % 2) * (outer ? 16 : 28); // 16 trigger towers per TCC for "outer" TCCs, 24 for "inner" TCCs but they are numbered from 0 to 27 with some missing
-            // We have x-axis in the format inner1 (28 bins), inner2 (28 bins), outer1 (16 bins), outer2 (16 bins) -- 88 bins in total
+            // For the following, the constants nTTInner and nTTOuter are defined in
+            // EcalDQMCommonUtils.h.
+            if(outer) bin += 2*nTTInner; // For outer TCCs, sets bin number to increment
+            // by twice the number of TTs in inner TCCs, because numbering of bins
+            // is in the order (inner1, inner2, outer1, outer2).
+            // ("inner"" := closer to the beam)
+            bin += (tccid % 2) * (outer ? nTTOuter : nTTInner); // Yields x-axis bin number
+            // in the format above; TTs in even-numbered TCCs are filled in inner1 or outer1,
+            // and those in odd-numbered TCC are filled in inner2 and outer2.
             return bin;
           }
           else
@@ -147,9 +153,15 @@ namespace ecaldqm
           if(tccid <= 36 || tccid >= 73){ // EE
             unsigned bin(ttId(_id));
             bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
-            if(outer) bin += 56; // Sets bin number to increment by 56 for TTs in "outer" TCCs (closer to the barrel)
-            bin += (tccid % 2) * (outer ? 16 : 28); // 16 trigger towers per TCC for "outer" TCCs, 24 for "inner" TCCs but they are numbered from 0 to 27 with some missing
-            // We have x-axis in the format inner1 (28 bins), inner2 (28 bins), outer1 (16 bins), outer2 (16 bins) -- 88 bins in total
+            // For the following, the constants nTTInner and nTTOuter are defined in
+            // EcalDQMCommonUtils.h.
+            if(outer) bin += 2*nTTInner; // For outer TCCs, sets bin number to increment
+            // by twice the number of TTs in inner TCCs, because numbering of bins
+            // is in the order (inner1, inner2, outer1, outer2).
+            // ("inner"" := closer to the beam)
+            bin += (tccid % 2) * (outer ? nTTOuter : nTTInner); // Yields x-axis bin number
+            // in the format above; TTs in even-numbered TCCs are filled in inner1 or outer1,
+            // and those in odd-numbered TCC are filled in inner2 and outer2.
             return bin;
           }
           else

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -214,7 +214,8 @@ namespace ecaldqm
           break;
         case kTriggerTower:
         case kPseudoStrip:
-          specs.nbins = isBarrel ? 68 : 88; // 88 bins required for EE: 28 for two inner tccs, 16 for two outer TCCs
+          specs.nbins = isBarrel ? 68 : (2*nTTOuter + 2*nTTInner); // For EE: numbering of bins
+          // is in the order (inner1, inner2, outer1, outer2). ("inner"" := closer to the beam)
           specs.low = 0.;
           specs.high = specs.nbins;
           specs.title = "tower";

--- a/DQM/EcalCommon/src/MESetDet1D.cc
+++ b/DQM/EcalCommon/src/MESetDet1D.cc
@@ -85,18 +85,23 @@ namespace ecaldqm
           me->setBinLabel(1, ss.str());
           ss.str("");
           ss << "TCC" << inner.second << " TT1";
-          me->setBinLabel(29, ss.str());
+          me->setBinLabel(1+nTTInner, ss.str());
           ss.str("");
           ss << "TCC" << outer.first << " TT1";
-          me->setBinLabel(57, ss.str());
+          me->setBinLabel(1+2*nTTInner, ss.str());
           ss.str("");
           ss << "TCC" << outer.second << " TT1";
-          me->setBinLabel(73, ss.str()); // Bins are numbered 1-->28, 29-->56 for two inner TCCs and 57-->72, 73-->88 for two outer TCCs
+          me->setBinLabel(1+2*nTTInner+nTTOuter, ss.str());
+          // Bins are numbered:
+          // inner1:(1)-->(nTTInner)
+          // inner2:(1+nTTInner)-->(1+nTTInner + nTTInner-1 = 2*nTTInner)
+          // outer1:(1+2*nTTInner)-->(1+2*nTTInner+nTTOuter-1=2*nTTInner+nTTOuter)
+          // outer2:(1+2*nTTInner+nTTOuter)-->(1+2*nTTInner+nTTOuter + nTTOuter-1 = 2*nTTInner+2*nTTOuter)
           int offset(0);
-          for(int iBin(4); iBin <= 88; iBin += 4){
-            if(iBin == 32) offset = 28;
-            else if(iBin == 60) offset = 56;
-            else if(iBin == 76) offset = 72;
+          for(int iBin(4); iBin <= (2*nTTOuter + 2*nTTInner); iBin += 4){
+            if(iBin == 4+nTTInner) offset = nTTInner;
+            else if(iBin == 4+2*nTTInner) offset = 2*nTTInner;
+            else if(iBin == 4+2*nTTInner+nTTOuter) offset = 2*nTTInner+nTTOuter;
             ss.str("");
             ss << iBin - offset;
             me->setBinLabel(iBin, ss.str());

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -216,6 +216,25 @@ ecalTrigPrimTask = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of the trigger primitive Et.')
+        ),
+        RealvEmulEt = cms.untracked.PSet(
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(256.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Real data TP Et (ADC)')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(256.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Emulated TP Et (ADC)')
+            ),
+            btype = cms.untracked.string('User'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
+            description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
         )
     )
 )

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -275,6 +275,7 @@ namespace ecaldqm
     MESet& meMatchedIndex(MEs_.at("MatchedIndex"));
     MESet& meEtEmulError(MEs_.at("EtEmulError"));
     MESet& meFGEmulError(MEs_.at("FGEmulError"));
+    MESet& meRealvEmulEt(MEs_.at("RealvEmulEt"));
 
     for(EcalTrigPrimDigiCollection::const_iterator tpItr(_tps.begin()); tpItr != _tps.end(); ++tpItr){
       EcalTrigTowerDetId ttid(tpItr->id());
@@ -337,6 +338,9 @@ namespace ecaldqm
             } // iDigi
             if(!matchedIndex.size()) matchedIndex.push_back(0); // no Et match found => no emul
                         
+            // Fill Real vs Emulated TP Et
+            meRealvEmulEt.fill( ttid,realEt,(*tpItr)[2].compressedEt() ); // iDigi=2:in-time BX
+
             // Fill matchedIndex ME
             for(std::vector<int>::iterator matchItr(matchedIndex.begin()); matchItr != matchedIndex.end(); ++matchItr){
               meMatchedIndex.fill(ttid, *matchItr + 0.5);


### PR DESCRIPTION
1) Add Real vs Emulated TP Et plot
2) Replaced hardcoded constants for the number of inner and outer trigger towers with constant variables having suitable names

Corresponding PR for 80x: https://github.com/cms-sw/cmssw/pull/14369
