### PR TITLE
Premixing for QIE10

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -70,6 +70,7 @@ def customise_HcalPhase0p5(process):
         process.horeco.digiLabel = cms.InputTag("simHcalDigis")
         process.hfreco.digiLabel = cms.InputTag("simHcalDigis")
         process.zdcreco.digiLabel = cms.InputTag("simHcalUnsuppressedDigis")
+        process.zdcreco.digiLabelhcal = cms.InputTag("simHcalUnsuppressedDigis")
         process.hcalnoise.digiCollName = cms.string('simHcalDigis')
     
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -72,6 +72,8 @@ def customise_HcalPhase0p5(process):
         process.zdcreco.digiLabel = cms.InputTag("simHcalUnsuppressedDigis")
         process.zdcreco.digiLabelhcal = cms.InputTag("simHcalUnsuppressedDigis")
         process.hcalnoise.digiCollName = cms.string('simHcalDigis')
+    if hasattr(process,'datamixing_step'):
+        process=customise_mixing(process)
     
     return process
     
@@ -247,4 +249,11 @@ def customise_Validation(process):
     return process
 
 def customise_condOverRides(process):
+    return process
+    
+def customise_mixing(process):
+    process.mixData.HBHEPileInputTag = cms.InputTag("simHcalUnsuppressedDigis")
+    process.mixData.HOPileInputTag = cms.InputTag("simHcalUnsuppressedDigis")
+    process.mixData.HFPileInputTag = cms.InputTag("simHcalUnsuppressedDigis")
+    process.mixData.QIE10PileInputTag = cms.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection")
     return process

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -136,7 +136,7 @@ void CaloHitResponse::add(const CaloSamples & signal)
   } else  {
     // need a "+=" to CaloSamples
     int sampleSize =  oldSignal->size();
-    assert(sampleSize == signal.size());
+    assert(sampleSize <= signal.size());
     assert(signal.presamples() == oldSignal->presamples());
 
     for(int i = 0; i < sampleSize; ++i) {

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h
@@ -8,6 +8,8 @@ public:
   typedef HBHEDigiCollection DigiCollection;
   typedef HBHEDataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 126;
 };
 
 
@@ -16,6 +18,8 @@ public:
   typedef HODigiCollection DigiCollection;
   typedef HODataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 126;
 };
 
 
@@ -24,6 +28,8 @@ public:
   typedef HFDigiCollection DigiCollection;
   typedef HFDataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 126;
 };
 
 
@@ -32,8 +38,24 @@ public:
   typedef ZDCDigiCollection DigiCollection;
   typedef ZDCDataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 126;
 };
 
+template<class Traits>
+class CaloTDigitizerQIE8Run {
+public:
+  typedef typename Traits::ElectronicsSim ElectronicsSim;
+  typedef typename Traits::Digi Digi;
+  typedef typename Traits::DigiCollection DigiCollection;
+
+  void operator()(DigiCollection & output, CLHEP::HepRandomEngine* engine, CaloSamples * analogSignal, std::vector<DetId>::const_iterator idItr, ElectronicsSim* theElectronicsSim){
+    Digi digi(*idItr);
+    theElectronicsSim->analogToDigital(engine, *analogSignal , digi, Traits::PreMixFactor, Traits::PreMixBits);
+    output.push_back(std::move(digi));
+  }
+  
+};
 
 #endif
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
@@ -7,6 +7,8 @@
    */
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalCoderFactory.h"
 
 class HBHEDataFrame;
 class HODataFrame;
@@ -15,34 +17,33 @@ class ZDCDataFrame;
 class HcalUpgradeDataFrame;
 class QIE10DataFrame;
 
-class HcalAmplifier;
-class HcalCoderFactory;
-
 namespace CLHEP {
   class HepRandomEngine;
 }
 
 class HcalElectronicsSim {
 public:
-  HcalElectronicsSim(HcalAmplifier * amplifier, 
-                     const HcalCoderFactory * coderFactory, bool PreMix);
+  HcalElectronicsSim(HcalAmplifier * amplifier, const HcalCoderFactory * coderFactory, bool PreMix);
   ~HcalElectronicsSim();
 
   void setDbService(const HcalDbService * service);
 
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HBHEDataFrame & result);
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HODataFrame & result);
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HFDataFrame & result);
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, ZDCDataFrame & result);
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HcalUpgradeDataFrame& result);
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, QIE10DataFrame& result);
+  //these need to be overloads instead of templates to avoid linking issues when calling private member function templates
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HBHEDataFrame & result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HODataFrame & result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HFDataFrame & result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, ZDCDataFrame & result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HcalUpgradeDataFrame& result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, QIE10DataFrame& result, double preMixFactor=10.0, unsigned preMixBits=126);
   /// Things that need to be initialized every event
   /// sets starting CapID randomly
   void newEvent(CLHEP::HepRandomEngine*);
   void setStartingCapId(int startingCapId);
 
 private:
+  template<class Digi> void analogToDigitalImpl(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, Digi & result, double preMixFactor, unsigned preMixBits);
   template<class Digi> void convert(CaloSamples & frame, Digi & result, CLHEP::HepRandomEngine*);
+  template<class Digi> void premix(CaloSamples & frame, Digi & result, double preMixFactor, unsigned preMixBits);
 
   HcalAmplifier * theAmplifier;
   const HcalCoderFactory * theCoderFactory;
@@ -52,4 +53,5 @@ private:
   bool theStartingCapIdIsRandom;
   bool PreMixDigis;
 };
+
 #endif

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalQIE10Traits.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalQIE10Traits.h
@@ -10,6 +10,8 @@ public:
   typedef QIE10DigiCollection DigiCollection;
   typedef QIE10DataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 254;
 };
 
 template<class Traits>
@@ -22,7 +24,7 @@ public:
   void operator()(DigiCollection & output, CLHEP::HepRandomEngine* engine, CaloSamples * analogSignal, std::vector<DetId>::const_iterator idItr, ElectronicsSim* theElectronicsSim){
     output.push_back( idItr->rawId() ) ;
     Digi digi ( output.back() ) ;  //QIEDataFrame gets ptr to edm::DataFrame data
-    theElectronicsSim->analogToDigital( engine, *analogSignal , digi ) ;
+    theElectronicsSim->analogToDigital( engine, *analogSignal , digi, Traits::PreMixFactor, Traits::PreMixBits ) ;
   }
   
 };

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -6,12 +6,14 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE10Traits.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
@@ -25,12 +27,12 @@ namespace edm {
   class ModuleCallingContext;
 }
 
-template<class HCALDIGITIZERTRAITS>
+template<class Traits>
 class HcalSignalGenerator : public HcalBaseSignalGenerator
 {
 public:
-  typedef typename HCALDIGITIZERTRAITS::Digi DIGI;
-  typedef typename HCALDIGITIZERTRAITS::DigiCollection COLLECTION;
+  typedef typename Traits::Digi DIGI;
+  typedef typename Traits::DigiCollection COLLECTION;
 
   HcalSignalGenerator():HcalBaseSignalGenerator() { }
 
@@ -77,7 +79,7 @@ public:
     else if(theEventPrincipal)
     {
        std::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
-	 edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
+       edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
        if(digisPTR) {
           digis = digisPTR->product();
        }
@@ -87,35 +89,32 @@ public:
       throw cms::Exception("HcalSignalGenerator") << "No Event or EventPrincipal was set";
     }
 
-    if (digis)
-    {
-
-      // loop over digis, adding these to the existing maps
-      for(typename COLLECTION::const_iterator it  = digis->begin();
-          it != digis->end(); ++it) 
-      {
-        // for the first signal, set the starting cap id
-        if((it == digis->begin()) && theElectronicsSim)
-        {
-          int startingCapId = (*it)[0].capid();
-          theElectronicsSim->setStartingCapId(startingCapId);
-          // theParameterMap->setFrameSize(it->id(), it->size()); //don't need this
-        }
-	if(validDigi(*it)) {
-	  theNoiseSignals.push_back(samplesInPE(*it));
-	}
-      }
-    }
+    if (digis) fillDigis(digis);
   }
 
 private:
 
+  virtual void fillDigis(const COLLECTION * digis){
+    // loop over digis, adding these to the existing maps
+    for(typename COLLECTION::const_iterator it  = digis->begin(); it != digis->end(); ++it) 
+    {
+      // for the first signal, set the starting cap id
+      if((it == digis->begin()) && theElectronicsSim)
+      {
+        int startingCapId = (*it)[0].capid();
+        theElectronicsSim->setStartingCapId(startingCapId);
+        // theParameterMap->setFrameSize(it->id(), it->size()); //don't need this
+      }
+      if(validDigi(*it)) {
+        theNoiseSignals.push_back(samplesInPE(*it));
+      }
+    }
+  }
 
   virtual void fillNoiseSignals(CLHEP::HepRandomEngine*) override {}
   virtual void fillNoiseSignals() override {}
 
-  bool validDigi(const DIGI & digi)
-  {
+  bool validDigi(const DIGI & digi){
     int DigiSum = 0;
     for(int id = 0; id<digi.size(); id++) {
       if(digi[id].adc() > 0) ++DigiSum;
@@ -123,59 +122,49 @@ private:
     return(DigiSum>0);
   }
 
-
-  CaloSamples samplesInPE(const DIGI & digi)
-  {
-
+  CaloSamples samplesInPE(const DIGI & digi){
+  
     // For PreMixing, (Note that modifications will need to be made for DataMixing) the 
     // energy for each channel is kept as fC*10, but stored as an integer in ADC.  If this
     // results in an overflow, the "standard" ADC conversion is used and that channel is marked
     // with an error that allows the "standard" decoding to convert ADC back to fC.  So, most
     // channels get to fC by just dividing ADC/10; some require special treatment.
-
+  
     // calibration, for future reference:  (same block for all Hcal types)
     HcalDetId cell = digi.id();
-    //         const HcalCalibrations& calibrations=conditions->getHcalCalibrations(cell);
-    //const HcalQIECoder* channelCoder = theConditions->getHcalCoder (cell);
-    //const HcalQIEShape* channelShape = theConditions->getHcalShape (cell);
-    //HcalCoderDb coder (*channelCoder, *channelShape);
-    CaloSamples result = CaloSamples(cell,digi.size());;
-    //coder.adc2fC(digi, result);
-
+    CaloSamples result = CaloSamples(cell,digi.size());
+  
     // first, check if there was an overflow in this fake digi:
     bool overflow = false;
     // find and list them
-
+  
     for(int isample=0; isample<digi.size(); ++isample) {
       if(digi[isample].er()) overflow = true; 
     }
- 
+  
     if(overflow) {  // do full conversion, go back and overwrite fake entries
- 
+  
       const HcalQIECoder* channelCoder = theConditions->getHcalCoder (cell);
       const HcalQIEShape* channelShape = theConditions->getHcalShape (cell);
       HcalCoderDb coder (*channelCoder, *channelShape);
       coder.adc2fC(digi, result);
- 
+  
       // overwrite with coded information
       for(int isample=0; isample<digi.size(); ++isample) {
-	if(!digi[isample].er()) result[isample] = float(digi[isample].adc())/10.;
+        if(!digi[isample].er()) result[isample] = float(digi[isample].adc())/Traits::PreMixFactor;
       }
     }
     else {  // saves creating the coder, etc., every time
       // use coded information
       for(int isample=0; isample<digi.size(); ++isample) {
-	result[isample] = float(digi[isample].adc())/10.;
+        result[isample] = float(digi[isample].adc())/Traits::PreMixFactor;
       }
       result.setPresamples(digi.presamples());
     }
- 
-    // std::cout << " HcalSignalGenerator: noise input ADC " << digi << std::endl;
-    // std::cout << " HcalSignalGenerator: noise input in fC " << result << std::endl;
- 
+  
     // translation done in fC, convert to pe: 
     fC2pe(result);
-
+  
     return result;
   }
     
@@ -188,10 +177,19 @@ private:
   edm::EDGetTokenT<COLLECTION> tok_;
 };
 
+//forward declarations of specializations
+template<>
+bool HcalSignalGenerator<HcalQIE10DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
+template<>
+CaloSamples HcalSignalGenerator<HcalQIE10DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
+template<>
+void HcalSignalGenerator<HcalQIE10DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::COLLECTION * digis);
+
 typedef HcalSignalGenerator<HBHEDigitizerTraits> HBHESignalGenerator;
 typedef HcalSignalGenerator<HODigitizerTraits>   HOSignalGenerator;
 typedef HcalSignalGenerator<HFDigitizerTraits>   HFSignalGenerator;
 typedef HcalSignalGenerator<ZDCDigitizerTraits>  ZDCSignalGenerator;
+typedef HcalSignalGenerator<HcalQIE10DigitizerTraits>  QIE10SignalGenerator;
 
 #endif
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalUpgradeTraits.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalUpgradeTraits.h
@@ -10,6 +10,8 @@ public:
   typedef HcalUpgradeDigiCollection DigiCollection;
   typedef HcalUpgradeDataFrame Digi;
   typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 126;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
@@ -1,0 +1,70 @@
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h"
+
+//specializations
+
+template<>
+bool HcalSignalGenerator<HcalQIE10DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi)
+{
+  int DigiSum = 0;
+  for(int id = 0; id<digi.samples(); id++) {
+    if(digi[id].adc() > 0) ++DigiSum;
+  }
+  return(DigiSum>0);
+}
+
+template<>
+CaloSamples HcalSignalGenerator<HcalQIE10DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi){
+  HcalDetId cell = digi.id();
+  CaloSamples result = CaloSamples(cell,digi.samples());
+
+  // first, check if there was an overflow in this fake digi:
+  bool overflow = false;
+  // find and list them
+
+  for(int isample=0; isample<digi.samples(); ++isample) {
+    //only check error bit for non-zero ADCs
+    if(digi[isample].adc()>0 && !digi[isample].ok()) overflow = true; 
+  }
+
+  if(overflow) {  // do full conversion, go back and overwrite fake entries
+    const HcalQIECoder* channelCoder = theConditions->getHcalCoder (cell);
+    const HcalQIEShape* channelShape = theConditions->getHcalShape (cell);
+    HcalCoderDb coder (*channelCoder, *channelShape);
+    coder.adc2fC(digi, result);
+
+    // overwrite with coded information
+    for(int isample=0; isample<digi.samples(); ++isample) {
+      if(digi[isample].ok()) result[isample] = float(digi[isample].adc())/HcalQIE10DigitizerTraits::PreMixFactor;
+    }
+  }
+  else {  // saves creating the coder, etc., every time
+    // use coded information
+    for(int isample=0; isample<digi.samples(); ++isample) {
+      result[isample] = float(digi[isample].adc())/HcalQIE10DigitizerTraits::PreMixFactor;
+	  if(digi[isample].soi()) result.setPresamples(isample);
+    }
+  }
+
+  // translation done in fC, convert to pe: 
+  fC2pe(result);
+
+  return result;
+}
+
+template<>
+void HcalSignalGenerator<HcalQIE10DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::COLLECTION * digis){
+  // loop over digis, adding these to the existing maps
+  for(typename COLLECTION::const_iterator it  = digis->begin(); it != digis->end(); ++it) 
+  {
+    QIE10DataFrame df(*it);
+    // for the first signal, set the starting cap id
+    if((it == digis->begin()) && theElectronicsSim)
+    {
+      int startingCapId = df[0].capid();
+      theElectronicsSim->setStartingCapId(startingCapId);
+    }
+    if(validDigi(df)) {
+      theNoiseSignals.push_back(samplesInPE(df));
+    }
+  }
+}

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
@@ -26,43 +26,45 @@ private:
   HOSignalGenerator theHOSignalGenerator;
   HFSignalGenerator theHFSignalGenerator;
   ZDCSignalGenerator theZDCSignalGenerator;
+  QIE10SignalGenerator theQIE10SignalGenerator;
 
   edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
   edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
   edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
+  edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
 
-  edm::InputTag theHBHETag_, theHOTag_, theHFTag_, theZDCTag_;
+  edm::InputTag theHBHETag_, theHOTag_, theHFTag_, theZDCTag_, theQIE10Tag_;
 
 };
 
 
 HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfig)
 : theMap(),
-  /*theHBHESignalGenerator(iConfig.getParameter<edm::InputTag>("HBHEdigiCollectionPile")),
-  theHOSignalGenerator(iConfig.getParameter<edm::InputTag>("HOdigiCollectionPile")),
-  theHFSignalGenerator(iConfig.getParameter<edm::InputTag>("HFdigiCollectionPile")),
-  theZDCSignalGenerator(iConfig.getParameter<edm::InputTag>("ZDCdigiCollectionPile"))*/
   theHBHETag_(iConfig.getParameter<edm::InputTag>("HBHEdigiCollectionPile")),
   theHOTag_(iConfig.getParameter<edm::InputTag>("HOdigiCollectionPile")),
   theHFTag_(iConfig.getParameter<edm::InputTag>("HFdigiCollectionPile")),
-  theZDCTag_(iConfig.getParameter<edm::InputTag>("ZDCdigiCollectionPile"))
+  theZDCTag_(iConfig.getParameter<edm::InputTag>("ZDCdigiCollectionPile")),
+  theQIE10Tag_(iConfig.getParameter<edm::InputTag>("QIE10digiCollectionPile"))
 {
 
   tok_hbhe_ = consumes<HBHEDigitizerTraits::DigiCollection>(theHBHETag_);
   tok_ho_ = consumes<HODigitizerTraits::DigiCollection>(theHOTag_);
   tok_hf_ = consumes<HFDigitizerTraits::DigiCollection>(theHFTag_);
   tok_zdc_ = consumes<ZDCDigitizerTraits::DigiCollection>(theZDCTag_);
+  tok_qie10_ = consumes<HcalQIE10DigitizerTraits::DigiCollection>(theQIE10Tag_);
 
   theHBHESignalGenerator = HBHESignalGenerator(theHBHETag_,tok_hbhe_);
   theHOSignalGenerator = HOSignalGenerator(theHOTag_,tok_ho_);
   theHFSignalGenerator = HFSignalGenerator(theHFTag_,tok_hf_);
   theZDCSignalGenerator = ZDCSignalGenerator(theZDCTag_,tok_zdc_);
+  theQIE10SignalGenerator = QIE10SignalGenerator(theQIE10Tag_,tok_qie10_);
 
   theHBHESignalGenerator.setParameterMap(&theMap);
   theHOSignalGenerator.setParameterMap(&theMap);
   theHFSignalGenerator.setParameterMap(&theMap);
   theZDCSignalGenerator.setParameterMap(&theMap);
+  theQIE10SignalGenerator.setParameterMap(&theMap);
 
 }
 
@@ -72,13 +74,13 @@ void HcalSignalGeneratorTest::analyze(const edm::Event& iEvent, const edm::Event
   theHOSignalGenerator.initializeEvent(&iEvent, &iSetup);
   theHFSignalGenerator.initializeEvent(&iEvent, &iSetup);
   theZDCSignalGenerator.initializeEvent(&iEvent, &iSetup);
+  theQIE10SignalGenerator.initializeEvent(&iEvent, &iSetup);
 
   theHBHESignalGenerator.fill(nullptr);
   theHOSignalGenerator.fill(nullptr);
   theHFSignalGenerator.fill(nullptr);
   theZDCSignalGenerator.fill(nullptr);
-
-  //dump(&theHBHESignalGenerator);
+  theQIE10SignalGenerator.fill(nullptr);
 }
 
 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest_cfg.py
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest_cfg.py
@@ -30,7 +30,8 @@ process.hcalSignal = cms.EDAnalyzer("HcalSignalGeneratorTest",
     HBHEdigiCollectionPile  = cms.InputTag("simHcalUnsuppressedDigis"),
     HOdigiCollectionPile    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionPile    = cms.InputTag("simHcalUnsuppressedDigis"),
-    ZDCdigiCollectionPile   = cms.InputTag("ZDCdigiCollection")
+    ZDCdigiCollectionPile   = cms.InputTag("ZDCdigiCollection"),
+    QIE10digiCollectionPile = cms.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection"),
 )
 
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -36,6 +36,7 @@ public:
   void setHFNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setHONoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
+  void setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -61,6 +61,7 @@ public:
   void setHFNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setHONoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
+  void setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
   void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHits, edm::Handle<std::vector<PCaloHit> > const& zdcHits, int bunchCrossing, CLHEP::HepRandomEngine*, const HcalTopology *h);
@@ -81,11 +82,11 @@ private:
   void darkening(std::vector<PCaloHit>& hcalHits);
   
   /** Reconstruction algorithm*/
-  typedef CaloTDigitizer<HBHEDigitizerTraits> HBHEDigitizer;
-  typedef CaloTDigitizer<HODigitizerTraits>   HODigitizer;
-  typedef CaloTDigitizer<HFDigitizerTraits>   HFDigitizer;
-  typedef CaloTDigitizer<ZDCDigitizerTraits>  ZDCDigitizer;
-  typedef CaloTDigitizer<HcalUpgradeDigitizerTraits> UpgradeDigitizer;
+  typedef CaloTDigitizer<HBHEDigitizerTraits,CaloTDigitizerQIE8Run> HBHEDigitizer;
+  typedef CaloTDigitizer<HODigitizerTraits,CaloTDigitizerQIE8Run>   HODigitizer;
+  typedef CaloTDigitizer<HFDigitizerTraits,CaloTDigitizerQIE8Run>   HFDigitizer;
+  typedef CaloTDigitizer<ZDCDigitizerTraits,CaloTDigitizerQIE8Run>  ZDCDigitizer;
+  typedef CaloTDigitizer<HcalUpgradeDigitizerTraits,CaloTDigitizerQIE8Run> UpgradeDigitizer;
   typedef CaloTDigitizer<HcalQIE10DigitizerTraits,CaloTDigitizerQIE10Run> QIE10Digitizer;
 
   HcalSimParameterMap * theParameterMap;
@@ -105,6 +106,7 @@ private:
   HcalAmplifier * theHFAmplifier;
   HcalAmplifier * theHOAmplifier;
   HcalAmplifier * theZDCAmplifier;
+  HcalAmplifier * theHFQIE10Amplifier;
 
   HPDIonFeedbackSim * theIonFeedback;
   HcalCoderFactory * theCoderFactory;

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -75,7 +75,10 @@ HcalDigiProducer::setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGene
   theDigitizer_.setZDCNoiseSignalGenerator(noiseGenerator);
 }
 
-
+void
+HcalDigiProducer::setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
+  theDigitizer_.setQIE10NoiseSignalGenerator(noiseGenerator);
+}
 
 CLHEP::HepRandomEngine* HcalDigiProducer::randomEngine(edm::StreamID const& streamID) {
   unsigned int index = streamID.value();

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -100,6 +100,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHFAmplifier(0),
   theHOAmplifier(0),
   theZDCAmplifier(0),
+  theHFQIE10Amplifier(0),
   theIonFeedback(0),
   theCoderFactory(0),
   theUpgradeCoderFactory(0),
@@ -176,13 +177,16 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHFAmplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theHOAmplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theZDCAmplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
+  theHFQIE10Amplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theHBHEAmplifier->setHBtuningParameter(HBtp);
   theHBHEAmplifier->setHEtuningParameter(HEtp);
   theHFAmplifier->setHFtuningParameter(HFtp);
+  theHFQIE10Amplifier->setHFtuningParameter(HFtp);
   theHOAmplifier->setHOtuningParameter(HOtp);
   theHBHEAmplifier->setUseOldHB(useOldNoiseHB);
   theHBHEAmplifier->setUseOldHE(useOldNoiseHE);
   theHFAmplifier->setUseOldHF(useOldNoiseHF);
+  theHFQIE10Amplifier->setUseOldHF(useOldNoiseHF);
   theHOAmplifier->setUseOldHO(useOldNoiseHO);
 
   theCoderFactory = new HcalCoderFactory(HcalCoderFactory::DB);
@@ -196,7 +200,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theZDCElectronicsSim = new HcalElectronicsSim(theZDCAmplifier, theCoderFactory, PreMix1);
   theUpgradeHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theUpgradeCoderFactory, PreMix1);
   theUpgradeHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theUpgradeCoderFactory, PreMix1);
-  theHFQIE10ElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theUpgradeCoderFactory, PreMix1); //should this use a different coder factory?
+  theHFQIE10ElectronicsSim = new HcalElectronicsSim(theHFQIE10Amplifier, theUpgradeCoderFactory, PreMix1); //should this use a different coder factory?
 
 //  std::cout << "HcalDigitizer: theUpgradeElectronicsSim created" <<  std::endl; 
 
@@ -340,6 +344,7 @@ HcalDigitizer::~HcalDigitizer() {
   if(theHODigitizer)           delete theHODigitizer;
   if(theHOSiPMDigitizer)       delete theHOSiPMDigitizer;
   if(theHFDigitizer)           delete theHFDigitizer;
+  if(theHFQIE10Digitizer)      delete theHFQIE10Digitizer;
   delete theZDCDigitizer;
   if(theHBHEUpgradeDigitizer)  delete theHBHEUpgradeDigitizer;
   if(theHFUpgradeDigitizer)    delete theHFUpgradeDigitizer;
@@ -357,10 +362,12 @@ HcalDigitizer::~HcalDigitizer() {
   delete theZDCElectronicsSim;
   delete theUpgradeHBHEElectronicsSim;
   delete theUpgradeHFElectronicsSim;
+  delete theHFQIE10ElectronicsSim;
   delete theHBHEAmplifier;
   delete theHFAmplifier;
   delete theHOAmplifier;
   delete theZDCAmplifier;
+  delete theHFQIE10Amplifier;
   delete theCoderFactory;
   delete theUpgradeCoderFactory;
   delete theHitCorrection;
@@ -381,8 +388,14 @@ void HcalDigitizer::setHFNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGen
   noiseGenerator->setElectronicsSim(theHFElectronicsSim);
   if(theHFDigitizer) theHFDigitizer->setNoiseSignalGenerator(noiseGenerator);
   if(theHFUpgradeDigitizer) theHFUpgradeDigitizer->setNoiseSignalGenerator(noiseGenerator);
-  if(theHFQIE10Digitizer) theHFQIE10Digitizer->setNoiseSignalGenerator(noiseGenerator);
   theHFAmplifier->setNoiseSignalGenerator(noiseGenerator);
+}
+
+void HcalDigitizer::setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
+  noiseGenerator->setParameterMap(theParameterMap);
+  noiseGenerator->setElectronicsSim(theHFQIE10ElectronicsSim);
+  if(theHFQIE10Digitizer) theHFQIE10Digitizer->setNoiseSignalGenerator(noiseGenerator);
+  theHFQIE10Amplifier->setNoiseSignalGenerator(noiseGenerator);
 }
 
 void HcalDigitizer::setHONoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
@@ -408,6 +421,7 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
   theHFAmplifier->setDbService(conditions.product());
   theHOAmplifier->setDbService(conditions.product());
   theZDCAmplifier->setDbService(conditions.product());
+  theHFQIE10Amplifier->setDbService(conditions.product());
   theUpgradeHBHEElectronicsSim->setDbService(conditions.product());
   theUpgradeHFElectronicsSim->setDbService(conditions.product());
   theHFQIE10ElectronicsSim->setDbService(conditions.product());

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -31,8 +31,7 @@ namespace {
   typedef std::multimap<DetId, CaloSamples> HcalDigiMap;
 
   template <class DIGI>
-  void convertFc2adc (const  CaloSamples& fC, const HcalDbService& conditions,
-		      DIGI& digi, int capIdOffset = 0) {
+  void convertFc2adc (const  CaloSamples& fC, const HcalDbService& conditions, DIGI& digi, int capIdOffset = 0) {
     HcalDetId id = fC.id();
     const HcalQIECoder* channelCoder = conditions.getHcalCoder (id);
     const HcalQIEShape* shape = conditions.getHcalShape (channelCoder);
@@ -41,6 +40,24 @@ namespace {
   }
 
   template <class DIGI>
+  void convertAdc2fChelper (const DIGI& digi, const HcalDbService& conditions, CaloSamples& fC, const HcalDetId& id) {
+    const HcalCalibrations& calib = conditions.getHcalCalibrations(id);
+    for (int i = 0; i < digi.size(); ++i) {
+      int capId (digi.sample(i).capid());
+      fC[i] -= calib.pedestal (capId);
+    }
+  }
+  
+  template <>
+  void convertAdc2fChelper<QIE10DataFrame> (const QIE10DataFrame& digi, const HcalDbService& conditions, CaloSamples& fC, const HcalDetId& id) {
+    const HcalCalibrations& calib = conditions.getHcalCalibrations(id);
+    for (int i = 0; i < digi.samples(); ++i) {
+      int capId (digi[i].capid());
+      fC[i] -= calib.pedestal (capId);
+    }
+  }
+  
+  template <class DIGI>
   void convertAdc2fC (const DIGI& digi, const HcalDbService& conditions, bool keepPedestals, CaloSamples& fC) {
     HcalDetId id (digi.id());
     const HcalQIECoder* channelCoder = conditions.getHcalCoder (id);
@@ -48,11 +65,7 @@ namespace {
     HcalCoderDb coder (*channelCoder, *shape);
     coder.adc2fC(digi, fC);
     if (!keepPedestals) { // subtract pedestals
-      const HcalCalibrations& calib = conditions.getHcalCalibrations(id);
-      for (int i = 0; i < digi.size(); ++i) {
-	int capId (digi.sample(i).capid());
-	fC[i] -= calib.pedestal (capId);
-      }
+      convertAdc2fChelper(digi,conditions,fC,id);
     }
   }
 
@@ -62,15 +75,28 @@ namespace {
       CaloSamples fC;
       convertAdc2fC (*digi, conditions, keepPedestals, fC);
       if (!keepPedestals && map.find(digi->id()) == map.end()) {
-	edm::LogWarning("DataMixingHcalDigiWorker")<<"No signal hits found for HCAL cell "<<digi->id()<<" Pedestals may be lost for mixed hit";
+        edm::LogWarning("DataMixingHcalDigiWorker")<<"No signal hits found for HCAL cell "<<digi->id()<<" Pedestals may be lost for mixed hit";
       }
       map.insert(HcalDigiMap::value_type (digi->id(), fC));
     }
   }
 
+  template <>
+   void convertHcalDigis<QIE10DigiCollection> (const QIE10DigiCollection& digis, const HcalDbService& conditions, bool keepPedestals, HcalDigiMap& map) {
+    for (auto digiItr = digis.begin(); digiItr != digis.end(); ++digiItr) {
+      QIE10DataFrame digi(*digiItr);
+	  CaloSamples fC;
+      convertAdc2fC (digi, conditions, keepPedestals, fC);
+      if (!keepPedestals && map.find(digi.id()) == map.end()) {
+        edm::LogWarning("DataMixingHcalDigiWorker")<<"No signal hits found for HCAL cell "<<digi.id()<<" Pedestals may be lost for mixed hit";
+      }
+      map.insert(HcalDigiMap::value_type (digi.id(), fC));
+    }
+  }
+  
   template <class DIGIS>
   bool convertSignalHcalDigis (const edm::Event &e, const edm::EDGetTokenT<DIGIS>& token,
-			       const HcalDbService& conditions, HcalDigiMap& map) {
+                               const HcalDbService& conditions, HcalDigiMap& map) {
     edm::Handle<DIGIS> digis;
     if (!e.getByToken (token, digis)) return false;
     convertHcalDigis (*digis, conditions, true, map); // keep pedestals
@@ -79,14 +105,29 @@ namespace {
 
   template <class DIGIS>
   bool convertPileupHcalDigis (const edm::EventPrincipal& ep, 
-			       const edm::InputTag& tag, const edm::ModuleCallingContext* mcc,
-			       const HcalDbService& conditions, HcalDigiMap& map) {
+                               const edm::InputTag& tag, const edm::ModuleCallingContext* mcc,
+                               const HcalDbService& conditions, HcalDigiMap& map) {
     auto digis = edm::getProductByTag<DIGIS>(ep, tag, mcc);
     if (!digis) return false;
     convertHcalDigis (*(digis->product()), conditions, false, map); // subtract pedestals
     return true;
-  }		 
+  }
 
+  template <class DIGIS>
+  void buildHcalDigisHelper (DIGIS& digis, const DetId& formerID, CaloSamples& resultSample, const HcalDbService& conditions){
+    // make new digi
+    digis.push_back(typename DIGIS::value_type(formerID));
+    convertFc2adc (resultSample, conditions, digis.back(), 0); // FR guess: simulation starts with 0
+  }
+  
+  template <>
+  void buildHcalDigisHelper<QIE10DigiCollection> (QIE10DigiCollection& digis, const DetId& formerID, CaloSamples& resultSample, const HcalDbService& conditions){
+    // make new digi
+    digis.push_back(formerID.rawId());
+	QIE10DataFrame digi( digis.back() );
+    convertFc2adc (resultSample, conditions, digi, 0); // FR guess: simulation starts with 0
+  }
+  
   template <class DIGIS>
   std::auto_ptr<DIGIS> buildHcalDigis (const HcalDigiMap& map, const HcalDbService& conditions) {
     std::auto_ptr<DIGIS> digis( new DIGIS );
@@ -102,29 +143,30 @@ namespace {
         //loop over digi samples in each CaloSample                                                  
         unsigned int sizenew = (hitSample).size();
         unsigned int sizeold = resultSample.size();
-	if (sizenew > sizeold) { // extend sample
-	  for (unsigned int isamp = sizeold; isamp < sizenew; ++isamp) resultSample[isamp] = 0;
-	  resultSample.setSize (sizenew);
-	}
+        if (sizenew > sizeold) { // extend sample
+          for (unsigned int isamp = sizeold; isamp < sizenew; ++isamp) resultSample[isamp] = 0;
+          resultSample.setSize (sizenew);
+        }
         for(unsigned int isamp = 0; isamp<sizenew; isamp++) { // add new values
-	  resultSample[isamp] += hitSample[isamp]; // for debugging below
+          resultSample[isamp] += hitSample[isamp]; // for debugging below
         }
       }
       auto hit1 = hit;
       bool lastEntry = (++hit1 ==  map.end());
       if (currentID != formerID || lastEntry) { // store current digi
-	if (formerID>0 || lastEntry) {
-	  // make new digi
-	  digis->push_back(typename DIGIS::value_type(formerID));
-	  convertFc2adc (resultSample, conditions, digis->back(), 0); // FR guess: simulation starts with 0
-	}
-	//reset pointers for next iteration                                                                 
-	formerID = currentID;
-	resultSample = hitSample;
+        if (formerID>0 || lastEntry) {
+          // make new digi
+          buildHcalDigisHelper(*digis,formerID,resultSample,conditions);
+        }
+        //reset pointers for next iteration                                                                 
+        formerID = currentID;
+        resultSample = hitSample;
       }
     }
     return digis;
   }
+  
+  
 
 } // namespace {}
 
@@ -137,8 +179,7 @@ namespace edm
 
   // Constructor 
   DataMixingHcalDigiWorker::DataMixingHcalDigiWorker(const edm::ParameterSet& ps, edm::ConsumesCollector && iC) : 
-							    label_(ps.getParameter<std::string>("Label"))
-
+                                                            label_(ps.getParameter<std::string>("Label"))
   {                                                         
 
     // get the subdetector names
@@ -152,19 +193,23 @@ namespace edm
     HOdigiCollectionSig_    = ps.getParameter<edm::InputTag>("HOdigiCollectionSig");
     HFdigiCollectionSig_    = ps.getParameter<edm::InputTag>("HFdigiCollectionSig");
     ZDCdigiCollectionSig_   = ps.getParameter<edm::InputTag>("ZDCdigiCollectionSig");
+    QIE10digiCollectionSig_   = ps.getParameter<edm::InputTag>("QIE10digiCollectionSig");
 
     HBHEPileInputTag_ = ps.getParameter<edm::InputTag>("HBHEPileInputTag");
     HOPileInputTag_ = ps.getParameter<edm::InputTag>("HOPileInputTag");
     HFPileInputTag_ = ps.getParameter<edm::InputTag>("HFPileInputTag");
     ZDCPileInputTag_ = ps.getParameter<edm::InputTag>("ZDCPileInputTag");
+    QIE10PileInputTag_ = ps.getParameter<edm::InputTag>("QIE10PileInputTag");
 
     HBHEDigiToken_ = iC.consumes<HBHEDigiCollection>(HBHEdigiCollectionSig_);
     HODigiToken_ = iC.consumes<HODigiCollection>(HOdigiCollectionSig_);
     HFDigiToken_ = iC.consumes<HFDigiCollection>(HFdigiCollectionSig_);
+    QIE10DigiToken_ = iC.consumes<QIE10DigiCollection>(HFdigiCollectionSig_);
 
     HBHEDigiPToken_ = iC.consumes<HBHEDigiCollection>(HBHEPileInputTag_);
     HODigiPToken_ = iC.consumes<HODigiCollection>(HOPileInputTag_);
     HFDigiPToken_ = iC.consumes<HFDigiCollection>(HFPileInputTag_);
+    QIE10DigiPToken_ = iC.consumes<QIE10DigiCollection>(HFPileInputTag_);
 
     DoZDC_ = false;
     if(ZDCPileInputTag_.label() != "") DoZDC_ = true;
@@ -179,10 +224,11 @@ namespace edm
     HODigiCollectionDM_   = ps.getParameter<std::string>("HODigiCollectionDM");
     HFDigiCollectionDM_   = ps.getParameter<std::string>("HFDigiCollectionDM");
     ZDCDigiCollectionDM_  = ps.getParameter<std::string>("ZDCDigiCollectionDM");
+    QIE10DigiCollectionDM_  = ps.getParameter<std::string>("QIE10DigiCollectionDM");
 
 
   }
-	       
+
   // Virtual destructor needed.
   DataMixingHcalDigiWorker::~DataMixingHcalDigiWorker() { 
   }  
@@ -200,6 +246,7 @@ namespace edm
     convertSignalHcalDigis<HBHEDigiCollection> (e, HBHEDigiToken_, *conditions, HBHEDigiStorage_);
     convertSignalHcalDigis<HODigiCollection> (e, HODigiToken_, *conditions, HODigiStorage_);
     convertSignalHcalDigis<HFDigiCollection> (e, HFDigiToken_, *conditions, HFDigiStorage_);
+    convertSignalHcalDigis<QIE10DigiCollection> (e, QIE10DigiToken_, *conditions, QIE10DigiStorage_);
 
 
 
@@ -221,12 +268,11 @@ namespace edm
  
      if (ZDCDigis)
        {
-	 // loop over digis, storing them in a map so we can add pileup later
-	 for(ZDCDigiCollection::const_iterator it  = ZDCDigis->begin();	
-	     it != ZDCDigis->end(); ++it) {
+         // loop over digis, storing them in a map so we can add pileup later
+         for(ZDCDigiCollection::const_iterator it  = ZDCDigis->begin(); it != ZDCDigis->end(); ++it) {
 
-	   // calibration, for future reference:  (same block for all Hcal types) ZDC is different                               
-	   HcalZDCDetId cell = it->id();
+           // calibration, for future reference:  (same block for all Hcal types) ZDC is different                               
+           HcalZDCDetId cell = it->id();
            //         const HcalCalibrations& calibrations=conditions->getHcalCalibrations(cell);                
            const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
            const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
@@ -236,15 +282,15 @@ namespace edm
            coder.adc2fC((*it),tool);
 
            ZDCDigiStorage_.insert(ZDCDigiMap::value_type( ( it->id() ), tool ));
-	 
-#ifdef DEBUG	 
+
+#ifdef DEBUG
            // Commented out because this does not compile anymore	 
            // LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
            //                                      << it->id() << "\n"
            //                                      << " digi energy: " << it->energy();
 #endif
 
-	 }
+         }
        }
    }
     
@@ -262,6 +308,7 @@ namespace edm
     convertPileupHcalDigis<HBHEDigiCollection> (*ep, HBHEPileInputTag_, mcc, *conditions, HBHEDigiStorage_);
     convertPileupHcalDigis<HODigiCollection> (*ep, HOPileInputTag_, mcc, *conditions, HODigiStorage_);
     convertPileupHcalDigis<HFDigiCollection> (*ep, HFPileInputTag_, mcc, *conditions, HFDigiStorage_);
+    convertPileupHcalDigis<QIE10DigiCollection> (*ep, QIE10PileInputTag_, mcc, *conditions, QIE10DigiStorage_);
 
 
     // ZDC Next
@@ -269,38 +316,35 @@ namespace edm
     if(DoZDC_) {
 
 
-      std::shared_ptr<Wrapper<ZDCDigiCollection>  const> ZDCDigisPTR = 
-	getProductByTag<ZDCDigiCollection>(*ep, ZDCPileInputTag_, mcc);
+      std::shared_ptr<Wrapper<ZDCDigiCollection>  const> ZDCDigisPTR = getProductByTag<ZDCDigiCollection>(*ep, ZDCPileInputTag_, mcc);
  
       if(ZDCDigisPTR ) {
 
-	const ZDCDigiCollection*  ZDCDigis = const_cast< ZDCDigiCollection * >(ZDCDigisPTR->product());
+        const ZDCDigiCollection*  ZDCDigis = const_cast< ZDCDigiCollection * >(ZDCDigisPTR->product());
 
-	LogDebug("DataMixingHcalDigiWorker") << "total # ZDC digis: " << ZDCDigis->size();
+        LogDebug("DataMixingHcalDigiWorker") << "total # ZDC digis: " << ZDCDigis->size();
 
-	// loop over digis, adding these to the existing maps
-	for(ZDCDigiCollection::const_iterator it  = ZDCDigis->begin();
-	    it != ZDCDigis->end(); ++it) {
+        // loop over digis, adding these to the existing maps
+        for(ZDCDigiCollection::const_iterator it  = ZDCDigis->begin(); it != ZDCDigis->end(); ++it) {
 
-	  // calibration, for future reference:  (same block for all Hcal types) ZDC is different                               
-	  HcalZDCDetId cell = it->id();
-	  //         const HcalCalibrations& calibrations=conditions->getHcalCalibrations(cell);                
-	  const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
-	  const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
-	  HcalCoderDb coder (*channelCoder, *shape);
+          // calibration, for future reference:  (same block for all Hcal types) ZDC is different
+          HcalZDCDetId cell = it->id();
+          const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
+          const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic
+          HcalCoderDb coder (*channelCoder, *shape);
 
-	  CaloSamples tool;
-	  coder.adc2fC((*it),tool);
+          CaloSamples tool;
+          coder.adc2fC((*it),tool);
 
-	  ZDCDigiStorage_.insert(ZDCDigiMap::value_type( (it->id()), tool ));
-	 
+          ZDCDigiStorage_.insert(ZDCDigiMap::value_type( (it->id()), tool ));
+
 #ifdef DEBUG
-          // Commented out because this does not compile anymore	 
-	  // LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
+          // Commented out because this does not compile anymore
+          // LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
           //                                      << it->id() << "\n"
           //                                      << " digi energy: " << it->energy();
 #endif
-	}
+        }
       }
     }
 
@@ -315,6 +359,7 @@ namespace edm
     std::auto_ptr< HBHEDigiCollection > HBHEdigis = buildHcalDigis<HBHEDigiCollection> (HBHEDigiStorage_, *conditions);
     std::auto_ptr< HODigiCollection > HOdigis = buildHcalDigis<HODigiCollection> (HODigiStorage_, *conditions);
     std::auto_ptr< HFDigiCollection > HFdigis = buildHcalDigis<HFDigiCollection> (HFDigiStorage_, *conditions);
+    std::auto_ptr< QIE10DigiCollection > QIE10digis = buildHcalDigis<QIE10DigiCollection> (QIE10DigiStorage_, *conditions);
     std::auto_ptr< ZDCDigiCollection > ZDCdigis( new ZDCDigiCollection );
 
     // loop over the maps we have, re-making individual hits or digis if necessary.
@@ -334,8 +379,7 @@ namespace edm
 
     ZDCDigiMap::const_iterator iZDCchk;
 
-    for(ZDCDigiMap::const_iterator iZDC  = ZDCDigiStorage_.begin();
-	iZDC != ZDCDigiStorage_.end(); ++iZDC) {
+    for(ZDCDigiMap::const_iterator iZDC  = ZDCDigiStorage_.begin(); iZDC != ZDCDigiStorage_.end(); ++iZDC) {
 
       currentID = iZDC->first; 
 
@@ -363,59 +407,58 @@ namespace edm
           else { fC_new = 0;}
 
           if(isamp < sizeold) {
-	    fC_old = ZDC_old[isamp];
+            fC_old = ZDC_old[isamp];
           }
           else { fC_old = 0;}
 
           // add values                                                                                      
           fC_sum = fC_new + fC_old;
 
-	  if(usenew) {ZDC_bigger[isamp] = fC_sum; }
-	  else { ZDC_old[isamp] = fC_sum; }  // overwrite old sample, adding new info     
+          if(usenew) {ZDC_bigger[isamp] = fC_sum; }
+          else { ZDC_old[isamp] = fC_sum; }  // overwrite old sample, adding new info     
 
         }
-	if(usenew) ZDC_old = ZDC_bigger; // save new, larger sized sample in "old" slot
+        if(usenew) ZDC_old = ZDC_bigger; // save new, larger sized sample in "old" slot
       
       }
       else {
-	if(formerID>0) {
-	  // make new digi
-	  ZDCdigis->push_back(ZDCDataFrame(formerID));	  
+        if(formerID>0) {
+          // make new digi
+          ZDCdigis->push_back(ZDCDataFrame(formerID));	  
 
-	  // set up information to convert back
+          // set up information to convert back
 
-	  HcalZDCDetId cell = ZDC_old.id();
-	  const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
-	  const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
-	  HcalCoderDb coder (*channelCoder, *shape);
+          HcalZDCDetId cell = ZDC_old.id();
+          const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
+          const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
+          HcalCoderDb coder (*channelCoder, *shape);
 
-	  unsigned int sizeold = ZDC_old.size();
-	  for(unsigned int isamp = 0; isamp<sizeold; isamp++) {
-	    coder.fC2adc(ZDC_old,(ZDCdigis->back()), 1 );   // as per simulation, capid=1
-	  }
-	}
-	//save pointers for next iteration                                                                 
-	formerID = currentID;
-	ZDC_old = iZDC->second;
+          unsigned int sizeold = ZDC_old.size();
+          for(unsigned int isamp = 0; isamp<sizeold; isamp++) {
+            coder.fC2adc(ZDC_old,(ZDCdigis->back()), 1 );   // as per simulation, capid=1
+          }
+        }
+        //save pointers for next iteration                                                                 
+        formerID = currentID;
+        ZDC_old = iZDC->second;
       }
 
       iZDCchk = iZDC;
       if((++iZDCchk) == ZDCDigiStorage_.end()) {  //make sure not to lose the last one                         
-	  // make new digi
-	  ZDCdigis->push_back(ZDCDataFrame(currentID));	  
+          // make new digi
+          ZDCdigis->push_back(ZDCDataFrame(currentID));	  
 
-	  // set up information to convert back
+          // set up information to convert back
 
-	  HcalZDCDetId cell = (iZDC->second).id();
-	  const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
-	  const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
-	  HcalCoderDb coder (*channelCoder, *shape);
+          HcalZDCDetId cell = (iZDC->second).id();
+          const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
+          const HcalQIEShape* shape = conditions->getHcalShape (channelCoder); // this one is generic         
+          HcalCoderDb coder (*channelCoder, *shape);
 
-	  unsigned int sizeold = (iZDC->second).size();
-	  for(unsigned int isamp = 0; isamp<sizeold; isamp++) {
-	    coder.fC2adc(ZDC_old,(ZDCdigis->back()), 1 );   // as per simulation, capid=1
-	  }
-
+          unsigned int sizeold = (iZDC->second).size();
+          for(unsigned int isamp = 0; isamp<sizeold; isamp++) {
+            coder.fC2adc(ZDC_old,(ZDCdigis->back()), 1 );   // as per simulation, capid=1
+          }
       }
     }
 
@@ -427,6 +470,7 @@ namespace edm
     LogInfo("DataMixingHcalDigiWorker") << "total # HBHE Merged digis: " << HBHEdigis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # HO Merged digis: " << HOdigis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # HF Merged digis: " << HFdigis->size() ;
+    LogInfo("DataMixingHcalDigiWorker") << "total # QIE10 Merged digis: " << QIE10digis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # ZDC Merged digis: " << ZDCdigis->size() ;
 
 
@@ -438,6 +482,7 @@ namespace edm
     e.put( HBHEdigis, HBHEDigiCollectionDM_ );
     e.put( HOdigis, HODigiCollectionDM_ );
     e.put( HFdigis, HFDigiCollectionDM_ );
+    e.put( QIE10digis, HFDigiCollectionDM_ );
     e.put( ZDCdigis, ZDCDigiCollectionDM_ );
     e.put( hbheupgradeResult, "HBHEUpgradeDigiCollection" );
     e.put( hfupgradeResult, "HFUpgradeDigiCollection" );
@@ -446,6 +491,7 @@ namespace edm
     HBHEDigiStorage_.clear();
     HODigiStorage_.clear();
     HFDigiStorage_.clear();
+    QIE10DigiStorage_.clear();
     ZDCDigiStorage_.clear();
 
   }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -204,12 +204,12 @@ namespace edm
     HBHEDigiToken_ = iC.consumes<HBHEDigiCollection>(HBHEdigiCollectionSig_);
     HODigiToken_ = iC.consumes<HODigiCollection>(HOdigiCollectionSig_);
     HFDigiToken_ = iC.consumes<HFDigiCollection>(HFdigiCollectionSig_);
-    QIE10DigiToken_ = iC.consumes<QIE10DigiCollection>(HFdigiCollectionSig_);
+    QIE10DigiToken_ = iC.consumes<QIE10DigiCollection>(QIE10digiCollectionSig_);
 
     HBHEDigiPToken_ = iC.consumes<HBHEDigiCollection>(HBHEPileInputTag_);
     HODigiPToken_ = iC.consumes<HODigiCollection>(HOPileInputTag_);
     HFDigiPToken_ = iC.consumes<HFDigiCollection>(HFPileInputTag_);
-    QIE10DigiPToken_ = iC.consumes<QIE10DigiCollection>(HFPileInputTag_);
+    QIE10DigiPToken_ = iC.consumes<QIE10DigiCollection>(QIE10PileInputTag_);
 
     DoZDC_ = false;
     if(ZDCPileInputTag_.label() != "") DoZDC_ = true;
@@ -482,7 +482,7 @@ namespace edm
     e.put( HBHEdigis, HBHEDigiCollectionDM_ );
     e.put( HOdigis, HODigiCollectionDM_ );
     e.put( HFdigis, HFDigiCollectionDM_ );
-    e.put( QIE10digis, HFDigiCollectionDM_ );
+    e.put( QIE10digis, QIE10DigiCollectionDM_ );
     e.put( ZDCdigis, ZDCDigiCollectionDM_ );
     e.put( hbheupgradeResult, "HBHEUpgradeDigiCollection" );
     e.put( hfupgradeResult, "HFUpgradeDigiCollection" );

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
@@ -27,6 +27,7 @@
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 
 
 #include <map>
@@ -64,46 +65,46 @@ namespace edm
       edm::InputTag HOdigiCollectionSig_  ; // secondary name given to collection of digis
       edm::InputTag HFdigiCollectionSig_  ; // secondary name given to collection of digis
       edm::InputTag ZDCdigiCollectionSig_ ; // secondary name given to collection of digis
+      edm::InputTag QIE10digiCollectionSig_ ; // secondary name given to collection of digis
 
       edm::InputTag HBHEPileInputTag_; // InputTag for Pileup Digis collection  
       edm::InputTag HOPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
 
       edm::EDGetTokenT<HBHEDigiCollection> HBHEDigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HODigiCollection> HODigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HFDigiCollection> HFDigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<ZDCDigiCollection> ZDCDigiToken_ ;  // Token to retrieve information 
+      edm::EDGetTokenT<QIE10DigiCollection> QIE10DigiToken_ ;  // Token to retrieve information 
 
       edm::EDGetTokenT<HBHEDigiCollection> HBHEDigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HODigiCollection> HODigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HFDigiCollection> HFDigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<ZDCDigiCollection> ZDCDigiPToken_ ;  // Token to retrieve information 
+      edm::EDGetTokenT<QIE10DigiCollection> QIE10DigiPToken_ ;  // Token to retrieve information 
 
 
       std::string HBHEDigiCollectionDM_; // secondary name to be given to collection of digis
       std::string HODigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string HFDigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to collection of digis
+      std::string QIE10DigiCollectionDM_ ; // secondary name to be given to collection of digis
 
       typedef std::multimap<DetId, CaloSamples> HBHEDigiMap;
       typedef std::multimap<DetId, CaloSamples> HFDigiMap;
       typedef std::multimap<DetId, CaloSamples> HODigiMap;
       typedef std::multimap<DetId, CaloSamples> ZDCDigiMap;
-
-      //      typedef std::multimap<DetId, HBHEDataFrame> HBHEDigiMap;
-      //      typedef std::multimap<DetId, HFDataFrame>   HFDigiMap;
-      //      typedef std::multimap<DetId, HODataFrame>   HODigiMap;
-      //      typedef std::multimap<DetId, ZDCDataFrame>  ZDCDigiMap;
+      typedef std::multimap<DetId, CaloSamples> QIE10DigiMap;
 
       HBHEDigiMap HBHEDigiStorage_;
       HFDigiMap   HFDigiStorage_;
       HODigiMap   HODigiStorage_;
       ZDCDigiMap  ZDCDigiStorage_;
+      QIE10DigiMap  QIE10DigiStorage_;
 
       bool DoZDC_;
-
-      //      unsigned int eventId_; //=0 for signal, from 1-n for pileup events
 
       std::string label_;
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -21,6 +21,7 @@ namespace edm {
     HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
     HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
     ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
+    QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
     label_(ps.getParameter<std::string>("Label"))
   {  
 
@@ -29,11 +30,13 @@ namespace edm {
     tok_ho_ = iC.consumes<HODigitizerTraits::DigiCollection>(HOPileInputTag_);
     tok_hf_ = iC.consumes<HFDigitizerTraits::DigiCollection>(HFPileInputTag_);
     tok_zdc_ = iC.consumes<ZDCDigitizerTraits::DigiCollection>(ZDCPileInputTag_);
+    tok_qie10_ = iC.consumes<HcalQIE10DigitizerTraits::DigiCollection>(QIE10PileInputTag_);
 
     theHBHESignalGenerator = HBHESignalGenerator(HBHEPileInputTag_,tok_hbhe_);
     theHOSignalGenerator = HOSignalGenerator(HOPileInputTag_,tok_ho_);
     theHFSignalGenerator = HFSignalGenerator(HFPileInputTag_,tok_hf_);
     theZDCSignalGenerator = ZDCSignalGenerator(ZDCPileInputTag_,tok_zdc_);
+    theQIE10SignalGenerator = QIE10SignalGenerator(QIE10PileInputTag_,tok_qie10_);
 
     // get the subdetector names
     //    this->getSubdetectorNames();  //something like this may be useful to check what we are supposed to do...
@@ -47,6 +50,7 @@ namespace edm {
     HODigiCollectionDM_   = ps.getParameter<std::string>("HODigiCollectionDM");
     HFDigiCollectionDM_   = ps.getParameter<std::string>("HFDigiCollectionDM");
     ZDCDigiCollectionDM_  = ps.getParameter<std::string>("ZDCDigiCollectionDM");
+    QIE10DigiCollectionDM_  = ps.getParameter<std::string>("QIE10DigiCollectionDM");
 
     // initialize HcalDigitizer here...
 
@@ -56,6 +60,7 @@ namespace edm {
     myHcalDigitizer_->setHFNoiseSignalGenerator( & theHFSignalGenerator );
     myHcalDigitizer_->setHONoiseSignalGenerator( & theHOSignalGenerator );
     myHcalDigitizer_->setZDCNoiseSignalGenerator( & theZDCSignalGenerator );
+    myHcalDigitizer_->setQIE10NoiseSignalGenerator( & theQIE10SignalGenerator );
 
   }
 	       
@@ -88,12 +93,14 @@ namespace edm {
     theHOSignalGenerator.initializeEvent(ep, &ES);
     theHFSignalGenerator.initializeEvent(ep, &ES);
     theZDCSignalGenerator.initializeEvent(ep, &ES);
+    theQIE10SignalGenerator.initializeEvent(ep, &ES);
 
     // put digis from pileup event into digitizer
 
     theHBHESignalGenerator.fill(mcc);
     theHOSignalGenerator.fill(mcc);
     theHFSignalGenerator.fill(mcc);
+    theQIE10SignalGenerator.fill(mcc);
   }
 
   void DataMixingHcalDigiWorkerProd::putHcal(edm::Event &e,const edm::EventSetup& ES) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -26,6 +26,7 @@
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h"
 #include "SimGeneral/DataMixingModule/plugins/HcalNoiseStorage.h"
@@ -67,30 +68,29 @@ namespace edm
       // data specifiers
 
       // Hcal
-      //      edm::InputTag HBHEdigiCollectionSig_; // secondary name given to collection of digis
-      // edm::InputTag HOdigiCollectionSig_  ; // secondary name given to collection of digis
-      //edm::InputTag HFdigiCollectionSig_  ; // secondary name given to collection of digis
-      //edm::InputTag ZDCdigiCollectionSig_ ; // secondary name given to collection of digis
       edm::InputTag HBHEPileInputTag_; // InputTag for Pileup Digis collection  
       edm::InputTag HOPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
       std::string HBHEDigiCollectionDM_; // secondary name to be given to collection of digis
       std::string HODigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string HFDigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to collection of digis
+      std::string QIE10DigiCollectionDM_ ; // secondary name to be given to collection of digis
 
       edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
       edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
       edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
       edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
-  
+      edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
 
       HcalDigiProducer* myHcalDigitizer_;
       HBHESignalGenerator theHBHESignalGenerator;
       HOSignalGenerator theHOSignalGenerator;
       HFSignalGenerator theHFSignalGenerator;
       ZDCSignalGenerator theZDCSignalGenerator;
+      QIE10SignalGenerator theQIE10SignalGenerator;
 
       std::string label_;
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -56,11 +56,6 @@ namespace edm
       void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
                           const edm::EventSetup& ES, edm::ModuleCallingContext const*);
 
-    // set tokens for data access
-    void setHBHEAccess( edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok) { tok_hbhe_ = tok; }
-    void setHOAccess( edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok) { tok_ho_ = tok; }
-    void setHFAccess( edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok) { tok_hf_ = tok; }
-    void setZDCAccess( edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok) { tok_zdc_ = tok; }
     void beginRun(const edm::Run& run, const edm::EventSetup& ES);
     void initializeEvent(const edm::Event &e, const edm::EventSetup& ES);
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -45,6 +45,7 @@ namespace edm
     HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
     HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
     ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
+    QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
 							    label_(ps.getParameter<std::string>("Label"))
   {  
 
@@ -58,6 +59,7 @@ namespace edm
     tok_ho_ = consumes<HODigitizerTraits::DigiCollection>(HOPileInputTag_);
     tok_hf_ = consumes<HFDigitizerTraits::DigiCollection>(HFPileInputTag_);
     tok_zdc_ = consumes<ZDCDigitizerTraits::DigiCollection>(ZDCPileInputTag_);
+    tok_qie10_ = consumes<HcalQIE10DigitizerTraits::DigiCollection>(QIE10PileInputTag_);
 
     // get the subdetector names
     this->getSubdetectorNames();  //something like this may be useful to check what we are supposed to do...

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -103,6 +103,7 @@ namespace edm {
       std::string HODigiCollectionDM_  ; // secondary name to be given to HO collection of hits
       std::string HFDigiCollectionDM_  ; // secondary name to be given to HF collection of hits
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to ZDC collection of hits
+      std::string QIE10DigiCollectionDM_ ; // secondary name to be given to QIE10 collection of hits
 
       // Muons
       // output:
@@ -144,10 +145,12 @@ namespace edm {
       edm::InputTag HOPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
       edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
       edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
       edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
       edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
+      edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
       edm::EDGetTokenT<EBDigitizerTraits::DigiCollection> tok_eb_;
       edm::EDGetTokenT<EEDigitizerTraits::DigiCollection> tok_ee_;
       edm::EDGetTokenT<ESDigitizerTraits::DigiCollection> tok_es_;

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
@@ -76,6 +76,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEdigiCollectionSig  = cms.InputTag("hcalDigis"),
     HOdigiCollectionSig    = cms.InputTag("hcalDigis"),
     HFdigiCollectionSig    = cms.InputTag("hcalDigis"),
+    QIE10digiCollectionSig = cms.InputTag("hcalDigis"),
     ZDCdigiCollectionSig   = cms.InputTag(""),
 #                         ZDCdigiCollectionSig   = cms.InputTag("hcalDigis"),          
     #
@@ -85,6 +86,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEPileInputTag = cms.InputTag("hcalDigis"),                  
     HOPileInputTag   = cms.InputTag("hcalDigis"),                  
     HFPileInputTag   = cms.InputTag("hcalDigis"),                  
+    QIE10PileInputTag   = cms.InputTag("hcalDigis"),                  
     ZDCPileInputTag  = cms.InputTag(""),
 #                         ZDCPileInputTag  = cms.InputTag("hcalDigis"),          
     #  Signal
@@ -130,7 +132,8 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEDigiCollectionDM = cms.string(''),
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
-    ZDCDigiCollectionDM  = cms.string('')
+    ZDCDigiCollectionDM  = cms.string(''),
+    QIE10DigiCollectionDM  = cms.string('')
 )
 
 mixData.doEB = cms.bool(True)

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
@@ -83,6 +83,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEdigiCollectionSig  = cms.InputTag("simHcalUnsuppressedDigis"),
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
     # Sim Level (for Prod mode) ?
@@ -94,6 +95,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEPileInputTag = cms.InputTag("hcalDigis"),                  
     HOPileInputTag   = cms.InputTag("hcalDigis"),                  
     HFPileInputTag   = cms.InputTag("hcalDigis"),                  
+    QIE10PileInputTag   = cms.InputTag("hcalDigis"),                  
     ZDCPileInputTag  = cms.InputTag("hcalDigis"),
     #  Signal
                    #
@@ -138,6 +140,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEDigiCollectionDM = cms.string(''),
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
+    QIE10DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 

--- a/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
@@ -77,6 +77,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEdigiCollectionSig  = cms.InputTag("simHcalUnsuppressedDigis"),
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
     #
@@ -86,6 +87,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEPileInputTag = cms.InputTag("simHcalDigis"),
     HOPileInputTag   = cms.InputTag("simHcalDigis"),
     HFPileInputTag   = cms.InputTag("simHcalDigis"),
+    QIE10PileInputTag   = cms.InputTag("simHcalDigis"),
     ZDCPileInputTag  = cms.InputTag(""),
 
     #  Signal
@@ -131,6 +133,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEDigiCollectionDM = cms.string(''),
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
+    QIE10DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -163,6 +163,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEdigiCollectionSig  = cms.InputTag("simHcalUnsuppressedDigis"),
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
                          
@@ -183,6 +184,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEPileInputTag = cms.InputTag("hcalDigis","","@MIXING"),
     HOPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
     HFPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
+    QIE10PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
     ZDCPileInputTag  = cms.InputTag(""),
 
     #  Signal
@@ -238,6 +240,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HBHEDigiCollectionDM = cms.string(''),
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
+    QIE10DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 


### PR DESCRIPTION
This PR extends HCAL premixing to include QIE10 digis. In the process, I cleaned up some of the HCAL-related premixing code, reducing duplication and replacing magic numbers with consts in the Traits classes. QIE10 has an 8 bit ADC, as opposed to the 7 bit ADC in QIE8, which is reflected in the `PreMixBits` value in `HcalQIE10Traits`.

Many thanks to @mdhildreth for helping me test the implementation. The fC spectrum for both standard mixing (blue) and premixing with QIE10 digis (red) is shown below, displaying good agreement.

![fC_standard_vs_premix_good.png](http://www.kjplanet.com/pr/fC_standard_vs_premix_good.png)

Typically I have backported QIE10 features to 80X, but this is a larger change and I don't foresee any need to premix QIE10 digis in 80X, so I do not plan to backport this.

Once this PR is merged, QIE10 will be nearly feature-complete (just missing the packer, which will come separately).
