### PR TITLE
Adding L1REPACK:FullMC workflow to run on RAW of MC (80x)

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1499,7 +1499,7 @@ class ConfigBuilder(object):
 
     def prepare_L1REPACK(self, sequence = None):
             """ Enrich the schedule with the L1 simulation step, running the L1 emulator on data unpacked from the RAW collection, and repacking the result in a new RAW collection"""
-	    supported = ['GT','GT1','GT2','GCTGT','Full','Full2015Data','uGT']
+	    supported = ['GT','GT1','GT2','GCTGT','Full','FullMC','Full2015Data','uGT']
             if sequence in supported:
                 self.loadAndRemember('Configuration/StandardSequences/SimL1EmulatorRepack_%s_cff'%sequence)
 		if self._options.scenario == 'HeavyIons':

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -62,7 +62,7 @@ else:
     simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
 
     # BMTF
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
     simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
 
     # OMTF

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -1,0 +1,109 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
+
+
+if not (eras.stage2L1Trigger.isChosen()):
+    print "L1T WARN:  L1REPACK:FullMC (intended for MC events with RAW eventcontent) only supports Stage 2 eras for now."
+    print "L1T WARN:  Use a legacy version of L1REPACK for now."
+else:
+    print "L1T INFO:  L1REPACK:FullMC  will unpack Calorimetry and Muon L1T inputs, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."
+
+    # First, Unpack all inputs to L1:
+
+    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.DTRawToDigi.dtunpacker_cfi
+    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    # Second, Re-Emulate the entire L1T
+    #
+    # Legacy trigger primitive emulations still running in 2016 trigger:
+    #
+    from SimCalorimetry.Configuration.SimCalorimetry_cff import *
+
+    # Ecal TPs
+    # cannot simulate EcalTPs, don't have EcalUnsuppressedDigis in RAW
+    #     simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
+    # further downstream, use unpacked EcalTPs
+
+    # Hcal TPs
+    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),
+        cms.InputTag('unpackHcal')
+    )
+
+    from L1Trigger.Configuration.SimL1Emulator_cff import *
+    # DT TPs
+    simDtTriggerPrimitiveDigis.digiTag                    = 'unpackDT'
+    # CSC TPs
+    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag('unpackCSC', 'MuonCSCComparatorDigi' )
+    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
+
+    # TWIN-MUX
+    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
+    simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+
+    # BMTF
+    simBmtfDigis.DTDigi_Source       = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+
+    # OMTF
+    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
+    simOmtfDigis.srcDTPh             = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simOmtfDigis.srcDTTh             = cms.InputTag("simDtTriggerPrimitiveDigis")
+    simOmtfDigis.srcCSC              = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
+
+    # EMTF
+    simEmtfDigis.CSCInput            = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
+
+    # CALO Layer1
+    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
+    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+
+    # Finally, pack the new L1T output back into RAW
+    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+    # combine the new L1 RAW with existing RAW for other FEDs
+    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+        verbose = cms.untracked.int32(0),
+        RawCollectionList = cms.VInputTag(
+            cms.InputTag('packCaloStage2'),
+            cms.InputTag('packGmtStage2'),
+            cms.InputTag('packGtStage2'),
+            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+            )
+        )
+
+    SimL1Emulator = cms.Sequence(unpackRPC
+                                + unpackDT
+                                + unpackCSC
+                                + unpackEcal
+                                + unpackHcal
+                                #+ simEcalTriggerPrimitiveDigis
+                                + simHcalTriggerPrimitiveDigis
+                                + SimL1EmulatorCore
+                                + packCaloStage2
+                                + packGmtStage2
+                                + packGtStage2
+                                + rawDataCollector)

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -78,7 +78,7 @@ else:
     simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
     simOmtfDigis.srcDTPh             = cms.InputTag("unpackBmtf")
     simOmtfDigis.srcDTTh             = cms.InputTag("unpackBmtf")
-    simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf") # replace when emtfDigis availalbe 
+    simOmtfDigis.srcCSC              = cms.InputTag("unpackCsctf") # replace when emtfDigis availalbe
 
     # EMTF
     simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf") # replace when emtfDigis availalbe 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -30,14 +30,6 @@ else:
 
     # Finally, pack the new L1T output back into RAW
     
-    # pack unpacked
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    packCaloStage2.InputLabel = cms.InputTag("unpackCaloStage2")
-
-    # pack unpacked
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
-    packGmtStage2.InputLabel = cms.InputTag("unpackGmtStage2")
-
     # pack simulated uGT
     from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
     packGtStage2.MuonInputTag   = cms.InputTag("unpackGmtStage2","Muon")


### PR DESCRIPTION
Adding L1REPACK:FullMC workflow to run on RAW of MC. 
(Also fixed Csc InputTag for Omtf emuator in REPACK:Full, and clean REPACK:uGT.

Available L1REPACK workflows of re-emulation of Stage2 L1T available now: 
- FullMC (for 2016 RAWAODSIM MC)
- Full  (for 2016 data)
- uGT (for 2016 data) 
- Full2015Data (for 2015Data)

L1REPACK:FullMC workflow starts from unpacking RPC, DT, CSC, ECAL, and HCAL. 
It uses unpacked TriggerPrimitives for ECAL and simulates TriggerPrimitives DT TPs, CSC TPs, and HCAL TPs. It then emulates TwinMux, muon track finders (BMTF, OMTF, EMTF) uGMT, Calo Layer1, Calo Layer2, and uGT at the end of the sequence. 
It re-packs re-emulated uGMT, CaloLayer2 and uGT in RAW data collection. 

In a MC-production-like workflow, use it as:

<pre>
cmsDriver.py reHLT --conditions auto:run2_mc -s L1REPACK:FullMC,HLT:@fake --datatier GEN-SIM-RAW,AODSIM -n 10 --era=Run2_2016 --eventcontent RAWSIM,AODSIM --filein "root://eoscms.cern.ch//eos/cms/store/mc/RunIISpring16DR80/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RAWAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_v3-v2/30000/040AFBF1-8E0B-E611-9C22-001E67E95A58.root" --processName HLT2 --python_filename reHLT.py 
</pre>

Add a flag to see printouts of L1 menu `--customise=HLTrigger/Configuration/CustomConfigs.L1T`

L1REPACK:Full workflow starts from unpacked TriggerPrimitives and re-emulates muon track finders, uGMT, Calo Layer1 and Layer2, and uGT at the end of the sequence. It re-packs re-emulated uGMT, CaloLayer2 and uGT in RAW data collection.  In a typical HLT test use it as:

<pre>
cmsDriver.py RelVal --step=L1REPACK:Full --conditions=auto:run2_hlt_GRun --filein=/store/data/Run2016A/ZeroBias1/RAW/v1/000/271/336/00000/00963A5A-BF0A-E611-A657-02163E0141FB.root --custom_conditions= --fileout=RelVal_L1RePack_GRun_DATA.root --number=10 --data --datatier GEN-SIM-DIGI-RAW --eventcontent=RAW --customise=HLTrigger/Configuration/CustomConfigs.L1T --era=Run2_2016 --customise= --scenario=pp --python_filename=RelVal_L1RePack_Full_GRun_DATA.py --customise=L1Trigger/Configuration/L1Trigger_custom.customiseResetPrescalesAndMasks 
</pre>


L1REPACK:uGT workflow starts from unpacked uGMT and CaloLayer2 outputs, re-emulates uGT, and packs the re-emulated uGT in RAW data collection.  In a typcal HLT test us it as:

<pre>
cmsDriver.py RelVal --step=L1REPACK:uGT --conditions=auto:run2_hlt_GRun --filein=/store/data/Run2016A/ZeroBias1/RAW/v1/000/271/336/00000/00963A5A-BF0A-E611-A657-02163E0141FB.root --custom_conditions= --fileout=RelVal_L1RePack_GRun_DATA.root --number=10 --data --datatier GEN-SIM-DIGI-RAW --eventcontent=RAW --customise=HLTrigger/Configuration/CustomConfigs.L1T --era=Run2_2016 --customise= --scenario=pp --python_filename=RelVal_L1RePack_uGT_GRun_DATA.py --customise=L1Trigger/Configuration/L1Trigger_custom.customiseResetPrescalesAndMasks 
</pre>


For L1REPACK:Full2015Data workflow is intended for 205 data, starts from unpacked TriggerPrimitives and re-emulates muon track finders, uGMT, Calo Layer1 and Layer2, and uGT at the end of the sequence. It re-packs re-emulated uGMT, CaloLayer2 and uGT in RAW data collection.  
Configuration for the HFTPs (1x1) which is different in 2016 wrt 2015 has already been included in the above workflow via setting ESProducer preference.  However, the geometry for 2016 needs to be loaded via a cmsDriver flag _--geometry_ flag.
For a typical HLT test use it as:

<pre>
cmsDriver.py RelVal --step=L1REPACK:Full2015Data --conditions=auto:run2_hlt_GRun --filein=/store/data/Run2015D/MuonEG/RAW/v1/000/256/677/00000/80950A90-745D-E511-92FD-02163E011C5D.root --custom_conditions= --fileout=RelVal_L1RePack_GRun_DATA.root --number=10 --data --datatier GEN-SIM-DIGI-RAW --eventcontent=RAW --customise=HLTrigger/Configuration/CustomConfigs.L1T --era=Run2_2016 --customise= --scenario=pp --python_filename=RelVal_L1RePackFull2015Data_GRun_DATA.py --customise=L1Trigger/Configuration/L1Trigger_custom.customiseResetPrescalesAndMasks --geometry=Extended2016,Extended2016Reco
</pre>
