### PR TITLE
Cleanup unused pixel CPE code

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -43,8 +43,6 @@
 #include <utility>
 #include <vector>
 
-#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
-
 #if 0
 /** \class PixelCPEGeneric
  * Perform the position and error evaluation of pixel hits using 
@@ -82,15 +80,9 @@ class PixelCPEGeneric : public PixelCPEBase
   float dx2   ; // CPE Generic x-bias for single double-pixel cluster
   };
 
-#ifdef NEW_CPEERROR
   PixelCPEGeneric(edm::ParameterSet const& conf, const MagneticField *, 
 		  const TrackerGeometry&, const TrackerTopology&, const SiPixelLorentzAngle *, 
 		  const SiPixelGenErrorDBObject *, const SiPixelLorentzAngle *);
-#else
-  PixelCPEGeneric(edm::ParameterSet const& conf, const MagneticField *, const TrackerGeometry&, const TrackerTopology&,
-		  const SiPixelLorentzAngle *, const SiPixelGenErrorDBObject *, 
-		  const SiPixelTemplateDBObject *,const SiPixelLorentzAngle *);
-#endif
 
   ~PixelCPEGeneric() {;}
 
@@ -164,11 +156,6 @@ private:
   //--- DB Error Parametrization object, new light templates 
   std::vector< SiPixelGenErrorStore > thePixelGenError_;
   //SiPixelCPEGenericDBErrorParametrization * genErrorsFromDB_;
-
-#ifndef NEW_CPEERROR
-  // For old template errors
-  std::vector< SiPixelTemplateStore > thePixelTemp_;
-#endif
 
 };
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -19,8 +19,6 @@
 #include <string>
 #include <memory>
 
-#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
-
 using namespace edm;
 
 PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p) 
@@ -77,7 +75,6 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
 
   const SiPixelGenErrorDBObject * genErrorDBObjectProduct = 0;
 
-#ifdef NEW_CPEERROR
   // Errors take only from new GenError
   ESHandle<SiPixelGenErrorDBObject> genErrorDBObject;
   if(UseErrorsFromTemplates_) {  // do only when generrors are needed
@@ -90,24 +87,6 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
                          pset_,magfield.product(),*pDD.product(),
 			 *hTT.product(),lorentzAngle.product(),
 			 genErrorDBObjectProduct,lorentzAngleWidthProduct);
-
-#else  // old full templates, not used anymore  
-  // Errors can be used from tempaltes or from GenError, for testing only
-  const bool useNewSimplerErrors = false;
-  if(useNewSimplerErrors) { // new genError object
-    ESHandle<SiPixelGenErrorDBObject> genErrorDBObject;
-    iRecord.getRecord<SiPixelGenErrorDBObjectRcd>().get(genErrorDBObject); //needs new TKPixelCPERecord.h
-    genErrorDBObjectProduct = genErrorDBObject.product();
-  }
-
-  // errors come from templates
-  ESHandle<SiPixelTemplateDBObject> templateDBobject;
-  iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
-
-  cpe_  = std::make_shared<PixelCPEGeneric>(
-					pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngle.product(),genErrorDBObjectProduct,
-					templateDBobject.product(),lorentzAngleWidthProduct);
-#endif
 
   return cpe_;
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -25,15 +25,6 @@
 
 using namespace std;
 
-#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
-
-namespace {
-#ifndef NEW_CPEERROR  
-  //const bool useNewSimplerErrors = true;
-  const bool useNewSimplerErrors = false; // must be tha same as in generic 
-#endif
-}
-
 //-----------------------------------------------------------------------------
 //  A constructor run for generic and templates
 //  
@@ -67,11 +58,7 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const & conf,
   //cout<<" new errors "<<genErrorDBObject<<" "<<genErrorDBObject_<<endl;
 
   //-- Template Calibration Object from DB
-#ifdef NEW_CPEERROR
   if(theFlag_!=0) templateDBobject_ = templateDBobject; // flag to check if it is generic or templates
-#else
-  templateDBobject_ = templateDBobject;
-#endif
 
   // Configurables 
   // For both templates & generic 
@@ -186,15 +173,8 @@ void PixelCPEBase::fillDetParams()
     // Cache the det id for templates and generic erros 
 
     if(theFlag_==0) { // for generic
-#ifdef NEW_CPEERROR
       if(LoadTemplatesFromDB_ ) // do only if genError requested 
 	p.detTemplateId = genErrorDBObject_->getGenErrorID(p.theDet->geographicalId().rawId());
-#else   
-      if(useNewSimplerErrors) 
-	p.detTemplateId = genErrorDBObject_->getGenErrorID(p.theDet->geographicalId().rawId());
-      else 
-        p.detTemplateId = templateDBobject_->getTemplateID(p.theDet->geographicalId().rawId());
-#endif
     } else {          // for templates
       p.detTemplateId = templateDBobject_->getTemplateID(p.theDet->geographicalId());
     }


### PR DESCRIPTION
Remove unused code from pixel CPE.
No changes to RECO/AOD/MiniAOD.
Tested with:
runTheMatrix.py -l limited
