### PR TITLE
fix scope of hbheCells

### DIFF
--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -149,6 +149,7 @@ private:
 
   // need to cache some DetIds for the digitizers,
   // if they don't come straight from the geometry
+  std::vector<DetId> hbheCells;
   std::vector<DetId> theHBHEQIE8DetIds, theHBHEQIE11DetIds;
   std::vector<DetId> theHOHPDDetIds;
   std::vector<DetId> theHOSiPMDetIds;

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -631,7 +631,7 @@ void  HcalDigitizer::updateGeometry(const edm::EventSetup & eventSetup) {
   if(hfCells.empty()) hfgeo = false;
   // combine HB & HE
 
-  std::vector<DetId> hbheCells = hbCells;
+  hbheCells = hbCells;
   hbheCells.insert(hbheCells.end(), heCells.begin(), heCells.end());
   //handle mixed QIE8/11 scenario in HBHE
   if(theHBHEUpgradeDigitizer) theHBHEUpgradeDigitizer->setDetIds(hbheCells);


### PR DESCRIPTION
theHBHEUpgradeDigitizer keeps a _pointer_ to the combined vector of HBHE DetIds, but this was accidentally made into a local variable in HcalDigitizer in #14482, leading to Weird Memory Issues™ in Phase2 workflows. Fixed with this PR.
