### PR TITLE
Fix setting the # of presamples for HcalUpgradeDataFrame.

### DIFF
--- a/DataFormats/HcalDigi/src/HcalUpgradeDataFrame.cc
+++ b/DataFormats/HcalDigi/src/HcalUpgradeDataFrame.cc
@@ -32,9 +32,9 @@ void HcalUpgradeDataFrame::setSize(int size) {
 }
 
 void HcalUpgradeDataFrame::setPresamples(int presamples) {
-  if (presamples>MAXSAMPLES) presamples_|=MAXSAMPLES&0xF;
+  if (presamples>MAXSAMPLES) presamples_=MAXSAMPLES&0xF;
   else if (presamples<=0) presamples_=0;
-  else presamples_|=presamples&0xF;
+  else presamples_=presamples&0xF;
 }
 
 void HcalUpgradeDataFrame::setReadoutIds(const HcalElectronicsId& eid) {


### PR DESCRIPTION
Original description of bug: One of the constructors will use an uninitialized value of the presamples and
modify it with a target presample size.

This bug had a side effect that all upgrade dataframes were marked as markAndPass, so the HcalSimpleReconstructor skipped them and the resulting RecHit collection was empty.
