### PR TITLE
fix vertex validation@HLT

### DIFF
--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -1,12 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
+from Validation.RecoTrack.associators_cff import *
+
+from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
+hltVertexAssociatorByPositionAndTracks = VertexAssociatorByPositionAndTracks.clone()
+hltVertexAssociatorByPositionAndTracks.trackAssociation = "tpToHLTpixelTrackAssociation"
+
+
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_cfi import *
 
 hltMultiPVanalysis = vertexAnalysis.clone()
-hltMultiPVanalysis.verbose               = cms.untracked.bool(False)
-hltMultiPVanalysis.sigma_z_match         = cms.untracked.double(3.0)
-hltMultiPVanalysis.root_folder           = cms.untracked.string("HLT/Vertexing/ValidationWRTsim")
+hltMultiPVanalysis.verbose               = False
+hltMultiPVanalysis.sigma_z_match         = 3.0
+hltMultiPVanalysis.root_folder           = "HLT/Vertexing/ValidationWRTsim"
 hltMultiPVanalysis.recoTrackProducer     = "hltPixelTracks"
+hltMultiPVanalysis.trackAssociatorMap    = "tpToHLTpixelTrackAssociation"
+hltMultiPVanalysis.vertexAssociator      = "hltVertexAssociatorByPositionAndTracks"
 hltMultiPVanalysis.vertexRecoCollections = cms.VInputTag(
     "hltPixelVertices",
     "hltTrimmedPixelVertices"
@@ -14,5 +23,8 @@ hltMultiPVanalysis.vertexRecoCollections = cms.VInputTag(
 )
 
 hltMultiPVValidation = cms.Sequence( 
-  hltMultiPVanalysis
+    hltTrackAssociatorByHits
+    + tpToHLTpixelTrackAssociation
+    + hltVertexAssociatorByPositionAndTracks
+    + hltMultiPVanalysis
 )


### PR DESCRIPTION
while developing tracking @HLT for pixel phase1,
I realized that the vertex validation for HLT reconstruction was still using association map between offline quantities ...
this PR should fix it
