### PR TITLE
updating SUSY HLT DQM config for lep+HT triggers

### DIFF
--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from copy import deepcopy
 
-SUSY_HLT_Ele_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+SUSY_HLT_Ele15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   electronCollection = cms.InputTag('gedGsfElectrons'),
                                                   muonCollection = cms.InputTag(''),
                                                   pfMetCollection = cms.InputTag('pfMet'),
@@ -42,8 +42,59 @@ SUSY_HLT_Ele_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   csvThreshold = cms.untracked.double(-1.0)
                                                   )
 
-SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT350_PFMET50'),
+                                                                 efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "pfMetTurnOn_eff ';Offline PF MET [GeV];#epsilon' pfMetTurnOn_num pfMetTurnOn_den"
+        ),
+                                                                 resolution = cms.vstring('')
+                                                                 )
+
+SUSY_HLT_Ele15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                  electronCollection = cms.InputTag('gedGsfElectrons'),
+                                                  muonCollection = cms.InputTag(''),
+                                                  pfMetCollection = cms.InputTag('pfMet'),
+                                                  pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                  jetTagCollection = cms.InputTag(''),
+
+                                                  vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                                  conversionCollection = cms.InputTag('conversions'),
+                                                  beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                                  leptonFilter = cms.InputTag('hltEle15VVVLGsfTrackIsoFilter','','HLT'),
+                                                  hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                                  hltMet = cms.InputTag('hltPFMETProducer','','HLT'),
+                                                  hltJets = cms.InputTag(''),
+                                                  hltJetTags = cms.InputTag(''),
+
+                                                  triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                                  trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                                  hltProcess = cms.string('HLT'),
+
+                                                  triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT400_PFMET50'),
+                                                  triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
+                                                  triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                  csvlCut = cms.untracked.double(0.244),
+                                                  csvmCut = cms.untracked.double(0.679),
+                                                  csvtCut = cms.untracked.double(0.898),
+
+                                                  jetPtCut = cms.untracked.double(30.0),
+                                                  jetEtaCut = cms.untracked.double(3.0),
+                                                  metCut = cms.untracked.double(250.0),
+                                                  htCut = cms.untracked.double(450.0),
+
+                                                  leptonPtThreshold = cms.untracked.double(25.0),
+                                                  htThreshold = cms.untracked.double(500.0),
+                                                  metThreshold = cms.untracked.double(250.0),
+                                                  csvThreshold = cms.untracked.double(-1.0)
+                                                  )
+
+SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400_PFMET50'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
         "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
@@ -55,4 +106,13 @@ SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClie
 
 # fastsim has no conversion collection (yet)
 from Configuration.StandardSequences.Eras import eras
-eras.fastSim.toModify(SUSY_HLT_Ele_HT_MET_SingleLepton,conversionCollection=cms.InputTag(''))
+eras.fastSim.toModify(SUSY_HLT_Ele15_HT350_MET50_SingleLepton,conversionCollection=cms.InputTag(''))
+eras.fastSim.toModify(SUSY_HLT_Ele15_HT400_MET50_SingleLepton,conversionCollection=cms.InputTag(''))
+
+SUSY_HLT_Ele_HT_MET_SingleLepton = cms.Sequence( SUSY_HLT_Ele15_HT350_MET50_SingleLepton
+                                                 + SUSY_HLT_Ele15_HT400_MET50_SingleLepton
+)
+
+SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING
+                                                                + SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING
+)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from copy import deepcopy
 
-SUSY_HLT_Ele_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+SUSY_HLT_Ele15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               electronCollection = cms.InputTag('gedGsfElectrons'),
                                               muonCollection = cms.InputTag(''),
                                               pfMetCollection = cms.InputTag('pfMet'),
@@ -42,8 +42,108 @@ SUSY_HLT_Ele_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT600'),
+                                                             efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                             resolution = cms.vstring('')
+                                                             )
+
+SUSY_HLT_Ele15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                              electronCollection = cms.InputTag('gedGsfElectrons'),
+                                              muonCollection = cms.InputTag(''),
+                                              pfMetCollection = cms.InputTag('pfMet'),
+                                              pfJetCollection = cms.InputTag('ak4PFJets'),
+                                              jetTagCollection = cms.InputTag(''),
+
+                                              vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                              conversionCollection = cms.InputTag('conversions'),
+                                              beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                              leptonFilter = cms.InputTag('hltEle15VVVLGsfTrackIsoFilter','','HLT'),
+                                              hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                              hltMet = cms.InputTag(''),
+                                              hltJets = cms.InputTag(''),
+                                              hltJetTags = cms.InputTag(''),
+
+                                              triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                              trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                              hltProcess = cms.string('HLT'),
+
+                                              triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT400'),
+                                              triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
+                                              triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                              csvlCut = cms.untracked.double(0.244),
+                                              csvmCut = cms.untracked.double(0.679),
+                                              csvtCut = cms.untracked.double(0.898),
+
+                                              jetPtCut = cms.untracked.double(30.0),
+                                              jetEtaCut = cms.untracked.double(3.0),
+                                              metCut = cms.untracked.double(250.0),
+                                              htCut = cms.untracked.double(450.0),
+
+                                              leptonPtThreshold = cms.untracked.double(25.0),
+                                              htThreshold = cms.untracked.double(500.0),
+                                              metThreshold = cms.untracked.double(-1.0),
+                                              csvThreshold = cms.untracked.double(-1.0)
+                                              )
+
+SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400'),
+                                                             efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                             resolution = cms.vstring('')
+                                                             )
+
+SUSY_HLT_Ele50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                              electronCollection = cms.InputTag('gedGsfElectrons'),
+                                              muonCollection = cms.InputTag(''),
+                                              pfMetCollection = cms.InputTag('pfMet'),
+                                              pfJetCollection = cms.InputTag('ak4PFJets'),
+                                              jetTagCollection = cms.InputTag(''),
+
+                                              vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                              conversionCollection = cms.InputTag('conversions'),
+                                              beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                              leptonFilter = cms.InputTag('hltEle50VVVLGsfTrackIsoFilter','','HLT'),
+                                              hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                              hltMet = cms.InputTag(''),
+                                              hltJets = cms.InputTag(''),
+                                              hltJetTags = cms.InputTag(''),
+
+                                              triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                              trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                              hltProcess = cms.string('HLT'),
+
+                                              triggerPath = cms.string('HLT_Ele50_IsoVVVL_PFHT400'),
+                                              triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
+                                              triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                              csvlCut = cms.untracked.double(0.244),
+                                              csvmCut = cms.untracked.double(0.679),
+                                              csvtCut = cms.untracked.double(0.898),
+
+                                              jetPtCut = cms.untracked.double(30.0),
+                                              jetEtaCut = cms.untracked.double(3.0),
+                                              metCut = cms.untracked.double(250.0),
+                                              htCut = cms.untracked.double(450.0),
+
+                                              leptonPtThreshold = cms.untracked.double(55.0),
+                                              htThreshold = cms.untracked.double(500.0),
+                                              metThreshold = cms.untracked.double(-1.0),
+                                              csvThreshold = cms.untracked.double(-1.0)
+                                              )
+
+SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele50_IsoVVVL_PFHT400'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
         "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
@@ -53,4 +153,16 @@ SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
 
 # fastsim has no conversion collection (yet)
 from Configuration.StandardSequences.Eras import eras
-eras.fastSim.toModify(SUSY_HLT_Ele_HT_SingleLepton,conversionCollection=cms.InputTag(''))
+eras.fastSim.toModify(SUSY_HLT_Ele15_HT600_SingleLepton,conversionCollection=cms.InputTag(''))
+eras.fastSim.toModify(SUSY_HLT_Ele15_HT400_SingleLepton,conversionCollection=cms.InputTag(''))
+eras.fastSim.toModify(SUSY_HLT_Ele50_HT400_SingleLepton,conversionCollection=cms.InputTag(''))
+
+SUSY_HLT_Ele_HT_SingleLepton = cms.Sequence( SUSY_HLT_Ele15_HT600_SingleLepton
+                                             + SUSY_HLT_Ele15_HT400_SingleLepton
+                                             + SUSY_HLT_Ele50_HT400_SingleLepton
+)
+
+SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING
+                                                            + SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING
+                                                            + SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING
+)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from copy import deepcopy
 
-SUSY_HLT_Mu_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+SUSY_HLT_Mu15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  electronCollection = cms.InputTag(''),
                                                  muonCollection = cms.InputTag('muons'),
                                                  pfMetCollection = cms.InputTag('pfMet'),
@@ -43,7 +43,7 @@ SUSY_HLT_Mu_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  )
 
 
-SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_PFMET50_v'),
                                                                 efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -53,3 +53,63 @@ SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClien
                                                                 resolution = cms.vstring('')
                                                                 )
 
+SUSY_HLT_Mu15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                 electronCollection = cms.InputTag(''),
+                                                 muonCollection = cms.InputTag('muons'),
+                                                 pfMetCollection = cms.InputTag('pfMet'),
+                                                 pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                 jetTagCollection = cms.InputTag(''),
+
+                                                 vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                                 conversionCollection = cms.InputTag(''),
+                                                 beamSpot = cms.InputTag(''),
+
+                                                 leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
+                                                 hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                                 hltMet = cms.InputTag('hltPFMETProducer','','HLT'),
+                                                 hltJets = cms.InputTag(''),
+                                                 hltJetTags = cms.InputTag(''),
+
+                                                 triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                                 trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                                 hltProcess = cms.string('HLT'),
+
+                                                 triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT400_PFMET50_v'),
+                                                 triggerPathAuxiliary = cms.string('HLT_IsoMu24_v'),
+                                                 triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                 csvlCut = cms.untracked.double(0.244),
+                                                 csvmCut = cms.untracked.double(0.679),
+                                                 csvtCut = cms.untracked.double(0.898),
+
+                                                 jetPtCut = cms.untracked.double(30.0),
+                                                 jetEtaCut = cms.untracked.double(3.0),
+                                                 metCut = cms.untracked.double(250.0),
+                                                 htCut = cms.untracked.double(450.0),
+
+                                                 leptonPtThreshold = cms.untracked.double(25.0),
+                                                 htThreshold = cms.untracked.double(500.0),
+                                                 metThreshold = cms.untracked.double(250.0),
+                                                 csvThreshold = cms.untracked.double(-1.0)
+                                                 )
+
+
+SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_PFMET50_v'),
+                                                                efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "pfMetTurnOn_eff ';Offline PF MET [GeV];#epsilon' pfMetTurnOn_num pfMetTurnOn_den"
+        ),
+                                                                resolution = cms.vstring('')
+                                                                )
+
+
+SUSY_HLT_Mu_HT_MET_SingleLepton = cms.Sequence( SUSY_HLT_Mu15_HT350_MET50_SingleLepton
+                                                + SUSY_HLT_Mu15_HT400_MET50_SingleLepton
+)
+
+SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING
+                                                               + SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING
+)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from copy import deepcopy
 
-SUSY_HLT_Mu_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+SUSY_HLT_Mu15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              electronCollection = cms.InputTag(''),
                                              muonCollection = cms.InputTag('muons'),
                                              pfMetCollection = cms.InputTag('pfMet'),
@@ -42,7 +42,7 @@ SUSY_HLT_Mu_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT600_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -51,3 +51,114 @@ SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
                                                             resolution = cms.vstring('')
                                                             )
 
+SUSY_HLT_Mu15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                             electronCollection = cms.InputTag(''),
+                                             muonCollection = cms.InputTag('muons'),
+                                             pfMetCollection = cms.InputTag('pfMet'),
+                                             pfJetCollection = cms.InputTag('ak4PFJets'),
+                                             jetTagCollection = cms.InputTag(''),
+
+                                             vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                             conversionCollection = cms.InputTag(''),
+                                             beamSpot = cms.InputTag(''),
+
+                                             leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
+                                             hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                             hltMet = cms.InputTag(''),
+                                             hltJets = cms.InputTag(''),
+                                             hltJetTags = cms.InputTag(''),
+
+                                             triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                             trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                             hltProcess = cms.string('HLT'),
+
+                                             triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT400_v'),
+                                             triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
+                                             triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                             csvlCut = cms.untracked.double(0.244),
+                                             csvmCut = cms.untracked.double(0.679),
+                                             csvtCut = cms.untracked.double(0.898),
+
+                                             jetPtCut = cms.untracked.double(30.0),
+                                             jetEtaCut = cms.untracked.double(3.0),
+                                             metCut = cms.untracked.double(250.0),
+                                             htCut = cms.untracked.double(450.0),
+
+                                             leptonPtThreshold = cms.untracked.double(25.0),
+                                             htThreshold = cms.untracked.double(500.0),
+                                             metThreshold = cms.untracked.double(-1.0),
+                                             csvThreshold = cms.untracked.double(-1.0)
+                                             )
+
+SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                            subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_v'),
+                                                            efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                            resolution = cms.vstring('')
+                                                            )
+
+SUSY_HLT_Mu50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                             electronCollection = cms.InputTag(''),
+                                             muonCollection = cms.InputTag('muons'),
+                                             pfMetCollection = cms.InputTag('pfMet'),
+                                             pfJetCollection = cms.InputTag('ak4PFJets'),
+                                             jetTagCollection = cms.InputTag(''),
+
+                                             vertexCollection = cms.InputTag('offlinePrimaryVertices'),
+                                             conversionCollection = cms.InputTag(''),
+                                             beamSpot = cms.InputTag(''),
+
+                                             leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
+                                             hltHt = cms.InputTag('hltPFHTJet30','','HLT'),
+                                             hltMet = cms.InputTag(''),
+                                             hltJets = cms.InputTag(''),
+                                             hltJetTags = cms.InputTag(''),
+
+                                             triggerResults = cms.InputTag('TriggerResults','','HLT'),
+                                             trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+
+                                             hltProcess = cms.string('HLT'),
+
+                                             triggerPath = cms.string('HLT_Mu50_IsoVVVL_PFHT400_v'),
+                                             triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
+                                             triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                             csvlCut = cms.untracked.double(0.244),
+                                             csvmCut = cms.untracked.double(0.679),
+                                             csvtCut = cms.untracked.double(0.898),
+
+                                             jetPtCut = cms.untracked.double(30.0),
+                                             jetEtaCut = cms.untracked.double(3.0),
+                                             metCut = cms.untracked.double(250.0),
+                                             htCut = cms.untracked.double(450.0),
+
+                                             leptonPtThreshold = cms.untracked.double(55.0),
+                                             htThreshold = cms.untracked.double(500.0),
+                                             metThreshold = cms.untracked.double(-1.0),
+                                             csvThreshold = cms.untracked.double(-1.0)
+                                             )
+
+SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                            subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu50_IsoVVVL_PFHT400_v'),
+                                                            efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                            resolution = cms.vstring('')
+                                                            )
+
+
+SUSY_HLT_Mu_HT_SingleLepton = cms.Sequence( SUSY_HLT_Mu15_HT600_SingleLepton
+                                             + SUSY_HLT_Mu15_HT400_SingleLepton
+                                             + SUSY_HLT_Mu50_HT400_SingleLepton
+)
+
+SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING
+                                                            + SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING
+                                                            + SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING
+
+)


### PR DESCRIPTION
The SUSY HLT DQM config is updated to include new paths:
HLT_Ele15_IsoVVVL_PFHT400_PFMET50
HLT_Ele15_IsoVVVL_PFHT400
HLT_Ele50_IsoVVVL_PFHT400
HLT_Mu15_IsoVVVL_PFHT400_PFMET50
HLT_Mu15_IsoVVVL_PFHT400
HLT_Mu50_IsoVVVL_PFHT400

This is the 80X version corresponding to #14393
