### PR TITLE
fix crash in case Limit on the number of clusters is really exceeded.

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -175,6 +175,7 @@
 	// Fatal error!  TO DO: throw an exception!
 	assert(0);
       }
+      {
       // Produce clusters for this DetUnit and store them in 
       // a DetSet
       edmNew::DetSetVector<SiPixelCluster>::FastFiller spc(output, DSViter->detId());
@@ -184,7 +185,7 @@
       } else {
 	numberOfClusters += spc.size();
       }
-
+      } // spc is not deleted and detsetvector updated
       if ((maxTotalClusters_ >= 0) && (numberOfClusters > maxTotalClusters_)) {
         edm::LogError("TooManyClusters") <<  "Limit on the number of clusters exceeded. An empty cluster collection will be produced instead.\n";
         edmNew::DetSetVector<SiPixelCluster> empty;


### PR DESCRIPTION
refer to discussion in cms-hlt@cern.ch and 
https://cmsonline.cern.ch/webcenter/portal/cmsonline/Common/Elog?_piref623564097.strutsAction=/viewMessageDetails.do%3fmsgId=922127

back port and deployment at HLT needed if required
@fwyzard 
