### PR TITLE
Fix test unit failure 

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -164,11 +164,9 @@
   <class name="std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > >"/>
   <class name="edmNew::DetSet< Phase2TrackerRecHit1D >"/>
   <class name="edmNew::DetSetVector< Phase2TrackerRecHit1D >"/>
-  <class name="edm::Ref< edmNew::DetSetVector< Phase2TrackerCluster1D >, Phase2TrackerCluster1D >"/>
   <class name="edm::Wrapper< Phase2TrackerRecHit1D >" splitLevel="0"/>
   <class name="edm::Wrapper< edmNew::DetSet< Phase2TrackerRecHit1D > >" splitLevel="0"/>
   <class name="edm::Wrapper< std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > > >" splitLevel="0"/>
   <class name="edm::Wrapper< Phase2TrackerRecHit1DCollectionNew >"/>
-  <class name="edm::Wrapper< edm::Ref< edmNew::DetSetVector< Phase2TrackerCluster1D >, Phase2TrackerCluster1D > >"/>
 
 </lcgdict>


### PR DESCRIPTION
Removing these lines since they are already defined in `DataFormats/Phase2TrackerCluster/src/classes_def.xml` 
in this way the Test Unit should not failing anymore.

No changes are expected.

@smuzaffar @slava77 
