### PR TITLE
CSC Unpacker fixes for 2016 TMB/OTMB firmware updates (80X)

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
@@ -31,3 +31,4 @@ private:
 };
 
 #endif
+

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -18,6 +18,7 @@
 class CSCDMBHeader;
 struct CSCTMBHeader2006;
 struct CSCTMBHeader2007;
+struct CSCTMBHeader2007_rev0x50c3;
 struct CSCTMBHeader2013;
 
 
@@ -71,6 +72,7 @@ class CSCTMBHeader {
 
   /// will throw if the cast fails
   CSCTMBHeader2007 tmbHeader2007()   const;
+  CSCTMBHeader2007_rev0x50c3 tmbHeader2007_rev0x50c3() const;
   CSCTMBHeader2006 tmbHeader2006()   const;
   CSCTMBHeader2013 tmbHeader2013()   const;
 
@@ -80,6 +82,12 @@ class CSCTMBHeader {
   uint16_t NCFEBs() const {
     return theHeaderFormat->NCFEBs();
   }
+
+  uint16_t syncError() const { return theHeaderFormat->syncError();}
+  uint16_t syncErrorCLCT() const { return theHeaderFormat->syncErrorCLCT();}
+  uint16_t syncErrorMPC0() const { return theHeaderFormat->syncErrorMPC0();}
+  uint16_t syncErrorMPC1() const { return theHeaderFormat->syncErrorMPC1();}
+
 
   void setNCFEBs(uint16_t ncfebs) {
 	theHeaderFormat->setNCFEBs(ncfebs);

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
@@ -22,6 +22,10 @@ struct CSCTMBHeader2006 : public CSCVTMBHeaderFormat {
   virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
   virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
   virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
+  virtual uint16_t syncError() const {return bits.syncError;}
+  virtual uint16_t syncErrorCLCT() const {return (bits.clct0_sync_err | bits.clct1_sync_err);}
+  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
+  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
   virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
@@ -22,6 +22,10 @@ struct CSCTMBHeader2007 : public CSCVTMBHeaderFormat {
   virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
   virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
   virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
+  virtual uint16_t syncError() const {return bits.syncError;}
+  virtual uint16_t syncErrorCLCT() const {return (bits.clct0_sync_err | bits.clct1_sync_err);}
+  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
+  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
   virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
@@ -21,6 +21,10 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   virtual uint16_t NTBins() const {return bits.nTBins;}
   virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
   virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
+  virtual uint16_t syncError() const {return bits.syncError;}
+  virtual uint16_t syncErrorCLCT() const {return bits.clct_sync_err;}
+  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
+  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
   virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
 
   ///returns CLCT digis
@@ -65,7 +69,7 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   unsigned bd_status:15, flag6:1;
   unsigned firmRevCode:15, flag7:1;
   // 8
-  unsigned bxnPreTrigger:12, reserved:2, lock_lost:1, flag8:1; 
+  unsigned bxnPreTrigger:12, tmb_clct0_discard:1, tmb_clct1_discard:1, lock_lost:1, flag8:1; 
   unsigned preTrigCounterLow:15, flag9:1;
   unsigned preTrigCounterHigh:15, flag10:1;
   unsigned clctCounterLow:15, flag11:1;
@@ -80,7 +84,7 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   unsigned uptimeCounterHigh:15, flag18:1;
   unsigned nCFEBs:3, nTBins:5, fifoPretrig:5, scopeExists:1, vmeExists:1, flag19:1;
   // 20
-  unsigned hitThresh:3, pidThresh:4, nphThresh:3, lyrThresh:3, layerTrigEnabled:1, staggerCSC:1, flag20:1;
+  unsigned hitThresh:3, pidThresh:4, nphThresh:3, pid_thresh_postdrift:4, staggerCSC:1, flag20:1;
   unsigned triadPersist:4, dmbThresh:3, alct_delay:4, clct_width:4, flag21:1;
   unsigned trigSourceVect:9, r_nlayers_hit_vec:6, flag22:1;
   unsigned activeCFEBs:5, readCFEBs:5, pop_l1a_match_win:4, aff_source:1, flag23:1;
@@ -91,8 +95,8 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   unsigned clct0_key_high:1, clct1_key_high:1, clct_bxn:2, clct_sync_err:1,  clct0Invalid:1, clct1Invalid:1, clct1Busy:1, parity_err_cfeb_ram:5, parity_err_rpc:1, parity_err_summary:1, flag27:1;
   // 28
   unsigned alct0Valid:1, alct0Quality:2, alct0Amu:1, alct0Key:7, alct_pretrig_win:4, flag28:1;
-  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, reserved3:1, layerTriggered:1, flag29:1;
-  unsigned alctBXN:5, alctSeqStatus:2, alctSEUStatus:2, alctReserved:4, alctCfg:1, reserved4:1, flag30:1;
+  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, bcb_read_enable:1, layerTriggered:1, flag29:1;
+  unsigned alctBXN:5, alct_ecc_err:2, cfeb_badbits_found:5, cfeb_badbits_blocked:1, alct_cfg_done:1, bx0_match:1, flag30:1;
   unsigned MPC_Muon0_wire_:7, MPC_Muon0_clct_pattern_:4, MPC_Muon0_quality_:4, flag31:1;
   // 32
   unsigned MPC_Muon0_halfstrip_clct_pattern:8, MPC_Muon0_bend_:1, MPC_Muon0_SyncErr_:1, MPC_Muon0_bx_:1, MPC_Muon0_bc0_:1, MPC_Muon0_cscid_low:3, flag32:1;
@@ -101,13 +105,12 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   unsigned MPC_Muon0_vpf_:1, MPC_Muon0_cscid_bit4:1, MPC_Muon1_vpf_:1, MPC_Muon1_cscid_bit4:1, MPCDelay:4, MPCAccept:2, CFEBsEnabled:5, flag35:1;
   // 36
   unsigned RPCList:2, NRPCs:2, RPCEnable:1, fifo_tbins_rpc:5, fifo_pretrig_rpc:5, flag36:1;
-
   unsigned r_wr_buf_adr:11, r_wr_buf_ready:1, wr_buf_ready:1, buf_q_full:1, buf_q_empty:1, flag37:1;
   unsigned r_buf_fence_dist:11, buf_q_ovf_err:1, buf_q_udf_err:1, buf_q_adr_err:1, buf_stalled:1, flag38:1;
-  unsigned buf_fence_cnt:12, reserved7:3, flag39:1;
+  unsigned buf_fence_cnt:12, reverse_hs_csc:1, reverse_hs_me1a:1, reverse_hs_me1b:1, flag39:1;
   // 40
-  unsigned buf_fence_cnt_peak:12, reserved8:3, flag40:1;
-  unsigned reserved9:15, flag41:1;
+  unsigned buf_fence_cnt_peak:12, trig_source_vect:2, tmb_trig_pulse:1, flag40:1;
+  unsigned tmb_allow_alct:1, tmb_allow_clct:1, tmb_allow_match:1, tmb_allow_alct_ro:1, tmb_allow_clct_ro:1, tmb_allow_match_ro:1, tmb_alct_only_ro:1, tmb_clct_only_ro:1, tmb_match_ro:1, tmb_trig_keep:1, tmb_non_trig_keep:1, lyr_thresh_pretrig:3, layer_trig_en:1, flag41:1;
   unsigned e0bline:16;
   } bits;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
@@ -22,6 +22,10 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
   virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x7F;}
   virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
+  virtual uint16_t syncError() const {return bits.syncError;}
+  virtual uint16_t syncErrorCLCT() const {return bits.clct_sync_err;}
+  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
+  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
   virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);
@@ -65,7 +69,7 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   unsigned bd_status:15, flag6:1;
   unsigned firmRevCode:15, flag7:1;
   // 8
-  unsigned bxnPreTrigger:12, reserved:2, lock_lost:1, flag8:1; 
+  unsigned bxnPreTrigger:12, tmb_clct0_discard:1, tmb_clct1_discard:1, clock_lock_lost:1, flag8:1; 
   unsigned preTrigCounterLow:15, flag9:1;
   unsigned preTrigCounterHigh:15, flag10:1;
   unsigned clctCounterLow:15, flag11:1;
@@ -80,7 +84,7 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   unsigned uptimeCounterHigh:15, flag18:1;
   unsigned nCFEBs:3, nTBins:5, fifoPretrig:5, scopeExists:1, vmeExists:1, flag19:1;
   // 20
-  unsigned hitThresh:3, pidThresh:4, nphThresh:3, lyrThresh:3, layerTrigEnabled:1, staggerCSC:1, flag20:1;
+  unsigned hitThresh:3, pidThresh:4, nphThresh:3, pid_thresh_postdrift:4, staggerCSC:1, flag20:1;
   unsigned triadPersist:4, dmbThresh:3, alct_delay:4, clct_width:4, flag21:1;
   unsigned trigSourceVect:9, r_nlayers_hit_vec:6, flag22:1;
   unsigned activeCFEBs:5, readCFEBs:5, pop_l1a_match_win:4, aff_source:1, flag23:1;
@@ -91,8 +95,8 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   unsigned clct0_key_high:1, clct1_key_high:1, clct_bxn:2, clct_sync_err:1,  clct0Invalid:1, clct1Invalid:1, clct1Busy:1, parity_err_cfeb_ram:5, parity_err_rpc:1, parity_err_summary:1, flag27:1;
   // 28
   unsigned alct0Valid:1, alct0Quality:2, alct0Amu:1, alct0Key:7, alct_pretrig_win:4, flag28:1;
-  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, reserved3:1, layerTriggered:1, flag29:1;
-  unsigned alctBXN:5, alctSeqStatus:2, alctSEUStatus:2, alctReserved:4, alctCfg:1, reserved4:1, flag30:1;
+  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, bcb_read_enable:1, hs_layer_trig:1, flag29:1;
+  unsigned alctBXN:5, alct_ecc_err:2, cfeb_badbits_found:5, cfeb_badbits_blocked:1, alctCfg:1, bx0_match:1, flag30:1;
   unsigned MPC_Muon0_wire_:7, MPC_Muon0_clct_pattern_:4, MPC_Muon0_quality_:4, flag31:1;
   // 32
   unsigned MPC_Muon0_halfstrip_clct_pattern:8, MPC_Muon0_bend_:1, MPC_Muon0_SyncErr_:1, MPC_Muon0_bx_:1, MPC_Muon0_bc0_:1, MPC_Muon0_cscid_low:3, flag32:1;
@@ -101,14 +105,13 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   unsigned MPC_Muon0_vpf_:1, MPC_Muon0_cscid_bit4:1, MPC_Muon1_vpf_:1, MPC_Muon1_cscid_bit4:1, MPCDelay:4, MPCAccept:2, CFEBsEnabled:5, flag35:1;
   // 36
   unsigned RPCList:2, NRPCs:2, RPCEnable:1, fifo_tbins_rpc:5, fifo_pretrig_rpc:5, flag36:1;
-
   unsigned r_wr_buf_adr:11, r_wr_buf_ready:1, wr_buf_ready:1, buf_q_full:1, buf_q_empty:1, flag37:1;
   unsigned r_buf_fence_dist:11, buf_q_ovf_err:1, buf_q_udf_err:1, buf_q_adr_err:1, buf_stalled:1, flag38:1;
-  unsigned buf_fence_cnt:12, reserved7:3, flag39:1;
+  unsigned buf_fence_cnt:12, reverse_hs_csc:1, reverse_hs_me1a:1, reverse_hs_me1b:1, flag39:1;
   // 40
   // unsigned buf_fence_cnt_peak:12, reserved8:3, flag40:1;
-  unsigned mxcfeb:1, activeCFEBs_2:2, readCFEBs_2:2, parity_err_cfeb_ram_2:2, cfeb_badbits_found:2, CFEBsEnabled_2:2, buf_fence_cnt_is_peak:1, flag40:1;
-  unsigned reserved9:15, flag41:1;
+  unsigned activeCFEBs_2:2, readCFEBs_2:2, cfeb_badbits_found_2:2, parity_err_cfeb_ram_2:2, CFEBsEnabled_2:2, buf_fence_cnt_is_peak:1, mxcfeb:1, trig_source_vec:2, tmb_trig_pulse:1, flag40:1;
+  unsigned tmb_allow_alct:1, tmb_allow_clct:1, tmb_allow_match:1, tmb_allow_alct_ro:1, tmb_allow_clct_ro:1, tmb_allow_match_ro:1, tmb_alct_only_ro:1, tmb_clct_only_ro:1, tmb_match_ro:1, tmb_trig_keep:1, tmb_non_trig_keep:1, lyr_thresh_pretrig:3, layer_trig_en:1, flag41:1;
   unsigned e0bline:16;
   } bits;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
@@ -38,3 +38,4 @@ private:
 };
 
 #endif
+

--- a/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
@@ -27,6 +27,10 @@ public:
   virtual uint16_t Bxn0Diff() const = 0;
   virtual uint16_t Bxn1Diff() const = 0;
   virtual uint16_t L1ANumber() const = 0;
+  virtual uint16_t syncError() const = 0;
+  virtual uint16_t syncErrorCLCT() const = 0;
+  virtual uint16_t syncErrorMPC0() const = 0;
+  virtual uint16_t syncErrorMPC1() const = 0;
   uint16_t sizeInBytes() const {
     return sizeInWords()*2;
   }

--- a/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
@@ -1001,17 +1001,22 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
         {
           if (fTMB_Format2007)
             {
-              if (TMB_Firmware_Revision >= 0x50c3)   // TMB2007 rev.0x50c3
+	      /* Checks for TMB2007 firmware revisions ranges to detect data format
+               * rev.0x50c3 - first revision with changed format 
+               * rev.0x42D5 - oldest known from 06/21/2007
+               * There is 4-bits year value rollover in revision number (0 in 2016)
+               */
+              if ((TMB_Firmware_Revision >= 0x50c3) || (TMB_Firmware_Revision < 0x42D5))  
                 {
                   // On/off * nRPCs * nTimebins * 2 words/RPC/bin
                   TMB_WordsRPC = ((buf_1[0]&0x0010)>>4) * ((buf_1[0]&0x000c)>>2) * ((buf_1[0]>>5) & 0x1F) * 2;
                 }
-              else   // TMB2007 (may not work since TMB_Tbins != RPC_Tbins)
+              else   // original TMB2007 data format (may not work since TMB_Tbins != RPC_Tbins)
                 {
                   TMB_WordsRPC = ((buf_1[0]&0x0040)>>6) * ((buf_1[0]&0x0030)>>4) * TMB_Tbins * 2;
                 }
             }
-          else   // Old format
+          else   // Old format 2006
             {
               TMB_WordsRPC   = ((buf_1[2]&0x0040)>>6) * ((buf_1[2]&0x0030)>>4) * TMB_Tbins * 2;
             }
@@ -1350,7 +1355,7 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
 
               if( fDMB_Trailer )   // F-Trailer exists
                 {
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0E00)>>9;      /// CFEB 1-3 FIFO Full
+                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0E00)>>7;      /// CFEB 1-3 FIFO Full
                   bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0003)<<3;      /// CFEB 4-5 FIFO Full
                   bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x000C)<<21;     /// CFEB 6-7 FIFO Full
                   bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0800)>>4;      /// ALCT Start Timeout

--- a/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
@@ -1,128 +1,157 @@
 //_________________________________________________________
 //
-//  CSCTMBBlockedCFEB July 2010  Alexander Sakharov                            
-//  Unpacks TMB Logic Blocked CFEB Analyzer and stores in CSCTMBBlockedCFEB.h  
+//  CSCTMBBlockedCFEB July 2010  Alexander Sakharov
+//  Unpacks TMB Logic Blocked CFEB Analyzer and stores in CSCTMBBlockedCFEB.h
 //_________________________________________________________
 //
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB) {
+CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB)
+{
 
   size_ = UnpackBlockedCFEB(buf,Line6BCB,Line6ECB);
 
 } ///CSCTMBMiniScope
 
 
-int CSCTMBBlockedCFEB::UnpackBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB) {
+int CSCTMBBlockedCFEB::UnpackBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB)
+{
 
-  if((Line6ECB-Line6BCB) != 0) {
-     
-      for(int i=0; i<(Line6ECB-Line6BCB-1); i++){
-         BlockedCFEBdata.push_back(buf[Line6BCB+1+i]);
-      }
+  if ((Line6ECB-Line6BCB) != 0)
+    {
 
-  }
+      for (int i=0; i<(Line6ECB-Line6BCB-1); i++)
+        {
+          BlockedCFEBdata.push_back(buf[Line6BCB+1+i]);
+        }
+
+    }
 
   //print();
   return (Line6ECB-Line6BCB + 1);
 
 } ///UnpackBlockedCFEB
 
-std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) const{
-     
-     std::vector< std::vector<int> > CFEBnByLayers;
-     CFEBnByLayers.clear();             
-     std::vector<int> CFEBnData;
-     CFEBnData.clear();
-     int idCFEB=-1;
-     
-     /// Get 4 words for a particular CFEB (CFEBn)
-     for(int i=0; i<(int)getData().size(); ++i){
-        idCFEB = (getData()[i] >> 12) & 0x7;
-        if(idCFEB==CFEBn){
+std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) const
+{
+
+  std::vector< std::vector<int> > CFEBnByLayers;
+  CFEBnByLayers.clear();
+  std::vector<int> CFEBnData;
+  CFEBnData.clear();
+  int idCFEB=-1;
+
+  /// Get 4 words for a particular CFEB (CFEBn)
+  for (int i=0; i<(int)getData().size(); ++i)
+    {
+      idCFEB = (getData()[i] >> 12) & 0x7;
+      if (idCFEB==CFEBn)
+        {
           CFEBnData.push_back(getData()[i] & 0xFFF);
         }
-        idCFEB = -1;
-     }
-     
-     std::vector<int> Layer0, Layer1, Layer2, Layer3, Layer4, Layer5;
-     Layer0.clear(); Layer1.clear(); Layer2.clear(); Layer3.clear(); Layer4.clear(); Layer5.clear();
-     
-     for(int k=0; k<(int)CFEBnData.size(); ++k){
-        for(int j=0; j<12; j++){
-           int DiStr=0;
-           DiStr = (CFEBnData[k] >> j) & 0x1;
-           if( (DiStr !=0) && (j<8) && (k==0) ){
-             Layer0.push_back(j);
-           }
-           if((DiStr !=0) && (j>7) && (j<12) && (k==0)){
-             Layer1.push_back(j);
-           }
-           if((DiStr !=0) && (j<4) && (k==1)){
-             Layer1.push_back(j);
-           }
-           if((DiStr !=0) && (j>3) && (j<12) && (k==1)){
-             Layer2.push_back(j);
-           }
-           if( (DiStr !=0) && (j<8) && (k==2) ){
-             Layer3.push_back(j);
-           }
-           if((DiStr !=0) && (j>7) && (j<12) && (k==2)){
-             Layer4.push_back(j);
-           }
-           if((DiStr !=0) && (j<4) && (k==3)){
-             Layer4.push_back(j);
-           }
-           if((DiStr !=0) && (j>3) && (j<12) && (k==3)){
-             Layer5.push_back(j);
-           }
-        }
-     }
-     
-     CFEBnByLayers.push_back(Layer0); 
-     CFEBnByLayers.push_back(Layer1);
-     CFEBnByLayers.push_back(Layer2);
-     CFEBnByLayers.push_back(Layer3);
-     CFEBnByLayers.push_back(Layer4);
-     CFEBnByLayers.push_back(Layer5);
-     
-return CFEBnByLayers;
-}
-
-void CSCTMBBlockedCFEB::print() const {
-     
-std::cout << " Blocked CFEB DiStrips List Content " << std::endl;
-     for(int i=0; i<(int)getData().size(); ++i){
-        std::cout << " word " << i << " : " << std::hex << getData()[i] << std::dec << std::endl;
-     }
-
-std::vector< std::vector<int> > anyCFEB;
-anyCFEB.clear();
-std::vector <int> anyLayer;
-anyLayer.clear();
-std::cout << std::endl;
-std::cout << " Blocked DiStrips by CFEB and Layers unpacked " << std::endl;
-for(int z=0; z<5; ++z){
-anyCFEB = getSingleCFEBList(z);
-std::cout << " CFEB# " << z << std::endl; 
-int LayerCnt=0;
-for(std::vector< std::vector<int> >::const_iterator layerIt=anyCFEB.begin(); layerIt !=anyCFEB.end(); layerIt++){
-    anyLayer=*layerIt;
-    std::cout << " Layer: " << LayerCnt;
-    if(anyLayer.size() !=0){
-      for(int i=0; i<(int)anyLayer.size(); i++){
-       std::cout << " " << anyLayer[i];
-      }
+      idCFEB = -1;
     }
-    else
-    std::cout << " No Blocked DiStrips on the Layer ";
-    std::cout << std::endl;
-    LayerCnt++;
-    anyLayer.clear();
+
+  std::vector<int> Layer0, Layer1, Layer2, Layer3, Layer4, Layer5;
+  Layer0.clear();
+  Layer1.clear();
+  Layer2.clear();
+  Layer3.clear();
+  Layer4.clear();
+  Layer5.clear();
+
+  for (int k=0; k<(int)CFEBnData.size(); ++k)
+    {
+      for (int j=0; j<12; j++)
+        {
+          int DiStr=0;
+          DiStr = (CFEBnData[k] >> j) & 0x1;
+          if ( (DiStr !=0) && (j<8) && (k==0) )
+            {
+              Layer0.push_back(j);
+            }
+          if ((DiStr !=0) && (j>7) && (j<12) && (k==0))
+            {
+              Layer1.push_back(j);
+            }
+          if ((DiStr !=0) && (j<4) && (k==1))
+            {
+              Layer1.push_back(j);
+            }
+          if ((DiStr !=0) && (j>3) && (j<12) && (k==1))
+            {
+              Layer2.push_back(j);
+            }
+          if ( (DiStr !=0) && (j<8) && (k==2) )
+            {
+              Layer3.push_back(j);
+            }
+          if ((DiStr !=0) && (j>7) && (j<12) && (k==2))
+            {
+              Layer4.push_back(j);
+            }
+          if ((DiStr !=0) && (j<4) && (k==3))
+            {
+              Layer4.push_back(j);
+            }
+          if ((DiStr !=0) && (j>3) && (j<12) && (k==3))
+            {
+              Layer5.push_back(j);
+            }
+        }
+    }
+
+  CFEBnByLayers.push_back(Layer0);
+  CFEBnByLayers.push_back(Layer1);
+  CFEBnByLayers.push_back(Layer2);
+  CFEBnByLayers.push_back(Layer3);
+  CFEBnByLayers.push_back(Layer4);
+  CFEBnByLayers.push_back(Layer5);
+
+  return CFEBnByLayers;
 }
-anyCFEB.clear();
+
+void CSCTMBBlockedCFEB::print() const
+{
+
+  std::cout << " Blocked CFEB DiStrips List Content " << std::endl;
+  for (int i=0; i<(int)getData().size(); ++i)
+    {
+      std::cout << " word " << i << " : " << std::hex << getData()[i] << std::dec << std::endl;
+    }
+
+  std::vector< std::vector<int> > anyCFEB;
+  anyCFEB.clear();
+  std::vector <int> anyLayer;
+  anyLayer.clear();
+  std::cout << std::endl;
+  std::cout << " Blocked DiStrips by CFEB and Layers unpacked " << std::endl;
+  for (int z=0; z<5; ++z)
+    {
+      anyCFEB = getSingleCFEBList(z);
+      std::cout << " CFEB# " << z << std::endl;
+      int LayerCnt=0;
+      for (std::vector< std::vector<int> >::const_iterator layerIt=anyCFEB.begin(); layerIt !=anyCFEB.end(); layerIt++)
+        {
+          anyLayer=*layerIt;
+          std::cout << " Layer: " << LayerCnt;
+          if (anyLayer.size() !=0)
+            {
+              for (int i=0; i<(int)anyLayer.size(); i++)
+                {
+                  std::cout << " " << anyLayer[i];
+                }
+            }
+          else
+            std::cout << " No Blocked DiStrips on the Layer ";
+          std::cout << std::endl;
+          LayerCnt++;
+          anyLayer.clear();
+        }
+      anyCFEB.clear();
+    }
+
 }
-     
-}
+

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -31,9 +31,17 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision):
     }
   else if(firmwareVersion == 2007)
     {
-      if(firmwareRevision >= 0x50c3)
-        {
-          if (firmwareRevision >= 0x7a76) ///!!! Put actual firmware revision code
+
+      /* Checks for TMB2007 firmware revisions ranges to detect data format
+       * rev.0x50c3 - first revision with changed format 
+       * rev.0x42D5 - oldest known from 06/21/2007
+       * There is 4-bits year value rollover in revision number (0 in 2016)
+       */
+      if((firmwareRevision >= 0x50c3) || (firmwareRevision < 0x42D5))
+        { 
+          // if (firmwareRevision >= 0x7a76) // First OTMB firmware revision with 2013 format
+          /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
+          if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5))
             {
               theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
             }
@@ -65,9 +73,16 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short * buf)
     {
       theFirmwareVersion=2007;
       theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007(buf));
-      if(theHeaderFormat->firmwareRevision() >= 0x50c3)
+      /* Checks for TMB2007 firmware revisions ranges to detect data format
+       * rev.0x50c3 - first revision with changed format 
+       * rev.0x42D5 - oldest known from 06/21/2007
+       * There is 4-bits year value rollover in revision number (0 in 2016)
+       */
+      if ((theHeaderFormat->firmwareRevision() >= 0x50c3) || (theHeaderFormat->firmwareRevision() < 0x42D5))
         {
-          if (theHeaderFormat->firmwareRevision() >= 0x7a76) ///!!! Put actual firmware revision code
+          // if (theHeaderFormat->firmwareRevision() >= 0x7a76) // First OTMB firmware revision with 2013 format
+          /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
+          if ((theHeaderFormat->firmwareRevision() >= 0x6000) || (theHeaderFormat->firmwareRevision() < 0x42D5))
             {
               theFirmwareVersion=2013;
               theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013(buf));
@@ -148,6 +163,16 @@ CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007()   const
   if(result == 0)
     {
       throw cms::Exception("Could not get 2007 TMB header format");
+    }
+  return *result;
+}
+
+CSCTMBHeader2007_rev0x50c3 CSCTMBHeader::tmbHeader2007_rev0x50c3()   const
+{
+  CSCTMBHeader2007_rev0x50c3 * result = dynamic_cast<CSCTMBHeader2007_rev0x50c3 *>(theHeaderFormat.get());
+  if(result == 0)
+    {
+      throw cms::Exception("Could not get 2007 rev0x50c3 TMB header format");
     }
   return *result;
 }


### PR DESCRIPTION
- Updated CSC unpacking code to properly recognize new OTMB/TMB firmware revisions for 2016
- Number of TMB 2013 header data bits positions are updated to match latest TMB data format revision documentation
- Reformatted number of TMB related files (added missing end of lines and etc. )
- Fixed bug in the CSCDCCExaminer to properly detect DMB CFEB1-3 FIFO Full status

If it is possible please give this update higher priority for tests and deployment as urgent patch. 
The final deployment of updated TMB firmware (with new important features) depends on this code availability CMS-wide.
