### PR TITLE
Correctly configure CSC trigger primitive emulator for Run2 (81X)

### DIFF
--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -22,7 +22,7 @@ class CSCConstants
 
   enum Digis_Info { MAX_DIGIS_PER_ALCT = 10, MAX_DIGIS_PER_CLCT = 8 };
 
-  enum MPC_stubs { maxStubs = 3 };
+  enum MPC_stubs { maxStubs = 18 };
 
 };
 

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -131,6 +131,9 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev,
     lctBuilder_->setConfigParameters(conf.product());
   }
   
+  // temporary hack to run on data
+  lctBuilder_->runOnData(ev.eventAuxiliary().isRealData());
+  
   // Get the collections of comparator & wire digis from event.
   edm::Handle<CSCComparatorDigiCollection> compDigis;
   edm::Handle<CSCWireDigiCollection>       wireDigis;

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigisPostLS1_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigisPostLS1_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+print " ######################################################################################################### "
+print " # WARNING: the module L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi is deprecated. # "
+print " # Please import L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi                             # "
+print " ######################################################################################################### "
+
 from L1Trigger.CSCCommonTrigger.CSCCommonTrigger_cfi import *
 # Default parameters for CSCTriggerPrimitives generator
 # =====================================================

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigisPostLS1_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigisPostLS1_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
-print " ######################################################################################################### "
-print " # WARNING: the module L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi is deprecated. # "
-print " # Please import L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi                             # "
-print " ######################################################################################################### "
+sys.stderr.write(" ######################################################################################################### ")
+sys.stderr.write(" # WARNING: the module L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi is deprecated. # ")
+sys.stderr.write(" # Please import L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi                             # ")
+sys.stderr.write(" ######################################################################################################### ")
 
 from L1Trigger.CSCCommonTrigger.CSCCommonTrigger_cfi import *
 # Default parameters for CSCTriggerPrimitives generator

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -11,16 +11,7 @@ def _modifyCscTriggerPrimitiveDigisForRun2( object ) :
     """
     object.debugParameters = True
     object.checkBadChambers = False
-    object.commonParam.isSLHC = True
-    object.commonParam.smartME1aME1b = True
     object.commonParam.gangedME1a = False
-    object.alctParam07.alctNarrowMaskForR1 = True
-    object.alctParam07.alctGhostCancellationBxDepth = cms.int32(1)
-    object.alctParam07.alctGhostCancellationSideQuality = cms.bool(True)
-    object.alctParam07.alctPretrigDeadtime = cms.uint32(4)
-    object.clctParam07.clctPidThreshPretrig = 4
-    object.clctParam07.clctMinSeparation = 5
-    object.tmbParam.matchTrigWindowSize = 3
 
 
 def _modifyCscTriggerPrimitiveDigisForRun2GE11( object ) :
@@ -579,9 +570,15 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         maxME11LCTs = cms.uint32(2)
     ),
 
+    # MPC sorter config for Run2
+    mpcRun2 = cms.PSet(
+        sortStubs = cms.bool(False)
+    ),
+
     # MPC sorter config for SLHC studies
     mpcSLHC = cms.PSet(
-        mpcMaxStubs = cms.uint32(3)
+        mpcMaxStubs = cms.uint32(18),
+        sortStubs = cms.bool(False)
     )
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -572,13 +572,17 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
     # MPC sorter config for Run2
     mpcRun2 = cms.PSet(
-        sortStubs = cms.bool(False)
+        sortStubs = cms.bool(False),
+        dropInvalidStubs = cms.bool(False),
+        dropLowQualityStubs = cms.bool(False),
     ),
 
     # MPC sorter config for SLHC studies
     mpcSLHC = cms.PSet(
         mpcMaxStubs = cms.uint32(18),
-        sortStubs = cms.bool(False)
+        sortStubs = cms.bool(False),
+        dropInvalidStubs = cms.bool(False),
+        dropLowQualityStubs = cms.bool(False),
     )
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
@@ -37,6 +37,8 @@ CSCMuonPortCard::CSCMuonPortCard(const edm::ParameterSet& conf)
     edm::ParameterSet mpcParams = conf.getParameter<edm::ParameterSet>("mpcSLHC");
     max_stubs_ = mpcParams.getParameter<unsigned int>("mpcMaxStubs");
   }
+  edm::ParameterSet mpcRun2Params = conf.getParameter<edm::ParameterSet>("mpcRun2");
+  sort_stubs_ = mpcRun2Params.getParameter<bool>("sortStubs");
 }
 
 void CSCMuonPortCard::loadDigis(const CSCCorrelatedLCTDigiCollection& thedigis)
@@ -73,7 +75,7 @@ std::vector<csctf::TrackStub> CSCMuonPortCard::sort(const unsigned endcap, const
   }
 
   if (result.size()) {
-    std::sort(result.begin(), result.end(), std::greater<csctf::TrackStub>());
+    if (sort_stubs_) std::sort(result.begin(), result.end(), std::greater<csctf::TrackStub>());
     // Can only return maxStubs or less LCTs per bunch crossing.
     if (result.size() > max_stubs_)
       result.erase(result.begin() + max_stubs_, result.end());

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
@@ -39,6 +39,8 @@ CSCMuonPortCard::CSCMuonPortCard(const edm::ParameterSet& conf)
   }
   edm::ParameterSet mpcRun2Params = conf.getParameter<edm::ParameterSet>("mpcRun2");
   sort_stubs_ = mpcRun2Params.getParameter<bool>("sortStubs");
+  drop_invalid_stubs_ = mpcRun2Params.getParameter<bool>("dropInvalidStubs");
+  drop_low_quality_stubs_ = mpcRun2Params.getParameter<bool>("dropLowQualityStubs");
 }
 
 void CSCMuonPortCard::loadDigis(const CSCCorrelatedLCTDigiCollection& thedigis)
@@ -70,7 +72,8 @@ std::vector<csctf::TrackStub> CSCMuonPortCard::sort(const unsigned endcap, const
 
   // Make sure no Quality 0 or non-valid LCTs come through the portcard.
   for (LCT = result.begin(); LCT != result.end(); LCT++) {
-    if ( !(LCT->getQuality() && LCT->isValid()) )
+    if ( (drop_invalid_stubs_ && !LCT->isValid()) ||
+	 (drop_low_quality_stubs_ && LCT->getQuality()==0) )
       result.erase(LCT, LCT);
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.h
@@ -46,6 +46,7 @@ class CSCMuonPortCard
  private:
   CSCTriggerContainer<csctf::TrackStub> stubs_;
   unsigned int max_stubs_;
+  bool sort_stubs_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.h
@@ -47,6 +47,8 @@ class CSCMuonPortCard
   CSCTriggerContainer<csctf::TrackStub> stubs_;
   unsigned int max_stubs_;
   bool sort_stubs_;
+  bool drop_invalid_stubs_;
+  bool drop_low_quality_stubs_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -621,6 +621,12 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
   // run MPC simulation
   m_muonportcard->loadDigis(oc_lct);
 
+  // temporary hack to ensure that all MPC LCTs are read out
+  if (runOnData_) {
+    m_minBX = 5;
+    m_maxBX = 11;
+  }
+
   std::vector<csctf::TrackStub> result;
   for(int bx = m_minBX; bx <= m_maxBX; ++bx)
     for(int e = min_endcap; e <= max_endcap; ++e)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -54,6 +54,9 @@ class CSCTriggerPrimitivesBuilder
   void setGEMGeometry(const GEMGeometry *g) { gem_g = g; }
   void setRPCGeometry(const RPCGeometry *g) { rpc_g = g; }
 
+  /* temporary function to check if running on data */
+  void runOnData(bool runOnData) {runOnData_ = runOnData;}
+
   /** Build anode, cathode, and correlated LCTs in each chamber and fill
    *  them into output collections.  Select up to three best correlated LCTs
    *  in each (sub)sector and put them into an output collection as well. */
@@ -87,6 +90,9 @@ class CSCTriggerPrimitivesBuilder
   static const int max_subsector;
   static const int min_chamber;   // chambers per trigger subsector
   static const int max_chamber;
+
+  /// temporary flag to run on data
+  bool runOnData_;
 
   /// a flag whether to skip chambers from the bad chambers map
   bool checkBadChambers_;


### PR DESCRIPTION
@ptcox @jrorie @tahuang @pakhotin

This pull request corrects known issues in the configuration of the CSC trigger primitive emulator for Run2. The era customizations should be cleaned up as well (it's a bit of a mess). Allow me to do this in another pull request. Fixing the settings is more urgent right now. 

I validated these changes by running on 2016B data using /store/user/abrinke1/EMTF/Run2016B/2016_04_29/RAW/ZeroBias1/272012/. 

I compared the BX of the LCT types:
- simCscTriggerPrimitiveDigis: emulated RAW data
- simCscTriggerPrimitiveDigis_MPCSORTED: emulated RAW data after sorting in the MPC
- csctfDigis: unpacked RAW data from CSC TrackFinder
- muonCSCDigis: : unpacked RAW data from Muon TrackFinder

I tuned the configuration so that simCscTriggerPrimitiveDigis_MPCSORTED would correspond better to csctfDigis. Results are shown below:

1) situation as it is in CMSSW 81X
![comparison_lct_bx_2016b_original](https://cloud.githubusercontent.com/assets/4134786/15058520/54e59e0e-12e2-11e6-941b-b7603b3c66e1.png)

2) after the changes from https://github.com/cms-sw/cmssw/pull/14391/commits/f1d5d4c4af8570a2bc36039171023db33c2de152
![comparison_lct_bx_2016b_mpclct18_nosorting_nosmart](https://cloud.githubusercontent.com/assets/4134786/15058564/96bf5f36-12e2-11e6-93f5-048cacf11368.png)

3) after shifting the BX of simCscTriggerPrimitiveDigis and simCscTriggerPrimitiveDigis_MPCSORTED by 2 to compare with csctfDigis
![comparison_lct_bx_2016b_mpclct18_nosorting_nosmart_bxshift2](https://cloud.githubusercontent.com/assets/4134786/15058566/9c4f65fe-12e2-11e6-943e-ba17f43da8d9.png)

4) after the changes up to https://github.com/cms-sw/cmssw/pull/14391/commits/3e1dbd92393250918cc041d36c3495971d0e5528. Again, the BX of simCscTriggerPrimitiveDigis and simCscTriggerPrimitiveDigis_MPCSORTED is downshifted by 2 to compare with csctfDigis - the actual readout window is thus [5,11] for data LCTs. As can be seen the agreement between data and emulator is ~1.5%.
![comparison_lct_bx_2016b_mpclct18_nosorting_nosmart_bxshift2_changereadout5to11_v2](https://cloud.githubusercontent.com/assets/4134786/15090573/2389ffe8-13f1-11e6-80f9-209efb97098b.png)
