### PR TITLE
Electron validation 81X preshower

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -379,6 +379,7 @@ ElectronMcFakeValidator::ElectronMcFakeValidator( const edm::ParameterSet & conf
   h2_ele_HoEVsPhi = 0 ;
   h2_ele_HoEVsE = 0 ;
   h1_scl_ESFrac = 0 ;
+  h1_scl_ESFrac_endcaps = 0 ;
 
   h1_ele_fbrem = 0 ;
   p1_ele_fbremVsEta_mode = 0 ;
@@ -686,7 +687,8 @@ void ElectronMcFakeValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::
   h2_ele_HoEVsPhi = bookH2(iBooker, "HoEVsPhi","ele hadronic energy / em energy vs phi",phi2D_nbin,phi_min,phi_max,hoe_nbin, hoe_min, hoe_max) ;
   h2_ele_HoEVsE = bookH2(iBooker, "HoEVsE","ele hadronic energy / em energy vs E",p_nbin, 0.,300.,hoe_nbin, hoe_min, hoe_max) ;
   setBookPrefix("h_scl") ;
-  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,1.5,"E_{PS} / E^{raw}_{SC}");
+  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
+  h1_scl_ESFrac_endcaps = bookH1withSumw2(iBooker, "ESFrac_endcaps","Preshower over SC raw energy , endcaps",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
 
   // seeds
   setBookPrefix("h_ele") ;
@@ -1053,28 +1055,27 @@ void ElectronMcFakeValidator::analyze( const edm::Event & iEvent, const edm::Eve
       reco::SuperClusterRef sclRef = bestGsfElectron.superCluster();
       if (!bestGsfElectron.ecalDrivenSeed()&&bestGsfElectron.trackerDrivenSeed()) sclRef = bestGsfElectron.parentSuperCluster();
       if( sclRef.isNonnull() ) {
-	h1_scl_En_->Fill(sclRef->energy());      
-	double R=TMath::Sqrt(sclRef->x()*sclRef->x() + sclRef->y()*sclRef->y() +sclRef->z()*sclRef->z());
-	double Rt=TMath::Sqrt(sclRef->x()*sclRef->x() + sclRef->y()*sclRef->y());
-	h1_scl_Et_->Fill(sclRef->energy()*(Rt/R));
-	h2_scl_EtVsEta_->Fill(sclRef->eta(),sclRef->energy()*(Rt/R));
-	h2_scl_EtVsPhi_->Fill(sclRef->phi(),sclRef->energy()*(Rt/R));
-	if (bestGsfElectron.classification() < 100)  h1_scl_EoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
-	if (bestGsfElectron.classification() >= 100)  h1_scl_EoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
-	h1_scl_Eta_->Fill(sclRef->eta());
-	h2_scl_EtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
-	h1_scl_Phi_->Fill(sclRef->phi());
+        h1_scl_En_->Fill(sclRef->energy());      
+        double R=TMath::Sqrt(sclRef->x()*sclRef->x() + sclRef->y()*sclRef->y() +sclRef->z()*sclRef->z());
+        double Rt=TMath::Sqrt(sclRef->x()*sclRef->x() + sclRef->y()*sclRef->y());
+        h1_scl_Et_->Fill(sclRef->energy()*(Rt/R));
+        h2_scl_EtVsEta_->Fill(sclRef->eta(),sclRef->energy()*(Rt/R));
+        h2_scl_EtVsPhi_->Fill(sclRef->phi(),sclRef->energy()*(Rt/R));
+        if (bestGsfElectron.classification() < 100)  h1_scl_EoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
+        if (bestGsfElectron.classification() >= 100)  h1_scl_EoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
+        h1_scl_Eta_->Fill(sclRef->eta());
+        h2_scl_EtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
+        h1_scl_Phi_->Fill(sclRef->phi());
         /*New from 06 05 2016*/
-    h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
+        h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
+        if (bestGsfElectron.isEE()) h1_scl_ESFrac_endcaps->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
       }
       h1_scl_SigIEtaIEta_->Fill(bestGsfElectron.scSigmaIEtaIEta());
       if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_barrel_->Fill(bestGsfElectron.scSigmaIEtaIEta());
       if (bestGsfElectron.isEE()) h1_scl_SigIEtaIEta_endcaps_->Fill(bestGsfElectron.scSigmaIEtaIEta());
-// new 2014.01.12
       h1_scl_full5x5_sigmaIetaIeta_->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
       if (bestGsfElectron.isEB()) h1_scl_full5x5_sigmaIetaIeta_barrel_->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
       if (bestGsfElectron.isEE()) h1_scl_full5x5_sigmaIetaIeta_endcaps_->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
-// new 2014.01.12
       h1_scl_E1x5_->Fill(bestGsfElectron.scE1x5());
       if (bestGsfElectron.isEB()) h1_scl_E1x5_barrel_->Fill(bestGsfElectron.scE1x5());
       if (bestGsfElectron.isEE()) h1_scl_E1x5_endcaps_->Fill(bestGsfElectron.scE1x5());
@@ -1280,7 +1281,6 @@ void ElectronMcFakeValidator::analyze( const edm::Event & iEvent, const edm::Eve
         double superclusterfbrem_mode_endcaps = bestGsfElectron.superClusterFbrem();
         h1_ele_superclusterfbrem_endcaps->Fill(superclusterfbrem_mode_endcaps);
        }
-// new 2014/02/12
 
       if (!readAOD_) // track extra does not exist in AOD
        {

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -378,7 +378,7 @@ ElectronMcFakeValidator::ElectronMcFakeValidator( const edm::ParameterSet & conf
   h2_ele_HoEVsEta = 0 ;
   h2_ele_HoEVsPhi = 0 ;
   h2_ele_HoEVsE = 0 ;
-  h1_scl_ESFrac = 0 ;
+//  h1_scl_ESFrac = 0 ;
   h1_scl_ESFrac_endcaps = 0 ;
 
   h1_ele_fbrem = 0 ;
@@ -687,7 +687,7 @@ void ElectronMcFakeValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::
   h2_ele_HoEVsPhi = bookH2(iBooker, "HoEVsPhi","ele hadronic energy / em energy vs phi",phi2D_nbin,phi_min,phi_max,hoe_nbin, hoe_min, hoe_max) ;
   h2_ele_HoEVsE = bookH2(iBooker, "HoEVsE","ele hadronic energy / em energy vs E",p_nbin, 0.,300.,hoe_nbin, hoe_min, hoe_max) ;
   setBookPrefix("h_scl") ;
-  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
+//  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
   h1_scl_ESFrac_endcaps = bookH1withSumw2(iBooker, "ESFrac_endcaps","Preshower over SC raw energy , endcaps",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
 
   // seeds
@@ -1067,7 +1067,7 @@ void ElectronMcFakeValidator::analyze( const edm::Event & iEvent, const edm::Eve
         h2_scl_EtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
         h1_scl_Phi_->Fill(sclRef->phi());
         /*New from 06 05 2016*/
-        h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
+//        h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
         if (bestGsfElectron.isEE()) h1_scl_ESFrac_endcaps->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
       }
       h1_scl_SigIEtaIEta_->Fill(bestGsfElectron.scSigmaIEtaIEta());

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -378,13 +378,14 @@ ElectronMcFakeValidator::ElectronMcFakeValidator( const edm::ParameterSet & conf
   h2_ele_HoEVsEta = 0 ;
   h2_ele_HoEVsPhi = 0 ;
   h2_ele_HoEVsE = 0 ;
+  h1_scl_ESFrac = 0 ;
 
   h1_ele_fbrem = 0 ;
   p1_ele_fbremVsEta_mode = 0 ;
   p1_ele_fbremVsEta_mean = 0 ;
-  h1_ele_superclusterfbrem = 0 ; // new 2014.02.12
-  h1_ele_superclusterfbrem_barrel = 0 ; // new 2014.02.12
-  h1_ele_superclusterfbrem_endcaps = 0 ; // new 2014.02.12
+  h1_ele_superclusterfbrem = 0 ;
+  h1_ele_superclusterfbrem_barrel = 0 ;
+  h1_ele_superclusterfbrem_endcaps = 0 ;
   h2_ele_PinVsPoutGolden_mode = 0 ;
   h2_ele_PinVsPoutShowering_mode = 0 ;
   h2_ele_PinVsPoutGolden_mean = 0 ;
@@ -684,8 +685,11 @@ void ElectronMcFakeValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::
   h2_ele_HoEVsEta = bookH2(iBooker, "HoEVsEta","ele hadronic energy / em energy vs eta",eta_nbin,eta_min,eta_max,hoe_nbin, hoe_min, hoe_max) ;
   h2_ele_HoEVsPhi = bookH2(iBooker, "HoEVsPhi","ele hadronic energy / em energy vs phi",phi2D_nbin,phi_min,phi_max,hoe_nbin, hoe_min, hoe_max) ;
   h2_ele_HoEVsE = bookH2(iBooker, "HoEVsE","ele hadronic energy / em energy vs E",p_nbin, 0.,300.,hoe_nbin, hoe_min, hoe_max) ;
+  setBookPrefix("h_scl") ;
+  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,1.5,"E_{PS} / E^{raw}_{SC}");
 
   // seeds
+  setBookPrefix("h_ele") ;
   h1_ele_seed_subdet2_ = bookH1withSumw2(iBooker, "seedSubdet2","ele seed subdet 2nd layer",11,-0.5,10.5,"2nd hit subdet Id") ;
   h1_ele_seed_mask_ = bookH1withSumw2(iBooker, "seedMask","ele seed hits mask",13,-0.5,12.5) ;
   h1_ele_seed_mask_bpix_ = bookH1withSumw2(iBooker, "seedMask_Bpix","ele seed hits mask when subdet2 is bpix",13,-0.5,12.5) ;
@@ -1060,6 +1064,8 @@ void ElectronMcFakeValidator::analyze( const edm::Event & iEvent, const edm::Eve
 	h1_scl_Eta_->Fill(sclRef->eta());
 	h2_scl_EtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
 	h1_scl_Phi_->Fill(sclRef->phi());
+        /*New from 06 05 2016*/
+    h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
       }
       h1_scl_SigIEtaIEta_->Fill(bestGsfElectron.scSigmaIEtaIEta());
       if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_barrel_->Fill(bestGsfElectron.scSigmaIEtaIEta());

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
@@ -336,7 +336,7 @@ class ElectronMcFakeValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_HoEVsEta;
     MonitorElement *h2_ele_HoEVsPhi;
     MonitorElement *h2_ele_HoEVsE;
-    MonitorElement *h1_scl_ESFrac;
+//    MonitorElement *h1_scl_ESFrac;
     MonitorElement *h1_scl_ESFrac_endcaps;
 
     MonitorElement *h1_ele_fbrem;

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
@@ -336,6 +336,7 @@ class ElectronMcFakeValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_HoEVsEta;
     MonitorElement *h2_ele_HoEVsPhi;
     MonitorElement *h2_ele_HoEVsE;
+    MonitorElement *h1_scl_ESFrac;
 
     MonitorElement *h1_ele_fbrem;
     MonitorElement *h1_ele_fbrem_barrel;

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.h
@@ -337,13 +337,14 @@ class ElectronMcFakeValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_ele_HoEVsPhi;
     MonitorElement *h2_ele_HoEVsE;
     MonitorElement *h1_scl_ESFrac;
+    MonitorElement *h1_scl_ESFrac_endcaps;
 
     MonitorElement *h1_ele_fbrem;
     MonitorElement *h1_ele_fbrem_barrel;
     MonitorElement *h1_ele_fbrem_endcaps;
-    MonitorElement *h1_ele_superclusterfbrem; // new 2014.02.12
-    MonitorElement *h1_ele_superclusterfbrem_barrel; // new 2014.02.12
-    MonitorElement *h1_ele_superclusterfbrem_endcaps; // new 2014.02.12
+    MonitorElement *h1_ele_superclusterfbrem;
+    MonitorElement *h1_ele_superclusterfbrem_barrel;
+    MonitorElement *h1_ele_superclusterfbrem_endcaps;
     MonitorElement *p1_ele_fbremVsEta_mode;
     MonitorElement *p1_ele_fbremVsEta_mean;
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -289,6 +289,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h2_scl_EtaVsPhi = 0 ;
   h1_scl_Eta = 0 ;
   h1_scl_Phi = 0 ;
+  h1_scl_ESFrac = 0 ;
 
   h2_scl_EoEtruePfVsEg  = 0 ;
 
@@ -769,6 +770,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_bcl_EtotoEtrue = bookH1withSumw2(iBooker, "bcl_EtotoEtrue","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_barrel = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_endcaps = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",50,0.,1.5,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
 
   // matched electron, gsf tracks
   setBookPrefix("h_ele") ;
@@ -1497,6 +1499,8 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     float pfEnergy=0. ;
     if (!bestGsfElectron.parentSuperCluster().isNull()) pfEnergy = bestGsfElectron.parentSuperCluster()->energy();
     h2_scl_EoEtruePfVsEg->Fill(bestGsfElectron.ecalEnergy()/mcIter->p(),pfEnergy/mcIter->p());
+    /*New from 06 05 2016*/
+    h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
 
     float Etot = 0.; 
     CaloCluster_iterator it = bestGsfElectron.superCluster()->clustersBegin();

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -290,6 +290,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_Eta = 0 ;
   h1_scl_Phi = 0 ;
   h1_scl_ESFrac = 0 ;
+  h1_scl_ESFrac_endcaps = 0 ;
 
   h2_scl_EoEtruePfVsEg  = 0 ;
 
@@ -770,7 +771,8 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_bcl_EtotoEtrue = bookH1withSumw2(iBooker, "bcl_EtotoEtrue","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_barrel = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_endcaps = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",50,0.,1.5,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
+  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
+  h1_scl_ESFrac_endcaps = bookH1withSumw2(iBooker, "ESFrac_endcaps","Preshower over SC raw energy , endcaps",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
 
   // matched electron, gsf tracks
   setBookPrefix("h_ele") ;
@@ -1501,6 +1503,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_scl_EoEtruePfVsEg->Fill(bestGsfElectron.ecalEnergy()/mcIter->p(),pfEnergy/mcIter->p());
     /*New from 06 05 2016*/
     h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
+    if (bestGsfElectron.isEE()) h1_scl_ESFrac_endcaps->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
 
     float Etot = 0.; 
     CaloCluster_iterator it = bestGsfElectron.superCluster()->clustersBegin();

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -289,7 +289,7 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h2_scl_EtaVsPhi = 0 ;
   h1_scl_Eta = 0 ;
   h1_scl_Phi = 0 ;
-  h1_scl_ESFrac = 0 ;
+//  h1_scl_ESFrac = 0 ;
   h1_scl_ESFrac_endcaps = 0 ;
 
   h2_scl_EoEtruePfVsEg  = 0 ;
@@ -771,7 +771,7 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_bcl_EtotoEtrue = bookH1withSumw2(iBooker, "bcl_EtotoEtrue","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_barrel = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
   h1_scl_bcl_EtotoEtrue_endcaps = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
+//  h1_scl_ESFrac = bookH1withSumw2(iBooker, "ESFrac","Preshower over SC raw energy",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
   h1_scl_ESFrac_endcaps = bookH1withSumw2(iBooker, "ESFrac_endcaps","Preshower over SC raw energy , endcaps",100,0.,0.8,"E_{PS} / E^{raw}_{SC}","Events","ELE_LOGY E1 P");
 
   // matched electron, gsf tracks
@@ -1502,7 +1502,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     if (!bestGsfElectron.parentSuperCluster().isNull()) pfEnergy = bestGsfElectron.parentSuperCluster()->energy();
     h2_scl_EoEtruePfVsEg->Fill(bestGsfElectron.ecalEnergy()/mcIter->p(),pfEnergy/mcIter->p());
     /*New from 06 05 2016*/
-    h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
+//    h1_scl_ESFrac->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
     if (bestGsfElectron.isEE()) h1_scl_ESFrac_endcaps->Fill( sclRef->preshowerEnergy() / sclRef->rawEnergy() );
 
     float Etot = 0.; 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -97,9 +97,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_recTrackNum;
     MonitorElement *h1_recSeedNum;
     MonitorElement *h1_recOfflineVertices;
-    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices; // new 2015.15.05
-    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_barrel; // new 2015.15.05
-    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_endcaps; // new 2015.15.05
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices;
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_barrel;
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_endcaps;
 
     MonitorElement *h1_mc_Eta;
     MonitorElement *h1_mc_AbsEta;
@@ -220,6 +220,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_Eta;
     MonitorElement *h1_scl_Phi;
     MonitorElement *h1_scl_ESFrac;
+    MonitorElement *h1_scl_ESFrac_endcaps;
 
     MonitorElement *h2_scl_EoEtruePfVsEg ;
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -219,7 +219,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_scl_EtaVsPhi;
     MonitorElement *h1_scl_Eta;
     MonitorElement *h1_scl_Phi;
-    MonitorElement *h1_scl_ESFrac;
+//    MonitorElement *h1_scl_ESFrac;
     MonitorElement *h1_scl_ESFrac_endcaps;
 
     MonitorElement *h2_scl_EoEtruePfVsEg ;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -219,6 +219,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h2_scl_EtaVsPhi;
     MonitorElement *h1_scl_Eta;
     MonitorElement *h1_scl_Phi;
+    MonitorElement *h1_scl_ESFrac;
 
     MonitorElement *h2_scl_EoEtruePfVsEg ;
 
@@ -243,9 +244,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_E5x5;
     MonitorElement *h1_scl_E5x5_barrel;
     MonitorElement *h1_scl_E5x5_endcaps;
-    MonitorElement *h1_scl_bcl_EtotoEtrue; // new 2015.18.05
-    MonitorElement *h1_scl_bcl_EtotoEtrue_barrel; // new 2015.18.05
-    MonitorElement *h1_scl_bcl_EtotoEtrue_endcaps; // new 2015.18.05
+    MonitorElement *h1_scl_bcl_EtotoEtrue;
+    MonitorElement *h1_scl_bcl_EtotoEtrue_barrel;
+    MonitorElement *h1_scl_bcl_EtotoEtrue_endcaps;
 
     MonitorElement *h1_ele_ambiguousTracks;
     MonitorElement *h2_ele_ambiguousTracksVsEta;

--- a/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
@@ -85,7 +85,8 @@ ElectronMcFakeValidator/h_scl_E2x5max_endcaps                     1 1 1 0
 ElectronMcFakeValidator/h_scl_E5x5                                1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_barrel                         1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_endcaps                        1 1 1 0
-ElectronMcFakeValidator/h_ele_HoEVsEta_pfx                        0 1 1 1
+ElectronMcFakeValidator/h_ele_HoEVsEta_pfx                        0 1 1 0
+ElectronMcFakeValidator/h_scl_ESFrac                              0 1 1 1
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
@@ -86,8 +86,7 @@ ElectronMcFakeValidator/h_scl_E5x5                                1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_barrel                         1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_endcaps                        1 1 1 0
 ElectronMcFakeValidator/h_ele_HoEVsEta_pfx                        0 1 1 0
-ElectronMcFakeValidator/h_scl_ESFrac                              1 1 0 0
-ElectronMcFakeValidator/h_scl_ESFrac_endcaps                      1 1 1 1
+ElectronMcFakeValidator/h_scl_ESFrac_endcaps                      0 1 1 1
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcFakeHistos.txt
@@ -86,7 +86,8 @@ ElectronMcFakeValidator/h_scl_E5x5                                1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_barrel                         1 1 0 0
 ElectronMcFakeValidator/h_scl_E5x5_endcaps                        1 1 1 0
 ElectronMcFakeValidator/h_ele_HoEVsEta_pfx                        0 1 1 0
-ElectronMcFakeValidator/h_scl_ESFrac                              0 1 1 1
+ElectronMcFakeValidator/h_scl_ESFrac                              1 1 0 0
+ElectronMcFakeValidator/h_scl_ESFrac_endcaps                      1 1 1 1
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
@@ -35,8 +35,8 @@ process.electronMcFakePostValidator.InputFolderName = cms.string("EgammaV/Electr
 process.electronMcFakePostValidator.OutputFolderName = cms.string("EgammaV/ElectronMcFakeValidator")
 
 from Configuration.AlCa.autoCond import autoCond
-#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
@@ -29,8 +29,8 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
-#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -134,8 +134,8 @@ ElectronMcSignalValidator/h_scl_E5x5                        1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_barrel                 1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_endcaps                1 1 1 0
 ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 0
-ElectronMcSignalValidator/h_scl_ESFrac                      1 1 0 0
-ElectronMcSignalValidator/h_scl_ESFrac_endcaps              1 1 1 1
+ElectronMcSignalValidator/h_scl_ESFrac_endcaps              0 1 1 1
+
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -134,7 +134,8 @@ ElectronMcSignalValidator/h_scl_E5x5                        1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_barrel                 1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_endcaps                1 1 1 0
 ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 0
-ElectronMcSignalValidator/h_scl_ESFrac                      0 1 1 1
+ElectronMcSignalValidator/h_scl_ESFrac                      1 1 0 0
+ElectronMcSignalValidator/h_scl_ESFrac_endcaps              1 1 1 1
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -133,7 +133,8 @@ ElectronMcSignalValidator/h_scl_E2x5max_endcaps             1 1 1 0
 ElectronMcSignalValidator/h_scl_E5x5                        1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_barrel                 1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_endcaps                1 1 1 0
-ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 1
+ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 0
+ElectronMcSignalValidator/h_scl_ESFrac                      0 1 1 1
 
 Electron track variables
 

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -608,7 +608,7 @@ int electronCompare()
        } while (cat.empty()) ;
      }
    }
-  std::cout << "on ferme le fichier : " << histo_file2 << std::endl;
+//  std::cout << "on ferme le fichier : " << histo_file2 << std::endl;
   histo_file2.close() ;
   web_page<<"</td></tr></table>\n" ;
 


### PR DESCRIPTION
The quantity superCluster()->preshowerEnergy() / superCluster()->rawEnergy() is used in the electron ID and tracking changes would be useful.

This new histo was added for validation in the case of endcaps only.
The files used for this implementation are : 
Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc (h)
Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc (h)

The files :+1: Validation/RecoEgamma/test/ElectronMcSignalHistos.txt and Validation/RecoEgamma/test/ElectronMcFakeHistos.txt are used for web page creation and include the new histo.

Others minors correction : 
Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
in which a small Global Tag use is corrected

Validation/RecoEgamma/test/electronCompare.C
for these file, there is a small correction in web page creation due to gcc530.

@beaudett @matteosan1 @fcouderc @pigard
