### PR TITLE
Fix QIE11 unpacking bug

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -649,10 +649,9 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
               std::cout << "OH NO! detector id is null!" << std::endl;
 #endif
           }
-      }
-
+      } else if (i.flavor() == 2){
       //////////////////////////////////////////////////HF UNPACKER/////////////////////////////////////////////////////////////////////
-      if (i.flavor() == 2) {
+
 	int ifiber=((i.channelid()>>3)&0x1F);
 	int ichan=(i.channelid()&0x7);
 	HcalElectronicsId eid(crate,slot,ifiber,ichan, false);


### PR DESCRIPTION
Further testing of #14461 revealed that only half (18 out of 36) of the CASTOR channels were being unpacked from RAW. The cause turned out to be an issue in the unpacker logic, only affecting QIE11 unpacking (which had not been used at all until now). This patch fixes the problem, and it will be added to #14462 for 80X.
