### PR TITLE
Add missing selection rules (GCC 6)

### DIFF
--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -174,6 +174,8 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
+  <class name="std::pair<uint8_t, CaloTowerDetId>"/>
+  <class name="std::vector<std::pair<uint8_t, CaloTowerDetId> >"/>
   <class name="HaloTowerStrip" ClassVersion="3">
    <version ClassVersion="3" checksum="3149281836"/>
    <version ClassVersion="2" checksum="665188928"/>


### PR DESCRIPTION
A unit test and a few workflows are failing with:

```
----- Begin Fatal Exception 07-May-2016 07:47:06 CEST-----------------------
An exception of category 'FileReadError' occurred while
   [0] Processing run: 1 lumi: 1 event: 13
   [1] Running path 'outpath'
   [2] Calling event method for module PoolOutputModule/'out'
   [3] Reading branch recoBeamHaloSummary_BeamHaloSummary__RECO.
   Additional Info:
      [a] Fatal Root Error: @SUB=TClass::New with placement
cannot create object of class pair<unsigned char,CaloTowerDetId> version 1 at address 0x7f60cfc7df40

----- End Fatal Exception -------------------------------------------------
```

This missing dictionary is being user by `HaloTowerStrip`
(DataFormats/METReco/interface/HcalHaloData.h) and we don't have
selection rules for all of the members.

It's currently unknown why this happens on GCC 6 branch. Adding these
rules resolves the issue, tested with 4.29 workflow. It could be related
to `std::pair` constructors which have been changed in new libstdc++.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
