### PR TITLE
Clean-up Sim Exceptions

### DIFF
--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -20,7 +20,6 @@
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "SimG4Core/Notification/interface/CurrentG4Track.h"
 #include "SimG4Core/Application/interface/G4RegionReporter.h"
@@ -127,15 +126,17 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   std::unique_ptr<PhysicsListMakerBase>
     physicsMaker(PhysicsListFactory::get()->create(
       m_pPhysics.getParameter<std::string> ("type")));
-  if (physicsMaker.get()==0) {
-    throw SimG4Exception("Unable to find the Physics list requested");
+  if (physicsMaker.get()==nullptr) {
+    throw edm::Exception( edm::errors::Configuration ) 
+      << "Unable to find the Physics list requested";
   }
   m_physicsList = 
     physicsMaker->make(map_,fPDGTable,m_chordFinderSetter.get(),m_pPhysics,m_registry);
 
   PhysicsList* phys = m_physicsList.get(); 
-  if (phys==0) { 
-    throw SimG4Exception("Physics list construction failed!"); 
+  if (phys==nullptr) { 
+    throw edm::Exception( edm::errors::Configuration,
+			  "Physics list construction failed!"); 
   }
 
   // adding GFlash, Russian Roulette for eletrons and gamma, 
@@ -169,7 +170,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   if (m_kernel->RunInitialization()) { m_managerInitialized = true; }
   else { 
-    throw SimG4Exception("G4RunManagerKernel initialization failed!"); 
+    throw edm::Exception( edm::errors::LogicError, 
+			  "G4RunManagerKernel initialization failed!"); 
   }
 
   if (m_StorePhysicsTables) {

--- a/SimG4Core/Application/src/SimRunInterface.cc
+++ b/SimG4Core/Application/src/SimRunInterface.cc
@@ -7,7 +7,6 @@
 #include "SimG4Core/Application/interface/TrackingAction.h"
 #include "SimG4Core/Application/interface/SteppingAction.h"
 #include "SimG4Core/Application/interface/G4SimEvent.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -39,13 +38,6 @@ SimRunInterface::~SimRunInterface()
 {}
 
 void SimRunInterface::setRunManagerMTWorker(RunManagerMTWorker *run) {
-  if(m_runManager) {
-    throw SimG4Exception("Calling SimRunInterface::setRunManagerMTWorker() while RunManager has been set");
-  }
-  else if(m_runManagerMT) {
-    throw SimG4Exception("Calling SimRunInterface::setRunManagerMTWorker() while RunManagerMT has been set");
-  }
-
   m_runManagerMTWorker = run;
 }
 

--- a/SimG4Core/Application/src/TrackingAction.cc
+++ b/SimG4Core/Application/src/TrackingAction.cc
@@ -7,7 +7,6 @@
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/TrackWithHistory.h"
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -21,7 +20,7 @@
 //using namespace std;
 
 TrackingAction::TrackingAction(EventAction * e, const edm::ParameterSet & p) 
-  : eventAction_(e),currentTrack_(0),g4Track_(0),
+  : eventAction_(e),currentTrack_(nullptr),g4Track_(nullptr),
   detailedTiming(p.getUntrackedParameter<bool>("DetailedTiming",false)),
   checkTrack(p.getUntrackedParameter<bool>("CheckTrack",false)),
   trackMgrVerbose(p.getUntrackedParameter<int>("G4TrackManagerVerbosity",0)) 
@@ -34,10 +33,6 @@ TrackingAction::~TrackingAction() {}
 void TrackingAction::PreUserTrackingAction(const G4Track * aTrack)
 {
   g4Track_ = aTrack;
-
-  if (currentTrack_ != 0) {
-    throw SimG4Exception("TrackingAction: currentTrack is a mess...");
-  }
   currentTrack_ = new TrackWithHistory(aTrack);
 
   /*
@@ -77,7 +72,7 @@ void TrackingAction::PreUserTrackingAction(const G4Track * aTrack)
 
 void TrackingAction::PostUserTrackingAction(const G4Track * aTrack)
 {
-  if (eventAction_->trackContainer() != 0) {
+  if (eventAction_->trackContainer() != nullptr) {
 
     TrackInformationExtractor extractor;
     if (extractor(aTrack).storeTrack()) {


### PR DESCRIPTION
There were places where exceptions were misused.
Begin, end run, Geant4 and geometry initialisation edm::Exception should be used; within event loop SimG4Exception should notify OscarProducer about run time problems.

This PR address remaining problem reported in issue  #14289
