### PR TITLE
Add DQMStore::getElement whichs throws an exception instead of a nullptr (80x) 

### DIFF
--- a/DQM/SiPixelMonitorClient/src/SiPixelCertification.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelCertification.cc
@@ -49,31 +49,31 @@ void SiPixelCertification::dqmEndLuminosityBlock(DQMStore::IBooker & iBooker, DQ
 
   edm::LogInfo( "SiPixelCertification") << "SiPixelCertification::endLuminosityBlock ";
   // Compute and fill overall certification bits, for now use smallest single value:
-  float dcsFrac = (iGetter.get("Pixel/EventInfo/DCSSummary"))->getFloatValue();
-  float daqFrac = (iGetter.get("Pixel/EventInfo/DAQSummary"))->getFloatValue();
-  float dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummary"))->getFloatValue();
+  float dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSSummary"))->getFloatValue();
+  float daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQSummary"))->getFloatValue();
+  float dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummary"))->getFloatValue();
   float pixel_all = std::min(dcsFrac,daqFrac);
   pixel_all = std::min(pixel_all,dqmFrac);
 //std::cout<<"Pixel numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_all<<std::endl;
-  CertificationPixel = iGetter.get("Pixel/EventInfo/CertificationSummary");
+  CertificationPixel = iGetter.getElement("Pixel/EventInfo/CertificationSummary");
   if(CertificationPixel) CertificationPixel->Fill(pixel_all);
 
-  dcsFrac = (iGetter.get("Pixel/EventInfo/DCSContents/PixelBarrelFraction"))->getFloatValue();
-  daqFrac = (iGetter.get("Pixel/EventInfo/DAQContents/PixelBarrelFraction"))->getFloatValue();
-  dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummaryContents/PixelBarrelFraction"))->getFloatValue();
+  dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSContents/PixelBarrelFraction"))->getFloatValue();
+  daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQContents/PixelBarrelFraction"))->getFloatValue();
+  dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummaryContents/PixelBarrelFraction"))->getFloatValue();
   float pixel_barrel = std::min(dcsFrac,daqFrac);
   pixel_barrel = std::min(pixel_barrel,dqmFrac);
 //std::cout<<"Barrel numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_barrel<<std::endl;
-  CertificationBarrel = iGetter.get("Pixel/EventInfo/CertificationContents/PixelBarrelFraction");
+  CertificationBarrel = iGetter.getElement("Pixel/EventInfo/CertificationContents/PixelBarrelFraction");
   if(CertificationBarrel) CertificationBarrel->Fill(pixel_barrel);
 
-  dcsFrac = (iGetter.get("Pixel/EventInfo/DCSContents/PixelEndcapFraction"))->getFloatValue();
-  daqFrac = (iGetter.get("Pixel/EventInfo/DAQContents/PixelEndcapFraction"))->getFloatValue();
-  dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummaryContents/PixelEndcapFraction"))->getFloatValue();
+  dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSContents/PixelEndcapFraction"))->getFloatValue();
+  daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQContents/PixelEndcapFraction"))->getFloatValue();
+  dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummaryContents/PixelEndcapFraction"))->getFloatValue();
   float pixel_endcap = std::min(dcsFrac,daqFrac);
   pixel_endcap = std::min(pixel_endcap,dqmFrac);
 //std::cout<<"Endcap numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_endcap<<std::endl;
-  CertificationEndcap = iGetter.get("Pixel/EventInfo/CertificationContents/PixelEndcapFraction");
+  CertificationEndcap = iGetter.getElement("Pixel/EventInfo/CertificationContents/PixelEndcapFraction");
   if(CertificationEndcap) CertificationEndcap->Fill(pixel_endcap);
 
 }
@@ -83,25 +83,25 @@ void SiPixelCertification::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGet
 //cout<<"Entering SiPixelCertification::endRun: "<<endl;
   edm::LogInfo( "SiPixelCertification") << "SiPixelCertification::endRun ";
   // Compute and fill overall certification bits, for now use smallest single value:
-  float dcsFrac = (iGetter.get("Pixel/EventInfo/DCSSummary"))->getFloatValue();
-  float daqFrac = (iGetter.get("Pixel/EventInfo/DAQSummary"))->getFloatValue();
-  float dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummary"))->getFloatValue();
+  float dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSSummary"))->getFloatValue();
+  float daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQSummary"))->getFloatValue();
+  float dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummary"))->getFloatValue();
   float pixel_all = std::min(dcsFrac,daqFrac);
   pixel_all = std::min(pixel_all,dqmFrac);
 //std::cout<<"Pixel numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_all<<std::endl;
   if(CertificationPixel) CertificationPixel->Fill(pixel_all);
 
-  dcsFrac = (iGetter.get("Pixel/EventInfo/DCSContents/PixelBarrelFraction"))->getFloatValue();
-  daqFrac = (iGetter.get("Pixel/EventInfo/DAQContents/PixelBarrelFraction"))->getFloatValue();
-  dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummaryContents/PixelBarrelFraction"))->getFloatValue();
+  dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSContents/PixelBarrelFraction"))->getFloatValue();
+  daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQContents/PixelBarrelFraction"))->getFloatValue();
+  dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummaryContents/PixelBarrelFraction"))->getFloatValue();
   float pixel_barrel = std::min(dcsFrac,daqFrac);
   pixel_barrel = std::min(pixel_barrel,dqmFrac);
 //std::cout<<"Barrel numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_barrel<<std::endl;
   if(CertificationBarrel) CertificationBarrel->Fill(pixel_barrel);
 
-  dcsFrac = (iGetter.get("Pixel/EventInfo/DCSContents/PixelEndcapFraction"))->getFloatValue();
-  daqFrac = (iGetter.get("Pixel/EventInfo/DAQContents/PixelEndcapFraction"))->getFloatValue();
-  dqmFrac = (iGetter.get("Pixel/EventInfo/reportSummaryContents/PixelEndcapFraction"))->getFloatValue();
+  dcsFrac = (iGetter.getElement("Pixel/EventInfo/DCSContents/PixelEndcapFraction"))->getFloatValue();
+  daqFrac = (iGetter.getElement("Pixel/EventInfo/DAQContents/PixelEndcapFraction"))->getFloatValue();
+  dqmFrac = (iGetter.getElement("Pixel/EventInfo/reportSummaryContents/PixelEndcapFraction"))->getFloatValue();
   float pixel_endcap = std::min(dcsFrac,daqFrac);
   pixel_endcap = std::min(pixel_endcap,dqmFrac);
 //std::cout<<"Endcap numbers: "<<dcsFrac<<" , "<<daqFrac<<" , "<<dqmFrac<<" , "<<pixel_endcap<<std::endl;

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -207,6 +207,10 @@ class DQMStore
 						 uint32_t runNumber = 0,
 						 uint32_t lumi = 0);
     MonitorElement * get(const std::string &path);
+
+    // same as get, throws an exception if histogram not found
+    MonitorElement * getElement(const std::string &path);
+
     std::vector<std::string> getSubdirs(void);
     std::vector<std::string> getMEs(void);
     bool containsAnyMonitorable(const std::string &path);

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -19,7 +19,10 @@
 #include <iterator>
 #include <cerrno>
 #include <boost/algorithm/string.hpp>
+
 #include <fstream>
+#include <sstream>
+#include <exception>
 
 /** @var DQMStore::verbose_
     Universal verbose flag for DQM. */
@@ -300,6 +303,20 @@ DQMStore::IGetter::getAllContents(const std::string &path,
 
 MonitorElement * DQMStore::IGetter::get(const std::string &path) {
   return owner_->get(path);
+}
+
+MonitorElement * DQMStore::IGetter::getElement(const std::string &path) {
+    MonitorElement *ptr = this->get(path);
+    if (ptr == nullptr) {
+      std::stringstream msg;
+      msg << "DQM object not found";
+        
+      msg << ": " << path;
+
+      // can't use cms::Exception inside DQMStore
+      throw std::out_of_range(msg.str());
+    }
+    return ptr;
 }
 
 std::vector<std::string> DQMStore::IGetter::getSubdirs(void) {


### PR DESCRIPTION
Half of DQM software does not check for nullptrs when retrieving histograms.
This usually causes a segfault and a few minute wait for gdb to produce the stacktrace.

Crashing the framework with an out-of-bounds exception is better and
more clean.

Also fixes DQM/SiPixelMonitorClient which would segfault online on
every  empty run. It still crashes, but in a 'nicer' way.
