### PR TITLE
Fix for handling copy of offline synchronized tags

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -158,6 +158,7 @@ class Synchronization(Enum):
     express    = 'express'
     prompt     = 'prompt'
     pcl        = 'pcl'
+    offline    = 'offline'
 
 class TimeType(Enum):
     run  = 'Run'


### PR DESCRIPTION
Fix for conddb copy command. Allows to copy tags synchronized with 'offline' type.
