### PR TITLE
ReferenceCounted* must always be the first in base class list

### DIFF
--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="TrackingTools/PatternTools"/>
 
 <use   name="clhepheader"/>
 <export>

--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -39,8 +39,8 @@ using TangentPlane = Plane;
  *  (e.g. Plane or Cylinder).
  */
 
-class Surface : public GloballyPositioned<float> 
-	      , public ReferenceCountedInConditions 
+class Surface : public ReferenceCountedInConditions
+              , public GloballyPositioned<float>
 {
 public:
   using Side =  SurfaceOrientation::Side;


### PR DESCRIPTION
In CMSSW with ICC 17.0 Beta we have a number of edmWriteConfigs
segfaults.

Interesting files are these (in order):
- DataFormats/GeometrySurface/interface/ReferenceCounted.h
- DataFormats/GeometrySurface/interface/Surface.h
- DataFormats/GeometrySurface/interface/Plane.h
- DataFormats/GeometrySurface/interface/BoundDisk.h
- TrackingTools/GeomPropagators/src/TrackerBounds.cc

`TrackerBounds.cc` contains static `ReferenceCountingPointer` which are
constructer at `dlopen()` time. These are basically
`boost::intrusive_ptr`.

We have:

```
┌─────────┐
│  Disk   │
└─────────┘
     ▲
     │
┌─────────┐
│  Plane  │
└─────────┘
     ▲
     │
┌─────────┐
│ Surface │
└─────────┘
     ▲
     │
     └─────────┬───────────────────────────────────┐
               │                                   │
               │                                   │
┌─────────────────────────────┐  ┌──────────────────────────────────┐
│  GloballyPositioned<float>  │  │   ReferenceCountedInConditions   │
│                             │  │   (is a BasicReferenceCounted)   │
└─────────────────────────────┘  └──────────────────────────────────┘
                                                   ▲
                                                   ║
                                                   ║
                          ╔════════════════════════╩════════════════╗
                          ║BasicReferenceCounted is responsible for ║
                          ║keeping reference count and destroying   ║
                          ║object once reference count drops to     ║
                          ║zero. Simply put handles                 ║
                          ║boost::intrusive_ptr.                    ║
                          ╚═════════════════════════════════════════╝
```

Note that `Surface` has multiple inheritance and
`ReferenceCountedInConditions` is the second in base class list.

The way C++ works:
- `Disk`, `Plane`, `Surface`, `GloballyPositioned<float>` will have the
  same `this` pointer.
- `ReferenceCountedInConditions` will at specific delta from previous
  `this`, i.e. its `this` pointer does not point to `Disk` object, but to
  some location in `Disk` allocation.

Now then time comes to destroy `Disk` object via `boost::intrusive_ptr`
mechanism we will be providing a wrong address to `free()`:

```
Invalid free() / delete / delete[] / realloc()
   at 0x4029134: operator delete(void*) (in /cvmfs/cms-ib.cern.ch/2016-20/slc6_amd64_gcc530/external/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0xFA29809: BasicReferenceCounted::removeReference() const (ReferenceCounted.h:48)
   by 0xFA28FDC: intrusive_ptr_release(BasicReferenceCounted const*) (ReferenceCounted.h:86)
   by 0xFA3AB60: boost::intrusive_ptr<Disk>::~intrusive_ptr() (intrusive_ptr.hpp:97)
   by 0xFA3AB7B: boost::intrusive_ptr<Disk>::~intrusive_ptr() (intrusive_ptr.hpp:95)
   by 0xFA3A0F9: ReferenceCountingPointer<Disk>::~ReferenceCountingPointer() (ReferenceCounted.h:63)
   by 0x70BBB21: exit (in /lib64/libc-2.12.so)
   by 0x70A4D63: (below main) (in /lib64/libc-2.12.so)
 Address 0x2e4c4798 is 8 bytes inside a block of size 128 alloc'd
   at 0x4028108: operator new(unsigned long) (in /cvmfs/cms-ib.cern.ch/2016-20/slc6_amd64_gcc530/external/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0xFA39D3F: _INTERNAL_105__mnt_build_davidlt_CMSSW_8_1_ICC_X_2016_05_09_2300_src_TrackingTools_GeomPropagators_src_TrackerBounds_cc_f6781c7c::initPositive() (TrackerBounds.cc:35)
   by 0xFA3A014: __sti___ZN13TrackerBounds15thePositiveDiskE (TrackerBounds.cc:49)
   by 0xFA39FB9: __sti__$E (TrackerBounds.cc:47)
   by 0x400E66E: call_init (dl-init.c:85)
   by 0x400E66E: _dl_init (dl-init.c:134)
   by 0x4012DC4: dl_open_worker (dl-open.c:496)
   by 0x400E285: _dl_catch_error (dl-error.c:178)
   by 0x4012599: _dl_open (dl-open.c:587)
   by 0x6643F65: dlopen_doit (in /lib64/libdl-2.12.so)
   by 0x400E285: _dl_catch_error (dl-error.c:178)
   by 0x664429B: _dlerror_run (in /lib64/libdl-2.12.so)
   by 0x6643EE0: dlopen@@GLIBC_2.2.5 (in /lib64/libdl-2.12.so)
```

Then our memory allocation will fail:

```
*** glibc detected *** edmWriteConfigs: free(): invalid pointer: 0x0000000004893e38 ***
```

If we make `ReferenceCountedInConditions` the first in base class it, it
will have a matching `this` pointer to `Disk` object being created.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
