### PR TITLE
SIMDVec: enable USE_SSEVECT for __INTEL_COMPILER

### DIFF
--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -1,8 +1,8 @@
 #ifndef DataFormat_Math_SIMDVec_H
 #define DataFormat_Math_SIMDVec_H
 
-#if ( defined(IN_DICTBUILD) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16) || defined(__INTEL_COMPILER)
-#elif defined(__GNUC__) || defined(__clang__)
+#if ( defined(IN_DICTBUILD) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
+#elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #  if defined(__x86_64__) && defined(__SSE__)
 #    define USE_SSEVECT
 #  else


### PR DESCRIPTION
There are no record why this was disabled on ICC. Thus ICC was using
`oldBasic3DVector.h`, but it's not compile with SSE and EXT
implementation thus causing build errors in
RecoParticleFlow/PFClusterTools:

```
RecoParticleFlow/PFClusterTools/src/LinkByRecHit.cc(9): error: class
"Basic2DVector<double>" has no member "v"
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
