### PR TITLE
Update OMTF treatment of Muon at edge of OMTF acceptance

### DIFF
--- a/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
@@ -22,7 +22,7 @@
 namespace {
 template <typename T> int sgn(T val) { return (T(0) < val) - (val < T(0)); }
 
-std::vector<float> bounds = { 1.27, 1.14353, 1.09844, 1.05168, 1.00313, 0.952728, 0.90037, 0.8};
+std::vector<float> bounds = { 1.24, 1.14353, 1.09844, 1.05168, 1.00313, 0.952728, 0.90037, 0.8};
 //   0.8       -> 73
 //   0.85      -> 78
 //   0.9265    -> 85
@@ -31,9 +31,9 @@ std::vector<float> bounds = { 1.27, 1.14353, 1.09844, 1.05168, 1.00313, 0.952728
 //   1.07506   -> 98.9 -> 99
 //   1.121     -> 103
 //   1.2       -> 110
-//   1.26      -> 115
+//   1.25      -> 115
 //
-// other (1.35) -> 1.035 -> 95
+// other (1.033) -> 1.033 -> 95
 
 int etaVal2Bit(float eta) { return bounds.rend() - std::lower_bound (bounds.rbegin(), bounds.rend(), fabs(eta) ); }
 
@@ -62,9 +62,10 @@ int etaVal2Code( double etaVal) {
 }
 
 int etaKeyWG2Code(const CSCDetId& detId, uint16_t keyWG) {
-  unsigned int etaCode = 0;
+  signed int etaCode = 121;
   if (detId.station()==1 && detId.ring()==2) {
-    if (keyWG <58)       etaCode = etaBit2Code(0);
+    if (keyWG < 49)      etaCode = 121;
+    else if (keyWG <=57) etaCode = etaBit2Code(0);
     else if (keyWG <=63) etaCode = etaBit2Code(1);
   } 
   else if (detId.station()==1 && detId.ring()==3) {
@@ -75,12 +76,14 @@ int etaKeyWG2Code(const CSCDetId& detId, uint16_t keyWG) {
     else if (keyWG <= 31) etaCode = etaBit2Code(6);
   } 
   else if ( (detId.station()==2 || detId.station()==3) && detId.ring()==2) {
-    if (keyWG <= 29)       etaCode = etaBit2Code(0);
-    else if (keyWG <=  45) etaCode = etaBit2Code(1);
-    else if (keyWG <=  52) etaCode = etaBit2Code(2);
-    else if (keyWG <=  60) etaCode = etaBit2Code(3);
-    else if (keyWG <=  63) etaCode = etaBit2Code(4);
+    if (keyWG < 24)       etaCode = 121;
+    else if (keyWG <= 29) etaCode = etaBit2Code(0);
+    else if (keyWG <= 43) etaCode = etaBit2Code(1);
+    else if (keyWG <= 49) etaCode = etaBit2Code(2);
+    else if (keyWG <= 56) etaCode = etaBit2Code(3);
+    else if (keyWG <= 63) etaCode = etaBit2Code(4);
   }
+
   if (detId.endcap()==2) etaCode *= -1;
   return etaCode;
 }
@@ -322,6 +325,8 @@ int AngleConverter::getGlobalEta(unsigned int rawid, const CSCCorrelatedLCTDigi 
 
 //  std::cout <<id<<" st: " << id.station()<< "ri: "<<id.ring()<<" eta: " <<  final_gp.eta() 
 //           <<" etaCode_simple: " <<  etaVal2Code( final_gp.eta() )<< " KW: "<<keyWG <<" etaKeyWG2Code: "<<etaKeyWG2Code(id,keyWG)<< std::endl;
+//  int station = (id.endcap()==1) ? id.station() : -id.station();
+//  std::cout <<"ETA_CSC: " << station <<" "<<id.ring()<<" "<< final_gp.eta()<<" "<<keyWG <<" "<< etaKeyWG2Code(id,keyWG) << std::endl;
 
    return etaKeyWG2Code(id,keyWG);
 

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -174,6 +174,7 @@ void OMTFSorter::sortProcessorAndFillCandidates(unsigned int iProcessor, l1t::tf
              || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001010000000").to_ulong()
            )
        ) quality =4;
+    if (abs(myCand.getEta()) == 121) quality = 4;
     candidate.setHwQual (quality);
 
     std::map<int, int> trackAddr;

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -166,7 +166,14 @@ void OMTFSorter::sortProcessorAndFillCandidates(unsigned int iProcessor, l1t::tf
  
     unsigned int quality = checkHitPatternValidity(myCand.getHits()) ? 0 | (1 << 2) | (1 << 3) 
                                                                      : 0 | (1 << 2);
-    if (abs(myCand.getEta()) == 115) quality = 4; 
+    if (    abs(myCand.getEta()) == 115
+        && (    static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001110000000").to_ulong() 
+             || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000001110000000").to_ulong()
+             || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000000110000000").to_ulong()
+             || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001100000000").to_ulong()
+             || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001010000000").to_ulong()
+           )
+       ) quality =4;
     candidate.setHwQual (quality);
 
     std::map<int, int> trackAddr;

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -135,7 +135,7 @@ void OMTFSorter::sortRefHitResults(const std::vector<OMTFProcessor::resultsMap> 
 bool OMTFSorter::checkHitPatternValidity(unsigned int hits){
 
   ///FIXME: read the list from configuration so this can be controlled at runtime.
-  std::vector<unsigned int> badPatterns = {99840, 34304, 3075, 36928, 12300, 98816, 98944, 33408, 66688, 66176, 7171, 20528, 33856, 35840, 4156, 34880, 896};
+  std::vector<unsigned int> badPatterns = {99840, 34304, 3075, 36928, 12300, 98816, 98944, 33408, 66688, 66176, 7171, 20528, 33856, 35840, 4156, 34880};
 
   for(auto aHitPattern: badPatterns){
     if(hits==aHitPattern) return false;
@@ -152,7 +152,6 @@ void OMTFSorter::sortProcessorAndFillCandidates(unsigned int iProcessor, l1t::tf
 
   for(auto myCand: algoCands){
     l1t::RegionalMuonCand candidate;
-    std::bitset<17> bits(myCand.getHits());
     candidate.setHwPt(myCand.getPt());
     candidate.setHwEta(myCand.getEta());
 
@@ -167,7 +166,8 @@ void OMTFSorter::sortProcessorAndFillCandidates(unsigned int iProcessor, l1t::tf
  
     unsigned int quality = checkHitPatternValidity(myCand.getHits()) ? 0 | (1 << 2) | (1 << 3) 
                                                                      : 0 | (1 << 2);
-    candidate.setHwQual ( quality);
+    if (abs(myCand.getEta()) == 115) quality = 4; 
+    candidate.setHwQual (quality);
 
     std::map<int, int> trackAddr;
     trackAddr[0] = myCand.getHits();

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -290,7 +290,8 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
       ///Accept CSC digis only up to eta=1.26.
       ///The nominal OMTF range is up to 1.24, but cutting at 1.24
       ///kill efficnency at the edge. 1.26 is one eta bin above nominal.
-      if(abs(iEta)>1.26/2.61*240) continue;
+      //if(abs(iEta)>1.26/2.61*240) continue;
+      if (abs(iEta) > 115) continue;
       unsigned int iInput= getInputNumber(rawid, iProcessor, type);      
       result.addLayerHit(iLayer,iInput,iPhi,iEta);     
     }


### PR DESCRIPTION
This updates the OMTF emulator to handle the tricky case of muons on edge of OMTF acceptance in a way that better matches latest OMTF firmware.
