### PR TITLE
Bugfix: Fake muon tracks become charged hadrons in PF 

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -147,6 +147,10 @@ importToBlock( const edm::Event& e,
 
 bool GeneralTracksImporter::
 goodPtResolution( const reco::TrackRef& trackref) const {
+  //recheck that the track is high purity!
+  if (!trackref->quality(reco::TrackBase::highPurity))
+    return false;
+    
 
   const double P = trackref->p();
   const double Pt = trackref->pt();

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -44,8 +44,8 @@ particleFlowBlock = cms.EDProducer(
                   cleanBadConvertedBrems = cms.bool(True),
                   useIterativeTracking = cms.bool(True),
                   maxDPtOPt      = cms.double(1.),                                 
-                  DPtOverPtCuts_byTrackAlgo = cms.vdouble(-1.0,-1.0,-1.0,
-                                                           1.0,1.0,5.0),
+                  DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,
+                                                           10.0,10.0,5.0),
                   NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3)
                   ),        
         # secondary GSF tracks are also turned off


### PR DESCRIPTION
This fixes tail events that appeared in 80X. Those fake tracks we have seen before  but they were appearing in less pure iterations for which we applied Dpt/pt cuts

Actions taken:
+Add a very loose Dpt/pt cut <20 in other iterations
+Cut tracks that are not belonging to muons but are not high purity

THis should only affect events in tails 
