### PR TITLE
remove unneeded hgchebackDigitizer

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -42,11 +42,10 @@ if eras.fastSim.isChosen():
     setattr(theDigitizers,"tracks",recoTrackAccumulator)
 
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer 
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer 
     
 eras.phase2_hgcal.toModify( theDigitizers,
                             hgceeDigitizer = cms.PSet(hgceeDigitizer),
-                            hgchebackDigitizer = cms.PSet(hgchebackDigitizer),
                             hgchefrontDigitizer = cms.PSet(hgchefrontDigitizer),
 )
 

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -219,7 +219,7 @@ mixPCFHepMCProducts = cms.PSet(
     type = cms.string('HepMCProductPCrossingFrame')
 )
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer
 
 from Configuration.StandardSequences.Eras import eras
 eras.run3_GEM.toModify( theMixObjects,
@@ -239,10 +239,8 @@ eras.phase2_muon.toModify( theMixObjects,
 eras.phase2_hgcal.toModify( theMixObjects,
     mixCH = dict(
         input = theMixObjects.mixCH.input + [ cms.InputTag("g4SimHits",hgceeDigitizer.hitCollection.value()),
-                                              cms.InputTag("g4SimHits",hgchebackDigitizer.hitCollection.value()),
                                               cms.InputTag("g4SimHits",hgchefrontDigitizer.hitCollection.value()) ],
         subdets = theMixObjects.mixCH.subdets + [ hgceeDigitizer.hitCollection.value(),
-                                                  hgchebackDigitizer.hitCollection.value(),
                                                   hgchefrontDigitizer.hitCollection.value() ]
     )
 )


### PR DESCRIPTION
For a while, we have had this message when running the Phase2 DIGI step:

```
%MSG-e HGCDigitizer:  MixingModule:mix 27-May-2016 10:06:49 CDT Run: 1 Event: 1
 @ accumulate : can't find HGCHitsHEback collection of g4SimHits
```

This occurred because the HCAL infrastructure is now used for the HEback simulation/digitization/reconstruction. The HGC HEback digitizer is not needed, so it can just be removed from the DIGI step entirely. The basic configuration for this digitizer in [SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py](https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py) is retained in case someone wants to use it for private studies.

attn: @lgray, @bsunanda
