### PR TITLE
use full geometry cffs for MB plotting scripts

### DIFF
--- a/Validation/Geometry/test/runP_BeamPipe_cfg.py
+++ b/Validation/Geometry/test/runP_BeamPipe_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_InnerServices_cfg.py
+++ b/Validation/Geometry/test/runP_InnerServices_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixBar_cfg.py
+++ b/Validation/Geometry/test/runP_PixBar_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdMinus_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
+++ b/Validation/Geometry/test/runP_PixFwdPlus_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TEC_cfg.py
+++ b/Validation/Geometry/test/runP_TEC_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TIB_cfg.py
+++ b/Validation/Geometry/test/runP_TIB_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TOB_cfg.py
+++ b/Validation/Geometry/test/runP_TOB_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_TkStrct_cfg.py
+++ b/Validation/Geometry/test/runP_TkStrct_cfg.py
@@ -6,10 +6,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
 
 #Magnetic Field
 #

--- a/Validation/Geometry/test/runP_Tracker_cfg.py
+++ b/Validation/Geometry/test/runP_Tracker_cfg.py
@@ -5,10 +5,11 @@ process = cms.Process("PROD")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 #Geometry
 #
-process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
+#process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+#process.load("Geometry.HcalCommonData.hcalParameters_cfi")
+#process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
 
 #Magnetic Field
 #
@@ -43,7 +44,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(5)
+    input = cms.untracked.int32(-1)
 )
 
 process.p1 = cms.Path(process.g4SimHits)


### PR DESCRIPTION
Cosmetic changes to python scripts for producing tracker material budget plots:
- in runP_Tracker_cfg.py, the default value for maxEvents is set to -1
- instead of individually loading geometry config files in every python script, the full geometry cff for Phase 1 is loaded instead
