### PR TITLE
Monitor CASTOR table data (80X)

### DIFF
--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -142,6 +142,11 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       setField (1, calibId.ieta());
       setField (2, calibId.iphi());
       setField (3, -999);
+    } else if (calibId.calibFlavor()==HcalCalibDetId::uMNqie) {
+      flavorName="UMNQIE";
+      setField (1, calibId.channel());
+      setField (2, -999);
+      setField (3, -999);
     }
   }
   else {
@@ -215,6 +220,10 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     int ieta=getField(1);
     int iphi=getField(2);
     mId = HcalCalibDetId (ieta,iphi);
+  }
+  else if (flavorName=="UMNQIE") {
+    int channel=getField(1);
+    mId = HcalCalibDetId (HcalCalibDetId::uMNqie,channel);
   }
   else if (flavorName == "NA") {
     mId = HcalDetId::Undefined;

--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -147,6 +147,11 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       setField (1, calibId.channel());
       setField (2, -999);
       setField (3, -999);
+    } else if (calibId.calibFlavor()==HcalCalibDetId::CastorRadFacility) {
+      flavorName="CRF";
+      setField (1, calibId.rm());
+      setField (2, calibId.fiber());
+      setField (3, calibId.channel());
     }
   }
   else {
@@ -224,6 +229,12 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
   else if (flavorName=="UMNQIE") {
     int channel=getField(1);
     mId = HcalCalibDetId (HcalCalibDetId::uMNqie,channel);
+  }
+  else if (flavorName=="CRF") {
+    int rm=getField(1);
+    int fiber=getField(2);
+    int channel=getField(3);
+    mId = HcalCalibDetId (HcalCalibDetId::CastorRadFacility,rm,fiber,channel);
   }
   else if (flavorName == "NA") {
     mId = HcalDetId::Undefined;

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -22,12 +22,15 @@
   *     [10:7] ieta
   *     [6:0] Iphi
   *
+  *  For uMNqie channels:
+  *     [0] channel (two possible)
+  *
   * \author J. Mans - Minnesota
   */
 class HcalCalibDetId : public HcalOtherDetId {
 public:
   /** Type identifier within calibration det ids */
-  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2 };
+  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3 };
 
   /** Create a null det id */
   HcalCalibDetId();

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -5,11 +5,10 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalOtherDetId.h"
 
-
 /** \class HcalCalibDetId
   *  
   *  Contents of the HcalCalibDetId :
-  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HX, 3=uMNio/qie)
+  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HX, 3=uMNio/qie, 4=CastorRad)
   *
   *  For CalibUnit:
   *     [16:14] Subdetector
@@ -20,17 +19,23 @@
   *  For HX (HOCrosstalk) channels:
   *     [11] side (true = positive)
   *     [10:7] ieta
-  *     [6:0] Iphi
+  *     [6:0] iphi
   *
   *  For uMNqie channels:
   *     [7:0] channel (typically just 0 or 1, but space for more if needed)
+  *
+  *  For Castor Radiation Facility:
+  *     [16:10] RM
+  *     [9:5] fiber-in-rm
+  *     [4:0] channel-on-fiber
+  *     
   *
   * \author J. Mans - Minnesota
   */
 class HcalCalibDetId : public HcalOtherDetId {
 public:
   /** Type identifier within calibration det ids */
-  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3 };
+  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3, CastorRadFacility = 4 };
 
   /** Create a null det id */
   HcalCalibDetId();
@@ -45,6 +50,8 @@ public:
   HcalCalibDetId(int ieta, int iphi);
   /** Construct a uMNqie id or other id which uses a single value plus a DetType */
   HcalCalibDetId(CalibDetType dt, int value);
+    /** Construct a Castor radiation test facility id or other id which uses three values plus a DetType */
+  HcalCalibDetId(CalibDetType dt, int value1, int value2, int value3);
 
   /// get the flavor of this calibration detid
   CalibDetType calibFlavor() const { return (CalibDetType)((id_>>17)&0x7); }
@@ -62,6 +69,11 @@ public:
   int cboxChannel() const;
   /// get the calibration box channel as a string (if relevant)
   std::string cboxChannelString() const;
+
+  /// get the rm (where relevant)
+  int rm() const;
+  /// get the fiber (where relevant)
+  int fiber() const;
   /// get the channel (for uMNio/qie or similar)
   int channel() const;
 

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -9,7 +9,7 @@
 /** \class HcalCalibDetId
   *  
   *  Contents of the HcalCalibDetId :
-  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HX)
+  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HX, 3=uMNio/qie)
   *
   *  For CalibUnit:
   *     [16:14] Subdetector
@@ -23,7 +23,7 @@
   *     [6:0] Iphi
   *
   *  For uMNqie channels:
-  *     [0] channel (two possible)
+  *     [7:0] channel (typically just 0 or 1, but space for more if needed)
   *
   * \author J. Mans - Minnesota
   */
@@ -43,6 +43,8 @@ public:
   HcalCalibDetId(HcalSubdetector subdet, int ieta, int iphi, int ctype);
   /** Construct an HO Crosstalk id  */
   HcalCalibDetId(int ieta, int iphi);
+  /** Construct a uMNqie id or other id which uses a single value plus a DetType */
+  HcalCalibDetId(CalibDetType dt, int value);
 
   /// get the flavor of this calibration detid
   CalibDetType calibFlavor() const { return (CalibDetType)((id_>>17)&0x7); }
@@ -60,6 +62,8 @@ public:
   int cboxChannel() const;
   /// get the calibration box channel as a string (if relevant)
   std::string cboxChannelString() const;
+  /// get the channel (for uMNio/qie or similar)
+  int channel() const;
 
   /// get the sign of ieta (+/-1)
   int zside() const;

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -40,9 +40,9 @@ HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value) : HcalOtherDetId(Hcal
 
 HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value1, int value2, int value3)  : HcalOtherDetId(HcalCalibration) {
   id_|=(dt<<17);
-  id_|=(value1&0x1F);
+  id_|=(value1&0x3F)<<10;
   id_|=(value2&0x1F)<<5;
-  id_|=(value3&0x3F)<<10;
+  id_|=(value3&0x1F);
 }
 
 HcalCalibDetId::HcalCalibDetId(const DetId& gen) {

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -38,6 +38,13 @@ HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value) : HcalOtherDetId(Hcal
   id_|=value&0xFF;
 }
 
+HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value1, int value2, int value3)  : HcalOtherDetId(HcalCalibration) {
+  id_|=(dt<<17);
+  id_|=(value1&0x1F);
+  id_|=(value2&0x1F)<<5;
+  id_|=(value3&0x3F)<<10;
+}
+
 HcalCalibDetId::HcalCalibDetId(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalOther)) {
     throw cms::Exception("Invalid DetId") << "Cannot initialize HcalCalibDetId from " << std::hex << gen.rawId() << std::dec; 
@@ -94,7 +101,12 @@ std::string HcalCalibDetId::cboxChannelString() const {
   }
 }
 
-int HcalCalibDetId::channel() const { return id_&0xFF; }
+int HcalCalibDetId::channel() const { return (calibFlavor()==uMNqie)?(id_&0xFF):(id_&0x1F); }
+
+int HcalCalibDetId::fiber() const { return (calibFlavor()==CastorRadFacility)?((id_>>5)&0x1F):(0); }
+
+int HcalCalibDetId::rm() const { return (calibFlavor()==CastorRadFacility)?((id_>>10)&0x3F):(0); }
+
 
 std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
   std::string sd;
@@ -114,6 +126,8 @@ std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
 	     << ')';
   case (HcalCalibDetId::uMNqie):
     return s << "(uMNqie " << id.channel() << ')';
+  case (HcalCalibDetId::CastorRadFacility):
+    return s << "(CastorRadFacility " << id.rm() << " / " << id.fiber() << " / " << id.channel() << ')';
   default: return s;
   };
 }

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -33,6 +33,11 @@ HcalCalibDetId::HcalCalibDetId(int ieta, int iphi) : HcalOtherDetId(HcalCalibrat
       |(((ieta > 0)?(1):(0))<<11); // z side, bit [11]
 }
 
+HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value) : HcalOtherDetId(HcalCalibration) {
+  id_|=(dt<<17);
+  id_|=value&0xFF;
+}
+
 HcalCalibDetId::HcalCalibDetId(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalOther)) {
     throw cms::Exception("Invalid DetId") << "Cannot initialize HcalCalibDetId from " << std::hex << gen.rawId() << std::dec; 
@@ -89,6 +94,8 @@ std::string HcalCalibDetId::cboxChannelString() const {
   }
 }
 
+int HcalCalibDetId::channel() const { return id_&0xFF; }
+
 std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
   std::string sd;
   switch (id.hcalSubdet()) {
@@ -105,6 +112,8 @@ std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
   case(HcalCalibDetId::HOCrosstalk):
     return s << "(HOCrosstalk "  << id.ieta() << "," << id.iphi() 
 	     << ')';
+  case (HcalCalibDetId::uMNqie):
+    return s << "(uMNqie " << id.channel() << ')';
   default: return s;
   };
 }

--- a/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
@@ -7,8 +7,9 @@
 
 /** \class HcalUMNioDigi
   *  
-  * $Date: $
-  * $Revision: $
+  * This class contains the readout data from the uMNio uTCA card as
+  * when used for orbit gap operations.
+  *
   * \author J. Mans - Minnesota
   */
 class HcalUMNioDigi {

--- a/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
@@ -2,7 +2,7 @@
 #define DATAFORMATS_HCALDIGI_HCALUMNIODIGI_H 1
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include <ostream>
 
 /** \class HcalUMNioDigi

--- a/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalUMNioDigi.h
@@ -1,0 +1,46 @@
+#ifndef DATAFORMATS_HCALDIGI_HCALUMNIODIGI_H
+#define DATAFORMATS_HCALDIGI_HCALUMNIODIGI_H 1
+
+#include <vector>
+#include <stdint.h>
+#include <ostream>
+
+/** \class HcalUMNioDigi
+  *  
+  * $Date: $
+  * $Revision: $
+  * \author J. Mans - Minnesota
+  */
+class HcalUMNioDigi {
+public:
+
+  HcalUMNioDigi();
+  HcalUMNioDigi(const uint16_t* ptr, int words);
+  HcalUMNioDigi(const std::vector<uint16_t>& words);
+  
+  uint32_t runNumber() const;
+  uint32_t orbitNumber() const;
+  uint16_t bunchNumber() const;
+  uint32_t eventNumber() const;
+
+  uint8_t eventType() const;
+  uint16_t spillCounter() const;
+  bool isSpill() const;
+
+  bool invalid() const { return (payload_.size()<16) || (payload_[6]&0xF000)!=0x3000; }
+  
+  int numberUserWords() const;
+  uint16_t idUserWord(int iword) const;
+  uint32_t valueUserWord(int iword) const;
+  bool hasUserWord(int id) const;
+  uint32_t getUserWord(int id) const;
+  bool getUserWord(int id, uint32_t& value) const;
+  
+private:
+  std::vector<uint16_t> payload_;
+};
+
+std::ostream& operator<<(std::ostream&, const HcalUMNioDigi&);
+
+
+#endif

--- a/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
+++ b/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
-#include <stddef.h>
 
 HcalUMNioDigi::HcalUMNioDigi() { }
 HcalUMNioDigi::HcalUMNioDigi(const uint16_t* ptr, int words) {

--- a/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
+++ b/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
@@ -1,0 +1,86 @@
+#include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
+#include <stddef.h>
+
+HcalUMNioDigi::HcalUMNioDigi() { }
+HcalUMNioDigi::HcalUMNioDigi(const uint16_t* ptr, int words) {
+  payload_.reserve(words);
+  for (int i=0; i<words; i++) payload_.push_back(ptr[i]);
+}
+HcalUMNioDigi::HcalUMNioDigi(const std::vector<uint16_t>& words) : payload_(words) {
+}
+  
+uint32_t HcalUMNioDigi::runNumber() const {
+  if (invalid()) return 0;
+  return payload_[10]+(uint32_t(payload_[11])<<16);
+}
+
+uint32_t HcalUMNioDigi::orbitNumber() const {
+  if (invalid()) return 0;
+  return payload_[5]+(uint32_t(payload_[8])<<16);
+}
+uint16_t HcalUMNioDigi::bunchNumber() const {
+  if (invalid()) return 0;
+  return (payload_[1]>>4)&0xFFF;
+}
+uint32_t HcalUMNioDigi::eventNumber() const {
+  if (invalid()) return 0;
+  return payload_[2]+(uint32_t(payload_[3]&0xFF)<<16);
+}
+
+uint8_t HcalUMNioDigi::eventType() const {
+  if (invalid()) return 0;
+  return (payload_[6]>>8)&0xF;
+}
+uint16_t HcalUMNioDigi::spillCounter() const {
+  if (invalid()) return 0;
+  return (payload_[9])&0x7FFF;
+}
+bool HcalUMNioDigi::isSpill() const {
+  if (invalid()) return 0;
+  return (payload_[9]&0x8000);
+}
+
+int HcalUMNioDigi::numberUserWords() const {
+  if (invalid()) return 0;
+  return (payload_[12]&0xFF);
+}
+
+uint16_t HcalUMNioDigi::idUserWord(int iword) const {
+  if (iword>=numberUserWords() || payload_.size()<(size_t)(16+iword*3)) return 0;
+  return payload_[13+3*iword];
+}
+uint32_t HcalUMNioDigi::valueUserWord(int iword) const {
+  if (iword>=numberUserWords() || payload_.size()<size_t(16+iword*3)) return 0;
+  return payload_[14+3*iword]+(uint32_t(payload_[15+3*iword])<<16);
+}
+bool HcalUMNioDigi::hasUserWord(int id) const {
+  uint32_t dummy;
+  return getUserWord(id,dummy);
+}
+uint32_t HcalUMNioDigi::getUserWord(int id) const {
+  uint32_t dummy(0);
+  getUserWord(id,dummy);
+  return dummy;
+}
+bool HcalUMNioDigi::getUserWord(int id, uint32_t& value) const {
+  int nwords=numberUserWords();
+  if (size_t(16+nwords*3)>payload_.size()) return false; // invalid format...
+  
+  for (int i=0; i<nwords; i++) {
+    if (payload_[14+3*i]==id) {
+      value=payload_[15+3*i]+(uint32_t(payload_[16+3*i])<<16);
+      return true;
+    }
+  }
+  return false;
+}
+
+
+std::ostream& operator<<(std::ostream& s, const HcalUMNioDigi& digi) {
+  s << "HcalUMNioDigi orbit/bunch " << digi.orbitNumber() << "/" << digi.bunchNumber() << std::endl;
+  s << " run/l1a " << digi.runNumber() << "/" << digi.eventNumber() << std::endl;
+  s << " eventType " << digi.eventType() << std::endl;
+  for (int i=0; i<digi.numberUserWords(); i++)
+    s << "   id=" << digi.idUserWord(i) << " value="<< digi.valueUserWord(i) << std::endl;
+  return s;
+}

--- a/DataFormats/HcalDigi/src/classes.h
+++ b/DataFormats/HcalDigi/src/classes.h
@@ -10,6 +10,7 @@
 #include "DataFormats/HcalDigi/interface/HcalUnpackerReport.h"
 #include "DataFormats/HcalDigi/interface/HcalLaserDigi.h"
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
+#include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 namespace DataFormats_HcalDigi {
@@ -65,6 +66,7 @@ namespace DataFormats_HcalDigi {
     edm::Wrapper<HcalHistogramDigiCollection> theHHw_; 
     edm::Wrapper<HcalUnpackerReport> theReport_;
     edm::Wrapper<HcalLaserDigi> theLaserw_;
+    edm::Wrapper<HcalUMNioDigi> theUMNIOw_;
     edm::Wrapper<HcalTTPDigiCollection> theTTPw_;
     edm::Wrapper<HBHEUpgradeDigiCollection> theUHBHEw_;
     edm::Wrapper<HFUpgradeDigiCollection> theUHFw_;

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -108,8 +108,8 @@
     <version ClassVersion="10" checksum="2447500554"/>
    </class>
    <class name="edm::Wrapper<HcalLaserDigi>" splitLevel="0"/>
-   <class name="HcalUMNioDigi" ClassVersion="0">
-    <!--version ClassVersion="0" checksum="2447500554"/-->
+   <class name="HcalUMNioDigi" ClassVersion="3">
+     <version ClassVersion="3" checksum="3062549710"/>
    </class>
    <class name="edm::Wrapper<HcalUMNioDigi>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -108,4 +108,8 @@
     <version ClassVersion="10" checksum="2447500554"/>
    </class>
    <class name="edm::Wrapper<HcalLaserDigi>" splitLevel="0"/>
+   <class name="HcalUMNioDigi" ClassVersion="0">
+    <!--version ClassVersion="0" checksum="2447500554"/-->
+   </class>
+   <class name="edm::Wrapper<HcalUMNioDigi>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
+#include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
 #include <iostream>
 
 using namespace std;
@@ -34,6 +35,7 @@ HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf) {
   consumesMany<HcalUpgradeDigiCollection>();
   consumesMany<QIE10DigiCollection>();
   consumesMany<QIE11DigiCollection>();
+  consumesMany<HcalUMNioDigi>();
 }
 
 void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
@@ -51,6 +53,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   std::vector<edm::Handle<HcalUpgradeDigiCollection> > hup;
   std::vector<edm::Handle<QIE10DigiCollection> > qie10s;
   std::vector<edm::Handle<QIE11DigiCollection> > qie11s;
+  std::vector<edm::Handle<HcalUMNioDigi> > umnio;
 
   try {
     e.getManyByType(hbhe);
@@ -224,6 +227,15 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   } catch (...) {
   }
 
+  try {
+    e.getManyByType(umnio);
+    std::vector<edm::Handle<HcalUMNioDigi> >::iterator i;
+    for (i=umnio.begin(); i!=umnio.end(); i++) {
+      cout << *(*i) << std::endl;
+    }
+  } catch (...) {
+  }
+  
   try {
     e.getManyByType(qie10s);
     std::vector<edm::Handle<QIE10DigiCollection> >::iterator i;

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -47,7 +47,7 @@ public:
 private:
   void unpackVME(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
   void unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
-  void unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNioDigi& umnio);
+  void unpackUMNio(const FEDRawData& raw, int slot, HcalUMNioDigi& umnio);
 
 
   int sourceIdOffset_; ///< number to subtract from the source id to get the dcc id

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -15,6 +15,7 @@
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
 #include <set>
 
 class HcalUnpacker {
@@ -46,6 +47,7 @@ public:
 private:
   void unpackVME(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
   void unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
+  void unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNioDigi& umnio);
 
 
   int sourceIdOffset_; ///< number to subtract from the source id to get the dcc id

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -858,17 +858,18 @@ void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap,
   }
 }
 // Method to unpack uMNio data
-void HcalUnpacker::unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNioDigi& umnio) {
+void HcalUnpacker::unpackUMNio(const FEDRawData& raw, int slot, HcalUMNioDigi& umnio) {
   const hcal::AMC13Header* amc13=(const hcal::AMC13Header*)(raw.data());
   int namc=amc13->NAMC();
   //Find AMC corresponding to uMNio slot
   for (int iamc=0; iamc<namc; iamc++) {
     if (amc13->AMCSlot(iamc) == slot) namc = iamc;
   }
+  if (namc==amc13->NAMC()) return;
+  
   const uint16_t* data = (uint16_t*)(amc13->AMCPayload(namc));
   size_t nwords = amc13->AMCSize(namc) * ( sizeof(uint64_t) / sizeof(uint16_t) );
-  std::cout << data << nwords << std::endl;
-  std::vector<uint16_t> words;
+
   umnio = HcalUMNioDigi(data, nwords);
   
 }

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -867,7 +867,7 @@ void HcalUnpacker::unpackUMNio(const FEDRawData& raw, int slot, HcalUMNioDigi& u
   }
   if (namc==amc13->NAMC()) return;
   
-  const uint16_t* data = (uint16_t*)(amc13->AMCPayload(namc));
+  const uint16_t* data = (const uint16_t*)(amc13->AMCPayload(namc));
   size_t nwords = amc13->AMCSize(namc) * ( sizeof(uint64_t) / sizeof(uint16_t) );
 
   umnio = HcalUMNioDigi(data, nwords);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -649,10 +649,9 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
               std::cout << "OH NO! detector id is null!" << std::endl;
 #endif
           }
-      }
-
+      } else if (i.flavor() == 2){
       //////////////////////////////////////////////////HF UNPACKER/////////////////////////////////////////////////////////////////////
-      if (i.flavor() == 2) {
+
 	int ifiber=((i.channelid()>>3)&0x1F);
 	int ichan=(i.channelid()&0x7);
 	HcalElectronicsId eid(crate,slot,ifiber,ichan, false);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -865,7 +865,10 @@ void HcalUnpacker::unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNio
   for (int iamc=0; iamc<namc; iamc++) {
     if (amc13->AMCSlot(iamc) == slot) namc = iamc;
   }
-  uint16_t* data = (uint16_t*)(amc13->AMCPayload(namc));
+  const uint16_t* data = (uint16_t*)(amc13->AMCPayload(namc));
   size_t nwords = amc13->AMCSize(namc) * ( sizeof(uint64_t) / sizeof(uint16_t) );
   std::cout << data << nwords << std::endl;
+  std::vector<uint16_t> words;
+  umnio = HcalUMNioDigi(data, nwords);
+  
 }

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -604,11 +604,11 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 #endif
 
       if (!i.isHeader()) {
-	++i;
+	    ++i;
 #ifdef DebugLog
-	std::cout << "its not a header" << std::endl;
+	    std::cout << "its not a header" << std::endl;
 #endif
-	continue;
+	    continue;
       }
       ///////////////////////////////////////////////HE UNPACKER//////////////////////////////////////////////////////////////////////////////////////
       if (i.flavor() == 1 || i.flavor() == 0) {
@@ -856,5 +856,8 @@ void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap,
       }
     }
   }
-}      
-
+}
+// Method to unpack uMNio data
+void HcalUnpacker::unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNioDigi& umnio) {
+  
+}

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -859,5 +859,13 @@ void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap,
 }
 // Method to unpack uMNio data
 void HcalUnpacker::unpackUMNio(const FEDRawData& raw, const int& slot, HcalUMNioDigi& umnio) {
-  
+  const hcal::AMC13Header* amc13=(const hcal::AMC13Header*)(raw.data());
+  int namc=amc13->NAMC();
+  //Find AMC corresponding to uMNio slot
+  for (int iamc=0; iamc<namc; iamc++) {
+    if (amc13->AMCSlot(iamc) == slot) namc = iamc;
+  }
+  uint16_t* data = (uint16_t*)(amc13->AMCPayload(namc));
+  size_t nwords = amc13->AMCSize(namc) * ( sizeof(uint64_t) / sizeof(uint16_t) );
+  std::cout << data << nwords << std::endl;
 }


### PR DESCRIPTION
This PR adds some functionality to unpack data from the CASTOR table, currently being used for HCAL radiation studies. The HcalCalibDetId is repurposed to store the necessary information about each channel. These new features should not interfere with any existing workflow. We request expedited review/approval so we can start using this online ASAP. This PR was backported from 81X.

attn: @jmmans, @Spudmeister, @bsunanda, @abdoulline, @vkhristenko
