### PR TITLE
[RecoTauTag] allow complete relax of tau isolation at high pt

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -39,6 +39,10 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
     calculateWeights_ = pset.exists("ApplyDiscriminationByWeightedECALIsolation") ?
       pset.getParameter<bool>("ApplyDiscriminationByWeightedECALIsolation") : false;
 
+    // RIC: allow to relax the isolation completely beyond a given tau pt
+    minPtForNoIso_ = pset.exists("minTauPtForNoIso") ?
+      pset.getParameter<double>("minTauPtForNoIso") : -99.;
+    
     applyOccupancyCut_ = pset.getParameter<bool>("applyOccupancyCut");
     maximumOccupancy_ = pset.getParameter<uint32_t>("maximumOccupancy");
 
@@ -223,6 +227,8 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   double maximumRelativeSumPt_;
   double offsetRelativeSumPt_;
   double customIsoCone_;
+  // RIC:
+  double minPtForNoIso_;
   
   bool applyPhotonPtSumOutsideSignalConeCut_;
   double maxAbsPhotonSumPt_outsideSignalCone_;
@@ -581,6 +587,12 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
     (applyRelativeSumPtCut_ && failsRelativeSumPtCut) ||
     (applyPhotonPtSumOutsideSignalConeCut_ && failsPhotonPtSumOutsideSignalConeCut);
 
+
+  if (pfTau->pt() > minPtForNoIso_ && minPtForNoIso_ > 0.){
+    return 1.;
+    LogDebug("discriminate") << "tau pt = " << pfTau->pt() <<  "\t  min cutoff pt = " << minPtForNoIso_ ;
+  }
+  
   // We did error checking in the constructor, so this is safe.
   if ( storeRawSumPt_ ) {
     return totalPt;

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -26,7 +26,7 @@ pfRecoTauDiscriminationByIsolation = cms.EDProducer("PFRecoTauDiscriminationByIs
     relativeSumPtCut = cms.double(0.0),
     relativeSumPtOffset = cms.double(0.0),
 
-    minTauPtForNoIso = cms.bool(-99.), # minimum tau pt at which the isolation is completely relaxed. If negative, this is disabled
+    minTauPtForNoIso = cms.double(-99.), # minimum tau pt at which the isolation is completely relaxed. If negative, this is disabled
     
     applyPhotonPtSumOutsideSignalConeCut = cms.bool(False),
     maxAbsPhotonSumPt_outsideSignalCone = cms.double(1.e+9),

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -26,6 +26,8 @@ pfRecoTauDiscriminationByIsolation = cms.EDProducer("PFRecoTauDiscriminationByIs
     relativeSumPtCut = cms.double(0.0),
     relativeSumPtOffset = cms.double(0.0),
 
+    minTauPtForNoIso = cms.bool(-99.), # minimum tau pt at which the isolation is completely relaxed. If negative, this is disabled
+    
     applyPhotonPtSumOutsideSignalConeCut = cms.bool(False),
     maxAbsPhotonSumPt_outsideSignalCone = cms.double(1.e+9),
     maxRelPhotonSumPt_outsideSignalCone = cms.double(0.10),


### PR DESCRIPTION
Add configurable option to completely relax the isolation when tau pt is above a given threshold, i.e. the discriminator always returns true.

The configuration parameter is optional and therefore backwards compatible.
