### PR TITLE
 Add a cut in the HLTPFJetIDProducer module.

### DIFF
--- a/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
+++ b/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
@@ -39,6 +39,7 @@ class HLTPFJetIDProducer : public edm::stream::EDProducer<> {
     double NHF_;              ///< neutral hadron fraction
     double CEF_;              ///< charged EM fraction
     double NEF_;              ///< neutral EM fraction
+    double maxCF_;            ///< total charged energy fraction
     int NCH_;                 ///< number of charged constituents
     int NTOT_;                ///< number of constituents
     edm::InputTag inputTag_;  ///< input PFJet collection

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -22,6 +22,7 @@ HLTPFJetIDProducer::HLTPFJetIDProducer(const edm::ParameterSet& iConfig) :
   NHF_      (iConfig.getParameter<double>("NHF")),
   CEF_      (iConfig.getParameter<double>("CEF")),
   NEF_      (iConfig.getParameter<double>("NEF")),
+  maxCF_    (iConfig.getParameter<double>("maxCF")),
   NCH_      (iConfig.getParameter<int>("NCH")),
   NTOT_     (iConfig.getParameter<int>("NTOT")),
   inputTag_ (iConfig.getParameter<edm::InputTag>("jetsInput")) {
@@ -43,6 +44,7 @@ void HLTPFJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descr
     desc.add<double>("NHF", 99.);
     desc.add<double>("CEF", 99.);
     desc.add<double>("NEF", 99.);
+    desc.add<double>("maxCF", 99.);
     desc.add<int>("NCH", 0);
     desc.add<int>("NTOT", 0);
     desc.add<edm::InputTag>("jetsInput", edm::InputTag("hltAntiKT4PFJets"));
@@ -77,6 +79,7 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             double nhf  = j->neutralHadronEnergyFraction();
             double cef  = j->chargedEmEnergyFraction();
             double nef  = j->neutralEmEnergyFraction();
+	    double cftot= chf + cef + j->chargedMuEnergyFraction();
             int    nch  = j->chargedMultiplicity();
             int    ntot = j->numberOfDaughters();
 
@@ -87,6 +90,7 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             pass = pass && (cef < CEF_ || std::abs(eta) >= 2.4);
             pass = pass && (chf > CHF_ || std::abs(eta) >= 2.4);
             pass = pass && (nch > NCH_ || std::abs(eta) >= 2.4);
+	    pass = pass && (cftot < maxCF_ || std::abs(eta) >= 2.4);
         }
 
         if (pass)  result->push_back(*j);

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -64,13 +64,14 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
         bool pass = false;
         double pt = j->pt();
         double eta = j->eta();
+	double abseta = std::abs(eta);
 
         if (!(pt > 0.))  continue;  // skip jets with zero or negative pt
 
         if (pt < minPt_) {
             pass = true;
 
-        } else if (std::abs(eta) >= maxEta_) {
+        } else if (abseta >= maxEta_) {
             pass = true;
 
         } else {
@@ -86,11 +87,11 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             pass = true;
             pass = pass && (ntot > NTOT_);
             pass = pass && (nef < NEF_);
-            pass = pass && (nhf < NHF_ || std::abs(eta) >= 2.4); //NHF-cut does not work in HF anymore with recent PF
-            pass = pass && (cef < CEF_ || std::abs(eta) >= 2.4);
-            pass = pass && (chf > CHF_ || std::abs(eta) >= 2.4);
-            pass = pass && (nch > NCH_ || std::abs(eta) >= 2.4);
-	    pass = pass && (cftot < maxCF_ || std::abs(eta) >= 2.4);
+            pass = pass && (nhf < NHF_ || abseta >= 2.4); //NHF-cut does not work in HF anymore with recent PF
+            pass = pass && (cef < CEF_ || abseta >= 2.4);
+            pass = pass && (chf > CHF_ || abseta >= 2.4);
+            pass = pass && (nch > NCH_ || abseta >= 2.4);
+	    pass = pass && (cftot < maxCF_ || abseta >= 2.4);
         }
 
         if (pass)  result->push_back(*j);


### PR DESCRIPTION
Add a cut on the total charged energy fraction in the HLTPFJetIDProducer module, in agreement with the TSG and the JetMET trigger conveners. The default value for the cut is set to 99.

This is an 80X backport PR for the following 81X PR: #14601.
