### PR TITLE
Updating to HLT paths to be monitored by TOP PAG in 2016 in 81X

### DIFF
--- a/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
@@ -99,7 +99,11 @@ namespace HLTOfflineDQMTopDiLepton {
 
       /// trigger table
       edm::EDGetTokenT< edm::TriggerResults > triggerTable_;
-      edm::EDGetTokenT< trigger::TriggerEventWithRefs > triggerEventWithRefsTag_;
+//      edm::EDGetTokenT< trigger::TriggerEventWithRefs > triggerEventWithRefsTag_;
+      edm::EDGetTokenT <trigger::TriggerEventWithRefs> triggerSummaryTokenRAW;
+      edm::EDGetTokenT <trigger::TriggerEventWithRefs> triggerSummaryTokenAOD;
+      bool hasRawTriggerSummary;
+
       /// trigger paths for monitoring, expected 
       /// to be of form signalPath:MonitorPath
       std::vector<std::string> elecMuPaths_;

--- a/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
@@ -93,7 +93,12 @@ namespace HLTOfflineDQMTopSingleLepton {
 
       /// trigger table
       edm::EDGetTokenT< edm::TriggerResults > triggerTable_;
-      edm::EDGetTokenT< trigger::TriggerEventWithRefs > triggerEventWithRefsTag_;
+//     edm::EDGetTokenT< trigger::TriggerEventWithRefs > triggerEventWithRefsTag_;
+      edm::EDGetTokenT <trigger::TriggerEventWithRefs> triggerSummaryTokenRAW;
+      edm::EDGetTokenT <trigger::TriggerEventWithRefs> triggerSummaryTokenAOD;
+      bool hasRawTriggerSummary;
+	  	
+ 
       /// trigger paths for monitoring, expected 
       /// to be of form signalPath:MonitorPath
       std::vector<std::string> triggerPaths_;

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -74,9 +74,9 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     ## will be empty
     triggerExtras = cms.PSet(
       src   = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666      
-	  paths = cms.vstring(['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v','HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v','HLT_IsoMu22_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v1', 'HLT_IsoMu20_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet30_v','HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v4'])
-    )
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+	  paths = cms.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v', 'HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v3','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v'])
+	  )
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
@@ -88,9 +88,9 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
   preselection = cms.PSet(
     trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-      select = cms.vstring((['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v','HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v','HLT_IsoMu22_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v1', 'HLT_IsoMu20_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet30_v','HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v4']))
-    ),  
+## Updating to HLT paths to be monitored by TOP PAG in 2016
+	  select =  cms.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v', 'HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v3','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v'])
+	),  
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
@@ -214,8 +214,8 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ## will be empty
     triggerExtras = cms.PSet(
 			src   = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-			paths = cms.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v','HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v'])
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+			paths = cms.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele22_eta2p1_WPLoose_Gsf_v', 'HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v'])		
 		)
 	),	
   ## ------------------------------------------------------
@@ -228,9 +228,9 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
 	preselection = cms.PSet(
 		trigger = cms.PSet(
 			src    = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-			select = cms.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v','HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v'])
-		),
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+			select = cms.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele22_eta2p1_WPLoose_Gsf_v', 'HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v'])
+			),
     ## [optional] : when omitted no preselection is applied
 		vertex = cms.PSet(
 			src    = cms.InputTag("offlinePrimaryVertices"),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -62,14 +62,17 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## [optional] : when omitted all monitoring plots for triggering
     ## will be empty
     triggerExtras = cms.PSet(
-        src = cms.InputTag("TriggerResults","","HLT"),
-        pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 
-                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
-        pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
-        pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
-                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
-    )    
+		src = cms.InputTag("TriggerResults","","HLT"),
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
+									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
+									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+	)																	  
   ),
                                   
   ## ------------------------------------------------------
@@ -83,7 +86,8 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## [optional] : when omitted no preselection is applied
     trigger = cms.PSet(
         src    = cms.InputTag("TriggerResults","","HLT"),
-        select = cms.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v', 'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+		select = cms.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v''HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v', 'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
     ),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
@@ -190,15 +194,17 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
         src = cms.InputTag("TriggerResults","","HLT"),
-        pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 
-                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
-        pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
-        pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
-                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
+									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_Dz_v']),
+		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
+									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
     )    
-  ),
-                                  
+  ),                                
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -324,13 +330,17 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
         src = cms.InputTag("TriggerResults","","HLT"),
-        pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 
-                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
-        pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
-        pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
-                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
-    )    
+
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                
+		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
+									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
+									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+	)	
   ),
                                   
   ## ------------------------------------------------------
@@ -459,13 +469,16 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
         src = cms.InputTag("TriggerResults","","HLT"),
-        pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 
-                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
-        pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
-        pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
-                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
-    )    
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
+									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
+									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+	)    
   ),
                                   
   ## ------------------------------------------------------
@@ -479,9 +492,12 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## [optional] : when omitted no preselection is applied
     trigger = cms.PSet(
         src    = cms.InputTag("TriggerResults","","HLT"),
-        select = cms.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 
-                              'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
-    ),
+### Updating to HLT paths to be monitored by TOP PAG in 2016 
+		select = cms.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',                                                                                            
+							  'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+							  'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
+							  'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v'])
+	),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -65,13 +65,13 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
 		src = cms.InputTag("TriggerResults","","HLT"),
 ### Updating to HLT paths to be monitored by TOP PAG in 2016
 		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+                                    'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
+                                    'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
 		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
 		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
-									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
 	)																	  
   ),
                                   
@@ -196,13 +196,13 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
         src = cms.InputTag("TriggerResults","","HLT"),
 ### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
 		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
-									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+                                    'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+                                    'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
 		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_Dz_v']),
+                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_Dz_v']),
 		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 
-									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
     )    
   ),                                
   ## ------------------------------------------------------
@@ -333,13 +333,13 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
 
 ### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                
 		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
-									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+                                    'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+                                    'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
 		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
 		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
-									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
 	)	
   ),
                                   
@@ -471,13 +471,13 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
         src = cms.InputTag("TriggerResults","","HLT"),
 ### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
 		pathsELECMU = cms.vstring([ 'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
-									'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
-									'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
+                                    'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+                                    'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 
+                                    'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
 		pathsDIMUON = cms.vstring([ 'HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v',
-									'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+                                    'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
 		pathsDIELEC = cms.vstring([ 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v',
-									'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
+                                    'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v'])
 	)    
   ),
                                   
@@ -494,9 +494,9 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
         src    = cms.InputTag("TriggerResults","","HLT"),
 ### Updating to HLT paths to be monitored by TOP PAG in 2016 
 		select = cms.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v',                                                                                            
-							  'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
-							  'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
-							  'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v'])
+                              'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v',
+                              'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v',
+                              'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v'])
 	),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
@@ -553,4 +553,3 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
   ),
 )
-

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -86,10 +86,9 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
   preselection = cms.PSet(
    trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-      select = cms.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v', 'HLT_IsoMu22_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v'])
-    ),
+### Updating to HLT paths to be monitored by TOP PAG in 2016  
+	select = cms.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele22_eta2p1_WPLoose_Gsf_v', 'HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v','HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v']),
+	),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
@@ -196,9 +195,9 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
       src   = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-      paths = cms.vstring(['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v', 'HLT_IsoMu22_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v'])
-    )
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+	  paths = cms.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v'])
+	)
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
@@ -210,9 +209,9 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
   preselection = cms.PSet(
    trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-      select = cms.vstring(['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v', 'HLT_IsoMu22_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v', 'HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v'])
-    ),
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+	  select = cms.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v'])
+	),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
@@ -350,9 +349,8 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
       src   = cms.InputTag("TriggerResults","","HLT"),
-
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666	  
-	  paths = cms.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v'])	
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+	  paths = cms.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v','HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v','HLT_Ele22_eta2p1_WPLoose_Gsf_v','HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v'])       
     )
   ),
   ## ------------------------------------------------------
@@ -365,10 +363,9 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
   preselection = cms.PSet(
    trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-	  select = cms.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v'])
-    ),
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+	  select = cms.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v','HLT_Ele22_eta2p1_WPLoose_Gsf_v','HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v'])  		      
+	),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),

--- a/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
@@ -118,7 +118,9 @@ namespace HLTOfflineDQMTopDiLepton {
     // and don't forget to do the histogram booking
     folder_=cfg.getParameter<std::string>("directory");
 
-    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","",processName_));
+//    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","",processName_));
+	triggerSummaryTokenRAW = iC.consumes <trigger::TriggerEventWithRefs>(edm::InputTag("hltTriggerSummaryRAW","",processName_));
+	triggerSummaryTokenAOD = iC.consumes <trigger::TriggerEventWithRefs> (edm::InputTag("hltTriggerSummaryAOD","",processName_));
 
   }
 
@@ -497,11 +499,33 @@ namespace HLTOfflineDQMTopDiLepton {
          ------------------------------------------------------------
          */
 
-      edm::Handle<trigger::TriggerEventWithRefs> triggerEventWithRefsHandle;
-      if(event.getByToken(triggerEventWithRefsTag_,triggerEventWithRefsHandle)) {
+//      if(event.getByToken(triggerEventWithRefsTag_,triggerEventWithRefsHandle)) {
+
+
+	edm::Handle<trigger::TriggerEventWithRefs> rawTriggerEvent;
+	event.getByToken(triggerSummaryTokenRAW,rawTriggerEvent);
+	 
+	edm::Handle<trigger::TriggerEventWithRefs> aodTriggerEvent;
+	event.getByToken(triggerSummaryTokenAOD,aodTriggerEvent);
+	  
+	hasRawTriggerSummary=true;
+	if(!rawTriggerEvent.isValid()){ 
+		hasRawTriggerSummary=false;
+		edm::LogWarning( "TopDiLeptonHLTOfflineDQM" ) 
+          << "No RAW trigger summary found! Returning... \n";
+
+		if(!aodTriggerEvent.isValid()){
+			edm::LogWarning( "TopDiLeptonHLTOfflineDQM" ) 
+			<< "No AOD trigger summary found! Returning... \n";
+
+			return;
+		}  
+	}	  	
+
+
 
         // loop over trigger paths 
-        for(unsigned int i=0; i<triggerNames.triggerNames().size(); ++i){
+	for(unsigned int i=0; i<triggerNames.triggerNames().size(); ++i){
           // consider only path from triggerPaths
           string name = triggerNames.triggerNames()[i].c_str();
           bool isInteresting = false;
@@ -514,7 +538,7 @@ namespace HLTOfflineDQMTopDiLepton {
           // get modules for the considered trigger path
           const vector<string>& moduleLabels(hltConfig.moduleLabels(triggerIndex));
           const unsigned int moduleIndex(triggerTable->index(triggerIndex));
-          // Results from TriggerEventWithRefs product
+          // Results from TriggerEvent product
           electronIds_.clear(); electronRefs_.clear();
           muonIds_.clear();     muonRefs_.clear();
           // look only for modules actually run in this path
@@ -524,19 +548,39 @@ namespace HLTOfflineDQMTopDiLepton {
             const string& moduleLabel(moduleLabels[k]);
             const string  moduleType(hltConfig.moduleType(moduleLabel));
             // check whether the module is packed up in TriggerEventWithRef product
-            const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
-            if (filterIndex<triggerEventWithRefsHandle->size()) {
-              triggerEventWithRefsHandle->getObjects(filterIndex,electronIds_,electronRefs_);
-              const unsigned int nElectrons(electronIds_.size());
-              if (nElectrons>0) kElec = k;
 
-              triggerEventWithRefsHandle->getObjects(filterIndex,muonIds_,muonRefs_);
-              const unsigned int nMuons(muonIds_.size());
-              if (nMuons>0) kMuon = k;
+//            const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
+//            if (filterIndex<triggerEventWithRefsHandle->size()) {
+   
+            if(hasRawTriggerSummary){ 
+				const unsigned int filterIndex(rawTriggerEvent->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
+            	if (filterIndex<rawTriggerEvent->size()) {
+              		rawTriggerEvent->getObjects(filterIndex,electronIds_,electronRefs_);
+              		const unsigned int nElectrons(electronIds_.size());
+              		if (nElectrons>0) kElec = k;
 
-            }
-          }
-          bool l1Matched = false;
+              		rawTriggerEvent->getObjects(filterIndex,muonIds_,muonRefs_);
+              		const unsigned int nMuons(muonIds_.size());
+              		if (nMuons>0) kMuon = k;
+            	}
+          	}
+
+			else{
+				const unsigned int filterIndex(aodTriggerEvent->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
+				if (filterIndex<aodTriggerEvent->size()) {
+					
+					aodTriggerEvent->getObjects(filterIndex,electronIds_,electronRefs_);
+					const unsigned int nElectrons(electronIds_.size());
+					if (nElectrons>0) kElec = k;
+
+					aodTriggerEvent->getObjects(filterIndex,muonIds_,muonRefs_);
+					const unsigned int nMuons(muonIds_.size());
+					if (nMuons>0) kMuon = k;
+				}	
+		  	}
+		  }		
+          
+		  bool l1Matched = false;
           bool l2Matched = false;
           double l1DeltaRMin = 500.;
           double l2DeltaRMin = 500.;
@@ -547,8 +591,19 @@ namespace HLTOfflineDQMTopDiLepton {
           if (kElec > 0 && kMuon < 1 && isoElecs.size()>0) {
             const string& moduleLabelElec(moduleLabels[kElec]);
             const string  moduleTypeElec(hltConfig.moduleType(moduleLabelElec));
-            const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
-            triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
+
+//          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+//			triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
+
+            if(hasRawTriggerSummary){ 
+				const unsigned int filterIndexElec(rawTriggerEvent->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+				rawTriggerEvent->getObjects(filterIndexElec,electronIds_,electronRefs_);
+			}
+			else{
+				const unsigned int filterIndexElec(aodTriggerEvent->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+				aodTriggerEvent->getObjects(filterIndexElec,electronIds_,electronRefs_);
+				
+			}		
             const unsigned int nElectrons(electronIds_.size());
             double deltar1 = 600.;
             double deltar2 = 600.;
@@ -584,8 +639,20 @@ namespace HLTOfflineDQMTopDiLepton {
           if (kMuon > 0 && kElec < 1 && isoMuons.size()>0) {
             const string& moduleLabelMuon(moduleLabels[kMuon]);
             const string  moduleTypeMuon(hltConfig.moduleType(moduleLabelMuon));
-            const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
-            triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+
+//          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+//          triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+			
+			if(hasRawTriggerSummary){
+				const unsigned int filterIndexMuon(rawTriggerEvent->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+				rawTriggerEvent->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+			}
+			
+			else{ 
+				const unsigned int filterIndexMuon(aodTriggerEvent->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+				aodTriggerEvent->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+			}	
+				
             trigger::VRmuon myMuonRefs;
             const unsigned int nMuons(muonIds_.size());
             for (unsigned int l=0; l<nMuons; l++) {
@@ -658,8 +725,19 @@ namespace HLTOfflineDQMTopDiLepton {
           if (kElec > 0 && kMuon > 0 && isoElecs.size()>0) {
             const string& moduleLabelElec(moduleLabels[kElec]);
             const string  moduleTypeElec(hltConfig.moduleType(moduleLabelElec));
-            const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
-            triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
+
+//            const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+//            triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
+
+			if(hasRawTriggerSummary){
+				const unsigned int filterIndexElec(rawTriggerEvent->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+				rawTriggerEvent->getObjects(filterIndexElec,electronIds_,electronRefs_);
+			}
+			else{
+				const unsigned int filterIndexElec(aodTriggerEvent->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
+				aodTriggerEvent->getObjects(filterIndexElec,electronIds_,electronRefs_);
+			}
+			
             const unsigned int nElectrons(electronIds_.size());
             double deltar = 600.;
             for (unsigned int inde = 0; inde < isoElecs.size(); inde++) {
@@ -679,8 +757,19 @@ namespace HLTOfflineDQMTopDiLepton {
           if (kElec > 0 && kMuon > 0 && isoMuons.size()>0) {
             const string& moduleLabelMuon(moduleLabels[kMuon]);
             const string  moduleTypeMuon(hltConfig.moduleType(moduleLabelMuon));
-            const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
-            triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+
+//            const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+//            triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+
+			if(hasRawTriggerSummary){
+				const unsigned int filterIndexMuon(rawTriggerEvent->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+				rawTriggerEvent->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+			}
+			else{
+				const unsigned int filterIndexMuon(aodTriggerEvent->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
+				aodTriggerEvent->getObjects(filterIndexMuon,muonIds_,muonRefs_);
+			}
+						
             const unsigned int nMuons(muonIds_.size());
             if (isoMuons.size()<1) continue;
             double deltar = 600.;
@@ -700,7 +789,7 @@ namespace HLTOfflineDQMTopDiLepton {
           }
           if (l1Matched && l2Matched) fill("matchingMon_", 2.5 );
         }
-      }
+//      }
 
     }
 

--- a/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
@@ -25,8 +25,8 @@ SingleTopSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation'
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
 
-# Soureek Renaming the triggerPaths according to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-		vsPaths	     = cms.untracked.vstring(['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v', 'HLT_IsoMu18_TriCentralPFJet50_40_30_v','HLT_IsoMu22_v', 'HLT_IsoMu18_v','HLT_IsoMu22_TriCentralPFJet50_40_30_v','HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v','HLT_IsoMu20_eta2p1_TriCentralPFJet30_v','HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v','HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v', 'HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v','HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v4']),
+### Updating to HLT paths to be monitored by TOP PAG in 2016 
+        vsPaths     = cms.untracked.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v']),
 )
 
 # single top electronique
@@ -53,6 +53,6 @@ SingleTopSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidat
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
 
-# Soureek Renaming the triggerPaths according to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-		vsPaths      = cms.untracked.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v', 'HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v', 'HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v',  'HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v','HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v','HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele32_eta2p1_WPLoose_Gsf_v','HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v']),
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+        vsPaths     = cms.untracked.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele22_eta2p1_WPLoose_Gsf_v', 'HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v']),
 )

--- a/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
@@ -23,7 +23,8 @@ DiMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
-        vsPaths      = cms.untracked.vstring(['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v', 'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
+### Updating to  HLT paths to be monitored by TOP PAG in 2016                                                                                                                
+		vsPaths      = cms.untracked.vstring(['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v', 'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v']),
 )
 
 # ttbar dielec
@@ -49,7 +50,8 @@ DiElectronHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
-        vsPaths      = cms.untracked.vstring(['HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+		vsPaths      = cms.untracked.vstring(['HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v', 'HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
 )
 
 # ttbar elec-muon
@@ -75,5 +77,6 @@ ElecMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
-        vsPaths      = cms.untracked.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v']),
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+		vsPaths      = cms.untracked.vstring(['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v', 'HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v']),
 )

--- a/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
@@ -24,8 +24,8 @@ topSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
 
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-        vsPaths      = cms.untracked.vstring(['HLT_IsoMu18_CentralPFJet30_BTagCSV_p063_v','HLT_IsoMu18_TriCentralPFJet50_40_30_v', 'HLT_IsoMu22_v', 'HLT_IsoMu18_v','HLT_IsoMu22_TriCentralPFJet50_40_30_v','HLT_IsoMu22_CentralPFJet30_BTagCSV_p063_v1','HLT_IsoMu20_eta2p1_TriCentralPFJet30_v','HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30_v','HLT_IsoMu20_eta2p1_CentralPFJet30_BTagCSV07_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_TriCentralPFJet30_v', 'HLT_IsoMu24_eta2p1_TriCentralPFJet50_40_30_v','HLT_IsoMu24_eta2p1_CentralPFJet30_BTagCSV_p063_v']), 
+### Updating to HLT paths to be monitored by TOP PAG in 2016                                                                                                                 
+        vsPaths     = cms.untracked.vstring(['HLT_IsoMu18_v', 'HLT_IsoMu20_v', 'HLT_IsoMu22_v', 'HLT_IsoMu24_v', 'HLT_IsoTkMu18_v', 'HLT_IsoTkMu20_v', 'HLT_IsoTkMu22_v', 'HLT_IsoTkMu24_v','HLT_IsoMu17_eta2p1_v','HLT_IsoMu20_eta2p1_v','HLT_IsoMu24_eta2p1_v','HLT_IsoTkMu20_eta2p1_v','HLT_IsoTkMu24_eta2p1_v3']),
 )
 
 # ttbar semi electronique
@@ -52,7 +52,6 @@ topSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
 
-#Soureek updating triggerPath name accrosding to JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-666
-
-        vsPaths      = cms.untracked.vstring(['HLT_Ele23_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele23_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v','HLT_Ele27_WPLoose_Gsf_WHbbBoost_v', 'HLT_Ele27_WPLoose_Gsf_v','HLT_Ele27_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v','HLT_Ele27_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele27_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV07_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_TriCentralPFJet50_40_30_v', 'HLT_Ele32_eta2p1_WPLoose_Gsf_v','HLT_Ele32_eta2p1_WPLoose_Gsf_CentralPFJet30_BTagCSV_p063_v1']),
+### Updating to HLT paths to be monitored by TOP PAG in 2016
+        vsPaths     = cms.untracked.vstring(['HLT_Ele27_WPLoose_Gsf_v','HLT_Ele23_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPTight_Gsf_v', 'HLT_Ele27_WPTight_Gsf_v','HLT_Ele27_eta2p1_WPLoose_Gsf_v', 'HLT_Ele22_eta2p1_WPLoose_Gsf_v', 'HLT_Ele24_eta2p1_WPLoose_Gsf_v','HLT_Ele25_eta2p1_WPLoose_Gsf_v']),
 )


### PR DESCRIPTION
Removing Lepton + btags/jets triggers from the list of triggers as the TOP PAG does not intend to monitor them further in 2016. The reason being these triggers are not being used in TOP analyses. Also adding token for "hltTriggerSummaryAOD" collection present in both data and MC. Replaced "cout" commands with edm::LogWarning. The code is tested to be Ok by running the matrix for TTbar_13 workflow for 25ns bunch spacing.
