### PR TITLE
SUSY HLT DQM updates for trimuon and dimu+MET paths, 81X

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -157,6 +157,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
             "HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v",
             "HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v",
             "HLT_TripleMu_12_10_5_v"
+            "HLT_TripleMu_5_3_3_v"
         ),
         recMuonLabel  = cms.string("muons"),
         recElecLabel  = cms.string("gedGsfElectrons"),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-SUSY_HLT_MET_MUON = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
+SUSY_HLT_MET120_MUON5 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
   trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
   MuonCollection = cms.InputTag("muons"),
   pfMETCollection = cms.InputTag("pfMet"),
@@ -21,7 +21,7 @@ SUSY_HLT_MET_MUON = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_MUON_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET120_MUON5_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_Mu5_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -30,4 +30,44 @@ SUSY_HLT_MET_MUON_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
        "pfMetTurnOn_eff 'Turn-on vs MET; PFMET (GeV); #epsilon' pfMetTurnOn_num pfMetTurnOn_den",
        "MuTurnOn_eff 'Turn-on vs Mu pT; pT (GeV); #epsilon' MuTurnOn_num MuTurnOn_den",
     )
+)
+
+SUSY_HLT_MET50_DIMUON3 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
+  trigSummary = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+  MuonCollection = cms.InputTag("muons"),
+  pfMETCollection = cms.InputTag("pfMet"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  TriggerResults = cms.InputTag('TriggerResults','','HLT'),
+  HLTProcess = cms.string('HLT'),
+  TriggerPath = cms.string('HLT_DoubleMu3_PFMET50_v'),
+  TriggerPathAuxiliaryForMuon = cms.string('HLT_PFMET90_PFMHT90_IDTight_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_Mu30_TkMu11_v'),
+  TriggerFilter = cms.InputTag('hltL3fL1sL1DoubleMu0ETM40lorDoubleMu0ETM55','','HLT'), #the last filter in the path
+  ptMuonOffline = cms.untracked.double(5.0), 
+  etaMuonOffline = cms.untracked.double(5.0), 
+  HTOffline = cms.untracked.double(0.0),
+  METOffline = cms.untracked.double(150.0),
+  PtThrJet = cms.untracked.double(30.0),
+  EtaThrJet = cms.untracked.double(3.0)
+)
+
+
+SUSY_HLT_MET50_DIMUON3_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu3_PFMET50_v"),
+    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
+    resolution     = cms.vstring(""),
+    efficiency     = cms.vstring(
+       "pfHTTurnOn_eff 'Turn-on vs HT; PFHT (GeV); #epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+       "pfMetTurnOn_eff 'Turn-on vs MET; PFMET (GeV); #epsilon' pfMetTurnOn_num pfMetTurnOn_den",
+       "MuTurnOn_eff 'Turn-on vs Mu pT; pT (GeV); #epsilon' MuTurnOn_num MuTurnOn_den",
+    )
+)
+
+SUSY_HLT_MET_MUON = cms.Sequence( SUSY_HLT_MET120_MUON5 +
+                                  SUSY_HLT_MET50_DIMUON3
+)
+
+SUSY_HLT_MET_MUON_POSTPROCESSING = cms.Sequence( SUSY_HLT_MET120_MUON5_POSTPROCESSING +
+                                                 SUSY_HLT_MET50_DIMUON3_POSTPROCESSING            
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
@@ -23,7 +23,6 @@ SUSY_HLT_MET120_MUON5 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 
 SUSY_HLT_MET120_MUON5_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_Mu5_v"),
-    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
        "pfHTTurnOn_eff 'Turn-on vs HT; PFHT (GeV); #epsilon' pfHTTurnOn_num pfHTTurnOn_den",
@@ -55,7 +54,6 @@ SUSY_HLT_MET50_DIMUON3 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 
 SUSY_HLT_MET50_DIMUON3_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu3_PFMET50_v"),
-    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
        "pfHTTurnOn_eff 'Turn-on vs HT; PFHT (GeV); #epsilon' pfHTTurnOn_num pfHTTurnOn_den",


### PR DESCRIPTION
This PR adds HLT DQM monitoring for the SUSY paths:
HLT_TripleMu_5_3_3
HLT_DoubleMu3_PFMET50

The code for the first is provided by Higgs PAG since they were already set up to monitor trimuon paths. For the second, existing susy muon+MET code is used.

This is the 81X version of the following PR in 80X:
#14581
