### PR TITLE
Changed global bool in TinyXML to be atomic

### DIFF
--- a/FWCore/Utilities/interface/tinyxml.h
+++ b/FWCore/Utilities/interface/tinyxml.h
@@ -44,6 +44,7 @@ so fixed them to return a reference to the object.
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <atomic>
 
 // Help out windows:
 #if defined( _DEBUG ) && !defined( DEBUG )
@@ -414,7 +415,7 @@ private:
 
 	};
 	static Entity entity[ NUM_ENTITY ];
-	static bool condenseWhiteSpace;
+	static std::atomic<bool> condenseWhiteSpace;
 };
 
 

--- a/FWCore/Utilities/src/tinyxml.cc
+++ b/FWCore/Utilities/src/tinyxml.cc
@@ -40,7 +40,7 @@ distribution.
 
 #include <boost/lexical_cast.hpp>
 
-bool TiXmlBase::condenseWhiteSpace = true;
+std::atomic<bool> TiXmlBase::condenseWhiteSpace{true};
 
 // Microsoft compiler security
 FILE* TiXmlFOpen( const char* filename, const char* mode )


### PR DESCRIPTION
The bool used to set whether the output should condense white space
was changed to be atomic to avoid race conditions.
