### PR TITLE
cleaning obsolete names of phase2 geometry in tracker packages

### DIFF
--- a/DPGAnalysis/SiStripTools/test/OccupancyPlotsTest_phase2_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/OccupancyPlotsTest_phase2_cfg.py
@@ -170,7 +170,7 @@ process.seqMultProd = cms.Sequence(#process.ssclusmultprod + process.ssclusoccup
 
 process.load("DPGAnalysis.SiStripTools.occupancyplots_cfi")
 #process.occupancyplots.wantedSubDets = OccupancyPlotsStripWantedSubDets
-process.occupancyplots.file = cms.untracked.FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseII/Pixel10D/PixelSkimmedGeometry.txt")
+process.occupancyplots.file = cms.untracked.FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometry.txt")
 
 process.pixeloccupancyplots = process.occupancyplots.clone()
 process.pixeloccupancyplots.wantedSubDets = process.spclusmultprod.wantedSubDets
@@ -247,7 +247,7 @@ process.load("DPGAnalysis.SiStripTools.duplicaterechits_cfi")
 
 #process.load("Configuration.StandardSequences.GeometryDB_cff")
 #process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5DPixel10DReco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023tiltedReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 #process.load("Configuration.Geometry.GeometryExtendedPhaseIPixelReco_cff")
 #process.load("Configuration.Geometry.GeometryExtendedPhaseIPixel_cff")

--- a/DPGAnalysis/SiStripTools/test/overlapproblem_EndCapsOTPhase2_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/overlapproblem_EndCapsOTPhase2_cfg.py
@@ -79,7 +79,7 @@ process.source = cms.Source("PoolSource",
 
 #process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 #process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023tiltedReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 #process.load("Configuration.Geometry.GeometryExtendedPhaseIPixelReco_cff")
 #process.load("Configuration.Geometry.GeometryExtendedPhaseIPixel_cff")
@@ -162,7 +162,7 @@ process.seqMultProd = cms.Sequence(
                                    )
 
 process.load("DPGAnalysis.SiStripTools.occupancyplots_cfi")
-process.occupancyplots.file = cms.untracked.FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseII/Pixel10D/PixelSkimmedGeometry.txt")
+process.occupancyplots.file = cms.untracked.FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometry.txt")
 
 process.pixeloccupancyplots = process.occupancyplots.clone()
 process.pixeloccupancyplots.wantedSubDets = process.spclusmultprod.wantedSubDets

--- a/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
@@ -19,8 +19,7 @@ process.source = cms.Source("PoolSource",
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023Muon_cff')
+process.load('Configuration.Geometry.GeometryExtended2023tiltedReco_cff')
 
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -48,7 +47,7 @@ process.p = cms.Path(process.digiana_seq)
 # customisation of the process.                                                                                                                              
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms                                                 
-from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023Muondev
+from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023tilted
 
-#call to customisation function cust_2023Muondev imported from SLHCUpgradeSimulations.Configuration.combinedCustoms                                          
-process = cust_2023Muondev(process)
+#call to customisation function cust_2023tilted imported from SLHCUpgradeSimulations.Configuration.combinedCustoms                                          
+process = cust_2023tilted(process)


### PR DESCRIPTION
Title says it all - 2023muon is not existing in 81X  - 
Replacing the cfgs still using it within the tracker packages by the supported phase2 scenario 
