### PR TITLE
Set entire FED to BAD Qt for vanishing occupancy

### DIFF
--- a/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 from DQM.EcalMonitorTasks.IntegrityTask_cfi import ecalIntegrityTask
+from DQM.EcalMonitorTasks.RawDataTask_cfi import ecalRawDataTask
 
 errFractionThreshold = 0.01
 
@@ -16,6 +17,8 @@ ecalIntegrityClient = cms.untracked.PSet(
         GainSwitch = ecalIntegrityTask.MEs.GainSwitch,
         ChId = ecalIntegrityTask.MEs.ChId,
         TowerId = ecalIntegrityTask.MEs.TowerId,
+        BXSRP = ecalRawDataTask.MEs.BXSRP,
+        BXTCC = ecalRawDataTask.MEs.BXTCC
     ),
     MEs = cms.untracked.PSet(
         QualitySummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/SummaryClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/SummaryClient_cfi.py
@@ -28,7 +28,9 @@ ecalSummaryClient = cms.untracked.PSet(
         DesyncByLumi = ecalRawDataTask.MEs.DesyncByLumi,
         FEByLumi = ecalRawDataTask.MEs.FEByLumi,
         TriggerPrimitives = ecalTrigPrimClient.MEs.EmulQualitySummary,
-        HotCell = ecalOccupancyClient.MEs.QualitySummary
+        HotCell = ecalOccupancyClient.MEs.QualitySummary,
+        BXSRP = ecalRawDataTask.MEs.BXSRP,
+        BXTCC = ecalRawDataTask.MEs.BXTCC
     ),
     MEs = cms.untracked.PSet(
         ReportSummaryMap = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -15,7 +15,9 @@ ecalTrigPrimClient = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
         MatchedIndex = ecalTrigPrimTask.MEs.MatchedIndex,
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
-        TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll
+        TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
+        TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
+        TPDigiThrAll = ecalOccupancyTask.MEs.TPDigiThrAll
     ),
     MEs = cms.untracked.PSet(
         NonSingleSummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -7,6 +7,7 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 namespace ecaldqm
 {
   OccupancyClient::OccupancyClient() :

--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -7,8 +7,6 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "TMath.h"
 namespace ecaldqm
 {
   OccupancyClient::OccupancyClient() :
@@ -181,22 +179,26 @@ namespace ecaldqm
 
     // Quality check: set entire FED to BAD if its occupancy begins to vanish
     // Fill FED statistics from (filtered) RecHit Occupancy 
-    std::vector<float> FEDStatsEB;
-    std::vector<float> FEDStatsEE;
+    float meanFEDEB(0), meanFEDEE(0), rmsFEDEB(0), rmsFEDEE(0);
+    unsigned int nFEDEB(0), nFEDEE(0);
     for ( unsigned iDCC(0); iDCC < nDCC; iDCC++ ) {
-      if ( iDCC >= kEBmLow && iDCC <= kEBpHigh )
-        FEDStatsEB.push_back( Nrhentries[iDCC] );
-      else
-        FEDStatsEE.push_back( Nrhentries[iDCC] );
+      if ( iDCC >=kEBmLow && iDCC <= kEBpHigh) {
+        meanFEDEB += Nrhentries[iDCC];
+        rmsFEDEB  += Nrhentries[iDCC]*Nrhentries[iDCC];
+        nFEDEB++;
+      }
+      else {
+        meanFEDEE += Nrhentries[iDCC];
+        rmsFEDEE  += Nrhentries[iDCC]*Nrhentries[iDCC];
+        nFEDEE++;
+      }
     }
+    meanFEDEB /= float( nFEDEB ); rmsFEDEB /= float( nFEDEB );
+    meanFEDEE /= float( nFEDEE ); rmsFEDEE /= float( nFEDEE );
+    rmsFEDEB   = sqrt( abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
+    rmsFEDEE   = sqrt( abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
     // Analyze FED statistics
-    float meanFED(0.);
-    float meanFEDEB( TMath::Mean( FEDStatsEB.begin(),FEDStatsEB.end()) );
-    float meanFEDEE( TMath::Mean( FEDStatsEE.begin(),FEDStatsEE.end()) );
-    float rmsFED(0.);
-    float rmsFEDEB( TMath::RMS( FEDStatsEB.begin(),FEDStatsEB.end()) );
-    float rmsFEDEE( TMath::RMS( FEDStatsEE.begin(),FEDStatsEE.end()) );
-    float nRMS(5.);
+    float meanFED(0.), rmsFED(0.), nRMS(5.);
     for ( MESet::iterator qsItr(meQualitySummary.beginChannel()); qsItr != meQualitySummary.end(); qsItr.toNextChannel() ) {
       DetId id( qsItr->getId() );
       unsigned iDCC( dccId(id)-1 );

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -95,6 +95,15 @@ namespace ecaldqm
 
     std::map<uint32_t, int> badChannelsCount;
 
+    // Override IntegrityByLumi check if Desync errors present
+    MESet const& sBXSRP(sources_.at("BXSRP"));
+    MESet const& sBXTCC(sources_.at("BXTCC"));
+    std::vector<bool> hasMismatchDCC(nDCC,false);
+    for ( unsigned iDCC(0); iDCC < nDCC; ++iDCC ) {
+      if ( sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50. ) // "any" => 50
+        hasMismatchDCC[iDCC] = true;
+    }
+
     MESet::iterator qEnd(meQualitySummary.end());
     for(MESet::iterator qItr(meQualitySummary.beginChannel()); qItr != qEnd; qItr.toNextChannel()){
 
@@ -115,7 +124,8 @@ namespace ecaldqm
 
       int rawdata(sRawData.getBinContent(id));
 
-      if(integrity == kBad && integrityByLumi[iDCC] == 0.) integrity = kGood;
+      //if(integrity == kBad && integrityByLumi[iDCC] == 0.) integrity = kGood;
+      if(integrity == kBad && integrityByLumi[iDCC] == 0. && !hasMismatchDCC[iDCC]) integrity = kGood;
       if(rawdata == kBad && rawDataByLumi[iDCC] == 0.) rawdata = kGood;
 
       int status(kGood);

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <cmath>
+
 namespace ecaldqm
 {
   TrigPrimClient::TrigPrimClient() :

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -8,6 +8,7 @@
 
 #include <cmath>
 
+#include "TMath.h"
 namespace ecaldqm
 {
   TrigPrimClient::TrigPrimClient() :
@@ -34,8 +35,12 @@ namespace ecaldqm
 
     MESet const& sEtEmulError(sources_.at("EtEmulError"));
     MESet const& sMatchedIndex(sources_.at("MatchedIndex"));
+    MESet const& sTPDigiThrAll(sources_.at("TPDigiThrAll"));
 
     uint32_t mask(1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING);
+
+    // Store # of entries for Occupancy analysis
+    std::vector<float> Nentries(nDCC,0.);
 
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++){
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
@@ -71,6 +76,10 @@ namespace ecaldqm
         meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
       else
         meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
+      
+      // Keep count for Occupancy analysis
+      unsigned iDCC( dccId(ttid)-1 );
+      Nentries[iDCC] += sTPDigiThrAll.getBinContent(ttid); 
     }
 
     // Fill TTF4 v Masking ME
@@ -96,7 +105,60 @@ namespace ecaldqm
       }   
     } // TT loop 
 
-  } // TrigPrimClient::producePlots()
+    // Quality check: set an entire FED to BAD if an "entire" FED shows any DCC-SRP flag mismatch errors
+    // Fill flag mismatch statistics
+    std::vector<float> nTTs(nDCC,0.);
+    std::vector<float> nTTFMismath(nDCC,0.);
+    MESet const& sTTFMismatch(sources_.at("TTFMismatch"));
+    for ( unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++ ) {
+      EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      unsigned iDCC( dccId(ttid)-1 );
+      if ( sTTFMismatch.getBinContent(ttid) > 0. )
+          nTTFMismath[iDCC]++;
+      nTTs[iDCC]++;
+    }
+    // Analyze flag mismatch statistics
+    for ( unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++ ) {
+      EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      unsigned iDCC( dccId(ttid)-1 );
+      if ( nTTFMismath[iDCC] > 0.8*nTTs[iDCC] ) // "entire" => 80%
+        meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
+    }
+
+    // Quality check: set entire FED to BAD if its occupancy begins to vanish
+    // Fill FED statistics from TP digi occupancy
+    std::vector<float> FEDStatsEB;
+    std::vector<float> FEDStatsEE;
+    for ( unsigned iDCC(0); iDCC < nDCC; iDCC++ ) {
+      if ( iDCC >= kEBmLow && iDCC <= kEBpHigh )
+        FEDStatsEB.push_back( Nentries[iDCC] );
+      else
+        FEDStatsEE.push_back( Nentries[iDCC] );
+    }
+    // Analyze FED statistics
+    float meanFED(0.);
+    float meanFEDEB( TMath::Mean( FEDStatsEB.begin(),FEDStatsEB.end()) );
+    float meanFEDEE( TMath::Mean( FEDStatsEE.begin(),FEDStatsEE.end()) );
+    float rmsFED(0.);
+    float rmsFEDEB( TMath::RMS( FEDStatsEB.begin(),FEDStatsEB.end()) );
+    float rmsFEDEE( TMath::RMS( FEDStatsEE.begin(),FEDStatsEE.end()) );
+    float nRMS(5.);
+    for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++){
+      EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      unsigned iDCC( dccId(ttid)-1 );
+      if ( iDCC >= kEBmLow && iDCC <= kEBpHigh ) {
+        meanFED = meanFEDEB;
+        rmsFED  = rmsFEDEB;
+      }
+      else {
+        meanFED = meanFEDEE;
+        rmsFED  = rmsFEDEE;
+      }
+      if ( meanFED > 100. && Nentries[iDCC] < meanFED - nRMS*rmsFED )
+        meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
+    }
+
+  } // producePlots()
 
   DEFINE_ECALDQM_WORKER(TrigPrimClient);
 }

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -7,8 +7,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <cmath>
-
-#include "TMath.h"
 namespace ecaldqm
 {
   TrigPrimClient::TrigPrimClient() :
@@ -127,22 +125,26 @@ namespace ecaldqm
 
     // Quality check: set entire FED to BAD if its occupancy begins to vanish
     // Fill FED statistics from TP digi occupancy
-    std::vector<float> FEDStatsEB;
-    std::vector<float> FEDStatsEE;
+    float meanFEDEB(0.), meanFEDEE(0.), rmsFEDEB(0.), rmsFEDEE(0.);
+    unsigned int nFEDEB(0), nFEDEE(0);
     for ( unsigned iDCC(0); iDCC < nDCC; iDCC++ ) {
-      if ( iDCC >= kEBmLow && iDCC <= kEBpHigh )
-        FEDStatsEB.push_back( Nentries[iDCC] );
-      else
-        FEDStatsEE.push_back( Nentries[iDCC] );
+      if ( iDCC >=kEBmLow && iDCC <= kEBpHigh) {
+        meanFEDEB += Nentries[iDCC];
+        rmsFEDEB  += Nentries[iDCC]*Nentries[iDCC];
+        nFEDEB++;
+      }
+      else {
+        meanFEDEE += Nentries[iDCC];
+        rmsFEDEE  += Nentries[iDCC]*Nentries[iDCC];
+        nFEDEE++;
+      }
     }
+    meanFEDEB /= float( nFEDEB ); rmsFEDEB /= float( nFEDEB );
+    meanFEDEE /= float( nFEDEE ); rmsFEDEE /= float( nFEDEE );
+    rmsFEDEB   = sqrt( abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
+    rmsFEDEE   = sqrt( abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
     // Analyze FED statistics
-    float meanFED(0.);
-    float meanFEDEB( TMath::Mean( FEDStatsEB.begin(),FEDStatsEB.end()) );
-    float meanFEDEE( TMath::Mean( FEDStatsEE.begin(),FEDStatsEE.end()) );
-    float rmsFED(0.);
-    float rmsFEDEB( TMath::RMS( FEDStatsEB.begin(),FEDStatsEB.end()) );
-    float rmsFEDEE( TMath::RMS( FEDStatsEE.begin(),FEDStatsEE.end()) );
-    float nRMS(5.);
+    float meanFED(0.), rmsFED(0.), nRMS(5.);
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++){
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
       unsigned iDCC( dccId(ttid)-1 );


### PR DESCRIPTION
Set entire FED/SuperModule to BAD (instead of YELLOW=low stats) in the Quality Summary if its occupancy begins to vanish under data taking conditions.

List of changes include:
1. Threshold on (filtered) rechit occupancy of the FED ( < mean FED occupancy - 5*FED rms, >1000 hits ) -> Hot Cell Quality Summary -> Global Quality Summary.
2. Threshold on DCC-SRP and DCC-TCC mismatch errors in the FED ( >50 errors per FED ) -> Integrity Quality Summary -> Global Quality Summary.
3. Threshold on % of FED showing any DCC-SRP mismatch errors ( > 0.8 or about 55 TTs in EB ) -> Emulator Error Quality summary -> Global Quality Summary. 
4. For past issue on missing TPs in entire FEDs: Threshold on the TP occupancy of the FED ( < mean FED occupancy - 5*FED rms, >100 hits ) -> Emulator Error Quality Summary -> Global Quality Summary.

In conjunction with 80X PR https://github.com/cms-sw/cmssw/pull/14704
