### PR TITLE
L1REPACK 2016 2015

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1499,7 +1499,7 @@ class ConfigBuilder(object):
 
     def prepare_L1REPACK(self, sequence = None):
             """ Enrich the schedule with the L1 simulation step, running the L1 emulator on data unpacked from the RAW collection, and repacking the result in a new RAW collection"""
-	    supported = ['GT','GT1','GT2','GCTGT','Full']
+	    supported = ['GT','GT1','GT2','GCTGT','Full','Full2015Data']
             if sequence in supported:
                 self.loadAndRemember('Configuration/StandardSequences/SimL1EmulatorRepack_%s_cff'%sequence)
 		if self._options.scenario == 'HeavyIons':

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -1,0 +1,101 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
+
+
+if not (eras.stage2L1Trigger.isChosen()):
+    print "L1T WARN:  L1REPACK:Full2015Data only supports Stage 2 eras for now."
+    print "L1T WARN:  Use a legacy version of L1REPACK for now."
+else:
+    print "L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."
+
+    # First, Unpack all inputs to L1:
+    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
+    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
+    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.DTRawToDigi.dtunpacker_cfi
+    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    # Second, Re-Emulate the entire L1T
+
+    # NOTE:  2016 HCAL HF TPs require a new emulation
+    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),
+        cms.InputTag('unpackHcal')
+    )
+    # L1TEventSetupForHF1x1TPs
+    from L1Trigger.L1TCalorimeter.caloStage2Params_HFTP_cfi import *
+
+    from L1Trigger.Configuration.SimL1Emulator_cff import *
+    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
+    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
+
+    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
+    simTwinMuxDigis.DTDigi_Source = cms.InputTag("unpackDttf")
+    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("unpackDttf")
+
+    # BMTF
+    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
+    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackDttf")
+
+    # OMTF
+    simOmtfDigis.srcRPC                = cms.InputTag('unpackRPC')
+    simOmtfDigis.srcDTPh               = cms.InputTag("unpackDttf")
+    simOmtfDigis.srcDTTh               = cms.InputTag("unpackDttf")
+    simOmtfDigis.srcCSC                = cms.InputTag("unpackCsctf")
+
+    # EMTF
+    simEmtfDigis.CSCInput              = cms.InputTag("unpackCsctf")
+
+    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
+    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+
+
+    # Finally, pack the new L1T output back into RAW
+    
+    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+    # combine the new L1 RAW with existing RAW for other FEDs
+    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+        verbose = cms.untracked.int32(0),
+        RawCollectionList = cms.VInputTag(
+            cms.InputTag('packCaloStage2'),
+            cms.InputTag('packGmtStage2'),
+            cms.InputTag('packGtStage2'),
+            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+            )
+        )
+
+
+    
+    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackDttf+unpackCsctf
+                                 +simHcalTriggerPrimitiveDigis+SimL1EmulatorCore+packCaloStage2
+                                 +packGmtStage2+packGtStage2+rawDataCollector)

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -48,6 +48,7 @@ else:
         cms.InputTag('unpackHcal')
     )
     # L1TEventSetupForHF1x1TPs
+    from Configuration.Geometry.GeometryExtended2016Reco_cff import * 
     from L1Trigger.L1TCalorimeter.caloStage2Params_HFTP_cfi import *
 
     from L1Trigger.Configuration.SimL1Emulator_cff import *

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -5,12 +5,16 @@ from Configuration.StandardSequences.Eras import eras
 
 
 if not (eras.stage2L1Trigger.isChosen()):
-    print "L1T WARN:  L1REPACK ALL only supports Stage 2 eras for now."
+    print "L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now."
     print "L1T WARN:  Use a legacy version of L1REPACK for now."
 else:
-    print "L1T INFO:  L1REPACK ALL will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."
+    print "L1T INFO:  L1REPACK:Full (intended for 2016 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."
 
     # First, Unpack all inputs to L1:
+    import EventFilter.L1TRawToDigi.bmtfDigis_cfi
+    unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
     import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
     unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
         DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
@@ -48,29 +52,39 @@ else:
         cms.InputTag('unpackHcal'),
         cms.InputTag('unpackHcal')
     )
-    # not sure when/if this is needed...
-    # HcalTPGCoderULUT.LUTGenerationMode = cms.bool(True)
 
     from L1Trigger.Configuration.SimL1Emulator_cff import *
+    
     simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
     simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
     simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
-    simOmtfDigis.srcRPC                = cms.InputTag('unpackRPC')
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
-    # Picking up simulation a bit further downstream for now:
-    simTwinMuxDigis.DTDigi_Source = cms.InputTag("unpackDttf")
-    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("unpackDttf")
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
-    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackDttf")
-    simOmtfDigis.srcDTPh               = cms.InputTag("unpackDttf")
-    simOmtfDigis.srcDTTh               = cms.InputTag("unpackDttf")
-    #fix for broken simCscTriggerPrimitiveDigis
-    print "L1T INFO:  L1REPACK Using fix for CSCTF"
-    simEmtfDigis.CSCInput              = cms.InputTag("unpackCsctf")
-    simOmtfDigis.srcCSC                = cms.InputTag("unpackCsctf")
 
+    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
+    simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+
+    # -----------------------------------------------------------
+    # change when availalbe simTwinMux and reliable DTTPs, CSCTPs
+    cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis','simTwinMuxDigis']
+    for b in cutlist:
+        SimL1EmulatorCore.remove(b)
+    # -----------------------------------------------------------
+
+    # BMTF
+    simBmtfDigis.DTDigi_Source       = cms.InputTag("unpackBmtf")
+    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackBmtf")
+
+    # OMTF
+    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
+    simOmtfDigis.srcDTPh             = cms.InputTag("unpackBmtf")
+    simOmtfDigis.srcDTTh             = cms.InputTag("unpackBmtf")
+    simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf") # replace when emtfDigis availalbe 
+
+    # EMTF
+    simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf") # replace when emtfDigis availalbe 
+
+    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
+    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('unpackHcal')
 
     # Finally, pack the new L1T output back into RAW
     
@@ -92,6 +106,6 @@ else:
 
 
     
-    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackDttf+unpackCsctf
-                                 +simHcalTriggerPrimitiveDigis+SimL1EmulatorCore+packCaloStage2
+    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackCsctf+unpackBmtf
+                                 +SimL1EmulatorCore+packCaloStage2
                                  +packGmtStage2+packGtStage2+rawDataCollector)

--- a/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+bmtfDigis = cms.EDProducer(
+    "L1TRawToDigi",
+    Setup = cms.string("stage2::BMTFSetup"),
+    InputLabel = cms.InputTag("rawDataCollector"),
+    FedIds = cms.vint32(1376,1377),
+    FWId = cms.uint32(1),
+    lenSlinkHeader = cms.untracked.int32(8),
+    lenSlinkTrailer = cms.untracked.int32(8),
+    lenAMCHeader = cms.untracked.int32(8),
+    lenAMCTrailer = cms.untracked.int32(0),
+    lenAMC13Header = cms.untracked.int32(8),
+    lenAMC13Trailer = cms.untracked.int32(8)
+)

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_HFTP_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_HFTP_cfi.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
+import L1Trigger.L1TCalorimeter.caloParams_cfi
+caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
+
+import CondCore.ESSources.CondDBESSource_cfi
+es_pool_hf1x1 = CondCore.ESSources.CondDBESSource_cfi.GlobalTag.clone()
+
+es_pool_hf1x1.timetype = cms.string('runnumber')
+es_pool_hf1x1.toGet = cms.VPSet(
+            cms.PSet(record = cms.string("HcalLutMetadataRcd"),
+                     tag = cms.string("HcalLutMetadata_HFTP_1x1")
+                     ),
+            cms.PSet(record = cms.string("HcalElectronicsMapRcd"),
+                     tag = cms.string("HcalElectronicsMap_HFTP_1x1")
+                     )
+            )
+es_pool_hf1x1.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
+es_pool_hf1x1.authenticationMethod = cms.untracked.uint32(0)
+
+es_prefer_es_pool_hf1x1 = cms.ESPrefer("PoolDBESSource", "es_pool_hf1x1")    
+
+#def L1TEventSetupForHF1x1TPs(process):
+#    process.es_pool_hf1x1 = cms.ESSource(
+#        "PoolDBESSource",
+#        #process.CondDBSetup,
+#        timetype = cms.string('runnumber'),
+#        toGet = cms.VPSet(
+#            cms.PSet(record = cms.string("HcalLutMetadataRcd"),
+#                     tag = cms.string("HcalLutMetadata_HFTP_1x1")
+#                     ),
+#            cms.PSet(record = cms.string("HcalElectronicsMapRcd"),
+#                     tag = cms.string("HcalElectronicsMap_HFTP_1x1")
+#                     )
+#            ),
+#        connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+#        authenticationMethod = cms.untracked.uint32(0)
+#        )
+#    process.es_prefer_es_pool_hf1x1 = cms.ESPrefer("PoolDBESSource", "es_pool_hf1x1")    


### PR DESCRIPTION
L1REPACK:Full2015Data workflow is defined. 
Necessary conditions configuration for HFTP1x1 are included,  as well as geometry Extended2016Reco (Hcal geometry needed for HF TP1x1).  
Usually, the geometry flag is passed to cmsDriver.py as --geometry=Extended2016,Extended2016Reco
but this geometry configuration is already loaded in the workflow which is meant to be used out box for the HLT folks. 

L1REPACK:Full is redefined to be compatible with 2016 data. 
