### PR TITLE
span full module in case of small pitch pixels (phase2 InnerPixel)

### DIFF
--- a/DataFormats/SiPixelDetId/README.md
+++ b/DataFormats/SiPixelDetId/README.md
@@ -1,0 +1,11 @@
+2016.05.11 ATricomi+EMigliore (INFN) changes in PixelChannelIdentifier.cc 
+Change PixelChannelIdentifier::thePacking() to have indexes spanning the full module in case of small pixels (phase II InnerPixel)
+
+PixelChannelIdentifier::thePacking( 11, 11, 0, 10); // It was row=8,col=9, time=4, adc=11
+
+Reserved bits
+row = 11 -> 2^11-1 = 2047
+col = 11 -> 2^11-1 = 2047
+time = 0 (not used)
+adc = 10 -> 2^10-1 = 1023
+

--- a/DataFormats/SiPixelDetId/src/PixelChannelIdentifier.cc
+++ b/DataFormats/SiPixelDetId/src/PixelChannelIdentifier.cc
@@ -30,4 +30,4 @@
 */
 
 // Initialization of static data members - DEFINES DIGI PACKING !
-const PixelChannelIdentifier::Packing PixelChannelIdentifier::thePacking( 8, 9, 4, 11); // row, col, time, adc
+const PixelChannelIdentifier::Packing PixelChannelIdentifier::thePacking( 11, 11, 0, 10); // row, col, time, adc


### PR DESCRIPTION
The change is on the implementation PixelChannelIdentifier.cc and not on the header PixelChannelIdentifier.h -> no dependencies found
Tested on workflows for phase2/phase1 simulation and on 2015D data
@atricomi @boudoul @delaere @dkotlins 
