### PR TITLE
Clean-up L1T unpacker warnings

### DIFF
--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -78,7 +78,7 @@ if not (eras.stage1L1Trigger.isChosen() or eras.stage2L1Trigger.isChosen()):
 if eras.stage1L1Trigger.isChosen() and not eras.stage2L1Trigger.isChosen():
     print "L1TRawToDigi Sequence configured for Stage-1 (2015) trigger. "    
     unpack_stage1()
-    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1);
+    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1)
 
 #
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
@@ -87,4 +87,9 @@ if eras.stage2L1Trigger.isChosen():
     print "L1TRawToDigi Sequence configured for Stage-2 (2016) trigger. "    
     unpack_stage1()
     unpack_stage2()
-    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1+L1TRawToDigi_Stage2);
+    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1+L1TRawToDigi_Stage2)
+    # we only warn if it is stage-2 era and it is an essential, always present, stage-2 payload:
+    caloStage2Digis.MinFeds = cms.uint32(1)
+    gmtStage2Digis.MinFeds = cms.uint32(1)
+    gtStage2Digis.MinFeds = cms.uint32(1)
+    

--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -77,6 +77,13 @@ def L1TReEmulFromRAW2015(process):
         print "L1TReEmul sequence:  "
         print process.L1TReEmul
         print process.schedule
+        # quiet warning abouts missing Stage-2 payloads, since they won't reliably exist in 2015 data.
+        if hasattr(process, "caloStage2Digis"):
+            process.caloStage2Digis.MinFeds = cms.uint32(0)
+        if hasattr(process, "gmtStage2Digis"):
+            process.gmtStage2Digis.MinFeds = cms.uint32(0)
+        if hasattr(process, "gtStage2Digis"):
+            process.gtStage2Digis.MinFeds = cms.uint32(0)            
         return process
     else:
         process.simRctDigis.ecalDigis = cms.VInputTag('simEcalTriggerPrimitiveDigis')

--- a/L1Trigger/L1TCommon/scripts/testL1T.pl
+++ b/L1Trigger/L1TCommon/scripts/testL1T.pl
@@ -241,7 +241,7 @@ sub test_reemul {
     if ($SLOW) {$nevt = 1000; }
 
     if (! $RECYCLE){
-	$status = long_command("cmsDriver.py L1TEST $PYTHON_OPT -s RAW2DIGI --era=Run2_2016 --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW2015 --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleEMU --customise=L1Trigger/Configuration/customiseUtils.L1TTurnOffUnpackStage2GtGmtAndCalo $COND_DATA_2015 -n $nevt --data --no_exec --no_output --filein=$file --geometry=Extended2016,Extended2016Reco --customise=L1Trigger/Configuration/customiseReEmul.L1TEventSetupForHF1x1TPs --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalSimDigisSummary --customise=L1Trigger/Configuration/customiseUtils.L1TAddInfoOutput >& CMSDRIVER.log");
+	$status = long_command("cmsDriver.py L1TEST $PYTHON_OPT -s RAW2DIGI --era=Run2_2016 --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW2015 --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleEMU $COND_DATA_2015 -n $nevt --data --no_exec --no_output --filein=$file --geometry=Extended2016,Extended2016Reco --customise=L1Trigger/Configuration/customiseReEmul.L1TEventSetupForHF1x1TPs --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalSimDigisSummary --customise=L1Trigger/Configuration/customiseUtils.L1TAddInfoOutput >& CMSDRIVER.log");
 
 	print "INFO: status of cmsDriver call is $status\n";
 	if ($status){


### PR DESCRIPTION
In the common unpacker/packer framework of L1T, this demotes "Warning"s about empty FED IDs to "Info" messages.  A "Warning" level message is now only issued if the number of non-empty payloads unpacked by a particular unpacker is less than a configurable threshold, typically 1 for data and MC standard sequences.  This handles as best as possible for now, the somewhat complicated situation in Calo packing/unpacking.  In contexts where we are e.g. unpacking Stage-2 in 2015 data (where it is unreliably available) the requirement is lowered to zero, to avoid unnecessary warnings.  Info level messages are always provided for expert use.
