### PR TITLE
Special case for only one ProductResolver matching a blank Process re…

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -467,4 +467,96 @@ namespace edm {
     << "Contact a Framework developer\n";
     
   }
+  
+  //---- SingleChoiceNoProcessProductResolver ----------------
+  ProductData const* SingleChoiceNoProcessProductResolver::resolveProduct_(ResolveStatus& resolveStatus,
+                                             Principal const& principal,
+                                             bool skipCurrentProcess,
+                                             SharedResourcesAcquirer* sra,
+                                             ModuleCallingContext const* mcc) const
+  {
+    //NOTE: Have to lookup the other ProductResolver each time rather than cache
+    // it's pointer since it appears the pointer can change at some later stage
+    return principal.getProductResolverByIndex(realResolverIndex_)
+      ->resolveProduct(resolveStatus, principal,
+                       skipCurrentProcess, sra, mcc);
+  }
+  void SingleChoiceNoProcessProductResolver::setProvenance_(ProductProvenanceRetriever const* , ProcessHistory const& , ProductID const& ) {
+  }
+  
+  void SingleChoiceNoProcessProductResolver::setProcessHistory_(ProcessHistory const& ) {
+  }
+  
+  ProductProvenance const* SingleChoiceNoProcessProductResolver::productProvenancePtr_() const {
+    return nullptr;
+  }
+  
+  void SingleChoiceNoProcessProductResolver::resetProductData_(bool) {
+  }
+  
+  bool SingleChoiceNoProcessProductResolver::singleProduct_() const {
+    return false;
+  }
+  
+  bool SingleChoiceNoProcessProductResolver::unscheduledWasNotRun_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::unscheduledWasNotRun_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  bool SingleChoiceNoProcessProductResolver::productUnavailable_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::productUnavailable_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  bool SingleChoiceNoProcessProductResolver::productResolved_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::productResolved_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  bool SingleChoiceNoProcessProductResolver::productWasDeleted_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::productWasDeleted_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  void SingleChoiceNoProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase> ) const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::putProduct_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  void SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp) const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp) not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  BranchDescription const& SingleChoiceNoProcessProductResolver::branchDescription_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::branchDescription_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  void SingleChoiceNoProcessProductResolver::resetBranchDescription_(std::shared_ptr<BranchDescription const>) {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::resetBranchDescription_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  Provenance const* SingleChoiceNoProcessProductResolver::provenance_() const {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::provenance_() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+  }
+  
+  void SingleChoiceNoProcessProductResolver::connectTo(ProductResolverBase const&, Principal const*) {
+    throw Exception(errors::LogicError)
+    << "SingleChoiceNoProcessProductResolver::connectTo() not implemented and should never be called.\n"
+    << "Contact a Framework developer\n";
+    
+  }
+
 }

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -257,6 +257,40 @@ namespace edm {
       std::vector<bool> ambiguous_;
   };
 
+  class SingleChoiceNoProcessProductResolver : public ProductResolverBase {
+  public:
+    typedef ProducedProductResolver::ProductStatus ProductStatus;
+    SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice):
+    ProductResolverBase(), realResolverIndex_(iChoice) {}
+    
+    virtual void connectTo(ProductResolverBase const& iOther, Principal const*) override final ;
+    
+  private:
+    virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus,
+                                               Principal const& principal,
+                                               bool skipCurrentProcess,
+                                               SharedResourcesAcquirer* sra,
+                                               ModuleCallingContext const* mcc) const override;
+    virtual bool unscheduledWasNotRun_() const override;
+    virtual bool productUnavailable_() const override;
+    virtual bool productWasDeleted_() const override;
+    virtual bool productResolved_() const override final;
+    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
+    virtual BranchDescription const& branchDescription_() const override;
+    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+    virtual Provenance const* provenance_() const override;
+    
+    virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
+    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+    virtual void setProcessHistory_(ProcessHistory const& ph) override;
+    virtual ProductProvenance const* productProvenancePtr_() const override;
+    virtual void resetProductData_(bool deleteEarly) override;
+    virtual bool singleProduct_() const override;
+    
+    ProductResolverIndex realResolverIndex_;
+  };
+
 }
 
 #endif


### PR DESCRIPTION
…quest

Created a special case ProductResolver to be used when looking up a data request which does not specify a Process name but would only match one data product in the job.
The special case will allow an efficiency optimization when requests are resolved asynchronously.
