### PR TITLE
Fix ordering bug in reworked PFBlockAlgo

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -164,7 +164,7 @@ void PFBlockAlgo::findBlocks() {
   QuickUnion qu(bare_elements_.size());
   const auto elem_size = bare_elements_.size();
   for( unsigned i = 0; i < elem_size; ++i ) {
-    for( unsigned j = i+1; j < elem_size; ++j ) {
+    for( unsigned j = 0; j < i; ++j ) {
       if( !_linkTests[_linkTestSquare[bare_elements_[i]->type()][bare_elements_[j]->type()]] ) {
         j = ranges_[bare_elements_[j]->type()].second;
         continue;

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -189,7 +189,7 @@ void PFBlockAlgo::findBlocks() {
   for( unsigned i = 0; i < elements_.size(); ++i ) {
     unsigned key = qu.find(i);
     auto pos  = std::lower_bound(keys.begin(),keys.end(),key);
-    if( *pos != key || 0 == keys.size() ) {
+    if( pos == keys.end() || *pos != key ) {
       keys.insert(pos,key);      
     }
     blocksmap.emplace(key,i);


### PR DESCRIPTION
This ordering bug was causing crashes in relvals for 810pre4.

I have checked in a few cases that the exceptions are no longer thrown.
Notably, in these cases more blocks were being created than with the old algorithm.
With the bugfix provided here, the old behavior is restored.
