### PR TITLE
Cleanup RPC local reconstruction

### DIFF
--- a/RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h
@@ -17,35 +17,31 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 
 #include "RecoLocalMuon/RPCRecHit/src/RPCRollMask.h"
-#include "RecoLocalMuon/RPCRecHit/src/RPCMaskReClusterizer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class RPCCluster;
 class RPCRoll;
 class RPCDetId;
 
 namespace edm {
-  class ParameterSet;
   class EventSetup;
 }
 
-
 class RPCRecHitBaseAlgo {
-
  public:
-  
   /// Constructor
   RPCRecHitBaseAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~RPCRecHitBaseAlgo();  
+  virtual ~RPCRecHitBaseAlgo() {};
 
   /// Pass the Event Setup to the algo at each event
   virtual void setES(const edm::EventSetup& setup) = 0;
 
   /// Build all hits in the range associated to the rpcId, at the 1st step.
   virtual edm::OwnVector<RPCRecHit> reconstruct(const RPCRoll& roll,
-						const RPCDetId& rpcId,
-						const RPCDigiCollection::Range& digiRange,
+                                                const RPCDetId& rpcId,
+                                                const RPCDigiCollection::Range& digiRange,
                                                 const RollMask& mask);
 
   /// standard local recHit computation
@@ -54,11 +50,10 @@ class RPCRecHitBaseAlgo {
                        LocalPoint& Point,
                        LocalError& error) const = 0;
 
-
   /// local recHit computation accounting for track direction and 
   /// absolute position
   virtual bool compute(const RPCRoll& roll,
-		       const RPCCluster& cl,
+                       const RPCCluster& cl,
                        const float& angle,
                        const GlobalPoint& globPos, 
                        LocalPoint& Point,

--- a/RecoLocalMuon/RPCRecHit/src/RPCClusterizer.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCClusterizer.h
@@ -5,19 +5,13 @@
  */
 
 #include "RPCClusterContainer.h"
+#include "RPCCluster.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 
-class RPCCluster;
 class RPCClusterizer{
  public:
-  RPCClusterizer();
-  ~RPCClusterizer();
+  RPCClusterizer() {};
+  ~RPCClusterizer() {};
   RPCClusterContainer doAction(const RPCDigiCollection::Range& digiRange);
-
- private:
-  RPCClusterContainer doActualAction(RPCClusterContainer& initialclusters);
-
- private:
-  RPCClusterContainer cls;
 };
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/RPCMaskReClusterizer.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCMaskReClusterizer.h
@@ -6,22 +6,16 @@
  */
 
 #include "RPCRollMask.h"
-
-#include "RPCCluster.h"
-#include "RPCClusterizer.h"
 #include "RPCClusterContainer.h"
-
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
-
-class RPCMaskReClusterizer 
+class RPCMaskReClusterizer
 {
  public :
-
-   RPCMaskReClusterizer();
-   ~RPCMaskReClusterizer();
-   RPCClusterContainer doAction(const RPCDetId& ,RPCClusterContainer& , const RollMask& );
-   int get(const RollMask& ,int );
+   RPCMaskReClusterizer() {};
+   ~RPCMaskReClusterizer() {};
+   RPCClusterContainer doAction(const RPCDetId& id,RPCClusterContainer& initClusters, const RollMask& mask) const;
+   bool get(const RollMask& mask,int strip) const;
 
 };
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
@@ -4,58 +4,44 @@
  *  \author M. Maggi -- INFN Bari
  */
 
-
-
 #include "RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h"
 #include "RecoLocalMuon/RPCRecHit/src/RPCClusterContainer.h"
 #include "RecoLocalMuon/RPCRecHit/src/RPCCluster.h"
 #include "RecoLocalMuon/RPCRecHit/src/RPCClusterizer.h"
 #include "RecoLocalMuon/RPCRecHit/src/RPCMaskReClusterizer.h"
 
-#include "Geometry/RPCGeometry/interface/RPCRoll.h"
-#include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
-#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-
 RPCRecHitBaseAlgo::RPCRecHitBaseAlgo(const edm::ParameterSet& config) {
   //  theSync = RPCTTrigSyncFactory::get()->create(config.getParameter<string>("tTrigMode"),
   //config.getParameter<ParameterSet>("tTrigModeConfig"));
 }
 
-RPCRecHitBaseAlgo::~RPCRecHitBaseAlgo(){}
-
-
 // Build all hits in the range associated to the layerId, at the 1st step.
 edm::OwnVector<RPCRecHit> RPCRecHitBaseAlgo::reconstruct(const RPCRoll& roll,
-							 const RPCDetId& rpcId,
-							 const RPCDigiCollection::Range& digiRange,
+                                                         const RPCDetId& rpcId,
+                                                         const RPCDigiCollection::Range& digiRange,
                                                          const RollMask& mask) {
-  edm::OwnVector<RPCRecHit> result; 
-
+  edm::OwnVector<RPCRecHit> result;
 
   RPCClusterizer clizer;
   RPCClusterContainer tcls = clizer.doAction(digiRange);
   RPCMaskReClusterizer mrclizer;
   RPCClusterContainer cls = mrclizer.doAction(rpcId,tcls,mask);
 
-
-  for (RPCClusterContainer::const_iterator cl = cls.begin();
-       cl != cls.end(); cl++){
-    
+  for ( auto cl : cls ) {
     LocalError tmpErr;
     LocalPoint point;
+
     // Call the compute method
-    bool OK = this->compute(roll, *cl, point, tmpErr);
+    const bool OK = this->compute(roll, cl, point, tmpErr);
     if (!OK) continue;
 
-    // Build a new pair of 1D rechit 
-    int firstClustStrip= cl->firstStrip();
-    int clusterSize=cl->clusterSize(); 
-    RPCRecHit*  recHit = new RPCRecHit(rpcId,cl->bx(),firstClustStrip,clusterSize,point,tmpErr);
-
+    // Build a new pair of 1D rechit
+    const int firstClustStrip = cl.firstStrip();
+    const int clusterSize = cl.clusterSize();
+    RPCRecHit* recHit = new RPCRecHit(rpcId,cl.bx(),firstClustStrip,clusterSize,point,tmpErr);
 
     result.push_back(recHit);
   }
+
   return result;
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
@@ -5,9 +5,6 @@
 
 #include "RPCRecHitProducer.h"
 
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
@@ -16,46 +13,38 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 
-#include "RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h"
 #include "RecoLocalMuon/RPCRecHit/interface/RPCRecHitAlgoFactory.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
-#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
 #include "CondFormats/DataRecord/interface/RPCMaskedStripsRcd.h"
-#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
 #include "CondFormats/DataRecord/interface/RPCDeadStripsRcd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <string>
-
+#include <fstream>
 
 using namespace edm;
 using namespace std;
 
-
-RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config){
-
+RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config):
+  theRPCDigiLabel(consumes<RPCDigiCollection>(config.getParameter<InputTag>("rpcDigiLabel"))),
+  maskSource_(MaskSource::EventSetup), deadSource_(MaskSource::EventSetup)
+{
   // Set verbose output
-
   produces<RPCRecHitCollection>();
 
-  theRPCDigiLabel = consumes<RPCDigiCollection>(config.getParameter<InputTag>("rpcDigiLabel"));
-  
   // Get the concrete reconstruction algo from the factory
-
-  string theAlgoName = config.getParameter<string>("recAlgo");
-  theAlgo = RPCRecHitAlgoFactory::get()->create(theAlgoName,
-						config.getParameter<ParameterSet>("recAlgoConfig"));
+  const string theAlgoName = config.getParameter<string>("recAlgo");
+  theAlgo.reset(RPCRecHitAlgoFactory::get()->create(theAlgoName,
+                config.getParameter<ParameterSet>("recAlgoConfig")));
 
   // Get masked- and dead-strip information
+  theRPCMaskedStripsObj.reset(new RPCMaskedStrips());
+  theRPCDeadStripsObj.reset(new RPCDeadStrips());
 
-  RPCMaskedStripsObj = new RPCMaskedStrips();
-
-  RPCDeadStripsObj = new RPCDeadStrips();
-
-  maskSource = config.getParameter<std::string>("maskSource");
-
+  const string maskSource = config.getParameter<std::string>("maskSource");
   if (maskSource == "File") {
+    maskSource_ = MaskSource::File;
     edm::FileInPath fp = config.getParameter<edm::FileInPath>("maskvecfile");
     std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
     if ( !inputFile ) {
@@ -70,9 +59,9 @@ RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config){
     inputFile.close();
   }
 
-  deadSource = config.getParameter<std::string>("deadSource");
-
+  const string deadSource = config.getParameter<std::string>("deadSource");
   if (deadSource == "File") {
+    deadSource_ = MaskSource::File;
     edm::FileInPath fp = config.getParameter<edm::FileInPath>("deadvecfile");
     std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
     if ( !inputFile ) {
@@ -86,90 +75,66 @@ RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config){
     }
     inputFile.close();
   }
-
 }
-
-
-RPCRecHitProducer::~RPCRecHitProducer(){
-
-  delete theAlgo;
-  delete RPCMaskedStripsObj;
-  delete RPCDeadStripsObj;
-
-}
-
 
 
 void RPCRecHitProducer::beginRun(const edm::Run& r, const edm::EventSetup& setup){
-
   // Getting the masked-strip information
-
-  if ( maskSource == "EventSetup" ) {
+  if ( maskSource_ == MaskSource::EventSetup ) {
     edm::ESHandle<RPCMaskedStrips> readoutMaskedStrips;
     setup.get<RPCMaskedStripsRcd>().get(readoutMaskedStrips);
     const RPCMaskedStrips* tmp_obj = readoutMaskedStrips.product();
-    RPCMaskedStripsObj->MaskVec = tmp_obj->MaskVec;
+    theRPCMaskedStripsObj->MaskVec = tmp_obj->MaskVec;
     delete tmp_obj;
   }
-  else if ( maskSource == "File" ) {
+  else if ( maskSource_ == MaskSource::File ) {
     std::vector<RPCMaskedStrips::MaskItem>::iterator posVec;
     for ( posVec = MaskVec.begin(); posVec != MaskVec.end(); ++posVec ) {
       RPCMaskedStrips::MaskItem Item; 
       Item.rawId = (*posVec).rawId;
       Item.strip = (*posVec).strip;
-      RPCMaskedStripsObj->MaskVec.push_back(Item);
+      theRPCMaskedStripsObj->MaskVec.push_back(Item);
     }
   }
 
   // Getting the dead-strip information
-
-  if ( deadSource == "EventSetup" ) {
+  if ( deadSource_ == MaskSource::EventSetup ) {
     edm::ESHandle<RPCDeadStrips> readoutDeadStrips;
     setup.get<RPCDeadStripsRcd>().get(readoutDeadStrips);
     const RPCDeadStrips* tmp_obj = readoutDeadStrips.product();
-    RPCDeadStripsObj->DeadVec = tmp_obj->DeadVec;
+    theRPCDeadStripsObj->DeadVec = tmp_obj->DeadVec;
     delete tmp_obj;
   }
-  else if ( deadSource == "File" ) {
+  else if ( deadSource_ == MaskSource::File ) {
     std::vector<RPCDeadStrips::DeadItem>::iterator posVec;
     for ( posVec = DeadVec.begin(); posVec != DeadVec.end(); ++posVec ) {
       RPCDeadStrips::DeadItem Item;
       Item.rawId = (*posVec).rawId;
       Item.strip = (*posVec).strip;
-      RPCDeadStripsObj->DeadVec.push_back(Item);
+      theRPCDeadStripsObj->DeadVec.push_back(Item);
     }
   }
 
 }
 
-
-
 void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
-
   // Get the RPC Geometry
-
   ESHandle<RPCGeometry> rpcGeom;
   setup.get<MuonGeometryRecord>().get(rpcGeom);
 
   // Get the digis from the event
-
   Handle<RPCDigiCollection> digis; 
   event.getByToken(theRPCDigiLabel,digis);
 
   // Pass the EventSetup to the algo
-
   theAlgo->setES(setup);
 
   // Create the pointer to the collection which will store the rechits
-
   auto_ptr<RPCRecHitCollection> recHitCollection(new RPCRecHitCollection());
 
   // Iterate through all digi collections ordered by LayerId   
 
-  RPCDigiCollection::DigiRangeIterator rpcdgIt;
-  for (rpcdgIt = digis->begin(); rpcdgIt != digis->end();
-       ++rpcdgIt){
-       
+  for ( auto rpcdgIt = digis->begin(); rpcdgIt != digis->end(); ++rpcdgIt ) {
     // The layerId
     const RPCDetId& rpcId = (*rpcdgIt).first;
 
@@ -183,31 +148,25 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
     // Get the iterators over the digis associated with this LayerId
     const RPCDigiCollection::Range& range = (*rpcdgIt).second;
 
-
     // Getting the roll mask, that includes dead strips, for the given RPCDet
-
     RollMask mask;
-    int rawId = rpcId.rawId();
-    int Size = RPCMaskedStripsObj->MaskVec.size();
-    for (int i = 0; i < Size; i++ ) {
-      if ( RPCMaskedStripsObj->MaskVec[i].rawId == rawId ) {
-	int bit = RPCMaskedStripsObj->MaskVec[i].strip;
-	mask.set(bit-1);
+    const int rawId = rpcId.rawId();
+    for ( const auto& tomask : theRPCMaskedStripsObj->MaskVec ) {
+      if ( tomask.rawId == rawId ) {
+        const int bit = tomask.strip;
+        mask.set(bit-1);
       }
     }
 
-    Size = RPCDeadStripsObj->DeadVec.size();
-    for (int i = 0; i < Size; i++ ) {
-      if ( RPCDeadStripsObj->DeadVec[i].rawId == rawId ) {
-	int bit = RPCDeadStripsObj->DeadVec[i].strip;
-	mask.set(bit-1);
+    for ( const auto& tomask : theRPCDeadStripsObj->DeadVec ) {
+      if ( tomask.rawId == rawId ) {
+        const int bit = tomask.strip;
+        mask.set(bit-1);
       }
     }
 
     // Call the reconstruction algorithm    
-
-    OwnVector<RPCRecHit> recHits =
-      theAlgo->reconstruct(*roll, rpcId, range, mask);
+    OwnVector<RPCRecHit> recHits = theAlgo->reconstruct(*roll, rpcId, range, mask);
     
     if(recHits.size() > 0) //FIXME: is it really needed?
       recHitCollection->put(rpcId, recHits.begin(), recHits.end());

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
@@ -7,36 +7,14 @@
  *  \author M. Maggim -- INFN Bari
  */
 
-
-#include <memory>
-#include <fstream>
-#include <iostream>
-#include <stdint.h>
-#include <cstdlib>
-#include <bitset>
-#include <map>
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/MuonDetId/interface/RPCDetId.h"
-
-#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
-#include "CondFormats/DataRecord/interface/RPCMaskedStripsRcd.h"
-#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
-#include "CondFormats/DataRecord/interface/RPCDeadStripsRcd.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
-
-
-#include "RPCRollMask.h"
-
-
-namespace edm {
-  class ParameterSet;
-  class Event;
-  class EventSetup;
-}
-
-class RPCRecHitBaseAlgo;
+#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
+#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
+#include "RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h"
 
 class RPCRecHitProducer : public edm::stream::EDProducer<> {
 
@@ -45,7 +23,7 @@ public:
   RPCRecHitProducer(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~RPCRecHitProducer();
+  virtual ~RPCRecHitProducer() {};
 
   // Method that access the EventSetup for each run
   virtual void beginRun(const edm::Run&, const edm::EventSetup& ) override;
@@ -54,22 +32,20 @@ public:
   virtual void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
 private:
-
   // The label to be used to retrieve RPC digis from the event
-  edm::EDGetTokenT<RPCDigiCollection> theRPCDigiLabel;
+  const edm::EDGetTokenT<RPCDigiCollection> theRPCDigiLabel;
   //  edm::InputTag theRPCDigiLabel;
 
   // The reconstruction algorithm
-  RPCRecHitBaseAlgo *theAlgo;
+  std::unique_ptr<RPCRecHitBaseAlgo> theAlgo;
 
-  RPCMaskedStrips* RPCMaskedStripsObj;
+  std::unique_ptr<RPCMaskedStrips> theRPCMaskedStripsObj;
   // Object with mask-strips-vector for all the RPC Detectors
 
-  RPCDeadStrips* RPCDeadStripsObj;
+  std::unique_ptr<RPCDeadStrips> theRPCDeadStripsObj;
   // Object with dead-strips-vector for all the RPC Detectors
 
-  std::string maskSource;
-  std::string deadSource;
+  enum class MaskSource { File, EventSetup } maskSource_, deadSource_;
 
   std::vector<RPCMaskedStrips::MaskItem> MaskVec;
   std::vector<RPCDeadStrips::DeadItem> DeadVec;

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
@@ -12,25 +12,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
-RPCRecHitStandardAlgo::RPCRecHitStandardAlgo(const edm::ParameterSet& config) :
-  RPCRecHitBaseAlgo(config) 
-{
-}
-
-
-
-RPCRecHitStandardAlgo::~RPCRecHitStandardAlgo()
-{
-}
-
-
-
-void RPCRecHitStandardAlgo::setES(const edm::EventSetup& setup) {
-}
-
-
-
 // First Step
 bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
 				    const RPCCluster& cluster,
@@ -38,29 +19,25 @@ bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
 				    LocalError& error)  const
 {
   // Get Average Strip position
-  float fstrip = (roll.centreOfStrip(cluster.firstStrip())).x();
-  float lstrip = (roll.centreOfStrip(cluster.lastStrip())).x();
-  float centreOfCluster = (fstrip + lstrip)/2;
+  const float fstrip = (roll.centreOfStrip(cluster.firstStrip())).x();
+  const float lstrip = (roll.centreOfStrip(cluster.lastStrip())).x();
+  const float centreOfCluster = (fstrip + lstrip)/2;
 
   LocalPoint loctemp2(centreOfCluster,0.,0.);
- 
+
   Point = loctemp2;
   error = roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.);
+
   return true;
 }
 
-
 bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
-				    const RPCCluster& cl,
-				    const float& angle,
-				    const GlobalPoint& globPos, 
-				    LocalPoint& Point,
-				    LocalError& error)  const
+                                    const RPCCluster& cl,
+                                    const float& angle,
+                                    const GlobalPoint& globPos,
+                                    LocalPoint& Point,
+                                    LocalError& error)  const
 {
-
-  // Glob Pos and angle not used so far...
-  if (globPos.z()<0){ } // Fake use to avoid warnings
-  if (angle<0.){ }      // Fake use to avoid warnings
   this->compute(roll,cl,Point,error);
   return true;
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
@@ -9,20 +9,16 @@
 
 #include "RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h"
 
-
-
 class RPCRecHitStandardAlgo : public RPCRecHitBaseAlgo {
  public:
   /// Constructor
-  RPCRecHitStandardAlgo(const edm::ParameterSet& config);
+  RPCRecHitStandardAlgo(const edm::ParameterSet& config):RPCRecHitBaseAlgo(config) {};
 
   /// Destructor
-  virtual ~RPCRecHitStandardAlgo();
-
-  // Operations
+  virtual ~RPCRecHitStandardAlgo() {};
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  virtual void setES(const edm::EventSetup& setup) {};
 
 
   virtual bool compute(const RPCRoll& roll,
@@ -34,10 +30,9 @@ class RPCRecHitStandardAlgo : public RPCRecHitBaseAlgo {
   virtual bool compute(const RPCRoll& roll,
                        const RPCCluster& cluster,
                        const float& angle,
-                       const GlobalPoint& globPos, 
+                       const GlobalPoint& globPos,
                        LocalPoint& point,
                        LocalError& error) const;
 };
 #endif
-
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRollMask.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRollMask.h
@@ -2,7 +2,6 @@
 #define RecoLocalMuon_RPCRollMask_h
 
 #include <bitset>
-#include <vector>
 
 const int maskSIZE=192;
 typedef std::bitset<maskSIZE> RollMask;


### PR DESCRIPTION
The PR is to cleanup the RPC local reconstruction codes for better readability with help of modern C++ syntax.

The largest change is on the clustering algorithm to remove unnecessary if-statements inside of the loop to make the logic clear and short. 
This does not change actual idea of the clustering, therefore the output should be exactly same as the previous one.
