### PR TITLE
Add tracking ntuple

### DIFF
--- a/Validation/RecoTrack/README.md
+++ b/Validation/RecoTrack/README.md
@@ -4,11 +4,45 @@ Tracking validation
 The workhorse of the tracking validation is MultiTrackValidator, for
 which documentation is available in
 https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMultiTrackValidator.
-
-There is also a version of MultiTrackValidator for seeds called
-TrackerSeedValidator, see
-https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTrackerSeedValidator
-for more details.
+In addition to tracks it can be used to study seeds.
 
 The plotting tools are documented in
 https://twiki.cern.ch/twiki/bin/view/CMS/TrackingValidationMC.
+
+
+Ntuple
+------
+
+There is also an ntuple-version of MultiTrackValidator, called
+[TrackingNtuple](plugins/TrackingNtuple.cc). It can be included in any
+`cmsDriver.py`-generated workflow containing `VALIDATION` sequence by
+including
+`--customise Validation/RecoTrack/customiseTrackingNtuple.customiseTrackingNtuple`
+argument to the `cmsDriver.py`. The customise function disables all
+output modules and replaces the validation sequence with a sequence
+producing the ntuple in `trackingNtuple.root` file. If ran without
+RECO, it needs both RECO and DIGI files as an input.
+
+For the ntuple content, take a look on the
+[TrackingNtuple](plugins/TrackingNtuple.cc) code itself, and an
+example PyROOT script for analysis,
+[`trackingNtupleExample.py`](test/trackingNtupleExample.py). The
+script uses a simple support library
+[`ntuple.py`](python/plotting/ntuple.py), but its use is not
+mandatory, i.e. you can use the ntuple also "directly". The main
+benefit of the library is to provide OO-like interface for all the
+links between the objects:
+* track <-> TrackingParticle
+* track -> seed
+* track <-> hit
+* seed <-> hit
+* glued strip hits -> mono and stereo strip hits
+* vertex -> track
+* TrackingParticle <-> hit
+* TrackingParticle <-> TrackingVertex
+
+By default the ntuple includes hits and seeds, which makes the ntuple
+rather large. These can be disabled with switches in
+[`trackingNtuple_cff`](python/trackingNtuple_cff.py). Note that to
+include seeds you have to run reconstruction as seeds are not stored
+in RECO or AOD.

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -28,9 +28,9 @@
 
 class MTVHistoProducerAlgoForTracker {
  public:
-  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, edm::ConsumesCollector && iC) :
-    MTVHistoProducerAlgoForTracker(pset, iC) {}
-  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, edm::ConsumesCollector & iC) ;
+  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const bool doSeedPlots, edm::ConsumesCollector && iC) :
+    MTVHistoProducerAlgoForTracker(pset, doSeedPlots, iC) {}
+  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const bool doSeedPlots, edm::ConsumesCollector & iC) ;
   ~MTVHistoProducerAlgoForTracker();
 
   void bookSimHistos(DQMStore::IBooker& ibook);
@@ -147,6 +147,8 @@ class MTVHistoProducerAlgoForTracker {
   double minDeDx, maxDeDx;  int nintDeDx;
   double minVertcount, maxVertcount;  int nintVertcount;
   double minTracks, maxTracks; int nintTracks;
+
+  const bool doSeedPlots_;
 
   //
   double ptRes_rangeMin,ptRes_rangeMax; int ptRes_nbin;

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -65,7 +65,6 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   edm::EDGetTokenT<edm::View<reco::Track> > labelTokenForDrCalculation;
   edm::EDGetTokenT<edm::View<reco::Vertex> > recoVertexToken_;
   edm::EDGetTokenT<reco::VertexToTrackingVertexAssociator> vertexAssociatorToken_;
-  std::vector<edm::EDGetTokenT<std::vector<int>>> seedToTrackTokens_;
 
   std::vector<MonitorElement *> h_reco_coll, h_assoc_coll, h_assoc2_coll, h_simul_coll, h_looper_coll, h_pileup_coll;
   std::vector<MonitorElement *> h_assoc_coll_allPt, h_simul_coll_allPt;

--- a/Validation/RecoTrack/interface/trackFromSeedFitFailed.h
+++ b/Validation/RecoTrack/interface/trackFromSeedFitFailed.h
@@ -1,0 +1,11 @@
+#ifndef Validation_RecoTrack_trackFomSeedFitFailed_h
+#define Validation_RecoTrack_trackFomSeedFitFailed_h
+
+#include "DataFormats/TrackReco/interface/Track.h"
+
+inline bool trackFromSeedFitFailed(const reco::Track& track) {
+  // these magic values denote a case where the fit has failed
+  return track.chi2() < 0 && track.ndof() < 0 && track.charge() == 0;
+}
+
+#endif

--- a/Validation/RecoTrack/plugins/BuildFile.xml
+++ b/Validation/RecoTrack/plugins/BuildFile.xml
@@ -29,6 +29,7 @@
 <use   name="CommonTools/TriggerUtils"/>
 <use   name="Validation/RecoTrack"/>
 <use   name="RecoPixelVertexing/PixelTrackFitting"/>
+<use   name="DataFormats/VertexReco"/>
 <lib   name="MathMore"/>
 <library   file="*.cc" name="ValidationRecoTrackPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/Validation/RecoTrack/plugins/BuildFile.xml
+++ b/Validation/RecoTrack/plugins/BuildFile.xml
@@ -28,6 +28,7 @@
 <use   name="CalibTracker/Records"/>
 <use   name="CommonTools/TriggerUtils"/>
 <use   name="Validation/RecoTrack"/>
+<use   name="RecoPixelVertexing/PixelTrackFitting"/>
 <lib   name="MathMore"/>
 <library   file="*.cc" name="ValidationRecoTrackPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
+++ b/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
@@ -150,7 +150,7 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
                                            tsAtClosestApproachSeed.trackStateAtPCA().momentum().z());
        //GlobalPoint vSeed(vSeed1.x()-beamSpot->x0(),vSeed1.y()-beamSpot->y0(),vSeed1.z()-beamSpot->z0());
        PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
-       tracks->emplace_back(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
+       tracks->emplace_back(0.,0., vSeed1, pSeed, state.charge(), seedPerigeeErrors.covarianceMatrix());
      }
      else {
        edm::LogVerbatim("SeedValidator")<<"TrajectoryStateClosestToBeamLine not valid";

--- a/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
+++ b/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
@@ -80,7 +80,6 @@ TrackFromSeedProducer::TrackFromSeedProducer(const edm::ParameterSet& iConfig)
   produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
-  produces<std::vector<int> >();
 
   // read parametes
   edm::InputTag seedsTag(iConfig.getParameter<edm::InputTag>("src"));
@@ -107,7 +106,6 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
    unique_ptr<TrackCollection> tracks(new TrackCollection);
    unique_ptr<TrackingRecHitCollection> rechits(new TrackingRecHitCollection);
    unique_ptr<TrackExtraCollection> trackextras(new TrackExtraCollection);
-   unique_ptr<vector<int> > seedToTrack(new vector<int>());
    
    // product references 
    TrackExtraRefProd ref_trackextras = iEvent.getRefBeforePut<TrackExtraCollection>();
@@ -143,28 +141,32 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
      TransientTrackingRecHit::RecHitPointer lastRecHit = tTRHBuilder->build(&*(seed.recHits().second-1));
      TrajectoryStateOnSurface state = trajectoryStateTransform::transientState( seed.startingState(), lastRecHit->surface(), theMF.product());
      TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed = tscblBuilder(*state.freeState(),*beamSpot);//as in TrackProducerAlgorithm
-     if(!(tsAtClosestApproachSeed.isValid())){
-       edm::LogVerbatim("SeedValidator")<<"TrajectoryStateClosestToBeamLine not valid";
-       seedToTrack->push_back(-1);
-       nfailed++;
-       continue;
+     if(tsAtClosestApproachSeed.isValid()) {
+       const reco::TrackBase::Point vSeed1(tsAtClosestApproachSeed.trackStateAtPCA().position().x(),
+                                           tsAtClosestApproachSeed.trackStateAtPCA().position().y(),
+                                           tsAtClosestApproachSeed.trackStateAtPCA().position().z());
+       const reco::TrackBase::Vector pSeed(tsAtClosestApproachSeed.trackStateAtPCA().momentum().x(),
+                                           tsAtClosestApproachSeed.trackStateAtPCA().momentum().y(),
+                                           tsAtClosestApproachSeed.trackStateAtPCA().momentum().z());
+       //GlobalPoint vSeed(vSeed1.x()-beamSpot->x0(),vSeed1.y()-beamSpot->y0(),vSeed1.z()-beamSpot->z0());
+       PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
+       tracks->emplace_back(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
      }
-     const reco::TrackBase::Point vSeed1(tsAtClosestApproachSeed.trackStateAtPCA().position().x(),
-					 tsAtClosestApproachSeed.trackStateAtPCA().position().y(),
-					 tsAtClosestApproachSeed.trackStateAtPCA().position().z());
-     const reco::TrackBase::Vector pSeed(tsAtClosestApproachSeed.trackStateAtPCA().momentum().x(),
-					 tsAtClosestApproachSeed.trackStateAtPCA().momentum().y(),
-					 tsAtClosestApproachSeed.trackStateAtPCA().momentum().z());
-     //GlobalPoint vSeed(vSeed1.x()-beamSpot->x0(),vSeed1.y()-beamSpot->y0(),vSeed1.z()-beamSpot->z0());
-     PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
-     tracks->push_back(Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix()));
-     seedToTrack->push_back(tracks->size()-1);
+     else {
+       edm::LogVerbatim("SeedValidator")<<"TrajectoryStateClosestToBeamLine not valid";
+       // use magic values chi2<0, ndof<0, charge=0 to denote a case where the fit has failed
+       // If this definition is changed, change also interface/trackFromSeedFitFailed.h
+       tracks->emplace_back(-1, -1, reco::TrackBase::Point(), reco::TrackBase::Vector(), 0, reco::TrackBase::CovarianceMatrix());
+       nfailed++;
+     }
+
      tracks->back().appendHits(seed.recHits().first,seed.recHits().second,ttopo);
      // store the hits
      size_t firsthitindex = rechits->size();
      for(auto hitit = seed.recHits().first;hitit != seed.recHits().second;++hitit){
        rechits->push_back(*hitit);
      }
+
      // create a trackextra, just to store the hit range
      trackextras->push_back(TrackExtra());
      trackextras->back().setHits(ref_rechits,firsthitindex,rechits->size() - firsthitindex);
@@ -177,7 +179,6 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
      edm::LogInfo("SeedValidator") << "failed to create tracks from " << nfailed <<  " out of " << seeds.size() << " seeds ";
    }
    iEvent.put(std::move(tracks));
-   iEvent.put(std::move(seedToTrack));
    iEvent.put(std::move(rechits));
    iEvent.put(std::move(trackextras));
 }

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -37,7 +37,7 @@ typedef edm::Ref<edm::HepMCProduct, HepMC::GenParticle > GenParticleRef;
 
 TrackerSeedValidator::TrackerSeedValidator(const edm::ParameterSet& pset):
   MultiTrackValidatorBase(pset, consumesCollector(),true),
-  histoProducerAlgo_(std::make_unique<MTVHistoProducerAlgoForTracker>(pset.getParameter<ParameterSet>("histoProducerAlgoBlock"), consumesCollector())) {
+  histoProducerAlgo_(std::make_unique<MTVHistoProducerAlgoForTracker>(pset.getParameter<ParameterSet>("histoProducerAlgoBlock"), false, consumesCollector())) {
   dirName_ = pset.getParameter<std::string>("dirName");
 
   tpSelector = TrackingParticleSelector(pset.getParameter<double>("ptMinTP"),

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1,0 +1,1370 @@
+// -*- C++ -*-
+//
+// Package:    NtupleDump/TrackingNtuple
+// Class:      TrackingNtuple
+//
+/**\class TrackingNtuple TrackingNtuple.cc NtupleDump/TrackingNtuple/plugins/TrackingNtuple.cc
+
+   Description: [one line class summary]
+
+   Implementation:
+   [Notes on implementation]
+*/
+//
+// Original Author:  Giuseppe Cerati
+//         Created:  Tue, 25 Aug 2015 13:22:49 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "RecoPixelVertexing/PixelTrackFitting/src/RZLine.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "TrackingTools/TrajectoryState/interface/PerigeeConversions.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
+#include "SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h"
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
+#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
+
+#include "TTree.h"
+
+/*
+todo: 
+add refitted hit position after track/seed fit
+add original algo (needs >=CMSSW746)
+add vertices
+add local angle, path length!
+add n 3d hits for sim tracks
+*/
+
+//
+// class declaration
+//
+
+class TrackingNtuple : public edm::EDAnalyzer {
+public:
+  explicit TrackingNtuple(const edm::ParameterSet&);
+  ~TrackingNtuple();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+  void clearVariables();
+
+  //copied from QuickTrackAssociatorByHits
+  static bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) { return (i.first.rawIndex()>j.first.rawIndex()); }
+
+  static bool intIntListGreater(std::pair<int, int> i,std::pair<int, int> j) { return (i.first>j.first); }
+
+  // ----------member data ---------------------------
+  std::vector<edm::InputTag> seedTags_;
+  edm::InputTag trackTag_;
+  std::string builderName_;
+  edm::ESHandle<MagneticField> theMF;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
+  TrackAssociatorBase*  associatorByHits;
+  const ParametersDefinerForTP* parametersDefiner;
+  bool debug;
+  const TrackerTopology* tTopo;
+
+  TTree* t;
+  //tracks
+  std::vector<float> trk_px       ;
+  std::vector<float> trk_py       ;
+  std::vector<float> trk_pz       ;
+  std::vector<float> trk_pt       ;
+  std::vector<float> trk_eta      ;
+  std::vector<float> trk_phi      ;
+  std::vector<float> trk_dxy      ;
+  std::vector<float> trk_dz       ;
+  std::vector<float> trk_ptErr    ;
+  std::vector<float> trk_etaErr   ;
+  std::vector<float> trk_phiErr   ;
+  std::vector<float> trk_dxyErr   ;
+  std::vector<float> trk_dzErr    ;
+  std::vector<float> trk_nChi2    ;
+  std::vector<float> trk_shareFrac;
+  std::vector<int> trk_q       ;
+  std::vector<int> trk_nValid  ;
+  std::vector<int> trk_nInvalid;
+  std::vector<int> trk_nPixel  ;
+  std::vector<int> trk_nStrip  ;
+  std::vector<int> trk_n3DLay  ;
+  std::vector<int> trk_algo    ;
+  std::vector<int> trk_isHP    ;
+  std::vector<int> trk_seedIdx ;
+  std::vector<int> trk_simIdx  ;
+  std::vector<std::vector<int> > trk_pixelIdx;
+  std::vector<std::vector<int> > trk_stripIdx;
+  //sim tracks
+  std::vector<float> sim_px       ;
+  std::vector<float> sim_py       ;
+  std::vector<float> sim_pz       ;
+  std::vector<float> sim_pt       ;
+  std::vector<float> sim_eta      ;
+  std::vector<float> sim_phi      ;
+  std::vector<float> sim_dxy      ;
+  std::vector<float> sim_dz       ;
+  std::vector<float> sim_prodx    ;
+  std::vector<float> sim_prody    ;
+  std::vector<float> sim_prodz    ;
+  std::vector<float> sim_shareFrac;
+  std::vector<int> sim_q       ;
+  std::vector<int> sim_nValid  ;
+  std::vector<int> sim_nPixel  ;
+  std::vector<int> sim_nStrip  ;
+  std::vector<int> sim_n3DLay  ;
+  std::vector<int> sim_trkIdx  ;
+  std::vector<std::vector<int> > sim_pixelIdx;
+  std::vector<std::vector<int> > sim_stripIdx;
+  //pixels: reco and sim hits
+  std::vector<int> pix_isBarrel ;
+  std::vector<int> pix_lay      ;
+  std::vector<int> pix_detId    ;
+  std::vector<int> pix_nSimTrk  ;
+  std::vector<int> pix_simTrkIdx;
+  std::vector<int> pix_particle ;
+  std::vector<int> pix_process  ;
+  std::vector<int> pix_bunchXing;
+  std::vector<int> pix_event    ;
+  std::vector<float> pix_x    ;
+  std::vector<float> pix_y    ;
+  std::vector<float> pix_z    ;
+  std::vector<float> pix_xx   ;
+  std::vector<float> pix_xy   ;
+  std::vector<float> pix_yy   ;
+  std::vector<float> pix_yz   ;
+  std::vector<float> pix_zz   ;
+  std::vector<float> pix_zx   ;
+  std::vector<float> pix_xsim ;
+  std::vector<float> pix_ysim ;
+  std::vector<float> pix_zsim ;
+  std::vector<float> pix_eloss;
+  std::vector<float> pix_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
+  std::vector<float> pix_bbxi ;
+  //strips: reco and sim hits
+  std::vector<int> str_isBarrel ;
+  std::vector<int> str_isStereo ;
+  std::vector<int> str_det      ;
+  std::vector<int> str_lay      ;
+  std::vector<int> str_detId    ;
+  std::vector<int> str_nSimTrk  ;
+  std::vector<int> str_simTrkIdx;
+  std::vector<int> str_particle ;
+  std::vector<int> str_process  ;
+  std::vector<int> str_bunchXing;
+  std::vector<int> str_event    ;
+  std::vector<float> str_x    ;
+  std::vector<float> str_y    ;
+  std::vector<float> str_z    ;
+  std::vector<float> str_xx   ;
+  std::vector<float> str_xy   ;
+  std::vector<float> str_yy   ;
+  std::vector<float> str_yz   ;
+  std::vector<float> str_zz   ;
+  std::vector<float> str_zx   ;
+  std::vector<float> str_xsim ;
+  std::vector<float> str_ysim ;
+  std::vector<float> str_zsim ;
+  std::vector<float> str_eloss;
+  std::vector<float> str_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
+  std::vector<float> str_bbxi ;
+  //strip matched hits: reco hits
+  std::vector<int> glu_isBarrel ;
+  std::vector<int> glu_det      ;
+  std::vector<int> glu_lay      ;
+  std::vector<int> glu_detId    ;
+  std::vector<int> glu_monoIdx  ;
+  std::vector<int> glu_stereoIdx;
+  std::vector<float> glu_x    ;
+  std::vector<float> glu_y    ;
+  std::vector<float> glu_z    ;
+  std::vector<float> glu_xx   ;
+  std::vector<float> glu_xy   ;
+  std::vector<float> glu_yy   ;
+  std::vector<float> glu_yz   ;
+  std::vector<float> glu_zz   ;
+  std::vector<float> glu_zx   ;
+  std::vector<float> glu_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
+  std::vector<float> glu_bbxi ;
+  //beam spot
+  float bsp_x;
+  float bsp_y;
+  float bsp_z;
+  float bsp_sigmax;
+  float bsp_sigmay;
+  float bsp_sigmaz;
+  //seeds
+  std::vector<float> see_px       ;
+  std::vector<float> see_py       ;
+  std::vector<float> see_pz       ;
+  std::vector<float> see_pt       ;
+  std::vector<float> see_eta      ;
+  std::vector<float> see_phi      ;
+  std::vector<float> see_dxy      ;
+  std::vector<float> see_dz       ;
+  std::vector<float> see_ptErr    ;
+  std::vector<float> see_etaErr   ;
+  std::vector<float> see_phiErr   ;
+  std::vector<float> see_dxyErr   ;
+  std::vector<float> see_dzErr    ;
+  std::vector<float> see_chi2     ;
+  std::vector<int> see_q       ;
+  std::vector<int> see_nValid  ;
+  std::vector<int> see_nPixel  ;
+  std::vector<int> see_nGlued  ;
+  std::vector<int> see_nStrip  ;
+  std::vector<int> see_algo    ;
+  std::vector<std::vector<int> > see_pixelIdx;
+  std::vector<std::vector<int> > see_gluedIdx;
+  std::vector<std::vector<int> > see_stripIdx;
+  //seed algo offset
+  std::vector<int> algo_offset  ;
+
+};
+
+//
+// constructors and destructor
+//
+TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
+  seedTags_(iConfig.getUntrackedParameter<std::vector<edm::InputTag> >("seeds")),
+  trackTag_(iConfig.getUntrackedParameter<edm::InputTag>("tracks")),
+  builderName_(iConfig.getParameter<std::string>("TTRHBuilder")),
+  debug(iConfig.getParameter<bool>("debug")) 
+{
+  //now do what ever initialization is needed
+}
+
+
+TrackingNtuple::~TrackingNtuple() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+void TrackingNtuple::clearVariables() {
+
+  //tracks
+  trk_px       .clear();
+  trk_py       .clear();
+  trk_pz       .clear();
+  trk_pt       .clear();
+  trk_eta      .clear();
+  trk_phi      .clear();
+  trk_dxy      .clear();
+  trk_dz       .clear();
+  trk_ptErr    .clear();
+  trk_etaErr   .clear();
+  trk_phiErr   .clear();
+  trk_dxyErr   .clear();
+  trk_dzErr    .clear();
+  trk_nChi2    .clear();
+  trk_shareFrac.clear();
+  trk_q        .clear();
+  trk_nValid   .clear();
+  trk_nInvalid .clear();
+  trk_nPixel   .clear();
+  trk_nStrip   .clear();
+  trk_n3DLay   .clear();
+  trk_algo     .clear();
+  trk_isHP     .clear();
+  trk_seedIdx  .clear();
+  trk_simIdx   .clear();
+  trk_pixelIdx .clear();
+  trk_stripIdx .clear();
+  //sim tracks
+  sim_px       .clear();
+  sim_py       .clear();
+  sim_pz       .clear();
+  sim_pt       .clear();
+  sim_eta      .clear();
+  sim_phi      .clear();
+  sim_dxy      .clear();
+  sim_dz       .clear();
+  sim_prodx    .clear();
+  sim_prody    .clear();
+  sim_prodz    .clear();
+  sim_shareFrac.clear();
+  sim_q        .clear();
+  sim_nValid   .clear();
+  sim_nPixel   .clear();
+  sim_nStrip   .clear();
+  sim_n3DLay   .clear();
+  sim_trkIdx   .clear();
+  sim_pixelIdx .clear();
+  sim_stripIdx .clear();
+  //pixels
+  pix_isBarrel .clear();
+  pix_lay      .clear();
+  pix_detId    .clear();
+  pix_nSimTrk  .clear();
+  pix_simTrkIdx.clear();
+  pix_particle .clear();
+  pix_process  .clear();
+  pix_bunchXing.clear();
+  pix_event    .clear();
+  pix_x    .clear();
+  pix_y    .clear();
+  pix_z    .clear();
+  pix_xx   .clear();
+  pix_xy   .clear();
+  pix_yy   .clear();
+  pix_yz   .clear();
+  pix_zz   .clear();
+  pix_zx   .clear();
+  pix_xsim .clear();
+  pix_ysim .clear();
+  pix_zsim .clear();
+  pix_eloss.clear();
+  pix_radL .clear();
+  pix_bbxi .clear();
+  //strips
+  str_isBarrel .clear();
+  str_isStereo .clear();
+  str_det      .clear();
+  str_lay      .clear();
+  str_detId    .clear();
+  str_nSimTrk  .clear();
+  str_simTrkIdx.clear();
+  str_particle .clear();
+  str_process  .clear();
+  str_bunchXing.clear();
+  str_event    .clear();
+  str_x    .clear();
+  str_y    .clear();
+  str_z    .clear();
+  str_xx   .clear();
+  str_xy   .clear();
+  str_yy   .clear();
+  str_yz   .clear();
+  str_zz   .clear();
+  str_zx   .clear();
+  str_xsim .clear();
+  str_ysim .clear();
+  str_zsim .clear();
+  str_eloss.clear();
+  str_radL .clear();
+  str_bbxi .clear();
+  //matched hits
+  glu_isBarrel .clear();
+  glu_det      .clear();
+  glu_lay      .clear();
+  glu_detId    .clear();
+  glu_monoIdx  .clear();
+  glu_stereoIdx.clear();
+  glu_x        .clear();
+  glu_y        .clear();
+  glu_z        .clear();
+  glu_xx       .clear();
+  glu_xy       .clear();
+  glu_yy       .clear();
+  glu_yz       .clear();
+  glu_zz       .clear();
+  glu_zx       .clear();
+  glu_radL     .clear();
+  glu_bbxi     .clear();
+  //beamspot
+  bsp_x = -9999.;
+  bsp_y = -9999.;
+  bsp_z = -9999.;
+  bsp_sigmax = -9999.;
+  bsp_sigmay = -9999.;
+  bsp_sigmaz = -9999.;
+  //seeds
+  see_px      .clear();
+  see_py      .clear();
+  see_pz      .clear();
+  see_pt      .clear();
+  see_eta     .clear();
+  see_phi     .clear();
+  see_dxy     .clear();
+  see_dz      .clear();
+  see_ptErr   .clear();
+  see_etaErr  .clear();
+  see_phiErr  .clear();
+  see_dxyErr  .clear();
+  see_dzErr   .clear();
+  see_chi2    .clear();
+  see_q       .clear();
+  see_nValid  .clear();
+  see_nPixel  .clear();
+  see_nGlued  .clear();
+  see_nStrip  .clear();
+  see_algo    .clear();
+  see_pixelIdx.clear();
+  see_gluedIdx.clear();
+  see_stripIdx.clear();
+  //seed algo offset
+  algo_offset .clear();
+  for (int i=0; i<20; ++i) algo_offset.push_back(-1);
+
+}
+
+
+// ------------ method called for each event  ------------
+void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+  using namespace reco;
+  using namespace std;
+
+  //initialize tree variables
+  clearVariables();
+
+  //get association maps, etc.
+  Handle<TrackingParticleCollection>  TPCollectionH;
+  iEvent.getByLabel("mix","MergedTrackTruth",TPCollectionH);
+  TrackingParticleCollection const & tPC = *(TPCollectionH.product());
+  Handle<ClusterTPAssociationProducer::ClusterTPAssociationList> pCluster2TPListH;
+  iEvent.getByLabel("tpClusterProducer", pCluster2TPListH);
+  ClusterTPAssociationProducer::ClusterTPAssociationList clusterToTPMap( *(pCluster2TPListH.product()) );//has to be non-const to sort
+  //make sure it is properly sorted
+  sort( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPAssociationListGreater );
+  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+  iEvent.getByLabel("simHitTPAssocProducer",simHitsTPAssoc);
+  //make a list to link TrackingParticles to its hits in recHit collections
+  //note only the first TP is saved so we ignore merged hits...
+  vector<pair<int, int> > tpPixList;
+  vector<pair<int, int> > tpRPhiList;
+  vector<pair<int, int> > tpStereoList;
+
+  //beamspot
+  Handle<reco::BeamSpot> recoBeamSpotHandle;
+  iEvent.getByLabel("offlineBeamSpot",recoBeamSpotHandle);
+  BeamSpot const & bs = *recoBeamSpotHandle;
+  bsp_x = bs.x0();
+  bsp_y = bs.y0();
+  bsp_z = bs.x0();
+  bsp_sigmax = bs.BeamWidthX();
+  bsp_sigmay = bs.BeamWidthY();
+  bsp_sigmaz = bs.sigmaZ();  
+
+  //pixel hits
+  edm::Handle<SiPixelRecHitCollection> pixelHits;
+  iEvent.getByLabel("siPixelRecHits", pixelHits);
+  for (auto it = pixelHits->begin(); it!=pixelHits->end(); it++ ) {
+    DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
+      int firstMatchingTp = -999;
+      int nMatchingTp = 0;
+      GlobalPoint simHitPos = GlobalPoint(0,0,0);
+      float energyLoss = -999.;
+      int particleType = -999;
+      int processType = -999;
+      int bunchCrossing = -999;
+      int event = -999;
+      //get the TP that produced the hit
+      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
+      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
+      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+      if( range.first != range.second ) {
+	nMatchingTp = range.second-range.first;
+	for( auto ip=range.first; ip != range.second; ++ip ) {
+	  const TrackingParticleRef trackingParticle=(ip->second);
+	  if( trackingParticle->numberOfHits() == 0 ) continue;
+	  firstMatchingTp = trackingParticle.key();
+	  tpPixList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
+	  //now get the corresponding sim hit
+	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
+	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
+	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
+					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+	  for(auto ip = range.first; ip != range.second; ++ip) {
+	    TrackPSimHitRef TPhit = ip->second;
+	    DetId dId = DetId(TPhit->detUnitId());
+	    if (dId.rawId()==hitId.rawId()) {
+	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
+	      energyLoss = TPhit->energyLoss();
+	      particleType = TPhit->particleType();
+	      processType = TPhit->processType();
+	      bunchCrossing = TPhit->eventId().bunchCrossing();
+	      event = TPhit->eventId().event();
+	    }
+	  }
+	  break;
+	}
+      }
+      pix_isBarrel .push_back( hitId.subdetId()==1 );
+      pix_lay      .push_back( tTopo->layer(hitId) );
+      pix_detId    .push_back( hitId.rawId() );
+      pix_nSimTrk  .push_back( nMatchingTp );
+      pix_simTrkIdx.push_back( firstMatchingTp );
+      pix_particle .push_back( particleType );
+      pix_process  .push_back( processType );
+      pix_bunchXing.push_back( bunchCrossing );
+      pix_event    .push_back( event );
+      pix_x    .push_back( ttrh->globalPosition().x() );
+      pix_y    .push_back( ttrh->globalPosition().y() );
+      pix_z    .push_back( ttrh->globalPosition().z() );
+      pix_xx   .push_back( ttrh->globalPositionError().cxx() );
+      pix_xy   .push_back( ttrh->globalPositionError().cyx() );
+      pix_yy   .push_back( ttrh->globalPositionError().cyy() );
+      pix_yz   .push_back( ttrh->globalPositionError().czy() );
+      pix_zz   .push_back( ttrh->globalPositionError().czz() );
+      pix_zx   .push_back( ttrh->globalPositionError().czx() );
+      pix_xsim .push_back( simHitPos.x() );
+      pix_ysim .push_back( simHitPos.y() );
+      pix_zsim .push_back( simHitPos.z() );
+      pix_eloss.push_back( energyLoss );
+      pix_radL .push_back( ttrh->surface()->mediumProperties().radLen() );
+      pix_bbxi .push_back( ttrh->surface()->mediumProperties().xi() );
+      if (debug) cout << "pixHit cluster=" << hit->cluster().key()
+		      << " subdId=" << hitId.subdetId()
+		      << " lay=" << tTopo->layer(hitId)
+		      << " rawId=" << hitId.rawId()
+		      << " pos =" << ttrh->globalPosition()
+		      << " firstMatchingTp=" << firstMatchingTp
+		      << " nMatchingTp=" << nMatchingTp
+		      << " simHitPos=" << simHitPos
+		      << " energyLoss=" << energyLoss
+		      << " particleType=" << particleType
+		      << " processType=" << processType
+		      << " bunchCrossing=" << bunchCrossing
+		      << " event=" << event
+		      << endl;
+    }
+  }
+
+  //strip hits
+  //index strip hit branches by cluster index
+  edm::Handle<SiStripRecHit2DCollection> rphiHits;
+  iEvent.getByLabel("siStripMatchedRecHits","rphiRecHit", rphiHits);
+  edm::Handle<SiStripRecHit2DCollection> stereoHits;
+  iEvent.getByLabel("siStripMatchedRecHits","stereoRecHit", stereoHits);
+  int totalStripHits = rphiHits->dataSize()+stereoHits->dataSize();
+  str_isBarrel .resize(totalStripHits);
+  str_isStereo .resize(totalStripHits);
+  str_det      .resize(totalStripHits);
+  str_lay      .resize(totalStripHits);
+  str_detId    .resize(totalStripHits);
+  str_nSimTrk  .resize(totalStripHits);
+  str_simTrkIdx.resize(totalStripHits);
+  str_particle .resize(totalStripHits);
+  str_process  .resize(totalStripHits);
+  str_bunchXing.resize(totalStripHits);
+  str_event    .resize(totalStripHits);
+  str_x    .resize(totalStripHits);
+  str_y    .resize(totalStripHits);
+  str_z    .resize(totalStripHits);
+  str_xx   .resize(totalStripHits);
+  str_xy   .resize(totalStripHits);
+  str_yy   .resize(totalStripHits);
+  str_yz   .resize(totalStripHits);
+  str_zz   .resize(totalStripHits);
+  str_zx   .resize(totalStripHits);
+  str_xsim .resize(totalStripHits);
+  str_ysim .resize(totalStripHits);
+  str_zsim .resize(totalStripHits);
+  str_eloss.resize(totalStripHits);
+  str_radL .resize(totalStripHits);
+  str_bbxi .resize(totalStripHits);
+  //rphi
+  for (auto it = rphiHits->begin(); it!=rphiHits->end(); it++ ) {
+    DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
+      int lay = tTopo->layer(hitId);
+      int firstMatchingTp = -1;
+      int nMatchingTp = 0;
+      GlobalPoint simHitPos = GlobalPoint(0,0,0);
+      float energyLoss = -999.;
+      int particleType = -999;
+      int processType = -999;
+      int bunchCrossing = -999;
+      int event = -999;
+      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
+      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
+      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+      if( range.first != range.second ) {
+	nMatchingTp = range.second-range.first;
+	for( auto ip=range.first; ip != range.second; ++ip ) {
+	  const TrackingParticleRef trackingParticle=(ip->second);
+	  if( trackingParticle->numberOfHits() == 0 ) continue;
+	  firstMatchingTp = trackingParticle.key();
+	  tpRPhiList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
+	  //now get the corresponding sim hit
+	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
+	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
+	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
+					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+	  for(auto ip = range.first; ip != range.second; ++ip) {
+	    TrackPSimHitRef TPhit = ip->second;
+	    DetId dId = DetId(TPhit->detUnitId());
+	    if (dId.rawId()==hitId.rawId()) {
+	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
+	      energyLoss = TPhit->energyLoss();
+	      particleType = TPhit->particleType();
+	      processType = TPhit->processType();
+	      bunchCrossing = TPhit->eventId().bunchCrossing();
+	      event = TPhit->eventId().event();
+	    }
+	  }
+	  break;
+	}
+      }
+      int key = hit->cluster().key();
+      str_isBarrel [key] = (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB);
+      str_isStereo [key] = 0;
+      str_det      [key] = hitId.subdetId();
+      str_lay      [key] = tTopo->layer(hitId);
+      str_detId    [key] = hitId.rawId();
+      str_nSimTrk  [key] = nMatchingTp;
+      str_simTrkIdx[key] = firstMatchingTp;
+      str_particle [key] = particleType;
+      str_process  [key] = processType;
+      str_bunchXing[key] = bunchCrossing;
+      str_event    [key] = event;
+      str_x    [key] = ttrh->globalPosition().x();
+      str_y    [key] = ttrh->globalPosition().y();
+      str_z    [key] = ttrh->globalPosition().z();
+      str_xx   [key] = ttrh->globalPositionError().cxx();
+      str_xy   [key] = ttrh->globalPositionError().cyx();
+      str_yy   [key] = ttrh->globalPositionError().cyy();
+      str_yz   [key] = ttrh->globalPositionError().czy();
+      str_zz   [key] = ttrh->globalPositionError().czz();
+      str_zx   [key] = ttrh->globalPositionError().czx();
+      str_xsim [key] = simHitPos.x();
+      str_ysim [key] = simHitPos.y();
+      str_zsim [key] = simHitPos.z();
+      str_eloss[key] = energyLoss;
+      str_radL [key] = ttrh->surface()->mediumProperties().radLen();
+      str_bbxi [key] = ttrh->surface()->mediumProperties().xi();
+      if (debug) cout << "stripRPhiHit cluster=" << key
+		      << " subdId=" << hitId.subdetId()
+		      << " lay=" << lay
+		      << " rawId=" << hitId.rawId()
+		      << " pos =" << ttrh->globalPosition()
+		      << " firstMatchingTp=" << firstMatchingTp
+		      << " nMatchingTp=" << nMatchingTp
+		      << " simHitPos=" << simHitPos
+		      << " energyLoss=" << energyLoss
+		      << " particleType=" << particleType
+		      << " processType=" << processType
+		      << " bunchCrossing=" << bunchCrossing
+		      << " event=" << event
+		      << endl;
+    }
+  }
+  //stereo
+  for (auto it = stereoHits->begin(); it!=stereoHits->end(); it++ ) {
+    DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
+      int lay = tTopo->layer(hitId);
+      int firstMatchingTp = -1;
+      int nMatchingTp = 0;
+      GlobalPoint simHitPos = GlobalPoint(0,0,0);
+      float energyLoss = -999.;
+      int particleType = -999;
+      int processType = -999;
+      int bunchCrossing = -999;
+      int event = -999;
+      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
+      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
+      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+      if( range.first != range.second ) {
+	nMatchingTp = range.second-range.first;
+	for( auto ip=range.first; ip != range.second; ++ip ) {
+	  const TrackingParticleRef trackingParticle=(ip->second);
+	  if( trackingParticle->numberOfHits() == 0 ) continue;
+	  firstMatchingTp = trackingParticle.key();
+	  tpStereoList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
+	  //now get the corresponding sim hit
+	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
+	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
+	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
+					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+	  for(auto ip = range.first; ip != range.second; ++ip) {
+	    TrackPSimHitRef TPhit = ip->second;
+	    DetId dId = DetId(TPhit->detUnitId());
+	    if (dId.rawId()==hitId.rawId()) {
+	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
+	      energyLoss = TPhit->energyLoss();
+	      particleType = TPhit->particleType();
+	      processType = TPhit->processType();
+	      bunchCrossing = TPhit->eventId().bunchCrossing();
+	      event = TPhit->eventId().event();
+	    }
+	  }
+	  break;
+	}
+      }
+      int key = hit->cluster().key();
+      str_isBarrel [key] = (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB);
+      str_isStereo [key] = 1;
+      str_det      [key] = hitId.subdetId();
+      str_lay      [key] = tTopo->layer(hitId);
+      str_detId    [key] = hitId.rawId();
+      str_nSimTrk  [key] = nMatchingTp;
+      str_simTrkIdx[key] = firstMatchingTp;
+      str_particle [key] = particleType;
+      str_process  [key] = processType;
+      str_bunchXing[key] = bunchCrossing;
+      str_event    [key] = event;
+      str_x    [key] = ttrh->globalPosition().x();
+      str_y    [key] = ttrh->globalPosition().y();
+      str_z    [key] = ttrh->globalPosition().z();
+      str_xx   [key] = ttrh->globalPositionError().cxx();
+      str_xy   [key] = ttrh->globalPositionError().cyx();
+      str_yy   [key] = ttrh->globalPositionError().cyy();
+      str_yz   [key] = ttrh->globalPositionError().czy();
+      str_zz   [key] = ttrh->globalPositionError().czz();
+      str_zx   [key] = ttrh->globalPositionError().czx();
+      str_xsim [key] = simHitPos.x();
+      str_ysim [key] = simHitPos.y();
+      str_zsim [key] = simHitPos.z();
+      str_eloss[key] = energyLoss;
+      str_radL [key] = ttrh->surface()->mediumProperties().radLen();
+      str_bbxi [key] = ttrh->surface()->mediumProperties().xi();
+      if (debug) cout << "stripStereoHit cluster=" << key
+		      << " subdId=" << hitId.subdetId()
+		      << " lay=" << lay
+		      << " rawId=" << hitId.rawId()
+		      << " pos =" << ttrh->globalPosition()
+		      << " firstMatchingTp=" << firstMatchingTp
+		      << " nMatchingTp=" << nMatchingTp
+		      << " simHitPos=" << simHitPos
+		      << " energyLoss=" << energyLoss
+		      << " particleType=" << particleType
+		      << " processType=" << processType
+		      << " bunchCrossing=" << bunchCrossing
+		      << " event=" << event
+		      << endl;
+    }
+  }
+
+  //matched hits
+  //prapare list to link matched hits to collection
+  vector<pair<int,int> > monoStereoClusterList;
+  edm::Handle<SiStripMatchedRecHit2DCollection> matchedHits;
+  iEvent.getByLabel("siStripMatchedRecHits","matchedRecHit", matchedHits);
+  for (auto it = matchedHits->begin(); it!=matchedHits->end(); it++ ) {
+    DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
+      int lay = tTopo->layer(hitId);
+      monoStereoClusterList.push_back(make_pair<int,int>(hit->monoHit().cluster().key(),hit->stereoHit().cluster().key()));
+      glu_isBarrel .push_back( (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB) );
+      glu_det      .push_back( hitId.subdetId() );
+      glu_lay      .push_back( tTopo->layer(hitId) );
+      glu_detId    .push_back( hitId.rawId() );
+      glu_monoIdx  .push_back( hit->monoHit().cluster().key() );
+      glu_stereoIdx.push_back( hit->stereoHit().cluster().key() );
+      glu_x        .push_back( ttrh->globalPosition().x() );
+      glu_y        .push_back( ttrh->globalPosition().y() );
+      glu_z        .push_back( ttrh->globalPosition().z() );
+      glu_xx       .push_back( ttrh->globalPositionError().cxx() );
+      glu_xy       .push_back( ttrh->globalPositionError().cyx() );
+      glu_yy       .push_back( ttrh->globalPositionError().cyy() );
+      glu_yz       .push_back( ttrh->globalPositionError().czy() );
+      glu_zz       .push_back( ttrh->globalPositionError().czz() );
+      glu_zx       .push_back( ttrh->globalPositionError().czx() );
+      glu_radL     .push_back( ttrh->surface()->mediumProperties().radLen() );
+      glu_bbxi     .push_back( ttrh->surface()->mediumProperties().xi() );
+      if (debug) cout << "stripMatchedHit"
+		      << " cluster0=" << hit->stereoHit().cluster().key()
+		      << " cluster1=" << hit->monoHit().cluster().key()
+		      << " subdId=" << hitId.subdetId()
+		      << " lay=" << lay
+		      << " rawId=" << hitId.rawId()
+		      << " pos =" << ttrh->globalPosition() << endl;
+    }
+  }
+
+  //seeds
+  int offset = 0;
+  TSCBLBuilderNoMaterial tscblBuilder;
+  for (unsigned int itsd=0;itsd<seedTags_.size();++itsd) {
+    InputTag seedTag_ = seedTags_[itsd];
+    Handle<TrajectorySeedCollection> seeds;
+    iEvent.getByLabel(seedTag_,seeds);
+    TString label = seedTag_.label();
+    if (debug) cout << "NEW SEED LABEL: " << label << " size: " << seeds->size();
+    //format label to match algoName
+    label.ReplaceAll("Seeds","");
+    label.ReplaceAll("muonSeeded","muonSeededStep");
+    if (debug) cout << " algo=" << TrackBase::algoByName(label.Data()) << endl;
+    int algo = TrackBase::algoByName(label.Data());
+    algo_offset[algo] = offset;
+    int seedCount = 0;
+    for(TrajectorySeedCollection::const_iterator itSeed = seeds->begin(); itSeed != seeds->end(); ++itSeed,++seedCount) {
+      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder->build(&*(itSeed->recHits().second-1));
+      TrajectoryStateOnSurface state = trajectoryStateTransform::transientState( itSeed->startingState(), lastRecHit->surface(), theMF.product());
+      int charge = state.charge();
+      float pt  = state.globalParameters().momentum().perp();
+      float eta = state.globalParameters().momentum().eta();
+      float phi = state.globalParameters().momentum().phi();
+      int nHits = itSeed->nHits();
+      see_px      .push_back( state.globalParameters().momentum().x() );
+      see_py      .push_back( state.globalParameters().momentum().y() );
+      see_pz      .push_back( state.globalParameters().momentum().z() );
+      see_pt      .push_back( pt );
+      see_eta     .push_back( eta );
+      see_phi     .push_back( phi );
+      see_q       .push_back( charge );
+      see_nValid  .push_back( nHits );
+      //convert seed into track to access parameters
+      TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed = tscblBuilder(*state.freeState(),bs);//as in TrackProducerAlgorithm
+      if(!(tsAtClosestApproachSeed.isValid())){
+        cout<<"TrajectoryStateClosestToBeamLine for seed not valid"<<endl;;
+        continue;
+      }
+      const reco::TrackBase::Point vSeed1(tsAtClosestApproachSeed.trackStateAtPCA().position().x(),
+					  tsAtClosestApproachSeed.trackStateAtPCA().position().y(),
+					  tsAtClosestApproachSeed.trackStateAtPCA().position().z());
+      const reco::TrackBase::Vector pSeed(tsAtClosestApproachSeed.trackStateAtPCA().momentum().x(),
+					  tsAtClosestApproachSeed.trackStateAtPCA().momentum().y(),
+					  tsAtClosestApproachSeed.trackStateAtPCA().momentum().z());
+      PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
+      reco::Track* matchedTrackPointer = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
+      see_dxy     .push_back(matchedTrackPointer->dxy(bs.position()));
+      see_dz      .push_back(matchedTrackPointer->dz(bs.position()));
+      see_ptErr   .push_back(matchedTrackPointer->ptError());
+      see_etaErr  .push_back(matchedTrackPointer->etaError());
+      see_phiErr  .push_back(matchedTrackPointer->phiError());
+      see_dxyErr  .push_back(matchedTrackPointer->dxyError());
+      see_dzErr   .push_back(matchedTrackPointer->dzError());
+      see_algo    .push_back(algo);
+      vector<int> pixelIdx;
+      vector<int> gluedIdx;
+      vector<int> stripIdx;
+      for (auto hit=itSeed->recHits().first; hit!=itSeed->recHits().second; ++hit) {
+	TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*hit);
+	int subid = recHit->geographicalId().subdetId();
+	if (subid == (int) PixelSubdetector::PixelBarrel || subid == (int) PixelSubdetector::PixelEndcap) {
+	  const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
+	  pixelIdx.push_back( bhit->firstClusterRef().cluster_pixel().key() );
+	} else {
+	  if (trackerHitRTTI::isMatched(*recHit)) {
+	    const SiStripMatchedRecHit2D * matchedHit = dynamic_cast<const SiStripMatchedRecHit2D *>(&*recHit);
+	    int monoIdx = matchedHit->monoClusterRef().key();
+	    int stereoIdx = matchedHit->stereoClusterRef().key();
+	    vector<pair<int,int> >::iterator pos = find( monoStereoClusterList.begin(), monoStereoClusterList.end(), make_pair(monoIdx,stereoIdx) );
+	    gluedIdx.push_back( pos - monoStereoClusterList.begin() );
+	  } else {
+	    const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
+	    stripIdx.push_back( bhit->firstClusterRef().cluster_strip().key() );
+	  }
+	}
+      }
+      see_pixelIdx.push_back( pixelIdx );
+      see_gluedIdx.push_back( gluedIdx );
+      see_stripIdx.push_back( stripIdx );
+      see_nPixel  .push_back( pixelIdx.size() );
+      see_nGlued  .push_back( gluedIdx.size() );
+      see_nStrip  .push_back( stripIdx.size() );
+      //the part below is not strictly needed
+      float chi2 = -1;
+      if (nHits==2) {
+	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder->build(&*(itSeed->recHits().first));
+	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder->build(&*(itSeed->recHits().first+1));
+	vector<GlobalPoint> gp(2);
+	vector<GlobalError> ge(2);
+	gp[0] = recHit0->globalPosition();
+	ge[0] = recHit0->globalPositionError();
+	gp[1] = recHit1->globalPosition();
+	ge[1] = recHit1->globalPositionError();
+	if (debug) {
+	  cout << "seed " << seedCount
+	       << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
+	       << " - PAIR - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId()
+	       << " hitpos: " << gp[0] << " " << gp[1]
+	       << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+	       << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+	       << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+	       << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+	       << " eta,phi: " << gp[0].eta() << "," << gp[0].phi()
+	       << endl;
+	}
+      } else if (nHits==3) {
+	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder->build(&*(itSeed->recHits().first));
+	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder->build(&*(itSeed->recHits().first+1));
+	TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder->build(&*(itSeed->recHits().first+2));
+	vector<GlobalPoint> gp(3);
+	vector<GlobalError> ge(3);
+	vector<bool> bl(3);
+	gp[0] = recHit0->globalPosition();
+	ge[0] = recHit0->globalPositionError();
+	int subid0 = recHit0->geographicalId().subdetId();
+	bl[0] = (subid0 == StripSubdetector::TIB || subid0 == StripSubdetector::TOB || subid0 == (int) PixelSubdetector::PixelBarrel);
+	gp[1] = recHit1->globalPosition();
+	ge[1] = recHit1->globalPositionError();
+	int subid1 = recHit1->geographicalId().subdetId();
+	bl[1] = (subid1 == StripSubdetector::TIB || subid1 == StripSubdetector::TOB || subid1 == (int) PixelSubdetector::PixelBarrel);
+	gp[2] = recHit2->globalPosition();
+	ge[2] = recHit2->globalPositionError();
+	int subid2 = recHit2->geographicalId().subdetId();
+	bl[2] = (subid2 == StripSubdetector::TIB || subid2 == StripSubdetector::TOB || subid2 == (int) PixelSubdetector::PixelBarrel);
+	RZLine rzLine(gp,ge,bl);
+	float  cottheta, intercept, covss, covii, covsi;
+	rzLine.fit(cottheta, intercept, covss, covii, covsi);
+	float seed_chi2 = rzLine.chi2(cottheta, intercept);
+	float seed_pt = state.globalParameters().momentum().perp();
+	if (debug) {
+	  cout << "seed " << seedCount
+	       << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
+	       << " - TRIPLET - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId() << " " << recHit2->geographicalId().rawId()
+	       << " hitpos: " << gp[0] << " " << gp[1] << " " << gp[2]
+	       << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+	       << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+	       << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+	       << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+	       << " trans2: " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+	       << " " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+	       << " local: " << recHit2->localPosition()
+	       << " tsos pos, mom: " << state.globalPosition()<<" "<<state.globalMomentum()
+	       << " eta,phi: " << gp[0].eta() << "," << gp[0].phi()
+	       << " pt,chi2: " << seed_pt << "," << seed_chi2 << endl;
+	}
+	chi2 = seed_chi2;
+      }
+      see_chi2   .push_back( chi2 );
+      offset++;
+    }
+  }
+
+  //tracks
+  edm::Handle<View<Track> > tracks;
+  iEvent.getByLabel(trackTag_,tracks);
+  reco::RecoToSimCollection recSimColl = associatorByHits->associateRecoToSim(tracks,TPCollectionH,&iEvent,&iSetup);
+  if (debug) cout << "NEW TRACK LABEL: " << trackTag_.label() << endl;
+  for(unsigned int i=0; i<tracks->size(); ++i){
+    RefToBase<Track> itTrack(tracks, i);
+    int nSimHits = 0;
+    double sharedFraction = 0.;
+    bool isSimMatched(false);
+    int tpIdx = -1;
+    if (recSimColl.find(itTrack) != recSimColl.end()) { 
+      auto const & tp = recSimColl[itTrack];
+      if (!tp.empty()) {
+	nSimHits = tp[0].first->numberOfTrackerHits();
+	sharedFraction = tp[0].second;
+	isSimMatched = true;
+	tpIdx = tp[0].first.key();
+      }
+    }
+    int charge = itTrack->charge();
+    float pt = itTrack->pt();
+    float eta = itTrack->eta();
+    float chi2 = itTrack->normalizedChi2();
+    float phi = itTrack->phi();
+    int nHits = itTrack->numberOfValidHits();
+    HitPattern hp = itTrack->hitPattern();
+    trk_px       .push_back(itTrack->px());
+    trk_py       .push_back(itTrack->py());
+    trk_pz       .push_back(itTrack->pz());
+    trk_pt       .push_back(pt);
+    trk_eta      .push_back(eta);
+    trk_phi      .push_back(phi);
+    trk_dxy      .push_back(itTrack->dxy(bs.position()));
+    trk_dz       .push_back(itTrack->dz(bs.position()));
+    trk_ptErr    .push_back(itTrack->ptError());
+    trk_etaErr   .push_back(itTrack->etaError());
+    trk_phiErr   .push_back(itTrack->phiError());
+    trk_dxyErr   .push_back(itTrack->dxyError());
+    trk_dzErr    .push_back(itTrack->dzError());
+    trk_nChi2    .push_back( itTrack->normalizedChi2());
+    trk_shareFrac.push_back(sharedFraction);
+    trk_q        .push_back(charge);
+    trk_nValid   .push_back(hp.numberOfValidHits());
+    //trk_nInvalid .push_back(hp.numberOfLostHits(HitPattern::TRACK_HITS)); / for 80X
+    trk_nInvalid .push_back(hp.numberOfLostHits());
+    trk_nPixel   .push_back(hp.numberOfValidPixelHits());
+    trk_nStrip   .push_back(hp.numberOfValidStripHits());
+    trk_n3DLay   .push_back(hp.numberOfValidStripLayersWithMonoAndStereo()+hp.pixelLayersWithMeasurement());
+    trk_algo     .push_back(itTrack->algo());
+    trk_isHP     .push_back(itTrack->quality(TrackBase::highPurity));
+    trk_seedIdx  .push_back( algo_offset[itTrack->algo()] + itTrack->seedRef().key() );
+    trk_simIdx   .push_back(tpIdx);
+    if (debug) { 
+      cout << "Track #" << i << " with q=" << charge
+	   << ", pT=" << pt << " GeV, eta: " << eta << ", phi: " << phi
+	   << ", chi2=" << chi2
+	   << ", Nhits=" << nHits
+	   << ", algo=" << itTrack->algoName(itTrack->algo()).c_str()
+	   << " hp=" << itTrack->quality(TrackBase::highPurity)
+	   << " seed#=" << itTrack->seedRef().key()
+	   << " simMatch=" << isSimMatched
+	   << " nSimHits=" << nSimHits
+	   << " sharedFraction=" << sharedFraction
+	   << " tpIdx=" << tpIdx
+	   << endl;
+    }
+    vector<int> pixelCluster;
+    vector<int> stripCluster;
+    int nhit = 0;
+    for (trackingRecHit_iterator i=itTrack->recHitsBegin(); i!=itTrack->recHitsEnd(); i++){
+      if (debug) cout << "hit #" << nhit;
+      TransientTrackingRecHit::RecHitPointer hit=theTTRHBuilder->build(&**i );
+      DetId hitId = hit->geographicalId();
+      if (debug) cout << " subdet=" << hitId.subdetId();
+      if(hitId.det() == DetId::Tracker) {
+	if (debug) {
+	  if (hitId.subdetId() == StripSubdetector::TIB )      cout << " - TIB ";
+	  else if (hitId.subdetId() == StripSubdetector::TOB ) cout << " - TOB ";
+	  else if (hitId.subdetId() == StripSubdetector::TEC ) cout << " - TEC ";
+	  else if (hitId.subdetId() == StripSubdetector::TID ) cout << " - TID ";
+	  else if (hitId.subdetId() == (int) PixelSubdetector::PixelBarrel ) cout << " - PixBar ";
+	  else if (hitId.subdetId() == (int) PixelSubdetector::PixelEndcap ) cout << " - PixFwd ";
+	  else cout << " UNKNOWN TRACKER HIT TYPE ";
+	  cout << tTopo->layer(hitId);
+	}
+	bool isPixel = (hitId.subdetId() == (int) PixelSubdetector::PixelBarrel || hitId.subdetId() == (int) PixelSubdetector::PixelEndcap );
+	if (hit->isValid()) {
+	  //ugly... but works
+	  const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*hit);
+	  if (debug) cout << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
+			  << " cluster=" << (bhit->firstClusterRef().isPixel() ? bhit->firstClusterRef().cluster_pixel().key() :  bhit->firstClusterRef().cluster_strip().key())
+			  << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi()  << endl;
+	  if (isPixel) pixelCluster.push_back( bhit->firstClusterRef().cluster_pixel().key() );
+	  else         stripCluster.push_back( bhit->firstClusterRef().cluster_strip().key() );
+	} else  {
+	  if (debug) cout << " - invalid hit" << endl;
+	  if (isPixel) pixelCluster.push_back( -1 );
+	  else         stripCluster.push_back( -1 );
+	}
+      }
+      nhit++;
+    }
+    if (debug) cout << endl;
+    trk_pixelIdx.push_back(pixelCluster);
+    trk_stripIdx.push_back(stripCluster);
+  }
+
+  //tracking particles
+  //sort association maps with clusters
+  sort( tpPixList.begin(), tpPixList.end(), intIntListGreater );
+  sort( tpRPhiList.begin(), tpRPhiList.end(), intIntListGreater );
+  sort( tpStereoList.begin(), tpStereoList.end(), intIntListGreater );
+  for (auto itp = tPC.begin(); itp != tPC.end(); ++itp) {
+    TrackingParticleRef tp(TPCollectionH,itp-tPC.begin());
+    if (debug) cout << "tracking particle pt=" << tp->pt() << " eta=" << tp->eta() << " phi=" << tp->phi() << endl;
+    reco::SimToRecoCollection simRecColl = associatorByHits->associateSimToReco(tracks,TPCollectionH,&iEvent,&iSetup);
+    bool isRecoMatched(false);
+    int tkIdx = -1;
+    float sharedFraction = -1;
+    if (simRecColl.find(tp) != simRecColl.end()) { 
+      auto const & tk = simRecColl[tp];
+      if (!tk.empty()) {
+	isRecoMatched = true;
+	tkIdx = tk[0].first.key();
+	sharedFraction = tk[0].second;
+      }
+    }
+    if (debug) cout << "matched to track = " << tkIdx << " isRecoMatched=" << isRecoMatched << endl;
+    sim_px       .push_back(tp->px());
+    sim_py       .push_back(tp->py());
+    sim_pz       .push_back(tp->pz());
+    sim_pt       .push_back(tp->pt());
+    sim_eta      .push_back(tp->eta());
+    sim_phi      .push_back(tp->phi());
+    sim_shareFrac.push_back(sharedFraction);
+    sim_q        .push_back(tp->charge());
+    sim_trkIdx   .push_back(tkIdx);
+    sim_prodx    .push_back(tp->vertex().x());
+    sim_prody    .push_back(tp->vertex().y());
+    sim_prodz    .push_back(tp->vertex().z());
+    //Calcualte the impact parameters w.r.t. PCA
+    TrackingParticle::Vector momentum = parametersDefiner->momentum(iEvent,iSetup,tp);
+    TrackingParticle::Point vertex = parametersDefiner->vertex(iEvent,iSetup,tp);
+    float dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
+    float dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2())
+      * momentum.z()/sqrt(momentum.perp2());
+    sim_dxy      .push_back(dxySim);
+    sim_dz       .push_back(dzSim);
+    vector<int> pixelCluster;
+    vector<int> stripCluster;
+    pair<int, int> tpPixPairDummy(tp.key(),-1);
+    auto rangePix = std::equal_range(tpPixList.begin(), tpPixList.end(), tpPixPairDummy, intIntListGreater);
+    for(auto ip = rangePix.first; ip != rangePix.second; ++ip) {
+      if (debug) cout << "pixHit cluster=" << ip->second << endl;
+      pixelCluster.push_back(ip->second);
+    }
+    pair<int, int> tpRPhiPairDummy(tp.key(),-1);
+    auto rangeRPhi = std::equal_range(tpRPhiList.begin(), tpRPhiList.end(), tpRPhiPairDummy, intIntListGreater);
+    for(auto ip = rangeRPhi.first; ip != rangeRPhi.second; ++ip) {
+      if (debug) cout << "rphiHit cluster=" << ip->second << endl;
+      stripCluster.push_back(ip->second);
+    }
+    pair<int, int> tpStereoPairDummy(tp.key(),-1);
+    auto rangeStereo = std::equal_range(tpStereoList.begin(), tpStereoList.end(), tpStereoPairDummy, intIntListGreater);
+    for(auto ip = rangeStereo.first; ip != rangeStereo.second; ++ip) {
+      if (debug) cout << "stereoHit cluster=" << ip->second << endl;
+      stripCluster.push_back(ip->second);
+    }
+    sim_nValid   .push_back( pixelCluster.size()+stripCluster.size() );
+    sim_nPixel   .push_back( pixelCluster.size() );
+    sim_nStrip   .push_back( stripCluster.size() );
+    sim_n3DLay   .push_back( -1 );//fixme
+    sim_pixelIdx.push_back(pixelCluster);
+    sim_stripIdx.push_back(stripCluster);
+  }
+
+  t->Fill();
+
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void TrackingNtuple::beginJob() {
+  
+  edm::Service<TFileService> fs;
+  fs->make<TTree>("tree","tree");
+  t = fs->getObject<TTree>("tree");
+
+  //tracks
+  t->Branch("trk_px"       , &trk_px);
+  t->Branch("trk_py"       , &trk_py);
+  t->Branch("trk_pz"       , &trk_pz);
+  t->Branch("trk_pt"       , &trk_pt);
+  t->Branch("trk_eta"      , &trk_eta);
+  t->Branch("trk_phi"      , &trk_phi);
+  t->Branch("trk_dxy"      , &trk_dxy      );
+  t->Branch("trk_dz"       , &trk_dz       );
+  t->Branch("trk_ptErr"    , &trk_ptErr    );
+  t->Branch("trk_etaErr"   , &trk_etaErr   );
+  t->Branch("trk_phiErr"   , &trk_phiErr   );
+  t->Branch("trk_dxyErr"   , &trk_dxyErr   );
+  t->Branch("trk_dzErr"    , &trk_dzErr    );
+  t->Branch("trk_nChi2"    , &trk_nChi2);
+  t->Branch("trk_shareFrac", &trk_shareFrac);
+  t->Branch("trk_q"        , &trk_q);
+  t->Branch("trk_nValid"   , &trk_nValid  );
+  t->Branch("trk_nInvalid" , &trk_nInvalid);
+  t->Branch("trk_nPixel"   , &trk_nPixel  );
+  t->Branch("trk_nStrip"   , &trk_nStrip  );
+  t->Branch("trk_n3DLay"   , &trk_n3DLay  );
+  t->Branch("trk_algo"     , &trk_algo    );
+  t->Branch("trk_isHP"     , &trk_isHP    );
+  t->Branch("trk_seedIdx"  , &trk_seedIdx );
+  t->Branch("trk_simIdx"   , &trk_simIdx  );
+  t->Branch("trk_pixelIdx" , &trk_pixelIdx);
+  t->Branch("trk_stripIdx" , &trk_stripIdx);
+  //sim tracks
+  t->Branch("sim_px"       , &sim_px       );
+  t->Branch("sim_py"       , &sim_py       );
+  t->Branch("sim_pz"       , &sim_pz       );
+  t->Branch("sim_pt"       , &sim_pt       );
+  t->Branch("sim_eta"      , &sim_eta      );
+  t->Branch("sim_phi"      , &sim_phi      );
+  t->Branch("sim_dxy"      , &sim_dxy      );
+  t->Branch("sim_dz"       , &sim_dz       );
+  t->Branch("sim_prodx"    , &sim_prodx    );
+  t->Branch("sim_prody"    , &sim_prody    );
+  t->Branch("sim_prodz"    , &sim_prodz    );
+  t->Branch("sim_shareFrac", &sim_shareFrac);
+  t->Branch("sim_q"        , &sim_q        );
+  t->Branch("sim_nValid"   , &sim_nValid   );
+  t->Branch("sim_nPixel"   , &sim_nPixel   );
+  t->Branch("sim_nStrip"   , &sim_nStrip   );
+  t->Branch("sim_n3DLay"   , &sim_n3DLay   );
+  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
+  t->Branch("sim_pixelIdx" , &sim_pixelIdx );
+  t->Branch("sim_stripIdx" , &sim_stripIdx );
+  //pixels
+  t->Branch("pix_isBarrel"  , &pix_isBarrel );
+  t->Branch("pix_lay"       , &pix_lay      );
+  t->Branch("pix_detId"     , &pix_detId    );
+  t->Branch("pix_nSimTrk"   , &pix_nSimTrk  );
+  t->Branch("pix_simTrkIdx" , &pix_simTrkIdx);
+  t->Branch("pix_particle"  , &pix_particle );
+  t->Branch("pix_process"   , &pix_process  );
+  t->Branch("pix_bunchXing" , &pix_bunchXing);
+  t->Branch("pix_event"     , &pix_event    );
+  t->Branch("pix_x"     , &pix_x    );
+  t->Branch("pix_y"     , &pix_y    );
+  t->Branch("pix_z"     , &pix_z    );
+  t->Branch("pix_xx"    , &pix_xx   );
+  t->Branch("pix_xy"    , &pix_xy   );
+  t->Branch("pix_yy"    , &pix_yy   );
+  t->Branch("pix_yz"    , &pix_yz   );
+  t->Branch("pix_zz"    , &pix_zz   );
+  t->Branch("pix_zx"    , &pix_zx   );
+  t->Branch("pix_xsim"  , &pix_xsim );
+  t->Branch("pix_ysim"  , &pix_ysim );
+  t->Branch("pix_zsim"  , &pix_zsim );
+  t->Branch("pix_eloss" , &pix_eloss);
+  t->Branch("pix_radL"  , &pix_radL );
+  t->Branch("pix_bbxi"  , &pix_bbxi );
+  //strips
+  t->Branch("str_isBarrel"  , &str_isBarrel );
+  t->Branch("str_isStereo"  , &str_isStereo );
+  t->Branch("str_det"       , &str_det      );
+  t->Branch("str_lay"       , &str_lay      );
+  t->Branch("str_detId"     , &str_detId    );
+  t->Branch("str_nSimTrk"   , &str_nSimTrk  );
+  t->Branch("str_simTrkIdx" , &str_simTrkIdx);
+  t->Branch("str_particle"  , &str_particle );
+  t->Branch("str_process"   , &str_process  );
+  t->Branch("str_bunchXing" , &str_bunchXing);
+  t->Branch("str_event"     , &str_event    );
+  t->Branch("str_x"     , &str_x    );
+  t->Branch("str_y"     , &str_y    );
+  t->Branch("str_z"     , &str_z    );
+  t->Branch("str_xx"    , &str_xx   );
+  t->Branch("str_xy"    , &str_xy   );
+  t->Branch("str_yy"    , &str_yy   );
+  t->Branch("str_yz"    , &str_yz   );
+  t->Branch("str_zz"    , &str_zz   );
+  t->Branch("str_zx"    , &str_zx   );
+  t->Branch("str_xsim"  , &str_xsim );
+  t->Branch("str_ysim"  , &str_ysim );
+  t->Branch("str_zsim"  , &str_zsim );
+  t->Branch("str_eloss" , &str_eloss);
+  t->Branch("str_radL"  , &str_radL );
+  t->Branch("str_bbxi"  , &str_bbxi );
+  //matched hits
+  t->Branch("glu_isBarrel"  , &glu_isBarrel );
+  t->Branch("glu_det"       , &glu_det      );
+  t->Branch("glu_lay"       , &glu_lay      );
+  t->Branch("glu_detId"     , &glu_detId    );
+  t->Branch("glu_monoIdx"   , &glu_monoIdx  );
+  t->Branch("glu_stereoIdx" , &glu_stereoIdx);
+  t->Branch("glu_x"         , &glu_x        );
+  t->Branch("glu_y"         , &glu_y        );
+  t->Branch("glu_z"         , &glu_z        );
+  t->Branch("glu_xx"        , &glu_xx       );
+  t->Branch("glu_xy"        , &glu_xy       );
+  t->Branch("glu_yy"        , &glu_yy       );
+  t->Branch("glu_yz"        , &glu_yz       );
+  t->Branch("glu_zz"        , &glu_zz       );
+  t->Branch("glu_zx"        , &glu_zx       );
+  t->Branch("glu_radL"      , &glu_radL     );
+  t->Branch("glu_bbxi"      , &glu_bbxi     );
+  //beam spot
+  t->Branch("bsp_x" , &bsp_x , "bsp_x/F");
+  t->Branch("bsp_y" , &bsp_y , "bsp_y/F");
+  t->Branch("bsp_z" , &bsp_z , "bsp_z/F");
+  t->Branch("bsp_sigmax" , &bsp_sigmax , "bsp_sigmax/F");
+  t->Branch("bsp_sigmay" , &bsp_sigmay , "bsp_sigmay/F");
+  t->Branch("bsp_sigmaz" , &bsp_sigmaz , "bsp_sigmaz/F");
+  //seeds
+  t->Branch("see_px"       , &see_px      );
+  t->Branch("see_py"       , &see_py      );
+  t->Branch("see_pz"       , &see_pz      );
+  t->Branch("see_pt"       , &see_pt      );
+  t->Branch("see_eta"      , &see_eta     );
+  t->Branch("see_phi"      , &see_phi     );
+  t->Branch("see_dxy"      , &see_dxy     );
+  t->Branch("see_dz"       , &see_dz      );
+  t->Branch("see_ptErr"    , &see_ptErr   );
+  t->Branch("see_etaErr"   , &see_etaErr  );
+  t->Branch("see_phiErr"   , &see_phiErr  );
+  t->Branch("see_dxyErr"   , &see_dxyErr  );
+  t->Branch("see_dzErr"    , &see_dzErr   );
+  t->Branch("see_chi2"     , &see_chi2    );
+  t->Branch("see_q"        , &see_q       );
+  t->Branch("see_nValid"   , &see_nValid  );
+  t->Branch("see_nPixel"   , &see_nPixel  );
+  t->Branch("see_nGlued"   , &see_nGlued  );
+  t->Branch("see_nStrip"   , &see_nStrip  );
+  t->Branch("see_algo"     , &see_algo    );
+  t->Branch("see_pixelIdx" , &see_pixelIdx);
+  t->Branch("see_gluedIdx" , &see_gluedIdx);
+  t->Branch("see_stripIdx" , &see_stripIdx);
+  //seed algo offset
+  t->Branch("algo_offset"  , &algo_offset );
+
+  //t->Branch("" , &);
+
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void TrackingNtuple::endJob() {}
+
+// ------------ method called when starting to processes a run  ------------
+void TrackingNtuple::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
+
+  iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+  iSetup.get<TransientRecHitRecord>().get(builderName_,theTTRHBuilder);
+  
+  edm::ESHandle<TrackAssociatorBase> theHitsAssociator;
+  iSetup.get<TrackAssociatorRecord>().get("quickTrackAssociatorByHits",theHitsAssociator);
+  associatorByHits = (TrackAssociatorBase *) theHitsAssociator.product();
+
+  //get parameters definer
+  edm::ESHandle<ParametersDefinerForTP> parametersDefinerH;
+  iSetup.get<TrackAssociatorRecord>().get("LhcParametersDefinerForTP",parametersDefinerH);
+  parametersDefiner = parametersDefinerH.product();
+  
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
+  tTopo = tTopoHandle.product();
+
+}
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+  void TrackingNtuple::endRun(edm::Run const&, edm::EventSetup const&) {}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+  void TrackingNtuple::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+  void TrackingNtuple::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TrackingNtuple);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -370,6 +370,7 @@ private:
   //sim tracks
   std::vector<int>   sim_event    ;
   std::vector<int>   sim_bunchCrossing;
+  std::vector<int>   sim_pdgId    ;
   std::vector<float> sim_px       ;
   std::vector<float> sim_py       ;
   std::vector<float> sim_pz       ;
@@ -510,6 +511,7 @@ private:
   // Tracking vertices
   std::vector<int>   simvtx_event;
   std::vector<int>   simvtx_bunchCrossing;
+  std::vector<unsigned int> simvtx_processType; // only from first SimVertex of TrackingVertex
   std::vector<float> simvtx_x;
   std::vector<float> simvtx_y;
   std::vector<float> simvtx_z;
@@ -600,6 +602,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   //sim tracks
   t->Branch("sim_event"    , &sim_event    );
   t->Branch("sim_bunchCrossing", &sim_bunchCrossing);
+  t->Branch("sim_pdgId"    , &sim_pdgId    );
   t->Branch("sim_px"       , &sim_px       );
   t->Branch("sim_py"       , &sim_py       );
   t->Branch("sim_pz"       , &sim_pz       );
@@ -747,6 +750,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   // tracking vertices
   t->Branch("simvtx_event"   , &simvtx_event    );
   t->Branch("simvtx_bunchCrossing", &simvtx_bunchCrossing);
+  t->Branch("simvtx_processType", &simvtx_processType);
   t->Branch("simvtx_x"       , &simvtx_x);
   t->Branch("simvtx_y"       , &simvtx_y);
   t->Branch("simvtx_z"       , &simvtx_z);
@@ -810,6 +814,7 @@ void TrackingNtuple::clearVariables() {
   //sim tracks
   sim_event    .clear();
   sim_bunchCrossing.clear();
+  sim_pdgId    .clear();
   sim_px       .clear();
   sim_py       .clear();
   sim_pz       .clear();
@@ -1744,6 +1749,7 @@ void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::
     LogTrace("TrackingNtuple") << "matched to tracks = " << make_VectorPrinter(tkIdx) << " isRecoMatched=" << isRecoMatched;
     sim_event    .push_back(tp->eventId().event());
     sim_bunchCrossing.push_back(tp->eventId().bunchCrossing());
+    sim_pdgId    .push_back(tp->pdgId());
     sim_px       .push_back(tp->px());
     sim_py       .push_back(tp->py());
     sim_pz       .push_back(tp->pz());
@@ -1823,8 +1829,15 @@ void TrackingNtuple::fillTrackingVertices(const TrackingVertexRefVector& trackin
       simpv_idx.push_back(simvtx_x.size());
     }
 
+    unsigned int processType = std::numeric_limits<unsigned int>::max();
+    if(!v.g4Vertices().empty()) {
+      processType = v.g4Vertices()[0].processType();
+    }
+
     simvtx_event.push_back(v.eventId().event());
     simvtx_bunchCrossing.push_back(v.eventId().bunchCrossing());
+    simvtx_processType.push_back(processType);
+
     simvtx_x.push_back(v.position().x());
     simvtx_y.push_back(v.position().y());
     simvtx_z.push_back(v.position().z());

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -364,7 +364,7 @@ private:
   std::vector<short> trk_isHP    ;
   std::vector<int> trk_seedIdx ;
   std::vector<std::vector<float> > trk_shareFrac;
-  std::vector<std::vector<int> > trk_simIdx;
+  std::vector<std::vector<int> > trk_simTrkIdx;
   std::vector<std::vector<int> > trk_hitIdx;
   std::vector<std::vector<int> > trk_hitType;
   //sim tracks
@@ -379,7 +379,6 @@ private:
   std::vector<float> sim_phi      ;
   std::vector<float> sim_dxy      ;
   std::vector<float> sim_dz       ;
-  std::vector<std::vector<float> > sim_shareFrac;
   std::vector<int> sim_q       ;
   std::vector<unsigned int> sim_nValid  ;
   std::vector<unsigned int> sim_nPixel  ;
@@ -387,9 +386,10 @@ private:
   std::vector<unsigned int> sim_nLay;
   std::vector<unsigned int> sim_nPixelLay;
   std::vector<unsigned int> sim_n3DLay  ;
+  std::vector<std::vector<int> > sim_trkIdx  ;
+  std::vector<std::vector<float> > sim_shareFrac;
   std::vector<int> sim_parentVtxIdx;
   std::vector<std::vector<int> > sim_decayVtxIdx;
-  std::vector<std::vector<int> > sim_trkIdx  ;
   std::vector<std::vector<int> > sim_hitIdx;
   std::vector<std::vector<int> > sim_hitType;
   //pixels: reco and sim hits
@@ -493,7 +493,7 @@ private:
   std::vector<unsigned int> see_nStrip  ;
   std::vector<unsigned int> see_algo    ;
   std::vector<std::vector<float> > see_shareFrac;
-  std::vector<std::vector<int> > see_simIdx;
+  std::vector<std::vector<int> > see_simTrkIdx;
   std::vector<std::vector<int> > see_hitIdx;
   std::vector<std::vector<int> > see_hitType;
   //seed algo offset
@@ -599,7 +599,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("trk_seedIdx"  , &trk_seedIdx );
   }
   t->Branch("trk_shareFrac", &trk_shareFrac);
-  t->Branch("trk_simIdx"   , &trk_simIdx  );
+  t->Branch("trk_simTrkIdx", &trk_simTrkIdx  );
   if(includeAllHits_) {
     t->Branch("trk_hitIdx" , &trk_hitIdx);
     t->Branch("trk_hitType", &trk_hitType);
@@ -616,7 +616,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   t->Branch("sim_phi"      , &sim_phi      );
   t->Branch("sim_dxy"      , &sim_dxy      );
   t->Branch("sim_dz"       , &sim_dz       );
-  t->Branch("sim_shareFrac", &sim_shareFrac);
   t->Branch("sim_q"        , &sim_q        );
   t->Branch("sim_nValid"   , &sim_nValid   );
   t->Branch("sim_nPixel"   , &sim_nPixel   );
@@ -624,9 +623,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   t->Branch("sim_nLay"     , &sim_nLay     );
   t->Branch("sim_nPixelLay", &sim_nPixelLay);
   t->Branch("sim_n3DLay"   , &sim_n3DLay   );
+  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
+  t->Branch("sim_shareFrac", &sim_shareFrac);
   t->Branch("sim_parentVtxIdx", &sim_parentVtxIdx);
   t->Branch("sim_decayVtxIdx", &sim_decayVtxIdx);
-  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
   if(includeAllHits_) {
     t->Branch("sim_hitIdx" , &sim_hitIdx );
     t->Branch("sim_hitType", &sim_hitType );
@@ -741,7 +741,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("see_nStrip"   , &see_nStrip  );
     t->Branch("see_algo"     , &see_algo    );
     t->Branch("see_shareFrac", &see_shareFrac);
-    t->Branch("see_simIdx"   , &see_simIdx  );
+    t->Branch("see_simTrkIdx", &see_simTrkIdx  );
     if(includeAllHits_) {
       t->Branch("see_hitIdx" , &see_hitIdx  );
       t->Branch("see_hitType", &see_hitType );
@@ -824,7 +824,7 @@ void TrackingNtuple::clearVariables() {
   trk_isHP     .clear();
   trk_seedIdx  .clear();
   trk_shareFrac.clear();
-  trk_simIdx   .clear();
+  trk_simTrkIdx.clear();
   trk_hitIdx   .clear();
   trk_hitType  .clear();
   //sim tracks
@@ -839,7 +839,6 @@ void TrackingNtuple::clearVariables() {
   sim_phi      .clear();
   sim_dxy      .clear();
   sim_dz       .clear();
-  sim_shareFrac.clear();
   sim_q        .clear();
   sim_nValid   .clear();
   sim_nPixel   .clear();
@@ -847,9 +846,10 @@ void TrackingNtuple::clearVariables() {
   sim_nLay     .clear();
   sim_nPixelLay.clear();
   sim_n3DLay   .clear();
+  sim_trkIdx   .clear();
+  sim_shareFrac.clear();
   sim_parentVtxIdx.clear();
   sim_decayVtxIdx.clear();
-  sim_trkIdx   .clear();
   sim_hitIdx   .clear();
   sim_hitType  .clear();
   //pixels
@@ -953,7 +953,7 @@ void TrackingNtuple::clearVariables() {
   see_nStrip  .clear();
   see_algo    .clear();
   see_shareFrac.clear();
-  see_simIdx   .clear();
+  see_simTrkIdx.clear();
   see_hitIdx  .clear();
   see_hitType .clear();
   //seed algo offset
@@ -1492,7 +1492,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_algo    .push_back( algo );
 
       see_shareFrac.push_back( sharedFraction );
-      see_simIdx   .push_back( tpIdx );
+      see_simTrkIdx.push_back( tpIdx );
 
       /// Hmm, the following could make sense instead of plain failing if propagation to beam line fails
       /*
@@ -1698,7 +1698,7 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
 
       trk_seedIdx  .push_back( offset->second + itTrack->seedRef().key() );
     }
-    trk_simIdx   .push_back(tpIdx);
+    trk_simTrkIdx.push_back(tpIdx);
     LogTrace("TrackingNtuple") << "Track #" << itTrack.key() << " with q=" << charge
                                << ", pT=" << pt << " GeV, eta: " << eta << ", phi: " << phi
                                << ", chi2=" << chi2
@@ -1799,9 +1799,9 @@ void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::
     sim_pt       .push_back(tp->pt());
     sim_eta      .push_back(tp->eta());
     sim_phi      .push_back(tp->phi());
-    sim_shareFrac.push_back(sharedFraction);
     sim_q        .push_back(tp->charge());
     sim_trkIdx   .push_back(tkIdx);
+    sim_shareFrac.push_back(sharedFraction);
     sim_parentVtxIdx.push_back( tvKeyToIndex.at(tp->parentVertex().key()) );
     std::vector<int> decayIdx;
     for(const auto& v: tp->decayVertices())

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -75,6 +75,7 @@
 #include "Validation/RecoTrack/interface/trackFromSeedFitFailed.h"
 
 #include <set>
+#include <map>
 
 #include "TTree.h"
 
@@ -111,6 +112,27 @@ namespace {
     const std::set<edm::ProductID>& set_;
   };
   std::ostream& operator<<(std::ostream& os, const ProductIDSetPrinter& o) {
+    o.print(os);
+    return os;
+  }
+  template <typename T>
+  struct ProductIDMapPrinter {
+    ProductIDMapPrinter(const std::map<edm::ProductID, T>& map): map_(map) {}
+
+    void print(std::ostream& os) const {
+      for(const auto& item: map_) {
+        os << item.first << " ";
+      }
+    }
+
+    const std::map<edm::ProductID, T>& map_;
+  };
+  template <typename T>
+  auto make_ProductIDMapPrinter(const std::map<edm::ProductID, T>& map) {
+    return ProductIDMapPrinter<T>(map);
+  }
+  template <typename T>
+  std::ostream& operator<<(std::ostream& os, const ProductIDMapPrinter<T>& o) {
     o.print(os);
     return os;
   }
@@ -196,7 +218,8 @@ private:
                  const TransientTrackingRecHitBuilder& theTTRHBuilder,
                  const MagneticField *theMF,
                  const std::vector<std::pair<int, int> >& monoStereoClusterList,
-                 const std::set<edm::ProductID>& hitProductIds
+                 const std::set<edm::ProductID>& hitProductIds,
+                 std::map<edm::ProductID, size_t>& seedToCollIndex
                  );
 
   void fillTracks(const edm::Handle<edm::View<reco::Track> >& tracks,
@@ -205,7 +228,8 @@ private:
                   const reco::TrackToTrackingParticleAssociator& associatorByHits,
                   const TransientTrackingRecHitBuilder& theTTRHBuilder,
                   const TrackerTopology& tTopo,
-                  const std::set<edm::ProductID>& hitProductIds
+                  const std::set<edm::ProductID>& hitProductIds,
+                  const std::map<edm::ProductID, size_t>& seedToCollIndex
                   );
 
   void fillTrackingParticles(const edm::Event& iEvent, const edm::EventSetup& iSetup,
@@ -426,8 +450,7 @@ private:
   std::vector<std::vector<int> > see_gluedIdx;
   std::vector<std::vector<int> > see_stripIdx;
   //seed algo offset
-  static constexpr unsigned int algo_offset_max = 20;
-  std::vector<int> algo_offset  ;
+  std::vector<unsigned int> see_offset  ;
 
 
   // Vertices
@@ -474,11 +497,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
   includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits"))
 {
-
-  if(seedTokens_.size() > algo_offset_max) {
-    throw cms::Exception("Configuration") << "TrackingNtuple has a hard-coded maximum of " << algo_offset_max << " seed collections, got " << seedTokens_.size() << ". Please increase TrackingNtuple::algo_offset_max";
-  }
-
   edm::Service<TFileService> fs;
   t = fs->make<TTree>("tree","tree");
 
@@ -656,7 +674,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
       t->Branch("see_stripIdx" , &see_stripIdx);
     }
     //seed algo offset
-    t->Branch("algo_offset"  , &algo_offset );
+    t->Branch("see_offset"  , &see_offset );
   }
 
   //vertices
@@ -856,8 +874,7 @@ void TrackingNtuple::clearVariables() {
   see_gluedIdx.clear();
   see_stripIdx.clear();
   //seed algo offset
-  algo_offset .clear();
-  for (unsigned int i=0; i<algo_offset_max; ++i) algo_offset.push_back(-1);
+  see_offset.clear();
 
   // vertices
   vtx_x.clear();
@@ -915,6 +932,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   vector<pair<int, int> > tpStereoList;
 
   std::set<edm::ProductID> hitProductIds;
+  std::map<edm::ProductID, size_t> seedCollToOffset;
 
   ev_run = iEvent.id().run();
   ev_lumi = iEvent.id().luminosityBlock();
@@ -942,13 +960,13 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
   //seeds
   if(includeSeeds_) {
-    fillSeeds(iEvent, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, theMF.product(), monoStereoClusterList, hitProductIds);
+    fillSeeds(iEvent, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, theMF.product(), monoStereoClusterList, hitProductIds, seedCollToOffset);
   }
 
   //tracks
   edm::Handle<edm::View<reco::Track> > tracks;
   iEvent.getByToken(trackToken_, tracks);
-  fillTracks(tracks, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, tTopo, hitProductIds);
+  fillTracks(tracks, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, tTopo, hitProductIds, seedCollToOffset);
 
   //tracking particles
   //sort association maps with clusters
@@ -1250,16 +1268,18 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                const MagneticField *theMF,
                                const std::vector<std::pair<int, int> >& monoStereoClusterList,
-                               const std::set<edm::ProductID>& hitProductIds
+                               const std::set<edm::ProductID>& hitProductIds,
+                               std::map<edm::ProductID, size_t>& seedCollToOffset
                                ) {
-  int offset = 0;
   TSCBLBuilderNoMaterial tscblBuilder;
   for(const auto& seedToken: seedTokens_) {
     edm::Handle<edm::View<reco::Track> > seedTracks;
     iEvent.getByToken(seedToken, seedTracks);
 
-    reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(seedTracks, TPCollectionH);
+    if(seedTracks->empty())
+      continue;
 
+    reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(seedTracks, TPCollectionH);
 
     edm::EDConsumerBase::Labels labels;
     labelsForToken(seedToken, labels);
@@ -1269,14 +1289,24 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     label.ReplaceAll("Seeds","");
     label.ReplaceAll("muonSeeded","muonSeededStep");
     int algo = reco::TrackBase::algoByName(label.Data());
-    LogTrace("TrackingNtuple") << "NEW SEED LABEL: " << label << " size: " << seedTracks->size() << " algo=" << algo;
-    algo_offset[algo] = offset;
-    int seedCount = 0;
-    for(unsigned int i=0; i<seedTracks->size(); ++i) {
-      auto seedTrackRef = seedTracks->refAt(i);
+
+    edm::ProductID id = (*seedTracks)[0].seedRef().id();
+    auto inserted = seedCollToOffset.emplace(id, see_fitok.size());
+    if(!inserted.second)
+      throw cms::Exception("Configuration") << "Trying to add seeds with ProductID " << id << " for a second time from collection " << labels.module << ", seed algo " << label << ". Typically this is caused by a configuration problem.";
+    see_offset.push_back(see_fitok.size());
+
+    LogTrace("TrackingNtuple") << "NEW SEED LABEL: " << label << " size: " << seedTracks->size() << " algo=" << algo
+                               << " ProductID " << id;
+
+    for(unsigned int iSeed=0; iSeed<seedTracks->size(); ++iSeed) {
+      auto seedTrackRef = seedTracks->refAt(iSeed);
       const auto& seedTrack = *seedTrackRef;
       const auto& seedRef = seedTrack.seedRef();
       const auto& seed = *seedRef;
+
+      if(seedRef.id() != id)
+        throw cms::Exception("LogicError") << "All tracks in 'TracksFromSeeds' collection should point to seeds in the same collection. Now the element 0 had ProductID " << id << " while the element " << iSeed << " had " << seedTrackRef.id() << ". The source collection is " << labels.module << ".";
 
       std::vector<float> sharedFraction;
       std::vector<int> tpIdx;
@@ -1379,7 +1409,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	ge[0] = recHit0->globalPositionError();
 	gp[1] = recHit1->globalPosition();
 	ge[1] = recHit1->globalPositionError();
-        LogTrace("TrackingNtuple") << "seed " << seedCount
+        LogTrace("TrackingNtuple") << "seed " << iSeed
                                    << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
                                    << " - PAIR - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId()
                                    << " hitpos: " << gp[0] << " " << gp[1]
@@ -1413,7 +1443,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	float seed_chi2 = rzLine.chi2(cottheta, intercept);
 	//float seed_pt = state.globalParameters().momentum().perp();
         float seed_pt = pt;
-	LogTrace("TrackingNtuple") << "seed " << seedCount
+	LogTrace("TrackingNtuple") << "seed " << iSeed
                                    << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
                                    << " - TRIPLET - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId() << " " << recHit2->geographicalId().rawId()
                                    << " hitpos: " << gp[0] << " " << gp[1] << " " << gp[2]
@@ -1430,7 +1460,6 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	chi2 = seed_chi2;
       }
       see_chi2   .push_back( chi2 );
-      offset++;
     }
   }
 }
@@ -1441,7 +1470,8 @@ void TrackingNtuple::fillTracks(const edm::Handle<edm::View<reco::Track> >& trac
                                 const reco::TrackToTrackingParticleAssociator& associatorByHits,
                                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                 const TrackerTopology& tTopo,
-                                const std::set<edm::ProductID>& hitProductIds
+                                const std::set<edm::ProductID>& hitProductIds,
+                                const std::map<edm::ProductID, size_t>& seedCollToOffset
                                 ) {
   reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(tracks,TPCollectionH);
   edm::EDConsumerBase::Labels labels;
@@ -1500,7 +1530,15 @@ void TrackingNtuple::fillTracks(const edm::Handle<edm::View<reco::Track> >& trac
     trk_stopReason.push_back(itTrack->stopReason());
     trk_isHP     .push_back(itTrack->quality(reco::TrackBase::highPurity));
     if(includeSeeds_) {
-      trk_seedIdx  .push_back( algo_offset[itTrack->algo()] + itTrack->seedRef().key() );
+      auto offset = seedCollToOffset.find(itTrack->seedRef().id());
+      if(offset == seedCollToOffset.end()) {
+        throw cms::Exception("Configuration") << "Track algo '" << reco::TrackBase::algoName(itTrack->algo())
+                                              << "' originalAlgo '" << reco::TrackBase::algoName(itTrack->originalAlgo())
+                                              << "' refers to seed collection " << itTrack->seedRef().id()
+                                              << ", but that seed collection is not given as an input. The following collections were given as an input " << make_ProductIDMapPrinter(seedCollToOffset);
+      }
+
+      trk_seedIdx  .push_back( offset->second + itTrack->seedRef().key() );
     }
     trk_simIdx   .push_back(tpIdx);
     LogTrace("TrackingNtuple") << "Track #" << i << " with q=" << charge

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -27,10 +27,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/transform.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -54,23 +58,93 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
-#include "SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+
+#include "Validation/RecoTrack/interface/trackFromSeedFitFailed.h"
+
+#include <set>
 
 #include "TTree.h"
 
 /*
 todo: 
 add refitted hit position after track/seed fit
-add original algo (needs >=CMSSW746)
-add vertices
 add local angle, path length!
 add n 3d hits for sim tracks
+add number of layers for all, pixel, strip, 3D
 */
+
+namespace {
+  std::string subdetstring(int subdet) {
+    switch(subdet) {
+    case StripSubdetector::TIB:         return "- TIB";
+    case StripSubdetector::TOB:         return "- TOB";
+    case StripSubdetector::TEC:         return "- TEC";
+    case StripSubdetector::TID:         return "- TID";
+    case PixelSubdetector::PixelBarrel: return "- PixBar";
+    case PixelSubdetector::PixelEndcap: return "- PixFwd";
+    default:                            return "UNKNOWN TRACKER HIT TYPE";
+    }
+  }
+
+  struct ProductIDSetPrinter {
+    ProductIDSetPrinter(const std::set<edm::ProductID>& set): set_(set) {}
+
+    void print(std::ostream& os) const {
+      for(const auto& item: set_) {
+        os << item << " ";
+      }
+    }
+
+    const std::set<edm::ProductID>& set_;
+  };
+  std::ostream& operator<<(std::ostream& os, const ProductIDSetPrinter& o) {
+    o.print(os);
+    return os;
+  }
+
+  template <typename T>
+  struct VectorPrinter {
+    VectorPrinter(const std::vector<T>& vec): vec_(vec) {}
+
+    void print(std::ostream& os) const {
+      for(const auto& item: vec_) {
+        os << item << " ";
+      }
+    }
+
+    const std::vector<T>& vec_;
+  };
+  template <typename T>
+  auto make_VectorPrinter(const std::vector<T>& vec) {
+    return VectorPrinter<T>(vec);
+  }
+  template <typename T>
+  std::ostream& operator<<(std::ostream& os, const VectorPrinter<T>& o) {
+    o.print(os);
+    return os;
+  }
+
+  void checkProductID(const std::set<edm::ProductID>& set, const edm::ProductID& id, const char *name) {
+    if(set.find(id) == set.end())
+      throw cms::Exception("Configuration") << "Got " << name << " with a hit with ProductID " << id
+                                            << " which does not match to the set of ProductID's for the hits: "
+                                            << ProductIDSetPrinter(set)
+                                            << ". Usually this is caused by a wrong hit collection in the configuration.";
+  }
+}
 
 //
 // class declaration
@@ -85,34 +159,114 @@ public:
 
 
 private:
-  virtual void beginJob() override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
-
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   void clearVariables();
 
-  //copied from QuickTrackAssociatorByHits
-  static bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) { return (i.first.rawIndex()>j.first.rawIndex()); }
+  void fillBeamSpot(const reco::BeamSpot& bs);
+  void fillPixelHits(const edm::Event& iEvent,
+                     const ClusterTPAssociation& clusterToTPMap,
+                     const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                     const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                     const TrackerTopology& tTopo,
+                     std::vector<std::pair<int, int> >& tpPixList,
+                     std::set<edm::ProductID>& hitProductIds
+                     );
+
+  void fillStripRphiStereoHits(const edm::Event& iEvent,
+                               const ClusterTPAssociation& clusterToTPMap,
+                               const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                               const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                               const TrackerTopology& tTopo,
+                               std::vector<std::pair<int, int> >& tpRPhiList,
+                               std::vector<std::pair<int, int> >& tpStereoList,
+                               std::set<edm::ProductID>& hitProductIds
+                               );
+
+  void fillStripMatchedHits(const edm::Event& iEvent,
+                            const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                            const TrackerTopology& tTopo,
+                            std::vector<std::pair<int, int> >& monoStereoClusterList
+                            );
+
+  void fillSeeds(const edm::Event& iEvent,
+                 const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                 const reco::BeamSpot& bs,
+                 const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                 const MagneticField *theMF,
+                 const std::vector<std::pair<int, int> >& monoStereoClusterList,
+                 const std::set<edm::ProductID>& hitProductIds
+                 );
+
+  void fillTracks(const edm::Handle<edm::View<reco::Track> >& tracks,
+                  const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                  const reco::BeamSpot& bs,
+                  const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                  const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                  const TrackerTopology& tTopo,
+                  const std::set<edm::ProductID>& hitProductIds
+                  );
+
+  void fillTrackingParticles(const edm::Event& iEvent, const edm::EventSetup& iSetup,
+                             const edm::Handle<edm::View<reco::Track> >& tracks,
+                             const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                             const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                             const std::vector<std::pair<int, int> >& tpPixList,
+                             const std::vector<std::pair<int, int> >& tpRPhiList,
+                             const std::vector<std::pair<int, int> >& tpStereoList
+                             );
+
+  void fillVertices(const reco::VertexCollection& vertices);
+
+  void fillTrackingVertices(const std::vector<const TrackingVertex *>& trackingVertices);
 
   static bool intIntListGreater(std::pair<int, int> i,std::pair<int, int> j) { return (i.first>j.first); }
 
+
+  struct SimHitData {
+    int firstMatchingTp = -1;
+    int nMatchingTp = 0;
+    GlobalPoint pos = GlobalPoint(0,0,0);
+    float energyLoss = -999;
+    int particleType = -999;
+    int processType = -999;
+    int bunchCrossing = 0;
+    int event = 0;
+  };
+
+  SimHitData matchCluster(const OmniClusterRef& cluster,
+                          DetId hitId, int clusterKey,
+                          const TransientTrackingRecHit::RecHitPointer& ttrh,
+                          const ClusterTPAssociation& clusterToTPMap,
+                          const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                          std::vector<std::pair<int, int> >& tpHitList) const;
+
   // ----------member data ---------------------------
-  std::vector<edm::InputTag> seedTags_;
-  edm::InputTag trackTag_;
+  std::vector<edm::EDGetTokenT<edm::View<reco::Track> > > seedTokens_;
+  edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
+  edm::EDGetTokenT<ClusterTPAssociation> clusterTPMapToken_;
+  edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitTPMapToken_;
+  edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorToken_;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitToken_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> stripRphiRecHitToken_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> stripStereoRecHitToken_;
+  edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> stripMatchedRecHitToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+  edm::EDGetTokenT<TrackingVertexCollection> trackingVertexToken_;
   std::string builderName_;
-  edm::ESHandle<MagneticField> theMF;
-  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
-  TrackAssociatorBase*  associatorByHits;
-  const ParametersDefinerForTP* parametersDefiner;
-  bool debug;
-  const TrackerTopology* tTopo;
+  std::string parametersDefinerName_;
+  const bool includeSeeds_;
+  const bool includeAllHits_;
 
   TTree* t;
+  // event
+  edm::RunNumber_t ev_run;
+  edm::LuminosityBlockNumber_t ev_lumi;
+  edm::EventNumber_t ev_event;
+
   //tracks
   std::vector<float> trk_px       ;
   std::vector<float> trk_py       ;
@@ -128,17 +282,22 @@ private:
   std::vector<float> trk_dxyErr   ;
   std::vector<float> trk_dzErr    ;
   std::vector<float> trk_nChi2    ;
-  std::vector<float> trk_shareFrac;
   std::vector<int> trk_q       ;
-  std::vector<int> trk_nValid  ;
-  std::vector<int> trk_nInvalid;
-  std::vector<int> trk_nPixel  ;
-  std::vector<int> trk_nStrip  ;
-  std::vector<int> trk_n3DLay  ;
-  std::vector<int> trk_algo    ;
-  std::vector<int> trk_isHP    ;
+  std::vector<unsigned int> trk_nValid  ;
+  std::vector<unsigned int> trk_nInvalid;
+  std::vector<unsigned int> trk_nPixel  ;
+  std::vector<unsigned int> trk_nStrip  ;
+  std::vector<unsigned int> trk_nPixelLay;
+  std::vector<unsigned int> trk_nStripLay;
+  std::vector<unsigned int> trk_n3DLay  ;
+  std::vector<unsigned int> trk_algo    ;
+  std::vector<unsigned int> trk_originalAlgo;
+  std::vector<decltype(reco::TrackBase().algoMaskUL())> trk_algoMask;
+  std::vector<unsigned int> trk_stopReason;
+  std::vector<short> trk_isHP    ;
   std::vector<int> trk_seedIdx ;
-  std::vector<int> trk_simIdx  ;
+  std::vector<std::vector<float> > trk_shareFrac;
+  std::vector<std::vector<int> > trk_simIdx;
   std::vector<std::vector<int> > trk_pixelIdx;
   std::vector<std::vector<int> > trk_stripIdx;
   //sim tracks
@@ -153,25 +312,25 @@ private:
   std::vector<float> sim_prodx    ;
   std::vector<float> sim_prody    ;
   std::vector<float> sim_prodz    ;
-  std::vector<float> sim_shareFrac;
+  std::vector<std::vector<float> > sim_shareFrac;
   std::vector<int> sim_q       ;
-  std::vector<int> sim_nValid  ;
-  std::vector<int> sim_nPixel  ;
-  std::vector<int> sim_nStrip  ;
-  std::vector<int> sim_n3DLay  ;
-  std::vector<int> sim_trkIdx  ;
+  std::vector<unsigned int> sim_nValid  ;
+  std::vector<unsigned int> sim_nPixel  ;
+  std::vector<unsigned int> sim_nStrip  ;
+  std::vector<unsigned int> sim_n3DLay  ;
+  std::vector<std::vector<int> > sim_trkIdx  ;
   std::vector<std::vector<int> > sim_pixelIdx;
   std::vector<std::vector<int> > sim_stripIdx;
   //pixels: reco and sim hits
-  std::vector<int> pix_isBarrel ;
-  std::vector<int> pix_lay      ;
-  std::vector<int> pix_detId    ;
-  std::vector<int> pix_nSimTrk  ;
+  std::vector<short> pix_isBarrel ;
+  std::vector<unsigned int> pix_lay      ;
+  std::vector<unsigned int> pix_detId    ;
+  std::vector<unsigned int> pix_nSimTrk  ;
   std::vector<int> pix_simTrkIdx;
   std::vector<int> pix_particle ;
   std::vector<int> pix_process  ;
-  std::vector<int> pix_bunchXing;
-  std::vector<int> pix_event    ;
+  std::vector<unsigned int> pix_bunchXing;
+  std::vector<unsigned int> pix_event    ;
   std::vector<float> pix_x    ;
   std::vector<float> pix_y    ;
   std::vector<float> pix_z    ;
@@ -188,11 +347,11 @@ private:
   std::vector<float> pix_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> pix_bbxi ;
   //strips: reco and sim hits
-  std::vector<int> str_isBarrel ;
-  std::vector<int> str_isStereo ;
-  std::vector<int> str_det      ;
-  std::vector<int> str_lay      ;
-  std::vector<int> str_detId    ;
+  std::vector<short> str_isBarrel ;
+  std::vector<short> str_isStereo ;
+  std::vector<unsigned int> str_det      ;
+  std::vector<unsigned int> str_lay      ;
+  std::vector<unsigned int> str_detId    ;
   std::vector<int> str_nSimTrk  ;
   std::vector<int> str_simTrkIdx;
   std::vector<int> str_particle ;
@@ -215,10 +374,10 @@ private:
   std::vector<float> str_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi ;
   //strip matched hits: reco hits
-  std::vector<int> glu_isBarrel ;
-  std::vector<int> glu_det      ;
-  std::vector<int> glu_lay      ;
-  std::vector<int> glu_detId    ;
+  std::vector<short> glu_isBarrel ;
+  std::vector<unsigned int> glu_det      ;
+  std::vector<unsigned int> glu_lay      ;
+  std::vector<unsigned int> glu_detId    ;
   std::vector<int> glu_monoIdx  ;
   std::vector<int> glu_stereoIdx;
   std::vector<float> glu_x    ;
@@ -240,6 +399,7 @@ private:
   float bsp_sigmay;
   float bsp_sigmaz;
   //seeds
+  std::vector<short> see_fitok     ;
   std::vector<float> see_px       ;
   std::vector<float> see_py       ;
   std::vector<float> see_pz       ;
@@ -255,29 +415,270 @@ private:
   std::vector<float> see_dzErr    ;
   std::vector<float> see_chi2     ;
   std::vector<int> see_q       ;
-  std::vector<int> see_nValid  ;
-  std::vector<int> see_nPixel  ;
-  std::vector<int> see_nGlued  ;
-  std::vector<int> see_nStrip  ;
-  std::vector<int> see_algo    ;
+  std::vector<unsigned int> see_nValid  ;
+  std::vector<unsigned int> see_nPixel  ;
+  std::vector<unsigned int> see_nGlued  ;
+  std::vector<unsigned int> see_nStrip  ;
+  std::vector<unsigned int> see_algo    ;
+  std::vector<std::vector<float> > see_shareFrac;
+  std::vector<std::vector<int> > see_simIdx;
   std::vector<std::vector<int> > see_pixelIdx;
   std::vector<std::vector<int> > see_gluedIdx;
   std::vector<std::vector<int> > see_stripIdx;
   //seed algo offset
+  static constexpr unsigned int algo_offset_max = 20;
   std::vector<int> algo_offset  ;
 
+
+  // Vertices
+  std::vector<float> vtx_x;
+  std::vector<float> vtx_y;
+  std::vector<float> vtx_z;
+  std::vector<float> vtx_xErr;
+  std::vector<float> vtx_yErr;
+  std::vector<float> vtx_zErr;
+  std::vector<float> vtx_ndof;
+  std::vector<float> vtx_chi2;
+  std::vector<short> vtx_fake;
+  std::vector<short> vtx_valid;
+  std::vector<std::vector<int> > vtx_trkIdx;
+
+  // Tracking vertices
+  std::vector<float> simvtx_x;
+  std::vector<float> simvtx_y;
+  std::vector<float> simvtx_z;
+  std::vector<int> simvtx_nTrack;
 };
 
 //
 // constructors and destructor
 //
 TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
-  seedTags_(iConfig.getUntrackedParameter<std::vector<edm::InputTag> >("seeds")),
-  trackTag_(iConfig.getUntrackedParameter<edm::InputTag>("tracks")),
-  builderName_(iConfig.getParameter<std::string>("TTRHBuilder")),
-  debug(iConfig.getParameter<bool>("debug")) 
+  seedTokens_(edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag> >("seedTracks"), [&](const edm::InputTag& tag) {
+        return consumes<edm::View<reco::Track> >(tag);
+      })),
+  trackToken_(consumes<edm::View<reco::Track> >(iConfig.getUntrackedParameter<edm::InputTag>("tracks"))),
+  trackingParticleToken_(consumes<TrackingParticleCollection>(iConfig.getUntrackedParameter<edm::InputTag>("trackingParticles"))),
+  clusterTPMapToken_(consumes<ClusterTPAssociation>(iConfig.getUntrackedParameter<edm::InputTag>("clusterTPMap"))),
+  simHitTPMapToken_(consumes<SimHitTPAssociationProducer::SimHitTPAssociationList>(iConfig.getUntrackedParameter<edm::InputTag>("simHitTPMap"))),
+  trackAssociatorToken_(consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<edm::InputTag>("trackAssociator"))),
+  beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"))),
+  pixelRecHitToken_(consumes<SiPixelRecHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("pixelRecHits"))),
+  stripRphiRecHitToken_(consumes<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripRphiRecHits"))),
+  stripStereoRecHitToken_(consumes<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripStereoRecHits"))),
+  stripMatchedRecHitToken_(consumes<SiStripMatchedRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripMatchedRecHits"))),
+  vertexToken_(consumes<reco::VertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vertices"))),
+  trackingVertexToken_(consumes<TrackingVertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("trackingVertices"))),
+  builderName_(iConfig.getUntrackedParameter<std::string>("TTRHBuilder")),
+  parametersDefinerName_(iConfig.getUntrackedParameter<std::string>("parametersDefiner")),
+  includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
+  includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits"))
 {
-  //now do what ever initialization is needed
+
+  if(seedTokens_.size() > algo_offset_max) {
+    throw cms::Exception("Configuration") << "TrackingNtuple has a hard-coded maximum of " << algo_offset_max << " seed collections, got " << seedTokens_.size() << ". Please increase TrackingNtuple::algo_offset_max";
+  }
+
+  edm::Service<TFileService> fs;
+  t = fs->make<TTree>("tree","tree");
+
+  t->Branch("event"        , &ev_event);
+  t->Branch("lumi"         , &ev_lumi);
+  t->Branch("run"          , &ev_run);
+
+  //tracks
+  t->Branch("trk_px"       , &trk_px);
+  t->Branch("trk_py"       , &trk_py);
+  t->Branch("trk_pz"       , &trk_pz);
+  t->Branch("trk_pt"       , &trk_pt);
+  t->Branch("trk_eta"      , &trk_eta);
+  t->Branch("trk_phi"      , &trk_phi);
+  t->Branch("trk_dxy"      , &trk_dxy      );
+  t->Branch("trk_dz"       , &trk_dz       );
+  t->Branch("trk_ptErr"    , &trk_ptErr    );
+  t->Branch("trk_etaErr"   , &trk_etaErr   );
+  t->Branch("trk_phiErr"   , &trk_phiErr   );
+  t->Branch("trk_dxyErr"   , &trk_dxyErr   );
+  t->Branch("trk_dzErr"    , &trk_dzErr    );
+  t->Branch("trk_nChi2"    , &trk_nChi2);
+  t->Branch("trk_q"        , &trk_q);
+  t->Branch("trk_nValid"   , &trk_nValid  );
+  t->Branch("trk_nInvalid" , &trk_nInvalid);
+  t->Branch("trk_nPixel"   , &trk_nPixel  );
+  t->Branch("trk_nStrip"   , &trk_nStrip  );
+  t->Branch("trk_nPixelLay", &trk_nPixelLay);
+  t->Branch("trk_nStripLay", &trk_nStripLay);
+  t->Branch("trk_n3DLay"   , &trk_n3DLay  );
+  t->Branch("trk_algo"     , &trk_algo    );
+  t->Branch("trk_originalAlgo", &trk_originalAlgo);
+  t->Branch("trk_algoMask" , &trk_algoMask);
+  t->Branch("trk_stopReason", &trk_stopReason);
+  t->Branch("trk_isHP"     , &trk_isHP    );
+  if(includeSeeds_) {
+    t->Branch("trk_seedIdx"  , &trk_seedIdx );
+  }
+  t->Branch("trk_shareFrac", &trk_shareFrac);
+  t->Branch("trk_simIdx"   , &trk_simIdx  );
+  if(includeAllHits_) {
+    t->Branch("trk_pixelIdx" , &trk_pixelIdx);
+    t->Branch("trk_stripIdx" , &trk_stripIdx);
+  }
+  //sim tracks
+  t->Branch("sim_px"       , &sim_px       );
+  t->Branch("sim_py"       , &sim_py       );
+  t->Branch("sim_pz"       , &sim_pz       );
+  t->Branch("sim_pt"       , &sim_pt       );
+  t->Branch("sim_eta"      , &sim_eta      );
+  t->Branch("sim_phi"      , &sim_phi      );
+  t->Branch("sim_dxy"      , &sim_dxy      );
+  t->Branch("sim_dz"       , &sim_dz       );
+  t->Branch("sim_prodx"    , &sim_prodx    );
+  t->Branch("sim_prody"    , &sim_prody    );
+  t->Branch("sim_prodz"    , &sim_prodz    );
+  t->Branch("sim_shareFrac", &sim_shareFrac);
+  t->Branch("sim_q"        , &sim_q        );
+  t->Branch("sim_nValid"   , &sim_nValid   );
+  t->Branch("sim_nPixel"   , &sim_nPixel   );
+  t->Branch("sim_nStrip"   , &sim_nStrip   );
+  t->Branch("sim_n3DLay"   , &sim_n3DLay   );
+  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
+  if(includeAllHits_) {
+    t->Branch("sim_pixelIdx" , &sim_pixelIdx );
+    t->Branch("sim_stripIdx" , &sim_stripIdx );
+  }
+  if(includeAllHits_) {
+    //pixels
+    t->Branch("pix_isBarrel"  , &pix_isBarrel );
+    t->Branch("pix_lay"       , &pix_lay      );
+    t->Branch("pix_detId"     , &pix_detId    );
+    t->Branch("pix_nSimTrk"   , &pix_nSimTrk  );
+    t->Branch("pix_simTrkIdx" , &pix_simTrkIdx);
+    t->Branch("pix_particle"  , &pix_particle );
+    t->Branch("pix_process"   , &pix_process  );
+    t->Branch("pix_bunchXing" , &pix_bunchXing);
+    t->Branch("pix_event"     , &pix_event    );
+    t->Branch("pix_x"     , &pix_x    );
+    t->Branch("pix_y"     , &pix_y    );
+    t->Branch("pix_z"     , &pix_z    );
+    t->Branch("pix_xx"    , &pix_xx   );
+    t->Branch("pix_xy"    , &pix_xy   );
+    t->Branch("pix_yy"    , &pix_yy   );
+    t->Branch("pix_yz"    , &pix_yz   );
+    t->Branch("pix_zz"    , &pix_zz   );
+    t->Branch("pix_zx"    , &pix_zx   );
+    t->Branch("pix_xsim"  , &pix_xsim );
+    t->Branch("pix_ysim"  , &pix_ysim );
+    t->Branch("pix_zsim"  , &pix_zsim );
+    t->Branch("pix_eloss" , &pix_eloss);
+    t->Branch("pix_radL"  , &pix_radL );
+    t->Branch("pix_bbxi"  , &pix_bbxi );
+    //strips
+    t->Branch("str_isBarrel"  , &str_isBarrel );
+    t->Branch("str_isStereo"  , &str_isStereo );
+    t->Branch("str_det"       , &str_det      );
+    t->Branch("str_lay"       , &str_lay      );
+    t->Branch("str_detId"     , &str_detId    );
+    t->Branch("str_nSimTrk"   , &str_nSimTrk  );
+    t->Branch("str_simTrkIdx" , &str_simTrkIdx);
+    t->Branch("str_particle"  , &str_particle );
+    t->Branch("str_process"   , &str_process  );
+    t->Branch("str_bunchXing" , &str_bunchXing);
+    t->Branch("str_event"     , &str_event    );
+    t->Branch("str_x"     , &str_x    );
+    t->Branch("str_y"     , &str_y    );
+    t->Branch("str_z"     , &str_z    );
+    t->Branch("str_xx"    , &str_xx   );
+    t->Branch("str_xy"    , &str_xy   );
+    t->Branch("str_yy"    , &str_yy   );
+    t->Branch("str_yz"    , &str_yz   );
+    t->Branch("str_zz"    , &str_zz   );
+    t->Branch("str_zx"    , &str_zx   );
+    t->Branch("str_xsim"  , &str_xsim );
+    t->Branch("str_ysim"  , &str_ysim );
+    t->Branch("str_zsim"  , &str_zsim );
+    t->Branch("str_eloss" , &str_eloss);
+    t->Branch("str_radL"  , &str_radL );
+    t->Branch("str_bbxi"  , &str_bbxi );
+    //matched hits
+    t->Branch("glu_isBarrel"  , &glu_isBarrel );
+    t->Branch("glu_det"       , &glu_det      );
+    t->Branch("glu_lay"       , &glu_lay      );
+    t->Branch("glu_detId"     , &glu_detId    );
+    t->Branch("glu_monoIdx"   , &glu_monoIdx  );
+    t->Branch("glu_stereoIdx" , &glu_stereoIdx);
+    t->Branch("glu_x"         , &glu_x        );
+    t->Branch("glu_y"         , &glu_y        );
+    t->Branch("glu_z"         , &glu_z        );
+    t->Branch("glu_xx"        , &glu_xx       );
+    t->Branch("glu_xy"        , &glu_xy       );
+    t->Branch("glu_yy"        , &glu_yy       );
+    t->Branch("glu_yz"        , &glu_yz       );
+    t->Branch("glu_zz"        , &glu_zz       );
+    t->Branch("glu_zx"        , &glu_zx       );
+    t->Branch("glu_radL"      , &glu_radL     );
+    t->Branch("glu_bbxi"      , &glu_bbxi     );
+  }
+  //beam spot
+  t->Branch("bsp_x" , &bsp_x , "bsp_x/F");
+  t->Branch("bsp_y" , &bsp_y , "bsp_y/F");
+  t->Branch("bsp_z" , &bsp_z , "bsp_z/F");
+  t->Branch("bsp_sigmax" , &bsp_sigmax , "bsp_sigmax/F");
+  t->Branch("bsp_sigmay" , &bsp_sigmay , "bsp_sigmay/F");
+  t->Branch("bsp_sigmaz" , &bsp_sigmaz , "bsp_sigmaz/F");
+  if(includeSeeds_) {
+    //seeds
+    t->Branch("see_fitok"    , &see_fitok   );
+    t->Branch("see_px"       , &see_px      );
+    t->Branch("see_py"       , &see_py      );
+    t->Branch("see_pz"       , &see_pz      );
+    t->Branch("see_pt"       , &see_pt      );
+    t->Branch("see_eta"      , &see_eta     );
+    t->Branch("see_phi"      , &see_phi     );
+    t->Branch("see_dxy"      , &see_dxy     );
+    t->Branch("see_dz"       , &see_dz      );
+    t->Branch("see_ptErr"    , &see_ptErr   );
+    t->Branch("see_etaErr"   , &see_etaErr  );
+    t->Branch("see_phiErr"   , &see_phiErr  );
+    t->Branch("see_dxyErr"   , &see_dxyErr  );
+    t->Branch("see_dzErr"    , &see_dzErr   );
+    t->Branch("see_chi2"     , &see_chi2    );
+    t->Branch("see_q"        , &see_q       );
+    t->Branch("see_nValid"   , &see_nValid  );
+    t->Branch("see_nPixel"   , &see_nPixel  );
+    t->Branch("see_nGlued"   , &see_nGlued  );
+    t->Branch("see_nStrip"   , &see_nStrip  );
+    t->Branch("see_algo"     , &see_algo    );
+    t->Branch("see_shareFrac", &see_shareFrac);
+    t->Branch("see_simIdx"   , &see_simIdx  );
+    if(includeAllHits_) {
+      t->Branch("see_pixelIdx" , &see_pixelIdx);
+      t->Branch("see_gluedIdx" , &see_gluedIdx);
+      t->Branch("see_stripIdx" , &see_stripIdx);
+    }
+    //seed algo offset
+    t->Branch("algo_offset"  , &algo_offset );
+  }
+
+  //vertices
+  t->Branch("vtx_x"       , &vtx_x);
+  t->Branch("vtx_y"       , &vtx_y);
+  t->Branch("vtx_z"       , &vtx_z);
+  t->Branch("vtx_xErr"    , &vtx_xErr);
+  t->Branch("vtx_yErr"    , &vtx_yErr);
+  t->Branch("vtx_zErr"    , &vtx_zErr);
+  t->Branch("vtx_ndof"    , &vtx_ndof);
+  t->Branch("vtx_chi2"    , &vtx_chi2);
+  t->Branch("vtx_fake"    , &vtx_fake);
+  t->Branch("vtx_valid"   , &vtx_valid);
+  t->Branch("vtx_trkIdx"  , &vtx_trkIdx);
+
+  // tracking vertices
+  t->Branch("simvtx_x"       , &simvtx_x);
+  t->Branch("simvtx_y"       , &simvtx_y);
+  t->Branch("simvtx_z"       , &simvtx_z);
+  t->Branch("simvtx_nTrack"  , &simvtx_nTrack);
+
+  //t->Branch("" , &);
 }
 
 
@@ -291,6 +692,10 @@ TrackingNtuple::~TrackingNtuple() {
 // member functions
 //
 void TrackingNtuple::clearVariables() {
+
+  ev_run = 0;
+  ev_lumi = 0;
+  ev_event = 0;
 
   //tracks
   trk_px       .clear();
@@ -307,16 +712,21 @@ void TrackingNtuple::clearVariables() {
   trk_dxyErr   .clear();
   trk_dzErr    .clear();
   trk_nChi2    .clear();
-  trk_shareFrac.clear();
   trk_q        .clear();
   trk_nValid   .clear();
   trk_nInvalid .clear();
   trk_nPixel   .clear();
   trk_nStrip   .clear();
+  trk_nPixelLay.clear();
+  trk_nStripLay.clear();
   trk_n3DLay   .clear();
   trk_algo     .clear();
+  trk_originalAlgo.clear();
+  trk_algoMask .clear();
+  trk_stopReason.clear();
   trk_isHP     .clear();
   trk_seedIdx  .clear();
+  trk_shareFrac.clear();
   trk_simIdx   .clear();
   trk_pixelIdx .clear();
   trk_stripIdx .clear();
@@ -419,6 +829,7 @@ void TrackingNtuple::clearVariables() {
   bsp_sigmay = -9999.;
   bsp_sigmaz = -9999.;
   //seeds
+  see_fitok   .clear();
   see_px      .clear();
   see_py      .clear();
   see_pz      .clear();
@@ -439,13 +850,27 @@ void TrackingNtuple::clearVariables() {
   see_nGlued  .clear();
   see_nStrip  .clear();
   see_algo    .clear();
+  see_shareFrac.clear();
+  see_simIdx   .clear();
   see_pixelIdx.clear();
   see_gluedIdx.clear();
   see_stripIdx.clear();
   //seed algo offset
   algo_offset .clear();
-  for (int i=0; i<20; ++i) algo_offset.push_back(-1);
+  for (unsigned int i=0; i<algo_offset_max; ++i) algo_offset.push_back(-1);
 
+  // vertices
+  vtx_x.clear();
+  vtx_y.clear();
+  vtx_z.clear();
+  vtx_xErr.clear();
+  vtx_yErr.clear();
+  vtx_zErr.clear();
+  vtx_ndof.clear();
+  vtx_chi2.clear();
+  vtx_fake.clear();
+  vtx_valid.clear();
+  vtx_trkIdx.clear();
 }
 
 
@@ -456,92 +881,193 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   using namespace reco;
   using namespace std;
 
+  edm::ESHandle<MagneticField> theMF;
+  iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
+  iSetup.get<TransientRecHitRecord>().get(builderName_,theTTRHBuilder);
+
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const TrackerTopology& tTopo = *tTopoHandle;
+
+  edm::Handle<reco::TrackToTrackingParticleAssociator> theAssociator;
+  iEvent.getByToken(trackAssociatorToken_, theAssociator);
+  const reco::TrackToTrackingParticleAssociator& associatorByHits = *theAssociator;
+
+  LogDebug("TrackingNtuple") << "Analyzing new event";
+
   //initialize tree variables
   clearVariables();
 
   //get association maps, etc.
   Handle<TrackingParticleCollection>  TPCollectionH;
-  iEvent.getByLabel("mix","MergedTrackTruth",TPCollectionH);
-  TrackingParticleCollection const & tPC = *(TPCollectionH.product());
-  Handle<ClusterTPAssociationProducer::ClusterTPAssociationList> pCluster2TPListH;
-  iEvent.getByLabel("tpClusterProducer", pCluster2TPListH);
-  ClusterTPAssociationProducer::ClusterTPAssociationList clusterToTPMap( *(pCluster2TPListH.product()) );//has to be non-const to sort
-  //make sure it is properly sorted
-  sort( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPAssociationListGreater );
+  iEvent.getByToken(trackingParticleToken_, TPCollectionH);
+  Handle<ClusterTPAssociation> pCluster2TPListH;
+  iEvent.getByToken(clusterTPMapToken_, pCluster2TPListH);
+  const ClusterTPAssociation& clusterToTPMap = *pCluster2TPListH;
   edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
-  iEvent.getByLabel("simHitTPAssocProducer",simHitsTPAssoc);
+  iEvent.getByToken(simHitTPMapToken_, simHitsTPAssoc);
   //make a list to link TrackingParticles to its hits in recHit collections
   //note only the first TP is saved so we ignore merged hits...
   vector<pair<int, int> > tpPixList;
   vector<pair<int, int> > tpRPhiList;
   vector<pair<int, int> > tpStereoList;
 
+  std::set<edm::ProductID> hitProductIds;
+
+  ev_run = iEvent.id().run();
+  ev_lumi = iEvent.id().luminosityBlock();
+  ev_event = iEvent.id().event();
+
+
   //beamspot
   Handle<reco::BeamSpot> recoBeamSpotHandle;
-  iEvent.getByLabel("offlineBeamSpot",recoBeamSpotHandle);
+  iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle);
   BeamSpot const & bs = *recoBeamSpotHandle;
+  fillBeamSpot(bs);
+
+  //prapare list to link matched hits to collection
+  vector<pair<int,int> > monoStereoClusterList;
+  if(includeAllHits_) {
+    //pixel hits
+    fillPixelHits(iEvent, clusterToTPMap, *simHitsTPAssoc, *theTTRHBuilder, tTopo, tpPixList, hitProductIds);
+
+    //strip hits
+    fillStripRphiStereoHits(iEvent, clusterToTPMap, *simHitsTPAssoc, *theTTRHBuilder, tTopo, tpRPhiList, tpStereoList, hitProductIds);
+
+    //matched hits
+    fillStripMatchedHits(iEvent, *theTTRHBuilder, tTopo, monoStereoClusterList);
+  }
+
+  //seeds
+  if(includeSeeds_) {
+    fillSeeds(iEvent, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, theMF.product(), monoStereoClusterList, hitProductIds);
+  }
+
+  //tracks
+  edm::Handle<edm::View<reco::Track> > tracks;
+  iEvent.getByToken(trackToken_, tracks);
+  fillTracks(tracks, TPCollectionH, bs, associatorByHits, *theTTRHBuilder, tTopo, hitProductIds);
+
+  //tracking particles
+  //sort association maps with clusters
+  sort( tpPixList.begin(), tpPixList.end(), intIntListGreater );
+  sort( tpRPhiList.begin(), tpRPhiList.end(), intIntListGreater );
+  sort( tpStereoList.begin(), tpStereoList.end(), intIntListGreater );
+  fillTrackingParticles(iEvent, iSetup, tracks, TPCollectionH, associatorByHits, tpPixList, tpRPhiList, tpStereoList);
+
+  // vertices
+  edm::Handle<reco::VertexCollection> vertices;
+  iEvent.getByToken(vertexToken_, vertices);
+  fillVertices(*vertices);
+
+  // tracking vertices
+  edm::Handle<TrackingVertexCollection> htv;
+  iEvent.getByToken(trackingVertexToken_, htv);
+  std::vector<const TrackingVertex *> trackingVertices;
+  int current_event = -1;
+  for(const TrackingVertex& v: *htv) {
+    // Associate only to primary vertices of the in-time pileup
+    // events (BX=0, first vertex in each of the events)
+    if(v.eventId().bunchCrossing() != 0) continue;
+    if(v.eventId().event() != current_event) {
+      current_event = v.eventId().event();
+      trackingVertices.push_back(&v);
+    }
+  }
+  fillTrackingVertices(trackingVertices);
+
+  t->Fill();
+
+}
+
+void TrackingNtuple::fillBeamSpot(const reco::BeamSpot& bs) {
   bsp_x = bs.x0();
   bsp_y = bs.y0();
   bsp_z = bs.x0();
   bsp_sigmax = bs.BeamWidthX();
   bsp_sigmay = bs.BeamWidthY();
-  bsp_sigmaz = bs.sigmaZ();  
+  bsp_sigmaz = bs.sigmaZ();
+}
 
-  //pixel hits
-  edm::Handle<SiPixelRecHitCollection> pixelHits;
-  iEvent.getByLabel("siPixelRecHits", pixelHits);
-  for (auto it = pixelHits->begin(); it!=pixelHits->end(); it++ ) {
-    DetId hitId = it->detId();
-    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
-      int firstMatchingTp = -999;
-      int nMatchingTp = 0;
-      GlobalPoint simHitPos = GlobalPoint(0,0,0);
-      float energyLoss = -999.;
-      int particleType = -999;
-      int processType = -999;
-      int bunchCrossing = -999;
-      int event = -999;
-      //get the TP that produced the hit
-      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
-      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
-      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
-      if( range.first != range.second ) {
-	nMatchingTp = range.second-range.first;
-	for( auto ip=range.first; ip != range.second; ++ip ) {
-	  const TrackingParticleRef trackingParticle=(ip->second);
-	  if( trackingParticle->numberOfHits() == 0 ) continue;
-	  firstMatchingTp = trackingParticle.key();
-	  tpPixList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
-	  //now get the corresponding sim hit
-	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
-	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
-	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
-					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-	  for(auto ip = range.first; ip != range.second; ++ip) {
-	    TrackPSimHitRef TPhit = ip->second;
-	    DetId dId = DetId(TPhit->detUnitId());
-	    if (dId.rawId()==hitId.rawId()) {
-	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
-	      energyLoss = TPhit->energyLoss();
-	      particleType = TPhit->particleType();
-	      processType = TPhit->processType();
-	      bunchCrossing = TPhit->eventId().bunchCrossing();
-	      event = TPhit->eventId().event();
-	    }
-	  }
-	  break;
-	}
+TrackingNtuple::SimHitData TrackingNtuple::matchCluster(const OmniClusterRef& cluster,
+                                                        DetId hitId, int clusterKey,
+                                                        const TransientTrackingRecHit::RecHitPointer& ttrh,
+                                                        const ClusterTPAssociation& clusterToTPMap,
+                                                        const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                                                        std::vector<std::pair<int, int> >& tpHitList) const {
+  SimHitData ret;
+
+  auto range = clusterToTPMap.equal_range( cluster );
+  if( range.first != range.second ) {
+    for( auto ip=range.first; ip != range.second; ++ip ) {
+      const TrackingParticleRef trackingParticle=(ip->second);
+      if( trackingParticle->numberOfHits() == 0 ) continue;
+      ret.nMatchingTp++;
+    }
+
+    for( auto ip=range.first; ip != range.second; ++ip ) {
+      const TrackingParticleRef trackingParticle=(ip->second);
+      if( trackingParticle->numberOfHits() == 0 ) continue;
+      ret.firstMatchingTp = trackingParticle.key();
+      tpHitList.emplace_back(trackingParticle.key(), clusterKey);
+      //now get the corresponding sim hit
+      std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
+      //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
+      auto range = std::equal_range(simHitsTPAssoc.begin(), simHitsTPAssoc.end(),
+                                    simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+      for(auto ip = range.first; ip != range.second; ++ip) {
+        TrackPSimHitRef TPhit = ip->second;
+        DetId dId = DetId(TPhit->detUnitId());
+        if (dId.rawId()==hitId.rawId()) {
+          ret.pos = ttrh->surface()->toGlobal(TPhit->localPosition());
+          ret.energyLoss = TPhit->energyLoss();
+          ret.particleType = TPhit->particleType();
+          ret.processType = TPhit->processType();
+          ret.bunchCrossing = TPhit->eventId().bunchCrossing();
+          ret.event = TPhit->eventId().event();
+          break;
+        }
       }
+      break;
+    }
+  }
+
+  return ret;
+}
+
+void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
+                                   const ClusterTPAssociation& clusterToTPMap,
+                                   const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                                   const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                   const TrackerTopology& tTopo,
+                                   std::vector<std::pair<int, int> >& tpPixList,
+                                   std::set<edm::ProductID>& hitProductIds
+                                   ) {
+  edm::Handle<SiPixelRecHitCollection> pixelHits;
+  iEvent.getByToken(pixelRecHitToken_, pixelHits);
+  for (auto it = pixelHits->begin(); it!=pixelHits->end(); it++ ) {
+    const DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&*hit);
+
+      hitProductIds.insert(hit->cluster().id());
+
+      const int key = hit->cluster().key();
+      const int lay = tTopo.layer(hitId);
+      SimHitData simHitData = matchCluster(hit->firstClusterRef(), hitId, key, ttrh,
+                                           clusterToTPMap, simHitsTPAssoc, tpPixList);
+
       pix_isBarrel .push_back( hitId.subdetId()==1 );
-      pix_lay      .push_back( tTopo->layer(hitId) );
+      pix_lay      .push_back( lay );
       pix_detId    .push_back( hitId.rawId() );
-      pix_nSimTrk  .push_back( nMatchingTp );
-      pix_simTrkIdx.push_back( firstMatchingTp );
-      pix_particle .push_back( particleType );
-      pix_process  .push_back( processType );
-      pix_bunchXing.push_back( bunchCrossing );
-      pix_event    .push_back( event );
+      pix_nSimTrk  .push_back( simHitData.nMatchingTp );
+      pix_simTrkIdx.push_back( simHitData.firstMatchingTp );
+      pix_particle .push_back( simHitData.particleType );
+      pix_process  .push_back( simHitData.processType );
+      pix_bunchXing.push_back( simHitData.bunchCrossing );
+      pix_event    .push_back( simHitData.event );
       pix_x    .push_back( ttrh->globalPosition().x() );
       pix_y    .push_back( ttrh->globalPosition().y() );
       pix_z    .push_back( ttrh->globalPosition().z() );
@@ -551,35 +1077,44 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       pix_yz   .push_back( ttrh->globalPositionError().czy() );
       pix_zz   .push_back( ttrh->globalPositionError().czz() );
       pix_zx   .push_back( ttrh->globalPositionError().czx() );
-      pix_xsim .push_back( simHitPos.x() );
-      pix_ysim .push_back( simHitPos.y() );
-      pix_zsim .push_back( simHitPos.z() );
-      pix_eloss.push_back( energyLoss );
+      pix_xsim .push_back( simHitData.pos.x() );
+      pix_ysim .push_back( simHitData.pos.y() );
+      pix_zsim .push_back( simHitData.pos.z() );
+      pix_eloss.push_back( simHitData.energyLoss );
       pix_radL .push_back( ttrh->surface()->mediumProperties().radLen() );
       pix_bbxi .push_back( ttrh->surface()->mediumProperties().xi() );
-      if (debug) cout << "pixHit cluster=" << hit->cluster().key()
-		      << " subdId=" << hitId.subdetId()
-		      << " lay=" << tTopo->layer(hitId)
-		      << " rawId=" << hitId.rawId()
-		      << " pos =" << ttrh->globalPosition()
-		      << " firstMatchingTp=" << firstMatchingTp
-		      << " nMatchingTp=" << nMatchingTp
-		      << " simHitPos=" << simHitPos
-		      << " energyLoss=" << energyLoss
-		      << " particleType=" << particleType
-		      << " processType=" << processType
-		      << " bunchCrossing=" << bunchCrossing
-		      << " event=" << event
-		      << endl;
+      LogTrace("TrackingNtuple") << "pixHit cluster=" << key
+                                 << " subdId=" << hitId.subdetId()
+                                 << " lay=" << lay
+                                 << " rawId=" << hitId.rawId()
+                                 << " pos =" << ttrh->globalPosition()
+                                 << " firstMatchingTp=" << simHitData.firstMatchingTp
+                                 << " nMatchingTp=" << simHitData.nMatchingTp
+                                 << " simHitPos=" << simHitData.pos
+                                 << " energyLoss=" << simHitData.energyLoss
+                                 << " particleType=" << simHitData.particleType
+                                 << " processType=" << simHitData.processType
+                                 << " bunchCrossing=" << simHitData.bunchCrossing
+                                 << " event=" << simHitData.event;
     }
   }
+}
 
-  //strip hits
+
+void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
+                                             const ClusterTPAssociation& clusterToTPMap,
+                                             const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                                             const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                             const TrackerTopology& tTopo,
+                                             std::vector<std::pair<int, int> >& tpRPhiList,
+                                             std::vector<std::pair<int, int> >& tpStereoList,
+                                             std::set<edm::ProductID>& hitProductIds
+                                             ) {
   //index strip hit branches by cluster index
   edm::Handle<SiStripRecHit2DCollection> rphiHits;
-  iEvent.getByLabel("siStripMatchedRecHits","rphiRecHit", rphiHits);
+  iEvent.getByToken(stripRphiRecHitToken_, rphiHits);
   edm::Handle<SiStripRecHit2DCollection> stereoHits;
-  iEvent.getByLabel("siStripMatchedRecHits","stereoRecHit", stereoHits);
+  iEvent.getByToken(stripStereoRecHitToken_, stereoHits);
   int totalStripHits = rphiHits->dataSize()+stereoHits->dataSize();
   str_isBarrel .resize(totalStripHits);
   str_isStereo .resize(totalStripHits);
@@ -607,195 +1142,82 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   str_eloss.resize(totalStripHits);
   str_radL .resize(totalStripHits);
   str_bbxi .resize(totalStripHits);
-  //rphi
-  for (auto it = rphiHits->begin(); it!=rphiHits->end(); it++ ) {
-    DetId hitId = it->detId();
-    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
-      int lay = tTopo->layer(hitId);
-      int firstMatchingTp = -1;
-      int nMatchingTp = 0;
-      GlobalPoint simHitPos = GlobalPoint(0,0,0);
-      float energyLoss = -999.;
-      int particleType = -999;
-      int processType = -999;
-      int bunchCrossing = -999;
-      int event = -999;
-      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
-      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
-      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
-      if( range.first != range.second ) {
-	nMatchingTp = range.second-range.first;
-	for( auto ip=range.first; ip != range.second; ++ip ) {
-	  const TrackingParticleRef trackingParticle=(ip->second);
-	  if( trackingParticle->numberOfHits() == 0 ) continue;
-	  firstMatchingTp = trackingParticle.key();
-	  tpRPhiList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
-	  //now get the corresponding sim hit
-	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
-	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
-	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
-					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-	  for(auto ip = range.first; ip != range.second; ++ip) {
-	    TrackPSimHitRef TPhit = ip->second;
-	    DetId dId = DetId(TPhit->detUnitId());
-	    if (dId.rawId()==hitId.rawId()) {
-	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
-	      energyLoss = TPhit->energyLoss();
-	      particleType = TPhit->particleType();
-	      processType = TPhit->processType();
-	      bunchCrossing = TPhit->eventId().bunchCrossing();
-	      event = TPhit->eventId().event();
-	    }
-	  }
-	  break;
-	}
-      }
-      int key = hit->cluster().key();
-      str_isBarrel [key] = (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB);
-      str_isStereo [key] = 0;
-      str_det      [key] = hitId.subdetId();
-      str_lay      [key] = tTopo->layer(hitId);
-      str_detId    [key] = hitId.rawId();
-      str_nSimTrk  [key] = nMatchingTp;
-      str_simTrkIdx[key] = firstMatchingTp;
-      str_particle [key] = particleType;
-      str_process  [key] = processType;
-      str_bunchXing[key] = bunchCrossing;
-      str_event    [key] = event;
-      str_x    [key] = ttrh->globalPosition().x();
-      str_y    [key] = ttrh->globalPosition().y();
-      str_z    [key] = ttrh->globalPosition().z();
-      str_xx   [key] = ttrh->globalPositionError().cxx();
-      str_xy   [key] = ttrh->globalPositionError().cyx();
-      str_yy   [key] = ttrh->globalPositionError().cyy();
-      str_yz   [key] = ttrh->globalPositionError().czy();
-      str_zz   [key] = ttrh->globalPositionError().czz();
-      str_zx   [key] = ttrh->globalPositionError().czx();
-      str_xsim [key] = simHitPos.x();
-      str_ysim [key] = simHitPos.y();
-      str_zsim [key] = simHitPos.z();
-      str_eloss[key] = energyLoss;
-      str_radL [key] = ttrh->surface()->mediumProperties().radLen();
-      str_bbxi [key] = ttrh->surface()->mediumProperties().xi();
-      if (debug) cout << "stripRPhiHit cluster=" << key
-		      << " subdId=" << hitId.subdetId()
-		      << " lay=" << lay
-		      << " rawId=" << hitId.rawId()
-		      << " pos =" << ttrh->globalPosition()
-		      << " firstMatchingTp=" << firstMatchingTp
-		      << " nMatchingTp=" << nMatchingTp
-		      << " simHitPos=" << simHitPos
-		      << " energyLoss=" << energyLoss
-		      << " particleType=" << particleType
-		      << " processType=" << processType
-		      << " bunchCrossing=" << bunchCrossing
-		      << " event=" << event
-		      << endl;
-    }
-  }
-  //stereo
-  for (auto it = stereoHits->begin(); it!=stereoHits->end(); it++ ) {
-    DetId hitId = it->detId();
-    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
-      int lay = tTopo->layer(hitId);
-      int firstMatchingTp = -1;
-      int nMatchingTp = 0;
-      GlobalPoint simHitPos = GlobalPoint(0,0,0);
-      float energyLoss = -999.;
-      int particleType = -999;
-      int processType = -999;
-      int bunchCrossing = -999;
-      int event = -999;
-      pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( hit->firstClusterRef(), TrackingParticleRef() );
-      //note: TP is dummy in clusterTPpairWithDummyTP since for clusterTPAssociationListGreater sorting only the cluster is needed
-      auto range=equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
-      if( range.first != range.second ) {
-	nMatchingTp = range.second-range.first;
-	for( auto ip=range.first; ip != range.second; ++ip ) {
-	  const TrackingParticleRef trackingParticle=(ip->second);
-	  if( trackingParticle->numberOfHits() == 0 ) continue;
-	  firstMatchingTp = trackingParticle.key();
-	  tpStereoList.push_back( make_pair<int, int>( trackingParticle.key(), hit->cluster().key() ) );
-	  //now get the corresponding sim hit
-	  std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());
-	  //SimHit is dummy: for simHitTPAssociationListGreater sorting only the TP is needed
-	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
-					simHitTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-	  for(auto ip = range.first; ip != range.second; ++ip) {
-	    TrackPSimHitRef TPhit = ip->second;
-	    DetId dId = DetId(TPhit->detUnitId());
-	    if (dId.rawId()==hitId.rawId()) {
-	      simHitPos = ttrh->surface()->toGlobal(TPhit->localPosition());
-	      energyLoss = TPhit->energyLoss();
-	      particleType = TPhit->particleType();
-	      processType = TPhit->processType();
-	      bunchCrossing = TPhit->eventId().bunchCrossing();
-	      event = TPhit->eventId().event();
-	    }
-	  }
-	  break;
-	}
-      }
-      int key = hit->cluster().key();
-      str_isBarrel [key] = (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB);
-      str_isStereo [key] = 1;
-      str_det      [key] = hitId.subdetId();
-      str_lay      [key] = tTopo->layer(hitId);
-      str_detId    [key] = hitId.rawId();
-      str_nSimTrk  [key] = nMatchingTp;
-      str_simTrkIdx[key] = firstMatchingTp;
-      str_particle [key] = particleType;
-      str_process  [key] = processType;
-      str_bunchXing[key] = bunchCrossing;
-      str_event    [key] = event;
-      str_x    [key] = ttrh->globalPosition().x();
-      str_y    [key] = ttrh->globalPosition().y();
-      str_z    [key] = ttrh->globalPosition().z();
-      str_xx   [key] = ttrh->globalPositionError().cxx();
-      str_xy   [key] = ttrh->globalPositionError().cyx();
-      str_yy   [key] = ttrh->globalPositionError().cyy();
-      str_yz   [key] = ttrh->globalPositionError().czy();
-      str_zz   [key] = ttrh->globalPositionError().czz();
-      str_zx   [key] = ttrh->globalPositionError().czx();
-      str_xsim [key] = simHitPos.x();
-      str_ysim [key] = simHitPos.y();
-      str_zsim [key] = simHitPos.z();
-      str_eloss[key] = energyLoss;
-      str_radL [key] = ttrh->surface()->mediumProperties().radLen();
-      str_bbxi [key] = ttrh->surface()->mediumProperties().xi();
-      if (debug) cout << "stripStereoHit cluster=" << key
-		      << " subdId=" << hitId.subdetId()
-		      << " lay=" << lay
-		      << " rawId=" << hitId.rawId()
-		      << " pos =" << ttrh->globalPosition()
-		      << " firstMatchingTp=" << firstMatchingTp
-		      << " nMatchingTp=" << nMatchingTp
-		      << " simHitPos=" << simHitPos
-		      << " energyLoss=" << energyLoss
-		      << " particleType=" << particleType
-		      << " processType=" << processType
-		      << " bunchCrossing=" << bunchCrossing
-		      << " event=" << event
-		      << endl;
-    }
-  }
 
-  //matched hits
-  //prapare list to link matched hits to collection
-  vector<pair<int,int> > monoStereoClusterList;
+  auto fill = [&](const SiStripRecHit2DCollection& hits, std::vector<std::pair<int, int> >& hitList, const char *name, bool isStereo) {
+    for(const auto& detset: hits) {
+      const DetId hitId = detset.detId();
+      for(const auto& hit: detset) {
+        TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&hit);
+
+        hitProductIds.insert(hit.cluster().id());
+
+        const int key = hit.cluster().key();
+        const int lay = tTopo.layer(hitId);
+        SimHitData simHitData = matchCluster(hit.firstClusterRef(), hitId, key, ttrh,
+                                             clusterToTPMap, simHitsTPAssoc, hitList);
+        str_isBarrel [key] = (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB);
+        str_isStereo [key] = isStereo;
+        str_det      [key] = hitId.subdetId();
+        str_lay      [key] = lay;
+        str_detId    [key] = hitId.rawId();
+        str_nSimTrk  [key] = simHitData.nMatchingTp;
+        str_simTrkIdx[key] = simHitData.firstMatchingTp;
+        str_particle [key] = simHitData.particleType;
+        str_process  [key] = simHitData.processType;
+        str_bunchXing[key] = simHitData.bunchCrossing;
+        str_event    [key] = simHitData.event;
+        str_x    [key] = ttrh->globalPosition().x();
+        str_y    [key] = ttrh->globalPosition().y();
+        str_z    [key] = ttrh->globalPosition().z();
+        str_xx   [key] = ttrh->globalPositionError().cxx();
+        str_xy   [key] = ttrh->globalPositionError().cyx();
+        str_yy   [key] = ttrh->globalPositionError().cyy();
+        str_yz   [key] = ttrh->globalPositionError().czy();
+        str_zz   [key] = ttrh->globalPositionError().czz();
+        str_zx   [key] = ttrh->globalPositionError().czx();
+        str_xsim [key] = simHitData.pos.x();
+        str_ysim [key] = simHitData.pos.y();
+        str_zsim [key] = simHitData.pos.z();
+        str_eloss[key] = simHitData.energyLoss;
+        str_radL [key] = ttrh->surface()->mediumProperties().radLen();
+        str_bbxi [key] = ttrh->surface()->mediumProperties().xi();
+        LogTrace("TrackingNtuple") << name << " cluster=" << key
+                                   << " subdId=" << hitId.subdetId()
+                                   << " lay=" << lay
+                                   << " rawId=" << hitId.rawId()
+                                   << " pos =" << ttrh->globalPosition()
+                                   << " firstMatchingTp=" << simHitData.firstMatchingTp
+                                   << " nMatchingTp=" << simHitData.nMatchingTp
+                                   << " simHitPos=" << simHitData.pos
+                                   << " energyLoss=" << simHitData.energyLoss
+                                   << " particleType=" << simHitData.particleType
+                                   << " processType=" << simHitData.processType
+                                   << " bunchCrossing=" << simHitData.bunchCrossing
+                                   << " event=" << simHitData.event;
+      }
+    }
+  };
+
+  fill(*rphiHits, tpRPhiList, "stripRPhiHit", false);
+  fill(*stereoHits, tpStereoList, "stripStereoHit", true);
+}
+
+void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
+                                          const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                          const TrackerTopology& tTopo,
+                                          std::vector<std::pair<int, int> >& monoStereoClusterList
+                                          ) {
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedHits;
-  iEvent.getByLabel("siStripMatchedRecHits","matchedRecHit", matchedHits);
+  iEvent.getByToken(stripMatchedRecHitToken_, matchedHits);
   for (auto it = matchedHits->begin(); it!=matchedHits->end(); it++ ) {
-    DetId hitId = it->detId();
+    const DetId hitId = it->detId();
     for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder->build(&*hit);
-      int lay = tTopo->layer(hitId);
-      monoStereoClusterList.push_back(make_pair<int,int>(hit->monoHit().cluster().key(),hit->stereoHit().cluster().key()));
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&*hit);
+      const int lay = tTopo.layer(hitId);
+      monoStereoClusterList.emplace_back(hit->monoHit().cluster().key(),hit->stereoHit().cluster().key());
       glu_isBarrel .push_back( (hitId.subdetId()==StripSubdetector::TIB || hitId.subdetId()==StripSubdetector::TOB) );
       glu_det      .push_back( hitId.subdetId() );
-      glu_lay      .push_back( tTopo->layer(hitId) );
+      glu_lay      .push_back( tTopo.layer(hitId) );
       glu_detId    .push_back( hitId.rawId() );
       glu_monoIdx  .push_back( hit->monoHit().cluster().key() );
       glu_stereoIdx.push_back( hit->stereoHit().cluster().key() );
@@ -810,89 +1232,133 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       glu_zx       .push_back( ttrh->globalPositionError().czx() );
       glu_radL     .push_back( ttrh->surface()->mediumProperties().radLen() );
       glu_bbxi     .push_back( ttrh->surface()->mediumProperties().xi() );
-      if (debug) cout << "stripMatchedHit"
-		      << " cluster0=" << hit->stereoHit().cluster().key()
-		      << " cluster1=" << hit->monoHit().cluster().key()
-		      << " subdId=" << hitId.subdetId()
-		      << " lay=" << lay
-		      << " rawId=" << hitId.rawId()
-		      << " pos =" << ttrh->globalPosition() << endl;
+      LogTrace("TrackingNtuple") << "stripMatchedHit"
+                                 << " cluster0=" << hit->stereoHit().cluster().key()
+                                 << " cluster1=" << hit->monoHit().cluster().key()
+                                 << " subdId=" << hitId.subdetId()
+                                 << " lay=" << lay
+                                 << " rawId=" << hitId.rawId()
+                                 << " pos =" << ttrh->globalPosition();
     }
   }
+}
 
-  //seeds
+void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
+                               const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                               const reco::BeamSpot& bs,
+                               const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                               const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                               const MagneticField *theMF,
+                               const std::vector<std::pair<int, int> >& monoStereoClusterList,
+                               const std::set<edm::ProductID>& hitProductIds
+                               ) {
   int offset = 0;
   TSCBLBuilderNoMaterial tscblBuilder;
-  for (unsigned int itsd=0;itsd<seedTags_.size();++itsd) {
-    InputTag seedTag_ = seedTags_[itsd];
-    Handle<TrajectorySeedCollection> seeds;
-    iEvent.getByLabel(seedTag_,seeds);
-    TString label = seedTag_.label();
-    if (debug) cout << "NEW SEED LABEL: " << label << " size: " << seeds->size();
+  for(const auto& seedToken: seedTokens_) {
+    edm::Handle<edm::View<reco::Track> > seedTracks;
+    iEvent.getByToken(seedToken, seedTracks);
+
+    reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(seedTracks, TPCollectionH);
+
+
+    edm::EDConsumerBase::Labels labels;
+    labelsForToken(seedToken, labels);
+    TString label = labels.module;
     //format label to match algoName
+    label.ReplaceAll("seedTracks", "");
     label.ReplaceAll("Seeds","");
     label.ReplaceAll("muonSeeded","muonSeededStep");
-    if (debug) cout << " algo=" << TrackBase::algoByName(label.Data()) << endl;
-    int algo = TrackBase::algoByName(label.Data());
+    int algo = reco::TrackBase::algoByName(label.Data());
+    LogTrace("TrackingNtuple") << "NEW SEED LABEL: " << label << " size: " << seedTracks->size() << " algo=" << algo;
     algo_offset[algo] = offset;
     int seedCount = 0;
-    for(TrajectorySeedCollection::const_iterator itSeed = seeds->begin(); itSeed != seeds->end(); ++itSeed,++seedCount) {
-      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder->build(&*(itSeed->recHits().second-1));
-      TrajectoryStateOnSurface state = trajectoryStateTransform::transientState( itSeed->startingState(), lastRecHit->surface(), theMF.product());
-      int charge = state.charge();
-      float pt  = state.globalParameters().momentum().perp();
-      float eta = state.globalParameters().momentum().eta();
-      float phi = state.globalParameters().momentum().phi();
-      int nHits = itSeed->nHits();
-      see_px      .push_back( state.globalParameters().momentum().x() );
-      see_py      .push_back( state.globalParameters().momentum().y() );
-      see_pz      .push_back( state.globalParameters().momentum().z() );
+    for(unsigned int i=0; i<seedTracks->size(); ++i) {
+      auto seedTrackRef = seedTracks->refAt(i);
+      const auto& seedTrack = *seedTrackRef;
+      const auto& seedRef = seedTrack.seedRef();
+      const auto& seed = *seedRef;
+
+      std::vector<float> sharedFraction;
+      std::vector<int> tpIdx;
+      auto foundTPs = recSimColl.find(seedTrackRef);
+      if (foundTPs != recSimColl.end()) {
+        for(const auto tpQuality: foundTPs->val) {
+          sharedFraction.push_back(tpQuality.second);
+          tpIdx.push_back(tpQuality.first.key());
+        }
+      }
+
+
+      const bool seedFitOk = !trackFromSeedFitFailed(seedTrack);
+      const int charge = seedTrack.charge();
+      const float pt  = seedFitOk ? seedTrack.pt()  : 0;
+      const float eta = seedFitOk ? seedTrack.eta() : 0;
+      const float phi = seedFitOk ? seedTrack.phi() : 0;
+      const int nHits = seedTrack.numberOfValidHits();
+
+      see_fitok   .push_back(seedFitOk);
+
+      see_px      .push_back( seedFitOk ? seedTrack.px() : 0 );
+      see_py      .push_back( seedFitOk ? seedTrack.py() : 0 );
+      see_pz      .push_back( seedFitOk ? seedTrack.pz() : 0 );
       see_pt      .push_back( pt );
       see_eta     .push_back( eta );
       see_phi     .push_back( phi );
       see_q       .push_back( charge );
       see_nValid  .push_back( nHits );
-      //convert seed into track to access parameters
-      TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed = tscblBuilder(*state.freeState(),bs);//as in TrackProducerAlgorithm
-      if(!(tsAtClosestApproachSeed.isValid())){
-        cout<<"TrajectoryStateClosestToBeamLine for seed not valid"<<endl;;
-        continue;
-      }
-      const reco::TrackBase::Point vSeed1(tsAtClosestApproachSeed.trackStateAtPCA().position().x(),
-					  tsAtClosestApproachSeed.trackStateAtPCA().position().y(),
-					  tsAtClosestApproachSeed.trackStateAtPCA().position().z());
-      const reco::TrackBase::Vector pSeed(tsAtClosestApproachSeed.trackStateAtPCA().momentum().x(),
-					  tsAtClosestApproachSeed.trackStateAtPCA().momentum().y(),
-					  tsAtClosestApproachSeed.trackStateAtPCA().momentum().z());
-      PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
-      reco::Track* matchedTrackPointer = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
-      see_dxy     .push_back(matchedTrackPointer->dxy(bs.position()));
-      see_dz      .push_back(matchedTrackPointer->dz(bs.position()));
-      see_ptErr   .push_back(matchedTrackPointer->ptError());
-      see_etaErr  .push_back(matchedTrackPointer->etaError());
-      see_phiErr  .push_back(matchedTrackPointer->phiError());
-      see_dxyErr  .push_back(matchedTrackPointer->dxyError());
-      see_dzErr   .push_back(matchedTrackPointer->dzError());
-      see_algo    .push_back(algo);
-      vector<int> pixelIdx;
-      vector<int> gluedIdx;
-      vector<int> stripIdx;
-      for (auto hit=itSeed->recHits().first; hit!=itSeed->recHits().second; ++hit) {
-	TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*hit);
+
+      see_dxy     .push_back( seedFitOk ? seedTrack.dxy(bs.position()) : 0);
+      see_dz      .push_back( seedFitOk ? seedTrack.dz(bs.position()) : 0);
+      see_ptErr   .push_back( seedFitOk ? seedTrack.ptError() : 0);
+      see_etaErr  .push_back( seedFitOk ? seedTrack.etaError() : 0);
+      see_phiErr  .push_back( seedFitOk ? seedTrack.phiError() : 0);
+      see_dxyErr  .push_back( seedFitOk ? seedTrack.dxyError() : 0);
+      see_dzErr   .push_back( seedFitOk ? seedTrack.dzError() : 0);
+      see_algo    .push_back( algo );
+
+      see_shareFrac.push_back( sharedFraction );
+      see_simIdx   .push_back( tpIdx );
+
+      /// Hmm, the following could make sense instead of plain failing if propagation to beam line fails
+      /*
+      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
+      TrajectoryStateOnSurface state = trajectoryStateTransform::transientState( itSeed->startingState(), lastRecHit->surface(), theMF);
+      float pt  = state.globalParameters().momentum().perp();
+      float eta = state.globalParameters().momentum().eta();
+      float phi = state.globalParameters().momentum().phi();
+      see_px      .push_back( state.globalParameters().momentum().x() );
+      see_py      .push_back( state.globalParameters().momentum().y() );
+      see_pz      .push_back( state.globalParameters().momentum().z() );
+      */
+
+      std::vector<int> pixelIdx;
+      std::vector<int> gluedIdx;
+      std::vector<int> stripIdx;
+      for (auto hit=seed.recHits().first; hit!=seed.recHits().second; ++hit) {
+	TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder.build(&*hit);
 	int subid = recHit->geographicalId().subdetId();
 	if (subid == (int) PixelSubdetector::PixelBarrel || subid == (int) PixelSubdetector::PixelEndcap) {
 	  const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
-	  pixelIdx.push_back( bhit->firstClusterRef().cluster_pixel().key() );
+          const auto& clusterRef = bhit->firstClusterRef();
+          if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "seed");
+	  pixelIdx.push_back( clusterRef.cluster_pixel().key() );
 	} else {
 	  if (trackerHitRTTI::isMatched(*recHit)) {
 	    const SiStripMatchedRecHit2D * matchedHit = dynamic_cast<const SiStripMatchedRecHit2D *>(&*recHit);
+            if(includeAllHits_) {
+              checkProductID(hitProductIds, matchedHit->monoClusterRef().id(), "seed");
+              checkProductID(hitProductIds, matchedHit->stereoClusterRef().id(), "seed");
+            }
 	    int monoIdx = matchedHit->monoClusterRef().key();
 	    int stereoIdx = matchedHit->stereoClusterRef().key();
-	    vector<pair<int,int> >::iterator pos = find( monoStereoClusterList.begin(), monoStereoClusterList.end(), make_pair(monoIdx,stereoIdx) );
+
+            std::vector<std::pair<int,int> >::const_iterator pos = find( monoStereoClusterList.begin(), monoStereoClusterList.end(), std::make_pair(monoIdx,stereoIdx) );
 	    gluedIdx.push_back( pos - monoStereoClusterList.begin() );
 	  } else {
 	    const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
-	    stripIdx.push_back( bhit->firstClusterRef().cluster_strip().key() );
+            const auto& clusterRef = bhit->firstClusterRef();
+            if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "seed");
+	    stripIdx.push_back( clusterRef.cluster_strip().key() );
 	  }
 	}
       }
@@ -905,33 +1371,30 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       //the part below is not strictly needed
       float chi2 = -1;
       if (nHits==2) {
-	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder->build(&*(itSeed->recHits().first));
-	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder->build(&*(itSeed->recHits().first+1));
-	vector<GlobalPoint> gp(2);
-	vector<GlobalError> ge(2);
+	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().first));
+	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().first+1));
+        std::vector<GlobalPoint> gp(2);
+        std::vector<GlobalError> ge(2);
 	gp[0] = recHit0->globalPosition();
 	ge[0] = recHit0->globalPositionError();
 	gp[1] = recHit1->globalPosition();
 	ge[1] = recHit1->globalPositionError();
-	if (debug) {
-	  cout << "seed " << seedCount
-	       << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
-	       << " - PAIR - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId()
-	       << " hitpos: " << gp[0] << " " << gp[1]
-	       << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
-	       << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
-	       << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
-	       << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
-	       << " eta,phi: " << gp[0].eta() << "," << gp[0].phi()
-	       << endl;
-	}
+        LogTrace("TrackingNtuple") << "seed " << seedCount
+                                   << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
+                                   << " - PAIR - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId()
+                                   << " hitpos: " << gp[0] << " " << gp[1]
+                                   << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " eta,phi: " << gp[0].eta() << "," << gp[0].phi();
       } else if (nHits==3) {
-	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder->build(&*(itSeed->recHits().first));
-	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder->build(&*(itSeed->recHits().first+1));
-	TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder->build(&*(itSeed->recHits().first+2));
-	vector<GlobalPoint> gp(3);
-	vector<GlobalError> ge(3);
-	vector<bool> bl(3);
+	TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().first));
+	TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().first+1));
+	TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&*(seed.recHits().first+2));
+	declareDynArray(GlobalPoint,4, gp);
+	declareDynArray(GlobalError,4, ge);
+	declareDynArray(bool,4, bl);
 	gp[0] = recHit0->globalPosition();
 	ge[0] = recHit0->globalPositionError();
 	int subid0 = recHit0->geographicalId().subdetId();
@@ -948,48 +1411,57 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 	float  cottheta, intercept, covss, covii, covsi;
 	rzLine.fit(cottheta, intercept, covss, covii, covsi);
 	float seed_chi2 = rzLine.chi2(cottheta, intercept);
-	float seed_pt = state.globalParameters().momentum().perp();
-	if (debug) {
-	  cout << "seed " << seedCount
-	       << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
-	       << " - TRIPLET - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId() << " " << recHit2->geographicalId().rawId()
-	       << " hitpos: " << gp[0] << " " << gp[1] << " " << gp[2]
-	       << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
-	       << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
-	       << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
-	       << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
-	       << " trans2: " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
-	       << " " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
-	       << " local: " << recHit2->localPosition()
-	       << " tsos pos, mom: " << state.globalPosition()<<" "<<state.globalMomentum()
-	       << " eta,phi: " << gp[0].eta() << "," << gp[0].phi()
-	       << " pt,chi2: " << seed_pt << "," << seed_chi2 << endl;
-	}
+	//float seed_pt = state.globalParameters().momentum().perp();
+        float seed_pt = pt;
+	LogTrace("TrackingNtuple") << "seed " << seedCount
+                                   << " pt=" << pt << " eta=" << eta << " phi=" << phi << " q=" << charge
+                                   << " - TRIPLET - ids: " << recHit0->geographicalId().rawId() << " " << recHit1->geographicalId().rawId() << " " << recHit2->geographicalId().rawId()
+                                   << " hitpos: " << gp[0] << " " << gp[1] << " " << gp[2]
+                                   << " trans0: " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " " << (recHit0->transientHits().size()>1 ? recHit0->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " trans1: " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " " << (recHit1->transientHits().size()>1 ? recHit1->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " trans2: " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[0]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " " << (recHit2->transientHits().size()>1 ? recHit2->transientHits()[1]->globalPosition() : GlobalPoint(0,0,0))
+                                   << " local: " << recHit2->localPosition()
+          //<< " tsos pos, mom: " << state.globalPosition()<<" "<<state.globalMomentum()
+                                   << " eta,phi: " << gp[0].eta() << "," << gp[0].phi()
+                                   << " pt,chi2: " << seed_pt << "," << seed_chi2;
 	chi2 = seed_chi2;
       }
       see_chi2   .push_back( chi2 );
       offset++;
     }
   }
+}
 
-  //tracks
-  edm::Handle<View<Track> > tracks;
-  iEvent.getByLabel(trackTag_,tracks);
-  reco::RecoToSimCollection recSimColl = associatorByHits->associateRecoToSim(tracks,TPCollectionH,&iEvent,&iSetup);
-  if (debug) cout << "NEW TRACK LABEL: " << trackTag_.label() << endl;
+void TrackingNtuple::fillTracks(const edm::Handle<edm::View<reco::Track> >& tracks,
+                                const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                                const reco::BeamSpot& bs,
+                                const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                                const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                const TrackerTopology& tTopo,
+                                const std::set<edm::ProductID>& hitProductIds
+                                ) {
+  reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(tracks,TPCollectionH);
+  edm::EDConsumerBase::Labels labels;
+  labelsForToken(trackToken_, labels);
+  LogTrace("TrackingNtuple") << "NEW TRACK LABEL: " << labels.module;
   for(unsigned int i=0; i<tracks->size(); ++i){
-    RefToBase<Track> itTrack(tracks, i);
+    auto itTrack = tracks->refAt(i);
     int nSimHits = 0;
-    double sharedFraction = 0.;
-    bool isSimMatched(false);
-    int tpIdx = -1;
-    if (recSimColl.find(itTrack) != recSimColl.end()) { 
-      auto const & tp = recSimColl[itTrack];
-      if (!tp.empty()) {
-	nSimHits = tp[0].first->numberOfTrackerHits();
-	sharedFraction = tp[0].second;
+    bool isSimMatched = false;
+    std::vector<float> sharedFraction;
+    std::vector<int> tpIdx;
+    auto foundTPs = recSimColl.find(itTrack);
+    if (foundTPs != recSimColl.end()) {
+      if (!foundTPs->val.empty()) {
+	nSimHits = foundTPs->val[0].first->numberOfTrackerHits();
 	isSimMatched = true;
-	tpIdx = tp[0].first.key();
+      }
+      for(const auto tpQuality: foundTPs->val) {
+        sharedFraction.push_back(tpQuality.second);
+	tpIdx.push_back(tpQuality.first.key());
       }
     }
     int charge = itTrack->charge();
@@ -998,7 +1470,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     float chi2 = itTrack->normalizedChi2();
     float phi = itTrack->phi();
     int nHits = itTrack->numberOfValidHits();
-    HitPattern hp = itTrack->hitPattern();
+    const reco::HitPattern& hp = itTrack->hitPattern();
     trk_px       .push_back(itTrack->px());
     trk_py       .push_back(itTrack->py());
     trk_pz       .push_back(itTrack->pz());
@@ -1016,91 +1488,97 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     trk_shareFrac.push_back(sharedFraction);
     trk_q        .push_back(charge);
     trk_nValid   .push_back(hp.numberOfValidHits());
-    //trk_nInvalid .push_back(hp.numberOfLostHits(HitPattern::TRACK_HITS)); / for 80X
-    trk_nInvalid .push_back(hp.numberOfLostHits());
+    trk_nInvalid .push_back(hp.numberOfLostHits(reco::HitPattern::TRACK_HITS));
     trk_nPixel   .push_back(hp.numberOfValidPixelHits());
     trk_nStrip   .push_back(hp.numberOfValidStripHits());
+    trk_nPixelLay.push_back(hp.pixelLayersWithMeasurement());
+    trk_nStripLay.push_back(hp.stripLayersWithMeasurement());
     trk_n3DLay   .push_back(hp.numberOfValidStripLayersWithMonoAndStereo()+hp.pixelLayersWithMeasurement());
     trk_algo     .push_back(itTrack->algo());
-    trk_isHP     .push_back(itTrack->quality(TrackBase::highPurity));
-    trk_seedIdx  .push_back( algo_offset[itTrack->algo()] + itTrack->seedRef().key() );
-    trk_simIdx   .push_back(tpIdx);
-    if (debug) { 
-      cout << "Track #" << i << " with q=" << charge
-	   << ", pT=" << pt << " GeV, eta: " << eta << ", phi: " << phi
-	   << ", chi2=" << chi2
-	   << ", Nhits=" << nHits
-	   << ", algo=" << itTrack->algoName(itTrack->algo()).c_str()
-	   << " hp=" << itTrack->quality(TrackBase::highPurity)
-	   << " seed#=" << itTrack->seedRef().key()
-	   << " simMatch=" << isSimMatched
-	   << " nSimHits=" << nSimHits
-	   << " sharedFraction=" << sharedFraction
-	   << " tpIdx=" << tpIdx
-	   << endl;
+    trk_originalAlgo.push_back(itTrack->originalAlgo());
+    trk_algoMask .push_back(itTrack->algoMaskUL());
+    trk_stopReason.push_back(itTrack->stopReason());
+    trk_isHP     .push_back(itTrack->quality(reco::TrackBase::highPurity));
+    if(includeSeeds_) {
+      trk_seedIdx  .push_back( algo_offset[itTrack->algo()] + itTrack->seedRef().key() );
     }
-    vector<int> pixelCluster;
-    vector<int> stripCluster;
+    trk_simIdx   .push_back(tpIdx);
+    LogTrace("TrackingNtuple") << "Track #" << i << " with q=" << charge
+                               << ", pT=" << pt << " GeV, eta: " << eta << ", phi: " << phi
+                               << ", chi2=" << chi2
+                               << ", Nhits=" << nHits
+                               << ", algo=" << itTrack->algoName(itTrack->algo()).c_str()
+                               << " hp=" << itTrack->quality(reco::TrackBase::highPurity)
+                               << " seed#=" << itTrack->seedRef().key()
+                               << " simMatch=" << isSimMatched
+                               << " nSimHits=" << nSimHits
+                               << " sharedFraction=" << (sharedFraction.empty()?-1:sharedFraction[0])
+                               << " tpIdx=" << (tpIdx.empty()?-1:tpIdx[0]);
+    std::vector<int> pixelCluster;
+    std::vector<int> stripCluster;
     int nhit = 0;
     for (trackingRecHit_iterator i=itTrack->recHitsBegin(); i!=itTrack->recHitsEnd(); i++){
-      if (debug) cout << "hit #" << nhit;
-      TransientTrackingRecHit::RecHitPointer hit=theTTRHBuilder->build(&**i );
+      TransientTrackingRecHit::RecHitPointer hit=theTTRHBuilder.build(&**i );
       DetId hitId = hit->geographicalId();
-      if (debug) cout << " subdet=" << hitId.subdetId();
+      LogTrace("TrackingNtuple") << "hit #" << nhit << " subdet=" << hitId.subdetId();
       if(hitId.det() == DetId::Tracker) {
-	if (debug) {
-	  if (hitId.subdetId() == StripSubdetector::TIB )      cout << " - TIB ";
-	  else if (hitId.subdetId() == StripSubdetector::TOB ) cout << " - TOB ";
-	  else if (hitId.subdetId() == StripSubdetector::TEC ) cout << " - TEC ";
-	  else if (hitId.subdetId() == StripSubdetector::TID ) cout << " - TID ";
-	  else if (hitId.subdetId() == (int) PixelSubdetector::PixelBarrel ) cout << " - PixBar ";
-	  else if (hitId.subdetId() == (int) PixelSubdetector::PixelEndcap ) cout << " - PixFwd ";
-	  else cout << " UNKNOWN TRACKER HIT TYPE ";
-	  cout << tTopo->layer(hitId);
-	}
+        LogTrace("TrackingNtuple") << " " << subdetstring(hitId.subdetId()) << " " << tTopo.layer(hitId);
 	bool isPixel = (hitId.subdetId() == (int) PixelSubdetector::PixelBarrel || hitId.subdetId() == (int) PixelSubdetector::PixelEndcap );
 	if (hit->isValid()) {
 	  //ugly... but works
 	  const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*hit);
-	  if (debug) cout << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
-			  << " cluster=" << (bhit->firstClusterRef().isPixel() ? bhit->firstClusterRef().cluster_pixel().key() :  bhit->firstClusterRef().cluster_strip().key())
-			  << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi()  << endl;
-	  if (isPixel) pixelCluster.push_back( bhit->firstClusterRef().cluster_pixel().key() );
-	  else         stripCluster.push_back( bhit->firstClusterRef().cluster_strip().key() );
+          const auto& clusterRef = bhit->firstClusterRef();
+
+          LogTrace("TrackingNtuple") << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
+                                     << " cluster=" << (clusterRef.isPixel() ? clusterRef.cluster_pixel().key() :  clusterRef.cluster_strip().key())
+                                     << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi();
+          if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "track");
+
+	  if (isPixel) pixelCluster.push_back( clusterRef.cluster_pixel().key() );
+	  else         stripCluster.push_back( clusterRef.cluster_strip().key() );
 	} else  {
-	  if (debug) cout << " - invalid hit" << endl;
+          LogTrace("TrackingNtuple") << " - invalid hit";
 	  if (isPixel) pixelCluster.push_back( -1 );
 	  else         stripCluster.push_back( -1 );
 	}
       }
       nhit++;
     }
-    if (debug) cout << endl;
     trk_pixelIdx.push_back(pixelCluster);
     trk_stripIdx.push_back(stripCluster);
   }
+}
 
-  //tracking particles
-  //sort association maps with clusters
-  sort( tpPixList.begin(), tpPixList.end(), intIntListGreater );
-  sort( tpRPhiList.begin(), tpRPhiList.end(), intIntListGreater );
-  sort( tpStereoList.begin(), tpStereoList.end(), intIntListGreater );
-  for (auto itp = tPC.begin(); itp != tPC.end(); ++itp) {
-    TrackingParticleRef tp(TPCollectionH,itp-tPC.begin());
-    if (debug) cout << "tracking particle pt=" << tp->pt() << " eta=" << tp->eta() << " phi=" << tp->phi() << endl;
-    reco::SimToRecoCollection simRecColl = associatorByHits->associateSimToReco(tracks,TPCollectionH,&iEvent,&iSetup);
-    bool isRecoMatched(false);
-    int tkIdx = -1;
-    float sharedFraction = -1;
-    if (simRecColl.find(tp) != simRecColl.end()) { 
-      auto const & tk = simRecColl[tp];
-      if (!tk.empty()) {
-	isRecoMatched = true;
-	tkIdx = tk[0].first.key();
-	sharedFraction = tk[0].second;
+
+void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::EventSetup& iSetup,
+                                           const edm::Handle<edm::View<reco::Track> >& tracks,
+                                           const edm::Handle<TrackingParticleCollection>& TPCollectionH,
+                                           const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                                           const std::vector<std::pair<int, int> >& tpPixList,
+                                           const std::vector<std::pair<int, int> >& tpRPhiList,
+                                           const std::vector<std::pair<int, int> >& tpStereoList
+                                           ) {
+  edm::ESHandle<ParametersDefinerForTP> parametersDefinerH;
+  iSetup.get<TrackAssociatorRecord>().get(parametersDefinerName_, parametersDefinerH);
+  const ParametersDefinerForTP *parametersDefiner = parametersDefinerH.product();
+
+  reco::SimToRecoCollection simRecColl = associatorByHits.associateSimToReco(tracks,TPCollectionH);
+
+  for (auto itp = TPCollectionH->begin(); itp != TPCollectionH->end(); ++itp) {
+    TrackingParticleRef tp(TPCollectionH, itp-TPCollectionH->begin());
+    LogTrace("TrackingNtuple") << "tracking particle pt=" << tp->pt() << " eta=" << tp->eta() << " phi=" << tp->phi();
+    bool isRecoMatched = false;
+    std::vector<int> tkIdx;
+    std::vector<float> sharedFraction;
+    auto foundTracks = simRecColl.find(tp);
+    if(foundTracks != simRecColl.end()) {
+      isRecoMatched = true;
+      for(const auto trackQuality: foundTracks->val) {
+        sharedFraction.push_back(trackQuality.second);
+        tkIdx.push_back(trackQuality.first.key());
       }
     }
-    if (debug) cout << "matched to track = " << tkIdx << " isRecoMatched=" << isRecoMatched << endl;
+    LogTrace("TrackingNtuple") << "matched to tracks = " << make_VectorPrinter(tkIdx) << " isRecoMatched=" << isRecoMatched;
     sim_px       .push_back(tp->px());
     sim_py       .push_back(tp->py());
     sim_pz       .push_back(tp->pz());
@@ -1121,24 +1599,24 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       * momentum.z()/sqrt(momentum.perp2());
     sim_dxy      .push_back(dxySim);
     sim_dz       .push_back(dzSim);
-    vector<int> pixelCluster;
-    vector<int> stripCluster;
-    pair<int, int> tpPixPairDummy(tp.key(),-1);
+    std::vector<int> pixelCluster;
+    std::vector<int> stripCluster;
+    std::pair<int, int> tpPixPairDummy(tp.key(),-1);
     auto rangePix = std::equal_range(tpPixList.begin(), tpPixList.end(), tpPixPairDummy, intIntListGreater);
     for(auto ip = rangePix.first; ip != rangePix.second; ++ip) {
-      if (debug) cout << "pixHit cluster=" << ip->second << endl;
+      LogTrace("TrackingNtuple") << "pixHit cluster=" << ip->second;
       pixelCluster.push_back(ip->second);
     }
-    pair<int, int> tpRPhiPairDummy(tp.key(),-1);
+    std::pair<int, int> tpRPhiPairDummy(tp.key(),-1);
     auto rangeRPhi = std::equal_range(tpRPhiList.begin(), tpRPhiList.end(), tpRPhiPairDummy, intIntListGreater);
     for(auto ip = rangeRPhi.first; ip != rangeRPhi.second; ++ip) {
-      if (debug) cout << "rphiHit cluster=" << ip->second << endl;
+      LogTrace("TrackingNtuple") << "rphiHit cluster=" << ip->second;
       stripCluster.push_back(ip->second);
     }
-    pair<int, int> tpStereoPairDummy(tp.key(),-1);
+    std::pair<int, int> tpStereoPairDummy(tp.key(),-1);
     auto rangeStereo = std::equal_range(tpStereoList.begin(), tpStereoList.end(), tpStereoPairDummy, intIntListGreater);
     for(auto ip = rangeStereo.first; ip != rangeStereo.second; ++ip) {
-      if (debug) cout << "stereoHit cluster=" << ip->second << endl;
+      LogTrace("TrackingNtuple") << "stereoHit cluster=" << ip->second;
       stripCluster.push_back(ip->second);
     }
     sim_nValid   .push_back( pixelCluster.size()+stripCluster.size() );
@@ -1148,222 +1626,73 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     sim_pixelIdx.push_back(pixelCluster);
     sim_stripIdx.push_back(stripCluster);
   }
-
-  t->Fill();
-
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void TrackingNtuple::beginJob() {
-  
-  edm::Service<TFileService> fs;
-  fs->make<TTree>("tree","tree");
-  t = fs->getObject<TTree>("tree");
+void TrackingNtuple::fillVertices(const reco::VertexCollection& vertices) {
+  for(const reco::Vertex& vertex: vertices) {
+    vtx_x.push_back(vertex.x());
+    vtx_y.push_back(vertex.y());
+    vtx_z.push_back(vertex.z());
+    vtx_xErr.push_back(vertex.xError());
+    vtx_yErr.push_back(vertex.yError());
+    vtx_zErr.push_back(vertex.zError());
+    vtx_chi2.push_back(vertex.chi2());
+    vtx_ndof.push_back(vertex.ndof());
+    vtx_fake.push_back(vertex.isFake());
+    vtx_valid.push_back(vertex.isValid());
 
-  //tracks
-  t->Branch("trk_px"       , &trk_px);
-  t->Branch("trk_py"       , &trk_py);
-  t->Branch("trk_pz"       , &trk_pz);
-  t->Branch("trk_pt"       , &trk_pt);
-  t->Branch("trk_eta"      , &trk_eta);
-  t->Branch("trk_phi"      , &trk_phi);
-  t->Branch("trk_dxy"      , &trk_dxy      );
-  t->Branch("trk_dz"       , &trk_dz       );
-  t->Branch("trk_ptErr"    , &trk_ptErr    );
-  t->Branch("trk_etaErr"   , &trk_etaErr   );
-  t->Branch("trk_phiErr"   , &trk_phiErr   );
-  t->Branch("trk_dxyErr"   , &trk_dxyErr   );
-  t->Branch("trk_dzErr"    , &trk_dzErr    );
-  t->Branch("trk_nChi2"    , &trk_nChi2);
-  t->Branch("trk_shareFrac", &trk_shareFrac);
-  t->Branch("trk_q"        , &trk_q);
-  t->Branch("trk_nValid"   , &trk_nValid  );
-  t->Branch("trk_nInvalid" , &trk_nInvalid);
-  t->Branch("trk_nPixel"   , &trk_nPixel  );
-  t->Branch("trk_nStrip"   , &trk_nStrip  );
-  t->Branch("trk_n3DLay"   , &trk_n3DLay  );
-  t->Branch("trk_algo"     , &trk_algo    );
-  t->Branch("trk_isHP"     , &trk_isHP    );
-  t->Branch("trk_seedIdx"  , &trk_seedIdx );
-  t->Branch("trk_simIdx"   , &trk_simIdx  );
-  t->Branch("trk_pixelIdx" , &trk_pixelIdx);
-  t->Branch("trk_stripIdx" , &trk_stripIdx);
-  //sim tracks
-  t->Branch("sim_px"       , &sim_px       );
-  t->Branch("sim_py"       , &sim_py       );
-  t->Branch("sim_pz"       , &sim_pz       );
-  t->Branch("sim_pt"       , &sim_pt       );
-  t->Branch("sim_eta"      , &sim_eta      );
-  t->Branch("sim_phi"      , &sim_phi      );
-  t->Branch("sim_dxy"      , &sim_dxy      );
-  t->Branch("sim_dz"       , &sim_dz       );
-  t->Branch("sim_prodx"    , &sim_prodx    );
-  t->Branch("sim_prody"    , &sim_prody    );
-  t->Branch("sim_prodz"    , &sim_prodz    );
-  t->Branch("sim_shareFrac", &sim_shareFrac);
-  t->Branch("sim_q"        , &sim_q        );
-  t->Branch("sim_nValid"   , &sim_nValid   );
-  t->Branch("sim_nPixel"   , &sim_nPixel   );
-  t->Branch("sim_nStrip"   , &sim_nStrip   );
-  t->Branch("sim_n3DLay"   , &sim_n3DLay   );
-  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
-  t->Branch("sim_pixelIdx" , &sim_pixelIdx );
-  t->Branch("sim_stripIdx" , &sim_stripIdx );
-  //pixels
-  t->Branch("pix_isBarrel"  , &pix_isBarrel );
-  t->Branch("pix_lay"       , &pix_lay      );
-  t->Branch("pix_detId"     , &pix_detId    );
-  t->Branch("pix_nSimTrk"   , &pix_nSimTrk  );
-  t->Branch("pix_simTrkIdx" , &pix_simTrkIdx);
-  t->Branch("pix_particle"  , &pix_particle );
-  t->Branch("pix_process"   , &pix_process  );
-  t->Branch("pix_bunchXing" , &pix_bunchXing);
-  t->Branch("pix_event"     , &pix_event    );
-  t->Branch("pix_x"     , &pix_x    );
-  t->Branch("pix_y"     , &pix_y    );
-  t->Branch("pix_z"     , &pix_z    );
-  t->Branch("pix_xx"    , &pix_xx   );
-  t->Branch("pix_xy"    , &pix_xy   );
-  t->Branch("pix_yy"    , &pix_yy   );
-  t->Branch("pix_yz"    , &pix_yz   );
-  t->Branch("pix_zz"    , &pix_zz   );
-  t->Branch("pix_zx"    , &pix_zx   );
-  t->Branch("pix_xsim"  , &pix_xsim );
-  t->Branch("pix_ysim"  , &pix_ysim );
-  t->Branch("pix_zsim"  , &pix_zsim );
-  t->Branch("pix_eloss" , &pix_eloss);
-  t->Branch("pix_radL"  , &pix_radL );
-  t->Branch("pix_bbxi"  , &pix_bbxi );
-  //strips
-  t->Branch("str_isBarrel"  , &str_isBarrel );
-  t->Branch("str_isStereo"  , &str_isStereo );
-  t->Branch("str_det"       , &str_det      );
-  t->Branch("str_lay"       , &str_lay      );
-  t->Branch("str_detId"     , &str_detId    );
-  t->Branch("str_nSimTrk"   , &str_nSimTrk  );
-  t->Branch("str_simTrkIdx" , &str_simTrkIdx);
-  t->Branch("str_particle"  , &str_particle );
-  t->Branch("str_process"   , &str_process  );
-  t->Branch("str_bunchXing" , &str_bunchXing);
-  t->Branch("str_event"     , &str_event    );
-  t->Branch("str_x"     , &str_x    );
-  t->Branch("str_y"     , &str_y    );
-  t->Branch("str_z"     , &str_z    );
-  t->Branch("str_xx"    , &str_xx   );
-  t->Branch("str_xy"    , &str_xy   );
-  t->Branch("str_yy"    , &str_yy   );
-  t->Branch("str_yz"    , &str_yz   );
-  t->Branch("str_zz"    , &str_zz   );
-  t->Branch("str_zx"    , &str_zx   );
-  t->Branch("str_xsim"  , &str_xsim );
-  t->Branch("str_ysim"  , &str_ysim );
-  t->Branch("str_zsim"  , &str_zsim );
-  t->Branch("str_eloss" , &str_eloss);
-  t->Branch("str_radL"  , &str_radL );
-  t->Branch("str_bbxi"  , &str_bbxi );
-  //matched hits
-  t->Branch("glu_isBarrel"  , &glu_isBarrel );
-  t->Branch("glu_det"       , &glu_det      );
-  t->Branch("glu_lay"       , &glu_lay      );
-  t->Branch("glu_detId"     , &glu_detId    );
-  t->Branch("glu_monoIdx"   , &glu_monoIdx  );
-  t->Branch("glu_stereoIdx" , &glu_stereoIdx);
-  t->Branch("glu_x"         , &glu_x        );
-  t->Branch("glu_y"         , &glu_y        );
-  t->Branch("glu_z"         , &glu_z        );
-  t->Branch("glu_xx"        , &glu_xx       );
-  t->Branch("glu_xy"        , &glu_xy       );
-  t->Branch("glu_yy"        , &glu_yy       );
-  t->Branch("glu_yz"        , &glu_yz       );
-  t->Branch("glu_zz"        , &glu_zz       );
-  t->Branch("glu_zx"        , &glu_zx       );
-  t->Branch("glu_radL"      , &glu_radL     );
-  t->Branch("glu_bbxi"      , &glu_bbxi     );
-  //beam spot
-  t->Branch("bsp_x" , &bsp_x , "bsp_x/F");
-  t->Branch("bsp_y" , &bsp_y , "bsp_y/F");
-  t->Branch("bsp_z" , &bsp_z , "bsp_z/F");
-  t->Branch("bsp_sigmax" , &bsp_sigmax , "bsp_sigmax/F");
-  t->Branch("bsp_sigmay" , &bsp_sigmay , "bsp_sigmay/F");
-  t->Branch("bsp_sigmaz" , &bsp_sigmaz , "bsp_sigmaz/F");
-  //seeds
-  t->Branch("see_px"       , &see_px      );
-  t->Branch("see_py"       , &see_py      );
-  t->Branch("see_pz"       , &see_pz      );
-  t->Branch("see_pt"       , &see_pt      );
-  t->Branch("see_eta"      , &see_eta     );
-  t->Branch("see_phi"      , &see_phi     );
-  t->Branch("see_dxy"      , &see_dxy     );
-  t->Branch("see_dz"       , &see_dz      );
-  t->Branch("see_ptErr"    , &see_ptErr   );
-  t->Branch("see_etaErr"   , &see_etaErr  );
-  t->Branch("see_phiErr"   , &see_phiErr  );
-  t->Branch("see_dxyErr"   , &see_dxyErr  );
-  t->Branch("see_dzErr"    , &see_dzErr   );
-  t->Branch("see_chi2"     , &see_chi2    );
-  t->Branch("see_q"        , &see_q       );
-  t->Branch("see_nValid"   , &see_nValid  );
-  t->Branch("see_nPixel"   , &see_nPixel  );
-  t->Branch("see_nGlued"   , &see_nGlued  );
-  t->Branch("see_nStrip"   , &see_nStrip  );
-  t->Branch("see_algo"     , &see_algo    );
-  t->Branch("see_pixelIdx" , &see_pixelIdx);
-  t->Branch("see_gluedIdx" , &see_gluedIdx);
-  t->Branch("see_stripIdx" , &see_stripIdx);
-  //seed algo offset
-  t->Branch("algo_offset"  , &algo_offset );
-
-  //t->Branch("" , &);
-
-
+    std::vector<int> trkIdx;
+    for(auto iTrack = vertex.tracks_begin(); iTrack != vertex.tracks_end(); ++iTrack) {
+      trkIdx.push_back(iTrack->key());
+    }
+    vtx_trkIdx.push_back(trkIdx);
+  }
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void TrackingNtuple::endJob() {}
-
-// ------------ method called when starting to processes a run  ------------
-void TrackingNtuple::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
-
-  iSetup.get<IdealMagneticFieldRecord>().get(theMF);
-  iSetup.get<TransientRecHitRecord>().get(builderName_,theTTRHBuilder);
-  
-  edm::ESHandle<TrackAssociatorBase> theHitsAssociator;
-  iSetup.get<TrackAssociatorRecord>().get("quickTrackAssociatorByHits",theHitsAssociator);
-  associatorByHits = (TrackAssociatorBase *) theHitsAssociator.product();
-
-  //get parameters definer
-  edm::ESHandle<ParametersDefinerForTP> parametersDefinerH;
-  iSetup.get<TrackAssociatorRecord>().get("LhcParametersDefinerForTP",parametersDefinerH);
-  parametersDefiner = parametersDefinerH.product();
-  
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
-  tTopo = tTopoHandle.product();
-
+void TrackingNtuple::fillTrackingVertices(const std::vector<const TrackingVertex *>& trackingVertices) {
+  for(const TrackingVertex *ptr: trackingVertices) {
+    const TrackingVertex& trackingVertex = *ptr;
+    simvtx_x.push_back(trackingVertex.position().x());
+    simvtx_y.push_back(trackingVertex.position().y());
+    simvtx_z.push_back(trackingVertex.position().z());
+    simvtx_nTrack.push_back(trackingVertex.nDaughterTracks());
+  }
 }
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-  void TrackingNtuple::endRun(edm::Run const&, edm::EventSetup const&) {}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-  void TrackingNtuple::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-  void TrackingNtuple::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.addUntracked<std::vector<edm::InputTag> >("seedTracks", std::vector<edm::InputTag>{
+      edm::InputTag("seedTracksinitialStepSeeds"),
+      edm::InputTag("seedTracksdetachedTripletStepSeeds"),
+      edm::InputTag("seedTrackspixelPairStepSeeds"),
+      edm::InputTag("seedTrackslowPtTripletStepSeeds"),
+      edm::InputTag("seedTracksmixedTripletStepSeeds"),
+      edm::InputTag("seedTrackspixelLessStepSeeds"),
+      edm::InputTag("seedTrackstobTecStepSeeds"),
+      edm::InputTag("seedTracksjetCoreRegionalStepSeeds"),
+      edm::InputTag("seedTracksmuonSeededSeedsInOut"),
+      edm::InputTag("seedTracksmuonSeededSeedsOutIn")
+  });
+  desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  desc.addUntracked<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.addUntracked<edm::InputTag>("clusterTPMap", edm::InputTag("tpClusterProducer"));
+  desc.addUntracked<edm::InputTag>("simHitTPMap", edm::InputTag("simHitTPAssocProducer"));
+  desc.addUntracked<edm::InputTag>("trackAssociator", edm::InputTag("quickTrackAssociatorByHits"));
+  desc.addUntracked<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.addUntracked<edm::InputTag>("pixelRecHits", edm::InputTag("siPixelRecHits"));
+  desc.addUntracked<edm::InputTag>("stripRphiRecHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
+  desc.addUntracked<edm::InputTag>("stripStereoRecHits", edm::InputTag("siStripMatchedRecHits", "stereoRecHit"));
+  desc.addUntracked<edm::InputTag>("stripMatchedRecHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.addUntracked<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.addUntracked<edm::InputTag>("trackingVertices", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle");
+  desc.addUntracked<std::string>("parametersDefiner", "LhcParametersDefinerForTP");
+  desc.addUntracked<bool>("includeSeeds", false);
+  desc.addUntracked<bool>("includeAllHits", false);
+  descriptions.add("trackingNtuple",desc);
 }
 
 //define this as a plug-in

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -396,6 +396,8 @@ private:
   std::vector<short> pix_isBarrel ;
   std::vector<unsigned int> pix_lay      ;
   std::vector<unsigned int> pix_detId    ;
+  std::vector<std::vector<int> > pix_trkIdx;
+  std::vector<std::vector<int> > pix_seeIdx;
   std::vector<std::vector<int> > pix_simTrkIdx;
   std::vector<std::vector<int> > pix_particle ;
   std::vector<std::vector<int> > pix_process  ;
@@ -421,6 +423,8 @@ private:
   std::vector<unsigned int> str_det      ;
   std::vector<unsigned int> str_lay      ;
   std::vector<unsigned int> str_detId    ;
+  std::vector<std::vector<int> > str_trkIdx;
+  std::vector<std::vector<int> > str_seeIdx;
   std::vector<std::vector<int> > str_simTrkIdx;
   std::vector<std::vector<int> > str_particle ;
   std::vector<std::vector<int> > str_process  ;
@@ -447,6 +451,7 @@ private:
   std::vector<unsigned int> glu_detId    ;
   std::vector<int> glu_monoIdx  ;
   std::vector<int> glu_stereoIdx;
+  std::vector<std::vector<int> > glu_seeIdx;
   std::vector<float> glu_x    ;
   std::vector<float> glu_y    ;
   std::vector<float> glu_z    ;
@@ -631,6 +636,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("pix_isBarrel"  , &pix_isBarrel );
     t->Branch("pix_lay"       , &pix_lay      );
     t->Branch("pix_detId"     , &pix_detId    );
+    t->Branch("pix_trkIdx"    , &pix_trkIdx   );
+    if(includeSeeds_) {
+      t->Branch("pix_seeIdx"    , &pix_seeIdx   );
+    }
     t->Branch("pix_simTrkIdx" , &pix_simTrkIdx);
     t->Branch("pix_particle"  , &pix_particle );
     t->Branch("pix_process"   , &pix_process  );
@@ -656,6 +665,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("str_det"       , &str_det      );
     t->Branch("str_lay"       , &str_lay      );
     t->Branch("str_detId"     , &str_detId    );
+    t->Branch("str_trkIdx"    , &str_trkIdx   );
+    if(includeSeeds_) {
+      t->Branch("str_seeIdx"    , &str_seeIdx   );
+    }
     t->Branch("str_simTrkIdx" , &str_simTrkIdx);
     t->Branch("str_particle"  , &str_particle );
     t->Branch("str_process"   , &str_process  );
@@ -682,6 +695,9 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("glu_detId"     , &glu_detId    );
     t->Branch("glu_monoIdx"   , &glu_monoIdx  );
     t->Branch("glu_stereoIdx" , &glu_stereoIdx);
+    if(includeSeeds_) {
+      t->Branch("glu_seeIdx"    , &glu_seeIdx   );
+    }
     t->Branch("glu_x"         , &glu_x        );
     t->Branch("glu_y"         , &glu_y        );
     t->Branch("glu_z"         , &glu_z        );
@@ -840,6 +856,8 @@ void TrackingNtuple::clearVariables() {
   pix_isBarrel .clear();
   pix_lay      .clear();
   pix_detId    .clear();
+  pix_trkIdx   .clear();
+  pix_seeIdx   .clear();
   pix_simTrkIdx.clear();
   pix_particle .clear();
   pix_process  .clear();
@@ -865,6 +883,8 @@ void TrackingNtuple::clearVariables() {
   str_det      .clear();
   str_lay      .clear();
   str_detId    .clear();
+  str_trkIdx   .clear();
+  str_seeIdx   .clear();
   str_simTrkIdx.clear();
   str_particle .clear();
   str_process  .clear();
@@ -891,6 +911,7 @@ void TrackingNtuple::clearVariables() {
   glu_detId    .clear();
   glu_monoIdx  .clear();
   glu_stereoIdx.clear();
+  glu_seeIdx   .clear();
   glu_x        .clear();
   glu_y        .clear();
   glu_z        .clear();
@@ -1193,6 +1214,8 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_isBarrel .push_back( hitId.subdetId()==1 );
       pix_lay      .push_back( lay );
       pix_detId    .push_back( hitId.rawId() );
+      pix_trkIdx   .emplace_back(); // filled in fillTracks
+      pix_seeIdx   .emplace_back(); // filled in fillSeeds
       pix_simTrkIdx.push_back( simHitData.matchingTp );
       pix_particle .push_back( simHitData.particleType );
       pix_process  .push_back( simHitData.processType );
@@ -1252,6 +1275,8 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_det      .resize(totalStripHits);
   str_lay      .resize(totalStripHits);
   str_detId    .resize(totalStripHits);
+  str_trkIdx   .resize(totalStripHits); // filled in fillTracks
+  str_seeIdx   .resize(totalStripHits); // filled in fillSeeds
   str_simTrkIdx.resize(totalStripHits);
   str_particle .resize(totalStripHits);
   str_process  .resize(totalStripHits);
@@ -1350,6 +1375,7 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
       glu_detId    .push_back( hitId.rawId() );
       glu_monoIdx  .push_back( hit->monoHit().cluster().key() );
       glu_stereoIdx.push_back( hit->stereoHit().cluster().key() );
+      glu_seeIdx   .emplace_back(); // filled in fillSeeds
       glu_x        .push_back( ttrh->globalPosition().x() );
       glu_y        .push_back( ttrh->globalPosition().y() );
       glu_z        .push_back( ttrh->globalPosition().z() );
@@ -1443,6 +1469,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       const float phi = seedFitOk ? seedTrack.phi() : 0;
       const int nHits = seedTrack.numberOfValidHits();
 
+      const auto seedIndex = see_fitok.size();
+
       see_fitok   .push_back(seedFitOk);
 
       see_px      .push_back( seedFitOk ? seedTrack.px() : 0 );
@@ -1487,8 +1515,12 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	if (subid == (int) PixelSubdetector::PixelBarrel || subid == (int) PixelSubdetector::PixelEndcap) {
 	  const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
           const auto& clusterRef = bhit->firstClusterRef();
-          if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "seed");
-          hitIdx.push_back( clusterRef.cluster_pixel().key() );
+          const auto clusterKey = clusterRef.cluster_pixel().key();
+          if(includeAllHits_) {
+            checkProductID(hitProductIds, clusterRef.id(), "seed");
+            pix_seeIdx[clusterKey].push_back(seedIndex);
+          }
+          hitIdx.push_back( clusterKey );
           hitType.push_back( HitPixel );
 	} else {
 	  if (trackerHitRTTI::isMatched(*recHit)) {
@@ -1501,13 +1533,19 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	    int stereoIdx = matchedHit->stereoClusterRef().key();
 
             std::vector<std::pair<int,int> >::const_iterator pos = find( monoStereoClusterList.begin(), monoStereoClusterList.end(), std::make_pair(monoIdx,stereoIdx) );
-            hitIdx.push_back( pos - monoStereoClusterList.begin() );
+            const auto gluedIndex = std::distance(monoStereoClusterList.begin(), pos);
+            if(includeAllHits_) glu_seeIdx[gluedIndex].push_back(seedIndex);
+            hitIdx.push_back( gluedIndex );
             hitType.push_back( HitGlued );
 	  } else {
 	    const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
             const auto& clusterRef = bhit->firstClusterRef();
-            if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "seed");
-            hitIdx.push_back( clusterRef.cluster_strip().key() );
+            const auto clusterKey = clusterRef.cluster_strip().key();
+            if(includeAllHits_) {
+              checkProductID(hitProductIds, clusterRef.id(), "seed");
+              str_seeIdx[clusterKey].push_back(seedIndex);
+            }
+            hitIdx.push_back( clusterKey );
             hitType.push_back( HitStrip );
 	  }
 	}
@@ -1597,7 +1635,8 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
   edm::EDConsumerBase::Labels labels;
   labelsForToken(trackToken_, labels);
   LogTrace("TrackingNtuple") << "NEW TRACK LABEL: " << labels.module;
-  for(const auto& itTrack: tracks) {
+  for(size_t iTrack = 0; iTrack<tracks.size(); ++iTrack) {
+    const auto& itTrack = tracks[iTrack];
     int nSimHits = 0;
     bool isSimMatched = false;
     std::vector<float> sharedFraction;
@@ -1693,7 +1732,11 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
         LogTrace("TrackingNtuple") << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
                                    << " cluster=" << clusterKey
                                    << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi();
-        if(includeAllHits_) checkProductID(hitProductIds, clusterRef.id(), "track");
+        if(includeAllHits_) {
+          checkProductID(hitProductIds, clusterRef.id(), "track");
+          if(isPixel) pix_trkIdx[clusterKey].push_back(iTrack);
+          else        str_trkIdx[clusterKey].push_back(iTrack);
+        }
 
         hitIdx.push_back(clusterKey);
       } else  {

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -334,7 +334,9 @@ private:
   edm::LuminosityBlockNumber_t ev_lumi;
   edm::EventNumber_t ev_event;
 
-  //tracks
+  ////////////////////
+  // tracks
+  // (first) index runs through tracks
   std::vector<float> trk_px       ;
   std::vector<float> trk_py       ;
   std::vector<float> trk_pz       ;
@@ -363,11 +365,13 @@ private:
   std::vector<unsigned int> trk_stopReason;
   std::vector<short> trk_isHP    ;
   std::vector<int> trk_seedIdx ;
-  std::vector<std::vector<float> > trk_shareFrac;
-  std::vector<std::vector<int> > trk_simTrkIdx;
-  std::vector<std::vector<int> > trk_hitIdx;
-  std::vector<std::vector<int> > trk_hitType;
-  //sim tracks
+  std::vector<std::vector<float> > trk_shareFrac; // second index runs through matched TrackingParticles
+  std::vector<std::vector<int> > trk_simTrkIdx;   // second index runs through matched TrackingParticles
+  std::vector<std::vector<int> > trk_hitIdx;      // second index runs through hits
+  std::vector<std::vector<int> > trk_hitType;     // second index runs through hits
+  ////////////////////
+  // sim tracks
+  // (first) index runs through TrackingParticles
   std::vector<int>   sim_event    ;
   std::vector<int>   sim_bunchCrossing;
   std::vector<int>   sim_pdgId    ;
@@ -386,26 +390,28 @@ private:
   std::vector<unsigned int> sim_nLay;
   std::vector<unsigned int> sim_nPixelLay;
   std::vector<unsigned int> sim_n3DLay  ;
-  std::vector<std::vector<int> > sim_trkIdx  ;
-  std::vector<std::vector<float> > sim_shareFrac;
+  std::vector<std::vector<int> > sim_trkIdx;      // second index runs through matched tracks
+  std::vector<std::vector<float> > sim_shareFrac; // second index runs through matched tracks
   std::vector<int> sim_parentVtxIdx;
-  std::vector<std::vector<int> > sim_decayVtxIdx;
-  std::vector<std::vector<int> > sim_hitIdx;
-  std::vector<std::vector<int> > sim_hitType;
-  //pixels: reco and sim hits
+  std::vector<std::vector<int> > sim_decayVtxIdx; // second index runs through decay vertices
+  std::vector<std::vector<int> > sim_hitIdx;      // second index runs through induced reco hits
+  std::vector<std::vector<int> > sim_hitType;     // second index runs through induced reco hits
+  ////////////////////
+  // pixel hits
+  // (first) index runs through hits
   std::vector<short> pix_isBarrel ;
   std::vector<unsigned int> pix_lay      ;
   std::vector<unsigned int> pix_detId    ;
-  std::vector<std::vector<int> > pix_trkIdx;
-  std::vector<std::vector<int> > pix_seeIdx;
-  std::vector<std::vector<int> > pix_simTrkIdx;
-  std::vector<std::vector<int> > pix_particle ;
-  std::vector<std::vector<int> > pix_process  ;
-  std::vector<std::vector<float> > pix_xsim ;
-  std::vector<std::vector<float> > pix_ysim ;
-  std::vector<std::vector<float> > pix_zsim ;
-  std::vector<std::vector<float> > pix_eloss;
-  std::vector<std::vector<float> > pix_tof;
+  std::vector<std::vector<int> > pix_trkIdx;    // second index runs through tracks containing this hit
+  std::vector<std::vector<int> > pix_seeIdx;    // second index runs through seeds containing this hit
+  std::vector<std::vector<int> > pix_simTrkIdx; // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<int> > pix_particle;  // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<int> > pix_process;   // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > pix_xsim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > pix_ysim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > pix_zsim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > pix_eloss;   // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > pix_tof;     // second index runs through TrackingParticles inducing this hit
   std::vector<float> pix_x    ;
   std::vector<float> pix_y    ;
   std::vector<float> pix_z    ;
@@ -417,22 +423,24 @@ private:
   std::vector<float> pix_zx   ;
   std::vector<float> pix_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> pix_bbxi ;
-  //strips: reco and sim hits
+  ////////////////////
+  // strip hits
+  // (first) index runs through hits
   std::vector<short> str_isBarrel ;
   std::vector<short> str_isStereo ;
   std::vector<unsigned int> str_det      ;
   std::vector<unsigned int> str_lay      ;
   std::vector<unsigned int> str_detId    ;
-  std::vector<std::vector<int> > str_trkIdx;
-  std::vector<std::vector<int> > str_seeIdx;
-  std::vector<std::vector<int> > str_simTrkIdx;
-  std::vector<std::vector<int> > str_particle ;
-  std::vector<std::vector<int> > str_process  ;
-  std::vector<std::vector<float> > str_xsim ;
-  std::vector<std::vector<float> > str_ysim ;
-  std::vector<std::vector<float> > str_zsim ;
-  std::vector<std::vector<float> > str_eloss;
-  std::vector<std::vector<float> > str_tof  ;
+  std::vector<std::vector<int> > str_trkIdx;    // second index runs through tracks containing this hit
+  std::vector<std::vector<int> > str_seeIdx;    // second index runs through seeds containing this hitw
+  std::vector<std::vector<int> > str_simTrkIdx; // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<int> > str_particle;  // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<int> > str_process;   // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > str_xsim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > str_ysim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > str_zsim;    // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > str_eloss;   // second index runs through TrackingParticles inducing this hit
+  std::vector<std::vector<float> > str_tof;     // second index runs through TrackingParticles inducing this hit
   std::vector<float> str_x    ;
   std::vector<float> str_y    ;
   std::vector<float> str_z    ;
@@ -444,14 +452,16 @@ private:
   std::vector<float> str_zx   ;
   std::vector<float> str_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi ;
-  //strip matched hits: reco hits
+  ////////////////////
+  // strip matched hits
+  // (first) index runs through hits
   std::vector<short> glu_isBarrel ;
   std::vector<unsigned int> glu_det      ;
   std::vector<unsigned int> glu_lay      ;
   std::vector<unsigned int> glu_detId    ;
   std::vector<int> glu_monoIdx  ;
   std::vector<int> glu_stereoIdx;
-  std::vector<std::vector<int> > glu_seeIdx;
+  std::vector<std::vector<int> > glu_seeIdx; // second index runs through seeds containing this hit
   std::vector<float> glu_x    ;
   std::vector<float> glu_y    ;
   std::vector<float> glu_z    ;
@@ -463,14 +473,17 @@ private:
   std::vector<float> glu_zx   ;
   std::vector<float> glu_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi ;
-  //beam spot
+  ////////////////////
+  // beam spot
   float bsp_x;
   float bsp_y;
   float bsp_z;
   float bsp_sigmax;
   float bsp_sigmay;
   float bsp_sigmaz;
-  //seeds
+  ////////////////////
+  // seeds
+  // (first) index runs through seeds
   std::vector<short> see_fitok     ;
   std::vector<float> see_px       ;
   std::vector<float> see_py       ;
@@ -492,15 +505,17 @@ private:
   std::vector<unsigned int> see_nGlued  ;
   std::vector<unsigned int> see_nStrip  ;
   std::vector<unsigned int> see_algo    ;
-  std::vector<std::vector<float> > see_shareFrac;
-  std::vector<std::vector<int> > see_simTrkIdx;
-  std::vector<std::vector<int> > see_hitIdx;
-  std::vector<std::vector<int> > see_hitType;
-  //seed algo offset
+  std::vector<std::vector<float> > see_shareFrac; // second index runs through matched TrackingParticles
+  std::vector<std::vector<int> > see_simTrkIdx;   // second index runs through matched TrackingParticles
+  std::vector<std::vector<int> > see_hitIdx;      // second index runs through hits
+  std::vector<std::vector<int> > see_hitType;     // second index runs through hits
+  //seed algo offset, index runs through iterations
   std::vector<unsigned int> see_offset  ;
 
 
+  ////////////////////
   // Vertices
+  // (first) index runs through vertices
   std::vector<float> vtx_x;
   std::vector<float> vtx_y;
   std::vector<float> vtx_z;
@@ -511,17 +526,19 @@ private:
   std::vector<float> vtx_chi2;
   std::vector<short> vtx_fake;
   std::vector<short> vtx_valid;
-  std::vector<std::vector<int> > vtx_trkIdx;
+  std::vector<std::vector<int> > vtx_trkIdx; // second index runs through tracks used in the vertex fit
 
+  ////////////////////
   // Tracking vertices
+  // (first) index runs through TrackingVertices
   std::vector<int>   simvtx_event;
   std::vector<int>   simvtx_bunchCrossing;
   std::vector<unsigned int> simvtx_processType; // only from first SimVertex of TrackingVertex
   std::vector<float> simvtx_x;
   std::vector<float> simvtx_y;
   std::vector<float> simvtx_z;
-  std::vector<std::vector<int> > simvtx_sourceSimIdx;
-  std::vector<std::vector<int> > simvtx_daughterSimIdx;
+  std::vector<std::vector<int> > simvtx_sourceSimIdx;   // second index runs through source TrackingParticles
+  std::vector<std::vector<int> > simvtx_daughterSimIdx; // second index runs through daughter TrackingParticles
   std::vector<int> simpv_idx;
 };
 

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseTrackingNtuple(process):
+    process.load("Validation.RecoTrack.trackingNtuple_cff")
+    process.TFileService = cms.Service("TFileService",
+        fileName = cms.string('trackingNtuple.root')
+    )
+
+    if process.trackingNtuple.includeSeeds.value() and not hasattr(process, "reconstruction_step"):
+        raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+
+    # Replace validation_step with ntuplePath
+    if not hasattr(process, "validation_step"):
+        raise Exception("TrackingNtuple customise assumes process.validation_step exists")
+
+    # Bit of a hack but works
+    modifier = cms.Modifier()
+    modifier._setChosen()
+    modifier.toReplaceWith(process.validation_step, cms.EndPath(process.trackingNtupleSequence))
+
+    if hasattr(process, "prevalidation_step"):
+        modifier.toReplaceWith(process.prevalidation_step, cms.Path())
+
+    # Remove all output modules
+    for outputModule in process.outputModules_().itervalues():
+        for path in process.paths_().itervalues():
+            path.remove(outputModule)
+        for path in process.endpaths_().itervalues():
+            path.remove(outputModule)
+        
+
+    return process

--- a/Validation/RecoTrack/python/plotting/ntuple.py
+++ b/Validation/RecoTrack/python/plotting/ntuple.py
@@ -1,19 +1,34 @@
 import ROOT
 
 class _Collection(object):
+    """Adaptor class representing a collection of objects.
+
+    Concrete collection classes should inherit from this class.
+
+    """
     def __init__(self, tree, sizeBranch, objclass):
+        """Constructor.
+
+        Arguments:
+        tree        -- TTree object
+        sizeBranch  -- Name of the branch to be used in size()
+        objclass    -- Class to be used for the objects in __getitem__()
+        """
         super(_Collection, self).__init__()
         self._tree = tree
         self._sizeBranch = sizeBranch
         self._objclass = objclass
 
     def size(self):
+        """Number of objects in the collection."""
         return int(getattr(self._tree, self._sizeBranch).size())
 
     def __len__(self):
+        """Number of objects in the collection."""
         return self.size()
 
     def __getitem__(self, index):
+        """Get object 'index' in the collection."""
         return self._objclass(self._tree, index)
 
     def __iter__(self):
@@ -22,59 +37,107 @@ class _Collection(object):
             yield self._objclass(self._tree, index)
 
 class _Object(object):
+    """Adaptor class representing a single object in a collection.
+
+    The member variables of the object are obtained from the branches
+    with common prefix and a given index.
+
+    Concrete object classes should inherit from this class.
+    """
     def __init__(self, tree, index, prefix):
+        """Constructor.
+
+        Arguments:
+        tree   -- TTree object
+        index  -- Index for this object
+        prefix -- Prefix of the branchs
+        """
         super(_Object, self).__init__()
         self._tree = tree
         self._index = index
         self._prefix = prefix
 
     def __getattr__(self, attr):
+        """Return object member variable.
+
+        'attr' is translated as a branch in the TTree (<prefix>_<attr>).
+        """
         self._checkIsValid()
         return lambda: getattr(self._tree, self._prefix+"_"+attr)[self._index]
 
     def _checkIsValid(self):
+        """Raise an exception if the object index is not valid."""
         if not self.isValid():
             raise Exception("%s is not valid" % self.__class__.__name__)
 
     def isValid(self):
+        """Check if object index is valid."""
         return self._index != -1
 
     def index(self):
+        """Return object index."""
         return self._index
 
 class _HitObject(_Object):
+    """Adaptor class for pixel/strip hit objects."""
     def __init__(self, tree, index, prefix):
+        """Constructor.
+
+        Arguments:
+        tree   -- TTree object
+        index  -- Index for this object
+        prefix -- Prefix of the branchs
+        """
+        """Constructor
+        """
         super(_HitObject, self).__init__(tree, index, prefix)
 
     def ntracks(self):
+        """Returns number of tracks containing this hit."""
         self._checkIsValid()
         return getattr(self._tree, self._prefix+"_trkIdx")[self._index].size()
 
     def tracks(self):
+        """Returns generator for tracks containing this hit.
+
+        The generator returns Track objects
+        """
         self._checkIsValid()
         for itrack in getattr(self._tree, self._prefix+"_trkIdx")[self._index]:
             yield Track(self._tree, itrack)
 
     def nseeds(self):
+        """Returns number of seeds containing this hit."""
         self._checkIsValid()
         return getattr(self._tree, self._prefix+"_seeIdx")[self._index].size()
 
     def seeds(self):
+        """Returns generator for tracks containing this hit.
+
+        The generator returns Seed objects
+        """
         self._checkIsValid()
         for iseed in getattr(self._tree, self._prefix+"_seeIdx")[self._index]:
             yield Seed(self._tree, iseed)
 
 
 class _HitAdaptor(object):
+    """Adaptor class for objects containing hits (e.g. tracks)"""
     def __init__(self):
         super(_HitAdaptor, self).__init__()
 
     def _hits(self):
-        self._checkIsValid()
+        """Internal method to generate pairs of hit index and type."""
         for ihit, hitType in zip(self.hitIdx(), self.hitType()):
             yield (ihit, hitType)
 
     def hits(self):
+        """Returns generator for hits.
+
+        Generator returns PixelHit/StripHit/GluedHit depending on the
+        hit type.
+
+        """
         for ihit, hitType in self._hits():
             if hitType == 0:
                 yield PixelHit(self._tree, ihit)
@@ -86,6 +149,7 @@ class _HitAdaptor(object):
                 raise Exception("Unknown hit type %d" % hitType)
 
     def pixelHits(self):
+        """Returns generator for pixel hits."""
         self._checkIsValid()
         for ihit, hitType in self._hits():
             if hitType != 0:
@@ -93,6 +157,7 @@ class _HitAdaptor(object):
             yield PixelHit(self._tree, ihit)
 
     def stripHits(self):
+        """Returns generator for strip hits."""
         self._checkIsValid()
         for ihit, hitType in self._hits():
             if hitType != 1:
@@ -100,6 +165,7 @@ class _HitAdaptor(object):
             yield StripHit(self._tree, ihit)
 
     def gluedHits(self):
+        """Returns generator for matched strip hits."""
         self._checkIsValid()
         for ihit, hitType in self._hits():
             if hitType != 2:
@@ -107,24 +173,44 @@ class _HitAdaptor(object):
             yield GluedHit(self._tree, ihit)
 
 class _TrackingParticleMatchAdaptor(object):
+    """Adaptor class for objects matched to TrackingParticles."""
     def __init__(self):
         super(_TrackingParticleMatchAdaptor, self).__init__()
 
     def _nMatchedTrackingParticles(self):
+        """Internal method to get the number of matched TrackingParticles."""
         return getattr(self._tree, self._prefix+"_simTrkIdx")[self._index].size()
 
     def nMatchedTrackingParticles(self):
+        """Returns the number of matched TrackingParticles."""
         self._checkIsValid()
         return self._nMatchedTrackingParticles()
 
     def matchedTrackingParticleInfos(self):
+        """Returns a generator for matched TrackingParticles.
+
+        The generator returns TrackingParticleMatchInfo objects.
+
+        """
         self._checkIsValid()
         for imatch in xrange(self._nMatchedTrackingParticles()):
             yield TrackingParticleMatchInfo(self._tree, self._index, imatch, self._prefix)
 
 ##########
 class TrackingNtuple(object):
+    """Class abstracting the whole ntuple/TTree.
+
+    Main benefit is to provide nice interface for
+    - iterating over events
+    - querying whether hit/seed information exists
+    """
     def __init__(self, fileName, tree="trackingNtuple/tree"):
+        """Constructor.
+
+        Arguments:
+        fileName -- String for path to the ROOT file
+        tree     -- Name of the TTree object inside the ROOT file (default: 'trackingNtuple/tree')
+        """
         super(TrackingNtuple, self).__init__()
         self._file = ROOT.TFile.Open(fileName)
         self._tree = self._file.Get(tree)
@@ -137,12 +223,19 @@ class TrackingNtuple(object):
         return self._entries
 
     def hasHits(self):
+        """Returns true if the ntuple has hit information."""
         return hasattr(self._tree, "pix_isBarrel")
 
     def hasSeeds(self):
+        """Returns true if the ntuple has seed information."""
         return hasattr(self._tree, "see_fitok")
 
     def __iter__(self):
+        """Returns generator for iterating over TTree entries (events)
+
+        Generator returns Event objects.
+
+        """
         for jentry in xrange(self._entries):
             # get the next tree in the chain and verify
             ientry = self._tree.LoadTree( jentry )
@@ -155,7 +248,18 @@ class TrackingNtuple(object):
 
 ##########
 class Event(object):
+    """Class abstracting a single event.
+
+    Main benefit is to provide nice interface to get various objects
+    or collections of objects.
+    """
     def __init__(self, tree, entry):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        entry -- Entry number in the tree
+        """
         super(Event, self).__init__()
         self._tree = tree
         self._entry = entry
@@ -167,83 +271,158 @@ class Event(object):
         return self._tree.event
 
     def lumi(self):
+        """Returns lumisection number."""
         return self._tree.lumi
 
     def run(self):
+        """Returns run number."""
         return self._tree.run
 
+    def beamspot(self):
+        """Returns BeamSpot object."""
+        return BeamSpot(self._tree)
+
     def tracks(self):
+        """Returns Tracks object."""
         return Tracks(self._tree)
 
     def pixelHits(self):
+        """Returns PixelHits object."""
         return PixelHits(self._tree)
 
     def stripHits(self):
+        """Returns StripHits object."""
         return StripHits(self._tree)
 
     def gluedHits(self):
+        """Returns GluedHits object."""
         return GluedHits(self._tree)
 
     def seeds(self):
+        """Returns Seeds object."""
         return Seeds(self._tree)
 
     def trackingParticles(self):
+        """Returns TrackingParticles object."""
         return TrackingParticles(self._tree)
 
     def vertices(self):
+        """Returns Vertices object."""
         return Vertices(self._tree)
 
     def trackingVertices(self):
+        """Returns TrackingVertices object."""
         return TrackingVertices(self._tree)
 
 ##########
 class BeamSpot(object):
+    """Class representing the beam spot."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(BeamSpot, self).__init__()
         self._tree = tree
         self._prefix = "bsp"
 
     def __getattr__(self, attr):
+        """Return object member variable.
+
+        'attr' is translated as a branch in the TTree (bsp_<attr>).
+        """
         return lambda: getattr(self._tree, self._prefix+"_"+attr)
 
 ##########
 class TrackingParticleMatchInfo(_Object):
+    """Class representing a match to a TrackingParticle.
+
+    The point of this class is to provide, in addition to the matched
+    TrackingParticle, also other information about the match (e.g.
+    shared hit fraction for tracks/seeds or SimHit information for hits.
+    """
     def __init__(self, tree, index, tpindex, prefix):
+        """Constructor.
+
+        Arguments:
+        tree    -- TTree object
+        index   -- Index of the object (track/seed/hit) matched to TrackingParticle
+        tpindex -- Index of the TrackingParticle match (second index in _simTrkIdx branch)
+        prefix  -- String for prefix of the object (track/seed/hit) matched to TrackingParticle
+        """
         super(TrackingParticleMatchInfo, self).__init__(tree, index, prefix)
         self._tpindex = tpindex
 
     def trackingParticle(self):
+        """Returns matched TrackingParticle."""
         self._checkIsValid()
         return TrackingParticle(self._tree, getattr(self._tree, self._prefix+"_simTrkIdx")[self._index][self._tpindex])
 
 class TrackMatchInfo(_Object):
-    def __init__(self, tree, index, tpindex, prefix, postfix):
+    """Class representing a match to a Track.
+
+    The point of this class is to provide, in addition to the matched
+    Track, also other information about the match (e.g. shared hit fraction.
+    """
+    def __init__(self, tree, index, trkindex, prefix, postfix):
+        """Constructor.
+
+        Arguments:
+        tree     -- TTree object
+        index    -- Index of the object (TrackingParticle) matched to track
+        trkindex -- Index of the track match (second index in _trkIdx branch)
+        prefix   -- String for prefix of the object (TrackingParticle) matched to track
+        """
         super(TrackMatchInfo, self).__init__(tree, index, prefix)
-        self._tpindex = tpindex
+        self._trkindex = trkindex
 
     def track(self):
+        """Returns matched Track."""
         self._checkIsValid()
-        return Track(self._tree, getattr(self._tree, self._prefix+"_trkIdx")[self._index][self._tpindex])
+        return Track(self._tree, getattr(self._tree, self._prefix+"_trkIdx")[self._index][self._trkindex])
 
 ##########
 class Track(_Object, _HitAdaptor, _TrackingParticleMatchAdaptor):
+    """Class presenting a track."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the track
+        """
         super(Track, self).__init__(tree, index, "trk")
 
     def seed(self):
+        """Returns Seed of the track."""
         self._checkIsValid()
         return Seed(self._tree, self._tree.trk_seedIdx[self._index])
 
 class Tracks(_Collection):
+    """Class presenting a collection of tracks."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(Tracks, self).__init__(tree, "trk_pt", Track)
 
 ##########
 class PixelHit(_HitObject, _TrackingParticleMatchAdaptor):
+    """Class representing a pixel hit."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the hit
+        """
         super(PixelHit, self).__init__(tree, index, "pix")
 
     def layerStr(self):
+        """Returns a string describing the layer of the hit."""
         if not self.isValid():
             return "Invalid"
         if self._tree.pix_isBarrel[self._index]:
@@ -253,52 +432,93 @@ class PixelHit(_HitObject, _TrackingParticleMatchAdaptor):
         return "%s%d" % (subdet, self._tree.pix_lay[self._index])
 
 class PixelHits(_Collection):
+    """Class presenting a collection of pixel hits."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(PixelHits, self).__init__(tree, "pix_isBarrel", PixelHit)
 
 ##########
 class StripHit(_HitObject, _TrackingParticleMatchAdaptor):
+    """Class representing a strip hit."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the hit
+        """
         super(StripHit, self).__init__(tree, index, "str")
 
     def layerStr(self):
+        """Returns a string describing the layer of the hit."""
         if not self.isValid():
             return "Invalid"
         return "%s%d" % ({3: "TIB", 4: "TID", 5: "TOB", 6: "TEC"}[self._tree.str_det[self._index]],
                          self._tree.str_lay[self._index])
 
 class StripHits(_Collection):
+    """Class presenting a collection of strip hits."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(StripHits, self).__init__(tree, "str_isBarrel", StripHit)
 
 ##########
 class GluedHit(_Object):
+    """Class representing a matched strip hit."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the hit
+        """
         super(GluedHit, self).__init__(tree, index, "glu")
 
     def monoHit(self):
+        """Returns a StripHit for the mono hit."""
         self._checkIsValid()
         return StripHit(self._tree, self._tree.glu_monoIdx[self._index])
 
     def stereoHit(self):
+        """Returns a StripHit for the stereo hit."""
         self._checkIsValid()
         return StripHit(self._tree, self._tree.glu_stereoIdx[self._index])
 
     def nseeds(self):
+        """Returns the number of seeds containing this hit."""
         self._checkIsValid()
         return self._tree.glu_seeIdx[self._index].size()
 
     def seeds(self):
+        """Returns generator for seeds containing this hit.
+
+        The generator returns Seed objects
+        """
         self._checkIsValid()
         for iseed in self._tree.glu_seeIdx[self._index]:
             yield Seed(self._tree, iseed)
 
 class GluedHits(_Collection):
+    """Class presenting a collection of matched strip hits."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(GluedHits, self).__init__(tree, "glu_isBarrel", GluedHit)
 
 ##########
 def _seedOffsetForAlgo(tree, algo):
+    """Internal function for returning a pair of indices for the beginning of seeds of a given 'algo', and the one-beyond-last index of the seeds."""
     for ioffset, offset in enumerate(tree.see_offset):
         if tree.see_algo[offset] == algo:
             next_offset = tree.see_offset[ioffset+1] if ioffset < tree.see_offset.size()-1 else tree.see_algo.size()
@@ -306,10 +526,21 @@ def _seedOffsetForAlgo(tree, algo):
     return (-1, -1)
 
 class Seed(_Object, _HitAdaptor, _TrackingParticleMatchAdaptor):
+    """Class presenting a seed."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the seed
+        """
         super(Seed, self).__init__(tree, index, "see")
 
     def indexWithinAlgo(self):
+        """Returns the seed index within the seeds of the same algo.
+
+        In case of errors, -1 is returned.
+        """
         self._checkIsValid()
         algo = self._tree.see_algo[self._index]
         (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
@@ -318,89 +549,159 @@ class Seed(_Object, _HitAdaptor, _TrackingParticleMatchAdaptor):
         return self._index - offset
 
 class Seeds(_Collection):
+    """Class presenting a collection of seeds."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(Seeds, self).__init__(tree, "see_pt", Seed)
 
     def nSeedsForAlgo(self, algo):
+        """Returns the number of seeds for a given 'algo'."""
         (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
         return next_offset - offset
 
     def seedsForAlgo(self, algo):
+        """Returns gnerator iterating over the seeds of a given 'algo'.
+
+        Generator returns Seed object.
+        """
         (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
         for isee in xrange(offset, next_offset):
             yield Seed(self._tree, isee)
 
 ##########
 class TrackingParticle(_Object, _HitAdaptor):
+    """Class representing a TrackingParticle."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the TrackingParticle
+        """
         super(TrackingParticle, self).__init__(tree, index, "sim")
 
     def _nMatchedTracks(self):
+        """Internal function to get the number of matched tracks."""
         return self._tree.sim_trkIdx[self._index].size()
 
     def nMatchedTracks(self):
+        """Returns the number of matched tracks."""
         self._checkIsValid()
         return self._nMatchedTracks()
 
     def matchedTrackInfos(self):
+        """Returns a generator for matched tracks.
+
+        The generator returns TrackMatchInfo objects.
+        """
         self._checkIsValid()
         for imach in xrange(self._nMatchedTracks()):
             yield TrackMatchInfo(self._tree, self._index, imatch, self._prefix)
 
     def parentVertex(self):
+        """Returns the parent TrackingVertex."""
         self._checkIsValid()
         return TrackingVertex(self._tree, self._tree.sim_parentVtxIdx[self._index])
 
     def decayVertices(self):
+        """Returns a generator for decay vertices.
+
+        The generator returns TrackingVertex objects.
+        """
         self._checkIsValid()
         for ivtx in self._tree.sim_decayVtxIdx[self._index]:
             yield TrackingVertex(self._tree, ivtx)
 
 class TrackingParticles(_Collection):
+    """Class presenting a collection of TrackingParticles."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(TrackingParticles, self).__init__(tree, "sim_pt", TrackingParticle)
-        
+
 ##########
 class Vertex(_Object):
+    """Class presenting a primary vertex."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the vertex
+        """
         super(Vertex, self).__init__(tree, index, "vtx")
 
     def nTracks(self):
+        """Returns the number of tracks used in the vertex fit."""
         self._checkIsValid()
         return self._tree.vtx_trkIdx[self._index].size()
 
     def tracks(self):
+        """Returns a generator for the tracks used in the vertex fit.
+
+        The generator returns Track object.
+        """
         self._checkIsValid()
         for itrk in self._tree.vtx_trkIdx[self._index]:
             yield Track(self._tree, itrk)
 
 class Vertices(_Collection):
+    """Class presenting a collection of vertices."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(Vertices, self).__init__(tree, "vtx_valid", Vertex)
 
 ##########
 class TrackingVertex(_Object):
+    """Class representing a TrackingVertex."""
     def __init__(self, tree, index):
+        """Constructor.
+
+        Arguments:
+        tree  -- TTree object
+        index -- Index of the TrackingVertex
+        """
         super(TrackingVertex, self).__init__(tree, index, "simvtx")
 
     def nSourceTrackingParticles(self):
+        """Returns the number of source TrackingParticles."""
         self._checkIsValid()
         return self._tree.simvtx_sourceSimIdx[self._index].size()
 
     def nDaughterTrackingParticles(self):
+        """Returns the number of daughter TrackingParticles."""
         self._checkIsValid()
         return self._tree.simvtx_daughterSimIdx[self._index].size()
 
     def sourceTrackingParticles(self):
+        """Returns a generator for the source TrackingParticles."""
         self._checkIsValid()
         for isim in self._tree.simvtx_sourceSimIdx[self._index]:
             yield TrackingParticle(self._tree, isim)
 
     def daughterTrackingParticles(self):
+        """Returns a generator for the daughter TrackingParticles."""
         self._checkIsValid()
         for isim in self._tree.simvtx_daughterSimIdx[self._index]:
             yield TrackingParticle(self._tree, isim)
 
 class TrackingVertices(_Collection, TrackingVertex):
+    """Class presenting a collection of TrackingVertices."""
     def __init__(self, tree):
+        """Constructor.
+
+        Arguments:
+        tree -- TTree object
+        """
         super(TrackingVertex, self).__init__(tree, "simvtx_x")

--- a/Validation/RecoTrack/python/plotting/ntuple.py
+++ b/Validation/RecoTrack/python/plotting/ntuple.py
@@ -1,0 +1,406 @@
+import ROOT
+
+class _Collection(object):
+    def __init__(self, tree, sizeBranch, objclass):
+        super(_Collection, self).__init__()
+        self._tree = tree
+        self._sizeBranch = sizeBranch
+        self._objclass = objclass
+
+    def size(self):
+        return int(getattr(self._tree, self._sizeBranch).size())
+
+    def __len__(self):
+        return self.size()
+
+    def __getitem__(self, index):
+        return self._objclass(self._tree, index)
+
+    def __iter__(self):
+        """Returns generator for the objects."""
+        for index in xrange(self.size()):
+            yield self._objclass(self._tree, index)
+
+class _Object(object):
+    def __init__(self, tree, index, prefix):
+        super(_Object, self).__init__()
+        self._tree = tree
+        self._index = index
+        self._prefix = prefix
+
+    def __getattr__(self, attr):
+        self._checkIsValid()
+        return lambda: getattr(self._tree, self._prefix+"_"+attr)[self._index]
+
+    def _checkIsValid(self):
+        if not self.isValid():
+            raise Exception("%s is not valid" % self.__class__.__name__)
+
+    def isValid(self):
+        return self._index != -1
+
+    def index(self):
+        return self._index
+
+class _HitObject(_Object):
+    def __init__(self, tree, index, prefix):
+        super(_HitObject, self).__init__(tree, index, prefix)
+
+    def ntracks(self):
+        self._checkIsValid()
+        return getattr(self._tree, self._prefix+"_trkIdx")[self._index].size()
+
+    def tracks(self):
+        self._checkIsValid()
+        for itrack in getattr(self._tree, self._prefix+"_trkIdx")[self._index]:
+            yield Track(self._tree, itrack)
+
+    def nseeds(self):
+        self._checkIsValid()
+        return getattr(self._tree, self._prefix+"_seeIdx")[self._index].size()
+
+    def seeds(self):
+        self._checkIsValid()
+        for iseed in getattr(self._tree, self._prefix+"_seeIdx")[self._index]:
+            yield Seed(self._tree, iseed)
+
+
+class _HitAdaptor(object):
+    def __init__(self):
+        super(_HitAdaptor, self).__init__()
+
+    def _hits(self):
+        self._checkIsValid()
+        for ihit, hitType in zip(self.hitIdx(), self.hitType()):
+            yield (ihit, hitType)
+
+    def hits(self):
+        for ihit, hitType in self._hits():
+            if hitType == 0:
+                yield PixelHit(self._tree, ihit)
+            elif hitType == 1:
+                yield StripHit(self._tree, ihit)
+            elif hitType == 2:
+                yield GluedHit(self._tree, ihit)
+            else:
+                raise Exception("Unknown hit type %d" % hitType)
+
+    def pixelHits(self):
+        self._checkIsValid()
+        for ihit, hitType in self._hits():
+            if hitType != 0:
+                continue
+            yield PixelHit(self._tree, ihit)
+
+    def stripHits(self):
+        self._checkIsValid()
+        for ihit, hitType in self._hits():
+            if hitType != 1:
+                continue
+            yield StripHit(self._tree, ihit)
+
+    def gluedHits(self):
+        self._checkIsValid()
+        for ihit, hitType in self._hits():
+            if hitType != 2:
+                continue
+            yield GluedHit(self._tree, ihit)
+
+class _TrackingParticleMatchAdaptor(object):
+    def __init__(self):
+        super(_TrackingParticleMatchAdaptor, self).__init__()
+
+    def _nMatchedTrackingParticles(self):
+        return getattr(self._tree, self._prefix+"_simTrkIdx")[self._index].size()
+
+    def nMatchedTrackingParticles(self):
+        self._checkIsValid()
+        return self._nMatchedTrackingParticles()
+
+    def matchedTrackingParticleInfos(self):
+        self._checkIsValid()
+        for imatch in xrange(self._nMatchedTrackingParticles()):
+            yield TrackingParticleMatchInfo(self._tree, self._index, imatch, self._prefix)
+
+##########
+class TrackingNtuple(object):
+    def __init__(self, fileName, tree="trackingNtuple/tree"):
+        super(TrackingNtuple, self).__init__()
+        self._file = ROOT.TFile.Open(fileName)
+        self._tree = self._file.Get(tree)
+        self._entries = self._tree.GetEntriesFast()
+
+    def tree(self):
+        return self._tree
+
+    def nevents(self):
+        return self._entries
+
+    def hasHits(self):
+        return hasattr(self._tree, "pix_isBarrel")
+
+    def hasSeeds(self):
+        return hasattr(self._tree, "see_fitok")
+
+    def __iter__(self):
+        for jentry in xrange(self._entries):
+            # get the next tree in the chain and verify
+            ientry = self._tree.LoadTree( jentry )
+            if ientry < 0: break
+            # copy next entry into memory and verify
+            nb = self._tree.GetEntry( jentry )
+            if nb <= 0: continue
+
+            yield Event(self._tree, jentry)
+
+##########
+class Event(object):
+    def __init__(self, tree, entry):
+        super(Event, self).__init__()
+        self._tree = tree
+        self._entry = entry
+
+    def entry(self):
+        return self._entry
+
+    def event(self):
+        return self._tree.event
+
+    def lumi(self):
+        return self._tree.lumi
+
+    def run(self):
+        return self._tree.run
+
+    def tracks(self):
+        return Tracks(self._tree)
+
+    def pixelHits(self):
+        return PixelHits(self._tree)
+
+    def stripHits(self):
+        return StripHits(self._tree)
+
+    def gluedHits(self):
+        return GluedHits(self._tree)
+
+    def seeds(self):
+        return Seeds(self._tree)
+
+    def trackingParticles(self):
+        return TrackingParticles(self._tree)
+
+    def vertices(self):
+        return Vertices(self._tree)
+
+    def trackingVertices(self):
+        return TrackingVertices(self._tree)
+
+##########
+class BeamSpot(object):
+    def __init__(self, tree):
+        super(BeamSpot, self).__init__()
+        self._tree = tree
+        self._prefix = "bsp"
+
+    def __getattr__(self, attr):
+        return lambda: getattr(self._tree, self._prefix+"_"+attr)
+
+##########
+class TrackingParticleMatchInfo(_Object):
+    def __init__(self, tree, index, tpindex, prefix):
+        super(TrackingParticleMatchInfo, self).__init__(tree, index, prefix)
+        self._tpindex = tpindex
+
+    def trackingParticle(self):
+        self._checkIsValid()
+        return TrackingParticle(self._tree, getattr(self._tree, self._prefix+"_simTrkIdx")[self._index][self._tpindex])
+
+class TrackMatchInfo(_Object):
+    def __init__(self, tree, index, tpindex, prefix, postfix):
+        super(TrackMatchInfo, self).__init__(tree, index, prefix)
+        self._tpindex = tpindex
+
+    def track(self):
+        self._checkIsValid()
+        return Track(self._tree, getattr(self._tree, self._prefix+"_trkIdx")[self._index][self._tpindex])
+
+##########
+class Track(_Object, _HitAdaptor, _TrackingParticleMatchAdaptor):
+    def __init__(self, tree, index):
+        super(Track, self).__init__(tree, index, "trk")
+
+    def seed(self):
+        self._checkIsValid()
+        return Seed(self._tree, self._tree.trk_seedIdx[self._index])
+
+class Tracks(_Collection):
+    def __init__(self, tree):
+        super(Tracks, self).__init__(tree, "trk_pt", Track)
+
+##########
+class PixelHit(_HitObject, _TrackingParticleMatchAdaptor):
+    def __init__(self, tree, index):
+        super(PixelHit, self).__init__(tree, index, "pix")
+
+    def layerStr(self):
+        if not self.isValid():
+            return "Invalid"
+        if self._tree.pix_isBarrel[self._index]:
+            subdet = "BPix"
+        else:
+            subdet = "FPix"
+        return "%s%d" % (subdet, self._tree.pix_lay[self._index])
+
+class PixelHits(_Collection):
+    def __init__(self, tree):
+        super(PixelHits, self).__init__(tree, "pix_isBarrel", PixelHit)
+
+##########
+class StripHit(_HitObject, _TrackingParticleMatchAdaptor):
+    def __init__(self, tree, index):
+        super(StripHit, self).__init__(tree, index, "str")
+
+    def layerStr(self):
+        if not self.isValid():
+            return "Invalid"
+        return "%s%d" % ({3: "TIB", 4: "TID", 5: "TOB", 6: "TEC"}[self._tree.str_det[self._index]],
+                         self._tree.str_lay[self._index])
+
+class StripHits(_Collection):
+    def __init__(self, tree):
+        super(StripHits, self).__init__(tree, "str_isBarrel", StripHit)
+
+##########
+class GluedHit(_Object):
+    def __init__(self, tree, index):
+        super(GluedHit, self).__init__(tree, index, "glu")
+
+    def monoHit(self):
+        self._checkIsValid()
+        return StripHit(self._tree, self._tree.glu_monoIdx[self._index])
+
+    def stereoHit(self):
+        self._checkIsValid()
+        return StripHit(self._tree, self._tree.glu_stereoIdx[self._index])
+
+    def nseeds(self):
+        self._checkIsValid()
+        return self._tree.glu_seeIdx[self._index].size()
+
+    def seeds(self):
+        self._checkIsValid()
+        for iseed in self._tree.glu_seeIdx[self._index]:
+            yield Seed(self._tree, iseed)
+
+class GluedHits(_Collection):
+    def __init__(self, tree):
+        super(GluedHits, self).__init__(tree, "glu_isBarrel", GluedHit)
+
+##########
+def _seedOffsetForAlgo(tree, algo):
+    for ioffset, offset in enumerate(tree.see_offset):
+        if tree.see_algo[offset] == algo:
+            next_offset = tree.see_offset[ioffset+1] if ioffset < tree.see_offset.size()-1 else tree.see_algo.size()
+            return (offset, next_offset)
+    return (-1, -1)
+
+class Seed(_Object, _HitAdaptor, _TrackingParticleMatchAdaptor):
+    def __init__(self, tree, index):
+        super(Seed, self).__init__(tree, index, "see")
+
+    def indexWithinAlgo(self):
+        self._checkIsValid()
+        algo = self._tree.see_algo[self._index]
+        (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
+        if offset == -1: # algo not found
+            return -1
+        return self._index - offset
+
+class Seeds(_Collection):
+    def __init__(self, tree):
+        super(Seeds, self).__init__(tree, "see_pt", Seed)
+
+    def nSeedsForAlgo(self, algo):
+        (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
+        return next_offset - offset
+
+    def seedsForAlgo(self, algo):
+        (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
+        for isee in xrange(offset, next_offset):
+            yield Seed(self._tree, isee)
+
+##########
+class TrackingParticle(_Object, _HitAdaptor):
+    def __init__(self, tree, index):
+        super(TrackingParticle, self).__init__(tree, index, "sim")
+
+    def _nMatchedTracks(self):
+        return self._tree.sim_trkIdx[self._index].size()
+
+    def nMatchedTracks(self):
+        self._checkIsValid()
+        return self._nMatchedTracks()
+
+    def matchedTrackInfos(self):
+        self._checkIsValid()
+        for imach in xrange(self._nMatchedTracks()):
+            yield TrackMatchInfo(self._tree, self._index, imatch, self._prefix)
+
+    def parentVertex(self):
+        self._checkIsValid()
+        return TrackingVertex(self._tree, self._tree.sim_parentVtxIdx[self._index])
+
+    def decayVertices(self):
+        self._checkIsValid()
+        for ivtx in self._tree.sim_decayVtxIdx[self._index]:
+            yield TrackingVertex(self._tree, ivtx)
+
+class TrackingParticles(_Collection):
+    def __init__(self, tree):
+        super(TrackingParticles, self).__init__(tree, "sim_pt", TrackingParticle)
+        
+##########
+class Vertex(_Object):
+    def __init__(self, tree, index):
+        super(Vertex, self).__init__(tree, index, "vtx")
+
+    def nTracks(self):
+        self._checkIsValid()
+        return self._tree.vtx_trkIdx[self._index].size()
+
+    def tracks(self):
+        self._checkIsValid()
+        for itrk in self._tree.vtx_trkIdx[self._index]:
+            yield Track(self._tree, itrk)
+
+class Vertices(_Collection):
+    def __init__(self, tree):
+        super(Vertices, self).__init__(tree, "vtx_valid", Vertex)
+
+##########
+class TrackingVertex(_Object):
+    def __init__(self, tree, index):
+        super(TrackingVertex, self).__init__(tree, index, "simvtx")
+
+    def nSourceTrackingParticles(self):
+        self._checkIsValid()
+        return self._tree.simvtx_sourceSimIdx[self._index].size()
+
+    def nDaughterTrackingParticles(self):
+        self._checkIsValid()
+        return self._tree.simvtx_daughterSimIdx[self._index].size()
+
+    def sourceTrackingParticles(self):
+        self._checkIsValid()
+        for isim in self._tree.simvtx_sourceSimIdx[self._index]:
+            yield TrackingParticle(self._tree, isim)
+
+    def daughterTrackingParticles(self):
+        self._checkIsValid()
+        for isim in self._tree.simvtx_daughterSimIdx[self._index]:
+            yield TrackingParticle(self._tree, isim)
+
+class TrackingVertices(_Collection, TrackingVertex):
+    def __init__(self, tree):
+        super(TrackingVertex, self).__init__(tree, "simvtx_x")

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -1,0 +1,94 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+from RecoLocalTracker.Configuration.RecoLocalTracker_cff import *
+from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
+from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
+from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
+from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
+from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
+
+from Validation.RecoTrack.trackingNtuple_cfi import *
+from Validation.RecoTrack.TrackValidation_cff import *
+import Validation.RecoTrack.TrackValidation_cff as _TrackValidation_cff
+
+_includeHits = True
+#_includeHits = False
+
+_includeSeeds = True
+#_includeSeeds = False
+
+from PhysicsTools.RecoAlgos.trackingParticleSelector_cfi import *
+trackingParticlesIntime = trackingParticleSelector.clone(
+    signalOnly = False,
+    intimeOnly = True,
+    chargedOnly = False,
+    tip = 1e5,
+    lip = 1e5,
+    minRapidity = -10,
+    maxRapidity = 10,
+    ptMin = 0,
+)
+simHitTPAssocProducerIntime = simHitTPAssocProducer.clone(
+    trackingParticleSrc = "trackingParticlesIntime"
+)
+tpClusterProducerIntime = tpClusterProducer.clone(
+    trackingParticleSrc = "trackingParticlesIntime"
+)
+quickTrackAssociatorByHitsIntime = quickTrackAssociatorByHits.clone(
+    cluster2TPSrc = "tpClusterProducerIntime",
+)
+trackingNtuple.trackingParticles = "trackingParticlesIntime"
+trackingNtuple.clusterTPMap = "tpClusterProducerIntime"
+trackingNtuple.simHitTPMap = "simHitTPAssocProducerIntime"
+trackingNtuple.trackAssociator = "quickTrackAssociatorByHitsIntime"
+trackingNtuple.includeAllHits = _includeHits
+trackingNtuple.includeSeeds = _includeSeeds
+
+def _filterForNtuple(lst):
+    ret = []
+    for item in lst:
+        if "PreSplitting" in item:
+            continue
+        if "SeedsA" in item and item.replace("SeedsA", "SeedsB") in lst:
+            ret.append(item.replace("SeedsA", "Seeds"))
+            continue
+        if "SeedsB" in item:
+            continue
+        if "SeedsPair" in item and item.replace("SeedsPair", "SeedsTripl") in lst:
+            ret.append(item.replace("SeedsPair", "Seeds"))
+            continue
+        if "SeedsTripl" in item:
+            continue
+        ret.append(item)
+    return ret
+_seedProducers = _filterForNtuple(_TrackValidation_cff._seedProducers)
+_seedProducers_trackingPhase1 = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase1)
+
+(_seedSelectors, trackingNtupleSeedSelectors) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
+(_seedSelectors_trackingPhase1, _trackingNtupleSeedSelectors_trackingPhase1) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase1, globals())
+eras.phase1Pixel.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1)
+
+trackingNtuple.seedTracks = _seedSelectors
+eras.trackingPhase1.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
+
+trackingNtupleSequence = cms.Sequence()
+# reproduce hits because they're not stored in RECO
+if _includeHits:
+    trackingNtupleSequence += (
+        siPixelRecHits +
+        siStripMatchedRecHits
+    )
+if _includeSeeds:
+    trackingNtupleSequence += trackingNtupleSeedSelectors
+
+trackingNtupleSequence += (
+    # sim information
+    cms.ignore(trackingParticlesIntime) +
+    simHitTPAssocProducerIntime +
+    tpClusterProducerIntime +
+    quickTrackAssociatorByHitsIntime +
+    # ntuplizer
+    trackingNtuple
+)

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -11,6 +11,7 @@ from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 from Validation.RecoTrack.trackingNtuple_cfi import *
 from Validation.RecoTrack.TrackValidation_cff import *
+from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff import *
 import Validation.RecoTrack.TrackValidation_cff as _TrackValidation_cff
 
 _includeHits = True
@@ -39,10 +40,16 @@ tpClusterProducerIntime = tpClusterProducer.clone(
 quickTrackAssociatorByHitsIntime = quickTrackAssociatorByHits.clone(
     cluster2TPSrc = "tpClusterProducerIntime",
 )
+trackingParticleNumberOfLayersProducerIntime = trackingParticleNumberOfLayersProducer.clone(
+    trackingParticles = "trackingParticlesIntime"
+)
 trackingNtuple.trackingParticles = "trackingParticlesIntime"
 trackingNtuple.clusterTPMap = "tpClusterProducerIntime"
 trackingNtuple.simHitTPMap = "simHitTPAssocProducerIntime"
 trackingNtuple.trackAssociator = "quickTrackAssociatorByHitsIntime"
+trackingNtuple.trackingParticleNlayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
+trackingNtuple.trackingParticleNpixellayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
+trackingNtuple.trackingParticleNstripstereolayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
 trackingNtuple.includeAllHits = _includeHits
 trackingNtuple.includeSeeds = _includeSeeds
 
@@ -89,6 +96,7 @@ trackingNtupleSequence += (
     simHitTPAssocProducerIntime +
     tpClusterProducerIntime +
     quickTrackAssociatorByHitsIntime +
+    trackingParticleNumberOfLayersProducerIntime +
     # ntuplizer
     trackingNtuple
 )

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -20,8 +20,8 @@ _includeHits = True
 _includeSeeds = True
 #_includeSeeds = False
 
-from PhysicsTools.RecoAlgos.trackingParticleSelector_cfi import *
-trackingParticlesIntime = trackingParticleSelector.clone(
+from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
+trackingParticlesIntime = _trackingParticleRefSelector.clone(
     signalOnly = False,
     intimeOnly = True,
     chargedOnly = False,
@@ -31,25 +31,8 @@ trackingParticlesIntime = trackingParticleSelector.clone(
     maxRapidity = 10,
     ptMin = 0,
 )
-simHitTPAssocProducerIntime = simHitTPAssocProducer.clone(
-    trackingParticleSrc = "trackingParticlesIntime"
-)
-tpClusterProducerIntime = tpClusterProducer.clone(
-    trackingParticleSrc = "trackingParticlesIntime"
-)
-quickTrackAssociatorByHitsIntime = quickTrackAssociatorByHits.clone(
-    cluster2TPSrc = "tpClusterProducerIntime",
-)
-trackingParticleNumberOfLayersProducerIntime = trackingParticleNumberOfLayersProducer.clone(
-    trackingParticles = "trackingParticlesIntime"
-)
 trackingNtuple.trackingParticles = "trackingParticlesIntime"
-trackingNtuple.clusterTPMap = "tpClusterProducerIntime"
-trackingNtuple.simHitTPMap = "simHitTPAssocProducerIntime"
-trackingNtuple.trackAssociator = "quickTrackAssociatorByHitsIntime"
-trackingNtuple.trackingParticleNlayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
-trackingNtuple.trackingParticleNpixellayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
-trackingNtuple.trackingParticleNstripstereolayers.setModuleLabel("trackingParticleNumberOfLayersProducerIntime")
+trackingNtuple.trackingParticlesRef = True
 trackingNtuple.includeAllHits = _includeHits
 trackingNtuple.includeSeeds = _includeSeeds
 
@@ -92,11 +75,11 @@ if _includeSeeds:
 
 trackingNtupleSequence += (
     # sim information
-    cms.ignore(trackingParticlesIntime) +
-    simHitTPAssocProducerIntime +
-    tpClusterProducerIntime +
-    quickTrackAssociatorByHitsIntime +
-    trackingParticleNumberOfLayersProducerIntime +
+    trackingParticlesIntime +
+    simHitTPAssocProducer +
+    tpClusterProducer +
+    quickTrackAssociatorByHits +
+    trackingParticleNumberOfLayersProducer +
     # ntuplizer
     trackingNtuple
 )

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -1,12 +1,11 @@
 #include "Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h"
+#include "Validation/RecoTrack/interface/trackFromSeedFitFailed.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/TrackReco/interface/DeDxData.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
-#include "DQMServices/ClientConfig/interface/FitSlicesYTool.h"
 
 
 #include "TMath.h"
@@ -41,7 +40,8 @@ namespace {
   }
 }
 
-MTVHistoProducerAlgoForTracker::MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, edm::ConsumesCollector & iC):
+MTVHistoProducerAlgoForTracker::MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const bool doSeedPlots, edm::ConsumesCollector & iC):
+  doSeedPlots_(doSeedPlots),
   h_ptSIM(nullptr), h_etaSIM(nullptr), h_tracksSIM(nullptr), h_vertposSIM(nullptr), h_bunchxSIM(nullptr)
 {
   //parameters for _vs_eta plots
@@ -305,7 +305,7 @@ void MTVHistoProducerAlgoForTracker::bookSimTrackHistos(DQMStore::IBooker& ibook
   }
 }
 
-void MTVHistoProducerAlgoForTracker::bookSimTrackPVAssociationHistos(DQMStore::IBooker& ibook) {
+void MTVHistoProducerAlgoForTracker::bookSimTrackPVAssociationHistos(DQMStore::IBooker& ibook){
   h_assocdxypv.push_back( ibook.book1D("num_assoc(simToReco)_dxypv","N of associated tracks (simToReco) vs dxy(PV)",nintDxy,minDxy,maxDxy) );
   h_simuldxypv.push_back( ibook.book1D("num_simul_dxypv","N of simulated tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
 
@@ -335,7 +335,7 @@ void MTVHistoProducerAlgoForTracker::bookSimTrackPVAssociationHistos(DQMStore::I
   h_simul2_dzpvsigcut_pt.back()->getTH1()->Sumw2();
 }
 
-void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
+void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook) {
   h_tracks.push_back( ibook.book1D("tracks","number of reconstructed tracks", nintTracks, minTracks, maxTracks) );
   h_fakes.push_back( ibook.book1D("fakes","number of fake reco tracks", nintTracks, minTracks, maxTracks) );
   h_charge.push_back( ibook.book1D("charge","charge",3,-1.5,1.5) );
@@ -357,61 +357,61 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   h_recoeta.push_back( ibook.book1D("num_reco_eta","N of reco track vs eta",nintEta,minEta,maxEta) );
   h_assoc2eta.push_back( ibook.book1D("num_assoc(recoToSim)_eta","N of associated (recoToSim) tracks vs eta",nintEta,minEta,maxEta) );
   h_loopereta.push_back( ibook.book1D("num_duplicate_eta","N of associated (recoToSim) duplicate tracks vs eta",nintEta,minEta,maxEta) );
-  h_misideta.push_back( ibook.book1D("num_chargemisid_eta","N of associated (recoToSim) charge misIDed tracks vs eta",nintEta,minEta,maxEta) );
+  if(!doSeedPlots_) h_misideta.push_back( ibook.book1D("num_chargemisid_eta","N of associated (recoToSim) charge misIDed tracks vs eta",nintEta,minEta,maxEta) );
   h_pileupeta.push_back( ibook.book1D("num_pileup_eta","N of associated (recoToSim) pileup tracks vs eta",nintEta,minEta,maxEta) );
   //
   h_recopT.push_back( ibook.book1D("num_reco_pT","N of reco track vs pT",nintPt,minPt,maxPt) );
   h_assoc2pT.push_back( ibook.book1D("num_assoc(recoToSim)_pT","N of associated (recoToSim) tracks vs pT",nintPt,minPt,maxPt) );
   h_looperpT.push_back( ibook.book1D("num_duplicate_pT","N of associated (recoToSim) duplicate tracks vs pT",nintPt,minPt,maxPt) );
-  h_misidpT.push_back( ibook.book1D("num_chargemisid_pT","N of associated (recoToSim) charge misIDed tracks vs pT",nintPt,minPt,maxPt) );
+  if(!doSeedPlots_) h_misidpT.push_back( ibook.book1D("num_chargemisid_pT","N of associated (recoToSim) charge misIDed tracks vs pT",nintPt,minPt,maxPt) );
   h_pileuppT.push_back( ibook.book1D("num_pileup_pT","N of associated (recoToSim) pileup tracks vs pT",nintPt,minPt,maxPt) );
   //
   h_recohit.push_back( ibook.book1D("num_reco_hit","N of reco track vs hit",nintHit,minHit,maxHit) );
   h_assoc2hit.push_back( ibook.book1D("num_assoc(recoToSim)_hit","N of associated (recoToSim) tracks vs hit",nintHit,minHit,maxHit) );
   h_looperhit.push_back( ibook.book1D("num_duplicate_hit","N of associated (recoToSim) duplicate tracks vs hit",nintHit,minHit,maxHit) );
-  h_misidhit.push_back( ibook.book1D("num_chargemisid_hit","N of associated (recoToSim) charge misIDed tracks vs hit",nintHit,minHit,maxHit) );
+  if(!doSeedPlots_) h_misidhit.push_back( ibook.book1D("num_chargemisid_hit","N of associated (recoToSim) charge misIDed tracks vs hit",nintHit,minHit,maxHit) );
   h_pileuphit.push_back( ibook.book1D("num_pileup_hit","N of associated (recoToSim) pileup tracks vs hit",nintHit,minHit,maxHit) );
   //
   h_recolayer.push_back( ibook.book1D("num_reco_layer","N of reco track vs layer",nintLayers,minLayers,maxLayers) );
   h_assoc2layer.push_back( ibook.book1D("num_assoc(recoToSim)_layer","N of associated (recoToSim) tracks vs layer",nintLayers,minLayers,maxLayers) );
   h_looperlayer.push_back( ibook.book1D("num_duplicate_layer","N of associated (recoToSim) duplicate tracks vs layer",nintLayers,minLayers,maxLayers) );
-  h_misidlayer.push_back( ibook.book1D("num_chargemisid_layer","N of associated (recoToSim) charge misIDed tracks vs layer",nintLayers,minLayers,maxLayers) );
+  if(!doSeedPlots_) h_misidlayer.push_back( ibook.book1D("num_chargemisid_layer","N of associated (recoToSim) charge misIDed tracks vs layer",nintLayers,minLayers,maxLayers) );
   h_pileuplayer.push_back( ibook.book1D("num_pileup_layer","N of associated (recoToSim) pileup tracks vs layer",nintLayers,minLayers,maxLayers) );
   //
   h_recopixellayer.push_back( ibook.book1D("num_reco_pixellayer","N of reco track vs pixellayer",nintLayers,minLayers,maxLayers) );
   h_assoc2pixellayer.push_back( ibook.book1D("num_assoc(recoToSim)_pixellayer","N of associated (recoToSim) tracks vs pixellayer",nintLayers,minLayers,maxLayers) );
   h_looperpixellayer.push_back( ibook.book1D("num_duplicate_pixellayer","N of associated (recoToSim) duplicate tracks vs pixellayer",nintLayers,minLayers,maxLayers) );
-  h_misidpixellayer.push_back( ibook.book1D("num_chargemisid_pixellayer","N of associated (recoToSim) charge misIDed tracks vs pixellayer",nintLayers,minLayers,maxLayers) );
+  if(!doSeedPlots_) h_misidpixellayer.push_back( ibook.book1D("num_chargemisid_pixellayer","N of associated (recoToSim) charge misIDed tracks vs pixellayer",nintLayers,minLayers,maxLayers) );
   h_pileuppixellayer.push_back( ibook.book1D("num_pileup_pixellayer","N of associated (recoToSim) pileup tracks vs pixellayer",nintLayers,minLayers,maxLayers) );
   //
   h_reco3Dlayer.push_back( ibook.book1D("num_reco_3Dlayer","N of reco track vs 3D layer",nintLayers,minLayers,maxLayers) );
   h_assoc23Dlayer.push_back( ibook.book1D("num_assoc(recoToSim)_3Dlayer","N of associated (recoToSim) tracks vs 3D layer",nintLayers,minLayers,maxLayers) );
   h_looper3Dlayer.push_back( ibook.book1D("num_duplicate_3Dlayer","N of associated (recoToSim) duplicate tracks vs 3D layer",nintLayers,minLayers,maxLayers) );
-  h_misid3Dlayer.push_back( ibook.book1D("num_chargemisid_3Dlayer","N of associated (recoToSim) charge misIDed tracks vs 3D layer",nintLayers,minLayers,maxLayers) );
+  if(!doSeedPlots_) h_misid3Dlayer.push_back( ibook.book1D("num_chargemisid_3Dlayer","N of associated (recoToSim) charge misIDed tracks vs 3D layer",nintLayers,minLayers,maxLayers) );
   h_pileup3Dlayer.push_back( ibook.book1D("num_pileup_3Dlayer","N of associated (recoToSim) pileup tracks vs 3D layer",nintLayers,minLayers,maxLayers) );
   //
   h_recopu.push_back( ibook.book1D("num_reco_pu","N of reco track vs pu",nintPu,minPu,maxPu) );
   h_assoc2pu.push_back( ibook.book1D("num_assoc(recoToSim)_pu","N of associated (recoToSim) tracks vs pu",nintPu,minPu,maxPu) );
   h_looperpu.push_back( ibook.book1D("num_duplicate_pu","N of associated (recoToSim) duplicate tracks vs pu",nintPu,minPu,maxPu) );
-  h_misidpu.push_back( ibook.book1D("num_chargemisid_pu","N of associated (recoToSim) charge misIDed tracks vs pu",nintPu,minPu,maxPu) );
+  if(!doSeedPlots_) h_misidpu.push_back( ibook.book1D("num_chargemisid_pu","N of associated (recoToSim) charge misIDed tracks vs pu",nintPu,minPu,maxPu) );
   h_pileuppu.push_back( ibook.book1D("num_pileup_pu","N of associated (recoToSim) pileup tracks vs pu",nintPu,minPu,maxPu) );
   //
   h_recophi.push_back( ibook.book1D("num_reco_phi","N of reco track vs phi",nintPhi,minPhi,maxPhi) );
   h_assoc2phi.push_back( ibook.book1D("num_assoc(recoToSim)_phi","N of associated (recoToSim) tracks vs phi",nintPhi,minPhi,maxPhi) );
   h_looperphi.push_back( ibook.book1D("num_duplicate_phi","N of associated (recoToSim) duplicate tracks vs phi",nintPhi,minPhi,maxPhi) );
-  h_misidphi.push_back( ibook.book1D("num_chargemisid_phi","N of associated (recoToSim) charge misIDed tracks vs phi",nintPhi,minPhi,maxPhi) );
+  if(!doSeedPlots_) h_misidphi.push_back( ibook.book1D("num_chargemisid_phi","N of associated (recoToSim) charge misIDed tracks vs phi",nintPhi,minPhi,maxPhi) );
   h_pileupphi.push_back( ibook.book1D("num_pileup_phi","N of associated (recoToSim) pileup tracks vs phi",nintPhi,minPhi,maxPhi) );
 
   h_recodxy.push_back( ibook.book1D("num_reco_dxy","N of reco track vs dxy",nintDxy,minDxy,maxDxy) );
   h_assoc2dxy.push_back( ibook.book1D("num_assoc(recoToSim)_dxy","N of associated (recoToSim) tracks vs dxy",nintDxy,minDxy,maxDxy) );
   h_looperdxy.push_back( ibook.book1D("num_duplicate_dxy","N of associated (recoToSim) looper tracks vs dxy",nintDxy,minDxy,maxDxy) );
-  h_misiddxy.push_back( ibook.book1D("num_chargemisid_dxy","N of associated (recoToSim) charge misIDed tracks vs dxy",nintDxy,minDxy,maxDxy) );
+  if(!doSeedPlots_) h_misiddxy.push_back( ibook.book1D("num_chargemisid_dxy","N of associated (recoToSim) charge misIDed tracks vs dxy",nintDxy,minDxy,maxDxy) );
   h_pileupdxy.push_back( ibook.book1D("num_pileup_dxy","N of associated (recoToSim) pileup tracks vs dxy",nintDxy,minDxy,maxDxy) );
 
   h_recodz.push_back( ibook.book1D("num_reco_dz","N of reco track vs dz",nintDz,minDz,maxDz) );
   h_assoc2dz.push_back( ibook.book1D("num_assoc(recoToSim)_dz","N of associated (recoToSim) tracks vs dz",nintDz,minDz,maxDz) );
   h_looperdz.push_back( ibook.book1D("num_duplicate_dz","N of associated (recoToSim) looper tracks vs dz",nintDz,minDz,maxDz) );
-  h_misiddz.push_back( ibook.book1D("num_chargemisid_versus_dz","N of associated (recoToSim) charge misIDed tracks vs dz",nintDz,minDz,maxDz) );
+  if(!doSeedPlots_) h_misiddz.push_back( ibook.book1D("num_chargemisid_versus_dz","N of associated (recoToSim) charge misIDed tracks vs dz",nintDz,minDz,maxDz) );
   h_pileupdz.push_back( ibook.book1D("num_pileup_dz","N of associated (recoToSim) pileup tracks vs dz",nintDz,minDz,maxDz) );
 
   h_recovertpos.push_back( ibook.book1D("num_reco_vertpos","N of reconstructed tracks vs transverse ref point position",nintVertpos,minVertpos,maxVertpos) );
@@ -436,7 +436,7 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   h_recochi2.push_back( ibook.book1D("num_reco_chi2","N of reco track vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
   h_assoc2chi2.push_back( ibook.book1D("num_assoc(recoToSim)_chi2","N of associated (recoToSim) tracks vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
   h_looperchi2.push_back( ibook.book1D("num_duplicate_chi2","N of associated (recoToSim) looper tracks vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
-  h_misidchi2.push_back( ibook.book1D("num_chargemisid_chi2","N of associated (recoToSim) charge misIDed tracks vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
+  if(!doSeedPlots_) h_misidchi2.push_back( ibook.book1D("num_chargemisid_chi2","N of associated (recoToSim) charge misIDed tracks vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
   h_pileupchi2.push_back( ibook.book1D("num_pileup_chi2","N of associated (recoToSim) pileup tracks vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
 
 
@@ -581,7 +581,7 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
     BinLogX(cotThetares_vs_pt.back()->getTH2F());
     BinLogX(ptres_vs_pt.back()->getTH2F());
     BinLogX(h_looperpT.back()->getTH1F());
-    BinLogX(h_misidpT.back()->getTH1F());
+    if(!doSeedPlots_) BinLogX(h_misidpT.back()->getTH1F());
     BinLogX(h_recopT.back()->getTH1F());
     BinLogX(h_assoc2pT.back()->getTH1F());
     BinLogX(h_pileuppT.back()->getTH1F());
@@ -592,13 +592,13 @@ void MTVHistoProducerAlgoForTracker::bookRecoPVAssociationHistos(DQMStore::IBook
   h_recodxypv.push_back( ibook.book1D("num_reco_dxypv","N of reco track vs dxy(PV)",nintDxy,minDxy,maxDxy) );
   h_assoc2dxypv.push_back( ibook.book1D("num_assoc(recoToSim)_dxypv","N of associated (recoToSim) tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
   h_looperdxypv.push_back( ibook.book1D("num_duplicate_dxypv","N of associated (recoToSim) looper tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
-  h_misiddxypv.push_back( ibook.book1D("num_chargemisid_dxypv","N of associated (recoToSim) charge misIDed tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
+  if(!doSeedPlots_) h_misiddxypv.push_back( ibook.book1D("num_chargemisid_dxypv","N of associated (recoToSim) charge misIDed tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
   h_pileupdxypv.push_back( ibook.book1D("num_pileup_dxypv","N of associated (recoToSim) pileup tracks vs dxy(PV)",nintDxy,minDxy,maxDxy) );
 
   h_recodzpv.push_back( ibook.book1D("num_reco_dzpv","N of reco track vs dz(PV)",nintDz,minDz,maxDz) );
   h_assoc2dzpv.push_back( ibook.book1D("num_assoc(recoToSim)_dzpv","N of associated (recoToSim) tracks vs dz(PV)",nintDz,minDz,maxDz) );
   h_looperdzpv.push_back( ibook.book1D("num_duplicate_dzpv","N of associated (recoToSim) looper tracks vs dz(PV)",nintDz,minDz,maxDz) );
-  h_misiddzpv.push_back( ibook.book1D("num_chargemisid_versus_dzpv","N of associated (recoToSim) charge misIDed tracks vs dz(PV)",nintDz,minDz,maxDz) );
+  if(!doSeedPlots_) h_misiddzpv.push_back( ibook.book1D("num_chargemisid_versus_dzpv","N of associated (recoToSim) charge misIDed tracks vs dz(PV)",nintDz,minDz,maxDz) );
   h_pileupdzpv.push_back( ibook.book1D("num_pileup_dzpv","N of associated (recoToSim) pileup tracks vs dz(PV)",nintDz,minDz,maxDz) );
 
   h_reco_dzpvcut.push_back( ibook.book1D("num_reco_dzpvcut","N of reco track vs dz(PV)",nintDzpvCum,0,maxDzpvCum) );
@@ -813,62 +813,68 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
   const bool fillSeedingLayerSets = !seedingLayerSetNames.empty();
   const unsigned int seedingLayerSetBin = fillSeedingLayerSets ? getSeedingLayerSetBin(track, ttopo) : 0;
 
-  fillPlotNoFlow(h_recoeta[count], eta);
-  fillPlotNoFlow(h_recophi[count], phi);
-  fillPlotNoFlow(h_recopT[count], pt);
-  fillPlotNoFlow(h_recodxy[count], dxy);
-  fillPlotNoFlow(h_recodz[count], dz);
+  const bool paramsValid = !trackFromSeedFitFailed(track);
+
+  if(paramsValid) {
+    fillPlotNoFlow(h_recoeta[count], eta);
+    fillPlotNoFlow(h_recophi[count], phi);
+    fillPlotNoFlow(h_recopT[count], pt);
+    fillPlotNoFlow(h_recodxy[count], dxy);
+    fillPlotNoFlow(h_recodz[count], dz);
+    fillPlotNoFlow(h_recochi2[count], chi2);
+    fillPlotNoFlow(h_recovertpos[count], vertxy);
+    fillPlotNoFlow(h_recozpos[count], vertz);
+    h_recodr[count]->Fill(deltar);
+  if(fillSeedingLayerSets) h_reco_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+    if(pvPosition) {
+      fillPlotNoFlow(h_recodxypv[count], dxypv);
+      fillPlotNoFlow(h_recodzpv[count], dzpv);
+
+      h_reco_dzpvcut[count]->Fill(std::abs(dzpv));
+      h_reco_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
+      h_reco_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
+      h_reco_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+    }
+  }
   fillPlotNoFlow(h_recohit[count], nhits);
   fillPlotNoFlow(h_recolayer[count], nlayers);
   fillPlotNoFlow(h_recopixellayer[count], nPixelLayers);
   fillPlotNoFlow(h_reco3Dlayer[count], n3DLayers);
   fillPlotNoFlow(h_recopu[count],numVertices);
-  fillPlotNoFlow(h_recochi2[count], chi2);
-  fillPlotNoFlow(h_recovertpos[count], vertxy);
-  fillPlotNoFlow(h_recozpos[count], vertz);
-  h_recodr[count]->Fill(deltar);
-  if(fillSeedingLayerSets) h_reco_seedingLayerSet[count]->Fill(seedingLayerSetBin);
-  if(pvPosition) {
-    fillPlotNoFlow(h_recodxypv[count], dxypv);
-    fillPlotNoFlow(h_recodzpv[count], dzpv);
-
-    h_reco_dzpvcut[count]->Fill(std::abs(dzpv));
-    h_reco_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
-    h_reco_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
-    h_reco_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
-  }
 
   if (isMatched) {
-    fillPlotNoFlow(h_assoc2eta[count], eta);
-    fillPlotNoFlow(h_assoc2phi[count], phi);
-    fillPlotNoFlow(h_assoc2pT[count], pt);
-    fillPlotNoFlow(h_assoc2dxy[count], dxy);
-    fillPlotNoFlow(h_assoc2dz[count], dz);
-    fillPlotNoFlow(h_assoc2hit[count], nhits);
+    if(paramsValid) {
+      fillPlotNoFlow(h_assoc2eta[count], eta);
+      fillPlotNoFlow(h_assoc2phi[count], phi);
+      fillPlotNoFlow(h_assoc2pT[count], pt);
+      fillPlotNoFlow(h_assoc2dxy[count], dxy);
+      fillPlotNoFlow(h_assoc2dz[count], dz);
+      fillPlotNoFlow(h_assoc2hit[count], nhits);
+      fillPlotNoFlow(h_assoc2chi2[count], chi2);
+      fillPlotNoFlow(h_assoc2vertpos[count], vertxy);
+      fillPlotNoFlow(h_assoc2zpos[count], vertz);
+      h_assoc2dr[count]->Fill(deltar);
+    if(fillSeedingLayerSets) h_assoc2_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+      if(pvPosition) {
+        fillPlotNoFlow(h_assoc2dxypv[count], dxypv);
+        fillPlotNoFlow(h_assoc2dzpv[count], dzpv);
+
+        h_assoc2_dzpvcut[count]->Fill(std::abs(dzpv));
+        h_assoc2_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
+        h_assoc2_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
+        h_assoc2_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+      }
+    }
     fillPlotNoFlow(h_assoc2layer[count], nlayers);
     fillPlotNoFlow(h_assoc2pixellayer[count], nPixelLayers);
     fillPlotNoFlow(h_assoc23Dlayer[count], n3DLayers);
     fillPlotNoFlow(h_assoc2pu[count],numVertices);
-    fillPlotNoFlow(h_assoc2chi2[count], chi2);
-    fillPlotNoFlow(h_assoc2vertpos[count], vertxy);
-    fillPlotNoFlow(h_assoc2zpos[count], vertz);
-    h_assoc2dr[count]->Fill(deltar);
-    if(fillSeedingLayerSets) h_assoc2_seedingLayerSet[count]->Fill(seedingLayerSetBin);
-    if(pvPosition) {
-      fillPlotNoFlow(h_assoc2dxypv[count], dxypv);
-      fillPlotNoFlow(h_assoc2dzpv[count], dzpv);
-
-      h_assoc2_dzpvcut[count]->Fill(std::abs(dzpv));
-      h_assoc2_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
-      h_assoc2_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
-      h_assoc2_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
-    }
 
     nrecHit_vs_nsimHit_rec2sim[count]->Fill( track.numberOfValidHits(),nSimHits);
     h_assocFraction[count]->Fill( sharedFraction);
     h_assocSharedHit[count]->Fill( sharedHits);
 
-    if (!isChargeMatched) {
+    if (!doSeedPlots_ && !isChargeMatched) {
       fillPlotNoFlow(h_misideta[count], eta);
       fillPlotNoFlow(h_misidphi[count], phi);
       fillPlotNoFlow(h_misidpT[count], pt);
@@ -887,51 +893,55 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
     }
 
     if (numAssocRecoTracks>1) {
-      fillPlotNoFlow(h_loopereta[count], eta);
-      fillPlotNoFlow(h_looperphi[count], phi);
-      fillPlotNoFlow(h_looperpT[count], pt);
-      fillPlotNoFlow(h_looperdxy[count], dxy);
-      fillPlotNoFlow(h_looperdz[count], dz);
+      if(paramsValid) {
+        fillPlotNoFlow(h_loopereta[count], eta);
+        fillPlotNoFlow(h_looperphi[count], phi);
+        fillPlotNoFlow(h_looperpT[count], pt);
+        fillPlotNoFlow(h_looperdxy[count], dxy);
+        fillPlotNoFlow(h_looperdz[count], dz);
+        fillPlotNoFlow(h_looperchi2[count], chi2);
+        fillPlotNoFlow(h_loopervertpos[count], vertxy);
+        fillPlotNoFlow(h_looperzpos[count], vertz);
+        h_looperdr[count]->Fill(deltar);
+      if(fillSeedingLayerSets) h_looper_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+        if(pvPosition) {
+          fillPlotNoFlow(h_looperdxypv[count], dxypv);
+          fillPlotNoFlow(h_looperdzpv[count], dzpv);
+        }
+      }
       fillPlotNoFlow(h_looperhit[count], nhits);
       fillPlotNoFlow(h_looperlayer[count], nlayers);
       fillPlotNoFlow(h_looperpixellayer[count], nPixelLayers);
       fillPlotNoFlow(h_looper3Dlayer[count], n3DLayers);
       fillPlotNoFlow(h_looperpu[count], numVertices);
-      fillPlotNoFlow(h_looperchi2[count], chi2);
-      fillPlotNoFlow(h_loopervertpos[count], vertxy);
-      fillPlotNoFlow(h_looperzpos[count], vertz);
-      h_looperdr[count]->Fill(deltar);
-      if(fillSeedingLayerSets) h_looper_seedingLayerSet[count]->Fill(seedingLayerSetBin);
-      if(pvPosition) {
-        fillPlotNoFlow(h_looperdxypv[count], dxypv);
-        fillPlotNoFlow(h_looperdzpv[count], dzpv);
-      }
     }
     if(!isSigMatched) {
-      fillPlotNoFlow(h_pileupeta[count], eta);
-      fillPlotNoFlow(h_pileupphi[count], phi);
-      fillPlotNoFlow(h_pileuppT[count], pt);
-      fillPlotNoFlow(h_pileupdxy[count], dxy);
-      fillPlotNoFlow(h_pileupdz[count], dz);
+      if(paramsValid) {
+        fillPlotNoFlow(h_pileupeta[count], eta);
+        fillPlotNoFlow(h_pileupphi[count], phi);
+        fillPlotNoFlow(h_pileuppT[count], pt);
+        fillPlotNoFlow(h_pileupdxy[count], dxy);
+        fillPlotNoFlow(h_pileupdz[count], dz);
+        fillPlotNoFlow(h_pileupchi2[count], chi2);
+        fillPlotNoFlow(h_pileupvertpos[count], vertxy);
+        fillPlotNoFlow(h_pileupzpos[count], vertz);
+        h_pileupdr[count]->Fill(deltar);
+      if(fillSeedingLayerSets) h_pileup_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+        if(pvPosition) {
+          fillPlotNoFlow(h_pileupdxypv[count], dxypv);
+          fillPlotNoFlow(h_pileupdzpv[count], dzpv);
+
+          h_pileup_dzpvcut[count]->Fill(std::abs(dzpv));
+          h_pileup_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
+          h_pileup_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
+          h_pileup_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+        }
+      }
       fillPlotNoFlow(h_pileuphit[count], nhits);
       fillPlotNoFlow(h_pileuplayer[count], nlayers);
       fillPlotNoFlow(h_pileuppixellayer[count], nPixelLayers);
       fillPlotNoFlow(h_pileup3Dlayer[count], n3DLayers);
       fillPlotNoFlow(h_pileuppu[count], numVertices);
-      fillPlotNoFlow(h_pileupchi2[count], chi2);
-      fillPlotNoFlow(h_pileupvertpos[count], vertxy);
-      fillPlotNoFlow(h_pileupzpos[count], vertz);
-      h_pileupdr[count]->Fill(deltar);
-      if(fillSeedingLayerSets) h_pileup_seedingLayerSet[count]->Fill(seedingLayerSetBin);
-      if(pvPosition) {
-        fillPlotNoFlow(h_pileupdxypv[count], dxypv);
-        fillPlotNoFlow(h_pileupdzpv[count], dzpv);
-
-        h_pileup_dzpvcut[count]->Fill(std::abs(dzpv));
-        h_pileup_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
-        h_pileup_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
-        h_pileup_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
-      }
     }
   }
 }
@@ -940,14 +950,17 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
 void MTVHistoProducerAlgoForTracker::fill_simAssociated_recoTrack_histos(int count,
 									 const reco::Track& track){
     //nchi2 and hits global distributions
-    h_nchi2[count]->Fill(track.normalizedChi2());
-    h_nchi2_prob[count]->Fill(TMath::Prob(track.chi2(),(int)track.ndof()));
     h_hits[count]->Fill(track.numberOfValidHits());
     h_losthits[count]->Fill(track.numberOfLostHits());
-    chi2_vs_nhits[count]->Fill(track.numberOfValidHits(),track.normalizedChi2());
-    h_charge[count]->Fill( track.charge() );
     h_nmisslayers_inner[count]->Fill(track.hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS));
     h_nmisslayers_outer[count]->Fill(track.hitPattern().numberOfHits(reco::HitPattern::MISSING_OUTER_HITS));
+    if(trackFromSeedFitFailed(track))
+      return;
+
+    h_nchi2[count]->Fill(track.normalizedChi2());
+    h_nchi2_prob[count]->Fill(TMath::Prob(track.chi2(),(int)track.ndof()));
+    chi2_vs_nhits[count]->Fill(track.numberOfValidHits(),track.normalizedChi2());
+    h_charge[count]->Fill( track.charge() );
 
     //chi2 and #hit vs eta: fill 2D histos
     const auto eta = getEta(track.eta());
@@ -988,6 +1001,8 @@ void MTVHistoProducerAlgoForTracker::fill_ResoAndPull_recoTrack_histos(int count
 								       int chargeTP,
 								       const reco::Track& track,
 								       const math::XYZPoint& bsPosition){
+  if(trackFromSeedFitFailed(track))
+    return;
 
   // evaluation of TP parameters
   double qoverpSim = chargeTP/sqrt(momentumTP.x()*momentumTP.x()+momentumTP.y()*momentumTP.y()+momentumTP.z()*momentumTP.z());

--- a/Validation/RecoTrack/test/trackingNtupleExample.py
+++ b/Validation/RecoTrack/test/trackingNtupleExample.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+import ROOT
+
+# The purpose of this file is to demonstrate mainly the links between
+# tracks, hits, seeds, and TrackingParticles.
+
+def main():
+    inputFile = ROOT.TFile.Open("trackingNtuple.root")
+    tree = inputFile.Get("trackingNtuple/tree")
+    entries = tree.GetEntriesFast()
+
+    tot_nevents = 0
+    tot_pv_ntracks = 0
+
+    tot_ntracks = 0
+    tot_hptracks = 0
+    tot_fakes = 0
+    tot_fakes_ninvalidhits = 0
+    tot_fakes_npixhits = 0
+    tot_fakes_nstrhits = 0
+    tot_fakes_npixhits_true = 0
+    tot_fakes_nstrhits_true = 0
+    tot_fakes_npixhits_tps = 0
+    tot_duplicates = 0
+
+    tot_tps = 0
+    tot_recoed = 0
+    tot_tp_dups = 0
+
+    tot_seeds = 0
+    tot_seeds_true = 0
+    tot_seeds_lowPtTriplet = 0
+    tot_track_seeds_true = 0
+
+    for jentry in xrange(entries):
+        # get the next tree in the chain and verify
+        ientry = tree.LoadTree( jentry )
+        if ientry < 0: break
+        # copy next entry into memory and verify
+        nb = tree.GetEntry( jentry )
+        if nb <= 0: continue
+
+        #print "Event", jentry
+        tot_nevents += 1
+
+        tot_pv_ntracks += tree.vtx_trkIdx[0].size()
+
+        # links from TrackingParticles to tracks
+        ntps = tree.sim_px.size()
+        tot_tps += ntps
+        neff = 0
+        ndups = 0
+        for itp in xrange(ntps):
+            if tree.sim_trkIdx[itp].size() >= 1:
+                neff += 1
+                if tree.sim_trkIdx[itp].size() > 1:
+                    ndups += 1
+        tot_recoed += neff
+        tot_tp_dups += ndups
+
+        # links from tracks to TrackingParticles
+        ntracks = tree.trk_px.size()
+        tot_ntracks += ntracks
+        nfakes = 0
+        nfakes_invalidhits = 0
+        nfakes_pixhits = 0
+        nfakes_strhits = 0
+        nfakes_pixhits_true = 0
+        nfakes_strhits_true = 0
+        nfakes_pixhits_tps = 0
+        ndups = 0
+        for itrack in xrange(ntracks):
+            if track.isHP():
+                tot_hptracks += 1
+
+            if tree.trk_simIdx[itrack].size() == 0:
+                #print "Track", itrack, " is fake"
+
+                nfakes += 1
+
+                # links from tracks to hits
+                if hasattr(tree, "pix_nSimTrk"):
+                    pix_simTrkIds = set()
+
+                    for ihit in tree.trk_pixelIdx[itrack]:
+                        if ihit == -1:
+                            nfakes_invalidhits += 1
+                            continue
+                        nfakes_pixhits += 1
+                        if tree.pix_nSimTrk[ihit] >= 1:
+                            nfakes_pixhits_true += 1
+                        pix_simTrkIds.add(tree.pix_simTrkIdx[ihit]) # currently the index of only the "first" matched TP is stored
+                    nfakes_pixhits_tps += len(pix_simTrkIds)
+
+                    for ihit in tree.trk_stripIdx[itrack]:
+                        if ihit == -1:
+                            nfakes_invalidhits += 1
+                            continue
+                        nfakes_strhits += 1
+                        if tree.str_nSimTrk[ihit] >= 1:
+                            nfakes_strhits_true += 1
+            else:
+                for itp in tree.trk_simIdx[itrack]:
+                    if tree.sim_trkIdx[itp].size() > 1:
+                        ndups += 1
+                        break
+        tot_fakes += nfakes
+        tot_fakes_ninvalidhits += nfakes_invalidhits
+        tot_fakes_npixhits += nfakes_pixhits
+        tot_fakes_nstrhits += nfakes_strhits
+        tot_fakes_npixhits_true += nfakes_pixhits_true
+        tot_fakes_nstrhits_true += nfakes_strhits_true
+        tot_fakes_npixhits_tps += nfakes_pixhits_tps
+        tot_duplicates += ndups
+
+        # seeds
+        if hasattr(tree, "see_simIdx"):
+            nseeds = tree.see_simIdx.size()
+            tot_seeds += nseeds
+
+            # finding seeds of a particular iteration
+            for ioffset, offset in enumerate(tree.see_offset):
+                if tree.see_algo[offset] == 5: # = lowPtTripletStep
+                    next_offset = tree.see_offset[ioffset+1] if ioffset < tree.see_offset.size() else tree.see_algo.size()
+                    tot_seeds_lowPtTriplet += next_offset - offset
+                    break
+
+            # links from seeds to TrackingParticles
+            ntrue = 0
+            for iseed in xrange(nseeds):
+                if tree.see_simIdx[iseed].size() >= 1:
+                    ntrue += 1
+            tot_seeds_true = ntrue
+
+            # links from tracks to seeds
+            ntracktrue = 0
+            for itrack in xrange(ntracks):
+                iseed = tree.trk_seedIdx[itrack]
+                if tree.see_simIdx[iseed].size() >= 1:
+                    ntracktrue += 1
+            tot_track_seeds_true += ntracktrue
+
+
+    print "Processed %d events" % tot_nevents
+    print "On average %f tracks from PV" % (float(tot_pv_ntracks)/tot_nevents)
+    print "On average %f TrackingParticles" % (float(tot_tps)/tot_nevents)
+    print " with %f %% reconstructed" % (float(tot_recoed)/tot_tps * 100)
+    print "  of which %f %% were reconstructed at least twice" % (float(tot_tp_dups)/tot_recoed * 100)
+    print "On average %f tracks" % (float(tot_ntracks)/tot_nevents)
+    print " with %f %% being high purity" % (float(tot_hptracks)/tot_ntracks * 100)
+    print " with fake rate %f %%" % (float(tot_fakes)/tot_ntracks * 100)
+    if tot_fakes_npixhits > 0:
+        print "  on average %f %% of pixel hits are true" % (float(tot_fakes_npixhits_true)/tot_fakes_npixhits * 100)
+        print "   pixel hits from %f TrackingParticles/track" % (float(tot_fakes_npixhits_tps)/tot_fakes)
+        print "  on average %f %% of strip hits are true" % (float(tot_fakes_nstrhits_true)/tot_fakes_nstrhits * 100)
+        print "  on average %f %% of hits are invalid" % (float(tot_fakes_ninvalidhits)/(tot_fakes_npixhits+tot_fakes_nstrhits) * 100)
+    print " with duplicate rate %f %%" % (float(tot_duplicates)/tot_ntracks * 100)
+    if tot_seeds > 0:
+        print " of which %f %% had a true seed" % (float(tot_track_seeds_true)/tot_ntracks * 100)
+        print "On average %f seeds" % (float(tot_seeds)/tot_nevents)
+        print " of which %f were from lowPtTripletStep" % (float(tot_seeds_lowPtTriplet)/tot_nevents)
+        print " of which %f %% were true" % (float(tot_seeds_true)/tot_seeds * 100)
+
+
+if __name__ == "__main__":
+    main()

--- a/Validation/RecoTrack/test/trackingNtupleExample.py
+++ b/Validation/RecoTrack/test/trackingNtupleExample.py
@@ -2,13 +2,13 @@
 
 import ROOT
 
+from Validation.RecoTrack.plotting.ntuple import *
+
 # The purpose of this file is to demonstrate mainly the links between
 # tracks, hits, seeds, and TrackingParticles.
 
 def main():
-    inputFile = ROOT.TFile.Open("trackingNtuple.root")
-    tree = inputFile.Get("trackingNtuple/tree")
-    entries = tree.GetEntriesFast()
+    ntuple = TrackingNtuple("trackingNtuple.root")
 
     tot_nevents = 0
     tot_pv_ntracks = 0
@@ -23,44 +23,57 @@ def main():
     tot_fakes_nstrhits_true = 0
     tot_fakes_npixhits_tps = 0
     tot_duplicates = 0
+    tot_secondaries = 0
 
     tot_tps = 0
     tot_recoed = 0
     tot_tp_dups = 0
 
+    tot_pix = 0
+    tot_pix_ntracks = 0
+    tot_pix_nseeds = 0
+    tot_str = 0
+    tot_str_ntracks = 0
+    tot_str_nseeds = 0
+    tot_glu = 0
+    tot_glu_nseeds = 0
+
     tot_seeds = 0
     tot_seeds_true = 0
     tot_seeds_lowPtTriplet = 0
+    tot_seeds_pixelhits = 0
+    tot_seeds_striphits = 0
+    tot_seeds_gluedhits = 0
     tot_track_seeds_true = 0
 
-    for jentry in xrange(entries):
-        # get the next tree in the chain and verify
-        ientry = tree.LoadTree( jentry )
-        if ientry < 0: break
-        # copy next entry into memory and verify
-        nb = tree.GetEntry( jentry )
-        if nb <= 0: continue
-
-        #print "Event", jentry
+    for event in ntuple:
+        #print "Event", event.entry()
         tot_nevents += 1
 
-        tot_pv_ntracks += tree.vtx_trkIdx[0].size()
+        vertices = event.vertices()
+        tot_pv_ntracks += vertices[0].nTracks()
 
         # links from TrackingParticles to tracks
-        ntps = tree.sim_px.size()
-        tot_tps += ntps
+        tps = event.trackingParticles()
+        tot_tps += len(tps)
         neff = 0
         ndups = 0
-        for itp in xrange(ntps):
-            if tree.sim_trkIdx[itp].size() >= 1:
+        for tp in tps:
+            if tp.nMatchedTracks() >= 1:
                 neff += 1
-                if tree.sim_trkIdx[itp].size() > 1:
+                if tp.nMatchedTracks() > 1:
                     ndups += 1
+
+                # links from TrackingParticles to reco hits
+                #print "TP", tp.index()
+                #for hit in tp.hits():
+                #    print " %s %d x %f y %f tof %f" % (hit.layerStr(), hit.detId(), hit.x(), hit.y(), hit.tof())
         tot_recoed += neff
         tot_tp_dups += ndups
 
         # links from tracks to TrackingParticles
-        ntracks = tree.trk_px.size()
+        tracks = event.tracks()
+        ntracks = len(tracks) # also tracks.size() works
         tot_ntracks += ntracks
         nfakes = 0
         nfakes_invalidhits = 0
@@ -70,41 +83,53 @@ def main():
         nfakes_strhits_true = 0
         nfakes_pixhits_tps = 0
         ndups = 0
-        for itrack in xrange(ntracks):
+        nsecondaries = 0
+        for track in tracks:
             if track.isHP():
                 tot_hptracks += 1
 
-            if tree.trk_simIdx[itrack].size() == 0:
-                #print "Track", itrack, " is fake"
+            if track.nMatchedTrackingParticles() == 0:
+                #print "Track", track.index(), " is fake"
 
                 nfakes += 1
 
+
                 # links from tracks to hits
-                if hasattr(tree, "pix_nSimTrk"):
+                if ntuple.hasHits():
                     pix_simTrkIds = set()
 
-                    for ihit in tree.trk_pixelIdx[itrack]:
-                        if ihit == -1:
+                    for hit in track.pixelHits():
+                        #print hit.layerStr()
+                        if not hit.isValid():
                             nfakes_invalidhits += 1
                             continue
                         nfakes_pixhits += 1
-                        if tree.pix_nSimTrk[ihit] >= 1:
+                        if hit.nMatchedTrackingParticles() >= 1:
+                            # links from hits to TrackingParticles
                             nfakes_pixhits_true += 1
-                        pix_simTrkIds.add(tree.pix_simTrkIdx[ihit]) # currently the index of only the "first" matched TP is stored
+                            for tpInfo in hit.matchedTrackingParticleInfos():
+                                pix_simTrkIds.add(tpInfo.trackingParticle().index())
                     nfakes_pixhits_tps += len(pix_simTrkIds)
 
-                    for ihit in tree.trk_stripIdx[itrack]:
-                        if ihit == -1:
+                    for hit in track.stripHits():
+                        #print hit.layerStr()
+                        if not hit.isValid():
                             nfakes_invalidhits += 1
                             continue
                         nfakes_strhits += 1
-                        if tree.str_nSimTrk[ihit] >= 1:
+                        if hit.nMatchedTrackingParticles() >= 1:
                             nfakes_strhits_true += 1
             else:
-                for itp in tree.trk_simIdx[itrack]:
-                    if tree.sim_trkIdx[itp].size() > 1:
+                for tpInfo in track.matchedTrackingParticleInfos():
+                    tp = tpInfo.trackingParticle()
+                    if tp.nMatchedTracks() > 1:
                         ndups += 1
                         break
+
+                    # TrackinParticle <-> TrackingVertex links
+                    if tp.parentVertex().nSourceTrackingParticles() > 0:
+                        nsecondaries += 1
+
         tot_fakes += nfakes
         tot_fakes_ninvalidhits += nfakes_invalidhits
         tot_fakes_npixhits += nfakes_pixhits
@@ -113,31 +138,68 @@ def main():
         tot_fakes_nstrhits_true += nfakes_strhits_true
         tot_fakes_npixhits_tps += nfakes_pixhits_tps
         tot_duplicates += ndups
+        tot_secondaries += nsecondaries
+
+        # hits
+        if ntuple.hasHits():
+            # links from hits to tracks
+            for hit in event.pixelHits():
+                tot_pix += 1
+                # hit -> track links
+                for track in hit.tracks():
+                    tot_pix_ntracks += 1
+
+            for hit in event.stripHits():
+                tot_str += 1
+                # hit -> track links
+                for track in hit.tracks():
+                    tot_str_ntracks += 1
+
+            tot_glu += len(event.gluedHits())
+
+            # hit -> seed links
+            if ntuple.hasSeeds():
+                for hit in event.pixelHits():
+                    for seed in hit.seeds():
+                        tot_pix_nseeds += 1
+                for hit in event.stripHits():
+                    for seed in hit.seeds():
+                        tot_str_nseeds += 1
+                for hit in event.gluedHits():
+                    for seed in hit.seeds():
+                        tot_glu_nseeds += 1
 
         # seeds
-        if hasattr(tree, "see_simIdx"):
-            nseeds = tree.see_simIdx.size()
+        if ntuple.hasSeeds():
+            seeds = event.seeds()
+            nseeds = len(seeds)
             tot_seeds += nseeds
 
             # finding seeds of a particular iteration
-            for ioffset, offset in enumerate(tree.see_offset):
-                if tree.see_algo[offset] == 5: # = lowPtTripletStep
-                    next_offset = tree.see_offset[ioffset+1] if ioffset < tree.see_offset.size() else tree.see_algo.size()
-                    tot_seeds_lowPtTriplet += next_offset - offset
-                    break
+            tot_seeds_lowPtTriplet += seeds.nSeedsForAlgo(5) # = lowPtTripletStep
 
             # links from seeds to TrackingParticles
             ntrue = 0
-            for iseed in xrange(nseeds):
-                if tree.see_simIdx[iseed].size() >= 1:
+            for seed in seeds:
+                if seed.nMatchedTrackingParticles() >= 1:
                     ntrue += 1
             tot_seeds_true = ntrue
 
+            # links from seeds to hits
+            for seed in seeds:
+                for hit in seed.hits():
+                    if isinstance(hit, PixelHit):
+                        tot_seeds_pixelhits += 1
+                    elif isinstance(hit, StripHit):
+                        tot_seeds_striphits += 1
+                    elif isinstance(hit, GluedHit):
+                        tot_seeds_gluedhits += 1
+
             # links from tracks to seeds
             ntracktrue = 0
-            for itrack in xrange(ntracks):
-                iseed = tree.trk_seedIdx[itrack]
-                if tree.see_simIdx[iseed].size() >= 1:
+            for track in tracks:
+                seed = track.seed()
+                if seed.nMatchedTrackingParticles() >= 1:
                     ntracktrue += 1
             tot_track_seeds_true += ntracktrue
 
@@ -149,6 +211,7 @@ def main():
     print "  of which %f %% were reconstructed at least twice" % (float(tot_tp_dups)/tot_recoed * 100)
     print "On average %f tracks" % (float(tot_ntracks)/tot_nevents)
     print " with %f %% being high purity" % (float(tot_hptracks)/tot_ntracks * 100)
+    print " with %f %% of true tracks being secondaries" % (float(tot_secondaries)/(tot_ntracks-tot_fakes) * 100)
     print " with fake rate %f %%" % (float(tot_fakes)/tot_ntracks * 100)
     if tot_fakes_npixhits > 0:
         print "  on average %f %% of pixel hits are true" % (float(tot_fakes_npixhits_true)/tot_fakes_npixhits * 100)
@@ -161,6 +224,18 @@ def main():
         print "On average %f seeds" % (float(tot_seeds)/tot_nevents)
         print " of which %f were from lowPtTripletStep" % (float(tot_seeds_lowPtTriplet)/tot_nevents)
         print " of which %f %% were true" % (float(tot_seeds_true)/tot_seeds * 100)
+        print " on average %f pixel hits / seed" % (float(tot_seeds_pixelhits)/tot_seeds)
+        print " on average %f strip hits / seed" % (float(tot_seeds_striphits)/tot_seeds)
+        print " on average %f glued hits / seed" % (float(tot_seeds_gluedhits)/tot_seeds)
+    if tot_pix > 0:
+        print "On average %f pixel hits" % (float(tot_pix)/tot_nevents)
+        print " on average %f tracks per hit" % (float(tot_pix_ntracks)/tot_pix)
+        print " on average %f seeds per hit" % (float(tot_pix_nseeds)/tot_pix)
+        print "On average %f strip hits" % (float(tot_str)/tot_nevents)
+        print " on average %f tracks per hit" % (float(tot_str_ntracks)/tot_str)
+        print " on average %f seeds per hit" % (float(tot_str_nseeds)/tot_str)
+        print "On average %f glued hits" % (float(tot_glu)/tot_nevents)
+        print " on average %f seeds per hit" % (float(tot_glu_nseeds)/tot_glu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds "tracking ntuple" that has more or less the same information as MultiTrackValidator in a form of an ntuple, easing detailed per-track studies. The code originates from @cerati, I have modernized and improved it.

On the same go (partly as a pre-requisite) the seed validation use-case of MultiTrackValidator is modified slightly (affects only the `trackingOnly` mode):
- pass also seeds, for which the fit in https://github.com/makortel/cmssw/blob/e32caa335e8e045aa3c5dc5389a5f4048202eabf/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc#L143 fails, to MultiTrackValidator
  - use special values (https://github.com/makortel/cmssw/blob/e32caa335e8e045aa3c5dc5389a5f4048202eabf/Validation/RecoTrack/interface/trackFromSeedFitFailed.h#L8) to flag such "reco::Track" objects
  - plots vs. e.g. pT are still filled for only those seeds for which the fit succeeds

Tested in CMSSW_8_1_X_2016-05-12-2300 (rebased on top of CMSSW_8_1_X_2016-05-31-2300), no changes expected in standard workflows.

@rovere @VinInn 
