### PR TITLE
Add detachedTripletStep to phase1 tracking sequence and reorder iterations

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -51,7 +51,7 @@ eras.trackingPhase1.toModify(
         'lowPtQuadStepTracks',
         'lowPtTripletStepTracks',
         'detachedQuadStepTracks',
-        #'detachedTripletStepTracks', # FIXME: disabled for now
+        'detachedTripletStepTracks',
         'mixedTripletStepTracks',
         'pixelLessStepTracks',
         'tobTecStepTracks'
@@ -63,7 +63,7 @@ eras.trackingPhase1.toModify(
         "lowPtQuadStep",
         "lowPtTripletStep",
         "detachedQuadStep",
-        #"detachedTripletStep", # FIXME: disabled for now
+        "detachedTripletStep",
         "mixedTripletStep",
         "pixelLessStep",
         "tobTecStep"

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -20,17 +20,17 @@ eras.trackingPhase1.toModify(detachedTripletStepSeedLayers,
     layerList = [
         'BPix1+BPix2+BPix3',
         'BPix2+BPix3+BPix4',
-        'BPix1+BPix3+BPix4',
-        'BPix1+BPix2+BPix4',
+#        'BPix1+BPix3+BPix4', # has "hole", not tested
+#        'BPix1+BPix2+BPix4', # has "hole", not tested
         'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
-        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
-        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+#        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', # mostly fake tracks, lots of seeds
+#        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',  # has "hole", not tested
         'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
-        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
-        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+#        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', # mostly fake tracks, lots of seeds
+#        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',  # has "hole", not tested
         'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
-        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
-        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
+#        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',  # has "hole", not tested
+#        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'  # has "hole", not tested
     ]
 )
 

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -16,8 +16,8 @@ pixelPairStepSeedClusterMask = seedClusterRemover.clone(
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
 )
 eras.trackingPhase1PU70.toModify(pixelPairStepSeedClusterMask, oldClusterRemovalInfo = "highPtTripletStepSeedClusterMask")
-# This is a pure guess to use lowPtTripletStep for phase1 here instead of the pixelPair in Run2 configuration
-lowPtTripletStepSeedClusterMask = seedClusterRemover.clone(
+# This is a pure guess to use detachedTripletStep for phase1 here instead of the pixelPair in Run2 configuration
+detachedTripletStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("lowPtTripletStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
 )
@@ -26,7 +26,7 @@ mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
     oldClusterRemovalInfo = cms.InputTag("pixelPairStepSeedClusterMask")
 )
 eras.trackingPhase1.toModify(mixedTripletStepSeedClusterMask,
-    oldClusterRemovalInfo = "lowPtTripletStepSeedClusterMask"
+    oldClusterRemovalInfo = "detachedTripletStepSeedClusterMask"
 )
 pixelLessStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("pixelLessStepSeeds"),
@@ -205,7 +205,7 @@ electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
                                  stripPairElectronSeeds*
                                  newCombinedSeeds)
 _electronSeedsSeq_Phase1 = electronSeedsSeq.copy()
-_electronSeedsSeq_Phase1.replace(pixelPairStepSeedClusterMask, lowPtTripletStepSeedClusterMask)
+_electronSeedsSeq_Phase1.replace(pixelPairStepSeedClusterMask, detachedTripletStepSeedClusterMask)
 eras.trackingPhase1.toReplaceWith(electronSeedsSeq, _electronSeedsSeq_Phase1)
 eras.trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -28,11 +28,11 @@ _iterations_trackingLowPU = [
 ]
 _iterations_trackingPhase1 = [
     "InitialStep",
+    "LowPtQuadStep",
     "HighPtTripletStep",
+    "LowPtTripletStep",
     "DetachedQuadStep",
     "DetachedTripletStep",
-    "LowPtQuadStep",
-    "LowPtTripletStep",
     "MixedTripletStep",
     "PixelLessStep",
     "TobTecStep",

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -30,7 +30,7 @@ _iterations_trackingPhase1 = [
     "InitialStep",
     "HighPtTripletStep",
     "DetachedQuadStep",
-    #"DetachedTripletStep", # FIXME: dropped for time being, but it may be enabled on the course of further tuning
+    "DetachedTripletStep",
     "LowPtQuadStep",
     "LowPtTripletStep",
     "MixedTripletStep",


### PR DESCRIPTION
As discussed in May 9 TRK POG meeting https://indico.cern.ch/event/527844/contributions/2161117/attachments/1269921/1881271/slides_phase1_20160509.pdf
this PR adds detachedTripletStep (only combinations of layers 2-3-4, and from BPix only 1-2-3), and reorders the iterations as `initialStep, lowPtQuadStep, highPtTripletStep, lowPtTripletStep, detachedQuadStep, detachedTripletStep).

Please find below MultiTrackValidator plots with 1000 TTbar+PU35 events showing the effect of this PR on top of 8_1_0_pre5+#14545 (strip alignment as in run2_asymptotic GT)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre5_detachedTriplet/

Tested in CMSSW_8_1_X_2016-05-25-2300, no changes expected in non-2017 workflows. In 2017 workflows efficiency increases in pT 0.3-2 GeV and r 2-8 cm, and also fake and duplicate rates increase (all caused by the addition of detachedTripletStep, fake rate increase mitigated a bit by iteration reordering). The timing should stay pretty much the same, thanks to more optimal order of iterations.

@rovere @VinInn 
