### PR TITLE
HLT path/module-name updates in the HLTObjectMonitor

### DIFF
--- a/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
@@ -1,37 +1,37 @@
 import FWCore.ParameterSet.Config as cms
 
 #setup names for multiple plots that use the same paths+modules
-photon_pathName = "HLT_Photon30_R9Id90_HE10_IsoM_v3"
+photon_pathName = "HLT_Photon30_R9Id90_HE10_IsoM"
 photon_moduleName ="hltEG30R9Id90HE10IsoMTrackIsoFilter"
 
-muon_pathName = "HLT_IsoMu27_v3"
+muon_pathName = "HLT_IsoMu27"
 muon_moduleName = "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"
 
-l2muon_pathName = "HLT_L2Mu10_v1"
+l2muon_pathName = "HLT_L2Mu10"
 l2muon_moduleName = "hltL2fL1sMu22L1f0L2Filtered10Q"
 
-l2NoBPTXmuon_pathName = "HLT_L2Mu10_NoVertex_NoBPTX3BX_v1"
+l2NoBPTXmuon_pathName = "HLT_L2Mu10_NoVertex_NoBPTX3BX"
 l2NoBPTXmuon_moduleName = "hltL2fL1sMuOpenNotBptxORNoHaloMu3BXL1f0NoVtxCosmicSeedMeanTimerL2Filtered10"
 
-electron_pathName = "HLT_Ele23_WPLoose_Gsf_v3"
+electron_pathName = "HLT_Ele23_WPLoose_Gsf"
 electron_moduleName = "hltEle23WPLooseGsfTrackIsoFilter"
 
-caloMet_pathName = "HLT_MET60_IsoTrk35_Loose_v1"
+caloMet_pathName = "HLT_MET60_IsoTrk35_Loose"
 caloMet_moduleName = "hltMET60"
 
-pfMet_pathName = "HLT_PFMET120_PFMHT120_IDTight_v2"
+pfMet_pathName = "HLT_PFMET120_PFMHT120_IDTight"
 pfMet_moduleName = "hltPFMET120"
 
-jetAk8_pathName = "HLT_AK8PFJet360_TrimMass30_v3"
+jetAk8_pathName = "HLT_AK8PFJet360_TrimMass30"
 jetAk8_moduleName = "hltAK8SinglePFJet360TrimModMass30"
 
-rsq_mr_pathName = "HLT_RsqMR240_Rsq0p09_MR200_v2"
+rsq_mr_pathName = "HLT_RsqMR240_Rsq0p09_MR200"
 rsq_mr_moduleName = "hltRsqMR240Rsq0p09MR200"
 
-bJet_pathNameCalo = "HLT_PFMET120_BTagCSV_p067_v1"
+bJet_pathNameCalo = "HLT_PFMET120_BTagCSV_p067"
 bJet_moduleNameCalo = "hltBTagCaloCSVp067Single"
 
-bJet_pathNamePF = "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq500_v1"
+bJet_pathNamePF = "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq500"
 bJet_moduleNamePF = "hltBTagPFCSVp016SingleWithMatching"
 
 #To avoid booking histogram, set pathName = cms.string("")
@@ -39,7 +39,7 @@ bJet_moduleNamePF = "hltBTagPFCSVp016SingleWithMatching"
 hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
     processName = cms.string("HLT"),
     alphaT = cms.PSet(
-        pathName = cms.string("HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63_v2"),
+        pathName = cms.string("HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63"),
         moduleName = cms.string("hltPFHT200PFAlphaT0p63"),
         axisLabel = cms.string("Alpha_{T}"),
         plotLabel = cms.string("alphaT"),
@@ -199,7 +199,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(3.4)
         ),
     jetPt = cms.PSet(
-        pathName = cms.string("HLT_PFJet200_v4"),
+        pathName = cms.string("HLT_PFJet200"),
         moduleName = cms.string("hltSinglePFJet200"),
         plotLabel = cms.string("Jet_pT"),
         axisLabel = cms.string("jet p_{T} [GeV]"),
@@ -229,7 +229,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(200)
         ),   
     tauPt = cms.PSet(
-        pathName = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v4"),
+        pathName = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg"),
         moduleName = cms.string("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
         axisLabel = cms.string("tau p_{T} [GeV]"),
         plotLabel = cms.string("Tau_pT"),
@@ -239,7 +239,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(350)
         ),
     diMuonLowMass = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu4_3_Jpsi_Displaced_v2"),
+        pathName = cms.string("HLT_DoubleMu4_3_Jpsi_Displaced"),
         moduleName = cms.string("hltDisplacedmumuFilterDoubleMu43Jpsi"),
         plotLabel = cms.string("Dimuon_LowMass"),
         axisLabel = cms.string("di-muon low mass [GeV]"),
@@ -289,7 +289,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(3.4)
         ),
     caloHtPt = cms.PSet(
-        pathName = cms.string("HLT_HT650_DisplacedDijet80_Inclusive_v2"),
+        pathName = cms.string("HLT_HT650_DisplacedDijet80_Inclusive"),
         moduleName = cms.string("hltHT650"),
         plotLabel = cms.string("CaloHT_pT"),
         axisLabel = cms.string("calo HT p_{T} [GeV]"),
@@ -299,7 +299,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(2000)
         ),
     pfHtPt = cms.PSet(
-        pathName = cms.string("HLT_PFHT750_4JetPt50_v3"),
+        pathName = cms.string("HLT_PFHT750_4JetPt50"),
         moduleName = cms.string("hltPF4JetPt50HT750"),
         plotLabel = cms.string("PFHT_pT"),
         axisLabel = cms.string("PF HT p_{T} [GeV]"),
@@ -373,7 +373,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(2000)
         ),
     diMuonMass = cms.PSet(
-        pathName = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v2"),
+        pathName = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ"),
         moduleName = cms.string("hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4DzFiltered0p2"),
         pathName_OR = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ"),
         moduleName_OR = cms.string("hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4DzFiltered0p2"),
@@ -385,7 +385,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(160)
         ),
     diElecMass = cms.PSet(
-        pathName = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v3"),
+        pathName = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ"),
         moduleName = cms.string("hltEle23Ele12CaloIdLTrackIdLIsoVLDZFilter"),
         plotLabel = cms.string("di-Electron_Mass"),
         axisLabel = cms.string("di-electron mass [GeV]"),
@@ -395,7 +395,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(160)
         ),
     muonDxy = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu18NoFiltersNoVtx_v2"),
+        pathName = cms.string("HLT_DoubleMu18NoFiltersNoVtx"),
         moduleName = cms.string("hltL3fDimuonL1f0L2NVf10L3NoFiltersNoVtxFiltered18"),
         plotLabel = cms.string("Muon_dxy"),
         axisLabel = cms.string("muon d_{xy} [mm]"),

--- a/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
@@ -1,35 +1,36 @@
 import FWCore.ParameterSet.Config as cms
 
 #setup names for multiple plots that use the same paths+modules
-photon_pathName = "HLT_Photon30_R9Id90_HE10_IsoM"
+photon_pathName = "HLT_Photon30_R9Id90_HE10_IsoM_v3"
 photon_moduleName ="hltEG30R9Id90HE10IsoMTrackIsoFilter"
 
-muon_pathName = "HLT_IsoMu27"
-muon_moduleName = "hltL3crIsoL1sMu25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"
+muon_pathName = "HLT_IsoMu27_v3"
+muon_moduleName = "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"
 
-l2muon_pathName = "HLT_L2Mu10"
-l2muon_moduleName = "hltL2fL1sMu16L1f0L2Filtered10Q"
+l2muon_pathName = "HLT_L2Mu10_v1"
+l2muon_moduleName = "hltL2fL1sMu22L1f0L2Filtered10Q"
 
-l2NoBPTXmuon_pathName = "HLT_L2Mu10_NoVertex_NoBPTX3BX_NoHalo"
-l2NoBPTXmuon_moduleName = "hltL2fL1sMuOpenNotBptxORL1f0NoVtxCosmicSeedMeanTimerL2Filtered10"
+l2NoBPTXmuon_pathName = "HLT_L2Mu10_NoVertex_NoBPTX3BX_v1"
+l2NoBPTXmuon_moduleName = "hltL2fL1sMuOpenNotBptxORNoHaloMu3BXL1f0NoVtxCosmicSeedMeanTimerL2Filtered10"
 
-electron_pathName = "HLT_Ele23_WPLoose_Gsf"
+electron_pathName = "HLT_Ele23_WPLoose_Gsf_v3"
 electron_moduleName = "hltEle23WPLooseGsfTrackIsoFilter"
 
-caloMet_pathName = "HLT_MET60_IsoTrk35_Loose"
+caloMet_pathName = "HLT_MET60_IsoTrk35_Loose_v1"
 caloMet_moduleName = "hltMET60"
 
-pfMet_pathName = "HLT_PFMET120_PFMHT120_IDTight"
+pfMet_pathName = "HLT_PFMET120_PFMHT120_IDTight_v2"
 pfMet_moduleName = "hltPFMET120"
 
-jetAk8_pathName = "HLT_AK8PFJet360_TrimMass30"
+jetAk8_pathName = "HLT_AK8PFJet360_TrimMass30_v3"
 jetAk8_moduleName = "hltAK8SinglePFJet360TrimModMass30"
 
-rsq_mr_pathName = "HLT_RsqMR240_Rsq0p09_MR200"
+rsq_mr_pathName = "HLT_RsqMR240_Rsq0p09_MR200_v2"
 rsq_mr_moduleName = "hltRsqMR240Rsq0p09MR200"
 
-bJet_pathNameCalo = "HLT_PFMET120_BTagCSV_p067"
+bJet_pathNameCalo = "HLT_PFMET120_BTagCSV_p067_v1"
 bJet_moduleNameCalo = "hltBTagCaloCSVp067Single"
+
 bJet_pathNamePF = "HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq500_v1"
 bJet_moduleNamePF = "hltBTagPFCSVp016SingleWithMatching"
 
@@ -38,7 +39,7 @@ bJet_moduleNamePF = "hltBTagPFCSVp016SingleWithMatching"
 hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
     processName = cms.string("HLT"),
     alphaT = cms.PSet(
-        pathName = cms.string("HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63"),
+        pathName = cms.string("HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63_v2"),
         moduleName = cms.string("hltPFHT200PFAlphaT0p63"),
         axisLabel = cms.string("Alpha_{T}"),
         plotLabel = cms.string("alphaT"),
@@ -198,7 +199,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(3.4)
         ),
     jetPt = cms.PSet(
-        pathName = cms.string("HLT_PFJet200"),
+        pathName = cms.string("HLT_PFJet200_v4"),
         moduleName = cms.string("hltSinglePFJet200"),
         plotLabel = cms.string("Jet_pT"),
         axisLabel = cms.string("jet p_{T} [GeV]"),
@@ -228,7 +229,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(200)
         ),   
     tauPt = cms.PSet(
-        pathName = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg"),
+        pathName = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v4"),
         moduleName = cms.string("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
         axisLabel = cms.string("tau p_{T} [GeV]"),
         plotLabel = cms.string("Tau_pT"),
@@ -238,7 +239,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(350)
         ),
     diMuonLowMass = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu4_3_Jpsi_Displaced"),
+        pathName = cms.string("HLT_DoubleMu4_3_Jpsi_Displaced_v2"),
         moduleName = cms.string("hltDisplacedmumuFilterDoubleMu43Jpsi"),
         plotLabel = cms.string("Dimuon_LowMass"),
         axisLabel = cms.string("di-muon low mass [GeV]"),
@@ -288,7 +289,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(3.4)
         ),
     caloHtPt = cms.PSet(
-        pathName = cms.string("HLT_HT650_DisplacedDijet80_Inclusive"),
+        pathName = cms.string("HLT_HT650_DisplacedDijet80_Inclusive_v2"),
         moduleName = cms.string("hltHT650"),
         plotLabel = cms.string("CaloHT_pT"),
         axisLabel = cms.string("calo HT p_{T} [GeV]"),
@@ -298,7 +299,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(2000)
         ),
     pfHtPt = cms.PSet(
-        pathName = cms.string("HLT_PFHT750_4JetPt50"),
+        pathName = cms.string("HLT_PFHT750_4JetPt50_v3"),
         moduleName = cms.string("hltPF4JetPt50HT750"),
         plotLabel = cms.string("PFHT_pT"),
         axisLabel = cms.string("PF HT p_{T} [GeV]"),
@@ -372,7 +373,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(2000)
         ),
     diMuonMass = cms.PSet(
-        pathName = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ"),
+        pathName = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v2"),
         moduleName = cms.string("hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4DzFiltered0p2"),
         pathName_OR = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ"),
         moduleName_OR = cms.string("hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4DzFiltered0p2"),
@@ -384,7 +385,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(160)
         ),
     diElecMass = cms.PSet(
-        pathName = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ"),
+        pathName = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v3"),
         moduleName = cms.string("hltEle23Ele12CaloIdLTrackIdLIsoVLDZFilter"),
         plotLabel = cms.string("di-Electron_Mass"),
         axisLabel = cms.string("di-electron mass [GeV]"),
@@ -394,7 +395,7 @@ hltObjectMonitor = cms.EDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(160)
         ),
     muonDxy = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu18NoFiltersNoVtx"),
+        pathName = cms.string("HLT_DoubleMu18NoFiltersNoVtx_v2"),
         moduleName = cms.string("hltL3fDimuonL1f0L2NVf10L3NoFiltersNoVtxFiltered18"),
         plotLabel = cms.string("Muon_dxy"),
         axisLabel = cms.string("muon d_{xy} [mm]"),


### PR DESCRIPTION
Updated names of trigger paths and modules in the `HLTObjectMonitor` in accordance with the `/online/collisions/2016/25ns10e33/v1.0/HLT/V4` configuration.
