### PR TITLE
Fixes for RunInfo O2O and cleanup of PopCon interface

### DIFF
--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -182,7 +182,11 @@ namespace cond {
       if( m_data->iovBuffer.size() ) {
 	std::sort(m_data->iovBuffer.begin(),m_data->iovBuffer.end(),iovSorter);
 	cond::Time_t l = std::get<0>(m_data->iovBuffer.front());
-	if( m_data->synchronizationType != cond::SYNCH_ANY && m_data->synchronizationType != cond::SYNCH_VALIDATION ){
+  //We do not allow for IOV updates (i.e. insertion in the past or overriding) on tags whose syncrosization is not "ANY" or "VALIDATION".
+  //This policy is stricter than the one deployed in the Condition Upload service,
+  //which allows insertions in the past or overriding for IOVs larger than the first condition safe run for HLT ("HLT"/"EXPRESS" synchronizations) and Tier0 ("PROMPT"/"PCL").
+  //This is intended: in the C++ API we have not got a way to determine the first condition safe runs.
+  if( m_data->synchronizationType != cond::SYNCH_ANY && m_data->synchronizationType != cond::SYNCH_VALIDATION ){
 	  // retrieve the last since
 	  cond::Time_t last = 0;
 	  cond::Hash h;

--- a/CondCore/PopCon/interface/PopCon.h
+++ b/CondCore/PopCon/interface/PopCon.h
@@ -72,8 +72,6 @@ namespace popcon {
     
     bool m_LoggingOn;
 
-    bool m_IsDestDbCheckedInQueryLog;
-    
     std::string m_tag;
     
     cond::TagInfo_t m_tagInfo;
@@ -81,9 +79,10 @@ namespace popcon {
     cond::LogDBEntry_t m_logDBEntry;
 
     bool m_close;
+    
     Time_t m_lastTill;
 
-    
+    static constexpr const char* const s_version = "5.0";
   };
 
 
@@ -103,15 +102,15 @@ namespace popcon {
   
   template<typename Container>
   const std::string displayIovHelper(Container const & payloads) {
-    if (payloads.empty()) return "Nothing to transfer;";
-    std::ostringstream s;    
+    if (payloads.empty()) return std::string("Nothing to transfer;");
+    std::ostringstream s;
     // when only 1 payload is transferred; 
-    if ( payloads.size()==1)  
-      s <<"Since " << (*payloads.begin()).time <<  "; " ;
+    if ( payloads.size()==1)
+      s << "Since " << (*payloads.begin()).time <<  "; " ;
     else{
       // when more than one payload are transferred;  
-      s <<   "first payload Since " <<  (*payloads.begin()).time <<  ","
-	<< "last payload Since "  << (*payloads.rbegin()).time <<  ";" ;  
+      s << "first payload Since " <<  (*payloads.begin()).time <<  ", "
+        << "last payload Since "  << (*payloads.rbegin()).time <<  "; " ;  
     }  
     return s.str();
   }
@@ -129,12 +128,12 @@ namespace popcon {
   								 m_tagInfo,m_logDBEntry); 
     Container const & payloads = *ret.first;
     
-    if(m_LoggingOn)
-      m_dbService->setLogHeaderForRecord(m_record,source.id(),"PopCon v4.0; " + 
-					 displayIovHelper(payloads) +  ret.second);
-    //m_dbService->setLogHeaderForRecord(m_record,source.id(),"PopCon v4.0; " + 
-    //				 cond::userInfo() + displayIovHelper(payloads) +  ret.second);
-    
+    if(m_LoggingOn) {
+      std::ostringstream s;
+      s << "PopCon v" << s_version << "; " << displayIovHelper(payloads) << ret.second;
+      //s << "PopCon v" << s_version << "; " << cond::userInfo() << displayIovHelper(payloads) << ret.second;
+      m_dbService->setLogHeaderForRecord(m_record,source.id(),s.str());
+    }
     displayHelper(payloads);
     
     std::for_each(payloads.begin(),payloads.end(),

--- a/CondCore/PopCon/src/PopCon.cc
+++ b/CondCore/PopCon/src/PopCon.cc
@@ -15,15 +15,14 @@ namespace popcon {
     m_record(pset.getParameter<std::string> ("record")),
     m_payload_name(pset.getUntrackedParameter<std::string> ("name","")),
     m_LoggingOn(pset.getUntrackedParameter< bool > ("loggingOn",true)),
-    m_IsDestDbCheckedInQueryLog( pset.getUntrackedParameter< bool >("IsDestDbCheckedInQueryLog",true)),
     m_close(pset.getUntrackedParameter< bool > ("closeIOV",false)),
     m_lastTill(pset.getUntrackedParameter< bool > ("lastTill",0))
     {
       //TODO set the policy (cfg or global configuration?)
       //Policy if corrupted data found
       
-      edm::LogInfo ("PopCon") << "This is PopCon (Populator of Condition) V4.0\n"
-			      << "Please report any problem and feature request through the savannah portal under the category conditions\n" ; 
+      edm::LogInfo ("PopCon") << "This is PopCon (Populator of Condition) v" << s_version << ".\n"
+                              << "Please report any problem and feature request through the JIRA project CMSCONDDB.\n" ; 
     }
   
   PopCon::~PopCon(){
@@ -53,30 +52,22 @@ namespace popcon {
       m_tagInfo.name = m_tag;
       m_tagInfo.size = iov.sequenceSize();
       if( m_tagInfo.size>0 ){
-	cond::Iov_t last = iov.getLast();
-	m_tagInfo.lastInterval = cond::ValidityInterval( last.since, last.till );
-	m_tagInfo.lastPayloadToken = last.payloadId;
+        cond::Iov_t last = iov.getLast();
+        m_tagInfo.lastInterval = cond::ValidityInterval( last.since, last.till );
+        m_tagInfo.lastPayloadToken = last.payloadId;
       }
 
-      //if( m_IsDestDbCheckedInQueryLog ) {
-      //m_dbService->queryLog().LookupLastEntryByTag( m_tag, connectionStr, m_logDBEntry );
-      //std::cout <<" ------ log info searched in the same db: "<< connectionStr << "------" <<std::endl;
-      //} else {
-      //m_dbService->queryLog().LookupLastEntryByTag( m_tag, m_logDBEntry );
-      //std::cout <<" ------ log info found in another db "<< "------" <<std::endl;
-      //}
-
-      edm::LogInfo ("PopCon") << "DB: " << connectionStr << "\n"
-			      << "TAG: " << m_tag 
-			      << ", last since/till: " <<  m_tagInfo.lastInterval.first
-			      << "/" << m_tagInfo.lastInterval.second
-			      << ", , size: " << m_tagInfo.size << "\n"
-			      << "Last writer: " <<  m_logDBEntry.provenance 
-			      << ", size: " << m_logDBEntry.payloadIdx+1 << std::endl;
+      edm::LogInfo ("PopCon") << "destination DB: " << connectionStr
+                              << ", target DB: " << ( m_targetConnectionString.empty() ? connectionStr : m_targetConnectionString ) << "\n"
+                              << "TAG: " << m_tag
+                              << ", last since/till: " <<  m_tagInfo.lastInterval.first
+                              << "/" << m_tagInfo.lastInterval.second
+                              << ", size: " << m_tagInfo.size << "\n" << std::endl;
     } else {
-      edm::LogInfo ("PopCon") << "DB: " << connectionStr << "\n"
-			      << "TAG: " << m_tag 
-			      << "; First writer to this new tag." << std::endl; 
+      edm::LogInfo ("PopCon") << "destination DB: " << connectionStr
+                              << ", target DB: " << ( m_targetConnectionString.empty() ? connectionStr : m_targetConnectionString ) << "\n"
+                              << "TAG: " << m_tag
+                              << "; First writer to this new tag." << std::endl;
     }
     return m_targetSession;
   }

--- a/CondTools/RunInfo/interface/RunInfoHandler.h
+++ b/CondTools/RunInfo/interface/RunInfoHandler.h
@@ -5,7 +5,7 @@
 
 #include "CondCore/PopCon/interface/PopConSourceHandler.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class RunInfoHandler : public popcon::PopConSourceHandler<RunInfo>{
  public:
@@ -19,7 +19,10 @@ class RunInfoHandler : public popcon::PopConSourceHandler<RunInfo>{
   std::string m_name;
   
   // for reading from omds
+  std::string m_runinfo_schema;
+  std::string m_dcsenv_schema;
   std::string m_connectionString;
+  edm::ParameterSet m_connectionPset;
 };
 
 #endif 

--- a/CondTools/RunInfo/interface/RunInfoHandler.h
+++ b/CondTools/RunInfo/interface/RunInfoHandler.h
@@ -15,14 +15,11 @@ class RunInfoHandler : public popcon::PopConSourceHandler<RunInfo>{
   RunInfoHandler(const edm::ParameterSet& pset); 
   
  private:
-  std::string m_name;
   unsigned long long m_since;
+  std::string m_name;
   
   // for reading from omds
   std::string m_connectionString;
-  std::string m_authpath;
-  std::string m_user;
-  std::string m_pass;
 };
 
 #endif 

--- a/CondTools/RunInfo/interface/RunInfoRead.h
+++ b/CondTools/RunInfo/interface/RunInfoRead.h
@@ -1,24 +1,18 @@
 #ifndef CondTools_RunInfo_RunInfoRead_h
 #define CondTools_RunInfo_RunInfoRead_h
 
-#include "CondTools/RunInfo/interface/TestBase.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include <string>
 
-class RunInfoRead : virtual public TestBase {
+class RunInfoRead {
  public:
-  RunInfoRead(const std::string& connectionString,
-	      const std::string& user,
-	      const std::string& pass);
-  virtual ~RunInfoRead();
-  void run();
+  RunInfoRead(const std::string& connectionString);
+  ~RunInfoRead();
   RunInfo readData(const std::string& table, const std::string& column, const int r_number);
  private:
   std::string m_tableToRead;
   std::string m_columnToRead;
   std::string m_connectionString;
-  std::string m_user;
-  std::string m_pass;
 };
 
 #endif

--- a/CondTools/RunInfo/interface/RunInfoRead.h
+++ b/CondTools/RunInfo/interface/RunInfoRead.h
@@ -2,17 +2,18 @@
 #define CondTools_RunInfo_RunInfoRead_h
 
 #include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <string>
 
 class RunInfoRead {
  public:
-  RunInfoRead(const std::string& connectionString);
+  RunInfoRead(const std::string& connectionString,
+	      const edm::ParameterSet& connectionPset);
   ~RunInfoRead();
-  RunInfo readData(const std::string& table, const std::string& column, const int r_number);
+  RunInfo readData(const std::string& runinfo_schema, const std::string& dcsenv_schema, const int r_number);
  private:
-  std::string m_tableToRead;
-  std::string m_columnToRead;
   std::string m_connectionString;
+  edm::ParameterSet m_connectionPset;
 };
 
 #endif

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -50,7 +50,7 @@ void RunInfoHandler::getNewObjects() {
                                      << std::endl;
   } 
   std::ostringstream ss;
- // transfer fake run for 1 to since for the first time
+  // transfer fake run for 1 to since for the first time
   if( tagInfo().size == 0 && m_since != 1 ) {
     m_to_transfer.push_back( std::make_pair( (RunInfo*)(r->Fake_RunInfo()), 1 ) );
     ss << "fake run number: " << 1 << ", ";
@@ -62,7 +62,6 @@ void RunInfoHandler::getNewObjects() {
   
   //reading from omds
   RunInfoRead rn( m_connectionString, m_connectionPset );
-  //*r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
   *r = rn.readData( m_runinfo_schema, m_dcsenv_schema, (int)m_since );
   m_to_transfer.push_back( std::make_pair( (RunInfo*)r, m_since) );
   ss << "run number: " << m_since << ";";

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -6,12 +6,9 @@
 #include<vector>
 
 RunInfoHandler::RunInfoHandler( const edm::ParameterSet& pset ) :
-   m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler" ) )
-  ,m_since( pset.getParameter<unsigned long long>( "runNumber" ) )
-  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO" ) )
-  ,m_authpath( pset.getUntrackedParameter<std::string>( "authenticationPath", "" ) )
-  ,m_user( pset.getUntrackedParameter<std::string>( "OnlineDBUser", "CMS_RUNINFO_R" ) )
-  ,m_pass( pset.getUntrackedParameter<std::string>( "OnlineDBPass", "PASSWORD") ) {
+   m_since( pset.getParameter<unsigned long long>( "runNumber" ) )
+  ,m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler" ) )
+  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO_R" ) ) {
 }
 
 RunInfoHandler::~RunInfoHandler() {}
@@ -62,7 +59,7 @@ void RunInfoHandler::getNewObjects() {
   }
   
   //reading from omds
-  RunInfoRead rn( m_connectionString, m_user, m_pass );
+  RunInfoRead rn( m_connectionString );
   *r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
   m_to_transfer.push_back( std::make_pair( (RunInfo*)r, m_since) );
   ss << "run number: " << m_since << ";";

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -25,6 +25,21 @@ void RunInfoHandler::getNewObjects() {
                                    << ", last object valid since " << tagInfo().lastInterval.first
                                    << " token " << tagInfo().lastPayloadToken << std::endl;
   edm::LogInfo( "RunInfoHandler" ) << "runnumber/first since = " << m_since << std::endl;
+
+  //check if a transfer is needed:
+  //if the new run number is smaller than or equal to the latest IOV, exit.
+  //This is needed as now the IOV Editor does not always protect for insertions:
+  //ANY and VALIDATION sychronizations are allowed to write in the past.
+  if( tagInfo().size > 0  && tagInfo().lastInterval.first >= m_since ) {
+    edm::LogWarning( "RunInfoHandler" ) << "------- " << m_name
+                                        << " - > getNewObjects\n"
+                                        << "last IOV " << tagInfo().lastInterval.first
+                                        << ( tagInfo().lastInterval.first == m_since ? " is equal to" : " is larger than" )
+                                        << " the run proposed for insertion " << m_since
+                                        << ". No transfer needed." << std::endl;
+    return;
+  }
+
   RunInfo* r = new RunInfo();
   
   //fill with null runinfo if empty run are found beetween the two last valid ones 

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -5,11 +5,11 @@
 #include<iostream>
 #include<vector>
 
-RunInfoHandler::RunInfoHandler(const edm::ParameterSet& pset) :
-   m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler") )
+RunInfoHandler::RunInfoHandler( const edm::ParameterSet& pset ) :
+   m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler" ) )
   ,m_since( pset.getParameter<unsigned long long>( "runNumber" ) )
-  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO") )
-  ,m_authpath( pset.getUntrackedParameter<std::string>( "authenticationPath", "." ) )
+  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO" ) )
+  ,m_authpath( pset.getUntrackedParameter<std::string>( "authenticationPath", "" ) )
   ,m_user( pset.getUntrackedParameter<std::string>( "OnlineDBUser", "CMS_RUNINFO_R" ) )
   ,m_pass( pset.getUntrackedParameter<std::string>( "OnlineDBPass", "PASSWORD") ) {
 }
@@ -18,21 +18,19 @@ RunInfoHandler::~RunInfoHandler() {}
 
 void RunInfoHandler::getNewObjects() {
   //check whats already inside of database
-  edm::LogInfo( "RunInfoHandler" ) << "------- " << m_name
-                                   << " - > getNewObjects\n"
-                                   << "got offlineInfo " << tagInfo().name
+  edm::LogInfo( "RunInfoHandler" ) << "[" << "RunInfoHandler::" << __func__ << "]:" << m_name << ": "
+                                   << "Destination Tag Info: name " << tagInfo().name
                                    << ", size " << tagInfo().size
                                    << ", last object valid since " << tagInfo().lastInterval.first
-                                   << " token " << tagInfo().lastPayloadToken << std::endl;
-  edm::LogInfo( "RunInfoHandler" ) << "runnumber/first since = " << m_since << std::endl;
+                                   << ", hash " << tagInfo().lastPayloadToken << std::endl;
+  edm::LogInfo( "RunInfoHandler" ) << "[" << "RunInfoHandler::" << __func__ << "]:" << m_name << ": runnumber/first since = " << m_since << std::endl;
 
   //check if a transfer is needed:
   //if the new run number is smaller than or equal to the latest IOV, exit.
   //This is needed as now the IOV Editor does not always protect for insertions:
   //ANY and VALIDATION sychronizations are allowed to write in the past.
   if( tagInfo().size > 0  && tagInfo().lastInterval.first >= m_since ) {
-    edm::LogWarning( "RunInfoHandler" ) << "------- " << m_name
-                                        << " - > getNewObjects\n"
+    edm::LogWarning( "RunInfoHandler" ) << "[" << "RunInfoHandler::" << __func__ << "]:" << m_name << ": "
                                         << "last IOV " << tagInfo().lastInterval.first
                                         << ( tagInfo().lastInterval.first == m_since ? " is equal to" : " is larger than" )
                                         << " the run proposed for insertion " << m_since
@@ -46,25 +44,28 @@ void RunInfoHandler::getNewObjects() {
   size_t n_empty_run = 0;
   if( tagInfo().size > 0  && (tagInfo().lastInterval.first + 1) < m_since ) {
     n_empty_run = m_since - tagInfo().lastInterval.first - 1;
-    edm::LogInfo( "RunInfoHandler" ) << "------- " << "entering fake run from "
+    edm::LogInfo( "RunInfoHandler" ) << "[" << "RunInfoHandler::" << __func__ << "]:" << m_name << ": "
+                                     << "entering fake run from "
                                      << tagInfo().lastInterval.first + 1
-                                     <<  "to " << m_since - 1 << "- > getNewObjects"
+                                     <<  " to " << m_since - 1
                                      << std::endl;
   } 
-  // transfer fake run for 1 to since for the first time
+  std::ostringstream ss;
+ // transfer fake run for 1 to since for the first time
   if( tagInfo().size == 0 && m_since != 1 ) {
     m_to_transfer.push_back( std::make_pair( (RunInfo*)(r->Fake_RunInfo()), 1 ) );
+    ss << "fake run number: " << 1 << ", ";
   }
   if ( n_empty_run != 0 ) {
     m_to_transfer.push_back(std::make_pair( (RunInfo*)(r->Fake_RunInfo()), tagInfo().lastInterval.first + 1 ) );
+    ss << "fake run number: " << tagInfo().lastInterval.first + 1 << ", ";
   }
   
   //reading from omds
   RunInfoRead rn( m_connectionString, m_user, m_pass );
   *r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
   m_to_transfer.push_back( std::make_pair( (RunInfo*)r, m_since) );
-  std::ostringstream ss;
-  ss << "since =" << m_since;
-  m_userTextLog = ss.str() + ";";
-  edm::LogInfo( "RunInfoHandler" ) << "------- " << m_name << " - > getNewObjects" << std::endl;
+  ss << "run number: " << m_since << ";";
+  m_userTextLog = ss.str();
+  edm::LogInfo( "RunInfoHandler" ) << "[" << "RunInfoHandler::" << __func__ << "]:" << m_name << ": END." << std::endl;
 }

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -1,5 +1,4 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondTools/RunInfo/interface/RunInfoHandler.h"
 #include "CondTools/RunInfo/interface/RunInfoRead.h"
 #include<iostream>
@@ -8,7 +7,10 @@
 RunInfoHandler::RunInfoHandler( const edm::ParameterSet& pset ) :
    m_since( pset.getParameter<unsigned long long>( "runNumber" ) )
   ,m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler" ) )
-  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO_R" ) ) {
+  ,m_runinfo_schema( pset.getUntrackedParameter<std::string>( "RunInfoSchema", "CMS_RUNINFO" ) )
+  ,m_dcsenv_schema( pset.getUntrackedParameter<std::string>( "DCSEnvSchema", "CMS_DCS_ENV_PVSS_COND") )
+  ,m_connectionString( pset.getParameter<std::string>( "connect" ) )
+  ,m_connectionPset( pset.getParameter<edm::ParameterSet>( "DBParameters" ) ) {
 }
 
 RunInfoHandler::~RunInfoHandler() {}
@@ -59,8 +61,9 @@ void RunInfoHandler::getNewObjects() {
   }
   
   //reading from omds
-  RunInfoRead rn( m_connectionString );
-  *r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
+  RunInfoRead rn( m_connectionString, m_connectionPset );
+  //*r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
+  *r = rn.readData( m_runinfo_schema, m_dcsenv_schema, (int)m_since );
   m_to_transfer.push_back( std::make_pair( (RunInfo*)r, m_since) );
   ss << "run number: " << m_since << ";";
   m_userTextLog = ss.str();

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -1,15 +1,12 @@
 //#include "CondFormats/Common/interface/TimeConversions.h"
 //#include "CondFormats/Common/interface/Time.h"
 #include "CondTools/RunInfo/interface/RunInfoRead.h"
-#include "CondCore/CondDB/interface/Auth.h"
+#include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "RelationalAccess/ConnectionService.h"
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/ITransaction.h"
 #include "RelationalAccess/ISchema.h"
 #include "RelationalAccess/ITable.h"
-#include "RelationalAccess/ITableDataEditor.h"
-#include "RelationalAccess/TableDescription.h"
 #include "RelationalAccess/IQuery.h"
 #include "RelationalAccess/ICursor.h"
 #include "CoralBase/AttributeList.h"
@@ -19,6 +16,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 #include <math.h>
@@ -32,83 +30,70 @@ namespace {
   std::string squoted( const std::string& s ){
     return quote+s+quote;
   }
-
-
+  //now strings for the tables and columns to be queried
+  std::string sParameterTable( "RUNSESSION_PARAMETER" );
+  std::string sDateTable( "RUNSESSION_DATE" );
+  std::string sStringTable( "RUNSESSION_STRING" );
+  std::string sIdParameterColumn( "ID" );
+  std::string sRunNumberParameterColumn( "RUNNUMBER" );
+  std::string sNameParameterColumn( "NAME" );
+  std::string sRunSessionParameterIdDataColumn( "RUNSESSION_PARAMETER_ID" );
+  std::string sValueDataColumn( "VALUE" );
+  std::string sDCSMagnetTable( "CMSFWMAGNET" );
+  std::string sDCSMagnetCurrentColumn( "CURRENT" );
+  std::string sDCSMagnetChangeDateColumn( "CHANGE_DATE" );
 }
-RunInfoRead::RunInfoRead( const std::string& connectionString ):
-   m_tableToRead( "" )
-  ,m_columnToRead( "" )
-  ,m_connectionString( connectionString ) {}
+
+RunInfoRead::RunInfoRead( const std::string& connectionString
+			, const edm::ParameterSet& connectionPset ):
+   m_connectionString( connectionString )
+  ,m_connectionPset( connectionPset ) {}
 
 RunInfoRead::~RunInfoRead() {}
 
 RunInfo 
-RunInfoRead::readData(const std::string & table, 
-		      const std::string &column, const int r_number) {
-  m_tableToRead = table; // to be cms_runinfo.runsession_parameter
-  m_columnToRead= column;  // to be string_value;
+RunInfoRead::readData( const std::string & runinfo_schema
+		     , const std::string & dcsenv_schema
+                     , const int r_number ) {
   RunInfo  sum;
   RunInfo temp_sum;
-  //RunInfo Sum; 
   //for B currents...
   bool Bnotchanged = 0;
   //from TimeConversions.h
-  const boost::posix_time::ptime time0 =
-    boost::posix_time::from_time_t(0);
+  const boost::posix_time::ptime time0 = boost::posix_time::from_time_t(0);
   //if cursor is null setting null values  
   temp_sum.m_run = r_number;
   std::cout << "entering readData" << std::endl;
-  coral::ConnectionService conserv;
-  coral::ISessionProxy* session = conserv.connect( m_connectionString, cond::auth::COND_READER_ROLE, coral::ReadOnly );
+  cond::persistency::ConnectionPool connection;
+  connection.setParameters( m_connectionPset );
+  connection.configure();
+  std::shared_ptr<coral::ISessionProxy> session = connection.createCoralSession( m_connectionString, false );
   try{
     session->transaction().start( true );
     std::cout << "starting session " << std::endl;
-    coral::ISchema& schema = session->schema("CMS_RUNINFO");
-    std::cout << " accessing schema " << std::endl;
-    std::cout << " trying to handle table ::  " << m_tableToRead << std::endl;
-    std::string m_columnToRead_id = "ID";
-    long long id_start = 0;
-    //new query to obtain the start_time, fist obtaining the id
-    coral::IQuery* queryI = schema.tableHandle(m_tableToRead).newQuery();  
-    //implementing the query here....... 
-    queryI->addToOutputList(m_tableToRead + dot + m_columnToRead_id, m_columnToRead_id);
-    //condition 
-    coral::AttributeList conditionData;
-    conditionData.extend<int>( "n_run" );
-    conditionData[0].data<int>() = r_number;
-    std::string condition1 = m_tableToRead + ".RUNNUMBER=:n_run AND " +  m_tableToRead +  ".NAME='CMS.LVL0:START_TIME_T'";
-    queryI->setCondition(condition1, conditionData);
-    coral::ICursor& cursorI = queryI->execute();
-    if( cursorI.next() ) {
-      //cursorI.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorI.currentRow();
-      id_start = row[m_columnToRead_id].data<long long>();
-    }
-    else {
-      id_start = -1;
-    }
-    //std::cout << "id for start time time extracted == " << id_start << std::endl;
-    delete queryI;
-    
-    //now extracting the start time
-    std::string m_tableToRead_date = "RUNSESSION_DATE";
-    std::string m_columnToRead_val = "VALUE";
-    //new query to obtain the start_time, fist obtaining the id
-    coral::IQuery* queryII = schema.tableHandle(m_tableToRead_date).newQuery();  
-    //implementing the query here....... 
-    queryII->addToOutputList(m_tableToRead_date + dot + m_columnToRead_val, m_columnToRead_val);
-    //condition 
-    coral::AttributeList conditionData2;
-    conditionData2.extend<long long>( "n_id" );
-    conditionData2[0].data<long long>() = id_start;
-    std::string condition2 = m_tableToRead_date + ".RUNSESSION_PARAMETER_ID=:n_id";
-    queryII->setCondition(condition2, conditionData2);
-    coral::ICursor& cursorII = queryII->execute();
+    coral::ISchema& schema = session->schema( runinfo_schema );
+    std::cout << " accessing schema " << runinfo_schema << std::endl;
+    //new query to obtain the start_time
+    std::unique_ptr<coral::IQuery> query( schema.newQuery() );
+    query->addToTableList( sParameterTable );
+    query->addToTableList( sDateTable );
+    query->addToOutputList( sValueDataColumn );
+    coral::AttributeList runTimeDataOutput;
+    runTimeDataOutput.extend<coral::TimeStamp>( sValueDataColumn );
+    query->defineOutput( runTimeDataOutput );
+    std::string runStartWhereClause( sRunNumberParameterColumn + std::string( "=:n_run AND " )
+                                     + sNameParameterColumn + std::string( "='CMS.LVL0:START_TIME_T' AND " )
+                                     + sIdParameterColumn + std::string( "=" ) + sRunSessionParameterIdDataColumn );
+    coral::AttributeList runNumberBindVariableList;
+    runNumberBindVariableList.extend<int>( "n_run" );
+    runNumberBindVariableList[ "n_run" ].data<int>() = r_number;
+    query->setCondition( runStartWhereClause, runNumberBindVariableList );
+    coral::ICursor& runStartCursor = query->execute();
     coral::TimeStamp start; //now all times are UTC!
-    if( cursorII.next() ) {
-      //cursorII.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorII.currentRow();
-      start = row[m_columnToRead_val].data<coral::TimeStamp>();
+    if( runStartCursor.next() ) {
+      //runStartCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      const coral::AttributeList& row = runStartCursor.currentRow();
+      start = row[ sValueDataColumn ].data<coral::TimeStamp>();
       /*
       std::cout << "start time extracted == " 
 		<< "-->year " << start.year()
@@ -132,44 +117,23 @@ RunInfoRead::readData(const std::string & table,
 	temp_sum.m_start_time_str = "null";
 	temp_sum.m_start_time_ll = -1;
     }
-    delete queryII;
     
-    //new query to obtain the stop_time, fist obtaining the id
-    coral::IQuery* queryIII = schema.tableHandle(m_tableToRead).newQuery();  
-    //implementing the query here....... 
-    queryIII->addToOutputList(m_tableToRead + dot + m_columnToRead_id, m_columnToRead_id);
-    //condition 
-    std::string condition3 = m_tableToRead + ".RUNNUMBER=:n_run AND " + m_tableToRead + ".NAME='CMS.LVL0:STOP_TIME_T'";
-    queryIII->setCondition(condition3, conditionData);
-    coral::ICursor& cursorIII = queryIII->execute();
-    long long id_stop = 0;
-    if( cursorIII.next() ) {
-      //cursorIII.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorIII.currentRow();
-      id_stop = row[m_columnToRead_id].data<long long>();  
-    }
-    else {
-      id_stop = -1;
-    }
-    //std::cout << "id for stop time time extracted == " << id_stop << std::endl;
-    delete queryIII;
-    
-    //now exctracting the stop time
-    coral::IQuery* queryIV = schema.tableHandle(m_tableToRead_date).newQuery(); 
-    //implementing the query here....... 
-    queryIV->addToOutputList(m_tableToRead_date + dot + m_columnToRead_val, m_columnToRead_val);
-    //condition
-    coral::AttributeList conditionData4;
-    conditionData4.extend<long long>( "n_id" );
-    conditionData4[0].data<long long>() = id_stop;
-    std::string condition4 = m_tableToRead_date + ".RUNSESSION_PARAMETER_ID=:n_id";
-    queryIV->setCondition(condition4, conditionData4);
-    coral::ICursor& cursorIV = queryIV->execute();
+    //new query to obtain the stop_time
+    query.reset( schema.newQuery() );
+    query->addToTableList( sParameterTable );
+    query->addToTableList( sDateTable );
+    query->addToOutputList( sValueDataColumn );
+    query->defineOutput( runTimeDataOutput );
+    std::string runStopWhereClause( sRunNumberParameterColumn + std::string( "=:n_run AND " )
+                                    + sNameParameterColumn + std::string( "='CMS.LVL0:STOP_TIME_T' AND " )
+                                    + sIdParameterColumn + std::string( "=" ) + sRunSessionParameterIdDataColumn );
+    query->setCondition( runStopWhereClause, runNumberBindVariableList );
+    coral::ICursor& runStopCursor = query->execute();
     coral::TimeStamp stop;
-    if( cursorIV.next() ) {
-      //cursorIV.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorIV.currentRow();
-      stop = row[m_columnToRead_val].data<coral::TimeStamp>(); 
+    if( runStopCursor.next() ) {
+      //runStopCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      const coral::AttributeList& row = runStopCursor.currentRow();
+      stop = row[ sValueDataColumn ].data<coral::TimeStamp>(); 
       /*
       std::cout << "stop time extracted == " 
 		<< "-->year " << stop.year()
@@ -193,30 +157,28 @@ RunInfoRead::readData(const std::string & table,
       temp_sum.m_stop_time_str = "null";
       temp_sum.m_stop_time_ll = -1;
     }
-    delete queryIV;
     
-    std::string m_tableToRead_fed = "RUNSESSION_STRING";
-    coral::IQuery* queryV = schema.newQuery();  
-    queryV->addToTableList(m_tableToRead);
-    queryV->addToTableList(m_tableToRead_fed);
-    queryV->addToOutputList(m_tableToRead_fed + dot + m_columnToRead_val, m_columnToRead_val);
-    //queryV->addToOutputList(m_tableToRead + dot + m_columnToRead, m_columnToRead);
-    //condition
-    std::string condition5 = m_tableToRead + ".RUNNUMBER=:n_run AND " + m_tableToRead + ".NAME='CMS.LVL0:FED_ENABLE_MASK' AND RUNSESSION_PARAMETER.ID = RUNSESSION_STRING.RUNSESSION_PARAMETER_ID";
-    //std::string condition5 = m_tableToRead + ".runnumber=:n_run AND " + m_tableToRead + ".name='CMS.LVL0:FED_ENABLE_MASK'";
-    queryV->setCondition(condition5, conditionData);
-    coral::ICursor& cursorV = queryV->execute();
+    //new query for obtaining the list of FEDs included in the run
+    query.reset( schema.newQuery() );  
+    query->addToTableList( sParameterTable );
+    query->addToTableList( sStringTable );
+    query->addToOutputList( sValueDataColumn );
+    query->defineOutputType( sValueDataColumn, "string" );
+    std::string fedWhereClause( sRunNumberParameterColumn + std::string( "=:n_run AND " )
+                                + sNameParameterColumn + std::string( "='CMS.LVL0:FED_ENABLE_MASK' AND " )
+                                + sIdParameterColumn + std::string( "=" ) + sRunSessionParameterIdDataColumn );
+    query->setCondition( fedWhereClause, runNumberBindVariableList );
+    coral::ICursor& fedCursor = query->execute();
     std::string fed;
-    if ( cursorV.next() ) {
-      //cursorV.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorV.currentRow();
-      fed = row[m_columnToRead_val].data<std::string>();
+    if ( fedCursor.next() ) {
+      //fedCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      const coral::AttributeList& row = fedCursor.currentRow();
+      fed = row[ sValueDataColumn ].data<std::string>();
     }
     else {
       fed="null";
     }
     //std::cout << "string fed emask == " << fed << std::endl;
-    delete queryV;
     
     std::replace(fed.begin(), fed.end(), '%', ' ');
     std::stringstream stream(fed);
@@ -236,76 +198,71 @@ RunInfoRead::readData(const std::string & table,
     std::cout << "feds in run:--> ";
     std::copy(temp_sum.m_fed_in.begin(), temp_sum.m_fed_in.end(), std::ostream_iterator<int>(std::cout, ", "));
     std::cout << std::endl;
-    /*
-    for (size_t i =0; i<temp_sum.m_fed_in.size() ; ++i){
-      std::cout << "fed in run:--> " << temp_sum.m_fed_in[i] << std::endl; 
-    } 
-    */
-    
-    coral::ISchema& schema2 = session->schema("CMS_DCS_ENV_PVSS_COND");
-    std::string m_tableToRead_cur= "CMSFWMAGNET";
-    std::string m_columnToRead_cur= "CURRENT";
-    std::string m_columnToRead_date= "CHANGE_DATE";
-    coral::IQuery* queryVI = schema2.tableHandle(m_tableToRead_cur).newQuery();
-    queryVI->addToOutputList(m_tableToRead_cur +  dot + squoted(m_columnToRead_cur), m_columnToRead_cur);
-    queryVI->addToOutputList(m_tableToRead_cur +  dot + m_columnToRead_date, m_columnToRead_date);
-    //condition 
-    coral::AttributeList conditionData6;
+
+    //we connect now to the DCS schema in order to retrieve the magnet current
+    coral::ISchema& schema2 = session->schema( dcsenv_schema );
+    query.reset( schema2.tableHandle( sDCSMagnetTable ).newQuery() );
+    query->addToOutputList( squoted( sDCSMagnetCurrentColumn ), sDCSMagnetCurrentColumn );
+    query->addToOutputList( sDCSMagnetChangeDateColumn );
+    coral::AttributeList magnetDataOutput;
+    magnetDataOutput.extend<float>( sDCSMagnetCurrentColumn );
+    magnetDataOutput.extend<coral::TimeStamp>( sDCSMagnetChangeDateColumn );
+    query->defineOutput( magnetDataOutput );
+    //condition
+    coral::AttributeList magnetCurrentBindVariableList;
     float last_current = -1;
-    if(temp_sum.m_stop_time_str != "null") { 
-      conditionData6.extend<coral::TimeStamp>( "runstart_time" );
-      conditionData6.extend<coral::TimeStamp>( "runstop_time" );
-      conditionData6["runstart_time"].data<coral::TimeStamp>() = start; //start_time ;
-      conditionData6["runstop_time"].data<coral::TimeStamp>() = stop; //stop_time ;
-      std::string conditionVI = " NOT " + m_tableToRead_cur + dot + squoted(m_columnToRead_cur) + " IS NULL AND " 
-	+ m_tableToRead_cur +  dot + m_columnToRead_date + ">:runstart_time AND " 
-	+ m_tableToRead_cur +  dot + m_columnToRead_date + "<:runstop_time"  /*" ORDER BY " + m_columnToRead_date + " DESC"*/;
-      queryVI->setCondition(conditionVI, conditionData6);
-      queryVI->addToOrderList(m_tableToRead_cur +  dot + m_columnToRead_date + " DESC");
+    magnetCurrentBindVariableList.extend<coral::TimeStamp>( "runstart_time" );
+    magnetCurrentBindVariableList[ "runstart_time" ].data<coral::TimeStamp>() = start;
+    std::string magnetCurrentWhereClause;
+    if(temp_sum.m_stop_time_str != "null") {
+      magnetCurrentBindVariableList.extend<coral::TimeStamp>( "runstop_time" );
+      magnetCurrentBindVariableList[ "runstop_time" ].data<coral::TimeStamp>() = stop;
+      magnetCurrentWhereClause = std::string( " NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
+                                 + sDCSMagnetChangeDateColumn + std::string( ">:runstart_time AND " ) 
+                                 + sDCSMagnetChangeDateColumn + std::string( "<:runstop_time" );
     } else {
       std::cout << "run stop null" << std::endl;
-      conditionData6.extend<coral::TimeStamp>( "runstart_time" );
-      conditionData6["runstart_time"].data<coral::TimeStamp>() = start; //start_time ;
-      std::string conditionVI = " NOT " + m_tableToRead_cur + dot + squoted(m_columnToRead_cur) + " IS NULL AND " 
-	+ m_tableToRead_cur +  dot + m_columnToRead_date + "<:runstart_time" /*" ORDER BY " + m_columnToRead_date + " DESC"*/;
-      queryVI->setCondition(conditionVI, conditionData6);
-      queryVI->addToOrderList(m_tableToRead_cur +  dot + m_columnToRead_date + " DESC");
+      magnetCurrentWhereClause = std::string( " NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
+                                 + sDCSMagnetChangeDateColumn + std::string( "<:runstart_time" );
     }
-    queryVI->limitReturnedRows(10000);
-    coral::ICursor& cursorVI = queryVI->execute();
+    query->setCondition( magnetCurrentWhereClause, magnetCurrentBindVariableList );
+    query->addToOrderList( sDCSMagnetChangeDateColumn + std::string( " DESC" ) );
+    query->limitReturnedRows( 10000 );
+    coral::ICursor& magnetCurrentCursor = query->execute();
     coral::TimeStamp lastCurrentDate;
     std::string last_date;
     std::vector<double> time_curr;
-    if ( !cursorVI.next() ) {
+    if ( !magnetCurrentCursor.next() ) {
       // we should deal with stable currents... so the query is returning no value and we should take the last modified current value...
       Bnotchanged = 1;
-      coral::AttributeList conditionData6bis;
-      conditionData6bis.extend<coral::TimeStamp>( "runstop_time" );
-      conditionData6bis["runstop_time"].data<coral::TimeStamp>() = stop; //stop_time ;
-      std::string conditionVIbis = " NOT " + m_tableToRead_cur + dot + squoted(m_columnToRead_cur) + " IS NULL AND " 
-	+ m_tableToRead_cur +  dot + m_columnToRead_date + " <:runstop_time" /*" ORDER BY " + m_columnToRead_date + " DESC"*/;
-      coral::IQuery* queryVIbis = schema2.tableHandle(m_tableToRead_cur).newQuery();
-      queryVIbis->addToOutputList(m_tableToRead_cur + dot +  squoted(m_columnToRead_cur), m_columnToRead_cur);
-      queryVIbis->setCondition(conditionVIbis, conditionData6bis);
-      queryVIbis->addToOrderList(m_tableToRead_cur +  dot + m_columnToRead_date + " DESC");
-      coral::ICursor& cursorVIbis= queryVIbis->execute();
-      if( cursorVIbis.next() ) {
-	//cursorVIbis.currentRow().toOutputStream(std::cout) << std::endl;
-	const coral::AttributeList& row = cursorVIbis.currentRow();
-	last_current = row[m_columnToRead_cur].data<float>();
+      std::unique_ptr<coral::IQuery> lastValueQuery( schema2.tableHandle(sDCSMagnetTable).newQuery() );
+      lastValueQuery->addToOutputList( squoted(sDCSMagnetCurrentColumn), sDCSMagnetCurrentColumn );
+      lastValueQuery->defineOutputType( sDCSMagnetCurrentColumn, "float" );
+      coral::AttributeList lastValueBindVariableList;
+      lastValueBindVariableList.extend<coral::TimeStamp>( "runstop_time" );
+      lastValueBindVariableList[ "runstop_time" ].data<coral::TimeStamp>() = stop;
+      std::string lastValueWhereClause( std::string( " NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
+                                        + sDCSMagnetChangeDateColumn + std::string( " <:runstop_time" ) );
+      lastValueQuery->setCondition( lastValueWhereClause, lastValueBindVariableList );
+      lastValueQuery->addToOrderList( sDCSMagnetChangeDateColumn + std::string( " DESC" ) );
+      coral::ICursor& lastValueCursor = lastValueQuery->execute();
+      if( lastValueCursor.next() ) {
+	//lastValueCursor.currentRow().toOutputStream(std::cout) << std::endl;
+	const coral::AttributeList& row = lastValueCursor.currentRow();
+	last_current = row[sDCSMagnetCurrentColumn].data<float>();
 	std::cout << "previos run(s) current, not changed in this run... " << last_current << std::endl;
-      } 
+      }
       temp_sum.m_avg_current = last_current;
       temp_sum.m_min_current = last_current;
       temp_sum.m_max_current = last_current;
       temp_sum.m_stop_current = last_current;
       temp_sum.m_start_current = last_current; 
     }
-    while( cursorVI.next() ) {
-      //cursorVI.currentRow().toOutputStream(std::cout) << std::endl;
-      const coral::AttributeList& row = cursorVI.currentRow();
-      lastCurrentDate = row[m_columnToRead_date].data<coral::TimeStamp>();
-      temp_sum.m_current.push_back( row[m_columnToRead_cur].data<float>() );
+    while( magnetCurrentCursor.next() ) {
+      //magnetCurrentCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      const coral::AttributeList& row = magnetCurrentCursor.currentRow();
+      lastCurrentDate = row[sDCSMagnetChangeDateColumn].data<coral::TimeStamp>();
+      temp_sum.m_current.push_back( row[sDCSMagnetCurrentColumn].data<float>() );
       if(temp_sum.m_stop_time_str == "null") break;
       /*
       std::cout << "  last current time extracted == " 
@@ -326,7 +283,6 @@ RunInfoRead::readData(const std::string & table,
       long long last_date_ll = lastCurrentDateTimeFromEpoch.total_microseconds();
       time_curr.push_back(last_date_ll);
     }
-    delete queryVI;
     
     size_t csize = temp_sum.m_current.size();
     std::cout << "size of currents  " << csize << std::endl;  
@@ -405,7 +361,6 @@ RunInfoRead::readData(const std::string & table,
                                             << "Unable to create a RunInfo payload. Original Exception:\n"
                                             << e.what() << std::endl;
   }
-  delete session;
   
   sum= temp_sum;
   return sum;

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -2,6 +2,7 @@
 //#include "CondFormats/Common/interface/Time.h"
 #include "CondTools/RunInfo/interface/RunInfoRead.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/ITransaction.h"
@@ -62,16 +63,16 @@ RunInfoRead::readData( const std::string & runinfo_schema
   const boost::posix_time::ptime time0 = boost::posix_time::from_time_t(0);
   //if cursor is null setting null values  
   temp_sum.m_run = r_number;
-  std::cout << "entering readData" << std::endl;
+  edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Initialising Connection Pool" << std::endl;
   cond::persistency::ConnectionPool connection;
   connection.setParameters( m_connectionPset );
   connection.configure();
+  edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Initialising read-only session to " << m_connectionString << std::endl;
   std::shared_ptr<coral::ISessionProxy> session = connection.createCoralSession( m_connectionString, false );
   try{
     session->transaction().start( true );
-    std::cout << "starting session " << std::endl;
     coral::ISchema& schema = session->schema( runinfo_schema );
-    std::cout << " accessing schema " << runinfo_schema << std::endl;
+    edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Accessing schema " << runinfo_schema << std::endl;
     //new query to obtain the start_time
     std::unique_ptr<coral::IQuery> query( schema.newQuery() );
     query->addToTableList( sParameterTable );
@@ -90,29 +91,34 @@ RunInfoRead::readData( const std::string & runinfo_schema
     coral::ICursor& runStartCursor = query->execute();
     coral::TimeStamp start; //now all times are UTC!
     if( runStartCursor.next() ) {
-      //runStartCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      std::ostringstream osstartdebug;
+      runStartCursor.currentRow().toOutputStream( osstartdebug );
+      LogDebug( "RunInfoReader" ) << osstartdebug.str() << std::endl;
       const coral::AttributeList& row = runStartCursor.currentRow();
       start = row[ sValueDataColumn ].data<coral::TimeStamp>();
-      /*
-      std::cout << "start time extracted == " 
-                << "-->year " << start.year()
-                << "-- month " << start.month()
-                << "-- day " << start.day()
-                << "-- hour " << start.hour()
-                << "-- minute " << start.minute()
-                << "-- second " << start.second()
-                << "-- nanosecond " << start.nanosecond() 
-                << std::endl;
-      */
+      LogDebug( "RunInfoReader" ) << "UTC start time extracted == " 
+                                  << "-->year " << start.year()
+                                  << "-- month " << start.month()
+                                  << "-- day " << start.day()
+                                  << "-- hour " << start.hour()
+                                  << "-- minute " << start.minute()
+                                  << "-- second " << start.second()
+                                  << "-- nanosecond " << start.nanosecond() 
+                                  << std::endl;
       boost::posix_time::ptime start_ptime = start.time();
-      std::cout << "Posix time for run start: "<< start_ptime << std::endl;
       boost::posix_time::time_duration startTimeFromEpoch = start_ptime - time0;
       temp_sum.m_start_time_str = boost::posix_time::to_iso_extended_string(start_ptime);
       temp_sum.m_start_time_ll = startTimeFromEpoch.total_microseconds();
-      std::cout << "start time string extracted == " << temp_sum.m_start_time_str << std::endl; 
-      std::cout << "microsecond since Epoch (UTC) : " << temp_sum.m_start_time_ll << std::endl;    
+      std::ostringstream osstart;
+      osstart << "[RunInfoRead::" << __func__ << "]: Timestamp for start of run " << r_number << std::endl
+              << "Posix time: " << start_ptime << std::endl
+              << "ISO string: " << temp_sum.m_start_time_str << std::endl
+              << "Microsecond since Epoch (UTC): " << temp_sum.m_start_time_ll;
+      edm::LogInfo( "RunInfoReader" ) << osstart.str() << std::endl;
     }
     else {
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: run " << r_number
+                                      << " start time not found." << std::endl;
       temp_sum.m_start_time_str = "null";
       temp_sum.m_start_time_ll = -1;
     }
@@ -130,29 +136,34 @@ RunInfoRead::readData( const std::string & runinfo_schema
     coral::ICursor& runStopCursor = query->execute();
     coral::TimeStamp stop;
     if( runStopCursor.next() ) {
-      //runStopCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      std::ostringstream osstopdebug;
+      runStopCursor.currentRow().toOutputStream( osstopdebug );
+      LogDebug( "RunInfoReader" ) << osstopdebug.str() << std::endl;
       const coral::AttributeList& row = runStopCursor.currentRow();
-      stop = row[ sValueDataColumn ].data<coral::TimeStamp>(); 
-      /*
-      std::cout << "stop time extracted == " 
-                << "-->year " << stop.year()
-                << "-- month " << stop.month()
-                << "-- day " << stop.day()
-                << "-- hour " << stop.hour()
-                << "-- minute " << stop.minute()
-                << "-- second " << stop.second()
-                << "-- nanosecond " << stop.nanosecond() 
-                << std::endl;
-      */
+      stop = row[ sValueDataColumn ].data<coral::TimeStamp>();
+      LogDebug( "RunInfoReader" ) << "stop time extracted == " 
+                                  << "-->year " << stop.year()
+                                  << "-- month " << stop.month()
+                                  << "-- day " << stop.day()
+                                  << "-- hour " << stop.hour()
+                                  << "-- minute " << stop.minute()
+                                  << "-- second " << stop.second()
+                                  << "-- nanosecond " << stop.nanosecond() 
+                                  << std::endl;
       boost::posix_time::ptime stop_ptime = stop.time();
-      std::cout << "Posix time for run stop: "<< stop_ptime << std::endl;
       boost::posix_time::time_duration stopTimeFromEpoch = stop_ptime - time0;
       temp_sum.m_stop_time_str = boost::posix_time::to_iso_extended_string(stop_ptime);
       temp_sum.m_stop_time_ll = stopTimeFromEpoch.total_microseconds();
-      std::cout << "stop time string extracted == " << temp_sum.m_stop_time_str << std::endl; 
-      std::cout << "microsecond since Epoch (UTC) : " << temp_sum.m_stop_time_ll << std::endl;
+      std::ostringstream osstop;
+      osstop << "[RunInfoRead::" << __func__ << "]: Timestamp for stop of run " << r_number << std::endl
+             << "Posix time: " << stop_ptime << std::endl
+             << "ISO string: " << temp_sum.m_stop_time_str << std::endl
+             << "Microsecond since Epoch (UTC): " << temp_sum.m_stop_time_ll;
+      edm::LogInfo( "RunInfoReader" ) << osstop.str() << std::endl;
     }
     else {
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: run " << r_number
+                                      << " stop time not found." << std::endl;
       temp_sum.m_stop_time_str = "null";
       temp_sum.m_stop_time_ll = -1;
     }
@@ -170,15 +181,17 @@ RunInfoRead::readData( const std::string & runinfo_schema
     coral::ICursor& fedCursor = query->execute();
     std::string fed;
     if ( fedCursor.next() ) {
-      //fedCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      std::ostringstream osfeddebug;
+      fedCursor.currentRow().toOutputStream( osfeddebug );
+      LogDebug( "RunInfoReader" ) << osfeddebug.str() << std::endl;
       const coral::AttributeList& row = fedCursor.currentRow();
       fed = row[ sValueDataColumn ].data<std::string>();
     }
     else {
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: run " << r_number
+                                      << "has no FED included." << std::endl;
       fed="null";
-    }
-    //std::cout << "string fed emask == " << fed << std::endl;
-    
+    } 
     std::replace(fed.begin(), fed.end(), '%', ' ');
     std::stringstream stream(fed);
     for(;;) {
@@ -189,16 +202,18 @@ RunInfoRead::readData( const std::string & runinfo_schema
       int fedNumber; 
       int val;
       ss >> fedNumber >> val;
-      //std::cout << "fed:: " << fed << "--> val:: " << val << std::endl; 
+      LogDebug( "RunInfoReader" ) << "FED: " << fedNumber << " --> value: " << val << std::endl; 
       //val bit 0 represents the status of the SLINK, but 5 and 7 means the SLINK/TTS is ON but NA or BROKEN (see mail of alex....)
       if( (val & 0001) == 1 && (val != 5) && (val != 7) ) 
       temp_sum.m_fed_in.push_back(fedNumber);
-    } 
-    std::cout << "feds in run:--> ";
-    std::copy(temp_sum.m_fed_in.begin(), temp_sum.m_fed_in.end(), std::ostream_iterator<int>(std::cout, ", "));
-    std::cout << std::endl;
+    }
+    std::ostringstream osfed;
+    osfed << "[RunInfoRead::" << __func__ << "]: feds included in run " << r_number << ": ";
+    std::copy(temp_sum.m_fed_in.begin(), temp_sum.m_fed_in.end(), std::ostream_iterator<int>(osfed, ", "));
+    edm::LogInfo( "RunInfoReader" ) << osfed.str() << std::endl;
 
     //we connect now to the DCS schema in order to retrieve the magnet current
+    edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Accessing schema " << dcsenv_schema << std::endl;
     coral::ISchema& schema2 = session->schema( dcsenv_schema );
     query.reset( schema2.tableHandle( sDCSMagnetTable ).newQuery() );
     query->addToOutputList( squoted( sDCSMagnetCurrentColumn ), sDCSMagnetCurrentColumn );
@@ -214,14 +229,18 @@ RunInfoRead::readData( const std::string & runinfo_schema
     magnetCurrentBindVariableList[ "runstart_time" ].data<coral::TimeStamp>() = start;
     std::string magnetCurrentWhereClause;
     if(temp_sum.m_stop_time_str != "null") {
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Accessing the magnet currents measured during run " << r_number
+                                      << " between " << temp_sum.m_start_time_str
+                                      << " and " << temp_sum.m_stop_time_str << std::endl;
       magnetCurrentBindVariableList.extend<coral::TimeStamp>( "runstop_time" );
       magnetCurrentBindVariableList[ "runstop_time" ].data<coral::TimeStamp>() = stop;
-      magnetCurrentWhereClause = std::string( " NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
+      magnetCurrentWhereClause = std::string( "NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
                                  + sDCSMagnetChangeDateColumn + std::string( ">:runstart_time AND " ) 
                                  + sDCSMagnetChangeDateColumn + std::string( "<:runstop_time" );
     } else {
-      std::cout << "run stop null" << std::endl;
-      magnetCurrentWhereClause = std::string( " NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Accessing the magnet currents measured before run " << r_number
+                                      << "start time " << temp_sum.m_start_time_str << std::endl;
+      magnetCurrentWhereClause = std::string( "NOT " ) + squoted(sDCSMagnetCurrentColumn) + std::string( " IS NULL AND " )
                                  + sDCSMagnetChangeDateColumn + std::string( "<:runstart_time" );
     }
     query->setCondition( magnetCurrentWhereClause, magnetCurrentBindVariableList );
@@ -233,6 +252,8 @@ RunInfoRead::readData( const std::string & runinfo_schema
     std::vector<double> time_curr;
     if ( !magnetCurrentCursor.next() ) {
       // we should deal with stable currents... so the query is returning no value and we should take the last modified current value...
+      edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: The magnet current did not change during run " << r_number
+                                      << ". Looking for the most recent change before " << temp_sum.m_stop_time_str << std::endl;
       Bnotchanged = 1;
       std::unique_ptr<coral::IQuery> lastValueQuery( schema2.tableHandle(sDCSMagnetTable).newQuery() );
       lastValueQuery->addToOutputList( squoted(sDCSMagnetCurrentColumn), sDCSMagnetCurrentColumn );
@@ -246,10 +267,13 @@ RunInfoRead::readData( const std::string & runinfo_schema
       lastValueQuery->addToOrderList( sDCSMagnetChangeDateColumn + std::string( " DESC" ) );
       coral::ICursor& lastValueCursor = lastValueQuery->execute();
       if( lastValueCursor.next() ) {
-        //lastValueCursor.currentRow().toOutputStream(std::cout) << std::endl;
+        std::ostringstream oslastvaluedebug;
+        lastValueCursor.currentRow().toOutputStream( oslastvaluedebug );
+        LogDebug( "RunInfoReader" ) << oslastvaluedebug.str() << std::endl;
         const coral::AttributeList& row = lastValueCursor.currentRow();
         last_current = row[sDCSMagnetCurrentColumn].data<float>();
-        std::cout << "previos run(s) current, not changed in this run... " << last_current << std::endl;
+        edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Magnet current of previos run(s), not changed during run " << r_number
+                                        << ": " << last_current << std::endl;
       }
       temp_sum.m_avg_current = last_current;
       temp_sum.m_min_current = last_current;
@@ -258,47 +282,52 @@ RunInfoRead::readData( const std::string & runinfo_schema
       temp_sum.m_start_current = last_current; 
     }
     while( magnetCurrentCursor.next() ) {
-      //magnetCurrentCursor.currentRow().toOutputStream(std::cout) << std::endl;
+      std::ostringstream oscurrentdebug;
+      magnetCurrentCursor.currentRow().toOutputStream( oscurrentdebug );
+      LogDebug( "RunInfoReader" ) << oscurrentdebug.str() << std::endl;
       const coral::AttributeList& row = magnetCurrentCursor.currentRow();
       lastCurrentDate = row[sDCSMagnetChangeDateColumn].data<coral::TimeStamp>();
       temp_sum.m_current.push_back( row[sDCSMagnetCurrentColumn].data<float>() );
       if(temp_sum.m_stop_time_str == "null") break;
-      /*
-      std::cout << "  last current time extracted == " 
-                << "-->year " << lastCurrentDate.year()
-                << "-- month " << lastCurrentDate.month()
-                << "-- day " << lastCurrentDate.day()
-                << "-- hour " << lastCurrentDate.hour() 
-                << "-- minute " << lastCurrentDate.minute() 
-                << "-- second " << lastCurrentDate.second()
-                << "-- nanosecond " << lastCurrentDate.nanosecond()
-                << std::endl;
-      */
+      LogDebug( "RunInfoReader" ) << "  last current time extracted == " 
+                                  << "-->year " << lastCurrentDate.year()
+                                  << "-- month " << lastCurrentDate.month()
+                                  << "-- day " << lastCurrentDate.day()
+                                  << "-- hour " << lastCurrentDate.hour() 
+                                  << "-- minute " << lastCurrentDate.minute() 
+                                  << "-- second " << lastCurrentDate.second()
+                                  << "-- nanosecond " << lastCurrentDate.nanosecond()
+                                  << std::endl;
       boost::posix_time::ptime lastCurrentDate_ptime = lastCurrentDate.time();
-      std::cout << "Posix time for last current time: " << lastCurrentDate_ptime << std::endl;
       boost::posix_time::time_duration lastCurrentDateTimeFromEpoch = lastCurrentDate_ptime - time0;
       last_date = boost::posix_time::to_iso_extended_string(lastCurrentDate_ptime);
-      std::cout << "last current time extracted  == " << last_date << std::endl;
       long long last_date_ll = lastCurrentDateTimeFromEpoch.total_microseconds();
       time_curr.push_back(last_date_ll);
+      std::ostringstream ostrans;
+      ostrans << "[RunInfoRead::" << __func__ << "]: Transition of the magnet current " << std::endl
+              << "New value: " << row[sDCSMagnetCurrentColumn].data<float>() << std::endl
+              << "Posix time for the transition timestamp: " << lastCurrentDate_ptime << std::endl
+              << "ISO string for the transition timestamp: " << last_date << std::endl
+              << "Microseconds since Epoch (UTC) for the transition timestamp: " << last_date_ll;
+      edm::LogInfo( "RunInfoReader" ) << ostrans.str() << std::endl;
     }
     
     size_t csize = temp_sum.m_current.size();
-    std::cout << "size of currents  " << csize << std::endl;  
     size_t tsize = time_curr.size(); 
-    std::cout << "size of time " << tsize << std::endl;
-    if(csize != tsize) { 
-      std::cout<< "current and time not filled correctly" << std::endl;
+    edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: size of time: " << tsize
+                                    << ", size of currents: " << csize << std::endl;  
+    if(csize != tsize) {
+      edm::LogWarning( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: current and time not filled correctly." << std::endl;
     }
     if(tsize > 1) { 
       temp_sum.m_run_intervall_micros = time_curr.front() - time_curr.back();
     } else { 
       temp_sum.m_run_intervall_micros = 0;
     }
-    std::cout << "change current during run interval in microseconds " << temp_sum.m_run_intervall_micros << std::endl;
+    edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: Duration in microseconds of the magnet ramp during run " << r_number
+                                    << ": " << temp_sum.m_run_intervall_micros << std::endl;
     
     double wi = 0;
-    //std::vector<double> v_wi;
     double sumwixi = 0;
     double sumwi = 0;
     float min = -1;
@@ -308,37 +337,36 @@ RunInfoRead::readData( const std::string & runinfo_schema
       min = temp_sum.m_current.front();
       max = temp_sum.m_current.front();
       for(size_t i = 0; i < csize; ++i) {
-        std::cout << "--> " << temp_sum.m_current[i] << std::endl;
         if( (tsize > 1) && ( i < csize - 1 ) ) { 
           wi = (time_curr[i] - time_curr[i+1]);
           temp_sum.m_times_of_currents.push_back(wi);
-          //v_wi.push_back(wi);
           sumwixi += wi * temp_sum.m_current[i] ;
           sumwi += wi;
         }
         min = std::min(min, temp_sum.m_current[i]);
         max = std::max(max, temp_sum.m_current[i]);
       }
-      //for (size_t i = 0; i < v_wi.size(); ++i) {
-      for (size_t i = 0; i < temp_sum.m_times_of_currents.size(); ++i){
-        std::cout << "wi " << temp_sum.m_times_of_currents[i] << std::endl;
-      }
-      temp_sum.m_start_current = temp_sum.m_current.back(); //temp_sum.m_current[csize - 1];
-      std::cout << "--> " << "start cur " << temp_sum.m_start_current << std::endl;
-      temp_sum.m_stop_current = temp_sum.m_current.front(); //temp_sum.m_current[0];
-      std::cout<< "--> " << "stop cur " << temp_sum.m_stop_current << std::endl;
+      std::ostringstream oswi;
+      oswi << "[RunInfoRead::" << __func__ << "]: Duration of current values in run " << r_number << ": ";
+      std::copy(temp_sum.m_times_of_currents.begin(), temp_sum.m_times_of_currents.end(), std::ostream_iterator<float>(oswi, ", "));
+      edm::LogInfo( "RunInfoReader" ) << oswi.str() << std::endl;
+      temp_sum.m_start_current = temp_sum.m_current.back();
+      LogDebug( "RunInfoReader" ) << "start current: " << temp_sum.m_start_current << std::endl;
+      temp_sum.m_stop_current = temp_sum.m_current.front();
+      LogDebug( "RunInfoReader" ) << "stop current: " << temp_sum.m_stop_current << std::endl;
       if (tsize>1) {
         temp_sum.m_avg_current=sumwixi/sumwi;
       } else { 
         temp_sum.m_avg_current= temp_sum.m_start_current; 
       }
-      std::cout<< "--> " << "avg cur  " << temp_sum.m_avg_current << std::endl;
+      LogDebug( "RunInfoReader" ) << "average current: " << temp_sum.m_avg_current << std::endl;
       temp_sum.m_max_current= max;
-      std::cout<< "--> " << "max cur  " << temp_sum.m_max_current << std::endl;
+      LogDebug( "RunInfoReader" ) << "maximum current: " << temp_sum.m_max_current << std::endl;
       temp_sum.m_min_current= min;
-      std::cout<< "--> " << "min cur  " << temp_sum.m_min_current << std::endl;
+      LogDebug( "RunInfoReader" ) << "minimum current: " << temp_sum.m_min_current << std::endl;
     } else {
       if (!Bnotchanged) {
+        edm::LogWarning( "RunInfoReader" ) << "Inserting fake values for magnet current." << std::endl;
         temp_sum.m_avg_current = -1;
         temp_sum.m_min_current = -1;
         temp_sum.m_max_current = -1;
@@ -346,12 +374,14 @@ RunInfoRead::readData( const std::string & runinfo_schema
         temp_sum.m_start_current = -1;
       }
     }
-    
-    std::cout << "temp_sum.m_avg_current " << temp_sum.m_avg_current << std::endl;
-    std::cout << "temp_sum.m_min_current " << temp_sum.m_min_current << std::endl;
-    std::cout << "temp_sum.m_max_current " << temp_sum.m_max_current << std::endl;
-    std::cout << "temp_sum.m_stop_current " << temp_sum.m_stop_current << std::endl;
-    std::cout << "temp_sum.m_start_current " << temp_sum.m_start_current << std::endl;
+    std::ostringstream oscurr;
+    oscurr << "[RunInfoRead::" << __func__ << "]: Values of currents for run " << r_number << std::endl;
+    oscurr << "Average current (A): " << temp_sum.m_avg_current << std::endl;
+    oscurr << "Minimum current (A): " << temp_sum.m_min_current << std::endl;
+    oscurr << "Maximum current (A): " << temp_sum.m_max_current << std::endl;
+    oscurr << "Current at run stop (A): " << temp_sum.m_stop_current << std::endl;
+    oscurr << "Current at run start (A): " << temp_sum.m_start_current;
+    edm::LogInfo( "RunInfoReader" ) << oscurr.str() << std::endl;
     
     session->transaction().commit();
   }

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -55,7 +55,6 @@ RunInfo
 RunInfoRead::readData( const std::string & runinfo_schema
 		     , const std::string & dcsenv_schema
                      , const int r_number ) {
-  RunInfo  sum;
   RunInfo temp_sum;
   //for B currents...
   bool Bnotchanged = 0;
@@ -362,6 +361,5 @@ RunInfoRead::readData( const std::string & runinfo_schema
                                             << e.what() << std::endl;
   }
   
-  sum= temp_sum;
-  return sum;
+  return temp_sum;
 }

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -45,7 +45,7 @@ namespace {
 }
 
 RunInfoRead::RunInfoRead( const std::string& connectionString
-			, const edm::ParameterSet& connectionPset ):
+                        , const edm::ParameterSet& connectionPset ):
    m_connectionString( connectionString )
   ,m_connectionPset( connectionPset ) {}
 
@@ -53,7 +53,7 @@ RunInfoRead::~RunInfoRead() {}
 
 RunInfo 
 RunInfoRead::readData( const std::string & runinfo_schema
-		     , const std::string & dcsenv_schema
+                     , const std::string & dcsenv_schema
                      , const int r_number ) {
   RunInfo temp_sum;
   //for B currents...
@@ -95,14 +95,14 @@ RunInfoRead::readData( const std::string & runinfo_schema
       start = row[ sValueDataColumn ].data<coral::TimeStamp>();
       /*
       std::cout << "start time extracted == " 
-		<< "-->year " << start.year()
-		<< "-- month " << start.month()
-		<< "-- day " << start.day()
-		<< "-- hour " << start.hour()
-		<< "-- minute " << start.minute()
-		<< "-- second " << start.second()
-		<< "-- nanosecond " << start.nanosecond() 
-		<< std::endl;
+                << "-->year " << start.year()
+                << "-- month " << start.month()
+                << "-- day " << start.day()
+                << "-- hour " << start.hour()
+                << "-- minute " << start.minute()
+                << "-- second " << start.second()
+                << "-- nanosecond " << start.nanosecond() 
+                << std::endl;
       */
       boost::posix_time::ptime start_ptime = start.time();
       std::cout << "Posix time for run start: "<< start_ptime << std::endl;
@@ -113,8 +113,8 @@ RunInfoRead::readData( const std::string & runinfo_schema
       std::cout << "microsecond since Epoch (UTC) : " << temp_sum.m_start_time_ll << std::endl;    
     }
     else {
-	temp_sum.m_start_time_str = "null";
-	temp_sum.m_start_time_ll = -1;
+      temp_sum.m_start_time_str = "null";
+      temp_sum.m_start_time_ll = -1;
     }
     
     //new query to obtain the stop_time
@@ -135,14 +135,14 @@ RunInfoRead::readData( const std::string & runinfo_schema
       stop = row[ sValueDataColumn ].data<coral::TimeStamp>(); 
       /*
       std::cout << "stop time extracted == " 
-		<< "-->year " << stop.year()
-		<< "-- month " << stop.month()
-		<< "-- day " << stop.day()
-		<< "-- hour " << stop.hour()
-		<< "-- minute " << stop.minute()
-		<< "-- second " << stop.second()
-		<< "-- nanosecond " << stop.nanosecond() 
-		<< std::endl;
+                << "-->year " << stop.year()
+                << "-- month " << stop.month()
+                << "-- day " << stop.day()
+                << "-- hour " << stop.hour()
+                << "-- minute " << stop.minute()
+                << "-- second " << stop.second()
+                << "-- nanosecond " << stop.nanosecond() 
+                << std::endl;
       */
       boost::posix_time::ptime stop_ptime = stop.time();
       std::cout << "Posix time for run stop: "<< stop_ptime << std::endl;
@@ -192,7 +192,7 @@ RunInfoRead::readData( const std::string & runinfo_schema
       //std::cout << "fed:: " << fed << "--> val:: " << val << std::endl; 
       //val bit 0 represents the status of the SLINK, but 5 and 7 means the SLINK/TTS is ON but NA or BROKEN (see mail of alex....)
       if( (val & 0001) == 1 && (val != 5) && (val != 7) ) 
-	temp_sum.m_fed_in.push_back(fedNumber);
+      temp_sum.m_fed_in.push_back(fedNumber);
     } 
     std::cout << "feds in run:--> ";
     std::copy(temp_sum.m_fed_in.begin(), temp_sum.m_fed_in.end(), std::ostream_iterator<int>(std::cout, ", "));
@@ -246,10 +246,10 @@ RunInfoRead::readData( const std::string & runinfo_schema
       lastValueQuery->addToOrderList( sDCSMagnetChangeDateColumn + std::string( " DESC" ) );
       coral::ICursor& lastValueCursor = lastValueQuery->execute();
       if( lastValueCursor.next() ) {
-	//lastValueCursor.currentRow().toOutputStream(std::cout) << std::endl;
-	const coral::AttributeList& row = lastValueCursor.currentRow();
-	last_current = row[sDCSMagnetCurrentColumn].data<float>();
-	std::cout << "previos run(s) current, not changed in this run... " << last_current << std::endl;
+        //lastValueCursor.currentRow().toOutputStream(std::cout) << std::endl;
+        const coral::AttributeList& row = lastValueCursor.currentRow();
+        last_current = row[sDCSMagnetCurrentColumn].data<float>();
+        std::cout << "previos run(s) current, not changed in this run... " << last_current << std::endl;
       }
       temp_sum.m_avg_current = last_current;
       temp_sum.m_min_current = last_current;
@@ -265,14 +265,14 @@ RunInfoRead::readData( const std::string & runinfo_schema
       if(temp_sum.m_stop_time_str == "null") break;
       /*
       std::cout << "  last current time extracted == " 
-		<< "-->year " << lastCurrentDate.year()
-	        << "-- month " << lastCurrentDate.month()
-	        << "-- day " << lastCurrentDate.day()
-		<< "-- hour " << lastCurrentDate.hour() 
-		<< "-- minute " << lastCurrentDate.minute() 
-		<< "-- second " << lastCurrentDate.second()
-		<< "-- nanosecond " << lastCurrentDate.nanosecond()
-		<< std::endl;
+                << "-->year " << lastCurrentDate.year()
+                << "-- month " << lastCurrentDate.month()
+                << "-- day " << lastCurrentDate.day()
+                << "-- hour " << lastCurrentDate.hour() 
+                << "-- minute " << lastCurrentDate.minute() 
+                << "-- second " << lastCurrentDate.second()
+                << "-- nanosecond " << lastCurrentDate.nanosecond()
+                << std::endl;
       */
       boost::posix_time::ptime lastCurrentDate_ptime = lastCurrentDate.time();
       std::cout << "Posix time for last current time: " << lastCurrentDate_ptime << std::endl;
@@ -308,29 +308,29 @@ RunInfoRead::readData( const std::string & runinfo_schema
       min = temp_sum.m_current.front();
       max = temp_sum.m_current.front();
       for(size_t i = 0; i < csize; ++i) {
-	std::cout << "--> " << temp_sum.m_current[i] << std::endl;
-	if( (tsize > 1) && ( i < csize - 1 ) ) { 
-	  wi = (time_curr[i] - time_curr[i+1])  ;
-	  temp_sum.m_times_of_currents.push_back(wi);
-	  //v_wi.push_back(wi);
-	  sumwixi += wi * temp_sum.m_current[i] ;
-	  sumwi += wi;
-	}  
-	min = std::min(min, temp_sum.m_current[i]);
-	max = std::max(max, temp_sum.m_current[i]);
+        std::cout << "--> " << temp_sum.m_current[i] << std::endl;
+        if( (tsize > 1) && ( i < csize - 1 ) ) { 
+          wi = (time_curr[i] - time_curr[i+1]);
+          temp_sum.m_times_of_currents.push_back(wi);
+          //v_wi.push_back(wi);
+          sumwixi += wi * temp_sum.m_current[i] ;
+          sumwi += wi;
+        }
+        min = std::min(min, temp_sum.m_current[i]);
+        max = std::max(max, temp_sum.m_current[i]);
       }
       //for (size_t i = 0; i < v_wi.size(); ++i) {
       for (size_t i = 0; i < temp_sum.m_times_of_currents.size(); ++i){
-	std::cout << "wi " << temp_sum.m_times_of_currents[i] << std::endl;
+        std::cout << "wi " << temp_sum.m_times_of_currents[i] << std::endl;
       }
       temp_sum.m_start_current = temp_sum.m_current.back(); //temp_sum.m_current[csize - 1];
       std::cout << "--> " << "start cur " << temp_sum.m_start_current << std::endl;
       temp_sum.m_stop_current = temp_sum.m_current.front(); //temp_sum.m_current[0];
       std::cout<< "--> " << "stop cur " << temp_sum.m_stop_current << std::endl;
       if (tsize>1) {
-	temp_sum.m_avg_current=sumwixi/sumwi;
+        temp_sum.m_avg_current=sumwixi/sumwi;
       } else { 
-	temp_sum.m_avg_current= temp_sum.m_start_current; 
+        temp_sum.m_avg_current= temp_sum.m_start_current; 
       }
       std::cout<< "--> " << "avg cur  " << temp_sum.m_avg_current << std::endl;
       temp_sum.m_max_current= max;
@@ -339,11 +339,11 @@ RunInfoRead::readData( const std::string & runinfo_schema
       std::cout<< "--> " << "min cur  " << temp_sum.m_min_current << std::endl;
     } else {
       if (!Bnotchanged) {
-	temp_sum.m_avg_current = -1;
-	temp_sum.m_min_current = -1;
-	temp_sum.m_max_current = -1;
-	temp_sum.m_stop_current = -1;
-	temp_sum.m_start_current = -1;
+        temp_sum.m_avg_current = -1;
+        temp_sum.m_min_current = -1;
+        temp_sum.m_max_current = -1;
+        temp_sum.m_stop_current = -1;
+        temp_sum.m_start_current = -1;
       }
     }
     

--- a/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
+++ b/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
@@ -51,9 +51,14 @@ OMDSDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messag
 process = cms.Process( "RunInfoPopulator" )
 
 process.MessageLogger = cms.Service( "MessageLogger"
-                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
                                    , destinations = cms.untracked.vstring( 'cout' )
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
                                      )
+
+if options.messageLevel == 3:
+    #enable LogDebug output: remember the USER_CXXFLAGS="-DEDM_ML_DEBUG" compilation flag!
+    process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string( 'DEBUG' ) )
+    process.MessageLogger.debugModules = cms.untracked.vstring( '*' )
 
 process.source = cms.Source( "EmptyIOVSource"
                            , lastValue = cms.uint64( options.runNumber )

--- a/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
+++ b/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
@@ -45,6 +45,9 @@ options.parseArguments()
 CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
 CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
 
+OMDSDBConnection = CondDB.clone( connect = cms.string( sourceConnection ) )
+OMDSDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
 process = cms.Process( "RunInfoPopulator" )
 
 process.MessageLogger = cms.Service( "MessageLogger"
@@ -71,8 +74,8 @@ process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
 process.popConRunInfo = cms.EDAnalyzer( "RunInfoPopConAnalyzer"
                                       , SinceAppendMode = cms.bool( True )
                                       , record = cms.string( 'RunInfoRcd' )
-                                      , Source = cms.PSet( runNumber = cms.uint64( options.runNumber )
-                                                         , connectionString = cms.untracked.string( sourceConnection )
+                                      , Source = cms.PSet( OMDSDBConnection
+                                                         , runNumber = cms.uint64( options.runNumber )
                                                            )
                                       , loggingOn = cms.untracked.bool( True )
                                       , targetDBConnectionString = cms.untracked.string( options.targetConnection )

--- a/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
+++ b/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 from CondCore.CondDB.CondDB_cfi import *
 
-sourceConnection = 'oracle://cms_omds_adg/CMS_RUNINFO'
+sourceConnection = 'oracle://cms_omds_adg/CMS_RUNINFO_R'
 if socket.getfqdn().find('.cms') != -1:
-    sourceConnection = 'oracle://cms_omds_lb/CMS_RUNINFO'
+    sourceConnection = 'oracle://cms_omds_lb/CMS_RUNINFO_R'
 
 options = VarParsing.VarParsing()
 options.register( 'runNumber'
@@ -73,9 +73,6 @@ process.popConRunInfo = cms.EDAnalyzer( "RunInfoPopConAnalyzer"
                                       , record = cms.string( 'RunInfoRcd' )
                                       , Source = cms.PSet( runNumber = cms.uint64( options.runNumber )
                                                          , connectionString = cms.untracked.string( sourceConnection )
-                                                         , authenticationPath = cms.untracked.string ( '' )
-                                                         , OnlineDBUser = cms.untracked.string( 'CMS_RUNINFO_R' )
-                                                         , OnlineDBPass = cms.untracked.string( 'PASSWORD' )
                                                            )
                                       , loggingOn = cms.untracked.bool( True )
                                       , targetDBConnectionString = cms.untracked.string( options.targetConnection )


### PR DESCRIPTION
The RunInfo O2O has been modified: 
- Make the tag population in synch with the `CondDBv2` tag policy. In https://github.com/diguida/cmssw/blob/fix_RunInfo_and_PopCon/CondCore/CondDB/src/IOVEditor.cc#L189-L201, as specified in the comment too, if the tag has synchronisation `ANY` or `VALIDATION`, IOV insertion in the past or overriding are allowed, while they are forbidden (an exception is thrown) for "production" tags. The RunInfo code is now protected so that it first tests the input run number against the last IOV of the target tag: if the new run number is smaller than or equal to the latest IOV in the target tag, the job exits, and no new IOVs are added irrespectively of the synchronisation;
- Use `CondCore` API as defined in `ConnectionPool` in order to authenticate `Oracle` access via roles, instead of the `CORAL` API in `RelationalAccess`;
- Improve queries by performing joins on PK-FK (query time improved by factor 2);
- Throw exceptions in case CORAL fails to execute a query;
- Improve logging messages;
- Improve code style;
- Review the configuration file to be fully complaint with the O2O online framework.

Removed a dead data member in PopCon.

Added a comment in `CondCore/CondDB/src/IOVEditor.cc` clarifying the tag update policy w.r.t. tag synchronisation.
