### PR TITLE
Fix SeedExtensionTrajectoryFilter when it is disabled

### DIFF
--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -23,6 +23,7 @@ public:
 private:
 
   template<class T> bool TBC(const T& traj) const {
+     if(theExtension <= 0) return true; // skipping checks explicitly when intended to be disabled is the safest way
      return theStrict? strictTBC(traj) : looseTBC(traj);
   }
   template<class T> bool looseTBC(const T& traj) const;


### PR DESCRIPTION
It turns out that in some corner cases the `SeedExtensionTrajectoryFilter`, with its default configuration parameters, stops trajectory propagation, in contrast to the intent of the default values (that would be "no effect"). These cases are essentially such that the trajectory has at most as many measurements as the seed, and no lost hits (i.e. the condition of `looseTBC`), and occur e.g. in `muonSeededStepInOut` (where seeds have many hits) when rebuilding the trajectory in the seed region (can lead to lost hits).

Here are MultiTrackValidator plots from 1000 TTbar+PU events (red is with this PR) https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_X_seedExtension/
The effect becomes more noticeable if we start to reject trajectories stopped by `SeedExtension` (as in #14356).

Tested in CMSSW_8_1_X_2016-05-09-2300, expecting tiny changes in tracking.

@rovere @VinInn: I decided to use the value of `seedExtension` parameter directly to dictate whether the filter should be enabled or not (`<= 0` for disabled, `> 0` for enabled) instead of introducing a new flag, since these interpretations of the parameter values are compatible with the current intended uses.
