### PR TITLE
Several improvements for the conddb tools

### DIFF
--- a/CondCore/CondDB/interface/IOVEditor.h
+++ b/CondCore/CondDB/interface/IOVEditor.h
@@ -53,9 +53,11 @@ namespace cond {
       std::string tag() const;
       cond::TimeType timeType() const;
       std::string payloadType() const;
-      cond::SynchronizationType synchronizationType() const;
       
       // getters/setters for the updatable parameters 
+      cond::SynchronizationType synchronizationType() const;
+      void setSynchronizationType( cond::SynchronizationType synchronizationType );
+
       cond::Time_t endOfValidity() const;
       void setEndOfValidity( cond::Time_t validity );
       
@@ -77,9 +79,10 @@ namespace cond {
       bool flush();
       bool flush( const boost::posix_time::ptime& operationTime );
       bool flush( const std::string& logText );
-      bool flush( const std::string& logText, const boost::posix_time::ptime& operationTime );
+      bool flush( const std::string& logText, bool forceInsertion );
       
     private:
+      bool flush( const std::string& logText, const boost::posix_time::ptime& operationTime, bool forceInsertion );
       void checkTransaction( const std::string& ctx );
       
     private:

--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -79,6 +79,9 @@ namespace cond {
       // loads in memory the tag information and the iov groups
       void load( const std::string& tag, const boost::posix_time::ptime& snapshottime, bool full=false );
 
+      // loads an IOV range in memory
+      void loadRange( const std::string& tag, const cond::Time_t& begin, const cond::Time_t& end );
+
       // reset the data in memory and execute again the queries for the current tag 
       void reload();
       

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -128,10 +128,13 @@ namespace cond {
       // functions to store a payload in the database. return the identifier of the item in the db. 
       template <typename T> cond::Hash storePayload( const T& payload, 
 						     const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
+
       template <typename T> std::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
       
-      // low-level function to access the payload data as a blob. mainly used for the data migration and testing.
-      // the version for ROOT 
+      cond::Hash storePayloadData( const std::string& payloadObjectType,
+                                   const std::pair<Binary,Binary>& payloadAndStreamerInfoData,
+                                   const boost::posix_time::ptime& creationTime );
+
       bool fetchPayloadData( const cond::Hash& payloadHash, 
 			     std::string& payloadType, 
 			     cond::Binary& payloadData,
@@ -157,11 +160,6 @@ namespace cond {
       coral::ISessionProxy& coralSession();
       // TO BE REMOVED in the long term. The new code will use coralSession().
       coral::ISchema& nominalSchema();
-      
-    private:
-      cond::Hash storePayloadData( const std::string& payloadObjectType, 
-				   const std::pair<Binary,Binary>& payloadAndStreamerInfoData, 
-				   const boost::posix_time::ptime& creationTime );
       
     private:
       

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -21,7 +21,7 @@ namespace cond {
       virtual void insert( const std::string& name, cond::TimeType timeType, const std::string& objectType, 
 			   cond::SynchronizationType synchronizationType, cond::Time_t endOfValidity, const std::string& description, 
 			   cond::Time_t lastValidatedTime, const boost::posix_time::ptime& insertionTime ) = 0;
-      virtual void update( const std::string& name, cond::Time_t& endOfValidity, const std::string& description, 
+      virtual void update( const std::string& name, cond::SynchronizationType synchronizationType, cond::Time_t& endOfValidity, const std::string& description, 
 			   cond::Time_t lastValidatedTime, const boost::posix_time::ptime& updateTime ) = 0;
       virtual void updateValidity( const std::string& name, cond::Time_t lastValidatedTime, 
 				   const boost::posix_time::ptime& updateTime ) = 0;

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -169,6 +169,32 @@ namespace cond {
       }
       m_data->snapshotTime = snapshotTime;
     }
+
+    void IOVProxy::loadRange( const std::string& tag, 
+			      const cond::Time_t& begin, 
+			      const cond::Time_t& end ){
+      if( !m_data.get() ) return;
+
+      // clear                                                                                                                                                                                            
+      reset();
+
+      checkTransaction( "IOVProxy::load" );
+
+      std::string dummy;
+      if(!m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, m_data->synchronizationType,
+                                                    m_data->endOfValidity, dummy, m_data->lastValidatedTime ) ){
+        throwException( "Tag \""+tag+"\" has not been found in the database.","IOVProxy::load");
+      }
+      m_data->tag = tag;
+
+      m_session->iovSchema().iovTable().selectLatestByGroup( m_data->tag, begin, end, m_data->iovSequence );
+
+      m_data->groupLowerIov = begin;
+      m_data->groupHigherIov = end;
+
+      boost::posix_time::ptime notime;
+      m_data->snapshotTime = notime;
+    }
     
     void IOVProxy::reload(){
       if(m_data.get() && !m_data->tag.empty()) load( m_data->tag, m_data->snapshotTime );

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -96,12 +96,17 @@ namespace cond {
     }
     
     void TAG::Table::update( const std::string& name, 
-		      cond::Time_t& endOfValidity, 
-		      const std::string& description, 
-		      cond::Time_t lastValidatedTime,
-		      const boost::posix_time::ptime& updateTime ){
+			     cond::SynchronizationType synchronizationType,
+			     cond::Time_t& endOfValidity, 
+			     const std::string& description, 
+			     cond::Time_t lastValidatedTime,
+			     const boost::posix_time::ptime& updateTime ){
       UpdateBuffer buffer;
-      buffer.setColumnData< END_OF_VALIDITY, DESCRIPTION, LAST_VALIDATED_TIME, MODIFICATION_TIME >( std::tie( endOfValidity, description, lastValidatedTime, updateTime  ) );
+      buffer.setColumnData< SYNCHRONIZATION, END_OF_VALIDITY, DESCRIPTION, LAST_VALIDATED_TIME, MODIFICATION_TIME >( std::tie( synchronizationType, 
+															       endOfValidity, 
+															       description, 
+															       lastValidatedTime, 
+															       updateTime  ) );
       buffer.addWhereCondition<NAME>( name );
       updateTable( m_schema, tname, buffer );  
     }

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -36,7 +36,7 @@ namespace cond {
 	void insert( const std::string& name, cond::TimeType timeType, const std::string& objectType, 
 		     cond::SynchronizationType synchronizationType, cond::Time_t endOfValidity, const std::string& description, 
 		     cond::Time_t lastValidatedTime, const boost::posix_time::ptime& insertionTime );
-	void update( const std::string& name, cond::Time_t& endOfValidity, const std::string& description, 
+	void update( const std::string& name, cond::SynchronizationType synchronizationType, cond::Time_t& endOfValidity, const std::string& description, 
 		     cond::Time_t lastValidatedTime, const boost::posix_time::ptime& updateTime );
 	void updateValidity( const std::string& name, cond::Time_t lastValidatedTime, const boost::posix_time::ptime& updateTime );
 	void setValidationMode(){}

--- a/CondCore/Utilities/bin/BuildFile.xml
+++ b/CondCore/Utilities/bin/BuildFile.xml
@@ -27,3 +27,6 @@
 <bin   file="conddb_test.cpp" name="conddb_test">
   <use   name="CondCore/CondDB"/>
 </bin>
+<bin   file="conddb_edit_tag.cpp" name="conddb_edit_tag">
+  <use   name="CondCore/CondDB"/>
+</bin>

--- a/CondCore/Utilities/bin/conddb_copy_iov.cpp
+++ b/CondCore/Utilities/bin/conddb_copy_iov.cpp
@@ -26,6 +26,7 @@ cond::CopyIovUtilities::CopyIovUtilities():Utilities("conddb_copy_iov"){
   addOption<std::string>("tag","t","destination tag (optional)");
   addOption<cond::Time_t>("sourceSince","s","since time of the iov to copy (required)");
   addOption<cond::Time_t>("destSince","d","since time of the destination iov (optional, default=sourceSince)");
+  addOption<std::string>("description","x","user text (for new tags, optional)");
 }
 
 cond::CopyIovUtilities::~CopyIovUtilities(){
@@ -45,6 +46,9 @@ int cond::CopyIovUtilities::execute(){
   cond::Time_t destSince = sourceSince;
   if( hasOptionValue("destSince") ) destSince = getOptionValue<cond::Time_t>( "destSince");
 
+  std::string description("");
+  if( hasOptionValue("description") ) description = getOptionValue<std::string>( "description" );
+
   persistency::ConnectionPool connPool;
   if( hasOptionValue("authPath") ){
     connPool.setAuthenticationPath( getOptionValue<std::string>( "authPath") ); 
@@ -57,7 +61,7 @@ int cond::CopyIovUtilities::execute(){
   std::cout <<"# input tag is "<<inputTag<<std::endl;
   std::cout <<"# destination tag is "<<tag<<std::endl;
 
-  bool imported = copyIov( session, inputTag, tag, sourceSince, destSince, "", true );
+  bool imported = copyIov( session, inputTag, tag, sourceSince, destSince, description );
     
   if( imported ) {
     std::cout <<"# 1 iov copied. "<<std::endl;

--- a/CondCore/Utilities/bin/conddb_edit_tag.cpp
+++ b/CondCore/Utilities/bin/conddb_edit_tag.cpp
@@ -1,0 +1,179 @@
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondCore/CondDB/interface/Utils.h"
+#include "CondCore/CondDB/interface/IOVEditor.h"
+#include "CondCore/CondDB/interface/IOVProxy.h"
+
+#include "CondCore/Utilities/interface/Utilities.h"
+#include "CondCore/Utilities/interface/CondDBTools.h"
+#include <iostream>
+
+#include <sstream>
+
+namespace cond {
+
+  class EditTagUtilities : public cond::Utilities {
+    public:
+      EditTagUtilities();
+      ~EditTagUtilities();
+      int execute();
+  };
+}
+
+cond::EditTagUtilities::EditTagUtilities():Utilities("conddb_edit_tag"){
+  addConnectOption("connect","c","target connection string (required)");
+  addAuthenticationOptions();
+  addOption<std::string>("tag","t","target tag (required)");
+  addOption<std::string>("payloadClassName","C","typename of the target payload object (required for new tags)");
+  addOption<std::string>("timeType","T","the IOV time type (required for new tag)");
+  addOption<std::string>("synchronizationType","S","the IOV synchronization type (optional, default=any for new tags)"); 
+  addOption<cond::Time_t>("endOfValidity","E","the IOV sequence end of validity (optional, default=infinity for new tags");
+  addOption<std::string>("description","D","user text (required for new tags)");
+  addOption<std::string>("editingNote","N","editing note (required for existing tags)");
+}
+
+cond::EditTagUtilities::~EditTagUtilities(){
+}
+
+int cond::EditTagUtilities::execute(){
+
+  bool debug = hasDebug();
+  std::string connect = getOptionValue<std::string>("connect");
+
+  // this is mandatory
+  std::string tag = getOptionValue<std::string>("tag");
+  std::cout <<"# Target tag is "<<tag<<std::endl;
+
+  persistency::ConnectionPool connPool;
+  if( hasOptionValue("authPath") ){
+    connPool.setAuthenticationPath( getOptionValue<std::string>( "authPath") ); 
+  }
+  connPool.configure();
+
+  std::cout <<"# Connecting to source database on "<<connect<<std::endl;
+  persistency::Session session = connPool.createSession( connect, true );
+
+  persistency::IOVEditor editor;
+  persistency::TransactionScope tsc( session.transaction() );
+  tsc.start( false );
+  bool exists = false;
+  if( !session.existsDatabase() ) {
+    session.createDatabase();
+  } else {
+    exists = session.existsIov( tag );
+  }
+
+  bool change = false;
+  std::map<std::string,std::pair<std::string,std::string> > changes;
+
+  std::string payloadType("");
+  if( hasOptionValue("payloadClassName") ) payloadType =  getOptionValue<std::string>( "payloadClassName" );
+  std::string description("");
+  if( hasOptionValue("description") ) description =  getOptionValue<std::string>( "description" );
+  std::string timeType("");
+  if( hasOptionValue("timeType") ) timeType =  getOptionValue<std::string>( "timeType" );
+  std::string synchronizationType("");
+  if( hasOptionValue("synchronizationType") ) synchronizationType =  getOptionValue<std::string>( "synchronizationType" );
+  std::string editingNote("");
+  if( hasOptionValue("editingNote") ) editingNote =  getOptionValue<std::string>( "editingNote" );
+
+  if( exists ){
+    if( !payloadType.empty() ){
+      std::cout <<"ERROR: can't change the payload type for an existing tag."<<std::endl;
+      return -1;
+    }
+    if( !timeType.empty() ){
+      std::cout <<"ERROR: can't change the time type for an existing tag."<<std::endl;
+      return -1;
+    }
+    if( editingNote.empty() ){
+      std::cout <<"ERROR: can't make changes to an existing tag without to provide the editing note."<<std::endl;
+      return -1;
+    }
+    editor = session.editIov( tag );
+    if( !synchronizationType.empty() ){
+      cond::SynchronizationType st = cond::synchronizationTypeFromName( synchronizationType );
+      changes.insert(std::make_pair("synchronizationType",std::make_pair(cond::synchronizationTypeNames(editor.synchronizationType()),synchronizationType)));
+      editor.setSynchronizationType( st );
+      change = true;
+    }
+    if( !description.empty() ){
+      changes.insert(std::make_pair("description",std::make_pair(editor.description(),description)));
+      editor.setDescription( description );
+      change = true;
+    }
+  } else {
+    if( payloadType.empty() ){
+      std::cout <<"ERROR: can't create the new tag, since the payload type has not been provided."<<std::endl;
+      return -1;
+    }
+    if( timeType.empty() ){
+      std::cout <<"ERROR: can't create the new tag, since the time type has not been provided."<<std::endl;
+      return -1;
+    }
+    if( description.empty() ){
+      std::cout <<"ERROR: can't create the new tag, since the description has not been provided."<<std::endl;
+      return -1;
+    }
+    if( synchronizationType.empty() ){
+      std::cout<<"# Synchronization type has not been provided. Using default value = \'any\'"<<std::endl;
+      synchronizationType = "any";
+    }
+    cond::TimeType tt = cond::time::timeTypeFromName( timeType );
+    cond::SynchronizationType st = cond::synchronizationTypeFromName( synchronizationType );
+    editor = session.createIov( payloadType, tag, tt, st );
+    change = true;
+    editor.setDescription( description );
+  }
+
+  if( hasOptionValue("endOfValidity") ){
+    cond::Time_t endOfValidity = getOptionValue<cond::Time_t>("endOfValidity");
+    changes.insert(std::make_pair("endOfValidity",std::make_pair(boost::lexical_cast<std::string>(editor.endOfValidity()),boost::lexical_cast<std::string>(endOfValidity))));
+    editor.setEndOfValidity( endOfValidity );
+    change = true;
+  }
+    
+  if( change ) {
+    if( exists ){
+      bool more = false;
+      std::cout <<"# Modifying existing tag.";
+      auto ie = changes.find("synchronizationType");
+      if( ie != changes.end() ) {
+	std::cout <<" "<<ie->first<<"=\""<<ie->second.second<<"\" (was \""<<ie->second.first<<"\")";
+	more = true;
+      }
+      ie = changes.find("endOfValidity");
+      if( ie!= changes.end() ){
+	if( more ) std::cout <<",";
+	std::cout <<" "<<ie->first<<"=\""<<ie->second.second<<"\" (was \""<<ie->second.first<<"\")";
+	more = true;	
+      }
+      if( more ) std::cout << std::endl;
+      ie = changes.find("description");
+      if( ie!= changes.end() ){
+	std::cout <<"# "<<ie->first<<": \""<<ie->second.second<<"\" (was \""<<ie->second.first<<"\")"<<std::endl;
+      }
+    } else {
+      
+      std::cout <<"# Creating new tag "<<tag<<" with: payloadType=\""<<payloadType<<"\", timeType=\""<<timeType;
+      std::cout <<"\", synchronizationType=\""<<synchronizationType<<"\", endOfValidity=\""<<editor.endOfValidity()<<"\""<<std::endl;
+      std::cout <<"# description: \""<<description<<"\""<<std::endl;
+    }
+    std::string confirm("");
+    std::cout <<"# Confirm changes (Y/N)? [N]";
+    std::getline(std::cin, confirm) ;
+    if(confirm != "Y" && confirm != "y") return 0;
+    editor.flush( editingNote );
+    tsc.commit();
+    std::cout <<"# Changes committed. "<<std::endl;
+  } else {
+    std::cout <<"#No change needed to be saved."<<std::endl;
+  }
+  return 0;
+}
+
+int main( int argc, char** argv ){
+
+  cond::EditTagUtilities utilities;
+  return utilities.run(argc,argv);
+}
+

--- a/CondCore/Utilities/interface/CondDBTools.h
+++ b/CondCore/Utilities/interface/CondDBTools.h
@@ -11,16 +11,6 @@ namespace cond {
 
     class Session;
 
-    typedef enum { NEW=0, UPDATE, REPLACE } UpdatePolicy;
-
-    size_t copyTag( const std::string& sourceTag, 
-		    Session& sourceSession, 
-		    const std::string& destTag, 
-		    Session& destSession, 
-		    UpdatePolicy policy,
-		    bool log ); 
-  
-
     size_t importIovs( const std::string& sourceTag, 
 		       Session& sourceSession, 
 		       const std::string& destTag, 
@@ -28,15 +18,17 @@ namespace cond {
 		       cond::Time_t begin,
 		       cond::Time_t end,
 		       const std::string& description,
-		       bool log );  
+		       const std::string& editingNote,
+                       bool override,
+		       bool serialize,
+		       bool forceInsert );  
 
     bool copyIov( Session& session,
 		  const std::string& sourceTag,
 		  const std::string& destTag,
 		  cond::Time_t souceSince,
 		  cond::Time_t destSince,
-		  const std::string& description,
-		  bool log );
+		  const std::string& description );
  
  }
 

--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -13,70 +13,21 @@ namespace cond {
 
   namespace persistency {
 
-    size_t copyTag( const std::string& sourceTag, 
-		    Session& sourceSession, 
-		    const std::string& destTag, 
-		    Session& destSession,
-		    UpdatePolicy policy,
-		    bool log ){
-      persistency::TransactionScope ssc( sourceSession.transaction() );
-      ssc.start();
-      if( log ) std::cout <<"    Loading source iov..."<<std::endl;
-      persistency::IOVProxy p = sourceSession.readIov( sourceTag, true );
-      if( p.loadedSize()==0 ) {
-	if( log ) std::cout <<"    Tag contains 0 iovs."<<std::endl; 
-	return 0;
-      }
-      if( log ) std::cout <<"    Copying tag. Iov size:"<<p.loadedSize()<<" timeType:"<<p.timeType()<<" payloadObjectType=\""<<p.payloadObjectType()<<"\""<<std::endl;
-
-      persistency::IOVEditor editor;
-      persistency::TransactionScope dsc( destSession.transaction() );
-      dsc.start( false );
-      bool exists = false;
-      if( !destSession.existsDatabase() ) {
-	destSession.createDatabase();
+    cond::Hash importPayload( Session& sourceSession, const cond::Hash& sourcePayloadId, Session& destSession, bool reserialize ){
+      if( reserialize ){
+	std::pair<std::string,std::shared_ptr<void> > readBackPayload = fetch( sourcePayloadId, sourceSession );
+	return import( sourceSession, sourcePayloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
       } else {
-	exists = destSession.existsIov( destTag );
-      }
-      if( exists ){
-	if( policy == REPLACE ){
-	  destSession.clearIov( destTag );
-	} else if( policy == NEW ){
-	  destSession.transaction().rollback();
-	  throwException("    Tag \""+destTag+"\" already exists.","copyTag");
+	std::string payloadType("");
+	cond::Binary payloadData;
+	cond::Binary streamerInfoData;
+	if( !sourceSession.fetchPayloadData( sourcePayloadId, payloadType, payloadData, streamerInfoData ) ){
+	  cond::throwException( "Payload with hash"+sourcePayloadId+" has not been found in the source database.","importPayload");
 	}
-	editor = destSession.editIov( destTag );
-      } else {
-	editor = destSession.createIov( p.payloadObjectType(), destTag, p.timeType(), p.synchronizationType() );
+	boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
+	return destSession.storePayloadData( payloadType, std::make_pair( payloadData, streamerInfoData ),now );  
       }
-      editor.setDescription("Tag "+sourceTag+" migrated from "+sourceSession.connectionString());
-
-      size_t niovs = 0;
-      std::set<cond::Hash> pids;
-      std::set<cond::Time_t> sinces;
-      for(  auto iov : p ){
-	// skip duplicated sinces
-	if( sinces.find( iov.since ) != sinces.end() ){
-	  if( log  ) std::cout <<"    WARNING. Skipping duplicated since="<<iov.since<<std::endl;
-	  continue;
-	}
-	sinces.insert( iov.since );
-	// make sure that we import the payload _IN_USE_
-	auto usedIov = p.getInterval( iov.since );
-	std::pair<std::string,std::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
-	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
-	editor.insert( iov.since, ph );
-	pids.insert( ph );
-	niovs++;
-	if( log && niovs && (niovs%1000==0) ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
-      } 
-      if( log ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
-      if( log ) std::cout <<"    Flushing changes..."<<std::endl;
-      editor.flush();
-      dsc.commit();
-      ssc.commit();
-      return niovs;
-    }
+    }  
 
     // comparison functor for iov tuples: Time_t only and Time_t,string
     struct IOVComp {
@@ -90,20 +41,23 @@ namespace cond {
 		       cond::Time_t begin,
 		       cond::Time_t end,
 		       const std::string& description,
-		       bool log ){
+		       const std::string& editingNote,
+                       bool override,
+		       bool reserialize,
+		       bool forceInsert ){
       persistency::TransactionScope ssc( sourceSession.transaction() );
       ssc.start();
-      if( log ) std::cout <<"    Loading source iov..."<<std::endl;
+      std::cout <<"    Loading source iov..."<<std::endl;
       persistency::IOVProxy p = sourceSession.readIov( sourceTag, true );
       if( p.loadedSize()==0 ) {
-	if( log ) std::cout <<"    Tag contains 0 iovs."<<std::endl; 
+	std::cout <<"    Tag contains 0 iovs."<<std::endl; 
 	return 0;
       } else {
-	if( log ) std::cout <<"    Iov size:"<<p.loadedSize()<<" timeType:"<<p.timeType()<<" payloadObjectType=\""<<p.payloadObjectType()<<"\""<<std::endl;
+	std::cout <<"    Iov size:"<<p.loadedSize()<<" timeType:"<<p.timeType()<<" payloadObjectType=\""<<p.payloadObjectType()<<"\""<<std::endl;
       }
       if( (*p.begin()).since > begin ) begin = (*p.begin()).since;
       if( end < begin ) {
-	if( log ) std::cout <<"    No Iov in the selected range."<<std::endl; 
+	std::cout <<"    No Iov in the selected range."<<std::endl; 
 	return 0;
       }
       persistency::IOVEditor editor;
@@ -115,11 +69,14 @@ namespace cond {
       } else {
 	exists = destSession.existsIov( destTag );
       }
+      persistency::IOVProxy dp;
       if( exists ){
+	dp = destSession.readIov( destTag );
 	editor = destSession.editIov( destTag );
+	if( !description.empty() ) std::cout <<"   INFO. Destination Tag "<<destTag<<" already exists. Provided description will be ignored."<<std::endl;
 	if( editor.timeType() != p.timeType() )
 	  throwException( "TimeType of the destination tag does not match with the source tag timeType.", "importIovs"); 
-	  if( editor.payloadType() != p.payloadObjectType() )
+	if( editor.payloadType() != p.payloadObjectType() )
 	  throwException( "PayloadType of the destination tag does not match with the source tag payloadType.", "importIovs");
       } else {
 	editor = destSession.createIov( p.payloadObjectType(), destTag, p.timeType(), p.synchronizationType() );
@@ -134,18 +91,29 @@ namespace cond {
       while( iiov != p.end() ){	
 	// skip duplicated sinces
 	if( sinces.find( newSince ) != sinces.end() ){
-	  if( log ) std::cout <<"    WARNING. Skipping duplicated since="<<newSince<<std::endl;
+	  std::cout <<"    WARNING. Skipping duplicated since="<<newSince<<std::endl;
 	  continue;
 	}
-	sinces.insert( newSince );
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( newSince );
-	std::pair<std::string,std::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
-	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
-	editor.insert( newSince, ph );
+	cond::Hash ph = importPayload( sourceSession, usedIov.payloadId, destSession, reserialize );
 	pids.insert( ph );
-	niovs++;
-	if( log && niovs && (niovs%1000==0) ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
+        bool skip = false;
+	if( exists ){
+	  // don't insert if the same entry is already there...
+	  auto ie = dp.find( newSince );
+	  if( ie != dp.end() ){
+	    if( ((*ie).since == newSince) && ((*ie).payloadId == usedIov.payloadId) ) {
+	      skip = true;
+	    }
+	  }
+	}
+	if( !skip ){
+	  editor.insert( newSince, ph );
+	  sinces.insert( newSince );
+	  niovs++;
+	  if( niovs && (niovs%1000==0) ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
+	}
 	iiov++;
 	if( iiov == p.end() || (*iiov).since > end ){
 	  break;
@@ -153,9 +121,27 @@ namespace cond {
 	  newSince = (*iiov).since;
 	}
       } 
-      if( log ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
-      if( log ) std::cout <<"    Flushing changes..."<<std::endl;
-      editor.flush();
+      if( exists && override ){
+	std::cout <<"    Adding overlying iovs..."<<std::endl;
+	persistency::IOVProxy dp;
+	dp = destSession.iovProxy();
+	dp.loadRange( destTag, begin, end );
+	std::set<cond::Time_t> extraSinces;
+        for( auto iov : dp ){
+          auto siov = p.getInterval( iov.since );
+	  if( siov.since != iov.since ) {
+            if( extraSinces.find( iov.since )==extraSinces.end() ){
+	      editor.insert( iov.since, siov.payloadId );
+	      extraSinces.insert( iov.since );
+	      niovs++;
+	      if( niovs && (niovs%1000==0) ) std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
+	    }
+	  }
+	}        	
+      }
+      std::cout <<"    Total of iov inserted: "<<niovs<<" payloads: "<<pids.size()<<std::endl;
+      std::cout <<"    Flushing changes..."<<std::endl;
+      editor.flush( editingNote, forceInsert );
       dsc.commit();
       ssc.commit();
       return niovs;
@@ -166,27 +152,27 @@ namespace cond {
 		  const std::string& destTag,
 		  cond::Time_t sourceSince,
 		  cond::Time_t destSince,
-		  const std::string& description,
-		  bool log ){
+		  const std::string& description ){
       persistency::TransactionScope ssc( session.transaction() );
       ssc.start( false );
-      if( log ) std::cout <<"    Loading source iov..."<<std::endl;
+      std::cout <<"    Loading source iov..."<<std::endl;
       persistency::IOVProxy p = session.readIov( sourceTag, true );
       if( p.loadedSize()==0 ) {
-	if( log ) std::cout <<"    Tag contains 0 iovs."<<std::endl; 
+	std::cout <<"    Tag contains 0 iovs."<<std::endl; 
 	return false;
       } else {
-	if( log ) std::cout <<"    Iov size:"<<p.loadedSize()<<" timeType:"<<p.timeType()<<" payloadObjectType=\""<<p.payloadObjectType()<<"\""<<std::endl;
+	std::cout <<"    Iov size:"<<p.loadedSize()<<" timeType:"<<p.timeType()<<" payloadObjectType=\""<<p.payloadObjectType()<<"\""<<std::endl;
       }
 
       auto iiov = p.find( sourceSince );
       if( iiov == p.end() ){
-	if( log ) std::cout <<"ERROR: No Iov valid found for target time "<<sourceSince<<std::endl;
+	std::cout <<"ERROR: No Iov valid found for target time "<<sourceSince<<std::endl;
 	return false;
       }
 
       persistency::IOVEditor editor;
       if( session.existsIov( destTag ) ){
+	if( !description.empty() ) std::cout <<"   INFO. Destination Tag "<<destTag<<" already exists. Provided description will be ignored."<<std::endl;
 	editor = session.editIov( destTag );
 	if( editor.timeType() != p.timeType() )
 	  throwException( "TimeType of the destination tag does not match with the source tag timeType.", "importIovs"); 
@@ -200,7 +186,7 @@ namespace cond {
 
       editor.insert( destSince, (*iiov).payloadId );
 
-      if( log ) std::cout <<"    Flushing changes..."<<std::endl;
+      std::cout <<"    Flushing changes..."<<std::endl;
       editor.flush();
       ssc.commit();
       return true;

--- a/CondCore/Utilities/src/Utilities.cc
+++ b/CondCore/Utilities/src/Utilities.cc
@@ -4,13 +4,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 //local includes
-//#include "CondCore/DBCommon/interface/DbConnection.h"
-//#include "CondCore/DBCommon/interface/SQLReport.h"
 #include "CondCore/Utilities/interface/Utilities.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
-//#include "CondCore/ORA/interface/SharedLibraryName.h"
 #include <boost/foreach.hpp>                   
 #include <fstream>
 #include <iostream>
@@ -87,7 +84,7 @@ cond::Utilities::addConnectOption(const std::string& connectionOptionName,
 
 void 
 cond::Utilities::addAuthenticationOptions(){
-  addOption<std::string>("authPath","P","path to authentication xml");
+  addOption<std::string>("authPath","P","path to the authentication key");
   addOption<std::string>("user","u","user name");
   addOption<std::string>("pass","p","password");
 }
@@ -157,75 +154,6 @@ bool cond::Utilities::hasDebug(){
 void cond::Utilities::initializePluginManager(){
   // dummy, to avoid to adapt non-CondCore clients
 }
-
-/**
-void cond::Utilities::initializeForDbConnection(){
-  if(!m_dbConnection){
-    m_dbConnection = new cond::DbConnection();
-    if( hasDebug() ){
-      m_dbConnection->configuration().setMessageLevel(coral::Debug);
-    } else {
-      m_dbConnection->configuration().setMessageLevel(coral::Error);
-    }
-    m_dbConnection->configuration().setPoolAutomaticCleanUp( false );
-    m_dbConnection->configuration().setConnectionTimeOut(0);
-
-    if(m_options.find_nothrow("authPath", false) &&
-       m_options.find_nothrow("user",false) &&
-       m_options.find_nothrow("pass",false)){
-      std::string authPath = getValueIfExists("authPath");
-      std::string user = getValueIfExists("user");
-      std::string pass = getValueIfExists("pass");
-      if( !authPath.empty() ){
-        m_dbConnection->configuration().setAuthenticationPath(authPath);
-      } else {
-        if( !user.empty()  && !pass.empty() ){
-          std::string userenv(std::string("CORAL_AUTH_USER=")+user);
-          std::string passenv(std::string("CORAL_AUTH_PASSWORD=")+pass);
-          ::putenv(const_cast<char*>(userenv.c_str()));
-          ::putenv(const_cast<char*>(passenv.c_str()));
-        }
-      }
-    }
-    if(m_options.find_nothrow("sql",false)){
-      if(m_values.count("sql")) {
-	m_dbConnection->configuration().setSQLMonitoring( true );
-      } 
-    }
-    m_dbConnection->configure();
-    
-  }
-  
-}
-
-cond::DbSession cond::Utilities::newDbSession( const std::string& connectionString, 
-						bool readOnly ){
-  initializeForDbConnection();
-  cond::DbSession session = m_dbConnection->createSession();
-  session.open( connectionString, readOnly );
-  return session;
-}
-cond::DbSession cond::Utilities::newDbSession( const std::string& connectionString, 
-					       const std::string& role, 
-					       bool readOnly ){
-  initializeForDbConnection();
-  cond::DbSession session = m_dbConnection->createSession();
-  session.open( connectionString, role, readOnly );
-  return session;
-}
-cond::DbSession cond::Utilities::openDbSession( const std::string& connectionParameterName, 
-						const std::string& role, 
-						bool readOnly ){
-  std::string connectionString = getOptionValue<std::string>( connectionParameterName );
-  return newDbSession( connectionString, role, readOnly );
-}
-
-cond::DbSession cond::Utilities::openDbSession( const std::string& connectionParameterName, 
-						bool readOnly ){
-  std::string connectionString = getOptionValue<std::string>( connectionParameterName );
-  return newDbSession( connectionString, readOnly );
-}
-**/
 
 std::string cond::Utilities::getValueIfExists(const std::string& fullName){
   std::string val("");


### PR DESCRIPTION
These changes aim to add functionalities to the conddb v2 c++ command line tools, namely:
- Move the de-serialization+re-serialization to a specific option in the import command. The default will transfer the blob without to read it.
- Implement an 'overriding' option for the import, allowing to ovverride the existing iovs of the concerned sequence interval, to make only the imported iovs active.
- Implement a 'forceInsert' option for the import, to allow the change of tags with synchronization else then any or validation ( will be possible only by the conddb admins anyhow )
- allow to provide the 'editingNote' which will be stored in the TagLog entry for the concerned change.
- provide a conddb_edit_tag command for general management of the Tag header, allowing to change the synchronization. It also allow to create new Tags without iovs.
