### PR TITLE
Use unique_ptr, not auto_ptr, in DQM

### DIFF
--- a/DQM/DataScouting/src/AlphaTVarProducer.cc
+++ b/DQM/DataScouting/src/AlphaTVarProducer.cc
@@ -52,7 +52,7 @@ AlphaTVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    edm::Handle<reco::CaloJetCollection> calojet_handle; 
    iEvent.getByToken(inputJetTagToken_, calojet_handle);
 
-   std::auto_ptr<std::vector<double> > result(new std::vector<double>); 
+   std::unique_ptr<std::vector<double> > result(new std::vector<double>); 
    // check the the input collections are available
    if (calojet_handle.isValid()){
      std::vector<TLorentzVector> myJets;
@@ -68,7 +68,7 @@ AlphaTVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      result->push_back(alphaT);
      result->push_back(HT);
    }
-   iEvent.put(result);
+   iEvent.put(std::move(result));
 }
 
 double 

--- a/DQM/DataScouting/src/DiJetVarProducer.cc
+++ b/DQM/DataScouting/src/DiJetVarProducer.cc
@@ -49,8 +49,8 @@ DiJetVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    using namespace reco;
 
    // ## The output collections        
-   //std::auto_ptr<std::vector<double> > dijetvariables(new std::vector<double>); 
-   std::auto_ptr<std::vector<math::PtEtaPhiMLorentzVector> > widejets(new std::vector<math::PtEtaPhiMLorentzVector>); 
+   //std::unique_ptr<std::vector<double> > dijetvariables(new std::vector<double>); 
+   std::unique_ptr<std::vector<math::PtEtaPhiMLorentzVector> > widejets(new std::vector<math::PtEtaPhiMLorentzVector>); 
 
    // ## Get jet collection
    edm::Handle<reco::CaloJetCollection> calojets_handle;
@@ -142,8 +142,8 @@ DiJetVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    //      }
 
    // ## Put objects in the Event
-   //iEvent.put(dijetvariables, "dijetvariables");
-   iEvent.put(widejets, "widejets");
+   //iEvent.put(std::move(dijetvariables), "dijetvariables");
+   iEvent.put(std::move(widejets), "widejets");
 
 }
 

--- a/DQM/DataScouting/src/RazorVarProducer.cc
+++ b/DQM/DataScouting/src/RazorVarProducer.cc
@@ -59,7 +59,7 @@ RazorVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    Handle<CaloMETCollection> inputMet;
    iEvent.getByToken(inputMetTagToken_, inputMet);
 
-   std::auto_ptr<std::vector<double> > result(new std::vector<double>); 
+   std::unique_ptr<std::vector<double> > result(new std::vector<double>); 
    // check the the input collections are available
    if (hemispheres.isValid() && inputMet.isValid() && hemispheres->size() > 1){
 
@@ -73,7 +73,7 @@ RazorVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      result->push_back(R);
      
    }
-   iEvent.put(result);
+   iEvent.put(std::move(result));
 }
 
 double 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
@@ -482,8 +482,8 @@ SiStripFineDelayHit::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
    // add the selected hits to the event.
    LogDebug("produce") << "Putting " << output.size() << " new hits in the event.";
-   std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > formatedOutput(new edm::DetSetVector<SiStripRawDigi>(output) );
-   iEvent.put(formatedOutput,"FineDelaySelection");
+   std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > formatedOutput(new edm::DetSetVector<SiStripRawDigi>(output) );
+   iEvent.put(std::move(formatedOutput),"FineDelaySelection");
 }
 
 // Simple solution when tracking is not available/ not working
@@ -558,8 +558,8 @@ SiStripFineDelayHit::produceNoTracking(edm::Event& iEvent, const edm::EventSetup
    }
    // add the selected hits to the event.
    LogDebug("produce") << "Putting " << output.size() << " new hits in the event.";
-   std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > formatedOutput(new edm::DetSetVector<SiStripRawDigi>(output) );
-   iEvent.put(formatedOutput,"FineDelaySelection");
+   std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > formatedOutput(new edm::DetSetVector<SiStripRawDigi>(output) );
+   iEvent.put(std::move(formatedOutput),"FineDelaySelection");
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h
@@ -59,7 +59,7 @@ namespace sistrip {
 
     void zeroSuppress(const std::vector<SiStripRawDigi> & cmSubtrDetSetData,
 		      edm::DetSet<SiStripDigi>    & zsDetSetData,
-		      const std::auto_ptr<SiStripRawProcessingAlgorithms> & algorithms);
+		      const std::unique_ptr<SiStripRawProcessingAlgorithms> & algorithms);
 
     uint32_t fedIndex(const uint16_t aFedChannel);
 

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyDigiConverter.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyDigiConverter.h
@@ -36,17 +36,17 @@ namespace sistrip {
          * If pAPVAddress is set, the map is filled with a map from FedKey to APVAddress.
          * minAllowedRange is the min allowed range of digis when determine the threshold.
          */
-        static std::auto_ptr<DSVRawDigis> extractPayloadDigis(const DSVRawDigis * inputScopeDigis,
+        static std::unique_ptr<DSVRawDigis> extractPayloadDigis(const DSVRawDigis * inputScopeDigis,
                                                               std::vector<uint32_t> * pAPVAddresses,
 							      const bool discardDigisWithAPVAddrErr,
                                                               const sistrip::SpyUtilities::FrameQuality & aQuality,
 							      const uint16_t expectedPos);
     
         /* \brief Reorder from readout order to physical order */
-        static std::auto_ptr<DSVRawDigis> reorderDigis(const DSVRawDigis* inputPayloadDigis);
+        static std::unique_ptr<DSVRawDigis> reorderDigis(const DSVRawDigis* inputPayloadDigis);
     
         /* \brief Merge channel digis into modules. */
-        static std::auto_ptr<DSVRawDigis> mergeModuleChannels(const DSVRawDigis* inputPhysicalOrderChannelDigis, const SiStripFedCabling& cabling);
+        static std::unique_ptr<DSVRawDigis> mergeModuleChannels(const DSVRawDigis* inputPhysicalOrderChannelDigis, const SiStripFedCabling& cabling);
 
 
       private:

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -34,14 +34,14 @@ namespace sistrip {
       class SpyDataCollections
       {
         public:
-        std::auto_ptr< FEDRawDataCollection > rawData;
-        std::auto_ptr< std::vector<uint32_t> > totalEventCounters;
-        std::auto_ptr< std::vector<uint32_t> > l1aCounters;
-        std::auto_ptr< std::vector<uint32_t> > apvAddresses;
-        std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > scopeDigis;
-        std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > payloadDigis;
-        std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > reorderedDigis;
-        std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > virginRawDigis;
+        std::unique_ptr< FEDRawDataCollection > rawData;
+        std::unique_ptr< std::vector<uint32_t> > totalEventCounters;
+        std::unique_ptr< std::vector<uint32_t> > l1aCounters;
+        std::unique_ptr< std::vector<uint32_t> > apvAddresses;
+        std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > scopeDigis;
+        std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > payloadDigis;
+        std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > reorderedDigis;
+        std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > virginRawDigis;
         SpyDataCollections();
         //NB. This will remove all elements in the containers pasted in. It does not copy the data. 
         SpyDataCollections(FEDRawDataCollection& theRawData,
@@ -52,8 +52,6 @@ namespace sistrip {
                            std::vector< edm::DetSet<SiStripRawDigi> >* thePayloadDigisVector,
                            std::vector< edm::DetSet<SiStripRawDigi> >* theReorderedDigisVector,
                            std::vector< edm::DetSet<SiStripRawDigi> >* theVirginRawDigisVector);
-        //does not copy, orginal object looses ownership of collections
-        SpyDataCollections& operator = (SpyDataCollections original);
       };
       struct MatchingOutput
       {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
@@ -203,7 +203,7 @@ namespace sistrip{
 
   void FEDEmulator::zeroSuppress(const std::vector<SiStripRawDigi> & cmSubtrDetSetData,
 				 edm::DetSet<SiStripDigi>    & zsDetSetData,
-				 const std::auto_ptr<SiStripRawProcessingAlgorithms> & algorithms)
+				 const std::unique_ptr<SiStripRawProcessingAlgorithms> & algorithms)
   {
     //transform the input digis to a vector of integers
     std::vector<int16_t> cmSubtrRawDigis;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
@@ -81,7 +81,7 @@ namespace sistrip
 
     static const char* messageLabel_;
   
-    std::auto_ptr<SiStripRawProcessingAlgorithms> algorithms_; //!< object for zero-suppression
+    std::unique_ptr<SiStripRawProcessingAlgorithms> algorithms_; //!< object for zero-suppression
 
     //utilities for cabling etc...
     SpyUtilities utility_;
@@ -251,32 +251,32 @@ namespace sistrip {
     }//loop on input channels
 
 
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > lPeds(new edm::DetSetVector<SiStripRawDigi>(pedsData,true));
-    std::auto_ptr<edm::DetSetVector<SiStripProcessedRawDigi> > lNoises(new edm::DetSetVector<SiStripProcessedRawDigi>(noiseData,true));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > lPeds(new edm::DetSetVector<SiStripRawDigi>(pedsData,true));
+    std::unique_ptr<edm::DetSetVector<SiStripProcessedRawDigi> > lNoises(new edm::DetSetVector<SiStripProcessedRawDigi>(noiseData,true));
 
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > lOutputPedSubtr(new edm::DetSetVector<SiStripRawDigi>(pedSubtrData,true));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > lOutputPedSubtr(new edm::DetSetVector<SiStripRawDigi>(pedSubtrData,true));
 
-    std::auto_ptr<edm::DetSetVector<SiStripRawDigi> > lOutputCMSubtr(new edm::DetSetVector<SiStripRawDigi>(cmSubtrData,true));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > lOutputCMSubtr(new edm::DetSetVector<SiStripRawDigi>(cmSubtrData,true));
 
-    std::auto_ptr<std::map<uint32_t,std::vector<uint32_t> > > lMedians(new std::map<uint32_t,std::vector<uint32_t> >(medsData));
+    std::unique_ptr<std::map<uint32_t,std::vector<uint32_t> > > lMedians(new std::map<uint32_t,std::vector<uint32_t> >(medsData));
   
     //zero suppressed digis
-    std::auto_ptr< edm::DetSetVector<SiStripDigi> > lOutputZS(new edm::DetSetVector<SiStripDigi>(zsData));
+    std::unique_ptr< edm::DetSetVector<SiStripDigi> > lOutputZS(new edm::DetSetVector<SiStripDigi>(zsData));
     
     if (!byModule_) {
-      iEvent.put(lMedians,"Medians");
-      iEvent.put(lPeds,"PedestalsOrdered");
-      iEvent.put(lNoises,"NoisesOrdered");
-      iEvent.put(lOutputPedSubtr,"PedSubtrDigisOrdered");
-      iEvent.put(lOutputCMSubtr,"CMSubtrDigisOrdered");
+      iEvent.put(std::move(lMedians),"Medians");
+      iEvent.put(std::move(lPeds),"PedestalsOrdered");
+      iEvent.put(std::move(lNoises),"NoisesOrdered");
+      iEvent.put(std::move(lOutputPedSubtr),"PedSubtrDigisOrdered");
+      iEvent.put(std::move(lOutputCMSubtr),"CMSubtrDigisOrdered");
     }
     else {
-      iEvent.put(lPeds,"ModulePedestals");
-      iEvent.put(lNoises,"ModuleNoises");
-      iEvent.put(lOutputPedSubtr,"PedSubtrModuleDigis");
-      iEvent.put(lMedians,"ModuleMedians");
-      iEvent.put(lOutputCMSubtr,"CMSubtrModuleDigis");
-      iEvent.put(lOutputZS,"ZSModuleDigis");
+      iEvent.put(std::move(lPeds),"ModulePedestals");
+      iEvent.put(std::move(lNoises),"ModuleNoises");
+      iEvent.put(std::move(lOutputPedSubtr),"PedSubtrModuleDigis");
+      iEvent.put(std::move(lMedians),"ModuleMedians");
+      iEvent.put(std::move(lOutputCMSubtr),"CMSubtrModuleDigis");
+      iEvent.put(std::move(lOutputZS),"ZSModuleDigis");
     }
 
   }//produce method

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverter.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverter.cc
@@ -20,7 +20,7 @@
 
 namespace sistrip {
 
-  std::auto_ptr<SpyDigiConverter::DSVRawDigis> 
+  std::unique_ptr<SpyDigiConverter::DSVRawDigis> 
   SpyDigiConverter::extractPayloadDigis(const DSVRawDigis* inputScopeDigis,
 					std::vector<uint32_t> * pAPVAddresses,
 					const bool discardDigisWithAPVAddrErr,
@@ -112,7 +112,7 @@ namespace sistrip {
     }
 
     //return DSV of output
-    return std::auto_ptr<DSVRawDigis>( new DSVRawDigis(outputData, true) );
+    return std::unique_ptr<DSVRawDigis>( new DSVRawDigis(outputData, true) );
     
   } // end of SpyDigiConverter::extractPayloadDigis method
 
@@ -181,7 +181,7 @@ namespace sistrip {
 
 
 
-  std::auto_ptr<SpyDigiConverter::DSVRawDigis> SpyDigiConverter::reorderDigis(const DSVRawDigis* inputPayloadDigis)
+  std::unique_ptr<SpyDigiConverter::DSVRawDigis> SpyDigiConverter::reorderDigis(const DSVRawDigis* inputPayloadDigis)
   {
     // Data is already sorted so push back fast into vector to avoid sorts and create DSV later
     std::vector<DetSetRawDigis> outputData;
@@ -202,10 +202,10 @@ namespace sistrip {
     }
     
     //return DSV of output
-    return std::auto_ptr<DSVRawDigis>( new DSVRawDigis(outputData,true) );
+    return std::unique_ptr<DSVRawDigis>( new DSVRawDigis(outputData,true) );
   } // end of SpyDigiConverter::reorderDigis method.
 
-  std::auto_ptr<SpyDigiConverter::DSVRawDigis>
+  std::unique_ptr<SpyDigiConverter::DSVRawDigis>
   SpyDigiConverter::mergeModuleChannels(const DSVRawDigis* inputPhysicalOrderChannelDigis, 
 					const SiStripFedCabling& cabling)
   {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
@@ -124,9 +124,9 @@ namespace sistrip {
     event.getByToken(productToken_, scopeDigisHandle);
     
     //32-bit to accomodate known CMSSW container
-    std::auto_ptr< std::vector<uint32_t> > pAPVAddresses(new std::vector<uint32_t>);
+    std::unique_ptr< std::vector<uint32_t> > pAPVAddresses(new std::vector<uint32_t>);
         
-    std::auto_ptr<sistrip::SpyDigiConverter::DSVRawDigis> payloadDigis, reorderedDigis, moduleDigis;
+    std::unique_ptr<sistrip::SpyDigiConverter::DSVRawDigis> payloadDigis, reorderedDigis, moduleDigis;
     
     //get the majority value for expected position of first header bit
     //from first event, compare to expected one, else output warning.
@@ -164,11 +164,11 @@ namespace sistrip {
     }
     
     //add to event
-    if (storePayloadDigis_) event.put(payloadDigis,"Payload");
-    if (storeReorderedDigis_) event.put(reorderedDigis,"Reordered");
-    if (storeModuleDigis_) event.put(moduleDigis,"VirginRaw");
+    if (storePayloadDigis_) event.put(std::move(payloadDigis),"Payload");
+    if (storeReorderedDigis_) event.put(std::move(reorderedDigis),"Reordered");
+    if (storeModuleDigis_) event.put(std::move(moduleDigis),"VirginRaw");
     if (storeAPVAddress_) {
-      event.put(pAPVAddresses, "APVAddress");
+      event.put(std::move(pAPVAddresses), "APVAddress");
     }
         
 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -229,10 +229,9 @@ namespace sistrip {
     MatchingOutput mo(outputRawData);
     source_->loopSpecified(*eventPrincipal_,fileNameHash,matchingEvents->begin(),matchingEvents->end(),boost::bind(&SpyEventMatcher::getCollections,this,_1,
                                                        eventId,apvAddress,boost::cref(cabling),boost::ref(mo)));
-    SpyDataCollections collections(mo.outputRawData_,mo.outputTotalEventCounters_,mo.outputL1ACounters_,mo.outputAPVAddresses_,
+    collectionsToCreate = SpyDataCollections(mo.outputRawData_,mo.outputTotalEventCounters_,mo.outputL1ACounters_,mo.outputAPVAddresses_,
                                    mo.outputScopeDigisVector_.get(),mo.outputPayloadDigisVector_.get(),
                                    mo.outputReorderedDigisVector_.get(),mo.outputVirginRawDigisVector_.get());
-    collectionsToCreate = collections;
   }
   
   void SpyEventMatcher::findMatchingFeds(const uint32_t eventId, const uint8_t apvAddress,
@@ -410,18 +409,6 @@ namespace sistrip {
       reorderedDigis(),
       virginRawDigis()
   {}
-  
-  SpyEventMatcher::SpyDataCollections& SpyEventMatcher::SpyDataCollections::operator = (SpyDataCollections original)
-  {
-    rawData = original.rawData;
-    totalEventCounters = original.totalEventCounters;
-    l1aCounters = original.l1aCounters;
-    apvAddresses = original.apvAddresses;
-    scopeDigis = original.scopeDigis;
-    payloadDigis = original.payloadDigis;
-    virginRawDigis = original.virginRawDigis;
-    return *this;
-  }
   
   SpyEventMatcher::CountersWrapper::CountersWrapper(const Counters* theCounters)
     : pConst(theCounters),

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -44,8 +44,8 @@ namespace sistrip {
       const bool doMerge_;
       const edm::InputTag primaryStreamRawDataTag_;
     edm::EDGetTokenT<FEDRawDataCollection> primaryStreamRawDataToken_;
-      std::auto_ptr<SpyEventMatcher> spyEventMatcher_;
-      std::auto_ptr<SpyUtilities> utils_;
+      std::unique_ptr<SpyEventMatcher> spyEventMatcher_;
+      std::unique_ptr<SpyUtilities> utils_;
   };
   
 }
@@ -116,7 +116,7 @@ namespace sistrip {
         LogDebug(messageLabel_) << "Failed to get FED data for FED ID " << *iFedId;
         continue;
       }
-      std::auto_ptr<FEDBuffer> buffer;
+      std::unique_ptr<FEDBuffer> buffer;
       try {
         buffer.reset(new FEDBuffer(data.data(),data.size()));
       } catch (const cms::Exception& e) {
@@ -159,14 +159,14 @@ namespace sistrip {
   {
     SpyEventMatcher::SpyDataCollections matchedCollections;
     spyEventMatcher_->getMatchedCollections(eventId,apvAddress,matches,cabling,matchedCollections);
-    if (matchedCollections.rawData.get()) event.put(matchedCollections.rawData,"RawSpyData");
-    if (matchedCollections.totalEventCounters.get()) event.put(matchedCollections.totalEventCounters,"SpyTotalEventCount");
-    if (matchedCollections.l1aCounters.get()) event.put(matchedCollections.l1aCounters,"SpyL1ACount");
-    if (matchedCollections.apvAddresses.get()) event.put(matchedCollections.apvAddresses,"SpyAPVAddress");
-    if (matchedCollections.scopeDigis.get()) event.put(matchedCollections.scopeDigis,"SpyScope");
-    if (matchedCollections.payloadDigis.get()) event.put(matchedCollections.payloadDigis,"SpyPayload");
-    if (matchedCollections.reorderedDigis.get()) event.put(matchedCollections.reorderedDigis,"SpyReordered");
-    if (matchedCollections.virginRawDigis.get()) event.put(matchedCollections.virginRawDigis,"SpyVirginRaw");
+    if (matchedCollections.rawData.get()) event.put(std::move(matchedCollections.rawData),"RawSpyData");
+    if (matchedCollections.totalEventCounters.get()) event.put(std::move(matchedCollections.totalEventCounters),"SpyTotalEventCount");
+    if (matchedCollections.l1aCounters.get()) event.put(std::move(matchedCollections.l1aCounters),"SpyL1ACount");
+    if (matchedCollections.apvAddresses.get()) event.put(std::move(matchedCollections.apvAddresses),"SpyAPVAddress");
+    if (matchedCollections.scopeDigis.get()) event.put(std::move(matchedCollections.scopeDigis),"SpyScope");
+    if (matchedCollections.payloadDigis.get()) event.put(std::move(matchedCollections.payloadDigis),"SpyPayload");
+    if (matchedCollections.reorderedDigis.get()) event.put(std::move(matchedCollections.reorderedDigis),"SpyReordered");
+    if (matchedCollections.virginRawDigis.get()) event.put(std::move(matchedCollections.virginRawDigis),"SpyVirginRaw");
   }
   
 }

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -76,7 +76,7 @@ namespace sistrip {
     for (uint16_t fedId = sistrip::FED_ID_MIN; fedId <= sistrip::FED_ID_MAX; ++fedId) {
       const FEDRawData& fedData = rawData.FEDData(fedId);
       if (fedData.size() && fedData.data()) {
-        std::auto_ptr<sistrip::FEDBufferBase> pBuffer;
+        std::unique_ptr<sistrip::FEDBufferBase> pBuffer;
         try {
           pBuffer.reset(new sistrip::FEDBufferBase(fedData.data(),fedData.size()));
         } catch (const cms::Exception& e) {
@@ -95,7 +95,7 @@ namespace sistrip {
     }
     
     //create summary object
-    std::auto_ptr<SiStripEventSummary> pSummary(new SiStripEventSummary);
+    std::unique_ptr<SiStripEventSummary> pSummary(new SiStripEventSummary);
     //set the trigger FED number to zero to indicate that it doesn't exist
     pSummary->triggerFed(0);
     //set the event number and Bx from the FED packets
@@ -119,7 +119,7 @@ namespace sistrip {
     pSummary->commissioningInfo(fakeTriggerFedData.get(),fedEventNumber);
     
     //store in event
-    event.put(pSummary);
+    event.put(std::move(pSummary));
   }
   
   void SpyEventSummaryProducer::warnAboutUnsupportedRunType()

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
@@ -145,13 +145,13 @@ namespace sistrip {
     event.getByToken( productToken_, buffers ); 
     
     //create container for digis
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > digis(new edm::DetSetVector<SiStripRawDigi>);
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > digis(new edm::DetSetVector<SiStripRawDigi>);
     
     //if necessary, create container for event counters
-    std::auto_ptr< std::vector<uint32_t> > pTotalCounts(new std::vector<uint32_t>);
-    std::auto_ptr< std::vector<uint32_t> > pL1ACounts(new std::vector<uint32_t>);
+    std::unique_ptr< std::vector<uint32_t> > pTotalCounts(new std::vector<uint32_t>);
+    std::unique_ptr< std::vector<uint32_t> > pL1ACounts(new std::vector<uint32_t>);
     //and for run number
-    std::auto_ptr<uint32_t> pGlobalRun(new uint32_t);
+    std::unique_ptr<uint32_t> pGlobalRun(new uint32_t);
     //create digis
     // Using FED IDs...
     unpacker_->createDigis(*lCabling, 
@@ -164,16 +164,16 @@ namespace sistrip {
 			   );
     
     // Add digis to event
-    if (storeScopeRawDigis_) event.put( digis, "ScopeRawDigis" );
+    if (storeScopeRawDigis_) event.put(std::move(digis), "ScopeRawDigis" );
     
     //add counters to event
     if (storeCounters_) {
-      event.put(pTotalCounts, "TotalEventCount");
-      event.put(pL1ACounts, "L1ACount");
+      event.put(std::move(pTotalCounts), "TotalEventCount");
+      event.put(std::move(pL1ACounts), "L1ACount");
     }
 
     //add global run to the event
-    event.put(pGlobalRun, "GlobalRunNumber");
+    event.put(std::move(pGlobalRun), "GlobalRunNumber");
 
   } // end of SpyUnpackerModule::produce method.
 

--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -113,7 +113,7 @@ public:
   void doPFTaus(edm::Event&,const edm::EventSetup&);
   void doMuons(edm::Event&,const edm::EventSetup&);
   void doElectrons(edm::Event&,const edm::EventSetup&);
-  void doElectronsFromZ(edm::Event&,const edm::EventSetup&,std::auto_ptr<LorentzVectorCollection>&);
+  void doElectronsFromZ(edm::Event&,const edm::EventSetup&,std::unique_ptr<LorentzVectorCollection>&);
   double ElectronTrkIsolation(const reco::TrackCollection*, const reco::GsfElectron&);
   void doJets(edm::Event&,const edm::EventSetup&);
   void doPhotons(edm::Event&,const edm::EventSetup&);

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -127,7 +127,7 @@ void HLTTauRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 void 
 HLTTauRefProducer::doPFTaus(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      auto_ptr<LorentzVectorCollection> product_PFTaus(new LorentzVectorCollection);
+      unique_ptr<LorentzVectorCollection> product_PFTaus(new LorentzVectorCollection);
       //Retrieve the collection
       edm::Handle<PFTauCollection> pftaus;
       if(iEvent.getByToken(PFTaus_,pftaus)) {
@@ -155,14 +155,14 @@ HLTTauRefProducer::doPFTaus(edm::Event& iEvent,const edm::EventSetup& iES)
               }
         }
       }
-      iEvent.put(product_PFTaus,"PFTaus");
+      iEvent.put(std::move(product_PFTaus),"PFTaus");
 }
 
 
 void 
 HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-  auto_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
   //Retrieve the collections
   
   edm::Handle<reco::ElectronIDAssociationCollection> pEleID;
@@ -179,7 +179,7 @@ HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
   iEvent.getByToken(e_ctfTrackCollection_, pCtfTracks);
   if (!pCtfTracks.isValid()) {
   edm::LogInfo("")<< "Error! Can't get " << e_ctfTrackCollectionSrc_.label() << " by label. ";
-  iEvent.put(product_Electrons,"Electrons"); 
+  iEvent.put(std::move(product_Electrons),"Electrons"); 
   return;
   }
   const reco::TrackCollection * ctfTracks = pCtfTracks.product();
@@ -228,13 +228,13 @@ HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
 	  }
       }
   
-  iEvent.put(product_Electrons,"Electrons"); 
+  iEvent.put(std::move(product_Electrons),"Electrons"); 
 }
 
 void 
 HLTTauRefProducer::doMuons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-  auto_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
   //Retrieve the collection
   edm::Handle<MuonCollection> muons;
       if(iEvent.getByToken(Muons_,muons))
@@ -250,7 +250,7 @@ HLTTauRefProducer::doMuons(edm::Event& iEvent,const edm::EventSetup& iES)
 	}
 
 
-      iEvent.put(product_Muons,"Muons");
+      iEvent.put(std::move(product_Muons),"Muons");
  
 }
 
@@ -258,7 +258,7 @@ HLTTauRefProducer::doMuons(edm::Event& iEvent,const edm::EventSetup& iES)
 void 
 HLTTauRefProducer::doJets(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      auto_ptr<LorentzVectorCollection> product_Jets(new LorentzVectorCollection);
+      unique_ptr<LorentzVectorCollection> product_Jets(new LorentzVectorCollection);
       //Retrieve the collection
       edm::Handle<CaloJetCollection> jets;
       if(iEvent.getByToken(Jets_,jets))
@@ -270,13 +270,13 @@ HLTTauRefProducer::doJets(edm::Event& iEvent,const edm::EventSetup& iES)
 		product_Jets->push_back(vec);
 	      }
 	}
-      iEvent.put(product_Jets,"Jets");
+      iEvent.put(std::move(product_Jets),"Jets");
 }
 
 void 
 HLTTauRefProducer::doTowers(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      auto_ptr<LorentzVectorCollection> product_Towers(new LorentzVectorCollection);
+      unique_ptr<LorentzVectorCollection> product_Towers(new LorentzVectorCollection);
       //Retrieve the collection
       edm::Handle<CaloTowerCollection> towers;
       if(iEvent.getByToken(Towers_,towers))
@@ -299,14 +299,14 @@ HLTTauRefProducer::doTowers(edm::Event& iEvent,const edm::EventSetup& iES)
 		  }
 	      }
 	}
-      iEvent.put(product_Towers,"Towers");
+      iEvent.put(std::move(product_Towers),"Towers");
 }
 
 
 void 
 HLTTauRefProducer::doPhotons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      auto_ptr<LorentzVectorCollection> product_Gammas(new LorentzVectorCollection);
+      unique_ptr<LorentzVectorCollection> product_Gammas(new LorentzVectorCollection);
       //Retrieve the collection
       edm::Handle<PhotonCollection> photons;
       if(iEvent.getByToken(Photons_,photons))
@@ -319,13 +319,13 @@ HLTTauRefProducer::doPhotons(edm::Event& iEvent,const edm::EventSetup& iES)
 		product_Gammas->push_back(vec);
 	      }
 	}
-      iEvent.put(product_Gammas,"Photons");
+      iEvent.put(std::move(product_Gammas),"Photons");
 }
 
 void
 HLTTauRefProducer::doMET(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-  auto_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
   //Retrieve the collection
   edm::Handle<reco::CaloMETCollection> met;
   if(iEvent.getByToken(MET_,met)){
@@ -335,6 +335,6 @@ HLTTauRefProducer::doMET(edm::Event& iEvent,const edm::EventSetup& iES)
     LorentzVector vec(px,py,0,pt);
     product_MET->push_back(vec);
   }
-  iEvent.put(product_MET,"MET");  
+  iEvent.put(std::move(product_MET),"MET");  
 }
 

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -456,18 +456,18 @@ MEtoEDMConverter::putData(T& iPutTo,
     }
   }
 
-  std::auto_ptr<MEtoEDM<long long> > pOutInt(new MEtoEDM<long long>(nInt64));
-  std::auto_ptr<MEtoEDM<double> > pOutDouble(new MEtoEDM<double>(nDouble));
-  std::auto_ptr<MEtoEDM<TString> > pOutString(new MEtoEDM<TString>(nString));
-  std::auto_ptr<MEtoEDM<TH1F> > pOut1(new MEtoEDM<TH1F>(n1F));
-  std::auto_ptr<MEtoEDM<TH1S> > pOut1s(new MEtoEDM<TH1S>(n1S));
-  std::auto_ptr<MEtoEDM<TH1D> > pOut1d(new MEtoEDM<TH1D>(n1D));
-  std::auto_ptr<MEtoEDM<TH2F> > pOut2(new MEtoEDM<TH2F>(n2F));
-  std::auto_ptr<MEtoEDM<TH2S> > pOut2s(new MEtoEDM<TH2S>(n2S));
-  std::auto_ptr<MEtoEDM<TH2D> > pOut2d(new MEtoEDM<TH2D>(n2D));
-  std::auto_ptr<MEtoEDM<TH3F> > pOut3(new MEtoEDM<TH3F>(n3F));
-  std::auto_ptr<MEtoEDM<TProfile> > pOutProf(new MEtoEDM<TProfile>(nProf));
-  std::auto_ptr<MEtoEDM<TProfile2D> > pOutProf2(new MEtoEDM<TProfile2D>(nProf2));
+  std::unique_ptr<MEtoEDM<long long> > pOutInt(new MEtoEDM<long long>(nInt64));
+  std::unique_ptr<MEtoEDM<double> > pOutDouble(new MEtoEDM<double>(nDouble));
+  std::unique_ptr<MEtoEDM<TString> > pOutString(new MEtoEDM<TString>(nString));
+  std::unique_ptr<MEtoEDM<TH1F> > pOut1(new MEtoEDM<TH1F>(n1F));
+  std::unique_ptr<MEtoEDM<TH1S> > pOut1s(new MEtoEDM<TH1S>(n1S));
+  std::unique_ptr<MEtoEDM<TH1D> > pOut1d(new MEtoEDM<TH1D>(n1D));
+  std::unique_ptr<MEtoEDM<TH2F> > pOut2(new MEtoEDM<TH2F>(n2F));
+  std::unique_ptr<MEtoEDM<TH2S> > pOut2s(new MEtoEDM<TH2S>(n2S));
+  std::unique_ptr<MEtoEDM<TH2D> > pOut2d(new MEtoEDM<TH2D>(n2D));
+  std::unique_ptr<MEtoEDM<TH3F> > pOut3(new MEtoEDM<TH3F>(n3F));
+  std::unique_ptr<MEtoEDM<TProfile> > pOutProf(new MEtoEDM<TProfile>(nProf));
+  std::unique_ptr<MEtoEDM<TProfile2D> > pOutProf2(new MEtoEDM<TProfile2D>(nProf2));
 
   for (mmi = items.begin (), mme = items.end (); mmi != mme; ++mmi) {
 
@@ -554,18 +554,18 @@ MEtoEDMConverter::putData(T& iPutTo,
   }
 
   // produce objects to put in events
-  iPutTo.put(pOutInt,sName);
-  iPutTo.put(pOutDouble,sName);
-  iPutTo.put(pOutString,sName);
-  iPutTo.put(pOut1,sName);
-  iPutTo.put(pOut1s,sName);
-  iPutTo.put(pOut1d,sName);
-  iPutTo.put(pOut2,sName);
-  iPutTo.put(pOut2s,sName);
-  iPutTo.put(pOut2d,sName);
-  iPutTo.put(pOut3,sName);
-  iPutTo.put(pOutProf,sName);
-  iPutTo.put(pOutProf2,sName);
+  iPutTo.put(std::move(pOutInt),sName);
+  iPutTo.put(std::move(pOutDouble),sName);
+  iPutTo.put(std::move(pOutString),sName);
+  iPutTo.put(std::move(pOut1),sName);
+  iPutTo.put(std::move(pOut1s),sName);
+  iPutTo.put(std::move(pOut1d),sName);
+  iPutTo.put(std::move(pOut2),sName);
+  iPutTo.put(std::move(pOut2s),sName);
+  iPutTo.put(std::move(pOut2d),sName);
+  iPutTo.put(std::move(pOut3),sName);
+  iPutTo.put(std::move(pOutProf),sName);
+  iPutTo.put(std::move(pOutProf2),sName);
 
 }
 

--- a/DQMServices/Components/test/DummyBookFillDQMStore.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStore.cc
@@ -278,8 +278,8 @@ DummyBookFillDQMStore::analyze(edm::Event const& iEvent,
 
   //Use the ExampleData to create an ExampleData2 which
   // is put into the Event
-  std::auto_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-  iEvent.put(pOut);
+  std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
+  iEvent.put(std::move(pOut));
   */
 
   /* this is an EventSetup example

--- a/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
@@ -270,8 +270,8 @@ DummyBookFillDQMStoreMultiThread::analyze(edm::Event const& iEvent,
 
   //Use the ExampleData to create an ExampleData2 which
   // is put into the Event
-  std::auto_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-  iEvent.put(pOut);
+  std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
+  iEvent.put(std::move(pOut));
   */
 
   /* this is an EventSetup example

--- a/DQMServices/Components/test/DummyTestReadDQMStore.cc
+++ b/DQMServices/Components/test/DummyTestReadDQMStore.cc
@@ -239,8 +239,8 @@ DummyTestReadDQMStore::analyze(edm::Event const& iEvent, edm::EventSetup const& 
 
   //Use the ExampleData to create an ExampleData2 which 
   // is put into the Event
-  std::auto_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-  iEvent.put(pOut);
+  std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
+  iEvent.put(std::move(pOut));
   */
 
   /* this is an EventSetup example

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -116,11 +116,11 @@ void DQMProtobufReader::beginLuminosityBlock(edm::LuminosityBlock& lb) {
   std::string path = currentLumi_.get_data_path();
   std::string jspath = currentLumi_.get_json_path();
 
-  std::auto_ptr<std::string> path_product(new std::string(path));
-  std::auto_ptr<std::string> json_product(new std::string(jspath));
+  std::unique_ptr<std::string> path_product(new std::string(path));
+  std::unique_ptr<std::string> json_product(new std::string(jspath));
 
-  lb.put(path_product, "sourceDataPath");
-  lb.put(json_product, "sourceJsonPath");
+  lb.put(std::move(path_product), "sourceDataPath");
+  lb.put(std::move(json_product), "sourceJsonPath");
 
   if (flagLoadFiles_) {
     if (!boost::filesystem::exists(path)) {

--- a/HLTriggerOffline/Common/src/HltComparator.cc
+++ b/HLTriggerOffline/Common/src/HltComparator.cc
@@ -164,7 +164,7 @@ HltComparator::filter(edm::Event & event,
   event.getByToken(hltOnlineResults_, onlineResults);
   event.getByToken(hltOfflineResults_, offlineResults);
 
-  std::auto_ptr<StringCollection> resultDescription(new StringCollection);
+  std::unique_ptr<StringCollection> resultDescription(new StringCollection);
   
   // Initialise comparator if required
   if (!init_) {
@@ -267,7 +267,7 @@ HltComparator::filter(edm::Event & event,
   }
 
   //std::cout << " HERE I STAY " << std::endl;
-  event.put(resultDescription,"failedTriggerDescription");
+  event.put(std::move(resultDescription),"failedTriggerDescription");
   //std::cout << " HERE I WENT " << std::endl;
 
   if ( hasDisagreement ) 

--- a/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
@@ -36,16 +36,16 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 {
   //All the code from HLTTauMCInfo is here :-) 
   
-  auto_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_Leptons(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_OneProng(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_ThreeProng(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_OneAndThreeProng(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_Other(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_Neutrina(new LorentzVectorCollection);
-  auto_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
-  auto_ptr<std::vector<int> > product_Mothers(new std::vector<int>);
+  unique_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Leptons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_OneProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_ThreeProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_OneAndThreeProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Other(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Neutrina(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
+  unique_ptr<std::vector<int> > product_Mothers(new std::vector<int>);
   
   edm::Handle<GenParticleCollection> genParticles;
   iEvent.getByToken(MC_, genParticles);
@@ -254,16 +254,16 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
     }
   }
 
-  iEvent.put(product_Leptons,"LeptonicTauLeptons");
-  iEvent.put(product_Electrons,"LeptonicTauElectrons");
-  iEvent.put(product_Muons,"LeptonicTauMuons");
-  iEvent.put(product_OneProng,"HadronicTauOneProng");
-  iEvent.put(product_ThreeProng,"HadronicTauThreeProng");
-  iEvent.put(product_OneAndThreeProng,"HadronicTauOneAndThreeProng");
-  iEvent.put(product_Other, "TauOther");
-  iEvent.put(product_Neutrina,"Neutrina");
-  iEvent.put(product_MET,"MET"); 
-  iEvent.put(product_Mothers,"Mothers"); 
+  iEvent.put(std::move(product_Leptons), "LeptonicTauLeptons");
+  iEvent.put(std::move(product_Electrons), "LeptonicTauElectrons");
+  iEvent.put(std::move(product_Muons), "LeptonicTauMuons");
+  iEvent.put(std::move(product_OneProng), "HadronicTauOneProng");
+  iEvent.put(std::move(product_ThreeProng), "HadronicTauThreeProng");
+  iEvent.put(std::move(product_OneAndThreeProng), "HadronicTauOneAndThreeProng");
+  iEvent.put(std::move(product_Other), "TauOther");
+  iEvent.put(std::move(product_Neutrina), "Neutrina");
+  iEvent.put(std::move(product_MET), "MET"); 
+  iEvent.put(std::move(product_Mothers), "Mothers"); 
   
 }
 

--- a/HLTriggerOffline/Tau/src/HLTTauRefCombiner.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauRefCombiner.cc
@@ -23,7 +23,7 @@ HLTTauRefCombiner::~HLTTauRefCombiner(){ }
 
 void HLTTauRefCombiner::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 {
-    auto_ptr<LorentzVectorCollection> out_product(new LorentzVectorCollection);
+    unique_ptr<LorentzVectorCollection> out_product(new LorentzVectorCollection);
 
     //Create The Handles..
     std::vector< Handle<LorentzVectorCollection> > handles;
@@ -73,7 +73,7 @@ void HLTTauRefCombiner::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 	  }
 
 	//Put product to file
-	iEvent.put(out_product,outName_);
+	iEvent.put(std::move(out_product),outName_);
 
       }
     

--- a/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
@@ -45,9 +45,9 @@ EcalSimHitsValidProducer::~EcalSimHitsValidProducer(){
 void
 EcalSimHitsValidProducer::produce(edm::Event& e, const edm::EventSetup&)
 {
-   std::auto_ptr<PEcalValidInfo> product(new PEcalValidInfo );
+   std::unique_ptr<PEcalValidInfo> product(new PEcalValidInfo );
    fillEventInfo(*product);
-   e.put(product,label);
+   e.put(std::move(product),label);
 }
 
 void 

--- a/Validation/GlobalDigis/src/GlobalDigisProducer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisProducer.cc
@@ -256,7 +256,7 @@ void GlobalDigisProducer::produce(edm::Event& iEvent,
       << "Done gathering data from event.";
 
   // produce object to put into event
-  std::auto_ptr<PGlobalDigi> pOut(new PGlobalDigi);
+  std::unique_ptr<PGlobalDigi> pOut(new PGlobalDigi);
 
   if (verbosity > 2)
     edm::LogInfo (MsgLoggerCat)
@@ -273,7 +273,7 @@ void GlobalDigisProducer::produce(edm::Event& iEvent,
   storeMuon(*pOut);
 
   // store information in event
-  iEvent.put(pOut,label);
+  iEvent.put(std::move(pOut),label);
 
   return;
 }
@@ -319,10 +319,10 @@ void GlobalDigisProducer::fillECal(edm::Event& iEvent,
 	<< "Unable to find cal barrel crossingFrame in event!";
       return;
     }
-    //std::auto_ptr<MixCollection<PCaloHit> >
+    //std::unique_ptr<MixCollection<PCaloHit> >
     //barrelHits(new MixCollection<PCaloHit>
     //		 (crossingFrame.product(), barrelHitsName));
-    std::auto_ptr<MixCollection<PCaloHit> >
+    std::unique_ptr<MixCollection<PCaloHit> >
       barrelHits(new MixCollection<PCaloHit>(crossingFrame.product()));
 
     // keep track of sum of simhit energy in each crystal
@@ -439,10 +439,10 @@ void GlobalDigisProducer::fillECal(edm::Event& iEvent,
 	<< "Unable to find cal endcap crossingFrame in event!";
       return;
     }
-    //std::auto_ptr<MixCollection<PCaloHit> >
+    //std::unique_ptr<MixCollection<PCaloHit> >
     //  endcapHits(new MixCollection<PCaloHit>
     //	 (crossingFrame.product(), endcapHitsName));
-    std::auto_ptr<MixCollection<PCaloHit> >
+    std::unique_ptr<MixCollection<PCaloHit> >
       endcapHits(new MixCollection<PCaloHit>(crossingFrame.product()));
 
     // keep track of sum of simhit energy in each crystal
@@ -559,10 +559,10 @@ void GlobalDigisProducer::fillECal(edm::Event& iEvent,
 	<< "Unable to find cal preshower crossingFrame in event!";
       return;
     }
-    //std::auto_ptr<MixCollection<PCaloHit> >
+    //std::unique_ptr<MixCollection<PCaloHit> >
     //  preshowerHits(new MixCollection<PCaloHit>
     //		 (crossingFrame.product(), preshowerHitsName));
-   std::auto_ptr<MixCollection<PCaloHit> >
+   std::unique_ptr<MixCollection<PCaloHit> >
       preshowerHits(new MixCollection<PCaloHit>(crossingFrame.product()));
 
     // keep track of sum of simhit energy in each crystal

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -722,9 +722,9 @@ void GlobalHitsProdHist::endRunProduce(edm::Run& iRun, const edm::EventSetup& iS
   for (std::size_t i = 0; i < histName_.size(); ++i) {
     iter = histMap_.find(histName_[i]);
     if (iter != histMap_.end()) {
-      std::auto_ptr<TH1F> hist1D(iter->second);
+      std::unique_ptr<TH1F> hist1D(iter->second);
       eventout += "\n Storing histogram " + histName_[i];
-      iRun.put(hist1D, histName_[i]);
+      iRun.put(std::move(hist1D), histName_[i]);
     } else {
       warning = true;
       eventoutw += "\n Unable to find histogram with name " + histName_[i];

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -245,7 +245,7 @@ void GlobalHitsProducer::produce(edm::Event& iEvent,
       << "Done gathering data from event.";
 
   // produce object to put into event
-  std::auto_ptr<PGlobalSimHit> pOut(new PGlobalSimHit);
+  std::unique_ptr<PGlobalSimHit> pOut(new PGlobalSimHit);
 
   if (verbosity > 2)
     edm::LogInfo (MsgLoggerCat)
@@ -264,7 +264,7 @@ void GlobalHitsProducer::produce(edm::Event& iEvent,
   storeHCal(*pOut);
 
   // store information in event
-  iEvent.put(pOut,label);
+  iEvent.put(std::move(pOut),label);
 
   return;
 }

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -216,7 +216,7 @@ void GlobalRecHitsProducer::produce(edm::Event& iEvent,
       << "Done gathering data from event.";
 
   // produce object to put into event
-  std::auto_ptr<PGlobalRecHit> pOut(new PGlobalRecHit);
+  std::unique_ptr<PGlobalRecHit> pOut(new PGlobalRecHit);
 
   if (verbosity > 2)
     edm::LogInfo (MsgLoggerCat)
@@ -233,7 +233,7 @@ void GlobalRecHitsProducer::produce(edm::Event& iEvent,
   storeMuon(*pOut);
 
   // store information in event
-  iEvent.put(pOut,label);
+  iEvent.put(std::move(pOut),label);
 
   return;
 }
@@ -283,10 +283,10 @@ void GlobalRecHitsProducer::fillECal(edm::Event& iEvent,
       << "Unable to find cal barrel crossingFrame in event!";
     return;
   }
-  //std::auto_ptr<MixCollection<PCaloHit> >
+  //std::unique_ptr<MixCollection<PCaloHit> >
   //  barrelHits(new MixCollection<PCaloHit>
   //	       (crossingFrame.product(), barrelHitsName));
-  std::auto_ptr<MixCollection<PCaloHit> >
+  std::unique_ptr<MixCollection<PCaloHit> >
     barrelHits(new MixCollection<PCaloHit>(crossingFrame.product()));  
 
   // keep track of sum of simhit energy in each crystal
@@ -355,10 +355,10 @@ void GlobalRecHitsProducer::fillECal(edm::Event& iEvent,
       << "Unable to find cal endcap crossingFrame in event!";
     return;
   }
-  //std::auto_ptr<MixCollection<PCaloHit> >
+  //std::unique_ptr<MixCollection<PCaloHit> >
   //  endcapHits(new MixCollection<PCaloHit>
   //	       (crossingFrame.product(), endcapHitsName));
-  std::auto_ptr<MixCollection<PCaloHit> >
+  std::unique_ptr<MixCollection<PCaloHit> >
     endcapHits(new MixCollection<PCaloHit>(crossingFrame.product()));  
 
   // keep track of sum of simhit energy in each crystal
@@ -419,10 +419,10 @@ void GlobalRecHitsProducer::fillECal(edm::Event& iEvent,
       << "Unable to find cal preshower crossingFrame in event!";
     return;
   }
-  //std::auto_ptr<MixCollection<PCaloHit> >
+  //std::unique_ptr<MixCollection<PCaloHit> >
   //  preshowerHits(new MixCollection<PCaloHit>
   //	       (crossingFrame.product(), preshowerHitsName));
-  std::auto_ptr<MixCollection<PCaloHit> >
+  std::unique_ptr<MixCollection<PCaloHit> >
     preshowerHits(new MixCollection<PCaloHit>(crossingFrame.product()));  
 
   // keep track of sum of simhit energy in each crystal

--- a/Validation/HGCalValidation/plugins/SimG4HGCalValidation.cc
+++ b/Validation/HGCalValidation/plugins/SimG4HGCalValidation.cc
@@ -126,9 +126,9 @@ SimG4HGCalValidation::~SimG4HGCalValidation() {
 
 void SimG4HGCalValidation::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<PHGCalValidInfo> productLayer(new PHGCalValidInfo);
+  std::unique_ptr<PHGCalValidInfo> productLayer(new PHGCalValidInfo);
   layerAnalysis(*productLayer);
-  e.put(productLayer,labelLayer_);
+  e.put(std::move(productLayer),labelLayer_);
 }
 
 void SimG4HGCalValidation::update(const BeginOfJob * job) {

--- a/Validation/HcalHits/src/SimG4HcalValidation.cc
+++ b/Validation/HcalHits/src/SimG4HcalValidation.cc
@@ -98,20 +98,20 @@ SimG4HcalValidation::~SimG4HcalValidation() {
 
 void SimG4HcalValidation::produce(edm::Event& e, const edm::EventSetup&) {
 
-  std::auto_ptr<PHcalValidInfoLayer> productLayer(new PHcalValidInfoLayer);
+  std::unique_ptr<PHcalValidInfoLayer> productLayer(new PHcalValidInfoLayer);
   layerAnalysis(*productLayer);
-  e.put(productLayer,labelLayer);
+  e.put(std::move(productLayer),labelLayer);
 
   if (infolevel > 0) {
-    std::auto_ptr<PHcalValidInfoNxN> productNxN(new PHcalValidInfoNxN);
+    std::unique_ptr<PHcalValidInfoNxN> productNxN(new PHcalValidInfoNxN);
     nxNAnalysis(*productNxN);
-    e.put(productNxN,labelNxN);
+    e.put(std::move(productNxN),labelNxN);
   }
 
   if (infolevel > 1) {
-    std::auto_ptr<PHcalValidInfoJets> productJets(new PHcalValidInfoJets);
+    std::unique_ptr<PHcalValidInfoJets> productJets(new PHcalValidInfoJets);
     jetAnalysis(*productJets);
-    e.put(productJets,labelJets);
+    e.put(std::move(productJets),labelJets);
   }
 }
 

--- a/Validation/RecoMuon/src/MuonSeedTrack.cc
+++ b/Validation/RecoMuon/src/MuonSeedTrack.cc
@@ -81,7 +81,7 @@ MuonSeedTrack::produce(edm::Event& event, const edm::EventSetup& eventSetup)
   theService->update(eventSetup);
 
   // the track collectios; they will be loaded in the event  
-  auto_ptr<reco::TrackCollection> trackCollection(new reco::TrackCollection());
+  unique_ptr<reco::TrackCollection> trackCollection(new reco::TrackCollection());
   // ... and its reference into the event
   reco::TrackRefProd trackCollectionRefProd = event.getRefBeforePut<reco::TrackCollection>();
 
@@ -99,7 +99,7 @@ MuonSeedTrack::produce(edm::Event& event, const edm::EventSetup& eventSetup)
     trackCollection->push_back(track);
   }
   
-  event.put(trackCollection);
+  event.put(std::move(trackCollection));
 
 }
 

--- a/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
+++ b/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
@@ -61,8 +61,8 @@ CollectionFromZLegProducer::~CollectionFromZLegProducer()
 //______________________________________________________________________________
 void CollectionFromZLegProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {  
-  std::auto_ptr<std::vector<reco::CompositeCandidate> > theTagLeg(new std::vector<reco::CompositeCandidate>) ;	     
-  std::auto_ptr<std::vector<reco::CompositeCandidate> > theProbeLeg(new std::vector<reco::CompositeCandidate>) ;	     
+  std::unique_ptr<std::vector<reco::CompositeCandidate> > theTagLeg(new std::vector<reco::CompositeCandidate>) ;	     
+  std::unique_ptr<std::vector<reco::CompositeCandidate> > theProbeLeg(new std::vector<reco::CompositeCandidate>) ;	     
   
   edm::Handle< std::vector<reco::CompositeCandidate> > theZHandle;
   iEvent.getByToken( v_RecoCompositeCandidateToken_,theZHandle );
@@ -90,8 +90,8 @@ void CollectionFromZLegProducer::produce(edm::Event& iEvent,const edm::EventSetu
 	  c++ ;
 	}
   } 
-  iEvent.put(theTagLeg  , "theTagLeg"   ) ;
-  iEvent.put(theProbeLeg, "theProbeLeg" ) ;
+  iEvent.put(std::move(theTagLeg), "theTagLeg"   ) ;
+  iEvent.put(std::move(theProbeLeg), "theProbeLeg" ) ;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
@@ -73,7 +73,7 @@ GsfElectronFromPVSelector::~GsfElectronFromPVSelector(){}
 //______________________________________________________________________________
 void GsfElectronFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {  
-  std::auto_ptr<std::vector<reco::GsfElectron> > goodGsfElectrons(new std::vector<reco::GsfElectron >);
+  std::unique_ptr<std::vector<reco::GsfElectron> > goodGsfElectrons(new std::vector<reco::GsfElectron >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
   iEvent.getByToken( v_recoVertexToken_, VertexHandle );
@@ -83,7 +83,7 @@ void GsfElectronFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup
   
   if( (VertexHandle->size() == 0) || (GsfElectronHandle->size() == 0) ) 
   {
-    iEvent.put(goodGsfElectrons);
+    iEvent.put(std::move(goodGsfElectrons));
     return ;
   }
   
@@ -102,7 +102,7 @@ void GsfElectronFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup
     }
   }  
   
-  iEvent.put(goodGsfElectrons);
+  iEvent.put(std::move(goodGsfElectrons));
   
 }
 

--- a/Validation/RecoTau/plugins/IsoTracks.cc
+++ b/Validation/RecoTau/plugins/IsoTracks.cc
@@ -61,14 +61,14 @@ IsoTracks::~IsoTracks(){}
 void IsoTracks::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
 
-  std::auto_ptr<std::vector<reco::Track> > IsoTracks(new std::vector<reco::Track >);
+  std::unique_ptr<std::vector<reco::Track> > IsoTracks(new std::vector<reco::Track >);
   
   edm::Handle< std::vector<reco::Track> > dirtyTracks;
   iEvent.getByToken( v_recoTrackToken_, dirtyTracks );
   
   if( dirtyTracks->size() == 0 ) 
   {
-    iEvent.put(IsoTracks);
+    iEvent.put(std::move(IsoTracks));
     return ;
   }
   
@@ -92,7 +92,7 @@ void IsoTracks::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 	  IsoTracks -> push_back( *dirtyTrackIt ) ; 
 	}
   }
-  iEvent.put(IsoTracks);
+  iEvent.put(std::move(IsoTracks));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/MuonFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/MuonFromPVSelector.cc
@@ -67,7 +67,7 @@ MuonFromPVSelector::~MuonFromPVSelector(){}
 //______________________________________________________________________________
 void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {  
-  std::auto_ptr<std::vector<reco::Muon> > goodMuons(new std::vector<reco::Muon >);
+  std::unique_ptr<std::vector<reco::Muon> > goodMuons(new std::vector<reco::Muon >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
   iEvent.getByToken( v_recoVertexToken_, VertexHandle );
@@ -77,7 +77,7 @@ void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   
   if( (VertexHandle->size() == 0) || (MuonHandle->size() == 0) ) 
   {
-    iEvent.put(goodMuons);
+    iEvent.put(std::move(goodMuons));
     return ;
   }
   
@@ -94,7 +94,7 @@ void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     }
   }  
   
-  iEvent.put(goodMuons);
+  iEvent.put(std::move(goodMuons));
   
 }
 

--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -122,7 +122,7 @@ ObjectViewCleaner<T>::~ObjectViewCleaner()
 template<typename T>
 void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
-  auto_ptr<edm::RefToBaseVector<T> >
+  unique_ptr<edm::RefToBaseVector<T> >
     cleanObjects(new edm::RefToBaseVector<T >());
 
   edm::Handle<edm::View<T> > candidates;
@@ -156,7 +156,7 @@ void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSe
   nObjectsClean_+=cleanObjects->size();
 
   delete [] isClean;  
-  iEvent.put(cleanObjects);
+  iEvent.put(std::move(cleanObjects));
 }
 
 

--- a/Validation/RecoTau/plugins/PVSorterBySumP.cc
+++ b/Validation/RecoTau/plugins/PVSorterBySumP.cc
@@ -63,14 +63,14 @@ bestPVselector<T1>::~bestPVselector(){}
 template<typename T1>
 void bestPVselector<T1>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {  
-  std::auto_ptr<std::vector<T1> > theBestPV(new std::vector<T1 >);
+  std::unique_ptr<std::vector<T1> > theBestPV(new std::vector<T1 >);
   
   edm::Handle< std::vector<T1> > VertexHandle;
   iEvent.getByToken(src_,VertexHandle);
   
   if( VertexHandle->size() == 0 ) 
   {
-    iEvent.put(theBestPV);
+    iEvent.put(std::move(theBestPV));
     return ;
   }
   
@@ -89,7 +89,7 @@ void bestPVselector<T1>::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   }
 
   theBestPV->push_back( *bestPV );  
-  iEvent.put(theBestPV);
+  iEvent.put(std::move(theBestPV));
   
 }
 

--- a/Validation/RecoTau/plugins/Selectors.cc
+++ b/Validation/RecoTau/plugins/Selectors.cc
@@ -102,8 +102,8 @@ ElectronIdFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
 
   //cout << "Putting in the event" << endl;
-  std::auto_ptr<reco::GsfElectronCollection> collection(product);
-  iEvent.put(collection);
+  std::unique_ptr<reco::GsfElectronCollection> collection(product);
+  iEvent.put(std::move(collection));
   return true;
 }
 

--- a/Validation/RecoTau/plugins/TrackFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/TrackFromPVSelector.cc
@@ -67,7 +67,7 @@ TrackFromPVSelector::~TrackFromPVSelector(){}
 //______________________________________________________________________________
 void TrackFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {  
-  std::auto_ptr<std::vector<reco::Track> > goodTracks(new std::vector<reco::Track >);
+  std::unique_ptr<std::vector<reco::Track> > goodTracks(new std::vector<reco::Track >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
   iEvent.getByToken( v_recoVertexToken_, VertexHandle );
@@ -77,7 +77,7 @@ void TrackFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSet
   
   if( (VertexHandle->size() == 0) || (TrackHandle->size() == 0) ) 
   {
-    iEvent.put(goodTracks);
+    iEvent.put(std::move(goodTracks));
     return ;
   }
   
@@ -92,7 +92,7 @@ void TrackFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSet
     }
   }  
   
-  iEvent.put(goodTracks);
+  iEvent.put(std::move(goodTracks));
   
 }
 

--- a/Validation/RecoTau/plugins/ZllArbitrator.cc
+++ b/Validation/RecoTau/plugins/ZllArbitrator.cc
@@ -74,14 +74,14 @@ void ZllArbitrator<T1>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup
 {
   std::stringstream ss ;
   
-  std::auto_ptr<std::vector<T1> > TheBestZ(new std::vector<T1 >);
+  std::unique_ptr<std::vector<T1> > TheBestZ(new std::vector<T1 >);
   
   edm::Handle< std::vector<T1> > ZCandidatesHandle;
   iEvent.getByToken(srcZCand_,ZCandidatesHandle);
   
   if( ZCandidatesHandle->size() == 0 ) 
   {
-    iEvent.put(TheBestZ);
+    iEvent.put(std::move(TheBestZ));
     return ;
   }
   
@@ -100,7 +100,7 @@ void ZllArbitrator<T1>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup
   }
 
   TheBestZ->push_back( *bestZCand );  
-  iEvent.put(TheBestZ);
+  iEvent.put(std::move(TheBestZ));
   
 }
 

--- a/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
+++ b/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
@@ -104,10 +104,10 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
    using namespace std;
    
    // output collection
-   auto_ptr<TrackCollection> tracks(new TrackCollection);
-   auto_ptr<TrackingRecHitCollection> rechits(new TrackingRecHitCollection);
-   auto_ptr<TrackExtraCollection> trackextras(new TrackExtraCollection);
-   auto_ptr<vector<int> > seedToTrack(new vector<int>());
+   unique_ptr<TrackCollection> tracks(new TrackCollection);
+   unique_ptr<TrackingRecHitCollection> rechits(new TrackingRecHitCollection);
+   unique_ptr<TrackExtraCollection> trackextras(new TrackExtraCollection);
+   unique_ptr<vector<int> > seedToTrack(new vector<int>());
    
    // product references 
    TrackExtraRefProd ref_trackextras = iEvent.getRefBeforePut<TrackExtraCollection>();
@@ -176,10 +176,10 @@ TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
    if (nfailed > 0) {
      edm::LogInfo("SeedValidator") << "failed to create tracks from " << nfailed <<  " out of " << seeds.size() << " seeds ";
    }
-   iEvent.put(tracks);
-   iEvent.put(seedToTrack);
-   iEvent.put(rechits);
-   iEvent.put(trackextras);
+   iEvent.put(std::move(tracks));
+   iEvent.put(std::move(seedToTrack));
+   iEvent.put(std::move(rechits));
+   iEvent.put(std::move(trackextras));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/RecoVertex/src/MCVerticesWeight.cc
+++ b/Validation/RecoVertex/src/MCVerticesWeight.cc
@@ -139,9 +139,9 @@ MCVerticesWeight::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
      
    }
    
-   std::auto_ptr<double> weight(new double(computed_weight));
+   std::unique_ptr<double> weight(new double(computed_weight));
    
-   iEvent.put(weight);
+   iEvent.put(std::move(weight));
    
    //
    

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -193,7 +193,7 @@ void TrackerHitProducer::produce(edm::Event& iEvent,
       << "Done gathering data from event.";
 
   // produce object to put into event
-  std::auto_ptr<PTrackerSimHit> pOut(new PTrackerSimHit);
+  std::unique_ptr<PTrackerSimHit> pOut(new PTrackerSimHit);
 
   if (verbosity > 2)
     edm::LogInfo ("TrackerHitProducer::produce")
@@ -206,7 +206,7 @@ void TrackerHitProducer::produce(edm::Event& iEvent,
   storeTrk(*pOut);
 
   // store information in event
-  iEvent.put(pOut,label);
+  iEvent.put(std::move(pOut),label);
 
   return;
 }


### PR DESCRIPTION
The last use of the deprecated std::auto_ptr in the CMS framework is the "put" interface for EDProducts, which also supports std::unique:ptr. This PR changes all put calls in DQM to use std::unique_ptr instead of std::auto_ptr. Some other instances of std::auto_ptr in DQM may also have been changed to std::unique_ptr. 
