### PR TITLE
add QIE11 support in hcal digitization

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -90,9 +90,6 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
     ),
 )
 
-from Configuration.StandardSequences.Eras import eras
-eras.run2_HF_2016.toModify( es_hardcode, testHFQIE10=cms.bool(True) )
-
 es_prefer_hcalHardcode = cms.ESPrefer("HcalHardcodeCalibrations", "es_hardcode")
 
 from Configuration.StandardSequences.Eras import eras

--- a/CalibFormats/HcalObjects/interface/HcalCoder.h
+++ b/CalibFormats/HcalObjects/interface/HcalCoder.h
@@ -8,6 +8,7 @@
 #include "DataFormats/HcalDigi/interface/ZDCDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 
 /** \class HcalCoder
@@ -25,6 +26,7 @@ public:
   virtual void adc2fC(const HcalCalibDataFrame& df, CaloSamples& lf) const = 0;
   virtual void adc2fC(const HcalUpgradeDataFrame& df, CaloSamples& lf) const = 0;
   virtual void adc2fC(const QIE10DataFrame& df, CaloSamples& lf) const = 0;
+  virtual void adc2fC(const QIE11DataFrame& df, CaloSamples& lf) const = 0;
   virtual void fC2adc(const CaloSamples& clf, HBHEDataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, HFDataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, HODataFrame& df, int fCapIdOffset) const = 0;
@@ -32,6 +34,7 @@ public:
   virtual void fC2adc(const CaloSamples& clf, HcalCalibDataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, QIE10DataFrame& df, int fCapIdOffset) const = 0;
+  virtual void fC2adc(const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const = 0;
 };
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalCoderDb.h
+++ b/CalibFormats/HcalObjects/interface/HcalCoderDb.h
@@ -16,6 +16,7 @@ class HcalCoderDb : public HcalCoder {
 public:
   HcalCoderDb (const HcalQIECoder& fCoder, const HcalQIEShape& fShape);
 
+  //these need to be overloads instead of templates to avoid linking issues when calling private member function templates
   virtual void adc2fC(const HBHEDataFrame& df, CaloSamples& lf) const;
   virtual void adc2fC(const HODataFrame& df, CaloSamples& lf) const;
   virtual void adc2fC(const HFDataFrame& df, CaloSamples& lf) const;
@@ -23,6 +24,7 @@ public:
   virtual void adc2fC(const HcalCalibDataFrame& df, CaloSamples& lf) const;
   virtual void adc2fC(const HcalUpgradeDataFrame& df, CaloSamples& lf) const;
   virtual void adc2fC(const QIE10DataFrame& df, CaloSamples& lf) const;
+  virtual void adc2fC(const QIE11DataFrame& df, CaloSamples& lf) const;
 
   virtual void fC2adc(const CaloSamples& clf, HBHEDataFrame& df, int fCapIdOffset) const;
   virtual void fC2adc(const CaloSamples& clf, HFDataFrame& df, int fCapIdOffset) const;
@@ -31,11 +33,11 @@ public:
   virtual void fC2adc(const CaloSamples& clf, HcalCalibDataFrame& df, int fCapIdOffset) const;
   virtual void fC2adc(const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const;
   virtual void fC2adc(const CaloSamples& clf, QIE10DataFrame& df, int fCapIdOffset) const;
+  virtual void fC2adc(const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const;
 
 private:
   template <class Digi> void adc2fC_ (const Digi& df, CaloSamples& clf) const;
   template <class Digi> void fC2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const;
-  template <class Digi> void fCUpgrade2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const;
 
   const HcalQIECoder* mCoder;
   const HcalQIEShape* mShape;

--- a/CalibFormats/HcalObjects/interface/HcalNominalCoder.h
+++ b/CalibFormats/HcalObjects/interface/HcalNominalCoder.h
@@ -24,6 +24,8 @@ public:
   virtual void fC2adc(const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const { }
   virtual void adc2fC(const QIE10DataFrame& df, CaloSamples& lf) const {}
   virtual void fC2adc(const CaloSamples& clf, QIE10DataFrame& df, int fCapIdOffset) const { }
+  virtual void adc2fC(const QIE11DataFrame& df, CaloSamples& lf) const {}
+  virtual void fC2adc(const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const { }
 };
 
 #endif

--- a/CalibFormats/HcalObjects/src/HcalCoderDb.cc
+++ b/CalibFormats/HcalObjects/src/HcalCoderDb.cc
@@ -29,6 +29,14 @@ template <> void HcalCoderDb::adc2fC_<QIE10DataFrame> (const QIE10DataFrame& df,
   }
 }
 
+template <> void HcalCoderDb::adc2fC_<QIE11DataFrame> (const QIE11DataFrame& df, CaloSamples& clf) const {
+  clf=CaloSamples(df.id(),df.samples());
+  for (int i=0; i<df.samples(); i++) {
+    clf[i]=mCoder->charge (*mShape, df[i].adc (), df[i].capid ());
+    if(df[i].soi()) clf.setPresamples(i);
+  }
+}
+
 template <class Digi> void HcalCoderDb::fC2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const {
   df = Digi (clf.id ());
   df.setSize (clf.size ());
@@ -39,12 +47,10 @@ template <class Digi> void HcalCoderDb::fC2adc_ (const CaloSamples& clf, Digi& d
   }
 }
 
-template <class Digi> void HcalCoderDb::fCUpgrade2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const {
-  df = HcalUpgradeDataFrame(clf.id(), fCapIdOffset, clf.size(), 
-			    clf.presamples());
+template <> void HcalCoderDb::fC2adc_<HcalUpgradeDataFrame> (const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const {
+  df = HcalUpgradeDataFrame(clf.id(), fCapIdOffset, clf.size(), clf.presamples());
   for (int i=0; i<clf.size(); ++i) {
-    df.setSample(i, mCoder->adc(*mShape, clf[i], df.capId(i)),
-		 0, true);
+    df.setSample(i, mCoder->adc(*mShape, clf[i], df.capId(i)), 0, true);
   }
 }
 
@@ -57,6 +63,16 @@ template <> void HcalCoderDb::fC2adc_<QIE10DataFrame> (const CaloSamples& clf, Q
   }
 }
 
+template <> void HcalCoderDb::fC2adc_<QIE11DataFrame> (const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const {
+  int presample = clf.presamples ();
+  df.setCapid0(fCapIdOffset%4);
+  for (int i=0; i<clf.size(); i++) {
+    int capId = (fCapIdOffset + i) % 4;
+	bool soi = (i==presample);
+    df.setSample(i, mCoder->adc(*mShape, clf[i], capId), 0, soi);
+  }
+}
+
 void HcalCoderDb::adc2fC(const HBHEDataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
 void HcalCoderDb::adc2fC(const HODataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
 void HcalCoderDb::adc2fC(const HFDataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
@@ -64,12 +80,14 @@ void HcalCoderDb::adc2fC(const ZDCDataFrame& df, CaloSamples& lf) const {adc2fC_
 void HcalCoderDb::adc2fC(const HcalCalibDataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
 void HcalCoderDb::adc2fC(const HcalUpgradeDataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
 void HcalCoderDb::adc2fC(const QIE10DataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
+void HcalCoderDb::adc2fC(const QIE11DataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
 
 void HcalCoderDb::fC2adc(const CaloSamples& clf, HBHEDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 void HcalCoderDb::fC2adc(const CaloSamples& clf, HFDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 void HcalCoderDb::fC2adc(const CaloSamples& clf, HODataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 void HcalCoderDb::fC2adc(const CaloSamples& clf, ZDCDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 void HcalCoderDb::fC2adc(const CaloSamples& clf, HcalCalibDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
-void HcalCoderDb::fC2adc(const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const {fCUpgrade2adc_ (clf, df, fCapIdOffset);}
+void HcalCoderDb::fC2adc(const CaloSamples& clf, HcalUpgradeDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 void HcalCoderDb::fC2adc(const CaloSamples& clf, QIE10DataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
+void HcalCoderDb::fC2adc(const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
 

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -360,6 +360,7 @@ DATAMIXEREventContent = cms.PSet(
                                                'keep HFDataFramesSorted_hcalDigis_*_*',
                                                'keep HODataFramesSorted_hcalDigis_*_*',
                                                'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_*_*',
+                                               'keep QIE11DataFrameHcalDataFrameContainer_hcalDigis_*_*',
                                                'keep ZDCDataFramesSorted_hcalDigis_*_*',
                                                'keep CastorDataFramesSorted_castorDigis_*_*',
                                                'keep EBDigiCollection_ecalDigis_*_*',

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -11,7 +11,7 @@ class Eras (object):
         self.run2_25ns_specific = cms.Modifier()
         self.run2_50ns_specific = cms.Modifier()
         self.run2_HI_specific = cms.Modifier()
-        self.run2_HF_2016 = cms.Modifier()
+        self.run2_HE_2017 = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
         self.stage2L1Trigger = cms.Modifier()
         self.phase1Pixel = cms.Modifier()
@@ -57,8 +57,8 @@ class Eras (object):
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
         # Future Run 2 scenarios.
-        self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger, self.run2_HF_2016 )
-        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1 )
+        self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger )
+        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1, self.run2_HE_2017 )
         # Scenarios further afield.
         # Run3 includes the GE1/1 upgrade
         self.Run3 = cms.ModifierChain( self.Run2_2017,self.run3_GEM )
@@ -83,7 +83,7 @@ class Eras (object):
         self.internalUseEras = [self.run2_common, self.run2_25ns_specific,
                                 self.run2_50ns_specific, self.run2_HI_specific,
                                 self.stage1L1Trigger, self.fastSim,
-                                self.run2_HF_2016, self.stage2L1Trigger,
+                                self.run2_HE_2017, self.stage2L1Trigger,
                                 self.phase1Pixel, self.run3_GEM,
                                 self.phase2_common, self.phase2_tracker,
                                 self.phase2_hgcal, self.phase2_muon,

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -28,7 +28,7 @@ public:
     static const int MASK_CAPID = 0x3;
     static const int OFFSET_CAPID = 8;
     int adc() const { return frame_[i_]&MASK_ADC; }
-    int tdc() const { return (frame_[i_]>>8)&MASK_TDC; }
+    int tdc() const { return (frame_[i_]>>OFFSET_TDC)&MASK_TDC; }
     bool soi() const { return frame_[i_]&MASK_SOI; }
     int capid() const { return ((((frame_[0]>>OFFSET_CAPID)&MASK_CAPID)+i_)&MASK_CAPID); }
   private:
@@ -64,6 +64,8 @@ public:
   bool capidError() const { return m_data[0]&MASK_CAPIDERROR; } 
   /// was this a mark-and-pass ZS event?
   bool zsMarkAndPass() const {return (flavor()==1); }
+  /// set ZS params
+  void setZSInfo(bool markAndPass);
   /// get the sample
   inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(m_data,i+HEADER_WORDS); }
   void setCapid0(int cap0);

--- a/DataFormats/HcalDigi/src/QIE11DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE11DataFrame.cc
@@ -24,6 +24,10 @@ int QIE11DataFrame::presamples() const {
   return -1;
 }
 
+void QIE11DataFrame::setZSInfo(bool markAndPass){
+	if(markAndPass) m_data[0] |= (markAndPass&MASK_FLAVOR)<<OFFSET_FLAVOR;
+}
+
 void QIE11DataFrame::setSample(edm::DataFrame::size_type isample, int adc, int tdc, bool soi) {
   if (isample>=size()) return;
   m_data[isample+1]=(adc&Sample::MASK_ADC)|(soi?(Sample::MASK_SOI):(0))|((tdc&Sample::MASK_TDC)<<Sample::OFFSET_TDC);

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -52,8 +52,21 @@ def load_HcalHardcode(process):
                 
     return process
 
-#intermediate customization ("Phase 0.5": HCAL 2017, HE and HF upgrades)
-def customise_HcalPhase0p5(process):
+#intermediate customization (HF 2016 upgrades)
+def customise_Hcal2016(process):
+    process=load_HcalHardcode(process)
+    
+    #for now, use HE run1 conditions - SiPM/QIE11 not ready
+    process.es_hardcode.testHFQIE10 = cms.bool(True)
+    
+    # to get reco to run
+    if hasattr(process,'reconstruction_step'):
+        process.hbheprereco.setNoiseFlags = cms.bool(False)
+    
+    return process
+    
+#intermediate customization (HCAL 2017, HE and HF upgrades - no SiPMs or QIE11)
+def customise_Hcal2017(process):
     process=load_HcalHardcode(process)
     
     #for now, use HE run1 conditions - SiPM/QIE11 not ready
@@ -74,6 +87,15 @@ def customise_HcalPhase0p5(process):
         process.hcalnoise.digiCollName = cms.string('simHcalDigis')
     if hasattr(process,'datamixing_step'):
         process=customise_mixing(process)
+    
+    return process
+    
+#intermediate customization (HCAL 2017, HE and HF upgrades - w/ SiPMs & QIE11)
+def customise_Hcal2017Full(process):
+    process=customise_Hcal2017(process)
+    
+    #use HE phase1 conditions - test SiPM/QIE11
+    process.es_hardcode.useHEUpgrade = cms.bool(True)
     
     return process
     
@@ -123,7 +145,6 @@ def customise_RawToDigi(process):
 def customise_Digi(process):
     if hasattr(process,'mix'):
         process.mix.digitizers.hcal.HBHEUpgradeQIE = True
-        process.mix.digitizers.hcal.hb.siPMCells = cms.vint32([1])
         process.mix.digitizers.hcal.hb.photoelectronsToAnalog = cms.vdouble([10.]*16)
         process.mix.digitizers.hcal.hb.pixels = cms.int32(4500*4*2)
         process.mix.digitizers.hcal.he.photoelectronsToAnalog = cms.vdouble([10.]*16)
@@ -256,4 +277,5 @@ def customise_mixing(process):
     process.mixData.HOPileInputTag = cms.InputTag("simHcalUnsuppressedDigis")
     process.mixData.HFPileInputTag = cms.InputTag("simHcalUnsuppressedDigis")
     process.mixData.QIE10PileInputTag = cms.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection")
+    process.mixData.QIE11PileInputTag = cms.InputTag("simHcalUnsuppressedDigis","HBHEQIE11DigiCollection")
     return process

--- a/SLHCUpgradeSimulations/Geometry/python/Digi_Phase1_R30F12_HCal_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/Digi_Phase1_R30F12_HCal_cff.py
@@ -55,7 +55,6 @@ hcalSimParameters.ho.pixels = cms.int32(2500)
 hcalSimParameters.ho.photoelectronsToAnalog = cms.vdouble([3.0]*16)
 
 #turn on SiPMs in HB/HE
-hcalSimParameters.hb.siPMCells = [1]
 hcalSimParameters.hb.pixels = cms.int32(4500*4*2)
 hcalSimParameters.hb.photoelectronsToAnalog = cms.vdouble(10.0)
 hcalSimParameters.he.pixels = cms.int32(4500*4)

--- a/SLHCUpgradeSimulations/Geometry/python/Digi_Phase1_R34F16_HCal_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/Digi_Phase1_R34F16_HCal_cff.py
@@ -55,7 +55,6 @@ hcalSimParameters.ho.pixels = cms.int32(2500)
 hcalSimParameters.ho.photoelectronsToAnalog = cms.vdouble([3.0]*16)
 
 #turn on SiPMs in HB/HE
-hcalSimParameters.hb.siPMCells = [1]
 hcalSimParameters.hb.pixels = cms.int32(4500*4*2)
 hcalSimParameters.hb.photoelectronsToAnalog = cms.vdouble(10.0)
 hcalSimParameters.he.pixels = cms.int32(4500*4)

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
@@ -16,6 +16,7 @@ class HFDataFrame;
 class ZDCDataFrame;
 class HcalUpgradeDataFrame;
 class QIE10DataFrame;
+class QIE11DataFrame;
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -35,6 +36,7 @@ public:
   void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, ZDCDataFrame & result, double preMixFactor=10.0, unsigned preMixBits=126);
   void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, HcalUpgradeDataFrame& result, double preMixFactor=10.0, unsigned preMixBits=126);
   void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, QIE10DataFrame& result, double preMixFactor=10.0, unsigned preMixBits=126);
+  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, QIE11DataFrame& result, double preMixFactor=10.0, unsigned preMixBits=126);
   /// Things that need to be initialized every event
   /// sets starting CapID randomly
   void newEvent(CLHEP::HepRandomEngine*);

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalHitFilter.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalHitFilter.h
@@ -9,15 +9,16 @@
 class HcalHitFilter : public CaloVHitFilter 
 {
 public:
-  explicit HcalHitFilter(HcalSubdetector subdet);
+  HcalHitFilter() {}
   virtual ~HcalHitFilter() {}
 
+  void setSubdets(const std::vector<HcalSubdetector> subdets);
   void setDetIds(const std::vector<DetId> & detIds);
 
   virtual bool accepts(const PCaloHit & hit) const;
 
-private:
-  HcalSubdetector theSubdet;
+protected:
+  std::vector<HcalSubdetector> theSubdets;
   // empty DetIds will always be accepted
   std::vector<DetId> theDetIds;
 };

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalQIE1011Traits.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalQIE1011Traits.h
@@ -14,8 +14,18 @@ public:
   static const unsigned PreMixBits = 254;
 };
 
+class HcalQIE11DigitizerTraits {
+
+public:
+  typedef QIE11DigiCollection DigiCollection;
+  typedef QIE11DataFrame Digi;
+  typedef HcalElectronicsSim ElectronicsSim;
+  static constexpr double PreMixFactor = 10.0;
+  static const unsigned PreMixBits = 254;
+};
+
 template<class Traits>
-class CaloTDigitizerQIE10Run {
+class CaloTDigitizerQIE1011Run {
 public:
   typedef typename Traits::ElectronicsSim ElectronicsSim;
   typedef typename Traits::Digi Digi;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -13,7 +13,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE10Traits.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE1011Traits.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
@@ -178,18 +178,19 @@ private:
 };
 
 //forward declarations of specializations
-template<>
-bool HcalSignalGenerator<HcalQIE10DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
-template<>
-CaloSamples HcalSignalGenerator<HcalQIE10DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
-template<>
-void HcalSignalGenerator<HcalQIE10DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::COLLECTION * digis);
+template<> bool HcalSignalGenerator<HcalQIE10DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
+template<> CaloSamples HcalSignalGenerator<HcalQIE10DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI & digi);
+template<> void HcalSignalGenerator<HcalQIE10DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE10DigitizerTraits>::COLLECTION * digis);
+template<> bool HcalSignalGenerator<HcalQIE11DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::DIGI & digi);
+template<> CaloSamples HcalSignalGenerator<HcalQIE11DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::DIGI & digi);
+template<> void HcalSignalGenerator<HcalQIE11DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::COLLECTION * digis);
 
 typedef HcalSignalGenerator<HBHEDigitizerTraits> HBHESignalGenerator;
 typedef HcalSignalGenerator<HODigitizerTraits>   HOSignalGenerator;
 typedef HcalSignalGenerator<HFDigitizerTraits>   HFSignalGenerator;
 typedef HcalSignalGenerator<ZDCDigitizerTraits>  ZDCSignalGenerator;
 typedef HcalSignalGenerator<HcalQIE10DigitizerTraits>  QIE10SignalGenerator;
+typedef HcalSignalGenerator<HcalQIE11DigitizerTraits>  QIE11SignalGenerator;
 
 #endif
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalHitFilter.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalHitFilter.cc
@@ -1,28 +1,23 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalHitFilter.h"
+#include <algorithm>
 
-
-HcalHitFilter::HcalHitFilter(HcalSubdetector subdet) 
-: theSubdet(subdet) 
+void HcalHitFilter::setSubdets(const std::vector<HcalSubdetector> subdets) 
 {
+  theSubdets = subdets;
+  std::sort(theSubdets.begin(),theSubdets.end());
 }
-
 
 void HcalHitFilter::setDetIds(const std::vector<DetId> & detIds) 
 {
   theDetIds = detIds;
+  std::sort(theDetIds.begin(),theDetIds.end());
 }
 
 
 bool HcalHitFilter::accepts(const PCaloHit & hit) const {
-  bool result = false;
   HcalDetId hcalDetId(hit.id());
-  if(hcalDetId.subdet() == theSubdet)
-  {
-    if(theDetIds.empty() || std::find(theDetIds.begin(), theDetIds.end(), DetId(hit.id())) != theDetIds.end())
-    {
-      result = true;
-    }
-  }
-  return result;
+  return ( (theSubdets.empty() || std::binary_search(theSubdets.begin(), theSubdets.end(), hcalDetId.subdet()))
+        && (theDetIds.empty() || std::binary_search(theDetIds.begin(), theDetIds.end(), DetId(hit.id())))
+  );
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
@@ -68,3 +68,70 @@ void HcalSignalGenerator<HcalQIE10DigitizerTraits>::fillDigis(const HcalSignalGe
     }
   }
 }
+
+template<>
+bool HcalSignalGenerator<HcalQIE11DigitizerTraits>::validDigi(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::DIGI & digi)
+{
+  int DigiSum = 0;
+  for(int id = 0; id<digi.samples(); id++) {
+    if(digi[id].adc() > 0) ++DigiSum;
+  }
+  return(DigiSum>0);
+}
+
+template<>
+CaloSamples HcalSignalGenerator<HcalQIE11DigitizerTraits>::samplesInPE(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::DIGI & digi){
+  HcalDetId cell = digi.id();
+  CaloSamples result = CaloSamples(cell,digi.samples());
+
+  // first, check if there was an overflow in this fake digi:
+  bool overflow = false;
+  // find and list them
+
+  uint16_t flag = digi.flags();
+  for(int isample=0; isample<digi.samples(); ++isample) {
+    if((flag>>isample)&1) overflow = true; 
+  }
+
+  if(overflow) {  // do full conversion, go back and overwrite fake entries
+    const HcalQIECoder* channelCoder = theConditions->getHcalCoder (cell);
+    const HcalQIEShape* channelShape = theConditions->getHcalShape (cell);
+    HcalCoderDb coder (*channelCoder, *channelShape);
+    coder.adc2fC(digi, result);
+
+    // overwrite with coded information
+    for(int isample=0; isample<digi.samples(); ++isample) {
+      if(!((flag>>isample)&1)) result[isample] = float(digi[isample].adc())/HcalQIE11DigitizerTraits::PreMixFactor;
+    }
+  }
+  else {  // saves creating the coder, etc., every time
+    // use coded information
+    for(int isample=0; isample<digi.samples(); ++isample) {
+      result[isample] = float(digi[isample].adc())/HcalQIE11DigitizerTraits::PreMixFactor;
+	  if(digi[isample].soi()) result.setPresamples(isample);
+    }
+  }
+
+  // translation done in fC, convert to pe: 
+  fC2pe(result);
+
+  return result;
+}
+
+template<>
+void HcalSignalGenerator<HcalQIE11DigitizerTraits>::fillDigis(const HcalSignalGenerator<HcalQIE11DigitizerTraits>::COLLECTION * digis){
+  // loop over digis, adding these to the existing maps
+  for(typename COLLECTION::const_iterator it  = digis->begin(); it != digis->end(); ++it) 
+  {
+    QIE11DataFrame df(*it);
+    // for the first signal, set the starting cap id
+    if((it == digis->begin()) && theElectronicsSim)
+    {
+      int startingCapId = df[0].capid();
+      theElectronicsSim->setStartingCapId(startingCapId);
+    }
+    if(validDigi(df)) {
+      theNoiseSignals.push_back(samplesInPE(df));
+    }
+  }
+}

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
@@ -27,14 +27,16 @@ private:
   HFSignalGenerator theHFSignalGenerator;
   ZDCSignalGenerator theZDCSignalGenerator;
   QIE10SignalGenerator theQIE10SignalGenerator;
+  QIE11SignalGenerator theQIE11SignalGenerator;
 
   edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
   edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
   edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
   edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
+  edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
 
-  edm::InputTag theHBHETag_, theHOTag_, theHFTag_, theZDCTag_, theQIE10Tag_;
+  edm::InputTag theHBHETag_, theHOTag_, theHFTag_, theZDCTag_, theQIE10Tag_, theQIE11Tag_;
 
 };
 
@@ -45,7 +47,8 @@ HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfi
   theHOTag_(iConfig.getParameter<edm::InputTag>("HOdigiCollectionPile")),
   theHFTag_(iConfig.getParameter<edm::InputTag>("HFdigiCollectionPile")),
   theZDCTag_(iConfig.getParameter<edm::InputTag>("ZDCdigiCollectionPile")),
-  theQIE10Tag_(iConfig.getParameter<edm::InputTag>("QIE10digiCollectionPile"))
+  theQIE10Tag_(iConfig.getParameter<edm::InputTag>("QIE10digiCollectionPile")),
+  theQIE11Tag_(iConfig.getParameter<edm::InputTag>("QIE11digiCollectionPile"))
 {
 
   tok_hbhe_ = consumes<HBHEDigitizerTraits::DigiCollection>(theHBHETag_);
@@ -53,18 +56,21 @@ HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfi
   tok_hf_ = consumes<HFDigitizerTraits::DigiCollection>(theHFTag_);
   tok_zdc_ = consumes<ZDCDigitizerTraits::DigiCollection>(theZDCTag_);
   tok_qie10_ = consumes<HcalQIE10DigitizerTraits::DigiCollection>(theQIE10Tag_);
+  tok_qie11_ = consumes<HcalQIE11DigitizerTraits::DigiCollection>(theQIE11Tag_);
 
   theHBHESignalGenerator = HBHESignalGenerator(theHBHETag_,tok_hbhe_);
   theHOSignalGenerator = HOSignalGenerator(theHOTag_,tok_ho_);
   theHFSignalGenerator = HFSignalGenerator(theHFTag_,tok_hf_);
   theZDCSignalGenerator = ZDCSignalGenerator(theZDCTag_,tok_zdc_);
   theQIE10SignalGenerator = QIE10SignalGenerator(theQIE10Tag_,tok_qie10_);
+  theQIE11SignalGenerator = QIE11SignalGenerator(theQIE11Tag_,tok_qie11_);
 
   theHBHESignalGenerator.setParameterMap(&theMap);
   theHOSignalGenerator.setParameterMap(&theMap);
   theHFSignalGenerator.setParameterMap(&theMap);
   theZDCSignalGenerator.setParameterMap(&theMap);
   theQIE10SignalGenerator.setParameterMap(&theMap);
+  theQIE11SignalGenerator.setParameterMap(&theMap);
 
 }
 
@@ -75,12 +81,14 @@ void HcalSignalGeneratorTest::analyze(const edm::Event& iEvent, const edm::Event
   theHFSignalGenerator.initializeEvent(&iEvent, &iSetup);
   theZDCSignalGenerator.initializeEvent(&iEvent, &iSetup);
   theQIE10SignalGenerator.initializeEvent(&iEvent, &iSetup);
+  theQIE11SignalGenerator.initializeEvent(&iEvent, &iSetup);
 
   theHBHESignalGenerator.fill(nullptr);
   theHOSignalGenerator.fill(nullptr);
   theHFSignalGenerator.fill(nullptr);
   theZDCSignalGenerator.fill(nullptr);
   theQIE10SignalGenerator.fill(nullptr);
+  theQIE11SignalGenerator.fill(nullptr);
 }
 
 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest_cfg.py
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest_cfg.py
@@ -32,6 +32,7 @@ process.hcalSignal = cms.EDAnalyzer("HcalSignalGeneratorTest",
     HFdigiCollectionPile    = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionPile   = cms.InputTag("ZDCdigiCollection"),
     QIE10digiCollectionPile = cms.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection"),
+    QIE11digiCollectionPile = cms.InputTag("simHcalUnsuppressedDigis","HBHEQIE11DigiCollection"),
 )
 
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -37,6 +37,7 @@ public:
   void setHONoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
+  void setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -4,10 +4,8 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalUpgradeTraits.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE10Traits.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HBHEHitFilter.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE1011Traits.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HFHitFilter.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HOHitFilter.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalHitFilter.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/ZDCHitFilter.h"
 #include "SimCalorimetry/HcalSimProducers/interface/HcalHitRelabeller.h"
@@ -62,6 +60,7 @@ public:
   void setHONoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
+  void setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
   void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHits, edm::Handle<std::vector<PCaloHit> > const& zdcHits, int bunchCrossing, CLHEP::HepRandomEngine*, const HcalTopology *h);
@@ -77,6 +76,7 @@ private:
 
   void buildHOSiPMCells(const std::vector<DetId>& allCells, const edm::EventSetup& eventSetup);
   void buildHFQIECells(const std::vector<DetId>& allCells, const edm::EventSetup& eventSetup);
+  void buildHBHEQIECells(const std::vector<DetId>& allCells, const edm::EventSetup& eventSetup);
 
   //function to evaluate aging at the digi level
   void darkening(std::vector<PCaloHit>& hcalHits);
@@ -87,7 +87,8 @@ private:
   typedef CaloTDigitizer<HFDigitizerTraits,CaloTDigitizerQIE8Run>   HFDigitizer;
   typedef CaloTDigitizer<ZDCDigitizerTraits,CaloTDigitizerQIE8Run>  ZDCDigitizer;
   typedef CaloTDigitizer<HcalUpgradeDigitizerTraits,CaloTDigitizerQIE8Run> UpgradeDigitizer;
-  typedef CaloTDigitizer<HcalQIE10DigitizerTraits,CaloTDigitizerQIE10Run> QIE10Digitizer;
+  typedef CaloTDigitizer<HcalQIE10DigitizerTraits,CaloTDigitizerQIE1011Run> QIE10Digitizer;
+  typedef CaloTDigitizer<HcalQIE11DigitizerTraits,CaloTDigitizerQIE1011Run> QIE11Digitizer;
 
   HcalSimParameterMap * theParameterMap;
   HcalShapes * theShapes;
@@ -107,6 +108,7 @@ private:
   HcalAmplifier * theHOAmplifier;
   HcalAmplifier * theZDCAmplifier;
   HcalAmplifier * theHFQIE10Amplifier;
+  HcalAmplifier * theHBHEQIE11Amplifier;
 
   HPDIonFeedbackSim * theIonFeedback;
   HcalCoderFactory * theCoderFactory;
@@ -119,10 +121,13 @@ private:
   HcalElectronicsSim * theUpgradeHBHEElectronicsSim;
   HcalElectronicsSim * theUpgradeHFElectronicsSim;
   HcalElectronicsSim * theHFQIE10ElectronicsSim;
+  HcalElectronicsSim * theHBHEQIE11ElectronicsSim;
 
-  HBHEHitFilter theHBHEHitFilter;
+  HcalHitFilter theHBHEHitFilter;
+  HcalHitFilter theHBHEQIE11HitFilter;
   HFHitFilter   theHFHitFilter;
-  HOHitFilter   theHOHitFilter;
+  HFHitFilter   theHFQIE10HitFilter;
+  HcalHitFilter theHOHitFilter;
   HcalHitFilter theHOSiPMHitFilter;
   ZDCHitFilter  theZDCHitFilter;
 
@@ -132,7 +137,6 @@ private:
   CaloVNoiseHitGenerator * theNoiseHitGenerator;
 
   HBHEDigitizer * theHBHEDigitizer;
-  HBHEDigitizer * theHBHESiPMDigitizer;
   HODigitizer* theHODigitizer;
   HODigitizer* theHOSiPMDigitizer;
   HFDigitizer* theHFDigitizer;
@@ -140,11 +144,12 @@ private:
   UpgradeDigitizer * theHBHEUpgradeDigitizer;
   UpgradeDigitizer * theHFUpgradeDigitizer;
   QIE10Digitizer * theHFQIE10Digitizer;
+  QIE11Digitizer * theHBHEQIE11Digitizer;
   HcalHitRelabeller* theRelabeller;
 
   // need to cache some DetIds for the digitizers,
   // if they don't come straight from the geometry
-  std::vector<DetId> theHBHEDetIds;
+  std::vector<DetId> theHBHEQIE8DetIds, theHBHEQIE11DetIds;
   std::vector<DetId> theHOHPDDetIds;
   std::vector<DetId> theHOSiPMDetIds;
   std::vector<DetId> theHFQIE8DetIds, theHFQIE10DetIds;

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -63,8 +63,7 @@ hcalSimParameters = cms.PSet(
             143.52),            
         syncPhase = cms.bool(True),
         timePhase = cms.double(6.0),
-        timeSmearing = cms.bool(True),
-        siPMCells = cms.vint32()
+        timeSmearing = cms.bool(True)
     ),
     he = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -101,18 +100,21 @@ hcalSimParameters.hoHamamatsu = hcalSimParameters.ho.clone()
 hcalSimParameters.hoHamamatsu.pixels = cms.int32(960)
 hcalSimParameters.hoHamamatsu.photoelectronsToAnalog = [3.0]*16
 
-#
-# Need to change the HO parameters for post LS1 running
-#
-def _modifyHcalSimParametersForPostLS1( object ) :
-    """
-    Customises the HCal digitiser for post LS1 running
-    """
-    object.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
-    object.ho.siPMCode = cms.int32(1)
-    object.ho.pixels = cms.int32(2500)
-    object.ho.doSiPMSmearing = cms.bool(False)
-    object.hf1.samplingFactor = cms.double(0.67)
-    object.hf2.samplingFactor = cms.double(0.67)
+# Customises the HCal digitiser for post LS1 running
+eras.run2_common.toModify( hcalSimParameters, 
+    ho = dict(
+        photoelectronsToAnalog = cms.vdouble([4.0]*16),
+        siPMCode = cms.int32(1),
+        pixels = cms.int32(2500),
+        doSiPMSmearing = cms.bool(False)
+    ),
+    hf1 = dict( samplingFactor = cms.double(0.67) ),
+    hf2 = dict( samplingFactor = cms.double(0.67) )
+)
 
-eras.run2_common.toModify( hcalSimParameters, func=_modifyHcalSimParametersForPostLS1 )
+eras.run2_HE_2017.toModify( hcalSimParameters,
+    he = dict(
+        photoelectronsToAnalog = cms.vdouble([10.]*14),
+        pixels = cms.int32(4500*4*2)
+    )
+)

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -26,10 +26,8 @@ hcalSimBlock = cms.PSet(
     useOldHE = cms.bool(True),
     useOldHF = cms.bool(True),
     useOldHO = cms.bool(True),
-    HBHEUpgradeQIE = cms.bool(True),
+    HBHEUpgradeQIE = cms.bool(False),
     HFUpgradeQIE   = cms.bool(False),
-    HFQIE8         = cms.bool(True),
-    HFQIE10        = cms.bool(False),
     #HPDNoiseLibrary = cms.PSet(
     #   FileName = cms.FileInPath("SimCalorimetry/HcalSimAlgos/data/hpdNoiseLibrary.root"),
     #   HPDName = cms.untracked.string("HPD")
@@ -49,29 +47,3 @@ hcalSimBlock = cms.PSet(
 
 from Configuration.StandardSequences.Eras import eras
 eras.fastSim.toModify( hcalSimBlock, hitsProducer=cms.string('famosSimHits') )
-eras.run2_HF_2016.toModify( hcalSimBlock, HFQIE8=cms.bool(True), HFQIE10=cms.bool(True) )
-    
-#from CondCore.CondDB.CondDB_cfi import *
-#CondDB_cholesky = CondDB.clone( connect = cms.string('sqlite_file:CondFormats/HcalObjects/data/cholesky_sql.db') )
-#es_cholesky = cms.ESSource("PoolDBESSource",
-#    CondDB_cholesky,
-#    timetype = cms.string('runnumber'),
-#    toGet = cms.VPSet(
-#        cms.PSet(
-#            record = cms.string("HcalCholeskyMatricesRcd"),
-#            tag = cms.string("TestCholesky")
-#        )),
-#    appendToDataLabel = cms.string('reference'),
-#    authenticationMethod = cms.untracked.uint32(0),
-#)
-
-
-#es_cholesky = cms.ESSource('HcalTextCalibrations',
-#    input = cms.VPSet(
-#        cms.PSet(
-#            object = cms.string('CholeskyMatrices'),
-#            file = cms.FileInPath("CondFormats/HcalObjects/data/CholeskyMatrices.txt")
-#        ),
-#    ),
-#    appendToDataLabel = cms.string('reference')
-#)

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -15,6 +15,7 @@ HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::E
   mixMod.produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");
   mixMod.produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");
   mixMod.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
+  mixMod.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
 
 }
 
@@ -78,6 +79,11 @@ HcalDigiProducer::setZDCNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGene
 void
 HcalDigiProducer::setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
   theDigitizer_.setQIE10NoiseSignalGenerator(noiseGenerator);
+}
+
+void
+HcalDigiProducer::setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
+  theDigitizer_.setQIE11NoiseSignalGenerator(noiseGenerator);
 }
 
 CLHEP::HepRandomEngine* HcalDigiProducer::randomEngine(edm::StreamID const& streamID) {

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -40,59 +40,15 @@
 
 //#define DebugLog
 
-namespace HcalDigitizerImpl {
-
-  template<typename SIPMDIGITIZER>
-  void fillSiPMCells(std::vector<int> & siPMCells, SIPMDIGITIZER * siPMDigitizer)
-  {
-    std::vector<DetId> siPMDetIds;
-    siPMDetIds.reserve(siPMCells.size());
-    for(std::vector<int>::const_iterator idItr = siPMCells.begin();
-        idItr != siPMCells.end(); ++idItr)
-    {
-      siPMDetIds.emplace_back(*idItr);
-    }
-    siPMDigitizer->setDetIds(siPMDetIds);
-  }
-
-  // if both exist, assume the SiPM one has cells filled, and
-  // assign the rest to the HPD
-  template<typename HPDDIGITIZER, typename SIPMDIGITIZER>
-  void fillCells(std::vector<DetId>& allCells,
-                 HPDDIGITIZER * hpdDigitizer,
-                 SIPMDIGITIZER * siPMDigitizer)
-  {
-    // if both digitizers exist, split up the cells
-    if(siPMDigitizer && hpdDigitizer)
-    {
-      std::vector<DetId> siPMDetIds = siPMDigitizer->detIds();
-      std::sort(siPMDetIds.begin(), siPMDetIds.end());
-      std::vector<DetId> sortedCells = allCells;
-      std::sort(sortedCells.begin(), sortedCells.end());
-      std::vector<DetId> hpdCells;
-      std::set_difference(sortedCells.begin(), sortedCells.end(),
-                          siPMDetIds.begin(), siPMDetIds.end(),
-                          std::back_inserter(hpdCells) );
-      hpdDigitizer->setDetIds(hpdCells);
-    }
-    else
-    {
-      if(siPMDigitizer) siPMDigitizer->setDetIds(allCells);
-      if(hpdDigitizer) hpdDigitizer->setDetIds(allCells);
-    }
-  }
-} // namespace HcaiDigitizerImpl
-
-
 HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector& iC) :
   theGeometry(0),
   theRecNumber(0),
   theParameterMap(new HcalSimParameterMap(ps)),
   theShapes(new HcalShapes()),
-  theHBHEResponse(0),
-  theHBHESiPMResponse(0),
-  theHOResponse(0),   
-  theHOSiPMResponse(0),
+  theHBHEResponse(new CaloHitResponse(theParameterMap, theShapes)),
+  theHBHESiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes)),
+  theHOResponse(new CaloHitResponse(theParameterMap, theShapes)),   
+  theHOSiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes)),
   theHFResponse(new CaloHitResponse(theParameterMap, theShapes)),
   theHFQIE10Response(new CaloHitResponse(theParameterMap, theShapes)),
   theZDCResponse(new CaloHitResponse(theParameterMap, theShapes)),
@@ -101,6 +57,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHOAmplifier(0),
   theZDCAmplifier(0),
   theHFQIE10Amplifier(0),
+  theHBHEQIE11Amplifier(0),
   theIonFeedback(0),
   theCoderFactory(0),
   theUpgradeCoderFactory(0),
@@ -111,16 +68,18 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theUpgradeHBHEElectronicsSim(0),
   theUpgradeHFElectronicsSim(0),
   theHFQIE10ElectronicsSim(0),
+  theHBHEQIE11ElectronicsSim(0),
   theHBHEHitFilter(),
+  theHBHEQIE11HitFilter(),
   theHFHitFilter(ps.getParameter<bool>("doHFWindow")),
+  theHFQIE10HitFilter(ps.getParameter<bool>("doHFWindow")),
   theHOHitFilter(),
-  theHOSiPMHitFilter(HcalOuter),
+  theHOSiPMHitFilter(),
   theZDCHitFilter(),
   theHitCorrection(0),
   theNoiseGenerator(0),
   theNoiseHitGenerator(0),
   theHBHEDigitizer(0),
-  theHBHESiPMDigitizer(0),
   theHODigitizer(0),
   theHOSiPMDigitizer(0),
   theHFDigitizer(0),
@@ -128,6 +87,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHBHEUpgradeDigitizer(0),
   theHFUpgradeDigitizer(0),
   theHFQIE10Digitizer(0),
+  theHBHEQIE11Digitizer(0),
   theRelabeller(0),
   isZDC(true),
   isHCAL(true),
@@ -162,8 +122,6 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   bool agingFlagHE = ps.getParameter<bool>("HEDarkening");
   bool agingFlagHF = ps.getParameter<bool>("HFDarkening");
   double minFCToDelay= ps.getParameter<double>("minFCToDelay");
-  bool doHFQIE10 = ps.getParameter<bool>("HFQIE10");
-  bool doHFQIE8 = ps.getParameter<bool>("HFQIE8");
 
   if(PreMix1 && PreMix2) {
      throw cms::Exception("Configuration")
@@ -178,21 +136,24 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theHOAmplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theZDCAmplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theHFQIE10Amplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
+  theHBHEQIE11Amplifier = new HcalAmplifier(theParameterMap, doNoise, PreMix1, PreMix2);
   theHBHEAmplifier->setHBtuningParameter(HBtp);
   theHBHEAmplifier->setHEtuningParameter(HEtp);
+  theHBHEQIE11Amplifier->setHBtuningParameter(HBtp);
+  theHBHEQIE11Amplifier->setHEtuningParameter(HEtp);
   theHFAmplifier->setHFtuningParameter(HFtp);
   theHFQIE10Amplifier->setHFtuningParameter(HFtp);
   theHOAmplifier->setHOtuningParameter(HOtp);
   theHBHEAmplifier->setUseOldHB(useOldNoiseHB);
   theHBHEAmplifier->setUseOldHE(useOldNoiseHE);
+  theHBHEQIE11Amplifier->setUseOldHB(useOldNoiseHB);
+  theHBHEQIE11Amplifier->setUseOldHE(useOldNoiseHE);
   theHFAmplifier->setUseOldHF(useOldNoiseHF);
   theHFQIE10Amplifier->setUseOldHF(useOldNoiseHF);
   theHOAmplifier->setUseOldHO(useOldNoiseHO);
 
   theCoderFactory = new HcalCoderFactory(HcalCoderFactory::DB);
   theUpgradeCoderFactory = new HcalCoderFactory(HcalCoderFactory::UPGRADE);
-
-//  std::cout << "HcalDigitizer: theUpgradeCoderFactory created" << std::endl;
 
   theHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theCoderFactory, PreMix1);
   theHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theCoderFactory, PreMix1);
@@ -201,70 +162,44 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theUpgradeHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theUpgradeCoderFactory, PreMix1);
   theUpgradeHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theUpgradeCoderFactory, PreMix1);
   theHFQIE10ElectronicsSim = new HcalElectronicsSim(theHFQIE10Amplifier, theUpgradeCoderFactory, PreMix1); //should this use a different coder factory?
+  theHBHEQIE11ElectronicsSim = new HcalElectronicsSim(theHBHEQIE11Amplifier, theUpgradeCoderFactory, PreMix1); //should this use a different coder factory?
 
-//  std::cout << "HcalDigitizer: theUpgradeElectronicsSim created" <<  std::endl; 
-
-  // a code of 1 means make all cells SiPM
-  std::vector<int> hbSiPMCells(ps.getParameter<edm::ParameterSet>("hb").getParameter<std::vector<int> >("siPMCells"));
-  //std::vector<int> hoSiPMCells(ps.getParameter<edm::ParameterSet>("ho").getParameter<std::vector<int> >("siPMCells"));
-  // 0 means none, 1 means all, and 2 means use hardcoded
-
-//  std::cout << std::endl << " hbSiPMCells = " << hbSiPMCells.size() << std::endl;
-
-  bool doHBHEHPD = hbSiPMCells.empty() || (hbSiPMCells[0] != 1);
   bool doHOHPD = (theHOSiPMCode != 1);
-  bool doHBHESiPM = !hbSiPMCells.empty();
   bool doHOSiPM = (theHOSiPMCode != 0);
-  if(doHBHEHPD) {
-    theHBHEResponse = new CaloHitResponse(theParameterMap, theShapes);
-    edm::LogInfo("HcalDigitizer") <<"Set scale for HB towers";
-    theHBHEResponse->initHBHEScale();
-
-    theHBHEResponse->setHitFilter(&theHBHEHitFilter);
-    theHBHEDigitizer = new HBHEDigitizer(theHBHEResponse, theHBHEElectronicsSim, doEmpty);
-    bool    changeResponse = ps.getParameter<bool>("ChangeResponse");
-    edm::FileInPath fname  = ps.getParameter<edm::FileInPath>("CorrFactorFile");
-    if (changeResponse) {
-      std::string corrFileName = fname.fullPath();
-      edm::LogInfo("HcalDigitizer") << "Set scale for HB towers from " << corrFileName;
-      theHBHEResponse->setHBHEScale(corrFileName); //GMA
-    }
-  }
   if(doHOHPD) {
     theHOResponse = new CaloHitResponse(theParameterMap, theShapes);
+	theHOHitFilter.setSubdets({HcalOuter});
     theHOResponse->setHitFilter(&theHOHitFilter);
     theHODigitizer = new HODigitizer(theHOResponse, theHOElectronicsSim, doEmpty);
   }
-
-  if(doHBHESiPM) {
-    theHBHESiPMResponse = new HcalSiPMHitResponse(theParameterMap, theShapes);
-    theHBHESiPMResponse->setHitFilter(&theHBHEHitFilter);
-    if (doHBHEUpgrade) {
-      theHBHEUpgradeDigitizer = new UpgradeDigitizer(theHBHESiPMResponse, theUpgradeHBHEElectronicsSim, doEmpty);
-
-//      std::cout << "HcalDigitizer: theHBHEUpgradeDigitizer created" << std::endl;
-
-    } else {
-      theHBHESiPMDigitizer = new HBHEDigitizer(theHBHESiPMResponse, theHBHEElectronicsSim, doEmpty);
-    }
-  }
   if(doHOSiPM) {
     theHOSiPMResponse = new HcalSiPMHitResponse(theParameterMap, theShapes);
+	theHOSiPMHitFilter.setSubdets({HcalOuter});
     theHOSiPMResponse->setHitFilter(&theHOSiPMHitFilter);
     theHOSiPMDigitizer = new HODigitizer(theHOSiPMResponse, theHOElectronicsSim, doEmpty);
   }
-
-  // if both are present, fill the SiPM cells now
-  if(doHBHEHPD && doHBHESiPM) {
-
-//    std::cout << "HcalDigitizer:  fill the SiPM cells now"  << std::endl;
-
-    HcalDigitizerImpl::fillSiPMCells(hbSiPMCells, theHBHESiPMDigitizer);
+  
+  theHBHEResponse->initHBHEScale();
+  edm::LogInfo("HcalDigitizer") <<"Set scale for HB towers";
+  theHBHEHitFilter.setSubdets({HcalBarrel,HcalEndcap});
+  theHBHEResponse->setHitFilter(&theHBHEHitFilter);
+  bool    changeResponse = ps.getParameter<bool>("ChangeResponse");
+  edm::FileInPath fname  = ps.getParameter<edm::FileInPath>("CorrFactorFile");
+  if (changeResponse) {
+    std::string corrFileName = fname.fullPath();
+    edm::LogInfo("HcalDigitizer") << "Set scale for HB towers from " << corrFileName;
+    theHBHEResponse->setHBHEScale(corrFileName); //GMA
   }
-
-  theHFResponse->setHitFilter(&theHFHitFilter);
-  theHFQIE10Response->setHitFilter(&theHFHitFilter);
-  theZDCResponse->setHitFilter(&theZDCHitFilter);
+  theHBHEQIE11HitFilter.setSubdets({HcalBarrel,HcalEndcap});
+  theHBHESiPMResponse->setHitFilter(&theHBHEQIE11HitFilter);
+  
+  if(doHBHEUpgrade){
+    theHBHEUpgradeDigitizer = new UpgradeDigitizer(theHBHESiPMResponse, theUpgradeHBHEElectronicsSim, doEmpty);
+  }
+  else { //QIE8 and QIE11 can coexist in HBHE
+    theHBHEQIE11Digitizer = new QIE11Digitizer(theHBHESiPMResponse, theHBHEQIE11ElectronicsSim, doEmpty);
+    theHBHEDigitizer = new HBHEDigitizer(theHBHEResponse, theHBHEElectronicsSim, doEmpty);
+  }
 
   bool doTimeSlew = ps.getParameter<bool>("doTimeSlew");
   //initialize: they won't be called later if flag is set
@@ -273,21 +208,21 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
     // no time slewing for HF
     theTimeSlewSim = new HcalTimeSlewSim(theParameterMap,minFCToDelay);
     theHBHEAmplifier->setTimeSlewSim(theTimeSlewSim);
+    theHBHEQIE11Amplifier->setTimeSlewSim(theTimeSlewSim);
     theHOAmplifier->setTimeSlewSim(theTimeSlewSim);
     theZDCAmplifier->setTimeSlewSim(theTimeSlewSim);
   }
 
-  if (doHFQIE10 || doHFQIE8) { //QIE8 and QIE10 can coexist in HF
-    if(doHFQIE10) theHFQIE10Digitizer = new QIE10Digitizer(theHFQIE10Response, theHFQIE10ElectronicsSim, doEmpty);
-	if(doHFQIE8) theHFDigitizer = new HFDigitizer(theHFResponse, theHFElectronicsSim, doEmpty);
-  }
-  else if (doHFUpgrade) {
+  theHFResponse->setHitFilter(&theHFHitFilter);
+  theHFQIE10Response->setHitFilter(&theHFQIE10HitFilter);
+  theZDCResponse->setHitFilter(&theZDCHitFilter);
+  
+  if(doHFUpgrade){
     theHFUpgradeDigitizer = new UpgradeDigitizer(theHFResponse, theUpgradeHFElectronicsSim, doEmpty);
-
-//    std::cout << "HcalDigitizer: theHFUpgradeDigitizer created" << std::endl;
-
-  } else {
-    theHFDigitizer = new HFDigitizer(theHFResponse, theHFElectronicsSim, doEmpty);
+  }
+  else { //QIE8 and QIE10 can coexist in HF
+    theHFQIE10Digitizer = new QIE10Digitizer(theHFQIE10Response, theHFQIE10ElectronicsSim, doEmpty);
+	theHFDigitizer = new HFDigitizer(theHFResponse, theHFElectronicsSim, doEmpty);
   }
   theZDCDigitizer = new ZDCDigitizer(theZDCResponse, theZDCElectronicsSim, doEmpty);
 
@@ -297,10 +232,9 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
 
   bool doHPDNoise = ps.getParameter<bool>("doHPDNoise");
   if(doHPDNoise) {
-    //edm::ParameterSet hpdNoisePset = ps.getParameter<edm::ParameterSet>("HPDNoiseLibrary");
     theNoiseGenerator = new HPDNoiseGenerator(ps); 
     if(theHBHEDigitizer) theHBHEDigitizer->setNoiseSignalGenerator(theNoiseGenerator);
-    if(theHBHESiPMDigitizer) theHBHESiPMDigitizer->setNoiseSignalGenerator(theNoiseGenerator);
+    if(theHBHEQIE11Digitizer) theHBHEQIE11Digitizer->setNoiseSignalGenerator(theNoiseGenerator);
   }
 
   if(ps.getParameter<bool>("doIonFeedback") && theHBHEResponse) {
@@ -314,20 +248,12 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   if(ps.getParameter<bool>("injectTestHits") ) {
     theNoiseHitGenerator = new HcalTestHitGenerator(ps);
     if(theHBHEDigitizer) theHBHEDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
-    if(theHBHESiPMDigitizer) theHBHESiPMDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
+    if(theHBHEQIE11Digitizer) theHBHEQIE11Digitizer->setNoiseHitGenerator(theNoiseHitGenerator);
+    if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
     if(theHODigitizer) theHODigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
     if(theHOSiPMDigitizer) theHOSiPMDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
-    if(theHBHEUpgradeDigitizer) {
-      theHBHEUpgradeDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
-
-//      std::cout << "HcalDigitizer: theHBHEUpgradeDigitizer setNoise" << std::endl; 
-    }
     if(theHFDigitizer) theHFDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
-    if(theHFUpgradeDigitizer) { 
-      theHFUpgradeDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
-
-//      std::cout << "HcalDigitizer: theHFUpgradeDigitizer setNoise" << std::endl;
-    }
+    if(theHFUpgradeDigitizer) theHFUpgradeDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
 	if(theHFQIE10Digitizer) theHFQIE10Digitizer->setNoiseHitGenerator(theNoiseHitGenerator);
     theZDCDigitizer->setNoiseHitGenerator(theNoiseHitGenerator);
   }
@@ -339,7 +265,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
 
 HcalDigitizer::~HcalDigitizer() {
   if(theHBHEDigitizer)         delete theHBHEDigitizer;
-  if(theHBHESiPMDigitizer)     delete theHBHESiPMDigitizer;
+  if(theHBHEQIE11Digitizer)    delete theHBHEQIE11Digitizer;
   if(theHODigitizer)           delete theHODigitizer;
   if(theHOSiPMDigitizer)       delete theHOSiPMDigitizer;
   if(theHFDigitizer)           delete theHFDigitizer;
@@ -362,11 +288,13 @@ HcalDigitizer::~HcalDigitizer() {
   delete theUpgradeHBHEElectronicsSim;
   delete theUpgradeHFElectronicsSim;
   delete theHFQIE10ElectronicsSim;
+  delete theHBHEQIE11ElectronicsSim;
   delete theHBHEAmplifier;
   delete theHFAmplifier;
   delete theHOAmplifier;
   delete theZDCAmplifier;
   delete theHFQIE10Amplifier;
+  delete theHBHEQIE11Amplifier;
   delete theCoderFactory;
   delete theUpgradeCoderFactory;
   delete theHitCorrection;
@@ -380,6 +308,13 @@ void HcalDigitizer::setHBHENoiseSignalGenerator(HcalBaseSignalGenerator * noiseG
   noiseGenerator->setElectronicsSim(theHBHEElectronicsSim);
   if (theHBHEDigitizer) theHBHEDigitizer->setNoiseSignalGenerator(noiseGenerator);
   theHBHEAmplifier->setNoiseSignalGenerator(noiseGenerator);
+}
+
+void HcalDigitizer::setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
+  noiseGenerator->setParameterMap(theParameterMap);
+  noiseGenerator->setElectronicsSim(theHBHEQIE11ElectronicsSim);
+  if(theHBHEQIE11Digitizer) theHBHEQIE11Digitizer->setNoiseSignalGenerator(noiseGenerator);
+  theHBHEQIE11Amplifier->setNoiseSignalGenerator(noiseGenerator);
 }
 
 void HcalDigitizer::setHFNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
@@ -416,14 +351,18 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
   // get the appropriate gains, noises, & widths for this event
   edm::ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
+  
   theHBHEAmplifier->setDbService(conditions.product());
   theHFAmplifier->setDbService(conditions.product());
   theHOAmplifier->setDbService(conditions.product());
   theZDCAmplifier->setDbService(conditions.product());
   theHFQIE10Amplifier->setDbService(conditions.product());
+  theHBHEQIE11Amplifier->setDbService(conditions.product());
+  
   theUpgradeHBHEElectronicsSim->setDbService(conditions.product());
   theUpgradeHFElectronicsSim->setDbService(conditions.product());
   theHFQIE10ElectronicsSim->setDbService(conditions.product());
+  theHBHEQIE11ElectronicsSim->setDbService(conditions.product());
 
   theCoderFactory->setDbService(conditions.product());
   theUpgradeCoderFactory->setDbService(conditions.product());
@@ -451,7 +390,7 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
 
   //initialize hits
   if(theHBHEDigitizer) theHBHEDigitizer->initializeHits();
-  if(theHBHESiPMDigitizer) theHBHESiPMDigitizer->initializeHits();
+  if(theHBHEQIE11Digitizer) theHBHEQIE11Digitizer->initializeHits();
   if(theHODigitizer) theHODigitizer->initializeHits();
   if(theHOSiPMDigitizer) theHOSiPMDigitizer->initializeHits();
   if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->initializeHits();
@@ -464,7 +403,7 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
 
 void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHandle, edm::Handle<std::vector<PCaloHit> > const& zdcHandle, int bunchCrossing, CLHEP::HepRandomEngine* engine, const HcalTopology *htopoP) {
 
-  // Step A: pass in inputs, and accumulate digirs
+  // Step A: pass in inputs, and accumulate digis
   if(isHCAL) {
     std::vector<PCaloHit> hcalHitsOrig = *hcalHandle.product();
     std::vector<PCaloHit> hcalHits;
@@ -485,14 +424,14 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
       DetId id(hcalHitsOrig[i].id());
       HcalDetId hid(id);
       if (!htopoP->validHcal(hid)) {
-	edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << " " << hid << std::endl;
+        edm::LogError("HcalDigitizer") << "bad hcal id found in digitizer. Skipping " << id.rawId() << " " << hid << std::endl;
       } else {
 #ifdef DebugLog
-	std::cout << "HcalDigitizer format " << hid.oldFormat() << " for " << hid << std::endl;
+        std::cout << "HcalDigitizer format " << hid.oldFormat() << " for " << hid << std::endl;
 #endif
         DetId newid = DetId(hid.newForm());
 #ifdef DebugLog
-	  std::cout << "Hit " << i << " out of " << hcalHits.size() << " " << std::hex << id.rawId() << " --> " << newid.rawId() << std::dec << " " << HcalDetId(newid.rawId()) << '\n';
+        std::cout << "Hit " << i << " out of " << hcalHits.size() << " " << std::hex << id.rawId() << " --> " << newid.rawId() << std::dec << " " << HcalDetId(newid.rawId()) << '\n';
 #endif
         hcalHitsOrig[i].setID(newid.rawId());
         hcalHits.push_back(hcalHitsOrig[i]);
@@ -504,10 +443,8 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const
     }
     if(hbhegeo) {
       if(theHBHEDigitizer) theHBHEDigitizer->add(hcalHits, bunchCrossing, engine);
-      if(theHBHESiPMDigitizer) theHBHESiPMDigitizer->add(hcalHits, bunchCrossing, engine);
-      if(theHBHEUpgradeDigitizer) {
-        theHBHEUpgradeDigitizer->add(hcalHits, bunchCrossing, engine);
-      }
+      if(theHBHEQIE11Digitizer) theHBHEQIE11Digitizer->add(hcalHits, bunchCrossing, engine);
+      if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->add(hcalHits, bunchCrossing, engine);
     }
 
     if(hogeo) {
@@ -581,17 +518,13 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   std::auto_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
   std::auto_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
   std::auto_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection());
+  std::auto_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection());
 
   // Step C: Invoke the algorithm, getting back outputs.
   if(isHCAL&&hbhegeo){
     if(theHBHEDigitizer)        theHBHEDigitizer->run(*hbheResult, engine);
-    if(theHBHESiPMDigitizer)    theHBHESiPMDigitizer->run(*hbheResult, engine);
-    if(theHBHEUpgradeDigitizer) {
-      theHBHEUpgradeDigitizer->run(*hbheupgradeResult, engine);
-#ifdef DebugLog
-      std::cout << "HcalDigitizer::finalizeEvent  theHBHEUpgradeDigitizer->run" << std::endl; 
-#endif
-    }
+    if(theHBHEQIE11Digitizer)    theHBHEQIE11Digitizer->run(*hbheQIE11Result, engine);
+    if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->run(*hbheupgradeResult, engine);
   }
   if(isHCAL&&hogeo) {
     if(theHODigitizer) theHODigitizer->run(*hoResult, engine);
@@ -609,21 +542,22 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   edm::LogInfo("HcalDigitizer") << "HCAL HBHE digis : " << hbheResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HO digis   : " << hoResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HF digis   : " << hfResult->size();
-  edm::LogInfo("HcalDigitizer") << "HCAL ZDC digis   : " << zdcResult->size();
+  edm::LogInfo("HcalDigitizer") << "HCAL ZDC digis  : " << zdcResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HBHE upgrade digis : " << hbheupgradeResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HF upgrade digis : " << hfupgradeResult->size();
   edm::LogInfo("HcalDigitizer") << "HCAL HF QIE10 digis : " << hfQIE10Result->size();
+  edm::LogInfo("HcalDigitizer") << "HCAL HBHE QIE11 digis : " << hbheQIE11Result->size();
 
 #ifdef DebugLog
   std::cout << std::endl;
   std::cout << "HCAL HBHE digis : " << hbheResult->size() << std::endl;
   std::cout << "HCAL HO   digis : " << hoResult->size() << std::endl;
   std::cout << "HCAL HF   digis : " << hfResult->size() << std::endl;
- 
-  std::cout << "HCAL HBHE upgrade digis : " << hbheupgradeResult->size()
-	    << std::endl;
-  std::cout << "HCAL HF   upgrade digis : " << hfupgradeResult->size()
-	    << std::endl;
+  std::cout << "HCAL ZDC  digis : " << zdcResult->size() << std::endl;
+  std::cout << "HCAL HBHE upgrade digis : " << hbheupgradeResult->size() << std::endl;
+  std::cout << "HCAL HF   upgrade digis : " << hfupgradeResult->size() << std::endl;
+  std::cout << "HCAL HF QIE10 digis : " << hfQIE10Result->size() << std::endl;
+  std::cout << "HCAL HBHE QIE11 digis : " << hbheQIE11Result->size() << std::endl;
 #endif
 
   // Step D: Put outputs into event
@@ -634,6 +568,7 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   e.put(hbheupgradeResult,"HBHEUpgradeDigiCollection");
   e.put(hfupgradeResult, "HFUpgradeDigiCollection");
   e.put(hfQIE10Result, "HFQIE10DigiCollection");
+  e.put(hbheQIE11Result, "HBHEQIE11DigiCollection");
 
 #ifdef DebugLog
   std::cout << std::endl << "========>  HcalDigitizer e.put " << std::endl <<  std::endl;
@@ -696,25 +631,19 @@ void  HcalDigitizer::updateGeometry(const edm::EventSetup & eventSetup) {
   if(hfCells.empty()) hfgeo = false;
   // combine HB & HE
 
-  theHBHEDetIds = hbCells;
-  theHBHEDetIds.insert(theHBHEDetIds.end(), heCells.begin(), heCells.end());
-
-  HcalDigitizerImpl::fillCells(theHBHEDetIds, theHBHEDigitizer, theHBHESiPMDigitizer);
-  //HcalDigitizerImpl::fillCells(hoCells, theHODigitizer, theHOSiPMDigitizer);
+  std::vector<DetId> hbheCells = hbCells;
+  hbheCells.insert(hbheCells.end(), heCells.begin(), heCells.end());
+  //handle mixed QIE8/11 scenario in HBHE
+  if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->setDetIds(hbheCells);
+  else buildHBHEQIECells(hbheCells,eventSetup);
+  
   buildHOSiPMCells(hoCells, eventSetup);
+  
   //handle mixed QIE8/10 scenario in HF
-  if(theHFDigitizer && theHFQIE10Digitizer) buildHFQIECells(hfCells,eventSetup);
-  else if(theHFDigitizer) theHFDigitizer->setDetIds(hfCells);
-  else if(theHFQIE10Digitizer) theHFQIE10Digitizer->setDetIds(hfCells);
   if(theHFUpgradeDigitizer) theHFUpgradeDigitizer->setDetIds(hfCells);
-  theZDCDigitizer->setDetIds(zdcCells); 
-  if(theHBHEUpgradeDigitizer) {
-    theHBHEUpgradeDigitizer->setDetIds(theHBHEDetIds);
-#ifdef DebugLog
-    std::cout << " HcalDigitizer::updateGeometry  theHBHEUpgradeDigitizer->setDetIds(theHBHEDetIds)"<< std::endl;   
-#endif
-  }
-
+  else buildHFQIECells(hfCells,eventSetup);
+  
+  theZDCDigitizer->setDetIds(zdcCells);
 }
 
 void HcalDigitizer::buildHFQIECells(const std::vector<DetId>& allCells, const edm::EventSetup & eventSetup) {
@@ -756,6 +685,52 @@ void HcalDigitizer::buildHFQIECells(const std::vector<DetId>& allCells, const ed
 	}
 }
 
+void HcalDigitizer::buildHBHEQIECells(const std::vector<DetId>& allCells, const edm::EventSetup & eventSetup) {
+	//if results are already cached, no need to look again
+	if(theHBHEQIE8DetIds.size()>0 || theHBHEQIE11DetIds.size()>0) return;
+	
+	//get the QIETypes
+	edm::ESHandle<HcalQIETypes> q;
+    eventSetup.get<HcalQIETypesRcd>().get(q);
+	edm::ESHandle<HcalTopology> htopo;
+    eventSetup.get<HcalRecNumberingRecord>().get(htopo);
+   
+    HcalQIETypes qieTypes(*q.product());
+    if (qieTypes.topo()==0) {
+      qieTypes.setTopo(htopo.product());
+    }
+	
+	for(std::vector<DetId>::const_iterator detItr = allCells.begin(); detItr != allCells.end(); ++detItr) {
+      HcalQIENum qieType = HcalQIENum(qieTypes.getValues(*detItr)->getValue());
+      if(qieType == QIE8) {
+        theHBHEQIE8DetIds.push_back(*detItr);
+      }
+      else if(qieType == QIE11) {
+        theHBHEQIE11DetIds.push_back(*detItr);
+      }
+      else { //default is QIE8
+        theHBHEQIE8DetIds.push_back(*detItr);
+      }
+    }
+	
+	if(theHBHEQIE8DetIds.size()>0) theHBHEDigitizer->setDetIds(theHBHEQIE8DetIds);
+	else {
+		delete theHBHEDigitizer;
+		theHBHEDigitizer = NULL;
+	}
+	
+	if(theHBHEQIE11DetIds.size()>0) theHBHEQIE11Digitizer->setDetIds(theHBHEQIE11DetIds);
+	else {
+		delete theHBHEQIE11Digitizer;
+		theHBHEQIE11Digitizer = NULL;
+	}
+	
+	if(theHBHEQIE8DetIds.size()>0 && theHBHEQIE11DetIds.size()>0){
+		theHBHEHitFilter.setDetIds(theHBHEQIE8DetIds);
+		theHBHEQIE11HitFilter.setDetIds(theHBHEQIE11DetIds);
+	}
+}
+
 void HcalDigitizer::buildHOSiPMCells(const std::vector<DetId>& allCells, const edm::EventSetup & eventSetup) {
   // all HPD
 
@@ -776,8 +751,7 @@ void HcalDigitizer::buildHOSiPMCells(const std::vector<DetId>& allCells, const e
       mcParams.setTopo(htopo.product());
     }
 
-    for(std::vector<DetId>::const_iterator detItr = allCells.begin();
-        detItr != allCells.end(); ++detItr) {
+    for(std::vector<DetId>::const_iterator detItr = allCells.begin(); detItr != allCells.end(); ++detItr) {
       int shapeType = mcParams.getValues(*detItr)->signalShape();
       if(shapeType == HcalShapes::ZECOTEK) {
         zecotekDetIds.emplace_back(*detItr);
@@ -790,12 +764,23 @@ void HcalDigitizer::buildHOSiPMCells(const std::vector<DetId>& allCells, const e
       }
     }
 
-    assert(theHODigitizer);
-    assert(theHOSiPMDigitizer);
-    theHODigitizer->setDetIds(theHOHPDDetIds);
-    theHOSiPMDigitizer->setDetIds(theHOSiPMDetIds);
-    theHOSiPMHitFilter.setDetIds(theHOSiPMDetIds);
-    // FIXME not applying a HitFilter to the HPDs, for now
+    if(theHOHPDDetIds.size()>0) theHODigitizer->setDetIds(theHOHPDDetIds);
+    else {
+      delete theHODigitizer;
+      theHODigitizer = NULL;
+    }
+	
+    if(theHOSiPMDetIds.size()>0) theHOSiPMDigitizer->setDetIds(theHOSiPMDetIds);
+    else {
+      delete theHOSiPMDigitizer;
+      theHOSiPMDigitizer = NULL;
+    }
+	
+	if(theHOHPDDetIds.size()>0 && theHOSiPMDetIds.size()>0){
+      theHOSiPMHitFilter.setDetIds(theHOSiPMDetIds);
+      theHOHitFilter.setDetIds(theHOHPDDetIds);
+    }
+	
     theParameterMap->setHOZecotekDetIds(zecotekDetIds);
     theParameterMap->setHOHamamatsuDetIds(hamamatsuDetIds);
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -21,6 +21,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const& conf):
   tok_hbheUpgrade_ = consumes<HBHEUpgradeDigiCollection>(edm::InputTag(inputLabel_, "HBHEUpgradeDigiCollection"));
   tok_hfUpgrade_ = consumes<HFUpgradeDigiCollection>(edm::InputTag(inputLabel_, "HFUpgradeDigiCollection"));
   tok_hfQIE10_ = consumes<QIE10DigiCollection>(edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
+  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
 
 
   std::vector<int> tmp = conf.getParameter<std::vector<int> >("HBregion");
@@ -91,6 +92,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const& conf):
     produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");
     produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");
     produces<QIE10DigiCollection>("HFQIE10DigiCollection");
+    produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
    
 }
     
@@ -107,6 +109,7 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   edm::Handle<HBHEUpgradeDigiCollection> hbheUpgrade;
   edm::Handle<HFUpgradeDigiCollection> hfUpgrade;
   edm::Handle<QIE10DigiCollection> hfQIE10;
+  edm::Handle<QIE11DigiCollection> hbheQIE11;
 
   edm::ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
@@ -130,11 +133,13 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   e.getByToken(tok_hbheUpgrade_,hbheUpgrade);
   e.getByToken(tok_hfUpgrade_,hfUpgrade);
   e.getByToken(tok_hfQIE10_,hfQIE10);
+  e.getByToken(tok_hbheQIE11_,hbheQIE11);
   
   // create empty output
   std::auto_ptr<HBHEUpgradeDigiCollection> zs_hbheUpgrade(new HBHEUpgradeDigiCollection);
   std::auto_ptr<HFUpgradeDigiCollection> zs_hfUpgrade(new HFUpgradeDigiCollection);
   std::auto_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection);
+  std::auto_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection);
   
   //run the algorithm
 
@@ -144,6 +149,7 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   algo_->suppress(*(hbheUpgrade.product()),*zs_hbheUpgrade);
   algo_->suppress(*(hfUpgrade.product()),*zs_hfUpgrade);
   algo_->suppress(*(hfQIE10.product()),*zs_hfQIE10);
+  algo_->suppress(*(hbheQIE11.product()),*zs_hbheQIE11);
 
   
   edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHE) input " << hbhe->size() << " digis, output " << zs_hbhe->size() << " digis" 
@@ -151,7 +157,8 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 				      <<  " (HF) input " << hf->size() << " digis, output " << zs_hf->size() << " digis"
 				      <<  " (HBHEUpgrade) input " << hbheUpgrade->size() << " digis, output " << zs_hbheUpgrade->size() << " digis"
 				      <<  " (HFUpgrade) input " << hfUpgrade->size() << " digis, output " << zs_hfUpgrade->size() << " digis"
-				      <<  " (HFQIE10) input " << hfQIE10->size() << " digis, output " << zs_hfQIE10->size() << " digis";
+				      <<  " (HFQIE10) input " << hfQIE10->size() << " digis, output " << zs_hfQIE10->size() << " digis"
+				      <<  " (HBHEQIE11) input " << hbheQIE11->size() << " digis, output " << zs_hbheQIE11->size() << " digis";
   
 
     // return result
@@ -161,5 +168,6 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
     e.put(zs_hbheUpgrade,"HBHEUpgradeDigiCollection");
     e.put(zs_hfUpgrade,"HFUpgradeDigiCollection");
     e.put(zs_hfQIE10,"HFQIE10DigiCollection");
+    e.put(zs_hbheQIE11,"HBHEQIE11DigiCollection");
 
 }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.h
@@ -31,6 +31,7 @@ private:
   edm::EDGetTokenT<HBHEUpgradeDigiCollection> tok_hbheUpgrade_;
   edm::EDGetTokenT<HFUpgradeDigiCollection> tok_hfUpgrade_;
   edm::EDGetTokenT<QIE10DigiCollection> tok_hfQIE10_;
+  edm::EDGetTokenT<QIE11DigiCollection> tok_hbheQIE11_;
 };
 
 #endif

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
@@ -23,7 +23,7 @@ public:
   virtual ~HcalSimpleAmplitudeZS();
   virtual void produce(edm::Event& e, const edm::EventSetup& c);
 private:
-  std::auto_ptr<HcalZSAlgoEnergy> hbhe_,ho_,hf_,hbheUpgrade_,hfUpgrade_,hfQIE10_;
+  std::auto_ptr<HcalZSAlgoEnergy> hbhe_,ho_,hf_,hbheUpgrade_,hfUpgrade_,hfQIE10_,hbheQIE11_;
   std::string inputLabel_;
   edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HODigiCollection> tok_ho_;
@@ -31,6 +31,7 @@ private:
   edm::EDGetTokenT<HBHEUpgradeDigiCollection> tok_hbheUpgrade_;
   edm::EDGetTokenT<HFUpgradeDigiCollection> tok_hfUpgrade_;
   edm::EDGetTokenT<QIE10DigiCollection> tok_hfQIE10_;
+  edm::EDGetTokenT<QIE11DigiCollection> tok_hbheQIE11_;
 };
 
 #endif

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.cc
@@ -67,6 +67,9 @@ bool HcalZSAlgoEnergy::shouldKeep(const HFDataFrame& digi) const {
 bool HcalZSAlgoEnergy::shouldKeep(const QIE10DataFrame& digi) const {
   return ZSEnergy_impl::keepMe<QIE10DataFrame>(*db_,digi,threshold_,firstsample_,samplecount_,twosided_);
 }
+bool HcalZSAlgoEnergy::shouldKeep(const QIE11DataFrame& digi) const {
+  return ZSEnergy_impl::keepMe<QIE11DataFrame>(*db_,digi,threshold_,firstsample_,samplecount_,twosided_);
+}
 bool HcalZSAlgoEnergy::shouldKeep(const HcalUpgradeDataFrame& digi) const {
   return ZSEnergy_impl::keepMe<HcalUpgradeDataFrame>(*db_,digi,threshold_,firstsample_,samplecount_,twosided_);
 }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
@@ -23,6 +23,7 @@ protected:
   virtual bool shouldKeep(const HODataFrame& digi) const;
   virtual bool shouldKeep(const HFDataFrame& digi) const;
   virtual bool shouldKeep(const QIE10DataFrame& digi) const;
+  virtual bool shouldKeep(const QIE11DataFrame& digi) const;
   virtual bool shouldKeep(const HcalUpgradeDataFrame& digi) const;
 private:
   int threshold_, firstsample_, samplecount_;

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
@@ -30,104 +30,10 @@ HcalZSAlgoRealistic::HcalZSAlgoRealistic(bool mp, std::pair<int,int> HBsearchTS,
   usingDBvalues = true;
 
 }
-
-
   
-//template <class DIGI> 
-//For HBHE Data Frame 
-bool HcalZSAlgoRealistic::keepMe(const HBHEDataFrame& inp, int start, int finish, int threshold, uint32_t hbhezsmask) const{
-  
+template <class Digi>
+bool HcalZSAlgoRealistic::keepMe(const Digi& inp, int start, int finish, int threshold, uint32_t zsmask) const{
   bool keepIt=false;
-  //int mask = 999;
-  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
-    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
-  }
-
-  //determine the sum of 2 timeslices
-  for (int i = start; i < finish && !keepIt; i++) {
-    int sum=0;
-    
-    for (int j = i; j < (i+2); j++){
-      sum+=inp[j].adc();
-      //pedsum+=pedave;
-    }
-    if ((hbhezsmask&(1<<i)) !=0) continue; 
-    else if (sum>=threshold) keepIt=true;
-  }
-  return keepIt;
-}
-
-//For HO Data Frame 
-bool HcalZSAlgoRealistic::keepMe(const HODataFrame& inp, int start, int finish, int threshold, uint32_t hozsmask) const{
-  
-  bool keepIt=false;
-  //  int mask = 999;
-  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
-    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
-  }
-
-  //determine the sum of 2 timeslices
-  for (int i = start; i < finish && !keepIt; i++) {
-    int sum=0;
-    
-    for (int j = i; j < (i+2); j++){
-      sum+=inp[j].adc();
-      //pedsum+=pedave;
-    }
-    if ((hozsmask&(1<<i)) !=0) continue; 
-    else if (sum>=threshold) keepIt=true;
-  }
-  return keepIt;
-}
-
-//For HF Data Frame 
-bool HcalZSAlgoRealistic::keepMe(const HFDataFrame& inp, int start, int finish, int threshold, uint32_t hfzsmask) const{
-  
-  bool keepIt=false;
-  //  int mask = 999;
-  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
-    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
-  }
-  
-  //determine the sum of 2 timeslices
-  for (int i = start; i < finish && !keepIt; i++) {
-    int sum=0;
-    
-    for (int j = i; j < (i+2); j++){
-      sum+=inp[j].adc();
-      //pedsum+=pedave;
-    }
-    if ((hfzsmask&(1<<i)) !=0) continue; 
-    else if (sum>=threshold) keepIt=true;
-  }
-  return keepIt;
-}
-
-bool HcalZSAlgoRealistic::keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold) const{
-  
-  bool keepIt=false;
-  //  int mask = 999;
-  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
-    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
-  }
-  
-  //determine the sum of 2 timeslices
-  for (int i = start; i < finish && !keepIt; i++) {
-    int sum=0;
-    
-    for (int j = i; j < (i+2); j++){
-      sum+=inp[j].adc();
-      //pedsum+=pedave;
-    }
-    if (sum>=threshold) keepIt=true;
-  }
-  return keepIt;
-}
-
-bool HcalZSAlgoRealistic::keepMe(const HcalUpgradeDataFrame& inp, int start, int finish, int threshold, uint32_t zsmask) const{
-  
-  bool keepIt=false;
-  //int mask = 999;
   if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
     threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
   }
@@ -144,49 +50,88 @@ bool HcalZSAlgoRealistic::keepMe(const HcalUpgradeDataFrame& inp, int start, int
   return keepIt;
 }
 
-bool HcalZSAlgoRealistic::shouldKeep(const HBHEDataFrame& digi) const{
+//zs mask not used for QIE10,11
 
+template<>
+bool HcalZSAlgoRealistic::keepMe<QIE10DataFrame>(const QIE10DataFrame& inp, int start, int finish, int threshold, uint32_t zsmask) const{
+  bool keepIt=false;
+  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
+    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
+  }
+  
+  //determine the sum of 2 timeslices
+  for (int i = start; i < finish && !keepIt; i++) {
+    int sum=0;
+    for (int j = i; j < (i+2); j++){
+      sum+=inp[j].adc();
+    }
+    if (sum>=threshold) keepIt=true;
+  }
+  return keepIt;
+}
+
+template<>
+bool HcalZSAlgoRealistic::keepMe<QIE11DataFrame>(const QIE11DataFrame& inp, int start, int finish, int threshold, uint32_t zsmask) const{
+  bool keepIt=false;
+  if ((usingDBvalues) && (threshold < 0) && (m_dbService != 0)){
+    threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
+  }
+  
+  //determine the sum of 2 timeslices
+  for (int i = start; i < finish && !keepIt; i++) {
+    int sum=0;
+    for (int j = i; j < (i+2); j++){
+      sum+=inp[j].adc();
+    }
+    if (sum>=threshold) keepIt=true;
+  }
+  return keepIt;
+}
+
+bool HcalZSAlgoRealistic::shouldKeep(const HBHEDataFrame& digi) const{
   if (digi.id().subdet()==HcalBarrel) {
     int start  = std::max(0,HBsearchTS_.first);
     int finish = std::min(digi.size()-1,HBsearchTS_.second);
-    /*
-    std::cout << " HBsearchTS_ : " <<  HBsearchTS_.first 
-	      << ", " << HBsearchTS_.second << std::endl;
-    std::cout << " HB start, finish = " << start << ", "
-	      << finish << std::endl;
-    */
     return keepMe(digi,start,finish,thresholdHB_,digi.zsCrossingMask());
   } else {
     int start  = std::max(0,HEsearchTS_.first);
     int finish = std::min(digi.size()-1,HEsearchTS_.second);
     return keepMe(digi,start,finish,thresholdHE_,digi.zsCrossingMask());
-
   }
 }  
 
 bool HcalZSAlgoRealistic::shouldKeep(const HODataFrame& digi) const{
-
   int start  = std::max(0,HOsearchTS_.first);
   int finish = std::min(digi.size()-1,HOsearchTS_.second);
   return keepMe(digi,start,finish,thresholdHO_,digi.zsCrossingMask());
 }
 
 bool HcalZSAlgoRealistic::shouldKeep(const HFDataFrame& digi) const{
-
   int start  = std::max(0,HFsearchTS_.first);
   int finish = std::min(digi.size()-1,HFsearchTS_.second);
   return keepMe(digi,start,finish,thresholdHF_,digi.zsCrossingMask());
 }
 
 bool HcalZSAlgoRealistic::shouldKeep(const QIE10DataFrame& digi) const{
-
   int start  = std::max(0,HFsearchTS_.first);
-  int finish = std::min((int)digi.size()-1,HFsearchTS_.second);
-  return keepMe(digi,start,finish,thresholdHF_);
+  int finish = std::min((int)digi.samples()-1,HFsearchTS_.second);
+  return keepMe(digi,start,finish,thresholdHF_,0);
+}
+
+bool HcalZSAlgoRealistic::shouldKeep(const QIE11DataFrame& digi) const{
+  HcalDetId hid(digi.id());
+  if (hid.subdet()==HcalBarrel) {
+    int start  = std::max(0,HBsearchTS_.first);
+    int finish = std::min(digi.samples()-1,HBsearchTS_.second);
+    return keepMe(digi,start,finish,thresholdHB_,0);
+  } else {
+    int start  = std::max(0,HEsearchTS_.first);
+    int finish = std::min(digi.samples()-1,HEsearchTS_.second);
+    return keepMe(digi,start,finish,thresholdHE_,0);
+  }
 }
 
 bool HcalZSAlgoRealistic::shouldKeep(const HcalUpgradeDataFrame& digi) const{
-
   if (digi.id().subdet()==HcalForward) {
     int start  = std::max(0,HFsearchTS_.first);
     int finish = std::min(digi.size()-1,HFsearchTS_.second);

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
@@ -17,20 +17,18 @@ public:
   HcalZSAlgoRealistic(bool markAndPass, int levelHB, int levelHE, int levelHO, int levelHF, std::pair<int,int> HBsearchTS, std::pair<int,int> HEsearchTS, std::pair<int,int> HOsearchTS, std::pair<int,int> HFsearchTS);
   
 protected:
+  //these need to be overloads instead of templates to avoid linking issues when calling private member function templates
   virtual bool shouldKeep(const HBHEDataFrame& digi) const;
   virtual bool shouldKeep(const HODataFrame& digi) const;
   virtual bool shouldKeep(const HFDataFrame& digi) const;
   virtual bool shouldKeep(const QIE10DataFrame& digi) const;
+  virtual bool shouldKeep(const QIE11DataFrame& digi) const;
   virtual bool shouldKeep(const HcalUpgradeDataFrame& digi) const;
 private:
   bool usingDBvalues; 
   int thresholdHB_, thresholdHE_, thresholdHO_, thresholdHF_;
   std::pair<int,int> HBsearchTS_,  HEsearchTS_, HOsearchTS_, HFsearchTS_;
-  bool keepMe(const HBHEDataFrame& inp, int start, int finish, int threshold, uint32_t hbhezsmask) const;
-  bool keepMe(const HODataFrame& inp, int start, int finish, int threshold, uint32_t hozsmask) const;
-  bool keepMe(const HFDataFrame& inp, int start, int finish, int threshold, uint32_t hfzsmask) const;
-  bool keepMe(const QIE10DataFrame& inp, int start, int finish, int threshold) const;
-  bool keepMe(const HcalUpgradeDataFrame& inp, int start, int finish, int threshold, uint32_t zsmask) const;
+  template<class Digi> bool keepMe(const Digi& inp, int start, int finish, int threshold, uint32_t zsmask) const;
 };
 
 #endif

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
@@ -88,19 +88,36 @@ void HcalZeroSuppressionAlgo::suppress(const HcalUpgradeDigiCollection& input, H
 
 void HcalZeroSuppressionAlgo::suppress(const QIE10DigiCollection& input, QIE10DigiCollection& output) {
   for (QIE10DigiCollection::const_iterator i=input.begin(); i!=input.end(); ++i) {
-    if (shouldKeep((*i))) {
+    QIE10DataFrame df(*i);
+    if (shouldKeep(df)) {
       if (!m_markAndPass) {
-	output.push_back(*i);
+        output.push_back(df);
       } else {
-	QIE10DataFrame df(*i);
-	df.setZSInfo(false);
-	output.push_back(df);
+        df.setZSInfo(false);
+        output.push_back(df);
       }
-    } else if (m_markAndPass) {
-      QIE10DataFrame df(*i);
+    } 
+    else if (m_markAndPass) {
       df.setZSInfo(true);
       output.push_back(df);
     }
   }
 }
 
+void HcalZeroSuppressionAlgo::suppress(const QIE11DigiCollection& input, QIE11DigiCollection& output) {
+  for (QIE11DigiCollection::const_iterator i=input.begin(); i!=input.end(); ++i) {
+    QIE11DataFrame df(*i);
+    if (shouldKeep(df)) {
+      if (!m_markAndPass) {
+        output.push_back(df);
+      } else {
+        df.setZSInfo(false);
+        output.push_back(df);
+      }
+    }
+	else if (m_markAndPass) {
+      df.setZSInfo(true);
+      output.push_back(df);
+    }
+  }
+}

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.h
@@ -19,11 +19,13 @@ public:
   void suppress(const HFDigiCollection& input, HFDigiCollection& output);
   void suppress(const HcalUpgradeDigiCollection& input, HcalUpgradeDigiCollection& output);
   void suppress(const QIE10DigiCollection& input, QIE10DigiCollection& output);
+  void suppress(const QIE11DigiCollection& input, QIE11DigiCollection& output);
   virtual bool shouldKeep(const HBHEDataFrame& digi) const = 0;
   virtual bool shouldKeep(const HODataFrame& digi) const = 0;
   virtual bool shouldKeep(const HFDataFrame& digi) const = 0;
   virtual bool shouldKeep(const HcalUpgradeDataFrame& digi) const = 0;
   virtual bool shouldKeep(const QIE10DataFrame& digi) const = 0;
+  virtual bool shouldKeep(const QIE11DataFrame& digi) const = 0;
   void setDbService(const HcalDbService* db) { m_dbService=db; }
   void clearDbService() { m_dbService=0; }
   //  template <class DIGI> bool keepMe(const DIGI& inp, int threshold);

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -57,6 +57,15 @@ namespace {
     }
   }
   
+  template <>
+  void convertAdc2fChelper<QIE11DataFrame> (const QIE11DataFrame& digi, const HcalDbService& conditions, CaloSamples& fC, const HcalDetId& id) {
+    const HcalCalibrations& calib = conditions.getHcalCalibrations(id);
+    for (int i = 0; i < digi.samples(); ++i) {
+      int capId (digi[i].capid());
+      fC[i] -= calib.pedestal (capId);
+    }
+  }
+  
   template <class DIGI>
   void convertAdc2fC (const DIGI& digi, const HcalDbService& conditions, bool keepPedestals, CaloSamples& fC) {
     HcalDetId id (digi.id());
@@ -85,6 +94,19 @@ namespace {
    void convertHcalDigis<QIE10DigiCollection> (const QIE10DigiCollection& digis, const HcalDbService& conditions, bool keepPedestals, HcalDigiMap& map) {
     for (auto digiItr = digis.begin(); digiItr != digis.end(); ++digiItr) {
       QIE10DataFrame digi(*digiItr);
+	  CaloSamples fC;
+      convertAdc2fC (digi, conditions, keepPedestals, fC);
+      if (!keepPedestals && map.find(digi.id()) == map.end()) {
+        edm::LogWarning("DataMixingHcalDigiWorker")<<"No signal hits found for HCAL cell "<<digi.id()<<" Pedestals may be lost for mixed hit";
+      }
+      map.insert(HcalDigiMap::value_type (digi.id(), fC));
+    }
+  }
+  
+  template <>
+   void convertHcalDigis<QIE11DigiCollection> (const QIE11DigiCollection& digis, const HcalDbService& conditions, bool keepPedestals, HcalDigiMap& map) {
+    for (auto digiItr = digis.begin(); digiItr != digis.end(); ++digiItr) {
+      QIE11DataFrame digi(*digiItr);
 	  CaloSamples fC;
       convertAdc2fC (digi, conditions, keepPedestals, fC);
       if (!keepPedestals && map.find(digi.id()) == map.end()) {
@@ -125,6 +147,14 @@ namespace {
     // make new digi
     digis.push_back(formerID.rawId());
 	QIE10DataFrame digi( digis.back() );
+    convertFc2adc (resultSample, conditions, digi, 0); // FR guess: simulation starts with 0
+  }
+  
+  template <>
+  void buildHcalDigisHelper<QIE11DigiCollection> (QIE11DigiCollection& digis, const DetId& formerID, CaloSamples& resultSample, const HcalDbService& conditions){
+    // make new digi
+    digis.push_back(formerID.rawId());
+	QIE11DataFrame digi( digis.back() );
     convertFc2adc (resultSample, conditions, digi, 0); // FR guess: simulation starts with 0
   }
   
@@ -194,22 +224,26 @@ namespace edm
     HFdigiCollectionSig_    = ps.getParameter<edm::InputTag>("HFdigiCollectionSig");
     ZDCdigiCollectionSig_   = ps.getParameter<edm::InputTag>("ZDCdigiCollectionSig");
     QIE10digiCollectionSig_   = ps.getParameter<edm::InputTag>("QIE10digiCollectionSig");
+    QIE11digiCollectionSig_   = ps.getParameter<edm::InputTag>("QIE11digiCollectionSig");
 
     HBHEPileInputTag_ = ps.getParameter<edm::InputTag>("HBHEPileInputTag");
     HOPileInputTag_ = ps.getParameter<edm::InputTag>("HOPileInputTag");
     HFPileInputTag_ = ps.getParameter<edm::InputTag>("HFPileInputTag");
     ZDCPileInputTag_ = ps.getParameter<edm::InputTag>("ZDCPileInputTag");
     QIE10PileInputTag_ = ps.getParameter<edm::InputTag>("QIE10PileInputTag");
+    QIE11PileInputTag_ = ps.getParameter<edm::InputTag>("QIE11PileInputTag");
 
     HBHEDigiToken_ = iC.consumes<HBHEDigiCollection>(HBHEdigiCollectionSig_);
     HODigiToken_ = iC.consumes<HODigiCollection>(HOdigiCollectionSig_);
     HFDigiToken_ = iC.consumes<HFDigiCollection>(HFdigiCollectionSig_);
     QIE10DigiToken_ = iC.consumes<QIE10DigiCollection>(QIE10digiCollectionSig_);
+    QIE11DigiToken_ = iC.consumes<QIE11DigiCollection>(QIE11digiCollectionSig_);
 
     HBHEDigiPToken_ = iC.consumes<HBHEDigiCollection>(HBHEPileInputTag_);
     HODigiPToken_ = iC.consumes<HODigiCollection>(HOPileInputTag_);
     HFDigiPToken_ = iC.consumes<HFDigiCollection>(HFPileInputTag_);
     QIE10DigiPToken_ = iC.consumes<QIE10DigiCollection>(QIE10PileInputTag_);
+    QIE11DigiPToken_ = iC.consumes<QIE11DigiCollection>(QIE11PileInputTag_);
 
     DoZDC_ = false;
     if(ZDCPileInputTag_.label() != "") DoZDC_ = true;
@@ -225,6 +259,7 @@ namespace edm
     HFDigiCollectionDM_   = ps.getParameter<std::string>("HFDigiCollectionDM");
     ZDCDigiCollectionDM_  = ps.getParameter<std::string>("ZDCDigiCollectionDM");
     QIE10DigiCollectionDM_  = ps.getParameter<std::string>("QIE10DigiCollectionDM");
+    QIE11DigiCollectionDM_  = ps.getParameter<std::string>("QIE11DigiCollectionDM");
 
 
   }
@@ -247,6 +282,7 @@ namespace edm
     convertSignalHcalDigis<HODigiCollection> (e, HODigiToken_, *conditions, HODigiStorage_);
     convertSignalHcalDigis<HFDigiCollection> (e, HFDigiToken_, *conditions, HFDigiStorage_);
     convertSignalHcalDigis<QIE10DigiCollection> (e, QIE10DigiToken_, *conditions, QIE10DigiStorage_);
+    convertSignalHcalDigis<QIE11DigiCollection> (e, QIE11DigiToken_, *conditions, QIE11DigiStorage_);
 
 
 
@@ -309,6 +345,7 @@ namespace edm
     convertPileupHcalDigis<HODigiCollection> (*ep, HOPileInputTag_, mcc, *conditions, HODigiStorage_);
     convertPileupHcalDigis<HFDigiCollection> (*ep, HFPileInputTag_, mcc, *conditions, HFDigiStorage_);
     convertPileupHcalDigis<QIE10DigiCollection> (*ep, QIE10PileInputTag_, mcc, *conditions, QIE10DigiStorage_);
+    convertPileupHcalDigis<QIE11DigiCollection> (*ep, QIE11PileInputTag_, mcc, *conditions, QIE11DigiStorage_);
 
 
     // ZDC Next
@@ -360,6 +397,7 @@ namespace edm
     std::auto_ptr< HODigiCollection > HOdigis = buildHcalDigis<HODigiCollection> (HODigiStorage_, *conditions);
     std::auto_ptr< HFDigiCollection > HFdigis = buildHcalDigis<HFDigiCollection> (HFDigiStorage_, *conditions);
     std::auto_ptr< QIE10DigiCollection > QIE10digis = buildHcalDigis<QIE10DigiCollection> (QIE10DigiStorage_, *conditions);
+    std::auto_ptr< QIE11DigiCollection > QIE11digis = buildHcalDigis<QIE11DigiCollection> (QIE11DigiStorage_, *conditions);
     std::auto_ptr< ZDCDigiCollection > ZDCdigis( new ZDCDigiCollection );
 
     // loop over the maps we have, re-making individual hits or digis if necessary.
@@ -471,6 +509,7 @@ namespace edm
     LogInfo("DataMixingHcalDigiWorker") << "total # HO Merged digis: " << HOdigis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # HF Merged digis: " << HFdigis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # QIE10 Merged digis: " << QIE10digis->size() ;
+    LogInfo("DataMixingHcalDigiWorker") << "total # QIE11 Merged digis: " << QIE11digis->size() ;
     LogInfo("DataMixingHcalDigiWorker") << "total # ZDC Merged digis: " << ZDCdigis->size() ;
 
 
@@ -483,6 +522,7 @@ namespace edm
     e.put( HOdigis, HODigiCollectionDM_ );
     e.put( HFdigis, HFDigiCollectionDM_ );
     e.put( QIE10digis, QIE10DigiCollectionDM_ );
+    e.put( QIE11digis, QIE11DigiCollectionDM_ );
     e.put( ZDCdigis, ZDCDigiCollectionDM_ );
     e.put( hbheupgradeResult, "HBHEUpgradeDigiCollection" );
     e.put( hfupgradeResult, "HFUpgradeDigiCollection" );
@@ -492,6 +532,7 @@ namespace edm
     HODigiStorage_.clear();
     HFDigiStorage_.clear();
     QIE10DigiStorage_.clear();
+    QIE11DigiStorage_.clear();
     ZDCDigiStorage_.clear();
 
   }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
@@ -28,6 +28,7 @@
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 
 
 #include <map>
@@ -66,24 +67,28 @@ namespace edm
       edm::InputTag HFdigiCollectionSig_  ; // secondary name given to collection of digis
       edm::InputTag ZDCdigiCollectionSig_ ; // secondary name given to collection of digis
       edm::InputTag QIE10digiCollectionSig_ ; // secondary name given to collection of digis
+      edm::InputTag QIE11digiCollectionSig_ ; // secondary name given to collection of digis
 
       edm::InputTag HBHEPileInputTag_; // InputTag for Pileup Digis collection  
       edm::InputTag HOPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
       edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE11PileInputTag_ ; // InputTag for Pileup Digis collection
 
       edm::EDGetTokenT<HBHEDigiCollection> HBHEDigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HODigiCollection> HODigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HFDigiCollection> HFDigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<ZDCDigiCollection> ZDCDigiToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<QIE10DigiCollection> QIE10DigiToken_ ;  // Token to retrieve information 
+      edm::EDGetTokenT<QIE11DigiCollection> QIE11DigiToken_ ;  // Token to retrieve information 
 
       edm::EDGetTokenT<HBHEDigiCollection> HBHEDigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HODigiCollection> HODigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<HFDigiCollection> HFDigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<ZDCDigiCollection> ZDCDigiPToken_ ;  // Token to retrieve information 
       edm::EDGetTokenT<QIE10DigiCollection> QIE10DigiPToken_ ;  // Token to retrieve information 
+      edm::EDGetTokenT<QIE11DigiCollection> QIE11DigiPToken_ ;  // Token to retrieve information 
 
 
       std::string HBHEDigiCollectionDM_; // secondary name to be given to collection of digis
@@ -91,18 +96,21 @@ namespace edm
       std::string HFDigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to collection of digis
       std::string QIE10DigiCollectionDM_ ; // secondary name to be given to collection of digis
+      std::string QIE11DigiCollectionDM_ ; // secondary name to be given to collection of digis
 
       typedef std::multimap<DetId, CaloSamples> HBHEDigiMap;
       typedef std::multimap<DetId, CaloSamples> HFDigiMap;
       typedef std::multimap<DetId, CaloSamples> HODigiMap;
       typedef std::multimap<DetId, CaloSamples> ZDCDigiMap;
       typedef std::multimap<DetId, CaloSamples> QIE10DigiMap;
+      typedef std::multimap<DetId, CaloSamples> QIE11DigiMap;
 
       HBHEDigiMap HBHEDigiStorage_;
       HFDigiMap   HFDigiStorage_;
       HODigiMap   HODigiStorage_;
       ZDCDigiMap  ZDCDigiStorage_;
       QIE10DigiMap  QIE10DigiStorage_;
+      QIE11DigiMap  QIE11DigiStorage_;
 
       bool DoZDC_;
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -22,6 +22,7 @@ namespace edm {
     HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
     ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
     QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
+    QIE11PileInputTag_(ps.getParameter<edm::InputTag>("QIE11PileInputTag")),
     label_(ps.getParameter<std::string>("Label"))
   {  
 
@@ -31,12 +32,14 @@ namespace edm {
     tok_hf_ = iC.consumes<HFDigitizerTraits::DigiCollection>(HFPileInputTag_);
     tok_zdc_ = iC.consumes<ZDCDigitizerTraits::DigiCollection>(ZDCPileInputTag_);
     tok_qie10_ = iC.consumes<HcalQIE10DigitizerTraits::DigiCollection>(QIE10PileInputTag_);
+    tok_qie11_ = iC.consumes<HcalQIE11DigitizerTraits::DigiCollection>(QIE11PileInputTag_);
 
     theHBHESignalGenerator = HBHESignalGenerator(HBHEPileInputTag_,tok_hbhe_);
     theHOSignalGenerator = HOSignalGenerator(HOPileInputTag_,tok_ho_);
     theHFSignalGenerator = HFSignalGenerator(HFPileInputTag_,tok_hf_);
     theZDCSignalGenerator = ZDCSignalGenerator(ZDCPileInputTag_,tok_zdc_);
     theQIE10SignalGenerator = QIE10SignalGenerator(QIE10PileInputTag_,tok_qie10_);
+    theQIE11SignalGenerator = QIE11SignalGenerator(QIE11PileInputTag_,tok_qie11_);
 
     // get the subdetector names
     //    this->getSubdetectorNames();  //something like this may be useful to check what we are supposed to do...
@@ -51,6 +54,7 @@ namespace edm {
     HFDigiCollectionDM_   = ps.getParameter<std::string>("HFDigiCollectionDM");
     ZDCDigiCollectionDM_  = ps.getParameter<std::string>("ZDCDigiCollectionDM");
     QIE10DigiCollectionDM_  = ps.getParameter<std::string>("QIE10DigiCollectionDM");
+    QIE11DigiCollectionDM_  = ps.getParameter<std::string>("QIE11DigiCollectionDM");
 
     // initialize HcalDigitizer here...
 
@@ -61,6 +65,7 @@ namespace edm {
     myHcalDigitizer_->setHONoiseSignalGenerator( & theHOSignalGenerator );
     myHcalDigitizer_->setZDCNoiseSignalGenerator( & theZDCSignalGenerator );
     myHcalDigitizer_->setQIE10NoiseSignalGenerator( & theQIE10SignalGenerator );
+    myHcalDigitizer_->setQIE11NoiseSignalGenerator( & theQIE11SignalGenerator );
 
   }
 	       
@@ -94,6 +99,7 @@ namespace edm {
     theHFSignalGenerator.initializeEvent(ep, &ES);
     theZDCSignalGenerator.initializeEvent(ep, &ES);
     theQIE10SignalGenerator.initializeEvent(ep, &ES);
+    theQIE11SignalGenerator.initializeEvent(ep, &ES);
 
     // put digis from pileup event into digitizer
 
@@ -101,6 +107,7 @@ namespace edm {
     theHOSignalGenerator.fill(mcc);
     theHFSignalGenerator.fill(mcc);
     theQIE10SignalGenerator.fill(mcc);
+    theQIE11SignalGenerator.fill(mcc);
   }
 
   void DataMixingHcalDigiWorkerProd::putHcal(edm::Event &e,const edm::EventSetup& ES) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -27,6 +27,7 @@
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h"
 #include "SimGeneral/DataMixingModule/plugins/HcalNoiseStorage.h"
@@ -68,17 +69,20 @@ namespace edm
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
       edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE11PileInputTag_ ; // InputTag for Pileup Digis collection
       std::string HBHEDigiCollectionDM_; // secondary name to be given to collection of digis
       std::string HODigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string HFDigiCollectionDM_  ; // secondary name to be given to collection of digis
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to collection of digis
       std::string QIE10DigiCollectionDM_ ; // secondary name to be given to collection of digis
+      std::string QIE11DigiCollectionDM_ ; // secondary name to be given to collection of digis
 
       edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
       edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
       edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
       edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
       edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
+      edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
 
       HcalDigiProducer* myHcalDigitizer_;
       HBHESignalGenerator theHBHESignalGenerator;
@@ -86,6 +90,7 @@ namespace edm
       HFSignalGenerator theHFSignalGenerator;
       ZDCSignalGenerator theZDCSignalGenerator;
       QIE10SignalGenerator theQIE10SignalGenerator;
+      QIE11SignalGenerator theQIE11SignalGenerator;
 
       std::string label_;
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -46,6 +46,7 @@ namespace edm
     HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
     ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
     QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
+    QIE11PileInputTag_(ps.getParameter<edm::InputTag>("QIE11PileInputTag")),
 							    label_(ps.getParameter<std::string>("Label"))
   {  
 
@@ -60,6 +61,7 @@ namespace edm
     tok_hf_ = consumes<HFDigitizerTraits::DigiCollection>(HFPileInputTag_);
     tok_zdc_ = consumes<ZDCDigitizerTraits::DigiCollection>(ZDCPileInputTag_);
     tok_qie10_ = consumes<HcalQIE10DigitizerTraits::DigiCollection>(QIE10PileInputTag_);
+    tok_qie11_ = consumes<HcalQIE11DigitizerTraits::DigiCollection>(QIE11PileInputTag_);
 
     // get the subdetector names
     this->getSubdetectorNames();  //something like this may be useful to check what we are supposed to do...
@@ -119,12 +121,12 @@ namespace edm
     // Hcal next
 
     if(MergeHcalDigis_){
-      //       cout<<"Hcal Digis TRUE!!!"<<endl;
-
       HBHEDigiCollectionDM_ = ps.getParameter<std::string>("HBHEDigiCollectionDM");
       HODigiCollectionDM_   = ps.getParameter<std::string>("HODigiCollectionDM");
       HFDigiCollectionDM_   = ps.getParameter<std::string>("HFDigiCollectionDM");
       ZDCDigiCollectionDM_  = ps.getParameter<std::string>("ZDCDigiCollectionDM");
+      QIE10DigiCollectionDM_  = ps.getParameter<std::string>("QIE10DigiCollectionDM");
+      QIE11DigiCollectionDM_  = ps.getParameter<std::string>("QIE11DigiCollectionDM");
 
       produces< HBHEDigiCollection >();
       produces< HODigiCollection >();
@@ -134,14 +136,10 @@ namespace edm
       produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");
       produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");
       produces<QIE10DigiCollection>("HFQIE10DigiCollection");
+      produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
 
-      if(MergeHcalDigisProd_) {
-	//        edm::ConsumesCollector iC(consumesCollector());
-	HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, consumesCollector());
-      }
-      else {HcalDigiWorker_ = new DataMixingHcalDigiWorker(ps, consumesCollector());
-      }
-
+      if(MergeHcalDigisProd_) HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, consumesCollector());
+      else HcalDigiWorker_ = new DataMixingHcalDigiWorker(ps, consumesCollector());
 
     }
     else{

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -104,6 +104,7 @@ namespace edm {
       std::string HFDigiCollectionDM_  ; // secondary name to be given to HF collection of hits
       std::string ZDCDigiCollectionDM_ ; // secondary name to be given to ZDC collection of hits
       std::string QIE10DigiCollectionDM_ ; // secondary name to be given to QIE10 collection of hits
+      std::string QIE11DigiCollectionDM_ ; // secondary name to be given to QIE11 collection of hits
 
       // Muons
       // output:
@@ -146,11 +147,13 @@ namespace edm {
       edm::InputTag HFPileInputTag_  ; // InputTag for Pileup Digis collection
       edm::InputTag ZDCPileInputTag_ ; // InputTag for Pileup Digis collection
       edm::InputTag QIE10PileInputTag_ ; // InputTag for Pileup Digis collection
+      edm::InputTag QIE11PileInputTag_ ; // InputTag for Pileup Digis collection
       edm::EDGetTokenT<HBHEDigitizerTraits::DigiCollection> tok_hbhe_;
       edm::EDGetTokenT<HODigitizerTraits::DigiCollection> tok_ho_;
       edm::EDGetTokenT<HFDigitizerTraits::DigiCollection> tok_hf_;
       edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
       edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
+      edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
       edm::EDGetTokenT<EBDigitizerTraits::DigiCollection> tok_eb_;
       edm::EDGetTokenT<EEDigitizerTraits::DigiCollection> tok_ee_;
       edm::EDGetTokenT<ESDigitizerTraits::DigiCollection> tok_es_;

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
@@ -77,6 +77,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOdigiCollectionSig    = cms.InputTag("hcalDigis"),
     HFdigiCollectionSig    = cms.InputTag("hcalDigis"),
     QIE10digiCollectionSig = cms.InputTag("hcalDigis"),
+    QIE11digiCollectionSig = cms.InputTag("hcalDigis"),
     ZDCdigiCollectionSig   = cms.InputTag(""),
 #                         ZDCdigiCollectionSig   = cms.InputTag("hcalDigis"),          
     #
@@ -87,6 +88,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOPileInputTag   = cms.InputTag("hcalDigis"),                  
     HFPileInputTag   = cms.InputTag("hcalDigis"),                  
     QIE10PileInputTag   = cms.InputTag("hcalDigis"),                  
+    QIE11PileInputTag   = cms.InputTag("hcalDigis"),                  
     ZDCPileInputTag  = cms.InputTag(""),
 #                         ZDCPileInputTag  = cms.InputTag("hcalDigis"),          
     #  Signal
@@ -133,7 +135,8 @@ mixData = cms.EDProducer("DataMixingModule",
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string(''),
-    QIE10DigiCollectionDM  = cms.string('')
+    QIE10DigiCollectionDM  = cms.string(''),
+    QIE11DigiCollectionDM  = cms.string('')
 )
 
 mixData.doEB = cms.bool(True)

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
@@ -84,6 +84,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE11digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
     # Sim Level (for Prod mode) ?
@@ -96,6 +97,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOPileInputTag   = cms.InputTag("hcalDigis"),                  
     HFPileInputTag   = cms.InputTag("hcalDigis"),                  
     QIE10PileInputTag   = cms.InputTag("hcalDigis"),                  
+    QIE11PileInputTag   = cms.InputTag("hcalDigis"),                  
     ZDCPileInputTag  = cms.InputTag("hcalDigis"),
     #  Signal
                    #
@@ -141,6 +143,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
     QIE10DigiCollectionDM   = cms.string(''),
+    QIE11DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 

--- a/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
@@ -78,6 +78,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE11digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
     #
@@ -88,6 +89,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOPileInputTag   = cms.InputTag("simHcalDigis"),
     HFPileInputTag   = cms.InputTag("simHcalDigis"),
     QIE10PileInputTag   = cms.InputTag("simHcalDigis"),
+    QIE11PileInputTag   = cms.InputTag("simHcalDigis"),
     ZDCPileInputTag  = cms.InputTag(""),
 
     #  Signal
@@ -134,6 +136,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
     QIE10DigiCollectionDM   = cms.string(''),
+    QIE11DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -164,6 +164,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
     QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
+    QIE11digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
     ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
                          
@@ -185,6 +186,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HOPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
     HFPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
     QIE10PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
+    QIE11PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
     ZDCPileInputTag  = cms.InputTag(""),
 
     #  Signal
@@ -241,6 +243,7 @@ mixData = cms.EDProducer("DataMixingModule",
     HODigiCollectionDM   = cms.string(''),
     HFDigiCollectionDM   = cms.string(''),
     QIE10DigiCollectionDM   = cms.string(''),
+    QIE11DigiCollectionDM   = cms.string(''),
     ZDCDigiCollectionDM  = cms.string('')
 )
 

--- a/SimGeneral/MixingModule/python/aliases_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_cfi.py
@@ -19,7 +19,8 @@ simHcalUnsuppressedDigis = cms.EDAlias(
       cms.PSet(type = cms.string('HFDataFramesSorted')),
       cms.PSet(type = cms.string('HODataFramesSorted')),
       cms.PSet(type = cms.string('ZDCDataFramesSorted')),
-      cms.PSet(type = cms.string('QIE10DataFrameHcalDataFrameContainer'))
+      cms.PSet(type = cms.string('QIE10DataFrameHcalDataFrameContainer')),
+      cms.PSet(type = cms.string('QIE11DataFrameHcalDataFrameContainer'))
     )
 )
 simSiPixelDigis = cms.EDAlias(

--- a/SimGeneral/MixingModule/python/hcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hcalDigitizer_cfi.py
@@ -22,7 +22,7 @@ eras.phase2_hgcal.toModify( hcalDigitizer,
     HBHEUpgradeQIE = cms.bool(True),
     HFUpgradeQIE = cms.bool(True),
     TestNumbering = cms.bool(True),
-    hb = dict( siPMCells =cms.vint32([1]),
+    hb = dict(
         photoelectronsToAnalog = cms.vdouble([10.]*16),
         pixels = cms.int32(4500*4*2)
     ),


### PR DESCRIPTION
This PR duplicates all QIE10 functionality for QIE11 (to be used with HE in 2017, and later with HB). Most of the changes are just a straight extension of the changes already made for QIE10. A few other notable changes:

1) Removed `run2_HF_2016` sub-era: `HcalDigitizer` now automatically assigns a cell to a digi collection based on `QIEType` in the database, no other need for this sub-era.

2) Cleanup: Removed some unused code in HcalDigitizer and reduced code duplication in a few classes.

3) Added `run2_HE_2017` sub-era for necessary customizations for the SiPM simulation.

4) Rearranged HcalCustoms slightly, following the idea that these customization functions will continue to be used for (temporary) development work with hardcode conditions. Now available: 
a) `customise_Hcal2016` (turns on `testHFQIE10` option)
b) `customise_Hcal2017` (turns on QIE10s throughout HF, uses QIE8/HPD for HE, but allows for extra depths if 2017dev geometry is used)
c) `customise_Hcal2017Full` (as previous, but with QIE11/SiPM conditions for HE; to use this, also enable `run2_HE_2017` sub-era)

5) Made some changes to the `HitFilter` classes so they are more uniform and more efficient:
a) Take a vector of subdet ids to handle HBHE case
b) Use `std::binary_search()` instead of `std::find()` when checking a list of DetIds

A few validations:

i) Premixing:
![fc_standard_vs_premix_qie11.png](http://www.kjplanet.com/pr/fc_standard_vs_premix_qie11.png)

ii) QIE11 digis with 2017dev geometry:
![qie11_ieta.png](http://www.kjplanet.com/pr/qie11_ieta.png)
![qie11_depth.png](http://www.kjplanet.com/pr/qie11_depth.png)

Script for testing with 2017dev geometry:

```
#!/bin/bash

 cmsDriver.py SinglePiE50HCAL_pythia8_cfi  --conditions auto:phase1_2017_design -n 10 --era Run2_2017 --geometry "Configuration.Geometry.GeometryExtended2017dev_cff,Configuration.Geometry.GeometryExtended2017devReco_cff" --eventcontent FEVTDEBUG -s GEN,SIM --datatier GEN-SIM --beamspot Realistic50ns13TeVCollision --fileout file:step1.root --customise SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Full > step1_SinglePiE50_UP15+SinglePiE50_UP15+DIGIUP15+RECOUP15+HARVESTUP15.log  2>&1


 cmsDriver.py step2  --conditions auto:phase1_2017_design -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval25ns --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n 10 --era Run2_2017 --geometry "Configuration.Geometry.GeometryExtended2017dev_cff,Configuration.Geometry.GeometryExtended2017devReco_cff" --eventcontent FEVTDEBUGHLT --filein file:step1.root  --fileout file:step2.root --customise SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Full > step2_SinglePiE50_UP15+SinglePiE50_UP15+DIGIUP15+RECOUP15+HARVESTUP15.log  2>&1


 cmsDriver.py step3  --runUnscheduled  --conditions auto:phase1_2017_design -s RAW2DIGI,L1Reco,RECO,EI,PAT --datatier GEN-SIM-RECO,MINIAODSIM -n 10 --era Run2_2017 --geometry "Configuration.Geometry.GeometryExtended2017dev_cff,Configuration.Geometry.GeometryExtended2017devReco_cff" --eventcontent RECOSIM,MINIAODSIM --filein file:step2.root  --fileout file:step3.root --customise SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Full > step3_SinglePiE50_UP15+SinglePiE50_UP15+DIGIUP15+RECOUP15+HARVESTUP15.log  2>&1
```
