### PR TITLE
Include full alignment and APE for Pixel Phase-I detector

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,9 +34,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v12',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v13',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_v4',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
@@ -21,7 +21,6 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(True)
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
@@ -21,7 +21,7 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
+trackerGeometry.applyAlignment = cms.bool(True)
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2017devReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017devReco_cff.py
@@ -21,7 +21,6 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(True)
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2017devReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017devReco_cff.py
@@ -21,7 +21,7 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
+trackerGeometry.applyAlignment = cms.bool(True)
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [80X_upgrade2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_realistic_v5) as [80X_upgrade2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_realistic_v5/80X_upgrade2017_realistic_v4): 
  - Ideal Tracker Alignment in Phase-I pixel, realistic run2 MC in Strips  
  - Ideal Tracker Alignment Errors in Phase-I pixel, realistic run2 MC in Strips
  - Ideal surface deformations in Phase-I pixel (null) and realistic Run2 surface deformations in Strips
- **PhaseI design scenario** : [80X_upgrade2017_design_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v13) as [80X_upgrade2017_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v13/80X_upgrade2017_design_v12): 
  - Ideal Tracker Alignment in Phase-I pixel
  - Ideal Tracker Alignment Errors in Phase-I pixel

This should allow to switch on the `applyAlignment` parameter of `trackerGeometry`
