### PR TITLE
Typo correction in config file

### DIFF
--- a/RecoMET/METProducers/python/CSCHaloData_cfi.py
+++ b/RecoMET/METProducers/python/CSCHaloData_cfi.py
@@ -77,7 +77,7 @@ CSCHaloData = cms.EDProducer("CSCHaloDataProducer",
                              # MLR
                              # Default values for identifying CSCSegments that are halo-like
                              MaxSegmentRDiff = cms.double(10.0),
-                             MaxSegmentPhiDiff = cms.double(0.35),
+                             MaxSegmentPhiDiff = cms.double(0.1),
                              MaxSegmentTheta = cms.double(0.7)
                              # End MLR
                              )


### PR DESCRIPTION
Typo correction. Previously this parameter was bypassed by a hardcoded value. 
This is not the case anymore but the value was not properly edited in the config file. 
The variable we cut on is shown in right figure of slide 38 here: https://indico.cern.ch/event/514418/contributions/1193447/attachments/1250430/1843419/laurent_v2.pdf
This parameter is used here: https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc#L427
