### PR TITLE
Phase I: new BPIX module cable materials, new FPIX portcard material and dimensions

### DIFF
--- a/Geometry/CMSCommonData/data/materials.xml
+++ b/Geometry/CMSCommonData/data/materials.xml
@@ -1181,7 +1181,8 @@
     <rMaterial name="materials:Oxygen"/>
    </MaterialFraction>
   </CompositeMaterial>
-  <!-- Phase1 BPIX micro-twisted pairs boundle material as defined by W. Bertl, effective density defined to matcht the measured weigth (0.0071+0.0208 g/cm) in a single 1.5mm diam. boundle-->
+
+  <!--OUTDATED Phase1 BPIX micro-twisted pairs boundle material as defined by W. Bertl, effective density defined to matcht the measured weigth (0.0071+0.0208 g/cm) in a single 1.5mm diam. boundle-->
   <CompositeMaterial name="micro_twisted_boundle" density="1.585*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.7455">
     <rMaterial name="materials:micro_twisted_power_cable"/>
@@ -1190,6 +1191,33 @@
     <rMaterial name="materials:micro_twisted_signal_cable"/>
    </MaterialFraction>
   </CompositeMaterial>
+
+  <!--Phase1 BPIX micro-twisted pairs boundle material as defined by L. Caminada-->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.639*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.36933">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.63067">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_1" density="2.93382*g/cm3" symbol=" " method="mixture by weight"> <!--for L1-->
+   <MaterialFraction fraction="0.04631">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95369">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_2" density="2.91735*g/cm3" symbol=" " method="mixture by weight"> <!--for L2,3,4-->
+   <MaterialFraction fraction="0.04964">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95036">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
   <CompositeMaterial name="Carbon_fibre_str_Upgrade" density="0.293*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00000000">
     <rMaterial name="materials:Carbon fibre str."/>

--- a/Geometry/TrackerCommonData/data/Materials/mixed_materials.input
+++ b/Geometry/TrackerCommonData/data/Materials/mixed_materials.input
@@ -90,4 +90,5 @@
 "LCP_Glass_Enforced"        -1.    -1.      2.0        18.1	     41.4
 "Polyoxymethylene"          -1.    -1.      1.4        27.4          55.2
 "Polyvinylchloride"         -1.    -1.      1.38       18.4          65.2
+"micro_twisted_power_cable" -1.    -1.      3.639      4.99768       31.71323
  

--- a/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
+++ b/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
@@ -669,6 +669,22 @@ cylinder in the PXB volume: PixelBarrelSupTubCables with MCvolume 13757
 * 5 "cooling pipes steel"          "Steel-008"                 161      1   COL
 * 6 "coolant"                      "C6F14_F2_-10C"             424      1   COL
 
+o Phase I Pixel Barrel module cables
+  --------------------------
+.....................................................................
+# "Power Cable (CCA15)"    "micro_twisted_power_cable"          1   -1.
+* 1 "Copper"                "Copper"                          0.15   1   CAB
+* 2 "Aluminium"             "Aluminium"                       0.85   1   CAB
+
+# "Phase I BPIX module cables L1"   "micro_twisted_boundle_1"      146   -1.
+* 1 "Signal Cable"                "Copper"                       0.123  18  CAB
+* 2 "Power Cable"                 "micro_twisted_power_cable"    0.877  128 CAB
+
+# "Phase I BPIX module cables L2-4"   "micro_twisted_boundle_2"      110   -1.
+* 1 "Signal Cable"                "Copper"                        0.127  14  CAB
+* 2 "Power Cable"                 "micro_twisted_power_cable"     0.873  96  CAB
+=====================================================================
+
 
 # "end"  "END"  0.  0.   
 this has to be the last line !

--- a/Geometry/TrackerCommonData/data/Materials/pixel_fwd.in
+++ b/Geometry/TrackerCommonData/data/Materials/pixel_fwd.in
@@ -163,7 +163,7 @@ We also have Bias and Ground Wires: Copper V = 0.0362 cm3
 
 SERVICE CYLINDER MATERIAL (V. Cuplov)
 =============================================
-The following description has been done by B. Gobbi and E. Spencer.
+The following description (Volumes 1-8) has been done by B. Gobbi and E. Spencer.
 See FPix DOC DB: 1628-v2
 https://docdb.fnal.gov/CMS-private/DocDB/DocumentDatabase 
 
@@ -225,6 +225,31 @@ https://docdb.fnal.gov/CMS-private/DocDB/DocumentDatabase
 * 2 "C6F14" "FPix_Cylind_C6F14" 170 1 COL
 * 3 "Aluminium (cooling tube)" "Aluminium" 82 1 COL
 * 4 "Poliax" "FPix_Cylind_POLIAX" 78 1 CAB 
+
+# "Volume 9: " "Pix_Fwd_DCDC_Converter"  24.497 1
+* 1 "Copper" "Copper" 0.475 1 ELE
+* 2 "G10" "FPix_Cylind_G10" 16.454 1 ELE
+* 3 "Kapton" "FPix_Kapton" 0.107 1 CAB
+* 4 "Polyester" "FPix_Cylind_Polyester" 3.526 1 CAB 
+* 5 "Solder" "FPix_TinLeadSolder" 0.009 1 ELE
+* 6 "Aluminium" "FPix_Alumina" 3.926 1 COL
+
+# "Volume 10: " "Pix_Fwd_Port_Cards_Phase1" 2703 1
+* 1 "G10" "FPix_Cylind_G10" 419.09 1 ELE
+* 2 "Copper" "Copper" 44.75 1 ELE
+* 3 "Polyimide (extension cable)" "FPix_Kapton" 134.29 1 CAB
+* 4 "Port card/ CCU connectors" "FPix_Cylind_Polyester" 48.83 1 CAB
+* 5 "Solder" "FPix_TinLeadSolder" 4.08 1 ELE
+* 6 "Resistors" "FPix_Alumina" 8.11 1 ELE
+* 7 "Capacitors" "Barium_Titanate" 4.08 1 ELE
+* 8 "Chips" "Silicon" 4.08 1 ELE
+* 9 "OH parts (mostly G10)" "FPix_Cylind_G10" 109.85 1 ELE
+* 10 "DCDC Copper" "Copper" 15.08 1 ELE
+* 11 "DCDC G10" "FPix_Cylind_G10" 521.97 1 ELE
+* 12 "DCDC Kapton" "FPix_Kapton" 3.39 1 CAB
+* 13 "DCDC Polyester" "FPix_Cylind_Polyester" 111.82 1 CAB 
+* 14 "DCDC Solder" "FPix_TinLeadSolder" 0.28 1 ELE
+* 15 "DCDC Aluminium" "FPix_Alumina" 124.52 1 COL
 
 # "END"  "END"  0.  0.   
 this has to be the last line !

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -165,19 +165,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_1"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_1"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_1"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_1"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
@@ -165,19 +165,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
@@ -149,19 +149,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
@@ -148,19 +148,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle"/>
+  <rMaterial name="materials:micro_twisted_boundle_2"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
@@ -52,10 +52,9 @@ root volume plus an anchor point for positioning.
  <Constant name="CylinderPipeLength1" value="(1177.16-239.58)*mm"/>
  <Constant name="CylinderPipeLength2" value="823.60*mm"/>
 
- <Constant name="CylindersPortCardsWidth" value="60.0*mm"/>
- <Constant name="CylindersPortCardsLength1" value="223.52*mm"/>
- <Constant name="CylindersPortCardsLength2" value="355.60*mm"/>
- <Constant name="CylindersPortCardsThickness" value="5.40*mm"/>
+ <Constant name="CylindersPortCardsWidth" value="67.0*mm"/><!--60.0 mm-->
+ <Constant name="CylindersPortCardsLength1" value="533.7*mm"/><!--523.0 mm-->
+ <Constant name="CylindersPortCardsThickness" value="18.9*mm"/><!--5.40 mm-->
 
  <Constant name="CylindersServiceZoff" value="320.0*mm"/>
  <Constant name="CylindersServiceRmin" value="100*mm"/>
@@ -132,8 +131,6 @@ root volume plus an anchor point for positioning.
 
   <Box name="PixelForwardCylindersPortCards1" dx="[CylindersPortCardsWidth]/2." dy="[CylindersPortCardsThickness]/2." dz="[CylindersPortCardsLength1]/2."/>
 
-  <Box name="PixelForwardCylindersPortCards2" dx="[CylindersPortCardsWidth]/2." dy="[CylindersPortCardsThickness]/2." dz="[CylindersPortCardsLength2]/2."/>
-
 </SolidSection>
  
 
@@ -190,12 +187,7 @@ root volume plus an anchor point for positioning.
 
  <LogicalPart name="PixelForwardCylindersPortCards1" category="support">
     <rSolid name="PixelForwardCylindersPortCards1"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards"/>
- </LogicalPart>
-
- <LogicalPart name="PixelForwardCylindersPortCards2" category="support">
-    <rSolid name="PixelForwardCylindersPortCards2"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards_Phase1"/>
  </LogicalPart>
 
 
@@ -388,14 +380,14 @@ root volume plus an anchor point for positioning.
          <rRotation name="pixfwdCylinder:PortCardsRot1"/>
       </PosPart>
 
-   <PosPart copyNumber="1">
+   <PosPart copyNumber="2">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
-         <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
+         <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot2"/>
       </PosPart>
 
-   <PosPart copyNumber="2">
+   <PosPart copyNumber="3">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]"/>
@@ -403,35 +395,35 @@ root volume plus an anchor point for positioning.
       </PosPart>
 
                                                          
-   <PosPart copyNumber="3">
+   <PosPart copyNumber="4">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot4"/>
       </PosPart>
 
-    <PosPart copyNumber="4">
+    <PosPart copyNumber="5">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot5"/>
       </PosPart>
                                                                     
-   <PosPart copyNumber="2">
+   <PosPart copyNumber="6">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
-         <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
+         <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot6"/>
       </PosPart>
 
-   <PosPart copyNumber="5">
+   <PosPart copyNumber="7">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot7"/>
       </PosPart>
 
-   <PosPart copyNumber="6">
+   <PosPart copyNumber="8">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
          <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -438,7 +438,31 @@
       <rMaterial name="materials:Silicon"/>
     </MaterialFraction>
   </CompositeMaterial>
-
+    <CompositeMaterial name="Pix_Fwd_Port_Cards_Phase1" density="1.23490*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+      <MaterialFraction fraction="0.53523">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1606">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05774">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06738">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01150">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15735">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00736">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00285">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
 </MaterialSection>
-
 </DDDefinition>

--- a/Validation/Geometry/data/trackerMaterials.l0
+++ b/Validation/Geometry/data/trackerMaterials.l0
@@ -157,6 +157,8 @@ Pix_Fwd_Port_Cards               0.000 0.000 0.176 0.000 0.824
 
 Pix_Fwd_Port_Cards_Pilot         0.000 0.000 0.176 0.000 0.824
 
+Pix_Fwd_Port_Cards_Phase1        0.000 0.000 0.139 0.137 0.725
+
 Pix_Fwd_End_Pipe_1               0.000 0.000 0.490 0.510 0.000
 
 Pix_Fwd_End_Pipe_2               0.000 0.000 0.497 0.503 0.000

--- a/Validation/Geometry/data/trackerMaterials.x0
+++ b/Validation/Geometry/data/trackerMaterials.x0
@@ -156,6 +156,8 @@ Pix_Fwd_Port_Cards               0.000 0.000 0.099 0.000 0.901
 
 Pix_Fwd_Port_Cards_Pilot         0.000 0.000 0.156 0.000 0.844
 
+Pix_Fwd_Port_Cards_Phase1        0.000 0.000 0.098 0.137 0.765
+
 Pix_Fwd_End_Pipe_1               0.000 0.000 0.734 0.266 0.000
 
 Pix_Fwd_End_Pipe_2               0.000 0.000 0.734 0.266 0.000


### PR DESCRIPTION
Modifications to Phase I Pixel geometry/material description:
- BPIX: new module cable materials (one for L1, one for L2-L4)
- FPIX: new portcard material, new temporary dimensions (to be possibly modified in later iteration of geometry description refinement, after receiving feedback from FNAL engineers)
