### PR TITLE
Set entire FED to BAD Qt for vanishing occupancy

### DIFF
--- a/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 from DQM.EcalMonitorTasks.IntegrityTask_cfi import ecalIntegrityTask
+from DQM.EcalMonitorTasks.RawDataTask_cfi import ecalRawDataTask
 
 errFractionThreshold = 0.01
 
@@ -16,6 +17,8 @@ ecalIntegrityClient = cms.untracked.PSet(
         GainSwitch = ecalIntegrityTask.MEs.GainSwitch,
         ChId = ecalIntegrityTask.MEs.ChId,
         TowerId = ecalIntegrityTask.MEs.TowerId,
+        BXSRP = ecalRawDataTask.MEs.BXSRP,
+        BXTCC = ecalRawDataTask.MEs.BXTCC
     ),
     MEs = cms.untracked.PSet(
         QualitySummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -15,7 +15,9 @@ ecalTrigPrimClient = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
         MatchedIndex = ecalTrigPrimTask.MEs.MatchedIndex,
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
-        TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll
+        TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
+        TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
+        TPDigiThrAll = ecalOccupancyTask.MEs.TPDigiThrAll
     ),
     MEs = cms.untracked.PSet(
         NonSingleSummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -8,6 +8,8 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
+#include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
+
 namespace ecaldqm
 {
   IntegrityClient::IntegrityClient() :
@@ -114,6 +116,23 @@ namespace ecaldqm
         qItr->setBinContent(doMask ? kMGood : kGood);
         meQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
       }
+    }
+
+    // Quality check: set an entire FED to BAD if "any" DCC-SRP or DCC-TCC mismatch errors are detected
+    // Fill mismatch statistics
+    MESet const& sBXSRP(sources_.at("BXSRP"));
+    MESet const& sBXTCC(sources_.at("BXTCC"));
+    std::vector<bool> hasMismatchDCC(nDCC,false);
+    for ( unsigned iDCC(0); iDCC < nDCC; ++iDCC ) {
+      if ( sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50. )
+        hasMismatchDCC[iDCC] = true;
+    }
+    // Analyze mismatch statistics
+    for ( MESet::iterator qsItr(meQualitySummary.beginChannel()); qsItr != meQualitySummary.end(); qsItr.toNextChannel() ) {
+      DetId id( qsItr->getId() );
+      unsigned iDCC( dccId(id)-1 );
+      if ( hasMismatchDCC[iDCC] )
+        meQualitySummary.setBinContent( id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad );
     }
 
   } // producePlots()

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -124,7 +124,7 @@ namespace ecaldqm
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC,false);
     for ( unsigned iDCC(0); iDCC < nDCC; ++iDCC ) {
-      if ( sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50. )
+      if ( sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50. ) // "any" => 50
         hasMismatchDCC[iDCC] = true;
     }
     // Analyze mismatch statistics

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -39,11 +39,12 @@ namespace ecaldqm
 
     uint32_t mask(1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING);
 
+    // Store # of entries for Occupancy analysis
     std::vector<float> Nentries(nDCC,0.);
+
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++){
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
 
-      unsigned iDCC( dccId(ttid)-1 );
       bool doMask(meEmulQualitySummary.maskMatches(ttid, mask, statusManager_));
 
       float towerEntries(0.);
@@ -76,6 +77,8 @@ namespace ecaldqm
       else
         meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
       
+      // Keep count for Occupancy analysis
+      unsigned iDCC( dccId(ttid)-1 );
       Nentries[iDCC] += sTPDigiThrAll.getBinContent(ttid); 
     }
 


### PR DESCRIPTION
**Urgent:** Set entire FED/SuperModule to BAD (instead of YELLOW=low stats) in the Quality Summary if its occupancy begins to vanish under data taking conditions.

List of changes include:
1. Threshold on (filtered) rechit occupancy of the FED ( < mean FED occupancy - 5*FED rms, >1000 hits ) -> Hot Cell Quality Summary -> Global Quality Summary.
2. Threshold on DCC-SRP and DCC-TCC mismatch errors in the FED ( >50 errors per FED ) -> Integrity Quality Summary -> Global Quality Summary.
3. Threshold on % of FED showing any DCC-SRP mismatch errors ( > 0.8 or about 55 TTs in EB ) -> Emulator Error Quality summary -> Global Quality Summary. 
4. For past issue on missing TPs in entire FEDs: Threshold on the TP occupancy of the FED ( < mean FED occupancy - 5*FED rms, >100 hits ) -> Emulator Error Quality Summary -> Global Quality Summary.
