### PR TITLE
Use unique_ptr, not auto_ptr, in Full Simulation

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
@@ -38,7 +38,7 @@ e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
 
 //access to SimHits
-std::auto_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
+std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
 //  if (hits.isValid()) {
     castorHitAnalyzer_.fillHits(*hits);
     CastorDigiAnalyzerImpl::analyze<CastorDigiCollection>(e, castorDigiStatistics_, castorDigiCollectionTag_);

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -119,7 +119,7 @@ void CastorDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSet
 void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup) {
   // Step B: Create empty output
 
-  std::auto_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection());
+  std::unique_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection());
 
   // Step C: Invoke the algorithm, getting back outputs.
   theCastorDigitizer->run(*castorResult, randomEngine(e.streamID()));
@@ -127,7 +127,7 @@ void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
   edm::LogInfo("CastorDigiProducer") << "HCAL/Castor digis   : " << castorResult->size();
 
   // Step D: Put outputs into event
-  e.put(castorResult);
+  e.put(std::move(castorResult));
 }
 
 

--- a/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
@@ -36,7 +36,7 @@ e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
 
   // access to SimHits
-std::auto_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
+std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
     castorAnalyzer_.fillHits(*hits);
     CastorHitAnalyzerImpl::analyze<CastorRecHitCollection>(e, castorAnalyzer_, castorRecHitCollectionTag_);
   }

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
@@ -11,7 +11,7 @@ CastorCoderFactory::CastorCoderFactory(CoderType coderType)
 }
 
 
-std::auto_ptr<CastorCoder> CastorCoderFactory::coder(const DetId & id) const {
+std::unique_ptr<CastorCoder> CastorCoderFactory::coder(const DetId & id) const {
   CastorCoder * result = 0;
   if(theCoderType == DB) {
     assert(theDbService != 0);
@@ -24,6 +24,6 @@ std::auto_ptr<CastorCoder> CastorCoderFactory::coder(const DetId & id) const {
   else {
     result = new CastorNominalCoder();
   }
-  return std::auto_ptr<CastorCoder>(result);
+  return std::unique_ptr<CastorCoder>(result);
 }
 

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.h
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.h
@@ -15,7 +15,7 @@ public:
   void setDbService(const CastorDbService * service) {theDbService = service;}
 
   /// user gets control of the pointer
-  std::auto_ptr<CastorCoder> coder(const DetId & detId) const;
+  std::unique_ptr<CastorCoder> coder(const DetId & detId) const;
 
 private:
 

--- a/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
+++ b/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
@@ -174,7 +174,7 @@ CastorDbService calibratorHandle(emptyPSet);
 
   castorDigitizer.setDetIds(hcastorDetIds);
   cout << "setDetIds" << std::endl;
-  auto_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection);
+  unique_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection);
   cout << "castorResult" << std::endl;
   cout << "test hit correction" << std::endl;
   //something breaks here!

--- a/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.cc
+++ b/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.cc
@@ -60,9 +60,9 @@ void CastorTTRecord::produce(edm::Event& e, const edm::EventSetup& eventSetup) {
     }
 
     // Put output into event
-    std::auto_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord()) ;
+    std::unique_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord()) ;
     output->setGtTechnicalTrigger(vecTT) ;    
-    e.put(output) ;
+    e.put(std::move(output)) ;
 }
 
 

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
@@ -112,15 +112,15 @@ protected:
 private:
   /** Formula defining the data frame samples
    */
-  std::auto_ptr<TFormula> formula_;
+  std::unique_ptr<TFormula> formula_;
 
   /** Formula defining the trigger primitives
    */
-  std::auto_ptr<TFormula> tpFormula_;
+  std::unique_ptr<TFormula> tpFormula_;
 
   /** Formula defining the sim hits
    */
-  std::auto_ptr<TFormula> simHitFormula_;
+  std::unique_ptr<TFormula> simHitFormula_;
   
   /** Verbosity switch
    */

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
@@ -33,9 +33,9 @@ EcalFEtoDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   if(debug_)
     std::cout << "[EcalFEtoDigi::produce] producing event " << current_bx << std::endl;
   
-  std::auto_ptr<EcalTrigPrimDigiCollection>  
+  std::unique_ptr<EcalTrigPrimDigiCollection>
     e_tpdigis (new EcalTrigPrimDigiCollection);
-  std::auto_ptr<EcalTrigPrimDigiCollection>  
+  std::unique_ptr<EcalTrigPrimDigiCollection>
     e_tpdigisTcp (new EcalTrigPrimDigiCollection);
 
   std::vector<TCCinput>::const_iterator it;
@@ -128,8 +128,8 @@ EcalFEtoDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     e_tpdigis->push_back(*e_digi);
   }
 
-  iEvent.put(e_tpdigis);
-  iEvent.put(e_tpdigisTcp,"formatTCP");
+  iEvent.put(std::move(e_tpdigis));
+  iEvent.put(std::move(e_tpdigisTcp),"formatTCP");
 
 }
 

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
@@ -16,7 +16,7 @@ using namespace edm;
 void EcalSimpleProducer::produce(edm::Event& evt, const edm::EventSetup&){
   const int ievt = evt.id().event();
   if(formula_.get()!=0){
-    auto_ptr<EBDigiCollection> digis(new EBDigiCollection);
+    unique_ptr<EBDigiCollection> digis(new EBDigiCollection);
     
     digis->reserve(170*360);
     
@@ -36,13 +36,13 @@ void EcalSimpleProducer::produce(edm::Event& evt, const edm::EventSetup&){
 	}
       }
     }
-    evt.put(digis);
+    evt.put(std::move(digis));
     //puts an empty digi collecion for endcap:
-    evt.put(auto_ptr<EEDigiCollection>(new EEDigiCollection()));
+    evt.put(unique_ptr<EEDigiCollection>(new EEDigiCollection()));
   }
   if(tpFormula_.get()!=0){
-    auto_ptr<EcalTrigPrimDigiCollection> tps
-      = auto_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
+    unique_ptr<EcalTrigPrimDigiCollection> tps
+      = unique_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
     tps->reserve(56*72);
     const int nSamples = 5;
     for(int iTtEta0=0; iTtEta0<56; ++iTtEta0){
@@ -69,11 +69,11 @@ void EcalSimpleProducer::produce(edm::Event& evt, const edm::EventSetup&){
 	tps->push_back(tpframe);
       }
     }
-    evt.put(tps);
+    evt.put(std::move(tps));
   }
   if(simHitFormula_.get()!=0){//generation of barrel sim hits
-    auto_ptr<PCaloHitContainer> hits
-      = auto_ptr<PCaloHitContainer>(new PCaloHitContainer);
+    unique_ptr<PCaloHitContainer> hits
+      = unique_ptr<PCaloHitContainer>(new PCaloHitContainer);
     for(int iEta0=0; iEta0<170; ++iEta0){
       for(int iPhi0=0; iPhi0<360; ++iPhi0){
 	int iEta1 = cIndex2iEta(iEta0);
@@ -87,9 +87,9 @@ void EcalSimpleProducer::produce(edm::Event& evt, const edm::EventSetup&){
 	hits->push_back(hit);
       }
     }
-    evt.put(hits, "EcalHitsEB");
+    evt.put(std::move(hits), "EcalHitsEB");
     //puts an empty digi collecion for endcap:
-    evt.put(auto_ptr<PCaloHitContainer>(new PCaloHitContainer()),
+    evt.put(unique_ptr<PCaloHitContainer>(new PCaloHitContainer()),
 	    "EcalHitsEE");
   }
 }
@@ -132,7 +132,7 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
   replaceAll(simHitFormula, "ievt0", "z");
   
   if(formula.size()!=0){
-    formula_ = auto_ptr<TFormula>(new TFormula("f", formula.c_str()));
+    formula_ = unique_ptr<TFormula>(new TFormula("f", formula.c_str()));
     Int_t err = formula_->Compile();
     if(err!=0){
       throw cms::Exception("Error in EcalSimpleProducer 'formula' config.");
@@ -141,7 +141,7 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
     produces<EEDigiCollection>();
   }
   if(tpFormula.size()!=0){
-    tpFormula_ = auto_ptr<TFormula>(new TFormula("f", tpFormula.c_str()));
+    tpFormula_ = unique_ptr<TFormula>(new TFormula("f", tpFormula.c_str()));
     Int_t err = tpFormula_->Compile();
     if(err!=0){
       throw cms::Exception("Error in EcalSimpleProducer 'tpFormula' config.");
@@ -150,7 +150,7 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
   }
   if(simHitFormula.size()!=0){
     simHitFormula_
-      = auto_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
+      = unique_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
     Int_t err = simHitFormula_->Compile();
     if(err!=0){
       throw cms::Exception("Error in EcalSimpleProducer "

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
@@ -102,7 +102,7 @@ private:
   printTTFlags(const EcalTrigPrimDigiCollection& tp, std::ostream& os) const;
 
 private:
-  std::auto_ptr<EcalSelectiveReadoutSuppressor> suppressor_;
+  std::unique_ptr<EcalSelectiveReadoutSuppressor> suppressor_;
   std::string digiProducer_; // name of module/plugin/producer making digis
   std::string ebdigiCollection_; // secondary name given to collection of input digis
   std::string eedigiCollection_; // secondary name given to collection of input digis
@@ -154,7 +154,7 @@ private:
   /** Used when settings_ is imported from configuration file. Just used
    * for memory management. Used settings_ to access to the object
    */
-  std::auto_ptr<EcalSRSettings> settingsFromFile_;
+  std::unique_ptr<EcalSRSettings> settingsFromFile_;
 
   // Tokens for consumes collection:
 

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -49,7 +49,7 @@ EcalSelectiveReadoutProducer::EcalSelectiveReadoutProducer(const edm::ParameterS
       "Selective readout configuration will be read from python file.";
   }
   if(!useCondDb_){
-    settingsFromFile_ = auto_ptr<EcalSRSettings>(new EcalSRSettings());
+    settingsFromFile_ = unique_ptr<EcalSRSettings>(new EcalSRSettings());
     EcalSRCondTools::importParameterSet(*settingsFromFile_, params);
     settings_ = settingsFromFile_.get();
   }
@@ -116,19 +116,19 @@ EcalSelectiveReadoutProducer::produce(edm::Event& event, const edm::EventSetup& 
     :&dummyEeDigiColl;
 
   //runs the selective readout algorithm:
-  auto_ptr<EBDigiCollection> selectedEBDigis;
-  auto_ptr<EEDigiCollection> selectedEEDigis;
-  auto_ptr<EBSrFlagCollection> ebSrFlags;
-  auto_ptr<EESrFlagCollection> eeSrFlags;
+  unique_ptr<EBDigiCollection> selectedEBDigis;
+  unique_ptr<EEDigiCollection> selectedEEDigis;
+  unique_ptr<EBSrFlagCollection> ebSrFlags;
+  unique_ptr<EESrFlagCollection> eeSrFlags;
 
   if(produceDigis_){
-    selectedEBDigis = auto_ptr<EBDigiCollection>(new EBDigiCollection);
-    selectedEEDigis = auto_ptr<EEDigiCollection>(new EEDigiCollection);
+    selectedEBDigis = unique_ptr<EBDigiCollection>(new EBDigiCollection);
+    selectedEEDigis = unique_ptr<EEDigiCollection>(new EEDigiCollection);
   }
 
   if(writeSrFlags_){
-    ebSrFlags = auto_ptr<EBSrFlagCollection>(new EBSrFlagCollection);
-    eeSrFlags = auto_ptr<EESrFlagCollection>(new EESrFlagCollection);
+    ebSrFlags = unique_ptr<EBSrFlagCollection>(new EBSrFlagCollection);
+    eeSrFlags = unique_ptr<EESrFlagCollection>(new EESrFlagCollection);
   }
 
   if(suppressor_.get() == 0){
@@ -136,7 +136,7 @@ EcalSelectiveReadoutProducer::produce(edm::Event& event, const edm::EventSetup& 
     checkValidity(*settings_);
     
     //instantiates the selective readout algorithm:
-    suppressor_ = auto_ptr<EcalSelectiveReadoutSuppressor>(new EcalSelectiveReadoutSuppressor(params_, settings_));
+    suppressor_ = unique_ptr<EcalSelectiveReadoutSuppressor>(new EcalSelectiveReadoutSuppressor(params_, settings_));
 
     // check that everything is up-to-date
     checkGeometry(eventSetup);
@@ -171,14 +171,14 @@ EcalSelectiveReadoutProducer::produce(edm::Event& event, const edm::EventSetup& 
 
   if(produceDigis_){
     //puts the selected digis into the event:
-    event.put(selectedEBDigis, ebSRPdigiCollection_);
-    event.put(selectedEEDigis, eeSRPdigiCollection_);
+    event.put(std::move(selectedEBDigis), ebSRPdigiCollection_);
+    event.put(std::move(selectedEEDigis), eeSRPdigiCollection_);
   }
 
   //puts the SR flags into the event:
   if(writeSrFlags_) {
-    event.put(ebSrFlags, ebSrFlagCollection_);
-    event.put(eeSrFlags, eeSrFlagCollection_);
+    event.put(std::move(ebSrFlags), ebSrFlagCollection_);
+    event.put(std::move(eeSrFlags), eeSrFlagCollection_);
   }
 }
 

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -587,11 +587,11 @@ EcalDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup cons
 void 
 EcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventSetup) {
    // Step B: Create empty output
-   std::auto_ptr<EBDigiCollection> apdResult      ( !m_apdSeparateDigi || !m_doEB ? nullptr :
+   std::unique_ptr<EBDigiCollection> apdResult      ( !m_apdSeparateDigi || !m_doEB ? nullptr :
 						    new EBDigiCollection() ) ;
-   std::auto_ptr<EBDigiCollection> barrelResult   ( new EBDigiCollection() ) ;
-   std::auto_ptr<EEDigiCollection> endcapResult   ( new EEDigiCollection() ) ;
-   std::auto_ptr<ESDigiCollection> preshowerResult( new ESDigiCollection() ) ;
+   std::unique_ptr<EBDigiCollection> barrelResult   ( new EBDigiCollection() ) ;
+   std::unique_ptr<EEDigiCollection> endcapResult   ( new EEDigiCollection() ) ;
+   std::unique_ptr<ESDigiCollection> preshowerResult( new ESDigiCollection() ) ;
    
    // run the algorithm
 
@@ -624,12 +624,12 @@ EcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventS
 
    // Step D: Put outputs into event
    if( m_apdSeparateDigi ) {
-     //event.put( apdResult,    m_apdDigiTag         ) ;
+     //event.put(std::move(apdResult),    m_apdDigiTag         ) ;
    }
 
-   event.put( barrelResult,    m_EBdigiCollection ) ;
-   event.put( endcapResult,    m_EEdigiCollection ) ;
-   event.put( preshowerResult, m_ESdigiCollection ) ;
+   event.put(std::move(barrelResult),    m_EBdigiCollection ) ;
+   event.put(std::move(endcapResult),    m_EEdigiCollection ) ;
+   event.put(std::move(preshowerResult), m_ESdigiCollection ) ;
 }
 
 void

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -56,9 +56,9 @@ class EcalTBDigiProducer : public EcalDigiProducer
       
       double m_tunePhaseShift ;
 
-      mutable std::auto_ptr<EBDigiCollection> m_ebDigis ;
-      mutable std::auto_ptr<EEDigiCollection> m_eeDigis ;
-      mutable std::auto_ptr<EcalTBTDCRawInfo> m_TDCproduct ;
+      mutable std::unique_ptr<EBDigiCollection> m_ebDigis ;
+      mutable std::unique_ptr<EEDigiCollection> m_eeDigis ;
+      mutable std::unique_ptr<EcalTBTDCRawInfo> m_TDCproduct ;
 };
 
 #endif 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -97,7 +97,7 @@ void EcalTBDigiProducer::finalizeEvent( edm::Event& event, const edm::EventSetup
 
    const EBDigiCollection* barrelResult ( &*m_ebDigis ) ;
 
-   std::auto_ptr<EBDigiCollection> barrelReadout( new EBDigiCollection() ) ;
+   std::unique_ptr<EBDigiCollection> barrelReadout( new EBDigiCollection() ) ;
    if( m_doReadout ) 
    {
       m_theTBReadout->performReadout( event,
@@ -114,8 +114,8 @@ void EcalTBDigiProducer::finalizeEvent( edm::Event& event, const edm::EventSetup
 	    << barrelReadout->size()<<std::endl ;
 
    std::string const instance("simEcalUnsuppressedDigis");
-   event.put(barrelReadout, instance + m_EBdigiFinalTag) ;
-   event.put(m_TDCproduct, instance) ;
+   event.put(std::move(barrelReadout), instance + m_EBdigiFinalTag) ;
+   event.put(std::move(m_TDCproduct), instance) ;
 
    m_ebDigis.reset(); // release memory
    m_eeDigis.reset(); // release memory

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
@@ -37,7 +37,7 @@ void ESZeroSuppressionProducer::produce(edm::Event& event, const edm::EventSetup
     fullESDigis = false;
   }  
 
-  std::auto_ptr<ESDigiCollection> ESZSDigis(new ESDigiCollection());
+  std::unique_ptr<ESDigiCollection> ESZSDigis(new ESDigiCollection());
   
   if (fullESDigis) {
     for (ESDigiCollection::const_iterator i (ESDigis->begin()); 
@@ -54,6 +54,6 @@ void ESZeroSuppressionProducer::produce(edm::Event& event, const edm::EventSetup
     }
   }     
   
-  event.put(ESZSDigis, ESZSdigiCollection_);  
+  event.put(std::move(ESZSDigis), ESZSdigiCollection_);
 }
 

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
@@ -58,8 +58,8 @@ void EcalZeroSuppressionProducer::produce(edm::Event& event, const edm::EventSet
 
   // collection of zero suppressed digis to put in the event
   
-  std::auto_ptr< EBDigiCollection > gzsBarrelDigis(new EBDigiCollection());
-  std::auto_ptr< EEDigiCollection > gzsEndcapDigis(new EEDigiCollection());
+  std::unique_ptr< EBDigiCollection > gzsBarrelDigis(new EBDigiCollection());
+  std::unique_ptr< EEDigiCollection > gzsEndcapDigis(new EEDigiCollection());
 
   CaloDigiCollectionSorter sorter(5);
 
@@ -113,8 +113,8 @@ void EcalZeroSuppressionProducer::produce(edm::Event& event, const edm::EventSet
   
   }
   // Step D: Put outputs into event
-  event.put(gzsBarrelDigis, EBZSdigiCollection_);
-  event.put(gzsEndcapDigis, EEZSdigiCollection_);
+  event.put(std::move(gzsBarrelDigis), EBZSdigiCollection_);
+  event.put(std::move(gzsEndcapDigis), EEZSdigiCollection_);
 
 }
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -42,7 +42,7 @@ class HGCDigitizerBase {
  /**
     @short steer digitization mode
  */
-  void run(std::auto_ptr<DColl> &digiColl, hgc::HGCSimHitDataAccumulator &simData, uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
+  void run(std::unique_ptr<DColl> &digiColl, hgc::HGCSimHitDataAccumulator &simData, uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
   
   /**
      @short getters
@@ -54,17 +54,17 @@ class HGCDigitizerBase {
   /**
      @short a trivial digitization: sum energies and digitize without noise
    */
-  void runSimple(std::auto_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  void runSimple(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
   
   /**
      @short prepares the output according to the number of time samples to produce
   */
-  void updateOutput(std::auto_ptr<DColl> &coll, const DFr& rawDataFrame);
+  void updateOutput(std::unique_ptr<DColl> &coll, const DFr& rawDataFrame);
   
   /**
      @short to be specialized by top class
   */
-  virtual void runDigitizer(std::auto_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
+  virtual void runDigitizer(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
   {
     throw cms::Exception("HGCDigitizerBaseException") << " Failed to find specialization of runDigitizer";
   }

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
@@ -8,7 +8,7 @@ class HGCEEDigitizer : public HGCDigitizerBase<HGCEEDataFrame> {
 
 public:
   HGCEEDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCEEDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
@@ -9,7 +9,7 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCHEDataFrame>
  public:
 
   HGCHEbackDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCHEbackDigitizer();
 
  private:
@@ -17,7 +17,7 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCHEDataFrame>
   //calice-like digitization parameters
   float keV2MIP_, noise_MIP_;
   float nPEperMIP_, nTotalPE_, xTalk_, sdPixels_;
-  void runCaliceLikeDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  void runCaliceLikeDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
 };
 
 #endif 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
@@ -8,7 +8,7 @@ class HGCHEfrontDigitizer : public HGCDigitizerBase<HGCHEDataFrame> {
 
 public:
   HGCHEfrontDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
   ~HGCHEfrontDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -67,24 +67,24 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
 {
   if( producesEEDigis() ) 
     {
-      std::auto_ptr<HGCEEDigiCollection> digiResult(new HGCEEDigiCollection() );
+      std::unique_ptr<HGCEEDigiCollection> digiResult(new HGCEEDigiCollection() );
       theHGCEEDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " EE hits";      
-      e.put(digiResult,digiCollection());
+      e.put(std::move(digiResult),digiCollection());
     }
   if( producesHEfrontDigis())
     {
-      std::auto_ptr<HGCHEDigiCollection> digiResult(new HGCHEDigiCollection() );
+      std::unique_ptr<HGCHEDigiCollection> digiResult(new HGCHEDigiCollection() );
       theHGCHEfrontDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " HE front hits";
-      e.put(digiResult,digiCollection());
+      e.put(std::move(digiResult),digiCollection());
     }
   if( producesHEbackDigis() )
     {
-      std::auto_ptr<HGCHEDigiCollection> digiResult(new HGCHEDigiCollection() );
+      std::unique_ptr<HGCHEDigiCollection> digiResult(new HGCHEDigiCollection() );
       theHGCHEbackDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " HE back hits";
-      e.put(digiResult,digiCollection());
+      e.put(std::move(digiResult),digiCollection());
     }
 }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -3,7 +3,7 @@
 using namespace hgc_digi;
 
 template<class DFr>
-void HGCDigitizerBase<DFr>::run( std::auto_ptr<HGCDigitizerBase::DColl> &digiColl,
+void HGCDigitizerBase<DFr>::run( std::unique_ptr<HGCDigitizerBase::DColl> &digiColl,
                                   HGCSimHitDataAccumulator &simData,
                                   uint32_t digitizationType,
                                   CLHEP::HepRandomEngine* engine) {
@@ -12,7 +12,7 @@ void HGCDigitizerBase<DFr>::run( std::auto_ptr<HGCDigitizerBase::DColl> &digiCol
 }
 
 template<class DFr>
-void HGCDigitizerBase<DFr>::runSimple(std::auto_ptr<HGCDigitizerBase::DColl> &coll,
+void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &coll,
                                        HGCSimHitDataAccumulator &simData, 
                                        CLHEP::HepRandomEngine* engine) {
   HGCSimHitData chargeColl,toa;
@@ -51,7 +51,7 @@ void HGCDigitizerBase<DFr>::runSimple(std::auto_ptr<HGCDigitizerBase::DColl> &co
 }
 
 template<class DFr>
-void HGCDigitizerBase<DFr>::updateOutput(std::auto_ptr<HGCDigitizerBase::DColl> &coll,
+void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl> &coll,
                                           const DFr& rawDataFrame) {
   int itIdx(9);
   if(rawDataFrame.size()<=itIdx+2) return;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
@@ -6,7 +6,7 @@ using namespace hgc_digi;
 HGCEEDigitizer::HGCEEDigitizer(const edm::ParameterSet& ps) : HGCDigitizerBase(ps) { }
 
 //
-void HGCEEDigitizer::runDigitizer(std::auto_ptr<HGCEEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
+void HGCEEDigitizer::runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
 }
 
 //

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -21,13 +21,13 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitiz
 }
 
 //
-void HGCHEbackDigitizer::runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine)
+void HGCHEbackDigitizer::runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine)
 {
   runCaliceLikeDigitizer(digiColl,simData,engine);
 }
   
 //
-void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine)
+void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine)
 {
   //switch to true if you want to print some details
   constexpr bool debug(false);

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
@@ -7,7 +7,7 @@ HGCHEfrontDigitizer::HGCHEfrontDigitizer(const edm::ParameterSet &ps) : HGCDigit
 }
 
 //
-void HGCHEfrontDigitizer::runDigitizer(std::auto_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
+void HGCHEfrontDigitizer::runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
 }
 
 //

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalCoderFactory.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalCoderFactory.h
@@ -15,7 +15,7 @@ public:
   void setDbService(const HcalDbService * service) {theDbService = service;}
 
   /// user gets control of the pointer
-  std::auto_ptr<HcalCoder> coder(const DetId & detId) const;
+  std::unique_ptr<HcalCoder> coder(const DetId & detId) const;
 
 private:
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalCoderFactory.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalCoderFactory.cc
@@ -8,7 +8,7 @@ HcalCoderFactory::HcalCoderFactory(CoderType coderType)
   : theCoderType(coderType), theDbService(0) { }
 
 
-std::auto_ptr<HcalCoder> HcalCoderFactory::coder(const DetId & id) const {
+std::unique_ptr<HcalCoder> HcalCoderFactory::coder(const DetId & id) const {
   HcalCoder * result = 0;
   if (theCoderType == DB || theCoderType == UPGRADE) {
     assert(theDbService != 0);
@@ -19,6 +19,6 @@ std::auto_ptr<HcalCoder> HcalCoderFactory::coder(const DetId & id) const {
   } else {
     result = new HcalNominalCoder();
   }
-  return std::auto_ptr<HcalCoder>(result);
+  return std::unique_ptr<HcalCoder>(result);
 }
 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -251,10 +251,10 @@ void HcalDigitizerTest::analyze(const edm::Event& iEvent,
   hoDigitizer.setDetIds(hoDetIds);
   zdcDigitizer.setDetIds(hzdcDetIds);
 
-  std::auto_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection);
-  std::auto_ptr<HODigiCollection> hoResult(new HODigiCollection);
-  std::auto_ptr<HFDigiCollection> hfResult(new HFDigiCollection);
-  std::auto_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection);
+  std::unique_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection);
+  std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection);
+  std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection);
+  std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection);
 
   MixCollection<PCaloHit> hitCollection(&crossingFrame);
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiAnalyzer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiAnalyzer.cc
@@ -45,8 +45,8 @@ void HcalDigiAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& c) {
   //e.getByLabel("mix", "ZDCHits", zdccf);
   
   // test access to SimHits for HcalHits and ZDC hits
-  std::auto_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(cf.product()));
-  //std::auto_ptr<MixCollection<PCaloHit> > zdcHits(new MixCollection<PCaloHit>(zdccf.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(cf.product()));
+  //std::unique_ptr<MixCollection<PCaloHit> > zdcHits(new MixCollection<PCaloHit>(zdccf.product()));
   hbheHitAnalyzer_.fillHits(*hits);
   hoHitAnalyzer_.fillHits(*hits);
   hfHitAnalyzer_.fillHits(*hits);

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -511,14 +511,14 @@ void HcalDigitizer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup co
 void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup, CLHEP::HepRandomEngine* engine) {
 
   // Step B: Create empty output
-  std::auto_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
-  std::auto_ptr<HODigiCollection> hoResult(new HODigiCollection());
-  std::auto_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
-  std::auto_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
-  std::auto_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
-  std::auto_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
-  std::auto_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection());
-  std::auto_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection());
+  std::unique_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
+  std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
+  std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
+  std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
+  std::unique_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
+  std::unique_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
+  std::unique_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection());
+  std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection());
 
   // Step C: Invoke the algorithm, getting back outputs.
   if(isHCAL&&hbhegeo){
@@ -561,14 +561,14 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
 #endif
 
   // Step D: Put outputs into event
-  e.put(hbheResult);
-  e.put(hoResult);
-  e.put(hfResult);
-  e.put(zdcResult);
-  e.put(hbheupgradeResult,"HBHEUpgradeDigiCollection");
-  e.put(hfupgradeResult, "HFUpgradeDigiCollection");
-  e.put(hfQIE10Result, "HFQIE10DigiCollection");
-  e.put(hbheQIE11Result, "HBHEQIE11DigiCollection");
+  e.put(std::move(hbheResult));
+  e.put(std::move(hoResult));
+  e.put(std::move(hfResult));
+  e.put(std::move(zdcResult));
+  e.put(std::move(hbheupgradeResult),"HBHEUpgradeDigiCollection");
+  e.put(std::move(hfupgradeResult), "HFUpgradeDigiCollection");
+  e.put(std::move(hfQIE10Result), "HFQIE10DigiCollection");
+  e.put(std::move(hbheQIE11Result), "HBHEQIE11DigiCollection");
 
 #ifdef DebugLog
   std::cout << std::endl << "========>  HcalDigitizer e.put " << std::endl <<  std::endl;

--- a/SimCalorimetry/HcalSimProducers/src/HcalHitAnalyzer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalHitAnalyzer.cc
@@ -40,8 +40,8 @@ void HcalHitAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& c) {
   //e.getByLabel("mix", "ZDCHits", zdccf);
 
   // test access to SimHits for HcalHits and ZDC hits
-  std::auto_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(cf.product()));
-  //std::auto_ptr<MixCollection<PCaloHit> > zdcHits(new MixCollection<PCaloHit>(zdccf.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(cf.product()));
+  //std::unique_ptr<MixCollection<PCaloHit> > zdcHits(new MixCollection<PCaloHit>(zdccf.product()));
   hbheAnalyzer_.fillHits(*hits); 
   //hoAnalyzer_.fillHits(*hits);
   //hfAnalyzer_.fillHits(*hits);

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -149,8 +149,8 @@ void HcalTBDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSet
 
 void HcalTBDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup) {
   // Step B: Create empty output
-  std::auto_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
-  std::auto_ptr<HODigiCollection> hoResult(new HODigiCollection());
+  std::unique_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
+  std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
   LogDebug("HcalSim") << "HcalTBDigiProducer::produce Empty collection created";
   // Step C: Invoke the algorithm, getting back outputs.
   theHBHEDigitizer->run(*hbheResult, randomEngine(e.streamID()));
@@ -160,8 +160,8 @@ void HcalTBDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
 
   // Step D: Put outputs into event
   std::string const instance("simHcalDigis");
-  e.put(hbheResult, instance);
-  e.put(hoResult, instance);
+  e.put(std::move(hbheResult), instance);
+  e.put(std::move(hoResult), instance);
 
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.cc
@@ -115,7 +115,7 @@ void HcalTTPDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSet
     eventSetup.get<HcalTPGRecord>().get(inputCoder) ;
 
     // Step B: Create empty output
-    std::auto_ptr<HcalTTPDigiCollection> ttpResult(new HcalTTPDigiCollection()) ; 
+    std::unique_ptr<HcalTTPDigiCollection> ttpResult(new HcalTTPDigiCollection()) ;
     
     // Step C: Compute TTP inputs
     uint16_t trigInputs[40] ;
@@ -167,6 +167,6 @@ void HcalTTPDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSet
     ttpResult->push_back( ttpDigi ) ;
     
     // Step E: Put outputs into event
-    e.put(ttpResult);
+    e.put(std::move(ttpResult));
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPTriggerRecord.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPTriggerRecord.cc
@@ -46,8 +46,8 @@ void HcalTTPTriggerRecord::produce(edm::Event& e, const edm::EventSetup& eventSe
     }
 
     // Put output into event
-    std::auto_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord()) ;
+    std::unique_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord()) ;
     output->setGtTechnicalTrigger(vecTT) ;    
-    e.put(output) ;
+    e.put(std::move(output)) ;
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -88,7 +88,7 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
   eventSetup.get<CaloGeometryRecord>().get(pG);
   
   // Step B: Create empty output
-  std::auto_ptr<HcalTrigPrimDigiCollection> result(new HcalTrigPrimDigiCollection());
+  std::unique_ptr<HcalTrigPrimDigiCollection> result(new HcalTrigPrimDigiCollection());
 
   edm::Handle<HBHEDigiCollection> hbheDigis;
   edm::Handle<HFDigiCollection>   hfDigis;
@@ -107,7 +107,7 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
               << "\nQuit returning empty product." << std::endl;
 
       // put empty HcalTrigPrimDigiCollection in the event
-      iEvent.put(result);
+      iEvent.put(std::move(result));
 
       return;
   }
@@ -120,7 +120,7 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
               << "\nQuit returning empty product." << std::endl;
 
       // put empty HcalTrigPrimDigiCollection in the event
-      iEvent.put(result);
+      iEvent.put(std::move(result));
 
       return;
   }
@@ -166,10 +166,10 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
                     << "\nQuit returning empty product." << std::endl;
 
             // produce empty HcalTrigPrimDigiCollection and put it in the event
-            std::auto_ptr < HcalTrigPrimDigiCollection > emptyResult(
+            std::unique_ptr < HcalTrigPrimDigiCollection > emptyResult(
                     new HcalTrigPrimDigiCollection());
 
-            iEvent.put(emptyResult);
+            iEvent.put(std::move(emptyResult));
 
             return;
         }
@@ -181,7 +181,7 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
   //  edm::LogInfo("HcalTrigPrimDigiProducer") << "HcalTrigPrims: " << result->size();
 
   // Step D: Put outputs into event
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -118,17 +118,17 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   e.getByToken(tok_hbhe_,hbhe);
   
   // create empty output
-  std::auto_ptr<HBHEDigiCollection> zs_hbhe(new HBHEDigiCollection);
+  std::unique_ptr<HBHEDigiCollection> zs_hbhe(new HBHEDigiCollection);
   
   e.getByToken(tok_ho_,ho);
   
   // create empty output
-  std::auto_ptr<HODigiCollection> zs_ho(new HODigiCollection);
+  std::unique_ptr<HODigiCollection> zs_ho(new HODigiCollection);
   
   e.getByToken(tok_hf_,hf);
   
   // create empty output
-  std::auto_ptr<HFDigiCollection> zs_hf(new HFDigiCollection);
+  std::unique_ptr<HFDigiCollection> zs_hf(new HFDigiCollection);
   
   e.getByToken(tok_hbheUpgrade_,hbheUpgrade);
   e.getByToken(tok_hfUpgrade_,hfUpgrade);
@@ -136,10 +136,10 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   e.getByToken(tok_hbheQIE11_,hbheQIE11);
   
   // create empty output
-  std::auto_ptr<HBHEUpgradeDigiCollection> zs_hbheUpgrade(new HBHEUpgradeDigiCollection);
-  std::auto_ptr<HFUpgradeDigiCollection> zs_hfUpgrade(new HFUpgradeDigiCollection);
-  std::auto_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection);
-  std::auto_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection);
+  std::unique_ptr<HBHEUpgradeDigiCollection> zs_hbheUpgrade(new HBHEUpgradeDigiCollection);
+  std::unique_ptr<HFUpgradeDigiCollection> zs_hfUpgrade(new HFUpgradeDigiCollection);
+  std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection);
+  std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection);
   
   //run the algorithm
 
@@ -162,12 +162,12 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   
 
     // return result
-    e.put(zs_hbhe);
-    e.put(zs_ho);
-    e.put(zs_hf);
-    e.put(zs_hbheUpgrade,"HBHEUpgradeDigiCollection");
-    e.put(zs_hfUpgrade,"HFUpgradeDigiCollection");
-    e.put(zs_hfQIE10,"HFQIE10DigiCollection");
-    e.put(zs_hbheQIE11,"HBHEQIE11DigiCollection");
+    e.put(std::move(zs_hbhe));
+    e.put(std::move(zs_ho));
+    e.put(std::move(zs_hf));
+    e.put(std::move(zs_hbheUpgrade),"HBHEUpgradeDigiCollection");
+    e.put(std::move(zs_hfUpgrade),"HFUpgradeDigiCollection");
+    e.put(std::move(zs_hfQIE10),"HFQIE10DigiCollection");
+    e.put(std::move(zs_hbheQIE11),"HBHEQIE11DigiCollection");
 
 }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
@@ -28,19 +28,19 @@ HcalSimpleAmplitudeZS::HcalSimpleAmplitudeZS(edm::ParameterSet const& conf):
 
   const edm::ParameterSet& psHBHE=conf.getParameter<edm::ParameterSet>("hbhe");
   bool markAndPass=psHBHE.getParameter<bool>("markAndPass");
-  hbhe_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+  hbhe_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 							     psHBHE.getParameter<int>("level"),
 							     psHBHE.getParameter<int>("firstSample"),
 							     psHBHE.getParameter<int>("samplesToAdd"),
 							     psHBHE.getParameter<bool>("twoSided")));
   produces<HBHEDigiCollection>();  
-  hbheUpgrade_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+  hbheUpgrade_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 								    psHBHE.getParameter<int>("level"),
 								    psHBHE.getParameter<int>("firstSample"),
 								    psHBHE.getParameter<int>("samplesToAdd"),
 								    psHBHE.getParameter<bool>("twoSided")));
   produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");  
-  hbheQIE11_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,	
+  hbheQIE11_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,	
 								  psHBHE.getParameter<int>("level"),
 								  psHBHE.getParameter<int>("firstSample"),
 								  psHBHE.getParameter<int>("samplesToAdd"),
@@ -49,7 +49,7 @@ HcalSimpleAmplitudeZS::HcalSimpleAmplitudeZS(edm::ParameterSet const& conf):
   
   const edm::ParameterSet& psHO=conf.getParameter<edm::ParameterSet>("ho");
   markAndPass=psHO.getParameter<bool>("markAndPass");
-  ho_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+  ho_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 							   psHO.getParameter<int>("level"),
 							   psHO.getParameter<int>("firstSample"),
 							   psHO.getParameter<int>("samplesToAdd"),
@@ -58,19 +58,19 @@ HcalSimpleAmplitudeZS::HcalSimpleAmplitudeZS(edm::ParameterSet const& conf):
   
   const edm::ParameterSet& psHF=conf.getParameter<edm::ParameterSet>("hf");
   markAndPass=psHF.getParameter<bool>("markAndPass");
-  hf_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,	
+  hf_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 							   psHF.getParameter<int>("level"),
 							   psHF.getParameter<int>("firstSample"),
 							   psHF.getParameter<int>("samplesToAdd"),
 							   psHF.getParameter<bool>("twoSided")));
   produces<HFDigiCollection>();
-  hfUpgrade_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,	
+  hfUpgrade_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 								  psHF.getParameter<int>("level"),
 								  psHF.getParameter<int>("firstSample"),
 								  psHF.getParameter<int>("samplesToAdd"),
 								  psHF.getParameter<bool>("twoSided")));
   produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");  
-  hfQIE10_=std::auto_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,	
+  hfQIE10_=std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
 								  psHF.getParameter<int>("level"),
 								  psHF.getParameter<int>("firstSample"),
 								  psHF.getParameter<int>("samplesToAdd"),
@@ -94,14 +94,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hbhe_,digi);
     
     // create empty output
-    std::auto_ptr<HBHEDigiCollection> zs(new HBHEDigiCollection);
+    std::unique_ptr<HBHEDigiCollection> zs(new HBHEDigiCollection);
     // run the algorithm
     hbhe_->suppress(*(digi.product()),*zs);
     
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHE) input " << digi->size() << " digis, output " << zs->size() << " digis";
     
     // return result
-    e.put(zs);
+    e.put(std::move(zs));
     hbhe_->done();
   } 
   {
@@ -110,14 +110,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_ho_,digi);
     
     // create empty output
-    std::auto_ptr<HODigiCollection> zs(new HODigiCollection);
+    std::unique_ptr<HODigiCollection> zs(new HODigiCollection);
     // run the algorithm
     ho_->suppress(*(digi.product()),*zs);
 
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HO) input " << digi->size() << " digis, output " << zs->size() << " digis";
 
     // return result
-    e.put(zs);    
+    e.put(std::move(zs));
     ho_->done();
   } 
   {
@@ -126,14 +126,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hf_,digi);
     
     // create empty output
-    std::auto_ptr<HFDigiCollection> zs(new HFDigiCollection);
+    std::unique_ptr<HFDigiCollection> zs(new HFDigiCollection);
     // run the algorithm
     hf_->suppress(*(digi.product()),*zs);
 
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HF) input " << digi->size() << " digis, output " << zs->size() << " digis";
 
     // return result
-    e.put(zs);     
+    e.put(std::move(zs));
     hf_->done();
   }
   {
@@ -142,14 +142,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hbheUpgrade_,digi);
     
     // create empty output
-    std::auto_ptr<HBHEUpgradeDigiCollection> zs(new HBHEUpgradeDigiCollection);
+    std::unique_ptr<HBHEUpgradeDigiCollection> zs(new HBHEUpgradeDigiCollection);
     // run the algorithm
     hbheUpgrade_->suppress(*(digi.product()),*zs);
     
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHEUpgrade) input " << digi->size() << " digis, output " << zs->size() << " digis";
     
     // return result
-    e.put(zs,"HBHEUpgradeDigiCollection");
+    e.put(std::move(zs),"HBHEUpgradeDigiCollection");
     hbheUpgrade_->done();
   } 
   {
@@ -158,14 +158,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hfUpgrade_,digi);
     
     // create empty output
-    std::auto_ptr<HFUpgradeDigiCollection> zs(new HFUpgradeDigiCollection);
+    std::unique_ptr<HFUpgradeDigiCollection> zs(new HFUpgradeDigiCollection);
     // run the algorithm
     hfUpgrade_->suppress(*(digi.product()),*zs);
 
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HFUpgrade) input " << digi->size() << " digis, output " << zs->size() << " digis";
 
     // return result
-    e.put(zs, "HFUpgradeDigiCollection");     
+    e.put(std::move(zs), "HFUpgradeDigiCollection");
     hfUpgrade_->done();
   }
   {
@@ -174,14 +174,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hfUpgrade_,digi);
     
     // create empty output
-    std::auto_ptr<QIE10DigiCollection> zs(new QIE10DigiCollection);
+    std::unique_ptr<QIE10DigiCollection> zs(new QIE10DigiCollection);
     // run the algorithm
     hfQIE10_->suppress(*(digi.product()),*zs);
 
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HFQIE10) input " << digi->size() << " digis, output " << zs->size() << " digis";
 
     // return result
-    e.put(zs, "HFQIE10DigiCollection");     
+    e.put(std::move(zs), "HFQIE10DigiCollection");
     hfQIE10_->done();
   }
   {
@@ -190,14 +190,14 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hbheQIE11_,digi);
     
     // create empty output
-    std::auto_ptr<QIE11DigiCollection> zs(new QIE11DigiCollection);
+    std::unique_ptr<QIE11DigiCollection> zs(new QIE11DigiCollection);
     // run the algorithm
     hbheQIE11_->suppress(*(digi.product()),*zs);
 
     edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHEQIE11) input " << digi->size() << " digis, output " << zs->size() << " digis";
 
     // return result
-    e.put(zs, "HBHEQIE11DigiCollection");     
+    e.put(std::move(zs), "HBHEQIE11DigiCollection");     
     hbheQIE11_->done();
   }
 }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
@@ -23,7 +23,7 @@ public:
   virtual ~HcalSimpleAmplitudeZS();
   virtual void produce(edm::Event& e, const edm::EventSetup& c);
 private:
-  std::auto_ptr<HcalZSAlgoEnergy> hbhe_,ho_,hf_,hbheUpgrade_,hfUpgrade_,hfQIE10_,hbheQIE11_;
+  std::unique_ptr<HcalZSAlgoEnergy> hbhe_,ho_,hf_,hbheUpgrade_,hfUpgrade_,hfQIE10_,hbheQIE11_;
   std::string inputLabel_;
   edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HODigiCollection> tok_ho_;

--- a/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
@@ -109,7 +109,7 @@ void EcalTBMCInfoProducer::produce(edm::Event & event, const edm::EventSetup& ev
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(event.streamID());
 
-  auto_ptr<PEcalTBInfo> product(new PEcalTBInfo());
+  unique_ptr<PEcalTBInfo> product(new PEcalTBInfo());
 
   // Fill the run information
 
@@ -158,5 +158,5 @@ void EcalTBMCInfoProducer::produce(edm::Event & event, const edm::EventSetup& ev
 
   // store the object in the framework event
 
-  event.put(product);
+  event.put(std::move(product));
 }

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
@@ -21,7 +21,7 @@ FakeTBEventHeaderProducer::~FakeTBEventHeaderProducer()
 
 void FakeTBEventHeaderProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
-  auto_ptr<EcalTBEventHeader> product(new EcalTBEventHeader());
+  unique_ptr<EcalTBEventHeader> product(new EcalTBEventHeader());
 
   // get the vertex information from the event
 
@@ -48,6 +48,6 @@ void FakeTBEventHeaderProducer::produce(edm::Event & event, const edm::EventSetu
 //   LogDebug("FakeTBHeader") << (*product);
 //   LogDebug("FakeTBHeader") << (*product).eventType();
 //   LogDebug("FakeTBHeader") << (*product).crystalInBeam();
-  event.put(product);
+  event.put(std::move(product));
   
 }

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
@@ -25,7 +25,7 @@ FakeTBHodoscopeRawInfoProducer::~FakeTBHodoscopeRawInfoProducer() {
 
 void FakeTBHodoscopeRawInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
-  auto_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
+  unique_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
 
   // get the vertex information from the event
 
@@ -64,6 +64,6 @@ void FakeTBHodoscopeRawInfoProducer::produce(edm::Event & event, const edm::Even
 
   LogDebug("EcalTBHodo") << (*product);
   
-  event.put(product);
+  event.put(std::move(product));
   
 }

--- a/SimG4CMS/EcalTestBeam/plugins/TBHodoActiveVolumeRawInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/TBHodoActiveVolumeRawInfoProducer.cc
@@ -27,7 +27,7 @@ TBHodoActiveVolumeRawInfoProducer::~TBHodoActiveVolumeRawInfoProducer() {
 
 void TBHodoActiveVolumeRawInfoProducer::produce(edm::Event & event, const edm::EventSetup& eventSetup)
 {
-  auto_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
+  unique_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
 
   // caloHit container
   edm::Handle<edm::PCaloHitContainer> pCaloHit;
@@ -83,5 +83,5 @@ void TBHodoActiveVolumeRawInfoProducer::produce(edm::Event & event, const edm::E
   
   LogDebug("EcalTBHodo") << (*product);
   
-  event.put(product); 
+  event.put(std::move(product));
 }

--- a/SimG4CMS/Forward/src/TotemTestGem.cc
+++ b/SimG4CMS/Forward/src/TotemTestGem.cc
@@ -53,9 +53,9 @@ TotemTestGem::~TotemTestGem() {
 
 void TotemTestGem::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<TotemTestHistoClass> product(new TotemTestHistoClass);
+  std::unique_ptr<TotemTestHistoClass> product(new TotemTestHistoClass);
   fillEvent(*product);
-  e.put(product);
+  e.put(std::move(product));
 }
 
 void TotemTestGem::update(const BeginOfEvent * evt) {

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
@@ -73,9 +73,9 @@ HcalTB02Analysis::~HcalTB02Analysis() {
 
 void HcalTB02Analysis::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<HcalTB02HistoClass> product(new HcalTB02HistoClass);
+  std::unique_ptr<HcalTB02HistoClass> product(new HcalTB02HistoClass);
   fillEvent(*product);
-  e.put(product);
+  e.put(std::move(product));
 }
 
 void HcalTB02Analysis::update(const BeginOfEvent * evt) {

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
@@ -124,9 +124,9 @@ HcalTB04Analysis::~HcalTB04Analysis() {
 
 void HcalTB04Analysis::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<PHcalTB04Info> product(new PHcalTB04Info);
+  std::unique_ptr<PHcalTB04Info> product(new PHcalTB04Info);
   fillEvent(*product);
-  e.put(product);
+  e.put(std::move(product));
 }
 
 void HcalTB04Analysis::init() {

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -110,7 +110,7 @@ private:
   edm::EDGetTokenT<edm::LHCTransportLinkContainer> m_LHCtr;
     
   bool m_nonBeam;
-  std::auto_ptr<PhysicsList> m_physicsList;
+  std::unique_ptr<PhysicsList> m_physicsList;
   PrimaryTransformer * m_primaryTransformer;
   bool m_managerInitialized;
   bool m_runInitialized;
@@ -152,7 +152,7 @@ private:
   std::vector<std::shared_ptr<SimWatcher> > m_watchers;
   std::vector<std::shared_ptr<SimProducer> > m_producers;
     
-  std::auto_ptr<SimTrackManager> m_trackManager;
+  std::unique_ptr<SimTrackManager> m_trackManager;
   sim::FieldBuilder             *m_fieldBuilder;
   sim::ChordFinderSetter        *m_chordFinderSetter;
     

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -176,16 +176,16 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
   try {
     m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
 
-    std::auto_ptr<edm::SimTrackContainer> 
+    std::unique_ptr<edm::SimTrackContainer>
       p1(new edm::SimTrackContainer);
-    std::auto_ptr<edm::SimVertexContainer> 
+    std::unique_ptr<edm::SimVertexContainer>
       p2(new edm::SimVertexContainer);
     G4SimEvent * evt = m_runManagerWorker->simEvent();
     evt->load(*p1);
     evt->load(*p2);   
 
-    e.put(p1);
-    e.put(p2);
+    e.put(std::move(p1));
+    e.put(std::move(p2));
 
     for (std::vector<SensitiveTkDetector*>::iterator it = sTk.begin();
 	 it != sTk.end(); ++it) {
@@ -194,10 +194,10 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
       for (std::vector<std::string>::iterator in = v.begin();
 	   in!= v.end(); ++in) {
 
-	std::auto_ptr<edm::PSimHitContainer>
+	std::unique_ptr<edm::PSimHitContainer>
 	  product(new edm::PSimHitContainer);
 	(*it)->fillHits(*product,*in);
-	e.put(product,*in);
+	e.put(std::move(product),*in);
       }
     }
     for (std::vector<SensitiveCaloDetector*>::iterator it = sCalo.begin();
@@ -208,10 +208,10 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
       for (std::vector<std::string>::iterator in = v.begin();
 	   in!= v.end(); in++) {
 
-	std::auto_ptr<edm::PCaloHitContainer>
+	std::unique_ptr<edm::PCaloHitContainer>
 	  product(new edm::PCaloHitContainer);
 	(*it)->fillHits(*product,*in);
-	e.put(product,*in);
+	e.put(std::move(product),*in);
       }
     }
 

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -165,16 +165,16 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
 
     m_runManager->produce(e, es);
 
-    std::auto_ptr<edm::SimTrackContainer> 
+    std::unique_ptr<edm::SimTrackContainer>
       p1(new edm::SimTrackContainer);
-    std::auto_ptr<edm::SimVertexContainer> 
+    std::unique_ptr<edm::SimVertexContainer>
       p2(new edm::SimVertexContainer);
     G4SimEvent * evt = m_runManager->simEvent();
     evt->load(*p1);
     evt->load(*p2);   
 
-    e.put(p1);
-    e.put(p2);
+    e.put(std::move(p1));
+    e.put(std::move(p2));
 
     for (std::vector<SensitiveTkDetector*>::iterator it = sTk.begin(); 
 	 it != sTk.end(); ++it) {
@@ -183,10 +183,10 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
       for (std::vector<std::string>::iterator in = v.begin(); 
 	   in!= v.end(); ++in) {
 
-	std::auto_ptr<edm::PSimHitContainer> 
+	std::unique_ptr<edm::PSimHitContainer>
 	  product(new edm::PSimHitContainer);
 	(*it)->fillHits(*product,*in);
-	e.put(product,*in);
+	e.put(std::move(product),*in);
       }
     }
     for (std::vector<SensitiveCaloDetector*>::iterator it = sCalo.begin(); 
@@ -197,10 +197,10 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
       for (std::vector<std::string>::iterator in = v.begin(); 
 	   in!= v.end(); in++) {
 
-	std::auto_ptr<edm::PCaloHitContainer> 
+	std::unique_ptr<edm::PCaloHitContainer>
 	  product(new edm::PCaloHitContainer);
 	(*it)->fillHits(*product,*in);
-	e.put(product,*in);
+	e.put(std::move(product),*in);
       }
     }
 

--- a/SimG4Core/CheckSecondary/src/StoreSecondary.cc
+++ b/SimG4Core/CheckSecondary/src/StoreSecondary.cc
@@ -38,13 +38,13 @@ StoreSecondary::~StoreSecondary() {
 
 void StoreSecondary::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<std::vector<math::XYZTLorentzVector> > secMom(new std::vector<math::XYZTLorentzVector>);
+  std::unique_ptr<std::vector<math::XYZTLorentzVector> > secMom(new std::vector<math::XYZTLorentzVector>);
   *secMom = secondaries;
-  e.put(secMom, "SecondaryMomenta");
+  e.put(std::move(secMom), "SecondaryMomenta");
 
-  std::auto_ptr<std::vector<int> > secNumber(new std::vector<int>);
+  std::unique_ptr<std::vector<int> > secNumber(new std::vector<int>);
   *secNumber = nsecs;
-  e.put(secNumber, "SecondaryParticles");
+  e.put(std::move(secNumber), "SecondaryParticles");
 
   LogDebug("CheckSecondary") << "StoreSecondary:: Event " << e.id() << " with "
 			     << nsecs.size() << " hadronic collisions with "

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -99,14 +99,14 @@ void RHStopTracer::update (const EndOfTrack * fTrack) {
 void RHStopTracer::produce(edm::Event& fEvent, const edm::EventSetup&) {
    LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::produce->";
 
-   std::auto_ptr<std::vector<std::string> > names (new std::vector<std::string>); 
-   std::auto_ptr<std::vector<float> > xs (new std::vector<float>);
-   std::auto_ptr<std::vector<float> > ys (new std::vector<float>);
-   std::auto_ptr<std::vector<float> > zs (new std::vector<float>);
-   std::auto_ptr<std::vector<float> > ts (new std::vector<float>);
-   std::auto_ptr<std::vector<int> > ids (new std::vector<int>);
-   std::auto_ptr<std::vector<float> > masses (new std::vector<float>);
-   std::auto_ptr<std::vector<float> > charges (new std::vector<float>);
+   std::unique_ptr<std::vector<std::string> > names(new std::vector<std::string>); 
+   std::unique_ptr<std::vector<float> > xs(new std::vector<float>);
+   std::unique_ptr<std::vector<float> > ys(new std::vector<float>);
+   std::unique_ptr<std::vector<float> > zs(new std::vector<float>);
+   std::unique_ptr<std::vector<float> > ts(new std::vector<float>);
+   std::unique_ptr<std::vector<int> > ids(new std::vector<int>);
+   std::unique_ptr<std::vector<float> > masses(new std::vector<float>);
+   std::unique_ptr<std::vector<float> > charges(new std::vector<float>);
 
    std::vector <StopPoint>::const_iterator stopPoint = mStopPoints.begin ();
    for (;  stopPoint != mStopPoints.end(); ++stopPoint) {
@@ -119,13 +119,13 @@ void RHStopTracer::produce(edm::Event& fEvent, const edm::EventSetup&) {
      masses->push_back (stopPoint->mass);
      charges->push_back (stopPoint->charge);
    }
-   fEvent.put (names, "StoppedParticlesName");
-   fEvent.put (xs, "StoppedParticlesX");
-   fEvent.put (ys, "StoppedParticlesY");
-   fEvent.put (zs, "StoppedParticlesZ");
-   fEvent.put (ts, "StoppedParticlesTime");
-   fEvent.put (ids, "StoppedParticlesPdgId");
-   fEvent.put (masses, "StoppedParticlesMass");
-   fEvent.put (charges, "StoppedParticlesCharge");
+   fEvent.put(std::move(names), "StoppedParticlesName");
+   fEvent.put(std::move(xs), "StoppedParticlesX");
+   fEvent.put(std::move(ys), "StoppedParticlesY");
+   fEvent.put(std::move(zs), "StoppedParticlesZ");
+   fEvent.put(std::move(ts), "StoppedParticlesTime");
+   fEvent.put(std::move(ids), "StoppedParticlesPdgId");
+   fEvent.put(std::move(masses), "StoppedParticlesMass");
+   fEvent.put(std::move(charges), "StoppedParticlesCharge");
    mStopPoints.clear ();
 }

--- a/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.cc
+++ b/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.cc
@@ -44,8 +44,8 @@ BeginOfTrackCounter::BeginOfTrackCounter(const edm::ParameterSet& iPSet) :
 void
 BeginOfTrackCounter::produce(edm::Event& e, const edm::EventSetup&)
 {
-   std::auto_ptr<int> product(new int(m_count));
-   e.put(product,m_label);
+   std::unique_ptr<int> product(new int(m_count));
+   e.put(std::move(product),m_label);
    m_count = 0;
 }
 

--- a/SimG4Core/Watcher/test/IntSimProducer.cc
+++ b/SimG4Core/Watcher/test/IntSimProducer.cc
@@ -23,8 +23,8 @@ class IntSimProducer : public SimProducer {
       IntSimProducer(const edm::ParameterSet&);
 
       void produce(edm::Event& e, const edm::EventSetup&) {
-	 std::auto_ptr<int> newInt(new int(++m_int));
-	 e.put(newInt);
+	 std::unique_ptr<int> newInt(new int(++m_int));
+	 e.put(std::move(newInt));
       }
    private:
       int m_int;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
@@ -264,9 +264,9 @@ namespace edm
   void DataMixingEMDigiWorker::putEM(edm::Event &e, const edm::EventSetup& ES) {
 
     // collection of digis to put in the event
-    std::auto_ptr< EBDigiCollection > EBdigis( new EBDigiCollection );
-    std::auto_ptr< EEDigiCollection > EEdigis( new EEDigiCollection );
-    std::auto_ptr< ESDigiCollection > ESdigis( new ESDigiCollection );
+    std::unique_ptr< EBDigiCollection > EBdigis( new EBDigiCollection );
+    std::unique_ptr< EEDigiCollection > EEdigis( new EEDigiCollection );
+    std::unique_ptr< ESDigiCollection > ESdigis( new ESDigiCollection );
 
 
     // loop over the maps we have, re-making individual hits or digis if necessary.
@@ -578,9 +578,9 @@ namespace edm
     LogInfo("DataMixingEMDigiWorker") << "total # EE Merged digis: " << EEdigis->size() ;
     LogInfo("DataMixingEMDigiWorker") << "total # ES Merged digis: " << ESdigis->size() ;
 
-    e.put( EBdigis, EBDigiCollectionDM_ );
-    e.put( EEdigis, EEDigiCollectionDM_ );
-    e.put( ESdigis, ESDigiCollectionDM_ );
+    e.put(std::move(EBdigis), EBDigiCollectionDM_ );
+    e.put(std::move(EEdigis), EEDigiCollectionDM_ );
+    e.put(std::move(ESdigis), ESDigiCollectionDM_ );
     
     // clear local storage after this event
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
@@ -253,9 +253,9 @@ namespace edm
   void DataMixingEMWorker::putEM(edm::Event &e) {
 
     // collection of rechits to put in the event
-    std::auto_ptr< EBRecHitCollection > EBrechits( new EBRecHitCollection );
-    std::auto_ptr< EERecHitCollection > EErechits( new EERecHitCollection );
-    std::auto_ptr< ESRecHitCollection > ESrechits( new ESRecHitCollection );
+    std::unique_ptr< EBRecHitCollection > EBrechits( new EBRecHitCollection );
+    std::unique_ptr< EERecHitCollection > EErechits( new EERecHitCollection );
+    std::unique_ptr< ESRecHitCollection > ESrechits( new ESRecHitCollection );
 
     // loop over the maps we have, re-making individual hits or digis if necessary.
     DetId formerID = 0;
@@ -376,9 +376,9 @@ namespace edm
     LogInfo("DataMixingEMWorker") << "total # EE Merged rechits: " << EErechits->size() ;
     LogInfo("DataMixingEMWorker") << "total # ES Merged rechits: " << ESrechits->size() ;
 
-    e.put( EBrechits, EBRecHitCollectionDM_ );
-    e.put( EErechits, EERecHitCollectionDM_ );
-    e.put( ESrechits, ESRecHitCollectionDM_ );
+    e.put(std::move(EBrechits), EBRecHitCollectionDM_ );
+    e.put(std::move(EErechits), EERecHitCollectionDM_ );
+    e.put(std::move(ESrechits), ESRecHitCollectionDM_ );
     
     // clear local storage after this event
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
@@ -58,7 +58,7 @@ namespace edm
 
     // Create new track list; Rely on the fact that addSignals gets called first...
 
-    NewTrackList_ = std::auto_ptr<reco::TrackCollection>(new reco::TrackCollection());
+    NewTrackList_ = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection());
 
     // grab tracks, store copy
 
@@ -112,7 +112,7 @@ namespace edm
 
     // put collection
 
-    e.put( NewTrackList_, GeneralTrackCollectionDM_ );
+    e.put(std::move(NewTrackList_), GeneralTrackCollectionDM_);
 
     // clear local storage for this event
     //NewTrackList_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
@@ -66,7 +66,7 @@ namespace edm
 
       // 
 
-      std::auto_ptr<reco::TrackCollection> NewTrackList_;
+      std::unique_ptr<reco::TrackCollection> NewTrackList_;
 
 
     };

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -159,8 +159,8 @@ namespace {
   }
   
   template <class DIGIS>
-  std::auto_ptr<DIGIS> buildHcalDigis (const HcalDigiMap& map, const HcalDbService& conditions) {
-    std::auto_ptr<DIGIS> digis( new DIGIS );
+  std::unique_ptr<DIGIS> buildHcalDigis (const HcalDigiMap& map, const HcalDbService& conditions) {
+    std::unique_ptr<DIGIS> digis( new DIGIS );
     // loop over the maps we have, re-making individual hits or digis if necessary.
     DetId formerID = 0;
     CaloSamples resultSample;
@@ -393,12 +393,12 @@ namespace edm
     ES.get<HcalDbRecord>().get(conditions);
 
     // collection of digis to put in the event
-    std::auto_ptr< HBHEDigiCollection > HBHEdigis = buildHcalDigis<HBHEDigiCollection> (HBHEDigiStorage_, *conditions);
-    std::auto_ptr< HODigiCollection > HOdigis = buildHcalDigis<HODigiCollection> (HODigiStorage_, *conditions);
-    std::auto_ptr< HFDigiCollection > HFdigis = buildHcalDigis<HFDigiCollection> (HFDigiStorage_, *conditions);
-    std::auto_ptr< QIE10DigiCollection > QIE10digis = buildHcalDigis<QIE10DigiCollection> (QIE10DigiStorage_, *conditions);
-    std::auto_ptr< QIE11DigiCollection > QIE11digis = buildHcalDigis<QIE11DigiCollection> (QIE11DigiStorage_, *conditions);
-    std::auto_ptr< ZDCDigiCollection > ZDCdigis( new ZDCDigiCollection );
+    std::unique_ptr< HBHEDigiCollection > HBHEdigis = buildHcalDigis<HBHEDigiCollection> (HBHEDigiStorage_, *conditions);
+    std::unique_ptr< HODigiCollection > HOdigis = buildHcalDigis<HODigiCollection> (HODigiStorage_, *conditions);
+    std::unique_ptr< HFDigiCollection > HFdigis = buildHcalDigis<HFDigiCollection> (HFDigiStorage_, *conditions);
+    std::unique_ptr< QIE10DigiCollection > QIE10digis = buildHcalDigis<QIE10DigiCollection> (QIE10DigiStorage_, *conditions);
+    std::unique_ptr< QIE11DigiCollection > QIE11digis = buildHcalDigis<QIE11DigiCollection> (QIE11DigiStorage_, *conditions);
+    std::unique_ptr< ZDCDigiCollection > ZDCdigis( new ZDCDigiCollection );
 
     // loop over the maps we have, re-making individual hits or digis if necessary.
     DetId formerID = 0;
@@ -514,18 +514,18 @@ namespace edm
 
 
     // make empty collections for now:
-    std::auto_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
-    std::auto_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
+    std::unique_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
+    std::unique_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
 
 
-    e.put( HBHEdigis, HBHEDigiCollectionDM_ );
-    e.put( HOdigis, HODigiCollectionDM_ );
-    e.put( HFdigis, HFDigiCollectionDM_ );
-    e.put( QIE10digis, QIE10DigiCollectionDM_ );
-    e.put( QIE11digis, QIE11DigiCollectionDM_ );
-    e.put( ZDCdigis, ZDCDigiCollectionDM_ );
-    e.put( hbheupgradeResult, "HBHEUpgradeDigiCollection" );
-    e.put( hfupgradeResult, "HFUpgradeDigiCollection" );
+    e.put(std::move(HBHEdigis), HBHEDigiCollectionDM_);
+    e.put(std::move(HOdigis), HODigiCollectionDM_);
+    e.put(std::move(HFdigis), HFDigiCollectionDM_);
+    e.put(std::move(QIE10digis), QIE10DigiCollectionDM_);
+    e.put(std::move(QIE11digis), QIE11DigiCollectionDM_);
+    e.put(std::move(ZDCdigis), ZDCDigiCollectionDM_);
+    e.put(std::move(hbheupgradeResult), "HBHEUpgradeDigiCollection");
+    e.put(std::move(hfupgradeResult), "HFUpgradeDigiCollection");
 
     // clear local storage after this event
     HBHEDigiStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
@@ -315,10 +315,10 @@ namespace edm
   void DataMixingHcalWorker::putHcal(edm::Event &e) {
 
     // collection of rechits to put in the event
-    std::auto_ptr< HBHERecHitCollection > HBHErechits( new HBHERecHitCollection );
-    std::auto_ptr< HORecHitCollection > HOrechits( new HORecHitCollection );
-    std::auto_ptr< HFRecHitCollection > HFrechits( new HFRecHitCollection );
-    std::auto_ptr< ZDCRecHitCollection > ZDCrechits( new ZDCRecHitCollection );
+    std::unique_ptr< HBHERecHitCollection > HBHErechits( new HBHERecHitCollection );
+    std::unique_ptr< HORecHitCollection > HOrechits( new HORecHitCollection );
+    std::unique_ptr< HFRecHitCollection > HFrechits( new HFRecHitCollection );
+    std::unique_ptr< ZDCRecHitCollection > ZDCrechits( new ZDCRecHitCollection );
 
     // loop over the maps we have, re-making individual hits or rechits if necessary.
     DetId formerID = 0;
@@ -486,10 +486,10 @@ namespace edm
     LogInfo("DataMixingHcalWorker") << "total # HF Merged rechits: " << HFrechits->size() ;
     LogInfo("DataMixingHcalWorker") << "total # ZDC Merged rechits: " << ZDCrechits->size() ;
 
-    e.put( HBHErechits, HBHERecHitCollectionDM_ );
-    e.put( HOrechits, HORecHitCollectionDM_ );
-    e.put( HFrechits, HFRecHitCollectionDM_ );
-    e.put( ZDCrechits, ZDCRecHitCollectionDM_ );
+    e.put(std::move(HBHErechits), HBHERecHitCollectionDM_ );
+    e.put(std::move(HOrechits), HORecHitCollectionDM_ );
+    e.put(std::move(HFrechits), HFRecHitCollectionDM_ );
+    e.put(std::move(ZDCrechits), ZDCRecHitCollectionDM_ );
 
     // clear local storage after this event
     HBHERecHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
@@ -378,11 +378,11 @@ namespace edm
   void DataMixingMuonWorker::putMuon(edm::Event &e) {
 
     // collections of digis to put in the event
-    std::auto_ptr< DTDigiCollection > DTDigiMerge( new DTDigiCollection );
-    std::auto_ptr< RPCDigiCollection > RPCDigiMerge( new RPCDigiCollection );
-    std::auto_ptr< CSCStripDigiCollection > CSCStripDigiMerge( new CSCStripDigiCollection );
-    std::auto_ptr< CSCWireDigiCollection > CSCWireDigiMerge( new CSCWireDigiCollection );
-    std::auto_ptr< CSCComparatorDigiCollection > CSCComparatorDigiMerge( new CSCComparatorDigiCollection );
+    std::unique_ptr< DTDigiCollection > DTDigiMerge( new DTDigiCollection );
+    std::unique_ptr< RPCDigiCollection > RPCDigiMerge( new RPCDigiCollection );
+    std::unique_ptr< CSCStripDigiCollection > CSCStripDigiMerge( new CSCStripDigiCollection );
+    std::unique_ptr< CSCWireDigiCollection > CSCWireDigiMerge( new CSCWireDigiCollection );
+    std::unique_ptr< CSCComparatorDigiCollection > CSCComparatorDigiMerge( new CSCComparatorDigiCollection );
 
     // Loop over DT digis, copying them from our own local storage
 
@@ -537,11 +537,11 @@ namespace edm
     //    LogDebug("DataMixingMuonWorker") << "total # CSCStrip Merged Digis: " << CSCStripDigiMerge->size() ;
     //    LogDebug("DataMixingMuonWorker") << "total # CSCWire Merged Digis: " << CSCWireDigiMerge->size() ;
 
-    e.put( DTDigiMerge );
-    e.put( RPCDigiMerge );
-    e.put( CSCStripDigiMerge, CSCStripDigiCollectionDM_ );
-    e.put( CSCWireDigiMerge, CSCWireDigiCollectionDM_ );
-    e.put( CSCComparatorDigiMerge, CSCComparatorDigiCollectionDM_ );
+    e.put(std::move(DTDigiMerge));
+    e.put(std::move(RPCDigiMerge));
+    e.put(std::move(CSCStripDigiMerge), CSCStripDigiCollectionDM_ );
+    e.put(std::move(CSCWireDigiMerge), CSCWireDigiCollectionDM_ );
+    e.put(std::move(CSCComparatorDigiMerge), CSCComparatorDigiCollectionDM_ );
 
     // clear local storage for this event
     delete OurDTDigis_;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
@@ -88,8 +88,8 @@ namespace edm
   }
  
   void DataMixingPileupCopy::putPileupInfo(edm::Event &e) {
-    std::auto_ptr<std::vector<PileupSummaryInfo> > PSIVector(new std::vector<PileupSummaryInfo>);
-    std::auto_ptr<int> bsInt(new int);
+    std::unique_ptr<std::vector<PileupSummaryInfo> > PSIVector(new std::vector<PileupSummaryInfo>);
+    std::unique_ptr<int> bsInt(new int);
 
     std::vector<PileupSummaryInfo>::const_iterator PSiter;
     for(PSiter = PileupSummaryStorage_.begin(); PSiter != PileupSummaryStorage_.end(); PSiter++){
@@ -99,11 +99,11 @@ namespace edm
     *bsInt=bsStorage_;
 
     if(FoundPlayback_ ) {
-      std::auto_ptr<CrossingFramePlaybackInfoNew> CFPlaybackInfo(new CrossingFramePlaybackInfoNew(CrossingFramePlaybackStorage_));
-      e.put(CFPlaybackInfo);
+      std::unique_ptr<CrossingFramePlaybackInfoNew> CFPlaybackInfo(new CrossingFramePlaybackInfoNew(CrossingFramePlaybackStorage_));
+      e.put(std::move(CFPlaybackInfo));
     }
-    e.put(PSIVector);
-    e.put(bsInt,"bunchSpacing");
+    e.put(std::move(PSIVector));
+    e.put(std::move(bsInt),"bunchSpacing");
 
     // clear local storage after this event
     PileupSummaryStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
@@ -568,7 +568,7 @@ bool DataMixingSiPixelMCDigiWorker::PixelEfficiencies::matches(const DetId& deti
   
 	  // Initilize the index converter
 	  //PixelIndices indexConverter(numColumns,numRows);
-	  std::auto_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
+	  std::unique_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
 
 
 	  int chipIndex = 0;
@@ -644,11 +644,11 @@ bool DataMixingSiPixelMCDigiWorker::PixelEfficiencies::matches(const DetId& deti
 
     // make new digi collection
     
-    std::auto_ptr< edm::DetSetVector<PixelDigi> > MyPixelDigis(new edm::DetSetVector<PixelDigi>(vPixelDigi) );
+    std::unique_ptr< edm::DetSetVector<PixelDigi> > MyPixelDigis(new edm::DetSetVector<PixelDigi>(vPixelDigi) );
 
     // put collection
 
-    e.put( MyPixelDigis, PixelDigiCollectionDM_ );
+    e.put(std::move(MyPixelDigis), PixelDigiCollectionDM_ );
 
     // clear local storage for this event
     SiHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
@@ -226,11 +226,11 @@ namespace edm
 
     // make new digi collection
     
-    std::auto_ptr< edm::DetSetVector<PixelDigi> > MyPixelDigis(new edm::DetSetVector<PixelDigi>(vPixelDigi) );
+    std::unique_ptr< edm::DetSetVector<PixelDigi> > MyPixelDigis(new edm::DetSetVector<PixelDigi>(vPixelDigi) );
 
     // put collection
 
-    e.put( MyPixelDigis, PixelDigiCollectionDM_ );
+    e.put(std::move(MyPixelDigis), PixelDigiCollectionDM_ );
 
     // clear local storage for this event
     SiHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
@@ -423,11 +423,11 @@ namespace edm
 
     // make new digi collection
     
-    std::auto_ptr< edm::DetSetVector<SiStripDigi> > MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi) );
+    std::unique_ptr< edm::DetSetVector<SiStripDigi> > MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi) );
 
     // put collection
 
-    e.put( MySiStripDigis, SiStripDigiCollectionDM_ );
+    e.put(std::move(MySiStripDigis), SiStripDigiCollectionDM_ );
 
     // clear local storage for this event
     SiHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
@@ -198,10 +198,10 @@ namespace edm
     //
 
     // make new raw digi collection
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > MySiStripRawDigis(new edm::DetSetVector<SiStripRawDigi>(vSiStripRawDigi) );
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > MySiStripRawDigis(new edm::DetSetVector<SiStripRawDigi>(vSiStripRawDigi) );
 
     // put collection
-    e.put( MySiStripRawDigis, SiStripDigiCollectionDM_ );
+    e.put(std::move(MySiStripRawDigis), SiStripDigiCollectionDM_ );
 
     // clear local storage for this event
     SiHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
@@ -204,11 +204,11 @@ namespace edm
 
     // make new digi collection
     
-    std::auto_ptr< edm::DetSetVector<SiStripDigi> > MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi) );
+    std::unique_ptr< edm::DetSetVector<SiStripDigi> > MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi) );
 
     // put collection
 
-    e.put( MySiStripDigis, SiStripDigiCollectionDM_ );
+    e.put(std::move(MySiStripDigis), SiStripDigiCollectionDM_ );
 
     // clear local storage for this event
     SiHitStorage_.clear();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.cc
@@ -104,8 +104,8 @@ namespace edm
 
     // Create new track/vertex lists, getting references, too, so that we can cross-link everything
 
-    NewTrackList_ = std::auto_ptr<std::vector<TrackingParticle>>(new std::vector<TrackingParticle>());
-    //NewVertexList_ = std::auto_ptr<std::vector<TrackingVertex>>(new std::vector<TrackingVertex>());
+    NewTrackList_ = std::unique_ptr<std::vector<TrackingParticle>>(new std::vector<TrackingParticle>());
+    //NewVertexList_ = std::unique_ptr<std::vector<TrackingVertex>>(new std::vector<TrackingVertex>());
     TempVertexList_ = std::vector<TrackingVertex>();
 
     TrackListRef_  =const_cast<edm::Event&>( e ).getRefBeforePut< std::vector<TrackingParticle> >(TrackingParticleCollectionDM_); 
@@ -374,23 +374,23 @@ namespace edm
 
     // collection of Vertices to put in the event
 
-    NewVertexList_ = std::auto_ptr<std::vector<TrackingVertex>>(new std::vector<TrackingVertex>(TempVertexList_));    
+    NewVertexList_ = std::unique_ptr<std::vector<TrackingVertex>>(new std::vector<TrackingVertex>(TempVertexList_));
 
     // put the collection of digis in the event   
     LogInfo("DataMixingTrackingParticleWorker") << "total # Merged Tracks: " << NewTrackList_->size() ;
 
     // put collections
 
-    e.put( NewTrackList_, TrackingParticleCollectionDM_ );
-    e.put( NewVertexList_, TrackingParticleCollectionDM_ );
+    e.put(std::move(NewTrackList_), TrackingParticleCollectionDM_ );
+    e.put(std::move(NewVertexList_), TrackingParticleCollectionDM_ );
 
-    e.put( std::move(NewStripLinkList_), StripLinkCollectionDM_ );
-    e.put( std::move(NewPixelLinkList_), PixelLinkCollectionDM_ );
+    e.put(std::move(NewStripLinkList_), StripLinkCollectionDM_ );
+    e.put(std::move(NewPixelLinkList_), PixelLinkCollectionDM_ );
 
-    e.put( std::move(NewCSCStripLinkList_), CSCStripLinkCollectionDM_ );
-    e.put( std::move(NewCSCWireLinkList_), CSCWireLinkCollectionDM_ );
-    e.put( std::move(NewRPCLinkList_), RPCLinkCollectionDM_ );
-    e.put( std::move(NewDTLinkList_), DTLinkCollectionDM_ );
+    e.put(std::move(NewCSCStripLinkList_), CSCStripLinkCollectionDM_ );
+    e.put(std::move(NewCSCWireLinkList_), CSCWireLinkCollectionDM_ );
+    e.put(std::move(NewRPCLinkList_), RPCLinkCollectionDM_ );
+    e.put(std::move(NewDTLinkList_), DTLinkCollectionDM_ );
 
 
     // clear local storage for this event

--- a/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingTrackingParticleWorker.h
@@ -102,8 +102,8 @@ namespace edm
 
       // 
 
-      std::auto_ptr<std::vector<TrackingParticle>> NewTrackList_;
-      std::auto_ptr<std::vector<TrackingVertex>> NewVertexList_;
+      std::unique_ptr<std::vector<TrackingParticle>> NewTrackList_;
+      std::unique_ptr<std::vector<TrackingVertex>> NewVertexList_;
       std::vector<TrackingVertex> TempVertexList_;
 
       std::unique_ptr<edm::DetSetVector<StripDigiSimLink> >          NewStripLinkList_;

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -21,7 +21,7 @@ namespace edm {
 
     static DigiAccumulatorMixModFactory const* get();
 
-    std::auto_ptr<DigiAccumulatorMixMod>
+    std::unique_ptr<DigiAccumulatorMixMod>
       makeDigiAccumulator(ParameterSet const&, stream::EDProducerBase&, ConsumesCollector&) const;
 
   private:

--- a/SimGeneral/MixingModule/plugins/CFWriter.cc
+++ b/SimGeneral/MixingModule/plugins/CFWriter.cc
@@ -158,8 +158,8 @@ void CFWriter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     if (gotTracks){ 
        PCrossingFrame<SimTrack> * PCFbis = new PCrossingFrame<SimTrack>(*cf_simtrack.product());
-       std::auto_ptr<PCrossingFrame<SimTrack> > pOutTrack(PCFbis);    
-       iEvent.put(pOutTrack,"g4SimHits");
+       std::unique_ptr<PCrossingFrame<SimTrack> > pOutTrack(PCFbis);
+       iEvent.put(std::move(pOutTrack),"g4SimHits");
     }
     else{
        LogInfo("MixingModule") << " Please, check if the object <SimTrack> has been mixed by the MixingModule!";  
@@ -174,8 +174,8 @@ void CFWriter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     if (gotSimVertex){ 
        PCrossingFrame<SimVertex> * PCFvtx = new PCrossingFrame<SimVertex>(*cf_simvtx.product());
-       std::auto_ptr<PCrossingFrame<SimVertex> > pOutVertex(PCFvtx);    
-       iEvent.put(pOutVertex,"g4SimHits");
+       std::unique_ptr<PCrossingFrame<SimVertex> > pOutVertex(PCFvtx);
+       iEvent.put(std::move(pOutVertex),"g4SimHits");
     }
     else{
        LogInfo("MixingModule") << " Please, check if the object <SimVertex> has been mixed by the MixingModule!";
@@ -192,8 +192,8 @@ void CFWriter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       
       if (gotPCaloHit){   
         PCrossingFrame<PCaloHit> * PCFPhCaloHit = new PCrossingFrame<PCaloHit>(*cf_calohit.product()); 
-        std::auto_ptr<PCrossingFrame<PCaloHit> > pOutHCalo(PCFPhCaloHit);
-	iEvent.put(pOutHCalo,labCaloHit[ii]); 
+        std::unique_ptr<PCrossingFrame<PCaloHit> > pOutHCalo(PCFPhCaloHit);
+	iEvent.put(std::move(pOutHCalo),labCaloHit[ii]);
       }
       else{
         LogInfo("MixingModule") << " Please, check if the object <PCaloHit> " << labCaloHit[ii] << " has been mixed by the MixingModule!";
@@ -211,8 +211,8 @@ void CFWriter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       
       if (gotPSimHit){ 
         PCrossingFrame<PSimHit> * PCFSimHit = new PCrossingFrame<PSimHit>(*cf_simhit.product());
-        std::auto_ptr<PCrossingFrame<PSimHit> > pOutSimHit(PCFSimHit);
-	iEvent.put(pOutSimHit,labSimHit[ii]); 
+        std::unique_ptr<PCrossingFrame<PSimHit> > pOutSimHit(PCFSimHit);
+	iEvent.put(std::move(pOutSimHit),labSimHit[ii]);
       }
       else{	      
         LogInfo("MixingModule") << " Please, check if the object <PSimHit> " << labSimHit[ii] << " has been mixed by the MixingModule!";
@@ -229,8 +229,8 @@ void CFWriter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     gotHepMCProduct=iEvent.getByLabel("mix","generatorSmeared",cf_hepmc);
     if (gotHepMCProduct){ 
        PCrossingFrame<edm::HepMCProduct> * PCFHepMC = new PCrossingFrame<edm::HepMCProduct>(*cf_hepmc.product());
-       std::auto_ptr<PCrossingFrame<edm::HepMCProduct> > pOuthepmcpr(PCFHepMC);
-       iEvent.put(pOuthepmcpr,"generator");
+       std::unique_ptr<PCrossingFrame<edm::HepMCProduct> > pOuthepmcpr(PCFHepMC);
+       iEvent.put(std::move(pOuthepmcpr),"generator");
     }
     else{
        LogInfo("MixingModule") << " Please, check if the object <HepMCProduct> has been mixed by the MixingModule!";

--- a/SimGeneral/MixingModule/plugins/HiMixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/HiMixingModule.cc
@@ -107,7 +107,7 @@ namespace edm{
 	 }
 	 
          if(get){
-	    std::auto_ptr<CrossingFrame<T> > crFrame(new CrossingFrame<T>() );	    
+	    std::unique_ptr<CrossingFrame<T> > crFrame(new CrossingFrame<T>() );
 	    crFrame->addSignals(handles[0].product(),e.id());
 	    for(size_t itag = 1; itag < tags_.size(); ++itag){
                std::vector<T>* product = const_cast<std::vector<T>*>(handles[itag].product());
@@ -117,7 +117,7 @@ namespace edm{
                }
 	       crFrame->addPileups(*product);	 
 	    }
-	    e.put(crFrame,label_);
+	    e.put(std::move(crFrame),label_);
 	 }
       }
    };
@@ -139,13 +139,13 @@ void HiMixingWorker<HepMCProduct>::addSignals(edm::Event &e){
    }
    
    if(get){
-      std::auto_ptr<CrossingFrame<HepMCProduct> > crFrame(new CrossingFrame<HepMCProduct>() );
+      std::unique_ptr<CrossingFrame<HepMCProduct> > crFrame(new CrossingFrame<HepMCProduct>() );
       crFrame->addSignals(handles[0].product(),e.id());
       for(size_t itag = 1; itag < tags_.size(); ++itag){
          HepMCProduct* product = const_cast<HepMCProduct*>(handles[itag].product());
          crFrame->addPileups(*product);	 
       }
-      e.put(crFrame,label_);
+      e.put(std::move(crFrame),label_);
    }
 }
 
@@ -260,8 +260,8 @@ HiMixingModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       (workers_[i])->addSignals(iEvent);
    }
 
-   std::auto_ptr< PileupMixingContent > PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent());
-   iEvent.put(PileupMixing_);
+   std::unique_ptr< PileupMixingContent > PileupMixing_ = std::unique_ptr< PileupMixingContent >(new PileupMixingContent());
+   iEvent.put(std::move(PileupMixing_));
 
 }
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -219,7 +219,7 @@ namespace edm {
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
-        std::auto_ptr<DigiAccumulatorMixMod> accumulator = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
+        std::unique_ptr<DigiAccumulatorMixMod> accumulator = std::unique_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {
           digiAccumulators_.push_back(accumulator.release());
@@ -461,7 +461,7 @@ namespace edm {
 
     // Keep track of pileup accounting...
 
-    std::auto_ptr<PileupMixingContent> PileupMixing_;
+    std::unique_ptr<PileupMixingContent> PileupMixing_;
 
     std::vector<int> numInteractionList;
     std::vector<int> bunchCrossingList;
@@ -489,13 +489,13 @@ namespace edm {
     }
 
 
-    PileupMixing_ = std::auto_ptr<PileupMixingContent>(new PileupMixingContent(bunchCrossingList,
+    PileupMixing_ = std::unique_ptr<PileupMixingContent>(new PileupMixingContent(bunchCrossingList,
                                                                                numInteractionList,
                                                                                TrueInteractionList,
 									       eventInfoList,
 									       bunchSpace_));
 
-    e.put(PileupMixing_);
+    e.put(std::move(PileupMixing_));
 
     // we have to do the ToF transformation for PSimHits once all pileup has been added
     for (unsigned int ii=0;ii<workers_.size();++ii) {
@@ -507,8 +507,8 @@ namespace edm {
   void MixingModule::put(edm::Event &e, const edm::EventSetup& setup) {
 
     if (playbackInfo_) {
-      std::auto_ptr<CrossingFramePlaybackInfoNew> pOut(playbackInfo_);
-      e.put(pOut);
+      std::unique_ptr<CrossingFramePlaybackInfoNew> pOut(playbackInfo_);
+      e.put(std::move(pOut));
     }
   }
 

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -155,8 +155,8 @@ namespace edm
       void setTof();
 
       virtual void put(edm::Event &e) {	
-        std::auto_ptr<CrossingFrame<T> > pOut(crFrame_);
-	e.put(pOut,label_);
+        std::unique_ptr<CrossingFrame<T> > pOut(crFrame_);
+	e.put(std::move(pOut),label_);
 	LogDebug("MixingModule") <<" CF was put for type "<<typeid(T).name()<<" with "<<label_;
       }
 

--- a/SimGeneral/MixingModule/plugins/TestMix.cc
+++ b/SimGeneral/MixingModule/plugins/TestMix.cc
@@ -125,7 +125,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   else {
     std::cout<<"\n\n=================== Starting SimHit access, subdet "<<subdet<<"  ==================="<<std::endl;
 
-    std::auto_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit.product(),std::pair<int,int>(-1,1)));
+    std::unique_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit.product(),std::pair<int,int>(-1,1)));
     std::cout<<*(col.get())<<std::endl;
     MixCollection<PSimHit>::iterator cfi;
     for (cfi=col->begin(); cfi!=col->end();cfi++) {
@@ -142,7 +142,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (!got) std::cout<<" Could not read CaloHits with label "<<subdetcalo<<"!!!!"<<std::endl;
   else {
     std::cout<<"\n\n=================== Starting CaloHit access, subdet "<<subdetcalo<<"  ==================="<<std::endl;
-    std::auto_ptr<MixCollection<PCaloHit> > colcalo(new MixCollection<PCaloHit>(cf_calo.product(), std::pair<int,int>(-1,1)));
+    std::unique_ptr<MixCollection<PCaloHit> > colcalo(new MixCollection<PCaloHit>(cf_calo.product(), std::pair<int,int>(-1,1)));
     std::cout<<*(colcalo.get())<<std::endl;
     MixCollection<PCaloHit>::iterator cficalo;
     count=0;
@@ -158,7 +158,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     std::cout<<"\n=================== Starting SimTrack access ==================="<<std::endl;
     //   edm::Handle<CrossingFrame<SimTrack> > cf_simtrack;
     //   iEvent.getByLabel("mix",cf_simtrack);
-    std::auto_ptr<MixCollection<SimTrack> > col2(new MixCollection<SimTrack>(cf_simtrack.product()));
+    std::unique_ptr<MixCollection<SimTrack> > col2(new MixCollection<SimTrack>(cf_simtrack.product()));
     MixCollection<SimTrack>::iterator cfi2;
     int count2=0;
     std::cout <<" \nWe got "<<col2->sizeSignal()<<" signal tracks and "<<col2->sizePileup()<<" pileup tracks, total: "<<col2->size()<<std::endl;
@@ -174,7 +174,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (!got) std::cout<<" Could not read Simvertices !!!!"<<std::endl;
   else {
     std::cout<<"\n=================== Starting SimVertex access ==================="<<std::endl;
-    std::auto_ptr<MixCollection<SimVertex> > col3(new MixCollection<SimVertex>(cf_simvtx.product()));
+    std::unique_ptr<MixCollection<SimVertex> > col3(new MixCollection<SimVertex>(cf_simvtx.product()));
     MixCollection<SimVertex>::iterator cfi3;
     int count3=0;
     std::cout <<" \nWe got "<<col3->sizeSignal()<<" signal vertices and "<<col3->sizePileup()<<" pileup vertices, total: "<<col3->size()<<std::endl;
@@ -188,8 +188,8 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   //test MixCollection constructor with several subdetector names
   bool got1,got2=false;
-  std::auto_ptr<MixCollection<PSimHit> > all_trackhits;
-  std::auto_ptr<MixCollection<PSimHit> > all_trackhits2;
+  std::unique_ptr<MixCollection<PSimHit> > all_trackhits;
+  std::unique_ptr<MixCollection<PSimHit> > all_trackhits2;
   std::cout<<"\n=================== Starting test for coll of several ROU-s ==================="<<std::endl;
   //  edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
   std::vector<const CrossingFrame<PSimHit> *> cfvec;
@@ -203,7 +203,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     if (got2) {
       cfvec.push_back(cf_simhit.product());
       std::cout <<" \nSecond container "<<track_containers_[1]<<" Nr signals "<<cf_simhit->getNrSignals() << ", Nr pileups "<<cf_simhit->getNrPileups() <<std::endl;
-      all_trackhits= std::auto_ptr<MixCollection<PSimHit> >(new MixCollection<PSimHit>(cfvec));
+      all_trackhits= std::unique_ptr<MixCollection<PSimHit> >(new MixCollection<PSimHit>(cfvec));
 
       std::cout <<" \nFor all containers we got "<<all_trackhits->sizeSignal()<<" signal hits and "<<all_trackhits->sizePileup()<<" pileup hits, total: "<<all_trackhits->size()<<std::endl;
     
@@ -227,7 +227,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     got2 = iEvent.getByToken(TrackerToken4_,cf_simhit);
     if (got2) {
       cfvec2.push_back(cf_simhit.product());
-      all_trackhits2= std::auto_ptr<MixCollection<PSimHit> > (new MixCollection<PSimHit>(cfvec2));
+      all_trackhits2= std::unique_ptr<MixCollection<PSimHit> > (new MixCollection<PSimHit>(cfvec2));
       std::cout <<" \nSame containers, different order: we got "<<all_trackhits2->sizeSignal()<<" signal hits and "<<all_trackhits2->sizePileup()<<" pileup hits, total: "<<all_trackhits2->size()<<std::endl;
       for (it2=all_trackhits2->begin(); it2!= all_trackhits2->end();it2++) {
 	std::cout<<" Hit "<<ii2<<" of all hits has tof "<<it2->timeOfFlight()<<" trackid "<<it2->trackId() <<" bunchcr "<<it2.bunch()<<" trigger "<<it2.getTrigger()<<", bcr from Id: "<<it2->eventId().bunchCrossing() <<" evtnr in id "<<it2->eventId().event()<<std::endl;
@@ -244,7 +244,7 @@ TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   got = iEvent.getByToken(HepMCToken_,cf_hepmc);
   if (!got) std::cout<<" Could not read HepMCProducts!!!!"<<std::endl;
   else {
-    std::auto_ptr<MixCollection<edm::HepMCProduct> > colhepmc(new MixCollection<edm::HepMCProduct>(cf_hepmc.product()));
+    std::unique_ptr<MixCollection<edm::HepMCProduct> > colhepmc(new MixCollection<edm::HepMCProduct>(cf_hepmc.product()));
     MixCollection<edm::HepMCProduct>::iterator cfihepmc;
     int counthepmc=0;
     std::cout <<" \nWe got "<<colhepmc->sizeSignal()<<" signal hepmc products and "<<colhepmc->sizePileup()<<" pileup hepmcs, total: "<<colhepmc->size()<<std::endl;

--- a/SimGeneral/MixingModule/plugins/TestMixedSource.cc
+++ b/SimGeneral/MixingModule/plugins/TestMixedSource.cc
@@ -127,7 +127,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (gotTracks) {
     outputFile<<"\n=================== Starting SimTrack access ==================="<<std::endl;
 
-    std::auto_ptr<MixCollection<SimTrack> > col1(new MixCollection<SimTrack>(cf_simtrack.product()));
+    std::unique_ptr<MixCollection<SimTrack> > col1(new MixCollection<SimTrack>(cf_simtrack.product()));
     MixCollection<SimTrack>::iterator cfi1;
     int count1=0;
     std::cout <<" \nWe got "<<col1->sizeSignal()<<" signal tracks and "<<col1->sizePileup()<<" pileup tracks, total: "<<col1->size()<<std::endl;
@@ -158,7 +158,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (!gotSimVertex) outputFile<<" Could not read Simvertices !!!!"<<std::endl;
   else {
     outputFile<<"\n=================== Starting SimVertex access ==================="<<std::endl;
-    std::auto_ptr<MixCollection<SimVertex> > col2(new MixCollection<SimVertex>(cf_simvtx.product()));
+    std::unique_ptr<MixCollection<SimVertex> > col2(new MixCollection<SimVertex>(cf_simvtx.product()));
     MixCollection<SimVertex>::iterator cfi2;
     int count2=0;
     outputFile <<" \nWe got "<<col2->sizeSignal()<<" signal vertices and "<<col2->sizePileup()<<" pileup vertices, total: "<<col2->size()<<std::endl;
@@ -182,7 +182,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (!gotHepMCP) std::cout<<" Could not read HepMCProducts!!!!"<<std::endl;
   else {
     outputFile<<"\n=================== Starting HepMCProduct access ==================="<<std::endl;
-    std::auto_ptr<MixCollection<edm::HepMCProduct> > colhepmc(new MixCollection<edm::HepMCProduct>(cf_hepmc.product()));
+    std::unique_ptr<MixCollection<edm::HepMCProduct> > colhepmc(new MixCollection<edm::HepMCProduct>(cf_hepmc.product()));
     MixCollection<edm::HepMCProduct>::iterator cfihepmc;
     
     int count3=0;
@@ -208,7 +208,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   if (!gotPCaloHit) outputFile<<" Could not read CaloHits with label "<<subdetcalo<<"!!!!"<<std::endl;
   else {
     outputFile<<"\n\n=================== Starting CaloHit access, subdet "<<subdetcalo<<"  ==================="<<std::endl;
-    std::auto_ptr<MixCollection<PCaloHit> > colcalo(new MixCollection<PCaloHit>(cf_calo.product()));
+    std::unique_ptr<MixCollection<PCaloHit> > colcalo(new MixCollection<PCaloHit>(cf_calo.product()));
     //outputFile<<*(colcalo.get())<<std::endl;
     MixCollection<PCaloHit>::iterator cficalo;
     int count4=0;
@@ -234,7 +234,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   else {
     outputFile<<"\n\n=================== Starting SimHit access, subdet "<<subdet<<"  ==================="<<std::endl;
 
-    std::auto_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit.product()));
+    std::unique_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit.product()));
     //outputFile<<*(col.get())<<std::endl;
     MixCollection<PSimHit>::iterator cfi;
     int count5=0;
@@ -268,7 +268,7 @@ TestMixedSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   else {
     outputFile<<"\n\n=================== Starting SimHit access, subdet "<<subdet1<<"  ==================="<<std::endl;
 
-    std::auto_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit1.product()));
+    std::unique_ptr<MixCollection<PSimHit> > col(new MixCollection<PSimHit>(cf_simhit1.product()));
     //outputFile<<*(col.get())<<std::endl;
     MixCollection<PSimHit>::iterator cfi;
     int count5=0;

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -29,14 +29,14 @@ namespace edm {
     return &singleInstance_;
   }
 
-  std::auto_ptr<DigiAccumulatorMixMod>
+  std::unique_ptr<DigiAccumulatorMixMod>
   DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, stream::EDProducerBase& mixMod, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
-    std::auto_ptr<DigiAccumulatorMixMod> wm;
-    wm = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, mixMod, iC));
+    std::unique_ptr<DigiAccumulatorMixMod> wm;
+    wm = std::unique_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, mixMod, iC));
     
-    if(wm.get()==0) {
+    if(wm.get()==nullptr) {
 	throw edm::Exception(errors::Configuration,"NoSourceModule")
 	  << "DigiAccumulator Factory:\n"
 	  << "Cannot find dig type from ParameterSet: "

--- a/SimGeneral/PileupInformation/interface/PileupInformation.h
+++ b/SimGeneral/PileupInformation/interface/PileupInformation.h
@@ -68,8 +68,8 @@ private:
 
     std::string MessageCategory_;
     //std::string simHitLabel_;
-    //std::auto_ptr<MixCollection<SimTrack> >   simTracks_;
-    //std::auto_ptr<MixCollection<SimVertex> >  simVertexes_;
+    //std::unique_ptr<MixCollection<SimTrack> >   simTracks_;
+    //std::unique_ptr<MixCollection<SimVertex> >  simVertexes_;
 
 
 

--- a/SimGeneral/PileupInformation/plugins/PileupInformation.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupInformation.cc
@@ -64,7 +64,7 @@ PileupInformation::PileupInformation(const edm::ParameterSet & config)
 void PileupInformation::produce(edm::Event &event, const edm::EventSetup & setup)
 {
 
-  std::auto_ptr<std::vector<PileupSummaryInfo> > PSIVector(new std::vector<PileupSummaryInfo>);
+  std::unique_ptr<std::vector<PileupSummaryInfo> > PSIVector(new std::vector<PileupSummaryInfo>);
 
   if ( isPreMixed_ ) {
     edm::Handle< std::vector<PileupSummaryInfo> > psiInput;  
@@ -82,11 +82,11 @@ void PileupInformation::produce(edm::Event &event, const edm::EventSetup & setup
     event.getByToken(bunchSpacingToken_,bsInput);
     int bunchSpacing=*(bsInput.product());
 
-    event.put(PSIVector);
+    event.put(std::move(PSIVector));
     
     //add bunch spacing to the event as a seperate integer for use by downstream modules
-    std::auto_ptr<int> bunchSpacingP(new int(bunchSpacing));
-    event.put(bunchSpacingP,"bunchSpacing");
+    std::unique_ptr<int> bunchSpacingP(new int(bunchSpacing));
+    event.put(std::move(bunchSpacingP),"bunchSpacing");
     
     return;
   }
@@ -408,11 +408,11 @@ void PileupInformation::produce(edm::Event &event, const edm::EventSetup & setup
 
   // put our vector of PileupSummaryInfo objects into the event.
 
-  event.put(PSIVector);
+  event.put(std::move(PSIVector));
 
   //add bunch spacing to the event as a seperate integer for use by downstream modules
-  std::auto_ptr<int> bunchSpacingP(new int(bunchSpacing));
-  event.put(bunchSpacingP,"bunchSpacing");
+  std::unique_ptr<int> bunchSpacingP(new int(bunchSpacing));
+  event.put(std::move(bunchSpacingP),"bunchSpacing");
 
 }
 

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -141,10 +141,10 @@ namespace cms
   void
   PileupVertexAccumulator::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-    std::auto_ptr<PileupVertexContent> PUVtxC(new PileupVertexContent(pT_Hats_, z_posns_));
+    std::unique_ptr<PileupVertexContent> PUVtxC(new PileupVertexContent(pT_Hats_, z_posns_));
 
     // write output to event
-    iEvent.put(PUVtxC);
+    iEvent.put(std::move(PUVtxC));
   }
 
 

--- a/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
@@ -30,7 +30,7 @@ SimHitTPAssociationProducer::~SimHitTPAssociationProducer() {
 }
 		
 void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& es) const {
-  std::auto_ptr<SimHitTPAssociationList> simHitTPList(new SimHitTPAssociationList);
+  std::unique_ptr<SimHitTPAssociationList> simHitTPList(new SimHitTPAssociationList);
  
   // TrackingParticle
   edm::Handle<TrackingParticleCollection>  TPCollectionH;
@@ -63,7 +63,7 @@ void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, con
   } 
   
   std::sort(simHitTPList->begin(),simHitTPList->end(),simHitTPAssociationListGreater);
-  iEvent.put(simHitTPList);
+  iEvent.put(std::move(simHitTPList));
 
 }
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -380,8 +380,8 @@ void TrackingTruthAccumulator::finalizeEvent( edm::Event& event, edm::EventSetup
 		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << unmergedOutput_.pTrackingParticles->size() << " TrackingParticles and " << unmergedOutput_.pTrackingVertices->size()
 				<< " TrackingVertexs to the event.";
 
-		event.put( unmergedOutput_.pTrackingParticles );
-		event.put( unmergedOutput_.pTrackingVertices );
+		event.put(std::move(unmergedOutput_.pTrackingParticles));
+		event.put(std::move(unmergedOutput_.pTrackingVertices));
 	}
 
 	if( createMergedCollection_ )
@@ -389,15 +389,15 @@ void TrackingTruthAccumulator::finalizeEvent( edm::Event& event, edm::EventSetup
 		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << mergedOutput_.pTrackingParticles->size() << " merged TrackingParticles and " << mergedOutput_.pTrackingVertices->size()
 				<< " merged TrackingVertexs to the event.";
 
-		event.put( mergedOutput_.pTrackingParticles, "MergedTrackTruth" );
-		event.put( mergedOutput_.pTrackingVertices, "MergedTrackTruth" );
+		event.put(std::move(mergedOutput_.pTrackingParticles), "MergedTrackTruth" );
+		event.put(std::move(mergedOutput_.pTrackingVertices), "MergedTrackTruth" );
 	}
 
 	if( createInitialVertexCollection_ )
 	{
 		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << pInitialVertices_->size() << " initial TrackingVertexs to the event.";
 
-		event.put( pInitialVertices_, "InitialVertices" );
+		event.put(std::move(pInitialVertices_), "InitialVertices" );
 	}
 }
 
@@ -444,8 +444,8 @@ template<class T> void TrackingTruthAccumulator::accumulateEvent( const T& event
 	DecayChain decayChain( *hSimTracks, *hSimVertices );
 
 	// I only want to create these collections if they're actually required
-	std::auto_ptr< ::OutputCollectionWrapper> pUnmergedCollectionWrapper;
-	std::auto_ptr< ::OutputCollectionWrapper> pMergedCollectionWrapper;
+	std::unique_ptr< ::OutputCollectionWrapper> pUnmergedCollectionWrapper;
+	std::unique_ptr< ::OutputCollectionWrapper> pMergedCollectionWrapper;
 	if( createUnmergedCollection_ ) pUnmergedCollectionWrapper.reset( new ::OutputCollectionWrapper( decayChain, unmergedOutput_ ) );
 	if( createMergedCollection_ ) pMergedCollectionWrapper.reset( new ::OutputCollectionWrapper( decayChain, mergedOutput_ ) );
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -3,7 +3,7 @@
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/Common/interface/TrackingParticleSelector.h"
-#include <memory> // required for std::auto_ptr
+#include <memory> // required for std::unique_ptr
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 
@@ -139,15 +139,15 @@ public:
 	// functions, so I might as well package them up in a struct.
 	struct OutputCollections
 	{
-		std::auto_ptr<TrackingParticleCollection> pTrackingParticles;
-		std::auto_ptr<TrackingVertexCollection> pTrackingVertices;
+		std::unique_ptr<TrackingParticleCollection> pTrackingParticles;
+		std::unique_ptr<TrackingVertexCollection> pTrackingVertices;
 		TrackingParticleRefProd refTrackingParticles;
 		TrackingVertexRefProd refTrackingVertexes;
 	};
 private:
 	OutputCollections unmergedOutput_;
 	OutputCollections mergedOutput_;
-	std::auto_ptr<TrackingVertexCollection> pInitialVertices_;
+	std::unique_ptr<TrackingVertexCollection> pInitialVertices_;
 };
 
 #endif // end of "#ifndef TrackingAnalysis_TrackingTruthAccumulator_h"

--- a/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
@@ -32,7 +32,7 @@ void MuonPSimHitSelector::select(PSimHitCollection & selection, edm::Event const
     }
 
     // Create a mix collection from the different psimhit collections
-    std::auto_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
     // Get CSC Bad Chambers (ME4/2)
     edm::ESHandle<CSCBadChambers> cscBadChambers;

--- a/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
@@ -48,7 +48,7 @@ void PSimHitSelector::select(PSimHitCollection & selection, edm::Event const & e
     if (cfPSimHitProductPointers.empty()) return;
 
     // Create a mix collection from the different psimhit collections
-    std::auto_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
     // Select all psimhits
     for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit)

--- a/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
@@ -30,7 +30,7 @@ void PixelPSimHitSelector::select(PSimHitCollection & selection, edm::Event cons
     }
 
     // Create a mix collection from the different psimhit collections
-    std::auto_ptr<MixCollection<PSimHit> > pSimHits( new MixCollection<PSimHit>(cfPSimHitProductPointers) );
+    std::unique_ptr<MixCollection<PSimHit> > pSimHits( new MixCollection<PSimHit>(cfPSimHitProductPointers) );
 
     // Accessing dead pixel modules from DB:
     edm::ESHandle<SiPixelQuality> siPixelBadModule;

--- a/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
@@ -33,7 +33,7 @@ void TrackerPSimHitSelector::select(PSimHitCollection & selection, edm::Event co
     }
 
     // Create a mix collection from the different psimhit collections
-    std::auto_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
     // Setup the cabling mapping
     std::map<uint32_t, std::vector<int> > theDetIdList;

--- a/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
+++ b/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
@@ -82,16 +82,16 @@ void CSCDigiProducer::produce(edm::Event& ev, const edm::EventSetup& eventSetup)
   edm::Handle<CrossingFrame<PSimHit> > cf;
   ev.getByToken(cf_token, cf);
 
-  std::auto_ptr<MixCollection<PSimHit> > 
+  std::unique_ptr<MixCollection<PSimHit> >
     hits( new MixCollection<PSimHit>(cf.product()) );
 
   // Create empty output
 
-  std::auto_ptr<CSCWireDigiCollection> pWireDigis(new CSCWireDigiCollection());
-  std::auto_ptr<CSCStripDigiCollection> pStripDigis(new CSCStripDigiCollection());
-  std::auto_ptr<CSCComparatorDigiCollection> pComparatorDigis(new CSCComparatorDigiCollection());
-  std::auto_ptr<DigiSimLinks> pWireDigiSimLinks(new DigiSimLinks() );
-  std::auto_ptr<DigiSimLinks> pStripDigiSimLinks(new DigiSimLinks() );
+  std::unique_ptr<CSCWireDigiCollection> pWireDigis(new CSCWireDigiCollection());
+  std::unique_ptr<CSCStripDigiCollection> pStripDigis(new CSCStripDigiCollection());
+  std::unique_ptr<CSCComparatorDigiCollection> pComparatorDigis(new CSCComparatorDigiCollection());
+  std::unique_ptr<DigiSimLinks> pWireDigiSimLinks(new DigiSimLinks() );
+  std::unique_ptr<DigiSimLinks> pStripDigiSimLinks(new DigiSimLinks() );
 
   //@@ DOES NOTHING IF NO HITS.  Remove this for when there's real neutrons
   if(hits->size() > 0) 
@@ -124,10 +124,10 @@ void CSCDigiProducer::produce(edm::Event& ev, const edm::EventSetup& eventSetup)
 
 
   // store them in the event
-  ev.put(pWireDigis, "MuonCSCWireDigi");
-  ev.put(pStripDigis, "MuonCSCStripDigi");
-  ev.put(pComparatorDigis, "MuonCSCComparatorDigi");
-  ev.put(pWireDigiSimLinks, "MuonCSCWireDigiSimLinks");
-  ev.put(pStripDigiSimLinks, "MuonCSCStripDigiSimLinks");
+  ev.put(std::move(pWireDigis), "MuonCSCWireDigi");
+  ev.put(std::move(pStripDigis), "MuonCSCStripDigi");
+  ev.put(std::move(pComparatorDigis), "MuonCSCComparatorDigi");
+  ev.put(std::move(pWireDigiSimLinks), "MuonCSCWireDigiSimLinks");
+  ev.put(std::move(pStripDigiSimLinks), "MuonCSCStripDigiSimLinks");
 }
 

--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -142,13 +142,13 @@ void DTDigitizer::produce(Event& iEvent, const EventSetup& iSetup){
   Handle<CrossingFrame<PSimHit> > xFrame;
   iEvent.getByToken(cf_token, xFrame);
   
-  auto_ptr<MixCollection<PSimHit> > 
+  unique_ptr<MixCollection<PSimHit> >
     simHits( new MixCollection<PSimHit>(xFrame.product()) );
 
    // create the pointer to the Digi container
-  auto_ptr<DTDigiCollection> output(new DTDigiCollection());
+  unique_ptr<DTDigiCollection> output(new DTDigiCollection());
    // pointer to the DigiSimLink container
-  auto_ptr<DTDigiSimLinkCollection> outputLinks(new DTDigiSimLinkCollection());
+  unique_ptr<DTDigiSimLinkCollection> outputLinks(new DTDigiSimLinkCollection());
   
   // Muon Geometry
   ESHandle<DTGeometry> muonGeom;
@@ -220,9 +220,9 @@ void DTDigitizer::produce(Event& iEvent, const EventSetup& iSetup){
 
   //************ 8 ***************  
   // Load the Digi Container in the Event
-  //iEvent.put(output,"MuonDTDigis");
-  iEvent.put(output);
-  iEvent.put(outputLinks);
+  //iEvent.put(std::move(output),"MuonDTDigis");
+  iEvent.put(std::move(output));
+  iEvent.put(std::move(outputLinks));
 
 }
 

--- a/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
@@ -72,12 +72,12 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   edm::Handle<CrossingFrame<PSimHit> > cf;
   e.getByToken(cf_token, cf);
 
-  std::auto_ptr<MixCollection<PSimHit> > hits(new MixCollection<PSimHit>(cf.product()));
+  std::unique_ptr<MixCollection<PSimHit> > hits(new MixCollection<PSimHit>(cf.product()));
 
   // Create empty output
-  std::auto_ptr<GEMDigiCollection> digis(new GEMDigiCollection());
-  std::auto_ptr<StripDigiSimLinks> stripDigiSimLinks(new StripDigiSimLinks() );
-  std::auto_ptr<GEMDigiSimLinks> gemDigiSimLinks(new GEMDigiSimLinks() );
+  std::unique_ptr<GEMDigiCollection> digis(new GEMDigiCollection());
+  std::unique_ptr<StripDigiSimLinks> stripDigiSimLinks(new StripDigiSimLinks() );
+  std::unique_ptr<GEMDigiSimLinks> gemDigiSimLinks(new GEMDigiSimLinks() );
 
   // arrange the hits by eta partition
   std::map<uint32_t, edm::PSimHitContainer> hitMap;
@@ -104,8 +104,8 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   }
 
   // store them in the event
-  e.put(digis);
-  e.put(stripDigiSimLinks,"GEM");
-  e.put(gemDigiSimLinks,"GEM");
+  e.put(std::move(digis));
+  e.put(std::move(stripDigiSimLinks),"GEM");
+  e.put(std::move(gemDigiSimLinks),"GEM");
 }
 

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
@@ -42,13 +42,13 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
   e.getByToken(digi_token_, hdigis);
 
   // Create empty output
-  std::auto_ptr<GEMPadDigiCollection> pPads(new GEMPadDigiCollection());
+  std::unique_ptr<GEMPadDigiCollection> pPads(new GEMPadDigiCollection());
 
   // build the pads
   buildPads(*(hdigis.product()), *pPads);
 
   // store them in the event
-  e.put(pPads);
+  e.put(std::move(pPads));
 }
 
 

--- a/SimMuon/GEMDigitizer/src/ME0DigiPreRecoProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0DigiPreRecoProducer.cc
@@ -68,10 +68,10 @@ void ME0DigiPreRecoProducer::produce(edm::Event& e, const edm::EventSetup& event
   edm::Handle<CrossingFrame<PSimHit> > cf;
   e.getByToken(cf_token, cf);
 
-  std::auto_ptr<MixCollection<PSimHit> > hits( new MixCollection<PSimHit>(cf.product()) );
+  std::unique_ptr<MixCollection<PSimHit> > hits( new MixCollection<PSimHit>(cf.product()) );
 
   // Create empty output
-  std::auto_ptr<ME0DigiPreRecoCollection> digis(new ME0DigiPreRecoCollection());
+  std::unique_ptr<ME0DigiPreRecoCollection> digis(new ME0DigiPreRecoCollection());
 
   // arrange the hits by eta partition
   std::map<uint32_t, edm::PSimHitContainer> hitMap;
@@ -96,6 +96,6 @@ void ME0DigiPreRecoProducer::produce(edm::Event& e, const edm::EventSetup& event
   }
   
   // store them in the event
-  e.put(digis);
+  e.put(std::move(digis));
 }
 

--- a/SimMuon/GEMDigitizer/test/GEMFakeEvent.cc
+++ b/SimMuon/GEMDigitizer/test/GEMFakeEvent.cc
@@ -51,7 +51,7 @@ GEMFakeEvent::produce(edm::Event & ev, const edm::EventSetup& es)
   edm::ESHandle<GEMGeometry> gemGeom;
   es.get<MuonGeometryRecord>().get(gemGeom);
 
-  auto_ptr<GEMDigiCollection> pDigis(new GEMDigiCollection());
+  unique_ptr<GEMDigiCollection> pDigis(new GEMDigiCollection());
 
   for (int e = -1; e <= 1; e += 2)
   {
@@ -78,7 +78,7 @@ GEMFakeEvent::produce(edm::Event & ev, const edm::EventSetup& es)
   }
 
   cout<<"Will put GEMDigiCollection into event..."<<endl;
-  ev.put(pDigis);
+  ev.put(std::move(pDigis));
   cout<<"Done with event!"<<endl;
 }
 

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
@@ -86,8 +86,8 @@ void MuonAssociatorEDProducer::produce(edm::Event& event, const edm::EventSetup&
    if (trackAvailable) LogTrace("MuonAssociatorEDProducer") <<"\t... size = "<<trackCollection->size();
    else LogTrace("MuonAssociatorEDProducer") <<"\t... NOT FOUND.";
 
-   std::auto_ptr<reco::RecoToSimCollection> rts;
-   std::auto_ptr<reco::SimToRecoCollection> str;
+   std::unique_ptr<reco::RecoToSimCollection> rts;
+   std::unique_ptr<reco::SimToRecoCollection> str;
 
    if (ignoreMissingTrackCollection && !trackAvailable) {
      //the track collection is not in the event and we're being told to ignore this.
@@ -116,7 +116,7 @@ void MuonAssociatorEDProducer::produce(edm::Event& event, const edm::EventSetup&
      rts.reset(new reco::RecoToSimCollection(recSimColl));
      str.reset(new reco::SimToRecoCollection(simRecColl));
      
-     event.put(rts);
-     event.put(str);
+     event.put(std::move(rts));
+     event.put(std::move(str));
    }
 }

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -43,9 +43,9 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   iSetup.get<TrackerTopologyRcd>().get(httopo);
   const TrackerTopology& ttopo = *httopo;
 
-  std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
-  std::auto_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
-  std::auto_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
+  std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
+  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
 
   reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
   reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
@@ -331,7 +331,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     } // if (isGoodResult)
   }  // loop on reco::MuonCollection
   
-  iEvent.put(selectedTracks);
-  iEvent.put(selectedTrackExtras);
-  iEvent.put(selectedTrackHits);
+  iEvent.put(std::move(selectedTracks));
+  iEvent.put(std::move(selectedTrackExtras));
+  iEvent.put(std::move(selectedTrackHits));
 }

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -81,9 +81,9 @@ SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     using namespace edm;
     using namespace std;
 
-    std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
-    std::auto_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
-    std::auto_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
+    std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
+    std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
+    std::unique_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
     
     reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
     reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
@@ -162,9 +162,9 @@ SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         selectedTrackExtras->push_back(theTrackExtra);
 
     }
-    iEvent.put(selectedTracks);
-    iEvent.put(selectedTrackExtras);
-    iEvent.put(selectedTrackHits);
+    iEvent.put(std::move(selectedTracks));
+    iEvent.put(std::move(selectedTrackExtras));
+    iEvent.put(std::move(selectedTrackHits));
     
 }
 

--- a/SimMuon/MCTruth/src/DTHitAssociator.cc
+++ b/SimMuon/MCTruth/src/DTHitAssociator.cc
@@ -97,7 +97,7 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent, const edm::EventSetup&
     edm::Handle<CrossingFrame<PSimHit> > xFrame;
     LogTrace("DTHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<DTsimhitsXFTag;
     iEvent.getByLabel(DTsimhitsXFTag,xFrame);
-    auto_ptr<MixCollection<PSimHit> > 
+    unique_ptr<MixCollection<PSimHit> > 
       DTsimhits( new MixCollection<PSimHit>(xFrame.product()) );
     LogTrace("DTHitAssociator") <<"... size = "<<DTsimhits->size();
     MixCollection<PSimHit>::MixItr isimhit;

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -43,7 +43,7 @@ void GEMHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eve
 	    LogTrace("GEMHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<GEMsimhitsXFTag;
 	    e.getByLabel(GEMsimhitsXFTag, cf);
 	    
-	    std::auto_ptr<MixCollection<PSimHit> > 
+	    std::unique_ptr<MixCollection<PSimHit> > 
 	      GEMsimhits( new MixCollection<PSimHit>(cf.product()) );
 	    LogTrace("GEMHitAssociator") <<"... size = "<<GEMsimhits->size();
 

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -82,7 +82,7 @@ namespace muonAssociatorByHitsDiagnostics {
          
     if (crossingframe) {
       event.getByLabel(simtracksXFTag,cf_simtracks);
-      auto_ptr<MixCollection<SimTrack> > SimTk( new MixCollection<SimTrack>(cf_simtracks.product()) );
+      unique_ptr<MixCollection<SimTrack> > SimTk( new MixCollection<SimTrack>(cf_simtracks.product()) );
       edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"CrossingFrame<SimTrack> collection with InputTag = "<<simtracksXFTag
                                               <<" has size = "<<SimTk->size();
       int k = 0;
@@ -95,7 +95,7 @@ namespace muonAssociatorByHitsDiagnostics {
           <<"\n * "<<*ITER <<endl;
       }
       event.getByLabel(simtracksXFTag,cf_simvertices);
-      auto_ptr<MixCollection<SimVertex> > SimVtx( new MixCollection<SimVertex>(cf_simvertices.product()) );
+      unique_ptr<MixCollection<SimVertex> > SimVtx( new MixCollection<SimVertex>(cf_simvertices.product()) );
       edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"CrossingFrame<SimVertex> collection with InputTag = "<<simtracksXFTag
                                               <<" has size = "<<SimVtx->size();
       int kv = 0;

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -70,7 +70,7 @@ void MuonTruth::initEvent(const edm::Event& event, const edm::EventSetup& setup)
     LogTrace("MuonTruth") <<"getting CrossingFrame<PSimHit> collection - "<<CSCsimHitsXFTag;
     event.getByLabel(CSCsimHitsXFTag, cf);
     
-    std::auto_ptr<MixCollection<PSimHit> > 
+    std::unique_ptr<MixCollection<PSimHit> > 
       CSCsimhits( new MixCollection<PSimHit>(cf.product()) );
     LogTrace("MuonTruth") <<"... size = "<<CSCsimhits->size();
 

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -43,7 +43,7 @@ void RPCHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eve
     LogTrace("RPCHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<RPCsimhitsXFTag;
     e.getByLabel(RPCsimhitsXFTag, cf);
     
-    std::auto_ptr<MixCollection<PSimHit> > 
+    std::unique_ptr<MixCollection<PSimHit> > 
       RPCsimhits( new MixCollection<PSimHit>(cf.product()) );
     LogTrace("RPCHitAssociator") <<"... size = "<<RPCsimhits->size();
 

--- a/SimMuon/Neutron/plugins/EmptyHepMCProducer.cc
+++ b/SimMuon/Neutron/plugins/EmptyHepMCProducer.cc
@@ -53,9 +53,9 @@ void
 EmptyHepMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   // create an empty output collection
-  std::auto_ptr<edm::HepMCProduct> theOutput(new edm::HepMCProduct());
+  std::unique_ptr<edm::HepMCProduct> theOutput(new edm::HepMCProduct());
   //theOutput->addHepMCData(theEvent);
-  iEvent.put(theOutput);
+  iEvent.put(std::move(theOutput));
 }
 
 void EmptyHepMCProducer::beginJob() {}

--- a/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
+++ b/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
@@ -113,118 +113,118 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
   // ----- MuonCSCHits -----
   //
-  std::auto_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
   if (neutron_label_csc.length()>0)
   {
     edm::Handle<edm::PSimHitContainer> MuonCSCHits;
     iEvent.getByLabel(neutron_label_csc,MuonCSCHits);
     for (hit = MuonCSCHits->begin();  hit != MuonCSCHits->end();  ++hit) simCSC->push_back(*hit);
   }
-  iEvent.put(simCSC, "MuonCSCHits");
+  iEvent.put(std::move(simCSC), "MuonCSCHits");
 
   // ----- MuonDTHits -----
   //
-  std::auto_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
   if (neutron_label_dt.length()>0)
   {
     edm::Handle<edm::PSimHitContainer> MuonDTHits;
     iEvent.getByLabel(neutron_label_dt,MuonDTHits);
     for (hit = MuonDTHits->begin();  hit != MuonDTHits->end();  ++hit) simDT->push_back(*hit);
   }
-  iEvent.put(simDT, "MuonDTHits");
+  iEvent.put(std::move(simDT), "MuonDTHits");
 
   // ----- MuonRPCHits -----
   //
-  std::auto_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
+  std::unique_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
   if (neutron_label_rpc.length()>0)
   {
     edm::Handle<edm::PSimHitContainer> MuonRPCHits;
     iEvent.getByLabel(neutron_label_rpc,MuonRPCHits);
     for (hit = MuonRPCHits->begin();  hit != MuonRPCHits->end();  ++hit) simRPC->push_back(*hit);
   }
-  iEvent.put(simRPC, "MuonRPCHits");
+  iEvent.put(std::move(simRPC), "MuonRPCHits");
 
   // Further, produce a bunch of empty collections
 
   // ----- calorimetry -----
   //
-  std::auto_ptr<edm::PCaloHitContainer> calout1(new edm::PCaloHitContainer);
-  iEvent.put(calout1, "EcalHitsEB");
-  std::auto_ptr<edm::PCaloHitContainer> calout2(new edm::PCaloHitContainer);
-  iEvent.put(calout2, "EcalHitsEE");
-  std::auto_ptr<edm::PCaloHitContainer> calout3(new edm::PCaloHitContainer);
-  iEvent.put(calout3, "EcalHitsES");
-  std::auto_ptr<edm::PCaloHitContainer> calout4(new edm::PCaloHitContainer);
-  iEvent.put(calout4, "HcalHits");
-  std::auto_ptr<edm::PCaloHitContainer> calout5(new edm::PCaloHitContainer);
-  iEvent.put(calout5, "CaloHitsTk");
-  std::auto_ptr<edm::PCaloHitContainer> calout6(new edm::PCaloHitContainer);
-  iEvent.put(calout6, "CastorPL");
-  std::auto_ptr<edm::PCaloHitContainer> calout7(new edm::PCaloHitContainer);
-  iEvent.put(calout7, "CastorFI");
-  std::auto_ptr<edm::PCaloHitContainer> calout8(new edm::PCaloHitContainer);
-  iEvent.put(calout8, "CastorBU");
-  std::auto_ptr<edm::PCaloHitContainer> calout9(new edm::PCaloHitContainer);
-  iEvent.put(calout9, "CastorTU");
-  std::auto_ptr<edm::PCaloHitContainer> calout10(new edm::PCaloHitContainer);
-  iEvent.put(calout10, "EcalTBH4BeamHits");
-  std::auto_ptr<edm::PCaloHitContainer> calout11(new edm::PCaloHitContainer);
-  iEvent.put(calout11, "HcalTB06BeamHits");
-  std::auto_ptr<edm::PCaloHitContainer> calout12(new edm::PCaloHitContainer);
-  iEvent.put(calout12, "ZDCHITS");
-  //std::auto_ptr<edm::PCaloHitContainer> calout13(new edm::PCaloHitContainer);
-  //iEvent.put(calout13, "ChamberHits");
-  //std::auto_ptr<edm::PCaloHitContainer> calout14(new edm::PCaloHitContainer);
-  //iEvent.put(calout14, "FibreHits");
-  //std::auto_ptr<edm::PCaloHitContainer> calout15(new edm::PCaloHitContainer);
-  //iEvent.put(calout15, "WedgeHits");
+  std::unique_ptr<edm::PCaloHitContainer> calout1(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout1), "EcalHitsEB");
+  std::unique_ptr<edm::PCaloHitContainer> calout2(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout2), "EcalHitsEE");
+  std::unique_ptr<edm::PCaloHitContainer> calout3(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout3), "EcalHitsES");
+  std::unique_ptr<edm::PCaloHitContainer> calout4(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout4), "HcalHits");
+  std::unique_ptr<edm::PCaloHitContainer> calout5(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout5), "CaloHitsTk");
+  std::unique_ptr<edm::PCaloHitContainer> calout6(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout6), "CastorPL");
+  std::unique_ptr<edm::PCaloHitContainer> calout7(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout7), "CastorFI");
+  std::unique_ptr<edm::PCaloHitContainer> calout8(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout8), "CastorBU");
+  std::unique_ptr<edm::PCaloHitContainer> calout9(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout9), "CastorTU");
+  std::unique_ptr<edm::PCaloHitContainer> calout10(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout10), "EcalTBH4BeamHits");
+  std::unique_ptr<edm::PCaloHitContainer> calout11(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout11), "HcalTB06BeamHits");
+  std::unique_ptr<edm::PCaloHitContainer> calout12(new edm::PCaloHitContainer);
+  iEvent.put(std::move(calout12), "ZDCHITS");
+  //std::unique_ptr<edm::PCaloHitContainer> calout13(new edm::PCaloHitContainer);
+  //iEvent.put(std::move(calout13), "ChamberHits");
+  //std::unique_ptr<edm::PCaloHitContainer> calout14(new edm::PCaloHitContainer);
+  //iEvent.put(std::move(calout14), "FibreHits");
+  //std::unique_ptr<edm::PCaloHitContainer> calout15(new edm::PCaloHitContainer);
+  //iEvent.put(std::move(calout15), "WedgeHits");
 
   // ----- Tracker -----
   //
-  std::auto_ptr<edm::PSimHitContainer> trout1(new edm::PSimHitContainer);
-  iEvent.put(trout1, "TrackerHitsPixelBarrelLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout2(new edm::PSimHitContainer);
-  iEvent.put(trout2, "TrackerHitsPixelBarrelHighTof");
-  std::auto_ptr<edm::PSimHitContainer> trout3(new edm::PSimHitContainer);
-  iEvent.put(trout3, "TrackerHitsTIBLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout4(new edm::PSimHitContainer);
-  iEvent.put(trout4, "TrackerHitsTIBHighTof");
-  std::auto_ptr<edm::PSimHitContainer> trout5(new edm::PSimHitContainer);
-  iEvent.put(trout5, "TrackerHitsTIDLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout6(new edm::PSimHitContainer);
-  iEvent.put(trout6, "TrackerHitsTIDHighTof");
-  std::auto_ptr<edm::PSimHitContainer> trout7(new edm::PSimHitContainer);
-  iEvent.put(trout7, "TrackerHitsPixelEndcapLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout8(new edm::PSimHitContainer);
-  iEvent.put(trout8, "TrackerHitsPixelEndcapHighTof");
-  std::auto_ptr<edm::PSimHitContainer> trout9(new edm::PSimHitContainer);
-  iEvent.put(trout9, "TrackerHitsTOBLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout10(new edm::PSimHitContainer);
-  iEvent.put(trout10, "TrackerHitsTOBHighTof");
-  std::auto_ptr<edm::PSimHitContainer> trout11(new edm::PSimHitContainer);
-  iEvent.put(trout11, "TrackerHitsTECLowTof");
-  std::auto_ptr<edm::PSimHitContainer> trout12(new edm::PSimHitContainer);
-  iEvent.put(trout12, "TrackerHitsTECHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout1(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout1), "TrackerHitsPixelBarrelLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout2(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout2), "TrackerHitsPixelBarrelHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout3(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout3), "TrackerHitsTIBLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout4(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout4), "TrackerHitsTIBHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout5(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout5), "TrackerHitsTIDLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout6(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout6), "TrackerHitsTIDHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout7(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout7), "TrackerHitsPixelEndcapLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout8(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout8), "TrackerHitsPixelEndcapHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout9(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout9), "TrackerHitsTOBLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout10(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout10), "TrackerHitsTOBHighTof");
+  std::unique_ptr<edm::PSimHitContainer> trout11(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout11), "TrackerHitsTECLowTof");
+  std::unique_ptr<edm::PSimHitContainer> trout12(new edm::PSimHitContainer);
+  iEvent.put(std::move(trout12), "TrackerHitsTECHighTof");
 
   // ----- Forward stuff -----
   //
-  std::auto_ptr<edm::PSimHitContainer> fwout1(new edm::PSimHitContainer);
-  iEvent.put(fwout1, "TotemHitsT1");
-  std::auto_ptr<edm::PSimHitContainer> fwout2(new edm::PSimHitContainer);
-  iEvent.put(fwout2, "TotemHitsT2Gem");
-  std::auto_ptr<edm::PSimHitContainer> fwout3(new edm::PSimHitContainer);
-  iEvent.put(fwout3, "TotemHitsRP");
-  std::auto_ptr<edm::PSimHitContainer> fwout4(new edm::PSimHitContainer);
-  iEvent.put(fwout4, "FP420SI");
-  std::auto_ptr<edm::PSimHitContainer> fwout5(new edm::PSimHitContainer);
-  iEvent.put(fwout5, "BSCHits");
+  std::unique_ptr<edm::PSimHitContainer> fwout1(new edm::PSimHitContainer);
+  iEvent.put(std::move(fwout1), "TotemHitsT1");
+  std::unique_ptr<edm::PSimHitContainer> fwout2(new edm::PSimHitContainer);
+  iEvent.put(std::move(fwout2), "TotemHitsT2Gem");
+  std::unique_ptr<edm::PSimHitContainer> fwout3(new edm::PSimHitContainer);
+  iEvent.put(std::move(fwout3), "TotemHitsRP");
+  std::unique_ptr<edm::PSimHitContainer> fwout4(new edm::PSimHitContainer);
+  iEvent.put(std::move(fwout4), "FP420SI");
+  std::unique_ptr<edm::PSimHitContainer> fwout5(new edm::PSimHitContainer);
+  iEvent.put(std::move(fwout5), "BSCHits");
 
   // ----- SimTracks & SimVertices -----
   //
-  std::auto_ptr<edm::SimTrackContainer> simTr(new edm::SimTrackContainer);
-  iEvent.put(simTr);
-  std::auto_ptr<edm::SimVertexContainer> simVe(new edm::SimVertexContainer);
-  iEvent.put(simVe);
+  std::unique_ptr<edm::SimTrackContainer> simTr(new edm::SimTrackContainer);
+  iEvent.put(std::move(simTr));
+  std::unique_ptr<edm::SimVertexContainer> simVe(new edm::SimVertexContainer);
+  iEvent.put(std::move(simVe));
 
 
 }

--- a/SimMuon/Neutron/src/EDMNeutronWriter.cc
+++ b/SimMuon/Neutron/src/EDMNeutronWriter.cc
@@ -2,8 +2,8 @@
 #include "FWCore/Framework/interface/Event.h"
 
 EDMNeutronWriter::EDMNeutronWriter()
-: theEvent(0),
-  theHits(0)
+: theEvent(nullptr),
+  theHits(nullptr)
 {
 }
 
@@ -20,12 +20,12 @@ void EDMNeutronWriter::writeCluster(int detType, const edm::PSimHitContainer & s
 void EDMNeutronWriter::beginEvent(edm::Event & e, const edm::EventSetup & es)
 {
   theEvent = &e;
-  theHits = std::auto_ptr<edm::PSimHitContainer>(new edm::PSimHitContainer());
+  theHits = std::unique_ptr<edm::PSimHitContainer>(new edm::PSimHitContainer());
 }
 
 void EDMNeutronWriter::endEvent()
 {
-  theEvent->put(theHits);
+  theEvent->put(std::move(theHits));
 }
 
 

--- a/SimMuon/Neutron/src/EDMNeutronWriter.h
+++ b/SimMuon/Neutron/src/EDMNeutronWriter.h
@@ -19,7 +19,7 @@ public:
 
 private:
   edm::Event * theEvent;
-  std::auto_ptr<edm::PSimHitContainer> theHits;
+  std::unique_ptr<edm::PSimHitContainer> theHits;
 };
 
 #endif

--- a/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
@@ -100,18 +100,18 @@ void RPCDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
   //New code, based on tokens
   e.getByToken(crossingFrameToken, cf);
 
-  std::auto_ptr<MixCollection<PSimHit> > 
+  std::unique_ptr<MixCollection<PSimHit> >
     hits( new MixCollection<PSimHit>(cf.product()) );
 
   // Create empty output
-  std::auto_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
-  std::auto_ptr<RPCDigitizerSimLinks> RPCDigitSimLink(new RPCDigitizerSimLinks() );
+  std::unique_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
+  std::unique_ptr<RPCDigitizerSimLinks> RPCDigitSimLink(new RPCDigitizerSimLinks() );
 
   // run the digitizer
   theDigitizer->doAction(*hits, *pDigis, *RPCDigitSimLink, engine);
 
   // store them in the event
-  e.put(pDigis);
-  e.put(RPCDigitSimLink,"RPCDigiSimLink");
+  e.put(std::move(pDigis));
+  e.put(std::move(RPCDigitSimLink),"RPCDigiSimLink");
 }
 

--- a/SimMuon/RPCDigitizer/test/RPCEventDump.cc
+++ b/SimMuon/RPCDigitizer/test/RPCEventDump.cc
@@ -42,7 +42,7 @@ RPCEventDump::produce(edm::Event & e, const edm::EventSetup& c)
       std::cout<<"Opening file "<<filesed[e.id().event()-1]<<std::endl;
     }
   }
-  std::auto_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
+  std::unique_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
 
   {
     RPCDetId r(0,1,1,10,1,1,1);
@@ -98,7 +98,7 @@ RPCEventDump::produce(edm::Event & e, const edm::EventSetup& c)
     RPCDigi rpcDigi6(6,0);
     pDigis->insertDigi(r,rpcDigi6);  
   }
-  e.put(pDigis);
+  e.put(std::move(pDigis));
 }
 
 DEFINE_FWK_MODULE(RPCEventDump);

--- a/SimMuon/RPCDigitizer/test/RPCFakeEvent.cc
+++ b/SimMuon/RPCDigitizer/test/RPCFakeEvent.cc
@@ -53,7 +53,7 @@ RPCFakeEvent::produce(edm::Event & e, const edm::EventSetup& c)
       std::cout<<"Opening file "<<filesed[e.id().event()-1]<<std::endl;
     }
   }
-  std::auto_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
+  std::unique_ptr<RPCDigiCollection> pDigis(new RPCDigiCollection());
 
   {
     std::cout <<"Station 1 RB1in"<<std::endl;
@@ -126,7 +126,7 @@ RPCFakeEvent::produce(edm::Event & e, const edm::EventSetup& c)
     RPCDigi rpcDigi1(46,0);
     pDigis->insertDigi(r,rpcDigi1);  
   }
-  e.put(pDigis);
+  e.put(std::move(pDigis));
 }
 
 DEFINE_FWK_MODULE(RPCFakeEvent);

--- a/SimRomanPot/SimFP420/interface/DigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/DigitizerFP420.h
@@ -51,10 +51,10 @@ namespace cms
     virtual void produce(edm::Event& e, const edm::EventSetup& c);
     
     //     virtual void prodfun(MixCollection<PSimHit>*, DigiCollectionFP420 &);
-    //  virtual void prodfun(std::auto_ptr<MixCollection<PSimHit> >*, DigiCollectionFP420 &);
+    //  virtual void prodfun(std::unique_ptr<MixCollection<PSimHit> >*, DigiCollectionFP420 &);
     
     
-    //           virtual void prodfun(std::auto_ptr<MixCollection<PSimHit> >&, DigiCollectionFP420 &);
+    //           virtual void prodfun(std::unique_ptr<MixCollection<PSimHit> >&, DigiCollectionFP420 &);
     
   private:
     //  std::vector<PSimHit> theStripHits;

--- a/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
+++ b/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
@@ -168,7 +168,7 @@ namespace cms
     for(uint32_t i = 0; i< trackerContainers.size();i++){
       iEvent.getByLabel("mix",trackerContainers[i],cf_simhit);
       cf_simhitvec.push_back(cf_simhit.product());   }
-    std::auto_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(cf_simhitvec));
+    std::unique_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(cf_simhitvec));
     
     // use instead of the previous
     /*    
@@ -177,7 +177,7 @@ namespace cms
 	  std::cout <<" ============== DigitizerFP420: start loop           2   " << std::endl;
 	  iEvent.getByLabel("mix","FP420SI",xFrame);
 	  std::cout <<" ============== DigitizerFP420: start loop           3   " << std::endl;
-	  std::auto_ptr<MixCollection<PSimHit> > allTrackerHits( new MixCollection<PSimHit>(xFrame.product()) );
+	  std::unique_ptr<MixCollection<PSimHit> > allTrackerHits( new MixCollection<PSimHit>(xFrame.product()) );
 	  std::cout <<" ============== DigitizerFP420: start loop           4   " << std::endl;
     */
     
@@ -189,12 +189,12 @@ namespace cms
 		 iEvent.getByLabel("mix",FP420HitsName,crossingFrame);
 		 MixCollection<PSimHit> * FP420Hits = 0 ;
 		 std::cout <<" ============== DigitizerFP420: start loop           1   " << std::endl;
-		 //    std::auto_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(crossingFrame.product()));
+		 //    std::unique_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(crossingFrame.product()));
 		 FP420Hits = new MixCollection<PSimHit>(crossingFrame.product());
 		 std::cout <<" ============== DigitizerFP420: start loop           2   " << std::endl;
 		 //  if ( ! FP420Hits->inRegistry()  ) isHit = false;
 		 //  if ( isHit ) {
-		 std::auto_ptr<MixCollection<PSimHit> >  allTrackerHits( FP420Hits );
+		 std::unique_ptr<MixCollection<PSimHit> >  allTrackerHits( FP420Hits );
 		 std::cout <<" ============== DigitizerFP420: start loop           3   " << std::endl;
 		 //  }  
 		 */
@@ -206,10 +206,10 @@ namespace cms
     
     ///////////////////////////////////////////////////////////////////////
       // Step C: create empty output collection
-      std::auto_ptr<DigiCollectionFP420> output(new DigiCollectionFP420);
-      //  std::auto_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new edm::DetSetVector<HDigiFP420>(output) );
-      //  std::auto_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new edm::DetSetVector<HDigiFP420>(output) );
-      //  std::auto_ptr<edm::DetSetVector<HDigiFP420SimLink> > outputlink(new edm::DetSetVector<HDigiFP420SimLink>(output) );
+      std::unique_ptr<DigiCollectionFP420> output(new DigiCollectionFP420);
+      //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new edm::DetSetVector<HDigiFP420>(output) );
+      //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new edm::DetSetVector<HDigiFP420>(output) );
+      //  std::unique_ptr<edm::DetSetVector<HDigiFP420SimLink> > outputlink(new edm::DetSetVector<HDigiFP420SimLink>(output) );
       
       SimHitMap.clear();
       
@@ -485,22 +485,22 @@ namespace cms
       
       
       // Step D: write output to file
-      //    iEvent.put(output);
+      //    iEvent.put(std::move(output));
       
       if(verbosity>0) {
 	std::cout << "DigitizerFP420 recoutput" << std::endl;
       }
       // Step D: write output to file
-      iEvent.put(output);
-      // iEvent.put(outputlink);
-      //	  iEvent.put(pDigis);
+      iEvent.put(std::move(output));
+      // iEvent.put(std::move(outputlink));
+      //	  iEvent.put(std::move(pDigis));
       
       // Step D: write output to file 
-      //  iEvent.put(output);
-      //  iEvent.put(outputlink);
+      //  iEvent.put(std::move(output));
+      //  iEvent.put(std::move(outputlink));
       //-------------------------------------------------------------------
       //    std::cout << "DigitizerFP420 recoutput" << std::endl;
-      //	  iEvent.put(pDigis);
+      //	  iEvent.put(std::move(pDigis));
       
       
       

--- a/SimTracker/Common/interface/SimHitSelectorFromDB.h
+++ b/SimTracker/Common/interface/SimHitSelectorFromDB.h
@@ -14,8 +14,8 @@ public:
   SimHitSelectorFromDB();
   ~SimHitSelectorFromDB(){};
   
-  //  std::vector<PSimHit> getSimHit(std::auto_ptr<MixCollection<PSimHit> >&,std::map<uint32_t, std::vector<int> >& );
-  std::vector<std::pair<const PSimHit*,int > > getSimHit(std::auto_ptr<MixCollection<PSimHit> >&,std::map<uint32_t, std::vector<int> >& );
+  //  std::vector<PSimHit> getSimHit(std::unique_ptr<MixCollection<PSimHit> >&,std::map<uint32_t, std::vector<int> >& );
+  std::vector<std::pair<const PSimHit*,int > > getSimHit(std::unique_ptr<MixCollection<PSimHit> >&,std::map<uint32_t, std::vector<int> >& );
 private:
   //  std::vector<PSimHit> theNewSimHitList;
   std::vector<std::pair<const PSimHit*, int > > theNewSimHitList;

--- a/SimTracker/Common/src/SimHitSelectorFromDB.cc
+++ b/SimTracker/Common/src/SimHitSelectorFromDB.cc
@@ -2,8 +2,8 @@
 
 SimHitSelectorFromDB::SimHitSelectorFromDB():theNewSimHitList(0){}
 
-//std::vector<PSimHit> SimHitSelectorFromDB::getSimHit(std::auto_ptr<MixCollection<PSimHit> >& simhit, 
-std::vector<std::pair<const PSimHit*,int> > SimHitSelectorFromDB::getSimHit(std::auto_ptr<MixCollection<PSimHit> >& simhit, 
+//std::vector<PSimHit> SimHitSelectorFromDB::getSimHit(std::unique_ptr<MixCollection<PSimHit> >& simhit, 
+std::vector<std::pair<const PSimHit*,int> > SimHitSelectorFromDB::getSimHit(std::unique_ptr<MixCollection<PSimHit> >& simhit, 
 						     std::map<uint32_t, std::vector<int> >& detId){
   theNewSimHitList.clear();
   int counter =0;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -273,14 +273,14 @@ namespace cms
     } 
     
     // Step C: create collection with the cache vector of DetSet 
-    std::auto_ptr<edm::DetSetVector<PixelDigi> > 
+    std::unique_ptr<edm::DetSetVector<PixelDigi> >
       output(new edm::DetSetVector<PixelDigi>(digiVector));
-    std::auto_ptr<edm::DetSetVector<PixelDigiSimLink> > 
+    std::unique_ptr<edm::DetSetVector<PixelDigiSimLink> >
       outputlink(new edm::DetSetVector<PixelDigiSimLink>(digiLinkVector));
     
     // Step D: write output to file 
-    iEvent.put(output, "Pixel");
-    iEvent.put(outputlink, "Pixel");
+    iEvent.put(std::move(output), "Pixel");
+    iEvent.put(std::move(outputlink), "Pixel");
   }
   void Phase2TrackerDigitizer::addOuterTrackerCollection(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     const TrackerTopology* tTopo = tTopoHand.product();
@@ -312,14 +312,14 @@ namespace cms
     } 
     
     // Step C: create collection with the cache vector of DetSet 
-    std::auto_ptr<edm::DetSetVector<Phase2TrackerDigi> > 
+    std::unique_ptr<edm::DetSetVector<Phase2TrackerDigi> >
       output(new edm::DetSetVector<Phase2TrackerDigi>(digiVector));
-    std::auto_ptr<edm::DetSetVector<PixelDigiSimLink> > 
+    std::unique_ptr<edm::DetSetVector<PixelDigiSimLink> >
       outputlink(new edm::DetSetVector<PixelDigiSimLink>(digiLinkVector));
     
     // Step D: write output to file 
-    iEvent.put(output, "Tracker");
-    iEvent.put(outputlink, "Tracker");
+    iEvent.put(std::move(output), "Tracker");
+    iEvent.put(std::move(outputlink), "Tracker");
   }
 }
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -290,14 +290,14 @@ namespace cms
     }
     
     // Step C: create collection with the cache vector of DetSet 
-    std::auto_ptr<edm::DetSetVector<PixelDigi> > 
+    std::unique_ptr<edm::DetSetVector<PixelDigi> > 
       output(new edm::DetSetVector<PixelDigi>(theDigiVector) );
-    std::auto_ptr<edm::DetSetVector<PixelDigiSimLink> > 
+    std::unique_ptr<edm::DetSetVector<PixelDigiSimLink> > 
       outputlink(new edm::DetSetVector<PixelDigiSimLink>(theDigiLinkVector) );
 
     // Step D: write output to file 
-    iEvent.put(output);
-    iEvent.put(outputlink);
+    iEvent.put(std::move(output));
+    iEvent.put(std::move(outputlink));
   }
 
   CLHEP::HepRandomEngine* SiPixelDigitizer::randomEngine(edm::StreamID const& streamID) {

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1534,7 +1534,7 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
   
   // Initilize the index converter
   //PixelIndices indexConverter(numColumns,numRows);
-  std::auto_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
+  std::unique_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
 
   int chipIndex = 0;
   int rowROC = 0;
@@ -1701,7 +1701,7 @@ float SiPixelDigitizerAlgorithm::missCalibrate(uint32_t detID, const PixelGeomDe
   // Use the pixel-by-pixel calibrations
   //transform to ROC index coordinates
   //int chipIndex=0, colROC=0, rowROC=0;
-  //std::auto_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
+  //std::unique_ptr<PixelIndices> pIndexConverter(new PixelIndices(numColumns,numRows));
   //pIndexConverter->transformToROC(col,row,chipIndex,colROC,rowROC);
 
   // Use calibration from a file

--- a/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
@@ -310,7 +310,7 @@ void PixelMixedSimHitsTest::analyze(const edm::Event& iEvent,
     edm::Handle<CrossingFrame> cf;
     iEvent.getByType(cf);
     
-    std::auto_ptr<MixCollection<PSimHit> > allPixelTrackerHits(new MixCollection<PSimHit>(cf.product(),trackerContainers));
+    std::unique_ptr<MixCollection<PSimHit> > allPixelTrackerHits(new MixCollection<PSimHit>(cf.product(),trackerContainers));
 
     //   for(vector<PSimHit>::const_iterator isim = PixelBarrelHitsLowTof->begin();
     //       isim != PixelBarrelHitsLowTof->end(); ++isim){

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.cc
@@ -115,7 +115,7 @@ void DigiSimLinkProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     cf_simhitvec.push_back(cf_simhit.product());
   }
 
-  std::auto_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(cf_simhitvec));
+  std::unique_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(cf_simhitvec));
   
   //Loop on PSimHit
   SimHitMap.clear();
@@ -201,7 +201,7 @@ void DigiSimLinkProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   // Step C: create output collection
-  std::auto_ptr<edm::DetSetVector<StripDigiSimLink> > outputlink(new edm::DetSetVector<StripDigiSimLink>(theDigiLinkVector));
+  std::unique_ptr<edm::DetSetVector<StripDigiSimLink> > outputlink(new edm::DetSetVector<StripDigiSimLink>(theDigiLinkVector));
   // Step D: write output to file
-  iEvent.put(outputlink);
+  iEvent.put(std::move(outputlink));
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -220,7 +220,7 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
 
   std::vector<edm::DetSet<SiStripDigi> > theDigiVector;
   std::vector<edm::DetSet<SiStripRawDigi> > theRawDigiVector;
-  std::auto_ptr< edm::DetSetVector<StripDigiSimLink> > pOutputDigiSimLink( new edm::DetSetVector<StripDigiSimLink> );
+  std::unique_ptr< edm::DetSetVector<StripDigiSimLink> > pOutputDigiSimLink( new edm::DetSetVector<StripDigiSimLink> );
   
   // Step B: LOOP on StripGeomDetUnit
   theDigiVector.reserve(10000);
@@ -255,28 +255,28 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
 
   if(zeroSuppression){
     // Step C: create output collection
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::auto_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(theDigiVector) );
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(theDigiVector) );
     // Step D: write output to file
-    iEvent.put(output, ZSDigi);
-    iEvent.put(output_scopemode, SCDigi);
-    iEvent.put(output_virginraw, VRDigi);
-    iEvent.put(output_processedraw, PRDigi);
-    if( makeDigiSimLinks_ ) iEvent.put( pOutputDigiSimLink ); // The previous EDProducer didn't name this collection so I won't either
+    iEvent.put(std::move(output), ZSDigi);
+    iEvent.put(std::move(output_scopemode), SCDigi);
+    iEvent.put(std::move(output_virginraw), VRDigi);
+    iEvent.put(std::move(output_processedraw), PRDigi);
+    if( makeDigiSimLinks_ ) iEvent.put(std::move(pOutputDigiSimLink)); // The previous EDProducer didn't name this collection so I won't either
   }else{
     // Step C: create output collection
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>(theRawDigiVector));
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::auto_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>() );
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>(theRawDigiVector));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>() );
     // Step D: write output to file
-    iEvent.put(output, ZSDigi);
-    iEvent.put(output_scopemode, SCDigi);
-    iEvent.put(output_virginraw, VRDigi);
-    iEvent.put(output_processedraw, PRDigi);
-    if( makeDigiSimLinks_ ) iEvent.put( pOutputDigiSimLink ); // The previous EDProducer didn't name this collection so I won't either
+    iEvent.put(std::move(output), ZSDigi);
+    iEvent.put(std::move(output_scopemode), SCDigi);
+    iEvent.put(std::move(output_virginraw), VRDigi);
+    iEvent.put(std::move(output_processedraw), PRDigi);
+    if( makeDigiSimLinks_ ) iEvent.put(std::move(pOutputDigiSimLink)); // The previous EDProducer didn't name this collection so I won't either
   }
 }
 

--- a/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
+++ b/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
@@ -60,7 +60,7 @@ void MCTrackMatcher::produce(edm::StreamID, Event& evt, const EventSetup& es) co
   Handle<GenParticleCollection> genParticles;
   evt.getByToken(genParticles_, genParticles );
   RecoToSimCollection associations = associator->associateRecoToSim ( tracks, trackingParticles);
-  auto_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
+  unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
   GenParticleMatch::Filler filler(*match);
   size_t n = tracks->size();
   vector<int> indices(n,-1);
@@ -81,7 +81,7 @@ void MCTrackMatcher::produce(edm::StreamID, Event& evt, const EventSetup& es) co
   }
   filler.insert(tracks, indices.begin(), indices.end());
   filler.fill();
-  evt.put(match);
+  evt.put(std::move(match));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimTracker/TrackAssociation/plugins/StripCompactDigiSimLinksProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/StripCompactDigiSimLinksProducer.cc
@@ -115,8 +115,8 @@ StripCompactDigiSimLinksProducer::produce(edm::Event & iEvent, const edm::EventS
         }
     }
    
-    std::auto_ptr< StripCompactDigiSimLinks > ptr(new StripCompactDigiSimLinks(output));
-    iEvent.put(ptr);
+    std::unique_ptr< StripCompactDigiSimLinks > ptr(new StripCompactDigiSimLinks(output));
+    iEvent.put(std::move(ptr));
 }
 
 DEFINE_FWK_MODULE(StripCompactDigiSimLinksProducer);

--- a/SimTracker/TrackAssociation/plugins/TrackAssociatorEDProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackAssociatorEDProducer.cc
@@ -84,8 +84,8 @@ TrackAssociatorEDProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
    Handle<edm::View<reco::Track> > trackCollection;
    bool trackAvailable = iEvent.getByToken(trackCollectionToken_, trackCollection );
 
-   std::auto_ptr<reco::RecoToSimCollection> rts;
-   std::auto_ptr<reco::SimToRecoCollection> str;
+   std::unique_ptr<reco::RecoToSimCollection> rts;
+   std::unique_ptr<reco::SimToRecoCollection> str;
 
    if (theIgnoremissingtrackcollection && !trackAvailable){
      //the track collection is not in the event and we're being told to ignore this.
@@ -103,8 +103,8 @@ TrackAssociatorEDProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
      rts.reset(new reco::RecoToSimCollection(recSimColl));
      str.reset(new reco::SimToRecoCollection(simRecColl));
 
-     iEvent.put(rts);
-     iEvent.put(str);
+     iEvent.put(std::move(rts));
+     iEvent.put(std::move(str));
    }
 }
 

--- a/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
+++ b/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
@@ -59,7 +59,7 @@ void GenTrackMatcher::produce(Event& evt, const EventSetup& es)
     evt.getByToken(genParticles_, barCodes);
     Handle<GenParticleCollection> genParticles;
     evt.getByToken(genParticles_, genParticles);
-    auto_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
+    unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
     GenParticleMatch::Filler filler(*match);
     size_t n = tracks->size();
     vector<int> indices(n,-1);
@@ -87,7 +87,7 @@ void GenTrackMatcher::produce(Event& evt, const EventSetup& es)
     }
     filler.insert(tracks, indices.begin(), indices.end());
     filler.fill();
-    evt.put(match);
+    evt.put(std::move(match));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
+++ b/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
@@ -55,7 +55,7 @@ void JetVetoedTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::E
     edm::Handle <reco::TrackCollection> tracks_h;
     fEvent.getByToken (mTracks, tracks_h);
 
-    std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+    std::unique_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
 
     // format inputs
     std::vector <edm::RefToBase<reco::Jet> > allJets;
@@ -67,7 +67,7 @@ void JetVetoedTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::E
     // run algo
     mAssociator.produce (&*jetTracks, allJets, allTracks, classifier);
     // store output
-    fEvent.put (jetTracks);
+    fEvent.put(std::move(jetTracks));
 }
 
 DEFINE_FWK_MODULE(JetVetoedTracksAssociatorAtVertex);

--- a/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
+++ b/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
@@ -52,8 +52,8 @@ void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event& event, cons
     event.getByToken(svTagInfoCollection_, svTagInfoCollection);
 
     // Auto pointers to the collection to be added to the event
-    std::auto_ptr<reco::VertexCollection> proxy (new reco::VertexCollection);
-    std::auto_ptr<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> > >
+    std::unique_ptr<reco::VertexCollection> proxy (new reco::VertexCollection);
+    std::unique_ptr<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> > >
     assoc (new edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> >);
 
     // Get a reference before to put in the event
@@ -78,8 +78,8 @@ void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event& event, cons
     }
 
     // Adding the collection to the event
-    event.put(proxy);
-    event.put(assoc);
+    event.put(std::move(proxy));
+    event.put(std::move(assoc));
 }
 
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -253,8 +253,8 @@ void TrackingMaterialProducer::update(const EndOfTrack* event)
 void TrackingMaterialProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   // transfer ownership to the Event
-  std::auto_ptr<std::vector<MaterialAccountingTrack> > tracks( m_tracks );
-  iEvent.put( tracks );
+  std::unique_ptr<std::vector<MaterialAccountingTrack> > tracks( m_tracks );
+  iEvent.put(std::move(tracks));
   m_tracks = 0;
 }
 

--- a/SimTransport/HectorProducer/src/HectorProducer.cc
+++ b/SimTransport/HectorProducer/src/HectorProducer.cc
@@ -111,13 +111,13 @@ void HectorProducer::produce(edm::Event & iEvent, const edm::EventSetup & es){
 
   edm::LogInfo("SimTransportHectorProducer") << "new HepMC product "; 
   
-  auto_ptr<edm::HepMCProduct> NewProduct(new edm::HepMCProduct()) ;
+  unique_ptr<edm::HepMCProduct> NewProduct(new edm::HepMCProduct());
   NewProduct->addHepMCData( evt_ ) ;
   
-  iEvent.put( NewProduct ) ;
+  iEvent.put(std::move(NewProduct));
 
   edm::LogInfo("SimTransportHectorProducer") << "new LHCTransportLinkContainer "; 
-  auto_ptr<edm::LHCTransportLinkContainer> NewCorrespondenceMap(new edm::LHCTransportLinkContainer() );
+  unique_ptr<edm::LHCTransportLinkContainer> NewCorrespondenceMap(new edm::LHCTransportLinkContainer());
   edm::LHCTransportLinkContainer thisLink(m_Hector->getCorrespondenceMap());
   (*NewCorrespondenceMap).swap(thisLink);
 
@@ -126,7 +126,7 @@ void HectorProducer::produce(edm::Event & iEvent, const edm::EventSetup & es){
       LogDebug("HectorEventProcessing") << "Hector correspondence table: " << (*NewCorrespondenceMap)[i];
   }
 
-  iEvent.put( NewCorrespondenceMap );
+  iEvent.put(std::move(NewCorrespondenceMap));
   edm::LogInfo("SimTransportHectorProducer") << "produce end "; 
 
 }


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in FullSimulation to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in Full Simulation may also have been changed to std::unique_ptr. 
