### PR TITLE
Add trackless analysis in EXO DQM (80X)

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaTracklessJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaTracklessJets_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+TracklessJetsPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_SingleCentralPFJet170_CFMax0p1_v",
+        "HLT_DiCentralPFJet170_CFMax0p1_v",
+        "HLT_DiCentralPFJet220_CFMax0p3_v",
+        "HLT_DiCentralPFJet330_CFMax0p5_v",
+        "HLT_DiCentralPFJet170_v",
+        "HLT_DiCentralPFJet430_v"
+        ),
+    recPFJetLabel   = cms.InputTag("ak4PFJets"),
+    recCaloJetLabel = cms.InputTag("ak4CaloJets"),
+
+    minCandidates = cms.uint32(1),
+    # -- Analysis specific binnings
+    parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 
+                                   500, 550, 600, 650, 700, 800, 900, 1000
+                                  ),
+
+    dropPt3 = cms.bool(True)
+)

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -206,6 +206,10 @@ hltExoticaDSTMuons = hltExoticaPostProcessor.clone()
 hltExoticaDSTMuons.subDirs = ['HLT/Exotica/DSTMuons']
 hltExoticaDSTMuons.efficiencyProfile = efficiency_strings
 
+hltExoticaTracklessJets = hltExoticaPostProcessor.clone()
+hltExoticaTracklessJets.subDirs = ['HLT/Exotica/TracklessJets']
+hltExoticaTracklessJets.efficiencyProfile = efficiency_strings
+
 hltExoticaPostProcessors = cms.Sequence(
     # Tri-lepton paths
     hltExoticaPostLowPtTrimuon +
@@ -239,6 +243,7 @@ hltExoticaPostProcessors = cms.Sequence(
     hltExoticaEleMu +
     hltExoticaPhotonMET +
     hltExoticaHTDisplacedJets +
+    hltExoticaTracklessJets +
     # scouting triggers
     hltExoticaDSTJets +
     hltExoticaDSTMuons 

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -42,6 +42,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaPhotonMET_cff         import Ph
 from HLTriggerOffline.Exotica.analyses.hltExoticaSingleMuon_cff        import SingleMuonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDSTJets_cff           import DSTJetsPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDSTMuons_cff          import DSTMuonsPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaTracklessJets_cff     import TracklessJetsPSet
 
 hltExoticaValidator = cms.EDAnalyzer(
 
@@ -80,7 +81,8 @@ hltExoticaValidator = cms.EDAnalyzer(
         "PhotonMET",
         "HTDisplacedJets",
         "DSTJets",
-        "DSTMuons"
+        "DSTMuons",
+        "TracklessJets"
         ),
     
     # -- The instance name of the reco::GenParticles collection
@@ -235,5 +237,6 @@ hltExoticaValidator = cms.EDAnalyzer(
     PhotonMET        = PhotonMETPSet,
     HTDisplacedJets  = HTDisplacedJetsPSet, 
     DSTJets          = DSTJetsPSet, 
-    DSTMuons         = DSTMuonsPSet
+    DSTMuons         = DSTMuonsPSet,
+    TracklessJets    = TracklessJetsPSet
 )


### PR DESCRIPTION
New category inside the Exotica DQM, as requested by the ticket:

https://its.cern.ch/jira/browse/CMSHLT-837

Example of output in picture below: 

![dqmoutput](https://cloud.githubusercontent.com/assets/4996585/15651220/8a59fcee-2654-11e6-8927-db5951a49b31.png)
