### PR TITLE
removing max updates limit (DAQ) 81X

### DIFF
--- a/EventFilter/Utilities/src/DataPoint.cc
+++ b/EventFilter/Utilities/src/DataPoint.cc
@@ -13,7 +13,7 @@
 #include <assert.h>
 
 //max collected updates per lumi
-#define MAXUPDATES 200
+#define MAXUPDATES 0xffffffff
 #define MAXBINS
 
 using namespace jsoncollector;


### PR DESCRIPTION
Removes limit to number of updates that are taken with 1 Hz. This is currently limiting measurement of processes stuck for a long time.
Same as 80X #14687
