### PR TITLE
Utilities/StaticAnalyzers: adjust to LLVM/Clang 3.8.0

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -218,7 +218,7 @@ void WalkAST::CheckCXXOperatorCallExpr(const clang::CXXOperatorCallExpr *OCE,con
      case OO_PipeEqual:
      case OO_LessLessEqual:
      case OO_GreaterGreaterEqual:
-     if (const clang::MemberExpr * ME = dyn_cast_or_null<clang::MemberExpr>(OCE->arg_begin()->IgnoreParenImpCasts())){
+     if (const clang::MemberExpr * ME = dyn_cast_or_null<clang::MemberExpr>((*OCE->arg_begin())->IgnoreParenImpCasts())){
           if (ME->isImplicitAccess())
                ReportMember(ME);
      } 

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -37,7 +37,7 @@ void ConstCastAwayChecker::checkPreStmt(const clang::ExplicitCastExpr *CE,
 	clang::QualType ToTy = Ctx.getCanonicalType(CE->getType());
 
 	if ( support::isConst( OrigTy ) && ! support::isConst(ToTy) ) {
-		if ( clang::ento::ExplodedNode *errorNode = C.generateSink()) {
+		if ( clang::ento::ExplodedNode *errorNode = C.generateErrorNode()) {
 			if (!BT)
 				BT.reset(new clang::ento::BugType(this,"const cast away","ThreadSafety"));
 			std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT, 

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -27,7 +27,7 @@ void ConstCastChecker::checkPreStmt(const clang::CXXConstCastExpr *CE,
 		std::string cname = CRD->getQualifiedNameAsString();
 		if (! support::isDataClass(cname) ) return; 
 	}
-	if (clang::ento::ExplodedNode *errorNode = C.generateSink()) {
+	if (clang::ento::ExplodedNode *errorNode = C.generateErrorNode()) {
 		if (!BT) BT.reset(new clang::ento::BugType(this,"const_cast used on a pointer to a data class ", "ThreadSafety"));
 		std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT,
 					"const_cast was used on a pointer to a data class ", errorNode);

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -30,7 +30,7 @@ void FiniteMathChecker::checkPreStmt(const clang::CallExpr *CE, clang::ento::Che
   if (!II->isStr("isnan") && !II->isStr("isinf")) 
     return;
 
-  clang::ento::ExplodedNode *N = ctx.generateSink();
+  clang::ento::ExplodedNode *N = ctx.generateErrorNode();
   if (!N)
     return;
 

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -88,7 +88,7 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 			os <<"'\n";	
 		} else {
 			os <<"calls edm::Event::getManyByType with argument '";
-			QualType QT = CE->arg_begin()->getType();
+			QualType QT = (*CE->arg_begin())->getType();
 			const CXXRecordDecl * RD = QT->getAsCXXRecordDecl();
 			os << "getManyByType , ";
 			const ClassTemplateSpecializationDecl *SD = dyn_cast<ClassTemplateSpecializationDecl>(RD);


### PR DESCRIPTION
See the following Clang commits:
- 440c44a96ab56806e40ee260f327fbeaea47b265
- 34d3857a24cef94be9b277803ad4f25574f3489a

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
(cherry picked from commit 6dbbf787ddfe840b31b044de2968b38e7b8cf3b7)

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
