### PR TITLE
restore functionality of removeMCMatching in PAT coreTools.py

### DIFF
--- a/PhysicsTools/PatAlgos/python/cleaningLayer1/tauCleaner_cfi.py
+++ b/PhysicsTools/PatAlgos/python/cleaningLayer1/tauCleaner_cfi.py
@@ -1,16 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
+## string added as general entry for modeul definition here and use in tauTools.py
+preselection = cms.string(
+    'tauID("decayModeFinding") > 0.5 &'
+    ' tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5 &'
+    ' tauID("againstMuonTight3") > 0.5 &'
+    ' tauID("againstElectronVLooseMVA6") > 0.5'
+    )
+
 cleanPatTaus = cms.EDProducer("PATTauCleaner",
     src = cms.InputTag("selectedPatTaus"),
 
     # preselection (any string-based cut on pat::Tau)
-    preselection = cms.string(
-        'tauID("decayModeFinding") > 0.5 &'
-        ' tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5 &'
-        ' tauID("againstMuonTight3") > 0.5 &'
-        ' tauID("againstElectronVLooseMVA6") > 0.5'
-    ),
-
+    preselection = preselection,
+                              
     # overlap checking configurables
     checkOverlaps = cms.PSet(
         muons = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -119,7 +119,7 @@ class RemoveMCMatching(ConfigToolBase):
             #Boosted Taus
             if( names[obj] == 'TausBoosted'      or names[obj] == 'All' ):
                 print "removing MC dependencies for taus boosted %s" %postfix
-                if hasattr(process, 'tauMatchBoosted'+postfix) and hasattr(process, 'patTausBoosted'+psotfix) :
+                if hasattr(process, 'tauMatchBoosted'+postfix) and hasattr(process, 'patTausBoosted'+postfix) :
                     _removeMCMatchingForPATObject(process, 'tauMatchBoosted', 'patTausBoosted', postfix)
                     ## remove mc extra configs for taus
                     tauProducer = getattr(process,'patTausBoosted'+postfix)

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -119,12 +119,15 @@ class RemoveMCMatching(ConfigToolBase):
             #Boosted Taus
             if( names[obj] == 'TausBoosted'      or names[obj] == 'All' ):
                 print "removing MC dependencies for taus boosted %s" %postfix
-                _removeMCMatchingForPATObject(process, 'tauMatchBoosted', 'patTausBoosted', postfix)
-                ## remove mc extra configs for taus
-                tauProducer = getattr(process,'patTausBoosted'+postfix)
-                tauProducer.addGenJetMatch   = False
-                tauProducer.embedGenJetMatch = False
-                tauProducer.genJetMatch      = ''
+                if hasattr(process, 'tauMatchBoosted'+postfix) and hasattr(process, 'patTausBoosted'+psotfix) :
+                    _removeMCMatchingForPATObject(process, 'tauMatchBoosted', 'patTausBoosted', postfix)
+                    ## remove mc extra configs for taus
+                    tauProducer = getattr(process,'patTausBoosted'+postfix)
+                    tauProducer.addGenJetMatch   = False
+                    tauProducer.embedGenJetMatch = False
+                    tauProducer.genJetMatch      = ''
+                else :
+                    print "...skipped since taus boosted %s" %postfix, "are not part of process."  
             if( names[obj] == 'Jets'      or names[obj] == 'All' ):
                 print "removing MC dependencies for jets"
                 jetPostfixes = []

--- a/PhysicsTools/PatAlgos/python/tools/tauTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/tauTools.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.GuiBrowsers.ConfigToolBase import *
 from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet
 from RecoTauTag.RecoTau.TauDiscriminatorTools import *
+from PhysicsTools.PatAlgos.cleaningLayer1.tauCleaner_cfi import preselection
 
 # applyPostFix function adapted to unscheduled mode
 def applyPostfix(process, label, postfix):
@@ -36,9 +37,10 @@ def switchToCaloTau(process,
 
     ## adapt cleanPatTaus
     if hasattr(process, "cleanPatTaus" + patTauLabel + postfix):
-        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = \
-      'tauID("leadingTrackFinding") > 0.5 & tauID("leadingTrackPtCut") > 0.5' \
-     + ' & tauID("byIsolation") > 0.5 & tauID("againstElectron") > 0.5 & (signalTracks.size() = 1 | signalTracks.size() = 3)'
+        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = preselection
+        #\
+        #'tauID("leadingTrackFinding") > 0.5 & tauID("leadingTrackPtCut") > 0.5' \
+        #+ ' & tauID("byIsolation") > 0.5 & tauID("againstElectron") > 0.5 & (signalTracks.size() = 1 | signalTracks.size() = 3)'
 
 def _buildIDSourcePSet(tauType, idSources, postfix =""):
     """ Build a PSet defining the tau ID sources to embed into the pat::Tau """
@@ -78,10 +80,11 @@ def _switchToPFTau(process,
     applyPostfix(process, "patTaus" + patTauLabel, postfix).tauIDSources = _buildIDSourcePSet(pfTauType, idSources, postfix)
 
     if hasattr(process, "cleanPatTaus" + patTauLabel + postfix):
-        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = \
-          'tauID("leadingTrackFinding") > 0.5 & tauID("leadingPionPtCut") > 0.5 & tauID("byIsolationUsingLeadingPion") > 0.5' \
-         + ' & tauID("againstMuon") > 0.5 & tauID("againstElectron") > 0.5' \
-         + ' & (signalPFChargedHadrCands.size() = 1 | signalPFChargedHadrCands.size() = 3)'
+        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = preselection
+        #\
+        #'tauID("leadingTrackFinding") > 0.5 & tauID("leadingPionPtCut") > 0.5 & tauID("byIsolationUsingLeadingPion") > 0.5' \
+        #+ ' & tauID("againstMuon") > 0.5 & tauID("againstElectron") > 0.5' \
+        #+ ' & (signalPFChargedHadrCands.size() = 1 | signalPFChargedHadrCands.size() = 3)'
 
 # Name mapping for classic tau ID sources (present for fixed and shrinkingCones)
 classicTauIDSources = [
@@ -214,9 +217,10 @@ def switchToPFTauHPS(process,
 
     ## adapt cleanPatTaus
     if hasattr(process, "cleanPatTaus" + patTauLabel + postfix):
-        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = \
-        'pt > 18 & abs(eta) < 2.3 & tauID("decayModeFinding") > 0.5 & tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5' \
-        + ' & tauID("againstMuonTight3") > 0.5 & tauID("againstElectronVLooseMVA6") > 0.5'
+        getattr(process, "cleanPatTaus" + patTauLabel + postfix).preselection = preselection
+        #\
+        #'pt > 18 & abs(eta) < 2.3 & tauID("decayModeFinding") > 0.5 & tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5' \
+        #+ ' & tauID("againstMuonTight3") > 0.5 & tauID("againstElectronVLooseMVA6") > 0.5'
 
 
 # Select switcher by string


### PR DESCRIPTION
Due to the introduction of the section for boosted taus in a former PR this function was broken for cases where there are now boosted taus in the sequences. The functionality has been restored with this single commit and an additional printout is being made to inform the user of what is being done and why. This is a change of a high level AT configuration tool, which is transparent for the user and with no correlation to any other package. 
