### PR TITLE
Adding merging type (DAQ) and changing defaults

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -261,7 +261,7 @@ DQMFileSaver::saveForOnline(int run, const std::string &suffix, const std::strin
 
 
 boost::property_tree::ptree
-DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, evf::FastMonitoringService *fms)
+DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, const std::string mergeTypeStr, evf::FastMonitoringService *fms)
 {
   namespace bpt = boost::property_tree;
   namespace bfs = boost::filesystem;
@@ -295,7 +295,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
   }
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
-  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination, hltErrorEvents;
+  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination, mergeType, hltErrorEvents;
 
   processedEvents.put("", nProcessed); // Processed events
   acceptedEvents.put("", nProcessed); // Accepted events, same as processed for our purposes
@@ -307,6 +307,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
   inputFiles.put("", ""); // We do not care about input files!
   fileAdler32.put("", -1); // placeholder to match output json definition
   transferDestination.put("", transferDestinationStr); // SM Transfer destination field
+  mergeType.put("", mergeTypeStr); // Merging type for merger and transfer services
   hltErrorEvents.put("", 0); // Error events
 
   data.push_back(std::make_pair("", processedEvents));
@@ -318,6 +319,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
   data.push_back(std::make_pair("", inputFiles));
   data.push_back(std::make_pair("", fileAdler32));
   data.push_back(std::make_pair("", transferDestination));
+  data.push_back(std::make_pair("", mergeType));
   data.push_back(std::make_pair("", hltErrorEvents));
 
   pt.add_child("data", data);
@@ -411,7 +413,7 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
   }
 
   // Write the json file in the open directory.
-  bpt::ptree pt = fillJson(run, lumi, histoFilePathName, transferDestination_, fms_);
+  bpt::ptree pt = fillJson(run, lumi, histoFilePathName, transferDestination_, mergeType_, fms_);
   write_json(openJsonFilePathName, pt);
   rename(openJsonFilePathName.c_str(), jsonFilePathName.c_str());
 }
@@ -649,6 +651,8 @@ DQMFileSaver::beginJob()
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_);
+    if (mergeType_.empty()) mergeType_="PB";
   } 
 }
 

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -651,8 +651,7 @@ DQMFileSaver::beginJob()
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
-    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_);
-    if (mergeType_.empty()) mergeType_="PB";
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_,evf::MergeTypePB);
   } 
 }
 

--- a/DQMServices/Components/src/DQMFileSaver.h
+++ b/DQMServices/Components/src/DQMFileSaver.h
@@ -22,7 +22,7 @@ public:
   // fms will be nullptr in such case
   static boost::property_tree::ptree fillJson(
       int run, int lumi, const std::string &dataFilePathName, const std::string transferDestinationStr,
-      evf::FastMonitoringService *fms);
+      const std::string mergeTypeStr, evf::FastMonitoringService *fms);
 
   
 protected:
@@ -95,6 +95,7 @@ private:
   static const std::string streamPrefix_;
   static const std::string streamSuffix_;
   std::string transferDestination_;
+  std::string mergeType_;
 };
 
 #endif // DQMSERVICES_COMPONEntS_DQMFILESAVER_H

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -88,7 +88,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
   }
 
   // Write the json file in the open directory.
-  bpt::ptree pt = fillJson(fp.run_, fp.lumi_, histoFilePathName, transferDestination_, mergeType_ fms);
+  bpt::ptree pt = fillJson(fp.run_, fp.lumi_, histoFilePathName, transferDestination_, mergeType_, fms);
   write_json(openJsonFilePathName, pt);
   ::rename(openJsonFilePathName.c_str(), jsonFilePathName.c_str());
 }

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -30,6 +30,7 @@ DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet &ps)
   streamLabel_ = ps.getUntrackedParameter<std::string>("streamLabel", "streamDQMHistograms");
 
   transferDestination_ = "";
+  mergeType_ = "";
 }
 
 DQMFileSaverPB::~DQMFileSaverPB() {}
@@ -37,6 +38,7 @@ DQMFileSaverPB::~DQMFileSaverPB() {}
 void DQMFileSaverPB::initRun() const {
   if (!fakeFilterUnitMode_) {
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel_);
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel_,evf::MergeTypePB);
   } 
 }
 
@@ -86,7 +88,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
   }
 
   // Write the json file in the open directory.
-  bpt::ptree pt = fillJson(fp.run_, fp.lumi_, histoFilePathName, transferDestination_, fms);
+  bpt::ptree pt = fillJson(fp.run_, fp.lumi_, histoFilePathName, transferDestination_, mergeType_ fms);
   write_json(openJsonFilePathName, pt);
   ::rename(openJsonFilePathName.c_str(), jsonFilePathName.c_str());
 }
@@ -96,7 +98,7 @@ void DQMFileSaverPB::saveRun(const FileParameters& fp) const {
 }
 
 boost::property_tree::ptree
-DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, evf::FastMonitoringService *fms)
+DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, const std::string mergeTypeStr, evf::FastMonitoringService *fms)
 {
   namespace bpt = boost::property_tree;
   namespace bfs = boost::filesystem;
@@ -130,7 +132,7 @@ DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName,
   }
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
-  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
+  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination, mergeType, hltErrorEvents;
 
   processedEvents.put("", nProcessed); // Processed events
   acceptedEvents.put("", nProcessed); // Accepted events, same as processed for our purposes
@@ -142,6 +144,8 @@ DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName,
   inputFiles.put("", ""); // We do not care about input files!
   fileAdler32.put("", -1); // placeholder to match output json definition
   transferDestination.put("", transferDestinationStr); // SM Transfer destination field
+  mergeType.put("", mergeTypeStr); // SM Transfer destination field
+  hltErrorEvents.put("", 0); // Error events
 
   data.push_back(std::make_pair("", processedEvents));
   data.push_back(std::make_pair("", acceptedEvents));
@@ -152,6 +156,8 @@ DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName,
   data.push_back(std::make_pair("", inputFiles));
   data.push_back(std::make_pair("", fileAdler32));
   data.push_back(std::make_pair("", transferDestination));
+  data.push_back(std::make_pair("", mergeType));
+  data.push_back(std::make_pair("", hltErrorEvents));
 
   pt.add_child("data", data);
 

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.h
@@ -21,7 +21,7 @@ class DQMFileSaverPB : public DQMFileSaverBase {
   // fms will be nullptr in such case
   static boost::property_tree::ptree fillJson(
       int run, int lumi, const std::string &dataFilePathName, const std::string transferDestinationStr,
-      evf::FastMonitoringService *fms);
+      const std::string mergeTypeStr, evf::FastMonitoringService *fms);
 
  protected:
   virtual void initRun() const override;

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.h
@@ -31,6 +31,7 @@ class DQMFileSaverPB : public DQMFileSaverBase {
   bool fakeFilterUnitMode_;
   std::string streamLabel_;
   mutable std::string transferDestination_;
+  mutable std::string mergeType_;
 
  public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
+++ b/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
@@ -39,8 +39,9 @@ JsonWritingTimeoutPoolOutputModule::physicalAndLogicalNameForNewFile() {
 void JsonWritingTimeoutPoolOutputModule::doExtrasAfterCloseFile() {
   std::string json_tmp_ = currentJsonName_ + ".open";
   std::string transferDest = "";
+  std::string mergeType = "ROOT";
   auto pt = DQMFileSaver::fillJson(runNumber_, sequence_, currentFileName_,
-                                   transferDest, nullptr);
+                                   transferDest, mergeType, nullptr);
   write_json(json_tmp_, pt);
   rename(json_tmp_.c_str(), currentJsonName_.c_str());
 }

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <iomanip>
 #include <vector>
+#include <map>
 #include <list>
 #include <mutex>
 
@@ -122,7 +123,9 @@ namespace evf{
         filesToDeletePtr_ = filesToDelete;
       }
       void checkTransferSystemPSet(edm::ProcessContext const& pc);
+      void checkMergeTypePSet(edm::ProcessContext const& pc);
       std::string getStreamDestinations(std::string const& stream) const;
+      std::string getStreamMergeType(std::string const& stream) const;
       bool emptyLumisectionMode() const {return emptyLumisectionMode_;}
       bool microMergeDisabled() const {return microMergeDisabled_;}
 
@@ -151,6 +154,7 @@ namespace evf{
       unsigned int fuLockPollInterval_;
       bool emptyLumisectionMode_;
       bool microMergeDisabled_;
+      std::string mergeTypePset_;
 
       std::string hostname_;
       std::string run_string_;
@@ -207,6 +211,7 @@ namespace evf{
       unsigned int stop_ls_override_ = 0;
 
       std::shared_ptr<Json::Value> transferSystemJson_;
+      std::map<std::string,std::string> mergeTypeMap_;
   };
 }
 

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -47,6 +47,8 @@ namespace edm {
 
 namespace evf{
 
+  enum MergeType { MergeTypeNULL = 0, MergeTypeDAT = 1, MergeTypePB = 2, MergeTypeJSNDATA = 3};
+
   class FastMonitoringService;
 
   class EvFDaqDirector
@@ -125,7 +127,7 @@ namespace evf{
       void checkTransferSystemPSet(edm::ProcessContext const& pc);
       void checkMergeTypePSet(edm::ProcessContext const& pc);
       std::string getStreamDestinations(std::string const& stream) const;
-      std::string getStreamMergeType(std::string const& stream) const;
+      std::string getStreamMergeType(std::string const& stream, MergeType defaultType);
       bool emptyLumisectionMode() const {return emptyLumisectionMode_;}
       bool microMergeDisabled() const {return microMergeDisabled_;}
 
@@ -212,6 +214,9 @@ namespace evf{
 
       std::shared_ptr<Json::Value> transferSystemJson_;
       std::map<std::string,std::string> mergeTypeMap_;
+
+      //values initialized in .cc file
+      static const std::vector<std::string> MergeTypeNames_;
   };
 }
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -260,9 +260,7 @@ namespace evf {
   {
     //get stream transfer destination
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
-    std::string mergeTypeVal = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_);
-    if (mergeTypeVal.empty()) mergeType_ = "DAT";
-    else mergeType_= mergeTypeVal;
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_,evf::MergeTypeDAT);
   }
 
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -62,6 +62,7 @@ namespace evf {
     jsoncollector::StringJ inputFiles_;
     jsoncollector::IntJ fileAdler32_; 
     jsoncollector::StringJ transferDestination_; 
+    jsoncollector::StringJ mergeType_;
     jsoncollector::IntJ hltErrorEvents_; 
     boost::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
     evf::FastMonitoringService *fms_;
@@ -87,6 +88,7 @@ namespace evf {
     inputFiles_(),
     fileAdler32_(1),
     transferDestination_(),
+    mergeType_(),
     hltErrorEvents_(0),
     outBuf_(new unsigned char[1024*1024])
   {
@@ -128,6 +130,7 @@ namespace evf {
     inputFiles_.setName("InputFiles");
     fileAdler32_.setName("FileAdler32");
     transferDestination_.setName("TransferDestination");
+    mergeType_.setName("MergeType");
     hltErrorEvents_.setName("HLTErrorEvents");
 
     outJsonDef_.setDefaultGroup("data");
@@ -140,6 +143,7 @@ namespace evf {
     outJsonDef_.addLegendItem("InputFiles","string",jsoncollector::DataPointDefinition::CAT);
     outJsonDef_.addLegendItem("FileAdler32","integer",jsoncollector::DataPointDefinition::ADLER32);
     outJsonDef_.addLegendItem("TransferDestination","string",jsoncollector::DataPointDefinition::SAME);
+    outJsonDef_.addLegendItem("MergeType","string",jsoncollector::DataPointDefinition::SAME);
     outJsonDef_.addLegendItem("HLTErrorEvents","integer",jsoncollector::DataPointDefinition::SUM);
     std::stringstream tmpss,ss;
     tmpss << baseRunDir << "/open/" << "output_" << getpid() << ".jsd";
@@ -169,6 +173,7 @@ namespace evf {
     jsonMonitor_->registerGlobalMonitorable(&inputFiles_,false);
     jsonMonitor_->registerGlobalMonitorable(&fileAdler32_,false);
     jsonMonitor_->registerGlobalMonitorable(&transferDestination_,false);
+    jsonMonitor_->registerGlobalMonitorable(&mergeType_,false);
     jsonMonitor_->registerGlobalMonitorable(&hltErrorEvents_,false);
     jsonMonitor_->commit(nullptr);
 
@@ -255,6 +260,9 @@ namespace evf {
   {
     //get stream transfer destination
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
+    std::string mergeTypeVal = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_);
+    if (mergeTypeVal.empty()) mergeType_ = "DAT";
+    else mergeType_= mergeTypeVal;
   }
 
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -51,8 +51,8 @@ namespace evf {
     selectedTransferMode_(pset.getUntrackedParameter<std::string>("selectedTransferMode","")),
     hltSourceDirectory_(pset.getUntrackedParameter<std::string>("hltSourceDirectory","")),
     fuLockPollInterval_(pset.getUntrackedParameter<unsigned int>("fuLockPollInterval",2000)),
-    emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",false)),
-    microMergeDisabled_(pset.getUntrackedParameter<bool>("microMergeDisabled",false)),
+    emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",true)),
+    microMergeDisabled_(pset.getUntrackedParameter<bool>("microMergeDisabled",true)),
     mergeTypePset_(pset.getUntrackedParameter<std::string>("mergeTypePset","")),
     hostname_(""),
     bu_readlock_fd_(-1),
@@ -287,8 +287,8 @@ namespace evf {
     desc.addUntracked<bool>("requireTransfersPSet",false)->setComment("Require complete transferSystem PSet in the process configuration");
     desc.addUntracked<std::string>("selectedTransferMode","")->setComment("Selected transfer mode (choice in Lvl0 propagated as Python parameter");
     desc.addUntracked<unsigned int>("fuLockPollInterval",2000)->setComment("Lock polling interval in microseconds for the input directory file lock");
-    desc.addUntracked<bool>("emptyLumisectionMode",false)->setComment("Enables writing stream output metadata even when no events are processed in a lumisection");
-    desc.addUntracked<bool>("microMergeDisabled",false)->setComment("Disabled micro-merging by the Output Module, so it is later done by hltd service");
+    desc.addUntracked<bool>("emptyLumisectionMode",true)->setComment("Enables writing stream output metadata even when no events are processed in a lumisection");
+    desc.addUntracked<bool>("microMergeDisabled",true)->setComment("Disabled micro-merging by the Output Module, so it is later done by hltd service");
     desc.addUntracked<std::string>("mergingPset","")->setComment("Name of merging PSet to look for merging type definitions for streams");
     desc.setAllowAnything();
     descriptions.add("EvFDaqDirector", desc);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -27,7 +27,11 @@
 
 using namespace jsoncollector;
 
+
 namespace evf {
+
+  //for enum MergeType
+  const std::vector<std::string> EvFDaqDirector::MergeTypeNames_ = {"","DAT","PB","JSNDATA"};
 
   namespace {
     struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid)
@@ -1015,13 +1019,15 @@ namespace evf {
     }
   }
  
-  std::string EvFDaqDirector::getStreamMergeType(std::string const& stream) const
+  std::string EvFDaqDirector::getStreamMergeType(std::string const& stream, MergeType defaultType)
   {
-    if (mergeTypePset_.empty()) return std::string();
     auto mergeTypeItr = mergeTypeMap_.find(stream.c_str());
     if (mergeTypeItr == mergeTypeMap_.end()) {
-           edm::LogWarning("EvFDaqDirector") << " No merging type specified for stream " << stream << ". Using default value";
-           return std::string();
+           edm::LogInfo("EvFDaqDirector") << " No merging type specified for stream " << stream << ". Using default value";
+           assert(defaultType<MergeTypeNames_.size());
+           std::string defaultName = MergeTypeNames_[defaultType];
+           mergeTypeMap_[stream] =  defaultName;
+           return defaultName;
     }
     return mergeTypeItr->second;
   }

--- a/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
@@ -50,12 +50,14 @@ namespace hltJson {
     std::string stHltJsd;   //Definition file name for JSON with rates  
 
     std::string streamHLTDestination;
+    std::string streamHLTMergeType;
   };
   //End lumi struct
   //Struct for storing variable written once per run
   struct runVars{
     mutable std::atomic<bool> wroteFiles;
     mutable std::string streamHLTDestination;
+    mutable std::string streamHLTMergeType;
   };
 }//End hltJson namespace   
 
@@ -79,6 +81,10 @@ class HLTriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hl
     std::shared_ptr<hltJson::runVars> rv(new hltJson::runVars);
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
+      std::string mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates");
+      if (!mergeType.empty()) rv->streamHLTMergeType=mergeType;
+      else rv->streamHLTMergeType="JSNDATA";
+
     }
     rv->wroteFiles = false;
     return rv;

--- a/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/HLTriggerJSONMonitoring.h
@@ -81,9 +81,7 @@ class HLTriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hl
     std::shared_ptr<hltJson::runVars> rv(new hltJson::runVars);
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
-      std::string mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates");
-      if (!mergeType.empty()) rv->streamHLTMergeType=mergeType;
-      else rv->streamHLTMergeType="JSNDATA";
+      rv->streamHLTMergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates",evf::MergeTypeJSNDATA);
 
     }
     rv->wroteFiles = false;

--- a/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
@@ -85,9 +85,7 @@ class L1TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<l1
     std::shared_ptr<l1Json::runVars> rv(new l1Json::runVars);
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
-      std::string mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates");
-      if (!mergeType.empty()) rv->streamL1MergeType=mergeType;
-      else rv->streamL1MergeType="JSNDATA";
+      rv->streamL1MergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates",evf::MergeTypeJSNDATA);
     }
     rv->wroteFiles = false;
     return rv;

--- a/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/L1TriggerJSONMonitoring.h
@@ -54,12 +54,14 @@ namespace l1Json {
     
     std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            
     std::string streamL1Destination;
+    std::string streamL1MergeType;
   };
   //End lumi struct
   //Struct for storing variable written once per run
   struct runVars{
     mutable std::atomic<bool> wroteFiles;
     mutable std::string streamL1Destination;
+    mutable std::string streamL1MergeType;
   };
 }//End l1Json namespace   
 
@@ -83,6 +85,9 @@ class L1TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<l1
     std::shared_ptr<l1Json::runVars> rv(new l1Json::runVars);
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
+      std::string mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates");
+      if (!mergeType.empty()) rv->streamL1MergeType=mergeType;
+      else rv->streamL1MergeType="JSNDATA";
     }
     rv->wroteFiles = false;
     return rv;

--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -108,12 +108,8 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
       rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
       rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
       std::string mergeType;
-      mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates");
-      if (!mergeType.empty()) rv->streamHLTMergeType=mergeType;
-      else rv->streamHLTMergeType="JSNDATA";
-      mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates");
-      if (!mergeType.empty()) rv->streamL1MergeType=mergeType;
-      else rv->streamL1MergeType="JSNDATA";
+      rv->streamHLTMergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates",evf::MergeTypeJSNDATA);
+      rv->streamL1MergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates",evf::MergeTypeJSNDATA);
 
     }
     rv->wroteFiles = false;

--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -72,6 +72,8 @@ namespace trigJson {
     std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            
     std::string streamL1Destination;
     std::string streamHLTDestination;
+    std::string streamL1MergeType;
+    std::string streamHLTMergeType;
   };
   //End lumi struct
   //Struct for storing variable written once per run
@@ -79,6 +81,8 @@ namespace trigJson {
     mutable std::atomic<bool> wroteFiles;
     mutable std::string streamL1Destination;
     mutable std::string streamHLTDestination;
+    mutable std::string streamL1MergeType;
+    mutable std::string streamHLTMergeType;
   };
 }//End trigJson namespace   
 
@@ -103,6 +107,14 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<trig
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
       rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
       rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
+      std::string mergeType;
+      mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamHLTRates");
+      if (!mergeType.empty()) rv->streamHLTMergeType=mergeType;
+      else rv->streamHLTMergeType="JSNDATA";
+      mergeType = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType("streamL1Rates");
+      if (!mergeType.empty()) rv->streamL1MergeType=mergeType;
+      else rv->streamL1MergeType="JSNDATA";
+
     }
     rv->wroteFiles = false;
     return rv;

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -250,6 +250,7 @@ HLTriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::Luminosity
   iSummary->baseRunDir           = "";
   iSummary->stHltJsd             = "";
   iSummary->streamHLTDestination = "";
+  iSummary->streamHLTMergeType  = "";
 
   return iSummary;
 }//End globalBeginLuminosityBlockSummary function  
@@ -277,6 +278,7 @@ HLTriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& i
     iSummary->baseRunDir = baseRunDir_;
     
     iSummary->streamHLTDestination = runCache()->streamHLTDestination;
+    iSummary->streamHLTMergeType   = runCache()->streamHLTMergeType;
   }
 
   else{
@@ -389,6 +391,7 @@ HLTriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBl
     hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles.value());
     hltDaqJsn[DataPoint::DATA].append(hltJsnFileAdler32);
     hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTDestination);
+    hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTMergeType);
     hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
 
     result = writer.write(hltDaqJsn);

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -239,6 +239,7 @@ L1TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::Luminosity
   iSummary->baseRunDir           = "";
   iSummary->stL1Jsd              = "";
   iSummary->streamL1Destination  = "";
+  iSummary->streamL1MergeType  = "";
 
   return iSummary;
 }//End globalBeginLuminosityBlockSummary function  
@@ -266,6 +267,7 @@ L1TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& i
     iSummary->stL1Jsd = stL1Jsd_;      
 
     iSummary->streamL1Destination  = runCache()->streamL1Destination;
+    iSummary->streamL1MergeType    = runCache()->streamL1MergeType;
   }
 
   else{
@@ -376,6 +378,7 @@ L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBl
     l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles.value());
     l1DaqJsn[DataPoint::DATA].append(l1JsnFileAdler32);
     l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1Destination);
+    l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1MergeType);
     l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
 
     result = writer.write(l1DaqJsn);

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -449,6 +449,8 @@ TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBl
   iSummary->stL1Jsd              = "";
   iSummary->streamL1Destination  = "";
   iSummary->streamHLTDestination = "";
+  iSummary->streamL1MergeType    = "";
+  iSummary->streamHLTMergeType   = "";
 
   return iSummary;
 }//End globalBeginLuminosityBlockSummary function  
@@ -495,6 +497,8 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
 
     iSummary->streamHLTDestination = runCache()->streamHLTDestination;
     iSummary->streamL1Destination  = runCache()->streamL1Destination;
+    iSummary->streamHLTMergeType   = runCache()->streamHLTMergeType;
+    iSummary->streamL1MergeType    = runCache()->streamL1MergeType;
   }
 
   else{
@@ -665,6 +669,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles.value());
     hltDaqJsn[DataPoint::DATA].append(hltJsnFileAdler32);
     hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTDestination);
+    hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTMergeType);
     hltDaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
 
     result = writer.write(hltDaqJsn);
@@ -691,6 +696,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles.value());
     l1DaqJsn[DataPoint::DATA].append(l1JsnFileAdler32);
     l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1Destination);
+    l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1MergeType);
     l1DaqJsn[DataPoint::DATA].append((unsigned int)daqJsnHLTErrorEvents.value());
 
     result = writer.write(l1DaqJsn);


### PR DESCRIPTION
- Merge type parameter added to output JSON to reflect difference between streams created by different output modules (different file format). This will be used to display streams differently in monitoring. Optionally, a PSet name can be specified and, if found in the configuration, will be parsed for per-stream overrides of this parameter (can be used e.g. if more specific differentiation of DAT streams is required for monitoring or merging).
- by default activate empty-LS mode and disable micro-merging in CMSSW. This has been already configured as such in production HLT menus for some time.
