### PR TITLE
Unify tracking iteration configurations in RECO, DQM, and VALIDATION, and automatize cluster removal

### DIFF
--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 seedInputTag      = {}
 trackCandInputTag = {}
@@ -135,53 +136,7 @@ clusterLabel     ['jetCoreRegionalStep'] = cms.vstring('Tot')
 clusterBin       ['jetCoreRegionalStep'] = cms.int32(500)
 clusterMax       ['jetCoreRegionalStep'] = cms.double(100000)
 
-selectedIterTrackingStep = [
-    'initialStep',
-    'lowPtTripletStep',
-    'pixelPairStep',
-    'detachedTripletStep',
-    'mixedTripletStep',
-    'pixelLessStep',
-    'tobTecStep',
-    'jetCoreRegionalStep',
-    'muonSeededStepInOut',
-    'muonSeededStepOutIn',
-#    'muonSeededStepOutInDisplaced'
-]
-selectedIterTrackingStep_trackingLowPU = [
-    "initialStep",
-    "lowPtTripletStep",
-    "pixelPairStep",
-    "detachedTripletStep",
-    "mixedTripletStep",
-    "pixelLessStep",
-    "tobTecStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-]
-selectedIterTrackingStep_trackingPhase1 = [
-    "initialStep",
-    "highPtTripletStep",
-    "detachedQuadStep",
-#    "detachedTripletStep",
-    "lowPtQuadStep",
-    "lowPtTripletStep",
-    "mixedTripletStep",
-    "pixelLessStep",
-    "tobTecStep",
-    "jetCoreRegionalStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-]
-selectedIterTrackingStep_trackingPhase1PU70 = [
-    "initialStep",
-    "highPtTripletStep",
-    "lowPtQuadStep",
-    "lowPtTripletStep",
-    "detachedQuadStep",
-    "mixedTripletStep",
-    "pixelPairStep",
-    "tobTecStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-]
+for era in _cfg.allEras():
+    pf = _cfg.postfix(era)
+    locals()["selectedIterTrackingStep"+pf] = _cfg.iterationAlgos(era)
+#selectedIterTrackingStep.append('muonSeededStepOutInDisplaced')

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ### load which are the tracks collection 2 be monitored
 from DQM.TrackingMonitorSource.TrackCollections2monitor_cff import *
@@ -177,8 +178,8 @@ for tracks in selectedTracks :
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0 += locals()[label]
 # seeding monitoring
-for era in ["", "trackingLowPU", "trackingPhase1", "trackingPhase1PU70"]:
-    postfix = "_"+era if era != "" else era
+for era in _cfg.allEras():
+    postfix = _cfg.postfix(era)
     _seq = cms.Sequence()
     for step in locals()["selectedIterTrackingStep"+postfix]:
         _seq += locals()["TrackSeedMon"+step]

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -1,29 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ###############################################
 # Low pT and detached tracks from pixel quadruplets
 ###############################################
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_detachedQuadStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = 9.0,
-    trajectories                             = "highPtTripletStepTracks",
-    pixelClusters                            = "siPixelClusters",
-    stripClusters                            = "siStripClusters",
-    oldClusterRemovalInfo                    = "highPtTripletStepClusters",
-    TrackQuality                             = 'highPurity',
-    minNumberOfLayersWithMeasBeforeFiltering = 0,
-)
-detachedQuadStepClusters = _detachedQuadStepClustersBase.clone(
-    trackClassifier                          = "highPtTripletStep:QualityMasks",
-)
-eras.trackingPhase1PU70.toReplaceWith(detachedQuadStepClusters, _detachedQuadStepClustersBase.clone(
-    trajectories                             = "lowPtTripletStepTracks",
-    oldClusterRemovalInfo                    = "lowPtTripletStepClusters",
-    overrideTrkQuals                         = "lowPtTripletStepSelector:lowPtTripletStep",
-))
+detachedQuadStepClusters = _cfg.clusterRemoverForIter("DetachedQuadStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(detachedQuadStepClusters, _cfg.clusterRemoverForIter("DetachedQuadStep", era))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -1,35 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ###############################################
 # Low pT and detached tracks from pixel triplets
 ###############################################
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
-
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_detachedTripletStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = cms.double(9.0),
-    trajectories                             = cms.InputTag("initialStepTracks"),
-    pixelClusters                            = cms.InputTag("siPixelClusters"),
-    stripClusters                            = cms.InputTag("siStripClusters"),
-    oldClusterRemovalInfo                    = cms.InputTag(""),
-    TrackQuality                             = cms.string('highPurity'),
-    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
-)
-detachedTripletStepClusters = _detachedTripletStepClustersBase.clone(
-   trackClassifier                          = cms.InputTag('initialStep',"QualityMasks"),
-)
-eras.trackingLowPU.toReplaceWith(detachedTripletStepClusters, _detachedTripletStepClustersBase.clone(
-    trajectories                             = "pixelPairStepTracks",
-    oldClusterRemovalInfo                    = "pixelPairStepClusters",
-    overrideTrkQuals                         = "pixelPairStepSelector:QualityMasks",
-))
-eras.trackingPhase1.toModify(detachedTripletStepClusters,
-    trajectories                             = "detachedQuadStepTracks",
-    oldClusterRemovalInfo                    = "detachedQuadStepClusters",
-    trackClassifier                          = "detachedQuadStep:QualityMasks",
-)
+detachedTripletStepClusters = _cfg.clusterRemoverForIter("DetachedTripletStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(detachedTripletStepClusters, _cfg.clusterRemoverForIter("DetachedTripletStep", era))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -1,24 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ### high-pT triplets ###
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_highPtTripletStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = 9.0,
-    trajectories                             = "initialStepTracks",
-    pixelClusters                            = "siPixelClusters",
-    stripClusters                            = "siStripClusters",
-    TrackQuality                             = 'highPurity',
-    minNumberOfLayersWithMeasBeforeFiltering = 0,
-)
-highPtTripletStepClusters = _highPtTripletStepClustersBase.clone(
-    trackClassifier                          = "initialStep:QualityMasks",
-)
-eras.trackingPhase1PU70.toReplaceWith(highPtTripletStepClusters, _highPtTripletStepClustersBase.clone(
-    overrideTrkQuals                         = "initialStepSelector:initialStep",
-))
+highPtTripletStepClusters = _cfg.clusterRemoverForIter("HighPtTripletStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(highPtTripletStepClusters, _cfg.clusterRemoverForIter("HighPtTripletStep", era))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -1,33 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_lowPtQuadStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = 9.0,
-    trajectories                             = "detachedTripletStepTracks",
-    pixelClusters                            = "siPixelClusters",
-    stripClusters                            = "siStripClusters",
-    oldClusterRemovalInfo                    = "detachedTripletStepClusters",
-    TrackQuality                             = 'highPurity',
-    minNumberOfLayersWithMeasBeforeFiltering = 0,
-)
-_lowPtQuadStepClusters = _lowPtQuadStepClustersBase.clone(
-    trackClassifier                          = "detachedTripletStep:QualityMasks",
-)
-# FIXME: detachedTriplet is dropped for time being, but may be enabled later
-lowPtQuadStepClusters = _lowPtQuadStepClusters.clone(
-    trajectories                             = "detachedQuadStepTracks",
-    oldClusterRemovalInfo                    = "detachedQuadStepClusters",
-    trackClassifier                          = "detachedQuadStep:QualityMasks",
-)
-eras.trackingPhase1PU70.toReplaceWith(lowPtQuadStepClusters, _lowPtQuadStepClustersBase.clone(
-    trajectories                             = "highPtTripletStepTracks",
-    oldClusterRemovalInfo                    = "highPtTripletStepClusters",
-    overrideTrkQuals                         = "highPtTripletStepSelector:highPtTripletStep",
-))
-
+lowPtQuadStepClusters = _cfg.clusterRemoverForIter("LowPtQuadStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter("LowPtQuadStep", era))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -1,34 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_lowPtTripletStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = cms.double(9.0),
-    trajectories                             = cms.InputTag("detachedTripletStepTracks"),
-    pixelClusters                            = cms.InputTag("siPixelClusters"),
-    stripClusters                            = cms.InputTag("siStripClusters"),
-    TrackQuality                             = cms.string('highPurity'),
-    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
-)
-lowPtTripletStepClusters = _lowPtTripletStepClustersBase.clone(
-    trackClassifier                          = cms.InputTag('detachedTripletStep',"QualityMasks"),
-    oldClusterRemovalInfo                    = cms.InputTag("detachedTripletStepClusters"),
-)
-eras.trackingLowPU.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
-    trajectories                             = "initialStepTracks",
-    overrideTrkQuals                         = "initialStepSelector:QualityMasks",
-))
-eras.trackingPhase1.toModify(lowPtTripletStepClusters,
-    trajectories                             = "lowPtQuadStepTracks",
-    oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
-    trackClassifier                          = "lowPtQuadStep:QualityMasks",
-)
-eras.trackingPhase1PU70.toReplaceWith(lowPtTripletStepClusters, _lowPtTripletStepClustersBase.clone(
-    trajectories                             = "lowPtQuadStepTracks",
-    oldClusterRemovalInfo                    = "lowPtQuadStepClusters",
-    overrideTrkQuals                         = "lowPtQuadStepSelector:lowPtQuadStep",
-))
+lowPtTripletStepClusters = _cfg.clusterRemoverForIter("LowPtTripletStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(lowPtTripletStepClusters, _cfg.clusterRemoverForIter("LowPtTripletStep", era))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -1,26 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ##########################################################################
 # Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
 ##########################################################################
 
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_pixelLessStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = cms.double(9.0),
-    trajectories                             = cms.InputTag("mixedTripletStepTracks"),
-    pixelClusters                            = cms.InputTag("siPixelClusters"),
-    stripClusters                            = cms.InputTag("siStripClusters"),
-    oldClusterRemovalInfo                    = cms.InputTag("mixedTripletStepClusters"),
-    TrackQuality                             = cms.string('highPurity'),
-    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
-)
-pixelLessStepClusters = _pixelLessStepClustersBase.clone(
-    trackClassifier                          = cms.InputTag('mixedTripletStep',"QualityMasks"),
-)
-eras.trackingLowPU.toReplaceWith(pixelLessStepClusters, _pixelLessStepClustersBase.clone(
-    overrideTrkQuals                         = "mixedTripletStep",
-))
+pixelLessStepClusters = _cfg.clusterRemoverForIter("PixelLessStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter("PixelLessStep", era))
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -1,29 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
-from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
-_pixelPairStepClustersBase = _trackClusterRemover.clone(
-    maxChi2                                  = cms.double(9.0),
-    trajectories                             = cms.InputTag("lowPtTripletStepTracks"),
-    pixelClusters                            = cms.InputTag("siPixelClusters"),
-    stripClusters                            = cms.InputTag("siStripClusters"),
-    oldClusterRemovalInfo                    = cms.InputTag("lowPtTripletStepClusters"),
-    TrackQuality                             = cms.string('highPurity'),
-    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
-)
-pixelPairStepClusters = _pixelPairStepClustersBase.clone(
-    trackClassifier                          = cms.InputTag('lowPtTripletStep',"QualityMasks"),
-)
-eras.trackingLowPU.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
-    overrideTrkQuals                         = "lowPtTripletStepSelector:QualityMasks",
-))
-eras.trackingPhase1PU70.toReplaceWith(pixelPairStepClusters, _pixelPairStepClustersBase.clone(
-    trajectories                             = "mixedTripletStepTracks",
-    oldClusterRemovalInfo                    = "mixedTripletStepClusters",
-    overrideTrkQuals                         = "mixedTripletStep",
-))
+pixelPairStepClusters = _cfg.clusterRemoverForIter("PixelPairStep")
+for era in _cfg.nonDefaultEras():
+    getattr(eras, era).toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter("PixelPairStep", era))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -52,6 +52,15 @@ _iterations_muonSeeded = [
     "MuonSeededStepInOut",
     "MuonSeededStepOutIn",
 ]
+_multipleSeedProducers = {
+    "MixedTripletStep": ["A", "B"],
+    "TobTecStep": ["Pair", "Tripl"],
+}
+_multipleSeedProducers_trackingLowPU = {
+    "MixedTripletStep": ["A", "B"],
+}
+_multipleSeedProducers_trackingPhase1 = _multipleSeedProducers
+_multipleSeedProducers_trackingPhase1PU70 = _multipleSeedProducers_trackingLowPU
 _oldStyleHasSelector = set([
     "InitialStep",
     "HighPtTripletStep",
@@ -108,6 +117,32 @@ def createEarlySequence(era, modDict):
 
 def iterationAlgos(era):
     return [_modulePrefix(i) for i in globals()["_iterations"+postfix(era)] + _iterations_muonSeeded]
+
+def _seedOrTrackProducers(era, typ):
+    ret = []
+    pf = postfix(era)
+    iters = globals()["_iterations"+pf]
+    if typ == "Seeds":
+        multipleSeedProducers = globals()["_multipleSeedProducers"+pf]
+    else:
+        multipleSeedProducers = None
+    for i in iters:
+        seeder = _modulePrefix(i)+typ
+        if multipleSeedProducers is not None and i in multipleSeedProducers:
+            ret.extend([seeder+m for m in multipleSeedProducers[i]])
+        else:
+            ret.append(seeder)
+
+    for i in _iterations_muonSeeded:
+        ret.append(_modulePrefix(i).replace("Step", typ))
+
+    return ret
+
+def seedProducers(era):
+    return _seedOrTrackProducers(era, "Seeds")
+
+def trackProducers(era):
+    return _seedOrTrackProducers(era, "Tracks")
 
 def clusterRemoverForIter(iteration, era="", module=None):
     if module is None:

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -1,0 +1,60 @@
+# This file is the authoritative source of the order of tracking
+# iterations. It is used in RECO, DQM, and VALIDATION. Note that here
+# InitialStepPreSplitting is not counted as an iteration.
+import FWCore.ParameterSet.Config as cms
+
+_defaultEra = ""
+_nonDefaultEras = ["trackingLowPU", "trackingPhase1", "trackingPhase1PU70"]
+_allEras = [_defaultEra] + _nonDefaultEras
+
+_iterations = [
+    "InitialStep",
+    "DetachedTripletStep",
+    "LowPtTripletStep",
+    "PixelPairStep",
+    "MixedTripletStep",
+    "PixelLessStep",
+    "TobTecStep",
+    "JetCoreRegionalStep",
+]
+_iterations_trackingLowPU = [
+    "InitialStep",
+    "LowPtTripletStep",
+    "PixelPairStep",
+    "DetachedTripletStep",
+    "MixedTripletStep",
+    "PixelLessStep",
+    "TobTecStep",
+]
+_iterations_trackingPhase1 = [
+    "InitialStep",
+    "HighPtTripletStep",
+    "DetachedQuadStep",
+    #"DetachedTripletStep", # FIXME: dropped for time being, but it may be enabled on the course of further tuning
+    "LowPtQuadStep",
+    "LowPtTripletStep",
+    "MixedTripletStep",
+    "PixelLessStep",
+    "TobTecStep",
+    "JetCoreRegionalStep",
+]
+_iterations_trackingPhase1PU70 = [
+    "InitialStep",
+    "HighPtTripletStep",
+    "LowPtQuadStep",
+    "LowPtTripletStep",
+    "DetachedQuadStep",
+    "MixedTripletStep",
+    "PixelPairStep",
+    "TobTecStep",
+]
+
+def nonDefaultEras():
+    return _nonDefaultEras
+
+def createEarlySequence(era, modDict):
+    postfix = "_"+era if era != _defaultEra else era
+    _seq = cms.Sequence()
+    for it in globals()["_iterations"+postfix]:
+        _seq += modDict[it]
+    return _seq

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -48,13 +48,82 @@ _iterations_trackingPhase1PU70 = [
     "PixelPairStep",
     "TobTecStep",
 ]
+_oldStyleHasSelector = set([
+    "InitialStep",
+    "HighPtTripletStep",
+    "LowPtQuadStep",
+    "LowPtTripletStep",
+    "PixelPairStep",
+    "PixelLessStep",
+    "TobTecStep",
+])
+
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+_trackClusterRemoverBase = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    TrackQuality                             = 'highPurity',
+    minNumberOfLayersWithMeasBeforeFiltering = 0,
+)
+
+def _postfix(era):
+    return "_"+era if era != _defaultEra else era
+
+def _modulePrefix(iteration):
+    return iteration[0].lower()+iteration[1:]
+
+def _clusterRemover(iteration):
+    return _modulePrefix(iteration)+"Clusters"
+
+def _tracks(iteration):
+    return _modulePrefix(iteration)+"Tracks"
+
+def _classifier(iteration, oldStyle=False, oldStyleQualityMasks=False):
+    pre = _modulePrefix(iteration)
+    if oldStyle:
+        if iteration in _oldStyleHasSelector:
+            return pre+"Selector:" + ("QualityMasks" if oldStyleQualityMasks else pre)
+        else:
+            return pre
+    else:
+        return pre+":QualityMasks"
 
 def nonDefaultEras():
     return _nonDefaultEras
 
 def createEarlySequence(era, modDict):
-    postfix = "_"+era if era != _defaultEra else era
-    _seq = cms.Sequence()
+    postfix = _postfix(era)
+    seq = cms.Sequence()
     for it in globals()["_iterations"+postfix]:
-        _seq += modDict[it]
-    return _seq
+        seq += modDict[it]
+    return seq
+
+def clusterRemoverForIter(iteration, era="", module=None):
+    if module is None:
+        module = _trackClusterRemoverBase.clone()
+
+    postfix = _postfix(era)
+    iters = globals()["_iterations"+postfix]
+    try:
+        ind = iters.index(iteration)
+    except ValueError:
+        # if the iteration is not active in era, just return the same
+        return module
+
+    if ind == 0:
+        raise Exception("Iteration %s is the first iteration in era %s, asking cluster remover configuration does not make sense" % (iteration, era))
+    prevIter = iters[ind-1]
+
+    customize = dict(
+        trajectories          = _tracks(prevIter),
+        oldClusterRemovalInfo = _clusterRemover(prevIter) if ind >= 2 else "", # 1st iteration does not have cluster remover
+    )
+    if era == "trackingPhase1PU70":
+        customize["overrideTrkQuals"] = _classifier(prevIter, oldStyle=True) # old-style selector
+    elif era == "trackingLowPU":
+        customize["overrideTrkQuals"] = _classifier(prevIter, oldStyle=True, oldStyleQualityMasks=True) # old-style selector with 'QualityMasks' instance label
+    else:
+        customize["trackClassifier"] = _classifier(prevIter)
+
+    return module.clone(**customize)

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -48,6 +48,10 @@ _iterations_trackingPhase1PU70 = [
     "PixelPairStep",
     "TobTecStep",
 ]
+_iterations_muonSeeded = [
+    "MuonSeededStepInOut",
+    "MuonSeededStepOutIn",
+]
 _oldStyleHasSelector = set([
     "InitialStep",
     "HighPtTripletStep",
@@ -67,7 +71,7 @@ _trackClusterRemoverBase = _trackClusterRemover.clone(
     minNumberOfLayersWithMeasBeforeFiltering = 0,
 )
 
-def _postfix(era):
+def postfix(era):
     return "_"+era if era != _defaultEra else era
 
 def _modulePrefix(iteration):
@@ -89,22 +93,28 @@ def _classifier(iteration, oldStyle=False, oldStyleQualityMasks=False):
     else:
         return pre+":QualityMasks"
 
+def allEras():
+    return _allEras
+
 def nonDefaultEras():
     return _nonDefaultEras
 
 def createEarlySequence(era, modDict):
-    postfix = _postfix(era)
+    pf = postfix(era)
     seq = cms.Sequence()
-    for it in globals()["_iterations"+postfix]:
+    for it in globals()["_iterations"+pf]:
         seq += modDict[it]
     return seq
+
+def iterationAlgos(era):
+    return [_modulePrefix(i) for i in globals()["_iterations"+postfix(era)] + _iterations_muonSeeded]
 
 def clusterRemoverForIter(iteration, era="", module=None):
     if module is None:
         module = _trackClusterRemoverBase.clone()
 
-    postfix = _postfix(era)
-    iters = globals()["_iterations"+postfix]
+    pf = postfix(era)
+    iters = globals()["_iterations"+pf]
     try:
         ind = iters.index(iteration)
     except ValueError:

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
 
 from RecoTracker.IterativeTracking.InitialStepPreSplitting_cff import *
 from RecoTracker.IterativeTracking.InitialStep_cff import *
@@ -21,15 +23,14 @@ from RecoTracker.FinalTrackSelectors.preDuplicateMergingGeneralTracks_cfi import
 from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
 
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
+
+iterTrackingEarly = _cfg.createEarlySequence("", globals())
+for _era in _cfg.nonDefaultEras():
+    getattr(eras, _era).toReplaceWith(iterTrackingEarly, _cfg.createEarlySequence(_era, globals()))
+
 iterTracking = cms.Sequence(InitialStepPreSplitting*
-                            InitialStep*
-                            DetachedTripletStep*
-                            LowPtTripletStep*
-                            PixelPairStep*
-                            MixedTripletStep*
-                            PixelLessStep*
-                            TobTecStep*
-			    JetCoreRegionalStep *	
+                            iterTrackingEarly*
                             earlyGeneralTracks*
                             muonSeededStep*
                             preDuplicateMergingGeneralTracks*
@@ -37,57 +38,3 @@ iterTracking = cms.Sequence(InitialStepPreSplitting*
                             ConvStep*
                             conversionStepTracks
                             )
-
-from Configuration.StandardSequences.Eras import eras
-eras.trackingLowPU.toReplaceWith(iterTracking, cms.Sequence(
-    InitialStepPreSplitting*
-    InitialStep*
-    LowPtTripletStep*
-    PixelPairStep*
-    DetachedTripletStep*
-    MixedTripletStep*
-    PixelLessStep*
-    TobTecStep*
-    earlyGeneralTracks*
-    muonSeededStep*
-    preDuplicateMergingGeneralTracks*
-    generalTracksSequence*
-    ConvStep*
-    conversionStepTracks
-))
-eras.trackingPhase1.toReplaceWith(iterTracking, cms.Sequence(
-    InitialStepPreSplitting +
-    InitialStep +
-    HighPtTripletStep +
-    DetachedQuadStep +
-    #DetachedTripletStep + # FIXME: dropped for time being, but it may be enabled on the course of further tuning
-    LowPtQuadStep +
-    LowPtTripletStep +
-    MixedTripletStep +
-    PixelLessStep +
-    TobTecStep +
-    JetCoreRegionalStep +
-    earlyGeneralTracks +
-    muonSeededStep +
-    preDuplicateMergingGeneralTracks +
-    generalTracksSequence +
-    ConvStep +
-    conversionStepTracks
-))
-eras.trackingPhase1PU70.toReplaceWith(iterTracking, cms.Sequence(
-    InitialStepPreSplitting +
-    InitialStep +
-    HighPtTripletStep +
-    LowPtQuadStep +
-    LowPtTripletStep +
-    DetachedQuadStep +
-    MixedTripletStep +
-    PixelPairStep +
-    TobTecStep +
-    earlyGeneralTracks +
-    muonSeededStep +
-    preDuplicateMergingGeneralTracks +
-    generalTracksSequence +
-    ConvStep +
-    conversionStepTracks
-))

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -164,6 +164,7 @@ def customise_Reco(process,pileup):
     process.reconstruction_fromRECO.remove(process.lowPtQuadStepTracks)
 
     del process.iterTracking
+    del process.iterTrackingEarly
     del process.ckftracks
     del process.ckftracks_woBH
     del process.ckftracks_wodEdX

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -164,6 +164,7 @@ def customise_Reco(process,pileup):
     process.reconstruction_fromRECO.remove(process.lowPtQuadStepTracks)
 
     del process.iterTracking
+    del process.iterTrackingEarly
     del process.ckftracks
     del process.ckftracks_woBH
     del process.ckftracks_wodEdX

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -18,80 +18,22 @@ from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff impo
 from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import recoChargedRefCandidateToTrackRefProducer as _recoChargedRefCandidateToTrackRefProducer
 
 from Configuration.StandardSequences.Eras import eras
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ### First define the stuff for the standard validation sequence
 ## Track selectors
-_algos = [
-    "generalTracks",
-    "initialStep",
-    "lowPtTripletStep",
-    "pixelPairStep",
-    "detachedTripletStep",
-    "mixedTripletStep",
-    "pixelLessStep",
-    "tobTecStep",
-    "jetCoreRegionalStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-    "duplicateMerge",
-]
-_algos_trackingLowPU = [
-    "generalTracks",
-    "initialStep",
-    "lowPtTripletStep",
-    "pixelPairStep",
-    "detachedTripletStep",
-    "mixedTripletStep",
-    "pixelLessStep",
-    "tobTecStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-]
-_algos_trackingPhase1 = [
-    "generalTracks",
-    "initialStep",
-    "highPtTripletStep",
-    "detachedQuadStep",
-    #"detachedTripletStep",
-    "lowPtQuadStep",
-    "lowPtTripletStep",
-    "mixedTripletStep",
-    "pixelLessStep",
-    "tobTecStep",
-    "jetCoreRegionalStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-    "duplicateMerge",
-]
-_algos_trackingPhase1PU70 = [
-    "generalTracks",
-    "initialStep",
-    "highPtTripletStep",
-    "lowPtQuadStep",
-    "lowPtTripletStep",
-    "detachedQuadStep",
-    "mixedTripletStep",
-    "pixelPairStep",
-    "tobTecStep",
-    "muonSeededStepInOut",
-    "muonSeededStepOutIn",
-]
+for era in _cfg.allEras():
+    pf = _cfg.postfix(era)
+    _seedProd = ["initialStepSeedsPreSplitting"]
+    _trackProd = ["initialStepTracksPreSplitting"]
+    if era in ["trackingLowPU", "trackingPhase1PU70"]: # these don't have preSplitting
+        _seedProd = []
+        _trackProd = []
 
-_seedProducers = [
-    "initialStepSeedsPreSplitting",
-    "initialStepSeeds",
-    "detachedTripletStepSeeds",
-    "lowPtTripletStepSeeds",
-    "pixelPairStepSeeds",
-    "mixedTripletStepSeedsA",
-    "mixedTripletStepSeedsB",
-    "pixelLessStepSeeds",
-    "tobTecStepSeedsPair",
-    "tobTecStepSeedsTripl",
-    "jetCoreRegionalStepSeeds",
-    "muonSeededSeedsInOut",
-    "muonSeededSeedsOutIn",
-]
+    locals()["_algos"+pf] = ["generalTracks"] + _cfg.iterationAlgos(era) + ["duplicateMerge"]
+    locals()["_seedProducers"+pf] = _seedProd + _cfg.seedProducers(era)
+    locals()["_trackProducers"+pf] = _trackProd + _cfg.trackProducers(era)
+del _algos_trackingLowPU[_algos_trackingLowPU.index("duplicateMerge")] # reproduce the "bug"
 
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",
@@ -99,107 +41,11 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "muonSeededSeedsOutIn"]
 _seedProducers_fastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
-_seedProducers_trackingLowPU = [
-    "initialStepSeeds",
-    "lowPtTripletStepSeeds",
-    "pixelPairStepSeeds",
-    "detachedTripletStepSeeds",
-    "mixedTripletStepSeedsA",
-    "mixedTripletStepSeedsB",
-    "pixelLessStepSeeds",
-    "tobTecStepSeeds",
-    "muonSeededSeedsInOut",
-    "muonSeededSeedsOutIn",
-]
-_seedProducers_trackingPhase1 = [
-    "initialStepSeedsPreSplitting",
-    "initialStepSeeds",
-    "highPtTripletStepSeeds",
-    "detachedQuadStepSeeds",
-    #"detachedTripletStepSeeds",
-    "lowPtQuadStepSeeds",
-    "lowPtTripletStepSeeds",
-    "mixedTripletStepSeedsA",
-    "mixedTripletStepSeedsB",
-    "pixelLessStepSeeds",
-    "tobTecStepSeedsPair",
-    "tobTecStepSeedsTripl",
-    "jetCoreRegionalStepSeeds",
-    "muonSeededSeedsInOut",
-    "muonSeededSeedsOutIn",
-]
-_seedProducers_trackingPhase1PU70 = [
-    "initialStepSeeds",
-    "highPtTripletStepSeeds",
-    "lowPtQuadStepSeeds",
-    "lowPtTripletStepSeeds",
-    "detachedQuadStepSeeds",
-    "mixedTripletStepSeedsA",
-    "mixedTripletStepSeedsB",
-    "pixelPairStepSeeds",
-    "tobTecStepSeeds",
-    "muonSeededSeedsInOut",
-    "muonSeededSeedsOutIn",
-]
-
-
-_trackProducers = [
-    "initialStepTracksPreSplitting",
-    "initialStepTracks",
-    "lowPtTripletStepTracks",
-    "pixelPairStepTracks",
-    "detachedTripletStepTracks",
-    "mixedTripletStepTracks",
-    "pixelLessStepTracks",
-    "tobTecStepTracks",
-    "jetCoreRegionalStepTracks",
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutIn",
-]
 _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "jetCoreRegionalStepTracks",
                                 "muonSeededTracksInOut",
                                 "muonSeededTracksOutIn"]
 _trackProducers_fastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
-
-_trackProducers_trackingLowPU = [
-    "initialStepTracks",
-    "lowPtTripletStepTracks",
-    "pixelPairStepTracks",
-    "detachedTripletStepTracks",
-    "mixedTripletStepTracks",
-    "pixelLessStepTracks",
-    "tobTecStepTracks",
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutIn",
-]
-_trackProducers_trackingPhase1 = [
-    "initialStepTracksPreSplitting",
-    "initialStepTracks",
-    "highPtTripletStepTracks",
-    "detachedQuadStepTracks",
-#    "detachedTripletStepTracks",
-    "lowPtQuadStepTracks",
-    "lowPtTripletStepTracks",
-    "mixedTripletStepTracks",
-    "pixelLessStepTracks",
-    "tobTecStepTracks",
-    "jetCoreRegionalStepTracks",
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutIn",
-]
-_trackProducers_trackingPhase1PU70 = [
-    "initialStepTracks",
-    "highPtTripletStepTracks",
-    "lowPtQuadStepTracks",
-    "lowPtTripletStepTracks",
-    "detachedQuadStepTracks",
-    "mixedTripletStepTracks",
-    "pixelPairStepTracks",
-    "tobTecStepTracks",
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutIn",
-]
 
 def _algoToSelector(algo):
     sel = ""

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -33,7 +33,6 @@ for era in _cfg.allEras():
     locals()["_algos"+pf] = ["generalTracks"] + _cfg.iterationAlgos(era) + ["duplicateMerge"]
     locals()["_seedProducers"+pf] = _seedProd + _cfg.seedProducers(era)
     locals()["_trackProducers"+pf] = _trackProd + _cfg.trackProducers(era)
-del _algos_trackingLowPU[_algos_trackingLowPU.index("duplicateMerge")] # reproduce the "bug"
 
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",


### PR DESCRIPTION
This PR demonstrates an approach for automatizing the cluster remover configurations in each tracking iteration making reordering the iterations super easy, that I used for the results shown in May 9 TRK POG  meeting https://indico.cern.ch/event/527844/contributions/2161117/attachments/1269921/1881271/slides_phase1_20160509.pdf. It started as a desire to reduce copy-paste between RECO, DQM, and VALIDATION configurations, but I soon realized that the same approach can be used also to automatize the cluster remover configurations.

~~The PR is currently marked as "RFC", because I'm unsure if~~
- ~~this is the way we want to solve the two "problems"~~
- ~~now is a good time do such changes~~
  - ~~I'm mainly thinking interference with Phase2 era migration, although I'd naively think this PR would make life easier also there~~

I tested all `(full workflow, trackingOnly workflow) x (Run2_2016, Run2_2016_trackingLowPU, Run2_2017, Run2_2017_trackingPhase1PU70, Run2_2017_trackingRun2, FastSim)` combinations as generated by #14540, and there should be no changes in RECO quantities. Validation (MultiTrackValidator) shows some changes because the order of input per-iteration track collections has changed in some of the combinations. In addition, the last commit 7293c47 adds plots for `duplicateMerge` tracks for `trackingLowPU` era that was inadvertently omitted before.

Tested in CMSSW_8_1_X_2016-05-16-2300 (rebased on top of CMSSW_8_1_X_2016-05-23-2300), no changes expected in standard workflows, except in MultiTrackValidator `*_coll` plots.

@rovere @VinInn ~~Please comment soon if the approach presented here has any chance to get integrated, i.e. I could use it to add `detachedTripletStep` back and reorder the iterations for phase1 (if not, I'll do them "manually").~~
