### PR TITLE
Blacklist -xSSE3 (ICC) in condformats_serialization_generate.py

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -479,7 +479,7 @@ class SerializationCodeGenerator(object):
 
     def cleanFlags(self, flagsIn):
         flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map', '-ax', '-wd')) ]
-        blackList = ['--', '-fipa-pta']
+        blackList = ['--', '-fipa-pta', '-xSSE3']
         return [x for x in flags if x not in blackList]
 
     def generate(self, outFileName):


### PR DESCRIPTION
Needed for ICC otherwise Clang will fail to load the translation unit.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
