### PR TITLE
Made static TiXmlBase::entity const

### DIFF
--- a/FWCore/Utilities/interface/tinyxml.h
+++ b/FWCore/Utilities/interface/tinyxml.h
@@ -414,7 +414,7 @@ private:
 		MAX_ENTITY_LENGTH = 6
 
 	};
-	static Entity entity[ NUM_ENTITY ];
+	static const Entity entity[ NUM_ENTITY ];
 	static std::atomic<bool> condenseWhiteSpace;
 };
 

--- a/FWCore/Utilities/src/tinyxmlparser.cc
+++ b/FWCore/Utilities/src/tinyxmlparser.cc
@@ -52,7 +52,7 @@ distribution.
 // Note tha "PutString" hardcodes the same list. This
 // is less flexible than it appears. Changing the entries
 // or order will break putstring.
-TiXmlBase::Entity TiXmlBase::entity[ NUM_ENTITY ] =
+TiXmlBase::Entity const TiXmlBase::entity[ NUM_ENTITY ] =
 {
 	{ "&amp;",  5, '&' },
 	{ "&lt;",   4, '<' },


### PR DESCRIPTION
The class static TiXmlBase::entity was made const. This did not
change any behavior since no code ever modified its values.
