### PR TITLE
Fixing L1 seed module name

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -133,7 +133,7 @@ HLTriggerJSONMonitoring::resetRun(bool changed){
       const std::vector<std::string> & moduleLabels(hltConfig_.moduleLabels(i));
       for (unsigned int j = 0; j < moduleLabels.size(); ++j) {
 	const std::string & label = hltConfig_.moduleType(moduleLabels[j]);
-	if (label == "HLTLevel1GTSeed")
+	if (label == "HLTL1TSeed")
 	  posL1s_[i] = j;
 	else if (label == "HLTPrescaler")
 	  posPre_[i] = j;


### PR DESCRIPTION
This PR corrects the module used as a means of calculating the rate after the L1 seed. In the release currently online, the name of this module still refers to the Stage 1 version causing artificially high post-L1 seed rates.
