### PR TITLE
Fix explicit GzInputStream::operator bool() const

### DIFF
--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -43,7 +43,7 @@ struct GzInputStream
    { gzclose(gzf) ; }
   explicit operator bool() const
   {
-    return ((eof == true) ? false : iss.fail());
+    return ((eof == true) ? false : !iss.fail());
   }
  } ;
 


### PR DESCRIPTION
A bug was introduced by PR 11308.

We need to return "!fail()".

Reported-by: Stefano Argiro' stefano.argiro@cern.ch
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
