### PR TITLE
CondCore/PopCon: define static constexpr member

### DIFF
--- a/CondCore/PopCon/src/PopCon.cc
+++ b/CondCore/PopCon/src/PopCon.cc
@@ -7,6 +7,8 @@
 
 namespace popcon {
 
+  constexpr const char* const PopCon::s_version;
+
   PopCon::PopCon(const edm::ParameterSet& pset):
     m_targetSession(),
     m_targetConnectionString(pset.getUntrackedParameter< std::string >("targetDBConnectionString","")),


### PR DESCRIPTION
The patch resolves issue with Clang compiler.
N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

```
src/CondCore/PopCon/src/CondCorePopCon/PopCon.o: In function 'popcon::PopCon::PopCon(edm::ParameterSet const&)':
src/CondCore/PopCon/src/PopCon.cc:(.text+0x274): undefined reference to 'popcon::PopCon::s_version'
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
