### PR TITLE
Revert "remove some printout in every event"

### DIFF
--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
@@ -261,7 +261,11 @@ void L1GlobalTriggerRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup
     int headerSize = 8;
 
     if ((ptrGt + headerSize) > endPtrGt) {
-      // a common error - no need to print an error anymore
+        edm::LogError("L1GlobalTriggerRawToDigi")
+                << "\nError: Pointer after header greater than end pointer."
+                << "\n Put empty products in the event!"
+                << "\n Quit unpacking this event." << std::endl;
+
         produceEmptyProducts(iEvent);
 
         return;


### PR DESCRIPTION
Reverts cms-sw/cmssw#14478

I do not think that this should be considered "a common error".
Usually it means that somebody is trying to unpack Stage 2 data with the Legacy/Stage 1 software.
