### PR TITLE
Modifications to include HLT_DoubleMu3_Trk_Tau3mu path in the HeavyFlavor DQM package

### DIFF
--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -102,7 +102,7 @@ hfvQ7 = heavyFlavorValidationHarvesting.clone(
 ### tau3mu
 hfvTau3mu = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu3_Trk_tau3mu_v')
-
+)
 
 combiner = cms.EDAnalyzer('PlotCombiner',
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -99,6 +99,10 @@ hfvQ7 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu16_TkMu0_dEta18_Phi_v')
 )
 
+### tau3mu
+hfvTau3mu = heavyFlavorValidationHarvesting.clone(
+  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu3_Trk_tau3mu_v')
+
 
 combiner = cms.EDAnalyzer('PlotCombiner',
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),
@@ -149,6 +153,7 @@ heavyFlavorValidationHarvestingSequence = cms.Sequence(
   +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8+hfvTnP9+hfvTnP10+hfvTnP11
   +hfv6+hfv7+hfv8+hfv9
   +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
+  +hfvTau3mu
 	+combiner+combiner2
 )
 

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
@@ -105,11 +105,17 @@ hfv9 = hfv6.clone(
     TriggerPathName = cms.untracked.string("HLT_Mu25_TkMu0_dEta18_Onia_v"),
 )
 
+### tau3mu
+hfvTau3mu = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_DoubleMu3_Trk_tau3mu_v")
+)
+
 
 heavyFlavorValidationSequence = cms.Sequence(
   hfv1+hfv2+hfv3+hfv4+hfv5 
   +hfvQuadmu1+hfvQuadmu2+hfvQuadmu3+hfvQuadmu4
   +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8+hfvTnP9+hfvTnP10+hfvTnP11
   +hfv6+hfv7+hfv8+hfv9
+  +hfvTau3mu
   +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
 )


### PR DESCRIPTION
Dear Experts,

Please incorporate the following modifications to include HLT_DoubleMu3_Trk_Tau3mu path in the HeavyFlavor DQM package :

https://github.com/cms-sw/cmssw/commit/ca912ffb64518b0ca84bac133e8ec0f79693b84b
https://github.com/cms-sw/cmssw/commit/83717008fc3dd7b3c945b8db5ca18f14ac3b4cb2

We have not made any changes in the c++ code.

Regards,
Nairit
