### PR TITLE
Adding the cosmic during collision reconstruction in CMSSW81X

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -69,7 +69,7 @@ reconstructionCosmics         = cms.Sequence(localReconstructionCosmics*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
-                                             cosmicCDCTracksSeq*
+                                             cosmicDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics*
                                              logErrorHarvester)
@@ -78,7 +78,7 @@ reconstructionCosmics_HcalNZS = cms.Sequence(localReconstructionCosmics_HcalNZS*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
-                                             cosmicCDCTracksSeq*
+                                             cosmicDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics*
                                              logErrorHarvester)
@@ -86,6 +86,6 @@ reconstructionCosmics_woTkBHM = cms.Sequence(localReconstructionCosmics*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
-                                             cosmicCDCTracksSeq*
+                                             cosmicDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics)

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -69,6 +69,7 @@ reconstructionCosmics         = cms.Sequence(localReconstructionCosmics*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
+                                             cosmicCDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics*
                                              logErrorHarvester)
@@ -77,6 +78,7 @@ reconstructionCosmics_HcalNZS = cms.Sequence(localReconstructionCosmics_HcalNZS*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
+                                             cosmicCDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics*
                                              logErrorHarvester)
@@ -84,5 +86,6 @@ reconstructionCosmics_woTkBHM = cms.Sequence(localReconstructionCosmics*
                                              jetsCosmics*
                                              muonsCosmics*
                                              regionalCosmicTracksSeq*
+                                             cosmicCDCTracksSeq*
                                              metrecoCosmics*
                                              egammaCosmics)

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -44,7 +44,7 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 
 # Cosmic During Collisions
-from RecoTracker.SpecialSeedGenerators.cosmicCDC_cff import *
+from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
 
 localreco = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
 localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
@@ -96,7 +96,7 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
                              recoPFMET*
                              PFTau*
                              reducedRecHits*
-                             cosmicCDCTracksSeq
+                             cosmicDCTracksSeq
                              )
 
 

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -95,16 +95,17 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
                              btagging*
                              recoPFMET*
                              PFTau*
-                             reducedRecHits
+                             reducedRecHits*
+                             cosmicCDCTracksSeq
                              )
 
 
 from FWCore.Modules.logErrorHarvester_cfi import *
 
 # "Export" Section
-reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
+reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
 
-reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking*cosmicCDCTracksSeq)
+reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well
@@ -185,15 +186,15 @@ reconstruction_noTracking = reconstruction.copyAndExclude(noTrackingAndDependent
 
 
 #sequences with additional stuff
-reconstruction_withPixellessTk  = cms.Sequence(localreco        *globalreco_plusPL*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
-reconstruction_HcalNZS = cms.Sequence(localreco_HcalNZS*globalreco       *highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
+reconstruction_withPixellessTk  = cms.Sequence(localreco        *globalreco_plusPL*highlevelreco*logErrorHarvester)
+reconstruction_HcalNZS = cms.Sequence(localreco_HcalNZS*globalreco       *highlevelreco*logErrorHarvester)
 
 #sequences without some stuffs
 #
-reconstruction_woCosmicMuons = cms.Sequence(localreco*globalreco*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
+reconstruction_woCosmicMuons = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
 
 
 # define a standard candle. please note I am picking up individual
 # modules instead of sequences
 #
-reconstruction_standard_candle = cms.Sequence(localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence*cosmicCDCTracksSeq)
+reconstruction_standard_candle = cms.Sequence(localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence)

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -43,6 +43,9 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
 from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 
+# Cosmic During Collisions
+from RecoTracker.SpecialSeedGenerators.cosmicCDC_cff import *
+
 localreco = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
 localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
@@ -99,9 +102,9 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
 from FWCore.Modules.logErrorHarvester_cfi import *
 
 # "Export" Section
-reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
 
-reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking)
+reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking*cosmicCDCTracksSeq)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well
@@ -182,15 +185,15 @@ reconstruction_noTracking = reconstruction.copyAndExclude(noTrackingAndDependent
 
 
 #sequences with additional stuff
-reconstruction_withPixellessTk  = cms.Sequence(localreco        *globalreco_plusPL*highlevelreco*logErrorHarvester)
-reconstruction_HcalNZS = cms.Sequence(localreco_HcalNZS*globalreco       *highlevelreco*logErrorHarvester)
+reconstruction_withPixellessTk  = cms.Sequence(localreco        *globalreco_plusPL*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
+reconstruction_HcalNZS = cms.Sequence(localreco_HcalNZS*globalreco       *highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
 
 #sequences without some stuffs
 #
-reconstruction_woCosmicMuons = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction_woCosmicMuons = cms.Sequence(localreco*globalreco*highlevelreco*cosmicCDCTracksSeq*logErrorHarvester)
 
 
 # define a standard candle. please note I am picking up individual
 # modules instead of sequences
 #
-reconstruction_standard_candle = cms.Sequence(localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence)
+reconstruction_standard_candle = cms.Sequence(localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence*cosmicCDCTracksSeq)

--- a/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
+++ b/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
@@ -135,6 +135,7 @@ _reco.egammaHighLevelRecoPrePF.remove(_reco.conversionSequence)
 ##########################################
 # not commisoned and not relevant in FastSim (?):
 _reco.globalreco.remove(_reco.muoncosmicreco)
+_reco.highlevelreco.remove(_reco.cosmicDCTracksSeq)
 _reco.highlevelreco.remove(_reco.muoncosmichighlevelreco)
 _reco.muons.FillCosmicsIdMap = False
 

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -29,6 +29,17 @@ muons.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 muons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
 muons.CaloExtractorPSet.CenterConeOnCalIntersection = True
 
+#similar to what's in pp configuration
+muonsFromCosmics = muons1stStep.clone()
+muonsFromCosmics.inputCollectionLabels = ['cosmicMuons']
+muonsFromCosmics.inputCollectionTypes = ['outer tracks']
+muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
+muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
+muonsFromCosmics.fillIsolation = False
+muonsFromCosmics.fillGlobalTrackQuality = False
+muonsFromCosmics.fillGlobalTrackRefits = False
+
 from RecoMuon.MuonIdentification.calomuons_cfi import *
 calomuons.inputTracks = 'ctfWithMaterialTracksP5LHCNavigation'
 calomuons.inputCollection = 'muons'
@@ -67,7 +78,7 @@ glbTrackQual.InputCollection = "globalCosmicMuons"
 allmuons = cms.Sequence(glbTrackQual*tevMuons*muons*muIsolation*calomuons)
 
 # Final sequence
-muonrecoforcosmics = cms.Sequence(muontrackingforcosmics*allmuons)
+muonrecoforcosmics = cms.Sequence(muontrackingforcosmics*allmuons*muonsFromCosmics)
 muonRecoAllGR = cms.Sequence(muonrecoforcosmics)
 
 # 1 leg mode

--- a/RecoTracker/Configuration/python/RecoTrackerP5_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_EventContent_cff.py
@@ -58,6 +58,9 @@ RecoTrackerFEVT = cms.PSet(
         'keep *_dedxTruncated40CosmicTF_*_*',
         'keep *_dedxHitInfoCosmicTF_*_*',
         'keep *_dedxHarmonic2CosmicTF_*_*',
+        'keep recoTracks_cosmicDCTracks_*_*',
+        'keep recoTrackExtras_cosmicDCTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
     )
 )
 #RECO content
@@ -110,6 +113,9 @@ RecoTrackerRECO = cms.PSet(
         'keep *_dedxTruncated40CosmicTF_*_*',
         'keep *_dedxHitInfoCosmicTF_*_*',
         'keep *_dedxHarmonic2CosmicTF_*_*',
+        'keep recoTracks_cosmicDCTracks_*_*',
+        'keep recoTrackExtras_cosmicDCTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
     )
 )
 #AOD content

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -79,4 +79,4 @@ from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 regionalCosmicTrackerSeeds.RegionInJetsCheckPSet = cms.PSet( doJetsExclusionCheck   = cms.bool( False ) )
 
 # CDC Reconstruction
-from RecoTracker.SpecialSeedGenerators.cosmicCDC_cff import *
+from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -77,3 +77,6 @@ ckfTrackCandidatesP5.useHitsSplitting = True
 # REGIONAL RECONSTRUCTION
 from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 regionalCosmicTrackerSeeds.RegionInJetsCheckPSet = cms.PSet( doJetsExclusionCheck   = cms.bool( False ) )
+
+# CDC Reconstruction
+from RecoTracker.SpecialSeedGenerators.cosmicCDC_cff import *

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -22,6 +22,9 @@ RecoTrackerFEVT = cms.PSet(
         'keep *_dedxHitInfo_*_*',
         'keep *_dedxHarmonic2_*_*',
         'keep *_trackExtrapolator_*_*',
+        'keep recoTracks_cosmicDCTracks_*_*',
+        'keep recoTrackExtras_cosmicDCTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
      )
 )
 #RECO content
@@ -44,7 +47,10 @@ RecoTrackerRECO = cms.PSet(
         'keep *_dedxTruncated40_*_*',
         'keep *_dedxHitInfo_*_*',
         'keep *_dedxHarmonic2_*_*',
-        'keep *_trackExtrapolator_*_*'
+        'keep *_trackExtrapolator_*_*',
+        'keep recoTracks_cosmicDCTracks_*_*',
+        'keep recoTrackExtras_cosmicDCTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
     )
 )
 #AOD content

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicCDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicCDC_cff.py
@@ -1,25 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
 # seeding
-cosmicMuonsWithCuts = cms.EDFilter("TrackSelector",
-  src=cms.InputTag("cosmicMuons"),
-  cut = cms.string('pt > 2 && abs(eta)<1.2 && phi<0'),           
-)
+from RecoMuon.CosmicMuonProducer.cosmicMuons_cfi import *
 import RecoMuon.MuonIdentification.muons1stStep_cfi
 muonsForCosmicCDC = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
-    inputCollectionLabels = cms.VInputTag("cosmicMuonsWithCuts"),
+    inputCollectionLabels = cms.VInputTag("cosmicMuons"),
     inputCollectionTypes = cms.vstring('outer tracks'),
     fillIsolation = cms.bool(False),
     fillGlobalTrackQuality = cms.bool(False),
     fillGlobalTrackRefits = cms.bool(False),
 )
-muonsForCosmicCDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuonsWithCuts")
+muonsForCosmicCDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuons")
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
 hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
     ComponentName = cms.string('hitCollectorForOutInMuonSeeds'),
     MaxChi2 = cms.double(100.0), ## was 30 ## TO BE TUNED
     nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
+    MaxDisplacement = cms.double(100),
+    MaxSagitta = cms.double(-1.0),
+    MinimalTolerance = cms.double(0.5),
+    appendToDataLabel = cms.string(''),
 )
 cosmicCDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
     src = cms.InputTag("muonsForCosmicCDC"),
@@ -42,4 +43,4 @@ cosmicCDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWit
 )
 
 # Final Sequence
-cosmicCDCTracksSeq = cms.Sequence( cosmicMuonsWithCuts * muonsForCosmicCDC * cosmicCDCSeeds * cosmicCDCCkfTrackCandidates * cosmicCDCTracks )
+cosmicCDCTracksSeq = cms.Sequence( cosmicMuons * muonsForCosmicCDC * cosmicCDCSeeds * cosmicCDCCkfTrackCandidates * cosmicCDCTracks )

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicCDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicCDC_cff.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+# seeding
+cosmicMuonsWithCuts = cms.EDFilter("TrackSelector",
+  src=cms.InputTag("cosmicMuons"),
+  cut = cms.string('pt > 2 && abs(eta)<1.2 && phi<0'),           
+)
+import RecoMuon.MuonIdentification.muons1stStep_cfi
+muonsForCosmicCDC = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
+    inputCollectionLabels = cms.VInputTag("cosmicMuonsWithCuts"),
+    inputCollectionTypes = cms.vstring('outer tracks'),
+    fillIsolation = cms.bool(False),
+    fillGlobalTrackQuality = cms.bool(False),
+    fillGlobalTrackRefits = cms.bool(False),
+)
+muonsForCosmicCDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuonsWithCuts")
+import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
+hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('hitCollectorForOutInMuonSeeds'),
+    MaxChi2 = cms.double(100.0), ## was 30 ## TO BE TUNED
+    nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
+)
+cosmicCDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
+    src = cms.InputTag("muonsForCosmicCDC"),
+    cut = cms.string("pt > 2 && abs(eta)<1.2 && phi<0"),
+    fromVertex = cms.bool(False),
+    maxEtaForTOB = cms.double(1.5),
+    minEtaForTEC = cms.double(0.7),
+)
+
+# Ckf pattern
+import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
+cosmicCDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
+    src = cms.InputTag( "cosmicCDCSeeds" ),
+)
+
+# Track producer
+import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff
+cosmicCDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
+    src = cms.InputTag( "cosmicCDCCkfTrackCandidates" ),
+)
+
+# Final Sequence
+cosmicCDCTracksSeq = cms.Sequence( cosmicMuonsWithCuts * muonsForCosmicCDC * cosmicCDCSeeds * cosmicCDCCkfTrackCandidates * cosmicCDCTracks )

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 # seeding
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
-hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('hitCollectorForOutInMuonSeeds'),
+hitCollectorForCosmicDCSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('hitCollectorForCosmicDCSeeds'),
     MaxChi2 = cms.double(100.0), ## was 30 ## TO BE TUNED
     nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
     MaxDisplacement = cms.double(100),
@@ -15,6 +15,7 @@ hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
 cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
     src = cms.InputTag("muonsFromCosmics"),
     cut = cms.string("pt > 2 && abs(eta)<1.2 && phi<0"),
+    hitCollector = cms.string('hitCollectorForCosmicDCSeeds'),
     fromVertex = cms.bool(False),
     maxEtaForTOB = cms.double(1.5),
     minEtaForTEC = cms.double(0.7),

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -1,16 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 # seeding
-from RecoMuon.CosmicMuonProducer.cosmicMuons_cfi import *
-import RecoMuon.MuonIdentification.muons1stStep_cfi
-muonsForCosmicDC = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
-    inputCollectionLabels = cms.VInputTag("cosmicMuons"),
-    inputCollectionTypes = cms.vstring('outer tracks'),
-    fillIsolation = cms.bool(False),
-    fillGlobalTrackQuality = cms.bool(False),
-    fillGlobalTrackRefits = cms.bool(False),
-)
-muonsForCosmicDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuons")
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
 hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
@@ -23,7 +13,7 @@ hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
     appendToDataLabel = cms.string(''),
 )
 cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-    src = cms.InputTag("muonsForCosmicDC"),
+    src = cms.InputTag("muonsFromCosmics"),
     cut = cms.string("pt > 2 && abs(eta)<1.2 && phi<0"),
     fromVertex = cms.bool(False),
     maxEtaForTOB = cms.double(1.5),
@@ -43,4 +33,4 @@ cosmicDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWith
 )
 
 # Final Sequence
-cosmicDCTracksSeq = cms.Sequence( cosmicMuons * muonsForCosmicDC * cosmicDCSeeds * cosmicDCCkfTrackCandidates * cosmicDCTracks )
+cosmicDCTracksSeq = cms.Sequence( cosmicDCSeeds * cosmicDCCkfTrackCandidates * cosmicDCTracks )

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -3,14 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # seeding
 from RecoMuon.CosmicMuonProducer.cosmicMuons_cfi import *
 import RecoMuon.MuonIdentification.muons1stStep_cfi
-muonsForCosmicCDC = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
+muonsForCosmicDC = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
     inputCollectionLabels = cms.VInputTag("cosmicMuons"),
     inputCollectionTypes = cms.vstring('outer tracks'),
     fillIsolation = cms.bool(False),
     fillGlobalTrackQuality = cms.bool(False),
     fillGlobalTrackRefits = cms.bool(False),
 )
-muonsForCosmicCDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuons")
+muonsForCosmicDC.TrackExtractorPSet.inputTrackCollection = cms.InputTag("cosmicMuons")
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
 hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
@@ -22,8 +22,8 @@ hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
     MinimalTolerance = cms.double(0.5),
     appendToDataLabel = cms.string(''),
 )
-cosmicCDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-    src = cms.InputTag("muonsForCosmicCDC"),
+cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
+    src = cms.InputTag("muonsForCosmicDC"),
     cut = cms.string("pt > 2 && abs(eta)<1.2 && phi<0"),
     fromVertex = cms.bool(False),
     maxEtaForTOB = cms.double(1.5),
@@ -32,15 +32,15 @@ cosmicCDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons
 
 # Ckf pattern
 import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
-cosmicCDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
-    src = cms.InputTag( "cosmicCDCSeeds" ),
+cosmicDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
+    src = cms.InputTag( "cosmicDCSeeds" ),
 )
 
 # Track producer
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff
-cosmicCDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
-    src = cms.InputTag( "cosmicCDCCkfTrackCandidates" ),
+cosmicDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
+    src = cms.InputTag( "cosmicDCCkfTrackCandidates" ),
 )
 
 # Final Sequence
-cosmicCDCTracksSeq = cms.Sequence( cosmicMuons * muonsForCosmicCDC * cosmicCDCSeeds * cosmicCDCCkfTrackCandidates * cosmicCDCTracks )
+cosmicDCTracksSeq = cms.Sequence( cosmicMuons * muonsForCosmicDC * cosmicDCSeeds * cosmicDCCkfTrackCandidates * cosmicDCTracks )


### PR DESCRIPTION
Implemention of cosmic reconstruction during collision. This could be really usuful for the alignment of the tracker. More details can be found in the following slides, presented at the tracking pog:
https://indico.cern.ch/event/527844/contributions/2160782/attachments/1269896/1881218/AnielloSpiezia_090516.pdf
