### PR TITLE
numeric header include  for std::accumulate to fix gcc600 error

### DIFF
--- a/RecoTracker/TkSeedGenerator/src/FastCircleFit.cc
+++ b/RecoTracker/TkSeedGenerator/src/FastCircleFit.cc
@@ -13,6 +13,8 @@
 #define PRINT LogTrace("FastCircleFit")
 #endif
 
+#include <numeric>
+
 namespace {
   template<typename T>
   T sqr(T t) { return t*t; }


### PR DESCRIPTION
recent builds in gcc 600 are failing with 

```
RecoTracker/TkSeedGenerator/src/FastCircleFit.cc:56:34: error: 'accumulate' is not a member of 'std'
    const float invTotWeight = 1.f/std::accumulate(weight.begin(), weight.end(), 0.f);
                                  ^~~
```

added `#include <numeric>` to resolve the issue.
Afrer rebuilding RecoTracker/TkSeedGenerator and all other packages that failed linking in CMSSW_8_1_X_2016-05-13-2300 the cmsRun is functional again.
