### PR TITLE
Added noexcept(false) to module destructors for gcc 6

### DIFF
--- a/Alignment/LaserAlignment/plugins/LaserAlignment.h
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.h
@@ -80,7 +80,7 @@
 ///
 ///
 ///
-class LaserAlignment : public edm::one::EDProducer<edm::EndRunProducer>, public TObject {
+class LaserAlignment : public edm::one::EDProducer<edm::EndRunProducer> {
 
  public:
 

--- a/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.h
+++ b/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.h
@@ -17,12 +17,11 @@
 // ROOT
 #include "TH1.h"
 #include "TH2.h"
-#include "TObject.h"
 class TFile;
 
 #include <iostream>
 
-class SimAnalyzer : public edm::EDAnalyzer, public TObject 
+class SimAnalyzer : public edm::EDAnalyzer
 {
  public:
 	/// constructor

--- a/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
+++ b/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
@@ -12,7 +12,7 @@ class SiStripCondObjBuilderBase {
  public:
 
   SiStripCondObjBuilderBase(const edm::ParameterSet& pset):_pset(pset){};
-  virtual ~SiStripCondObjBuilderBase(){};
+  virtual ~SiStripCondObjBuilderBase() noexcept(false) {};
   
   virtual void initialize(){};
 			    

--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -47,7 +47,7 @@ namespace ecaldqm{
 
   public:
     DQWorker();
-    virtual ~DQWorker();
+    virtual ~DQWorker() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription& _desc);
 

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -22,7 +22,7 @@ namespace ecaldqm
   class EcalDQMonitor {
   public:
     EcalDQMonitor(edm::ParameterSet const&);
-    virtual ~EcalDQMonitor();
+    virtual ~EcalDQMonitor() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription&);
 

--- a/DQM/EcalCommon/src/DQWorker.cc
+++ b/DQM/EcalCommon/src/DQWorker.cc
@@ -22,7 +22,7 @@ namespace ecaldqm
   {
   }
 
-  DQWorker::~DQWorker()
+  DQWorker::~DQWorker() noexcept(false)
   {
   }
 

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -42,7 +42,7 @@ namespace ecaldqm
       });
   }
 
-  EcalDQMonitor::~EcalDQMonitor()
+  EcalDQMonitor::~EcalDQMonitor() noexcept(false)
   {
     if(verbosity_ > 2) edm::LogInfo("EcalDQM") << moduleName_ << ": Deleting workers";
 

--- a/DQM/HcalCommon/interface/DQModule.h
+++ b/DQM/HcalCommon/interface/DQModule.h
@@ -39,7 +39,7 @@ namespace hcaldqm
 	{
 		public:
 			DQModule(edm::ParameterSet const&);
-			virtual ~DQModule() {}
+			virtual ~DQModule() noexcept(false) {}
 
 		protected:
 			//	Member variables	

--- a/DQMOffline/PFTau/interface/Benchmark.h
+++ b/DQMOffline/PFTau/interface/Benchmark.h
@@ -44,7 +44,7 @@ class Benchmark{
     etaMin_(-10), etaMax_(10), 
     phiMin_(-10), phiMax_(10) {}
 
-  virtual ~Benchmark();
+  virtual ~Benchmark() noexcept(false);
 
   void setParameters( Mode mode) { mode_ = mode;}
   

--- a/DQMOffline/PFTau/src/Benchmark.cc
+++ b/DQMOffline/PFTau/src/Benchmark.cc
@@ -10,7 +10,7 @@
 
 using namespace std;
 
-Benchmark::~Benchmark() {
+Benchmark::~Benchmark() noexcept(false) {
 
 }
 

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -49,7 +49,7 @@ class DataProxyProvider
       typedef std::map<EventSetupRecordKey, KeyedProxies> RecordProxies;
       
       DataProxyProvider();
-      virtual ~DataProxyProvider();
+      virtual ~DataProxyProvider() noexcept(false);
 
       // ---------- const member functions ---------------------
       bool isUsingRecord(const EventSetupRecordKey&) const;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -51,7 +51,7 @@ namespace edm {
     
   public:
     EDConsumerBase() : frozen_(false) {}
-    virtual ~EDConsumerBase();
+    virtual ~EDConsumerBase() noexcept(false);
     
     // disallow copying
     EDConsumerBase(EDConsumerBase const&) = delete;

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -79,7 +79,7 @@ namespace edm {
       enum Status {kContinue, kStop};
 
       EDLooperBase();
-      virtual ~EDLooperBase();
+      virtual ~EDLooperBase() noexcept(false);
 
       EDLooperBase(EDLooperBase const&) = delete; // Disallow copying and moving
       EDLooperBase& operator=(EDLooperBase const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -99,7 +99,7 @@ class ESProducer : public ESProxyFactoryProducer
 
    public:
       ESProducer();
-      virtual ~ESProducer();
+      virtual ~ESProducer() noexcept(false);
 
       // ---------- const member functions ---------------------
 

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -81,7 +81,7 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
 
    public:
       ESProxyFactoryProducer();
-      virtual ~ESProxyFactoryProducer();
+      virtual ~ESProxyFactoryProducer() noexcept(false);
 
       // ---------- const member functions ---------------------
 

--- a/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
@@ -35,7 +35,7 @@ class EventSetupRecordIntervalFinder
 
    public:
       EventSetupRecordIntervalFinder() : intervals_() {}
-      virtual ~EventSetupRecordIntervalFinder();
+      virtual ~EventSetupRecordIntervalFinder() noexcept(false);
 
       // ---------- const member functions ---------------------
       std::set<eventsetup::EventSetupRecordKey> findingForRecords() const ;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -98,7 +98,7 @@ namespace edm {
     explicit InputSource(ParameterSet const&, InputSourceDescription const&);
 
     /// Destructor
-    virtual ~InputSource();
+    virtual ~InputSource() noexcept(false);
 
     InputSource(InputSource const&) = delete; // Disallow copying and moving
     InputSource& operator=(InputSource const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -35,7 +35,7 @@ namespace edm {
   public:
     typedef ProductRegistryHelper::TypeLabelList TypeLabelList;
     ProducerBase ();
-    virtual ~ProducerBase();
+    virtual ~ProducerBase() noexcept(false);
  
     /// used by the fwk to register list of products
     std::function<void(BranchDescription const&)> registrationCallback() const;

--- a/FWCore/Framework/src/DataProxyProvider.cc
+++ b/FWCore/Framework/src/DataProxyProvider.cc
@@ -42,7 +42,7 @@ DataProxyProvider::DataProxyProvider() : recordProxies_(), description_()
 //    // do actual copying here;
 // }
 
-DataProxyProvider::~DataProxyProvider()
+DataProxyProvider::~DataProxyProvider() noexcept(false)
 {
 }
 

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -49,7 +49,7 @@ using namespace edm;
 //    // do actual copying here;
 // }
 
-EDConsumerBase::~EDConsumerBase()
+EDConsumerBase::~EDConsumerBase() noexcept(false)
 {
 }
 

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -32,7 +32,7 @@ namespace edm {
                                  moduleDescription_("Looper", "looper"),
                                  moduleCallingContext_(&moduleDescription_)
  { }
-  EDLooperBase::~EDLooperBase() { }
+  EDLooperBase::~EDLooperBase() noexcept(false) { }
 
   void
   EDLooperBase::doStartingNewLoop() {

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -36,7 +36,7 @@ ESProducer::ESProducer()
 //    // do actual copying here;
 // }
 
-ESProducer::~ESProducer()
+ESProducer::~ESProducer() noexcept(false)
 {
 }
 

--- a/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
@@ -37,7 +37,7 @@ namespace edm {
 //    // do actual copying here;
 // }
 
-EventSetupRecordIntervalFinder::~EventSetupRecordIntervalFinder()
+EventSetupRecordIntervalFinder::~EventSetupRecordIntervalFinder() noexcept(false)
 {
 }
 

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -102,7 +102,7 @@ namespace edm {
     }
   }
 
-  InputSource::~InputSource() {}
+  InputSource::~InputSource() noexcept(false) {}
 
   void
   InputSource::fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -13,7 +13,7 @@
 
 namespace edm {
   ProducerBase::ProducerBase() : ProductRegistryHelper(), callWhenNewProductsRegistered_() {}
-  ProducerBase::~ProducerBase() { }
+  ProducerBase::~ProducerBase() noexcept(false) { }
 
    std::function<void(BranchDescription const&)> ProducerBase::registrationCallback() const {
       return callWhenNewProductsRegistered_;

--- a/FWCore/Framework/test/stubs/TestOneProducers.cc
+++ b/FWCore/Framework/test/stubs/TestOneProducers.cc
@@ -41,7 +41,7 @@ namespace one {
       ++m_count;
     }
        
-    ~SharedResourcesProducer() {
+    ~SharedResourcesProducer() noexcept(false) {
       if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "SharedResourcesProducer transitions " 
@@ -91,7 +91,7 @@ namespace one {
       er = true;
     }
      
-   ~WatchRunsProducer() {
+    ~WatchRunsProducer() noexcept(false) {
        if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "WatchRunsProducer transitions " 
@@ -140,7 +140,7 @@ namespace one {
       el = true;
     }
 
-    ~WatchLumiBlocksProducer() {
+    ~WatchLumiBlocksProducer() noexcept(false) {
        if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "WatchLumiBlockProducer transitions " 
@@ -179,7 +179,7 @@ namespace one {
     void endRun(edm::Run const&, edm::EventSetup const&) override { 
     }
 
-   ~TestBeginRunProducer() {
+    ~TestBeginRunProducer() noexcept(false) {
      if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "TestBeginRunProducer transitions "
@@ -218,7 +218,7 @@ namespace one {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
     }
 
-   ~TestBeginLumiBlockProducer() {
+    ~TestBeginLumiBlockProducer() noexcept(false) {
      if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "TestBeginLumiBlockProducer transitions " 
@@ -258,7 +258,7 @@ namespace one {
     void endRun(edm::Run const&, edm::EventSetup const&) override { 
     }
 
-   ~TestEndRunProducer() {
+    ~TestEndRunProducer() noexcept(false) {
      if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "TestEndRunProducer transitions "
@@ -298,7 +298,7 @@ namespace one {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
     }
      
-   ~TestEndLumiBlockProducer() {
+    ~TestEndLumiBlockProducer() noexcept(false) {
      if(m_count != trans_) {
         throw cms::Exception("transitions")
           << "TestEndLumiBlockProducer transitions " 

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -10,7 +10,7 @@ namespace edm {
   class ThrowingSource : public ProducerSourceBase {
   public:
     explicit ThrowingSource(ParameterSet const&, InputSourceDescription const&);
-    ~ThrowingSource();
+    ~ThrowingSource() noexcept(false) ;
 
     virtual void beginJob();
     virtual void endJob();
@@ -55,7 +55,7 @@ namespace edm {
 
   }
 
-  ThrowingSource::~ThrowingSource() {
+  ThrowingSource::~ThrowingSource() noexcept(false) {
     if (whenToThrow_ == kDestructor) throw cms::Exception("TestThrow") << "ThrowingSource destructor";
   }
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -20,7 +20,7 @@ namespace edm {
   class ProducerSourceBase : public InputSource {
   public:
     explicit ProducerSourceBase(ParameterSet const& pset, InputSourceDescription const& desc, bool realData);
-    virtual ~ProducerSourceBase();
+    virtual ~ProducerSourceBase() noexcept(false);
 
     unsigned int numberEventsInRun() const {return numberEventsInRun_;} 
     unsigned int numberEventsInLumi() const {return numberEventsInLumi_;} 

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -39,7 +39,7 @@ namespace edm {
     // std::string eType = pset.getUntrackedParameter<std::string>("experimentType", std::string("Any"))),
   }
 
-  ProducerSourceBase::~ProducerSourceBase() {
+  ProducerSourceBase::~ProducerSourceBase() noexcept(false) {
   }
 
   std::shared_ptr<RunAuxiliary>

--- a/Fireworks/Core/interface/CmsShowMainBase.h
+++ b/Fireworks/Core/interface/CmsShowMainBase.h
@@ -50,7 +50,7 @@ class CmsShowMainBase
 {
 public:
    CmsShowMainBase();
-   virtual ~CmsShowMainBase();
+   virtual ~CmsShowMainBase() noexcept(false);
 
    FWModelChangeManager       *changeManager() {return m_changeManager.get(); }
    FWColorManager             *colorManager() { return  m_colorManager.get(); }

--- a/Fireworks/Core/src/CmsShowMainBase.cc
+++ b/Fireworks/Core/src/CmsShowMainBase.cc
@@ -70,7 +70,7 @@ CmsShowMainBase::CmsShowMainBase()
    sendVersionInfo();
 }
 
-CmsShowMainBase::~CmsShowMainBase()
+CmsShowMainBase::~CmsShowMainBase() noexcept(false)
 {
 }
 

--- a/GeneratorInterface/Core/interface/FortranInstance.h
+++ b/GeneratorInterface/Core/interface/FortranInstance.h
@@ -15,7 +15,7 @@ extern "C" {
 class FortranInstance {
     public:
 	FortranInstance() : instanceNesting(0) {}
-	virtual ~FortranInstance();
+        virtual ~FortranInstance() noexcept(false);
 
 	void call(void(&fn)())
 	{ InstanceWrapper wrapper(this); fn(); }

--- a/GeneratorInterface/Core/src/FortranInstance.cc
+++ b/GeneratorInterface/Core/src/FortranInstance.cc
@@ -34,7 +34,7 @@ const std::string gen::FortranInstance::kFortranInstance = "FortranInstance";
 
 // FortranInstance methods
 
-gen::FortranInstance::~FortranInstance()
+gen::FortranInstance::~FortranInstance() noexcept(false)
 {
 	if (currentInstance == this) {
 		edm::LogWarning("ReentrancyProblem")

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitBase.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitBase.h
@@ -27,7 +27,7 @@ public:
     theGenInfoRootFileName_( iConfig.getUntrackedParameter<std::string>("OutputGenInfoFileName", "genSimRecoPlots.root") ),
     debug_( iConfig.getUntrackedParameter<int>("debug",0) )
   {}
-  virtual ~MuScleFitBase() {}
+  virtual ~MuScleFitBase() noexcept(false) {}
 protected:
   /// Create the histograms map
   void fillHistoMap(TFile* outputFile, unsigned int iLoop);

--- a/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
@@ -26,7 +26,7 @@ class GenericBenchmark{
  public:
 
   GenericBenchmark();
-  virtual ~GenericBenchmark();
+  virtual ~GenericBenchmark() noexcept(false);
 
   void setup(DQMStore *DQM = NULL, 
 	     bool PlotAgainstReco_=true, 

--- a/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
@@ -36,7 +36,7 @@ using namespace std;
 
 GenericBenchmark::GenericBenchmark() {}
 
-GenericBenchmark::~GenericBenchmark() {}
+GenericBenchmark::~GenericBenchmark() noexcept(false) {}
 
 void GenericBenchmark::setup(DQMStore *DQM, bool PlotAgainstReco_, float minDeltaEt, float maxDeltaEt,
 			     float minDeltaPhi, float maxDeltaPhi, bool doMetPlots) {

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -36,7 +36,7 @@ namespace cms
 
     explicit CkfTrackCandidateMakerBase(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
 
-    virtual ~CkfTrackCandidateMakerBase();
+    virtual ~CkfTrackCandidateMakerBase() noexcept(false);
 
     virtual void beginRunBase (edm::Run const & , edm::EventSetup const & es);
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -120,7 +120,7 @@ namespace cms{
 
   
   // Virtual destructor needed.
-  CkfTrackCandidateMakerBase::~CkfTrackCandidateMakerBase() {
+  CkfTrackCandidateMakerBase::~CkfTrackCandidateMakerBase() noexcept(false) {
     if (theSeedCleaner) delete theSeedCleaner;
   }  
 

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -50,7 +50,7 @@ public:
         rekeyClusterRefs_(false) {}
 
   /// Destructor
-  virtual ~TrackProducerBase();
+  virtual ~TrackProducerBase() noexcept(false);
   
   /// Get needed services from the Event Setup
   virtual void getFromES(const edm::EventSetup&,

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -34,7 +34,7 @@
 
 //destructor
 template <class T>
-TrackProducerBase<T>::~TrackProducerBase(){ }
+TrackProducerBase<T>::~TrackProducerBase() noexcept(false) { }
 
 // member functions
 // ------------ method called to produce the data  ------------

--- a/TauAnalysis/MCEmbeddingTools/interface/ParticleReplacerBase.h
+++ b/TauAnalysis/MCEmbeddingTools/interface/ParticleReplacerBase.h
@@ -28,7 +28,7 @@ class ParticleReplacerBase
 {
  public:
   explicit ParticleReplacerBase(const edm::ParameterSet&);
-  virtual ~ParticleReplacerBase() {}
+  virtual ~ParticleReplacerBase() noexcept(false) {}
 
   virtual void declareExtraProducts(MCParticleReplacer*) {}
 

--- a/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
@@ -111,7 +111,7 @@ class MuonTrackValidatorBase {
     }
   
   /// Destructor
-  virtual ~MuonTrackValidatorBase(){ }
+  virtual ~MuonTrackValidatorBase() noexcept(false) { }
   
   virtual void doProfileX(TH2 * th2, MonitorElement* me){
     if (th2->GetNbinsX()==me->getNbinsX()){

--- a/Validation/RecoTrack/interface/MultiTrackValidatorBase.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidatorBase.h
@@ -45,7 +45,7 @@ class MultiTrackValidatorBase {
   MultiTrackValidatorBase(const edm::ParameterSet& pset, edm::ConsumesCollector && iC, bool isSeed = false);
     
   /// Destructor
-  virtual ~MultiTrackValidatorBase(){ }
+  virtual ~MultiTrackValidatorBase() noexcept(false) { }
   
   //virtual void initialize()=0;
 


### PR DESCRIPTION
For now, we will continue to allow module's destructors to throw exceptions. Explicitly added 'noexcept(false)' to base class destructors to silence warnings from gcc 6.
