### PR TITLE
Fix statistics of Trend plots

### DIFF
--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalMonitorTasks.PresampleTask_cfi import ecalPresampleTask
+from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 
 minChannelEntries = 6
 expectedMean = 200.0
@@ -17,7 +18,9 @@ ecalPresampleClient = cms.untracked.PSet(
         toleranceRMSFwd = cms.untracked.double(toleranceRMSFwd)
     ),
     sources = cms.untracked.PSet(
-        Pedestal = ecalPresampleTask.MEs.Pedestal
+        Pedestal = ecalPresampleTask.MEs.Pedestal,
+        PedestalByLS = ecalPresampleTask.MEs.PedestalByLS,
+        ChStatus = ecalIntegrityClient.MEs.ChStatus
     ),
     MEs = cms.untracked.PSet(
         RMS = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalMonitorTasks.TimingTask_cfi import ecalTimingTask
+from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 
 minChannelEntries = 5
 minTowerEntries = 15
@@ -27,7 +28,9 @@ ecalTimingClient = cms.untracked.PSet(
     ),
     sources = cms.untracked.PSet(
         TimeAllMap = ecalTimingTask.MEs.TimeAllMap,
-        TimeMap = ecalTimingTask.MEs.TimeMap
+        TimeMap = ecalTimingTask.MEs.TimeMap,
+        TimeMapByLS = ecalTimingTask.MEs.TimeMapByLS,
+        ChStatus = ecalIntegrityClient.MEs.ChStatus
     ),
     MEs = cms.untracked.PSet(
         RMSAll = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -44,6 +44,8 @@ namespace ecaldqm
     MESet& meRMSMapAll(MEs_.at("RMSMapAll"));
 
     MESet const& sPedestal(sources_.at("Pedestal"));
+    MESet const& sPedestalByLS(sources_.at("PedestalByLS"));
+    MESet const& sChStatus(sources_.at("ChStatus"));
 
     uint32_t mask(1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
 		  1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR);
@@ -51,6 +53,7 @@ namespace ecaldqm
     MESet::iterator qEnd(meQuality.end());
 
     MESet::const_iterator pItr(sPedestal);
+    MESet::const_iterator pLSItr(sPedestalByLS);
     double maxEB(0.), minEB(0.), maxEE(0.), minEE(0.);
     double rmsMaxEB(0.), rmsMaxEE(0.);
     for(MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()){
@@ -93,17 +96,32 @@ namespace ecaldqm
         meQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
       }
 
-      if(id.subdetId() == EcalBarrel){
-        if(mean > maxEB) maxEB = mean;
-        if(mean < minEB) minEB = mean;
-        if(rms > rmsMaxEB) rmsMaxEB = rms;
+      // Fill Presample Trend plots:
+      // Use PedestalByLS which only contains digis from "current" LS
+      pLSItr = qItr;
+      double entriesLS( pLSItr->getBinEntries() );
+      double meanLS( pLSItr->getBinContent() );
+      double rmsLS( pLSItr->getBinError() * std::sqrt(entries) );
+      float  chStatus( sChStatus.getBinContent(id) );
+
+      if ( entriesLS < minChannelEntries_ ) continue;
+      // Exclude problematic channels: see EcalChannelStatusCode.h
+      if ( chStatus != 0 ) continue;
+
+      // Get max/min
+      // Min is effectively just 0
+      if( id.subdetId() == EcalBarrel ){
+        if( meanLS > maxEB ) maxEB = meanLS;
+        if( meanLS < minEB ) minEB = meanLS;
+        if( rmsLS > rmsMaxEB ) rmsMaxEB = rmsLS;
       }
-      else{
-        if(mean > maxEE) maxEE = mean;
-        if(mean < minEE) minEE = mean;
-        if(rms > rmsMaxEE) rmsMaxEE = rms;
+      else {
+        if( meanLS > maxEE ) maxEE = meanLS;
+        if( meanLS < minEE ) minEE = meanLS;
+        if( rmsLS > rmsMaxEE ) rmsMaxEE = rmsLS;
       }
-    }
+
+    } // qItr
 
     towerAverage_(meRMSMapAll, meRMSMap, -1.);
 

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -3,6 +3,7 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 #include "CondFormats/EcalObjects/interface/EcalDQMStatusHelper.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatusCode.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -105,8 +106,7 @@ namespace ecaldqm
       float  chStatus( sChStatus.getBinContent(id) );
 
       if ( entriesLS < minChannelEntries_ ) continue;
-      // Exclude problematic channels: see EcalChannelStatusCode.h
-      if ( chStatus != 0 ) continue;
+      if ( chStatus != EcalChannelStatusCode::kOk ) continue; // exclude problematic channels
 
       // Get max/min
       // Min is effectively just 0

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -3,6 +3,7 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 #include "CondFormats/EcalObjects/interface/EcalDQMStatusHelper.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatusCode.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -144,9 +145,7 @@ namespace ecaldqm
       float chStatus( sChStatus.getBinContent(id) );
       
       if ( entriesLS < minChannelEntries ) continue;
-      // Exclude problematic channels: see EcalChannelStatusCode.h
-      if ( chStatus != 0 )
-          continue;
+      if ( chStatus != EcalChannelStatusCode::kOk ) continue; // exclude problematic channels
       
       // Keep running count of timing mean, rms, and N_hits
       if ( id.subdetId() == EcalBarrel ) {

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -56,6 +56,8 @@ namespace ecaldqm
 
     MESet const& sTimeAllMap(sources_.at("TimeAllMap"));
     MESet const& sTimeMap(sources_.at("TimeMap"));
+    MESet const& sTimeMapByLS(sources_.at("TimeMapByLS"));
+    MESet const& sChStatus(sources_.at("ChStatus"));
 
     uint32_t mask(1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING);
 
@@ -63,6 +65,7 @@ namespace ecaldqm
 
     MESet::iterator rItr(meRMSMap);
     MESet::const_iterator tItr(sTimeMap);
+    MESet::const_iterator tLSItr(sTimeMapByLS);
 
     float EBentries(0.), EEentries(0.);
     float EBmean(0.), EEmean(0.);
@@ -134,15 +137,26 @@ namespace ecaldqm
         qItr->setBinContent(doMask ? kMGood : kGood);
 
       // For Trend plots:
+      tLSItr = qItr;
+      float entriesLS( tLSItr->getBinEntries() );
+      float meanLS( tLSItr->getBinContent() );
+      float rmsLS( tLSItr->getBinError() * sqrt(entriesLS) );
+      float chStatus( sChStatus.getBinContent(id) );
+      
+      if ( entriesLS < minChannelEntries ) continue;
+      // Exclude problematic channels: see EcalChannelStatusCode.h
+      if ( chStatus != 0 )
+          continue;
+      
       // Keep running count of timing mean, rms, and N_hits
       if ( id.subdetId() == EcalBarrel ) {
-        EBmean += mean;
-        EBrms += rms;
-        EBentries += entries;
+        EBmean += meanLS;
+        EBrms += rmsLS;
+        EBentries += entriesLS;
       } else {
-        EEmean += mean;
-        EErms += rms;
-        EEentries += entries;
+        EEmean += meanLS;
+        EErms += rmsLS;
+        EEentries += entriesLS;
       }
 
     } // channel loop

--- a/DQM/EcalMonitorTasks/interface/PresampleTask.h
+++ b/DQM/EcalMonitorTasks/interface/PresampleTask.h
@@ -20,11 +20,13 @@ namespace ecaldqm
     template<typename DigiCollection> void runOnDigis(DigiCollection const&);
 
   private:
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
 
     bool doPulseMaxCheck_;
     int pulseMaxPosition_;
     int nSamples_;
+    MESet* mePedestalByLS;
   };
 
   inline bool PresampleTask::analyze(void const* _p, Collections _collection){

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -20,12 +20,15 @@ namespace ecaldqm {
     void runOnUncalibRecHits(EcalUncalibratedRecHitCollection const&);
 
   private:
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
 
     float chi2ThresholdEB_;
     float chi2ThresholdEE_;
     float energyThresholdEB_;
     float energyThresholdEE_;
+
+    MESet* meTimeMapByLS;
   };
 
   inline bool TimingTask::analyze(void const* _p, Collections _collection){

--- a/DQM/EcalMonitorTasks/python/PresampleTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/PresampleTask_cfi.py
@@ -13,6 +13,13 @@ ecalPresampleTask = cms.untracked.PSet(
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('2D distribution of mean presample value.')
+        ),
+        PedestalByLS = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sPedestalOnlineTask/Gain12/%(prefix)sPOT pedestal by LS %(sm)s G12'),
+            kind = cms.untracked.string('TProfile2D'),
+            otype = cms.untracked.string('SM'),
+            btype = cms.untracked.string('Crystal'),
+            description = cms.untracked.string('2D distribution of mean presample value for "current" LS.')
         )
     )
 )

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -31,6 +31,18 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('2D distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
         ),
+        TimeMapByLS = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing by LS %(sm)s'),
+            kind = cms.untracked.string('TProfile2D'),
+            zaxis = cms.untracked.PSet(
+                high = cms.untracked.double(timeWindow),
+                low = cms.untracked.double(-timeWindow),
+                title = cms.untracked.string('time (ns)')
+            ),
+            otype = cms.untracked.string('SM'),
+            btype = cms.untracked.string('Crystal'),
+            description = cms.untracked.string('2D distribution of the mean rec hit timing. Only hits with GOOD or OUT_OF_TIME reconstruction flags and energy above threshold are used. Hits with |t| > ' + str(timeWindow) + ' ns are discarded. The energy thresholds are ' + ('%f and %f' % (energyThresholdEB, energyThresholdEE)) + ' for EB and EE respectively.')
+        ),
         TimeAll = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing 1D summary%(suffix)s'),
             kind = cms.untracked.string('TH1F'),

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -12,7 +12,8 @@ namespace ecaldqm
     DQWorkerTask(),
     doPulseMaxCheck_(true),
     pulseMaxPosition_(0),
-    nSamples_(0)
+    nSamples_(0),
+    mePedestalByLS(0)
   {
   }
 
@@ -39,11 +40,22 @@ namespace ecaldqm
     return false;
   }
 
+  void
+  PresampleTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+  {
+    // Fill separate MEs with only 4 LSs worth of stats
+    // Used to correctly fill Presample Trend plots:
+    // 1 pt ~ 4 LS in Trend plots
+    mePedestalByLS = &MEs_.at("PedestalByLS");
+    if ( timestamp_.iLumi % 4 == 0 )
+      mePedestalByLS->reset();
+  }
+
   template<typename DigiCollection>
   void
   PresampleTask::runOnDigis(DigiCollection const& _digis)
   {
-    MESet& mePedestal(MEs_.at("Pedestal"));
+    MESet& mePedestal(MEs_.at("Pedestal")); // contains cumulative run stats => not suitable for Trend plots
 
     for(typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr){
       DetId id(digiItr->id());
@@ -71,8 +83,10 @@ namespace ecaldqm
         if(iMax != pulseMaxPosition_ || gainSwitch) continue;
       } // PulseMaxCheck
 
-      for(int iSample(0); iSample < nSamples_; ++iSample)
+      for(int iSample(0); iSample < nSamples_; ++iSample) {
         mePedestal.fill(id, double(dataFrame.sample(iSample).adc()));
+        mePedestalByLS->fill(id, double(dataFrame.sample(iSample).adc()));
+      }
 
     } // _digis loop
   } // runOnDigis

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -43,11 +43,11 @@ namespace ecaldqm
   void
   PresampleTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
   {
-    // Fill separate MEs with only 4 LSs worth of stats
+    // Fill separate MEs with only 10 LSs worth of stats
     // Used to correctly fill Presample Trend plots:
-    // 1 pt ~ 4 LS in Trend plots
+    // 1 pt:10 LS in Trend plots
     mePedestalByLS = &MEs_.at("PedestalByLS");
-    if ( timestamp_.iLumi % 4 == 0 )
+    if ( timestamp_.iLumi % 10 == 0 )
       mePedestalByLS->reset();
   }
 

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -13,7 +13,8 @@ namespace ecaldqm
     chi2ThresholdEB_(0.),
     chi2ThresholdEE_(0.),
     energyThresholdEB_(0.),
-    energyThresholdEE_(0.)
+    energyThresholdEE_(0.),
+    meTimeMapByLS(0)
   {
   }
 
@@ -41,6 +42,17 @@ namespace ecaldqm
     return false;
   }
 
+  void
+  TimingTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+  {
+    // Fill separate MEs with only 4 LSs worth of stats
+    // Used to correctly fill Presample Trend plots:
+    // 1 pt ~ 4 LS in Trend plots
+    meTimeMapByLS = &MEs_.at("TimeMapByLS");
+    if ( timestamp_.iLumi % 4 == 0 )
+      meTimeMapByLS->reset();
+  }
+
   void 
   TimingTask::runOnRecHits(EcalRecHitCollection const& _hits, Collections _collection)
   {
@@ -48,7 +60,7 @@ namespace ecaldqm
     MESet& meTimeAmpAll(MEs_.at("TimeAmpAll"));
     MESet& meTimeAll(MEs_.at("TimeAll"));
     MESet& meTimeAllMap(MEs_.at("TimeAllMap"));
-    MESet& meTimeMap(MEs_.at("TimeMap"));
+    MESet& meTimeMap(MEs_.at("TimeMap")); // contains cumulative run stats => not suitable for Trend plots
     MESet& meTime1D(MEs_.at("Time1D"));
     MESet& meChi2(MEs_.at("Chi2"));
 
@@ -64,25 +76,20 @@ namespace ecaldqm
                     float time(hit.time());
                     float energy(hit.energy());
 
+                    // Apply cut on chi2 of pulse shape fit
                     float chi2Threshold = ( id.subdetId() == EcalBarrel ) ? chi2ThresholdEB_ : chi2ThresholdEE_;
-                    if (id.subdetId() == EcalBarrel) {
-                      signedSubdet=EcalBarrel;
-                    }
+                    if ( id.subdetId() == EcalBarrel )
+                      signedSubdet = EcalBarrel;
                     else {
-                      EEDetId eeId(hit.id());
-                      if(eeId.zside() < 0){
+                      EEDetId eeId( hit.id() );
+                      if ( eeId.zside() < 0 )
                         signedSubdet = -EcalEndcap;
-                      }
-                      else{
-                        signedSubdet = EcalEndcap;
-                      }
+                      else
+                        signedSubdet =  EcalEndcap;
                     }
-
-                    if(energy > threshold){
+                    if ( energy > threshold )
                       meChi2.fill(signedSubdet, hit.chi2());
-                    }
-
-                    if( hit.chi2() > chi2Threshold ) return;
+                    if ( hit.chi2() > chi2Threshold ) return;
 
                     meTimeAmp.fill(id, energy, time);
                     meTimeAmpAll.fill(id, energy, time);
@@ -90,6 +97,7 @@ namespace ecaldqm
                     if(energy > threshold){
                       meTimeAll.fill(id, time);
                       meTimeMap.fill(id, time);
+                      meTimeMapByLS->fill(id, time); 
                       meTime1D.fill(id, time);
                       meTimeAllMap.fill(id, time);
                     }

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -45,11 +45,11 @@ namespace ecaldqm
   void
   TimingTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
   {
-    // Fill separate MEs with only 4 LSs worth of stats
+    // Fill separate MEs with only 10 LSs worth of stats
     // Used to correctly fill Presample Trend plots:
-    // 1 pt ~ 4 LS in Trend plots
+    // 1 pt:10 LS in Trend plots
     meTimeMapByLS = &MEs_.at("TimeMapByLS");
-    if ( timestamp_.iLumi % 4 == 0 )
+    if ( timestamp_.iLumi % 10 == 0 )
       meTimeMapByLS->reset();
   }
 


### PR DESCRIPTION
**Fix Presample and Timing Trend plots**
- Create new set of Task MEs that only contain statistics from "current LS" which the Client Trend plots will analyze
- Define "current LS" = 10 LSs (10 LSs = 1 pt in the Trend plots) and we want to collect sufficient stats so that different channels are well-represented beyond the minChannelEntries threshold
- Include a filter to exclude channels with status other than EcalChannelStatusCode::kOk.
- Previously, Trend plots were using cumulative statistics causing noisy channels to accumulate enough stats to bias trend which resulted in "jumping" phenomenon after plot resets
- See 81X PR https://github.com/cms-sw/cmssw/pull/14518
