### PR TITLE
cleanup RawToDigi redefinition of already loaded from RawToDigi_cff (bp of #14675)

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
@@ -2,22 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.RawToDigi_cff import *
 
-RawToDigi = cms.Sequence(
-                         siPixelDigis
-                         +siStripDigis
-                         +ecalDigis
-                         +ecalPreshowerDigis
-                         +hcalDigis
-                         +muonCSCDigis
-                         +muonDTDigis
-                         +muonRPCDigis
-                         +castorDigis
-                         +scalersRawToDigi
-                         +tcdsDigis
-                         +L1TRawToDigi)
 
 ecalDigis.DoRegional = False
-
-#set those back to "source"
 #False by default ecalDigis.DoRegional = False
 


### PR DESCRIPTION
(ported to 80X)
remove overriding RawToDigi definition for data configs
This could have been done in 2011 (rev 1.15) 
https://cvs.web.cern.ch/cvs/cgi-bin/viewcvs.cgi/CMSSW/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
when RawToDigi_cff was added back to this file via import.

Currently this prevents transparent updates and use of eras (discovered/realised while integrating CTPPS code).
