### PR TITLE
Ignore ICC specific flags (-ax*, -wd*)

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -478,7 +478,7 @@ class SerializationCodeGenerator(object):
         return os.path.join(self.cmssw_base, self.split_path[0], self.split_path[1], self.split_path[2], *path)
 
     def cleanFlags(self, flagsIn):
-	flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map')) ]
+        flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map', '-ax', '-wd')) ]
         blackList = ['--', '-fipa-pta']
         return [x for x in flags if x not in blackList]
 


### PR DESCRIPTION
The following is causing failures in ICC builds.

The script shouldn't use the current CXXFLAGS and should load them from
Clang specific toolfile.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
