### PR TITLE
Move CaloTowerDetId selection rules to DataFormats/CaloTowers

### DIFF
--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -35,6 +35,8 @@
   <class name="std::vector<edm::FwdPtr<CaloTower> >"/>
 
   <class name="std::vector<CaloTowerDetId>"/>
+  <class name="std::pair<uint8_t, CaloTowerDetId>"/>
+  <class name="std::vector<std::pair<uint8_t, CaloTowerDetId> >"/>
 
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
   <class name="edm::AtomicPtrCache<std::vector<CaloTowerPtr> >">

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -174,8 +174,6 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
-  <class name="std::pair<uint8_t, CaloTowerDetId>"/>
-  <class name="std::vector<std::pair<uint8_t, CaloTowerDetId> >"/>
   <class name="HaloTowerStrip" ClassVersion="3">
    <version ClassVersion="3" checksum="3149281836"/>
    <version ClassVersion="2" checksum="665188928"/>


### PR DESCRIPTION
Found by `duplicateReflexLibrarySearch.py --dir ./ --lostDefs`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
