### PR TITLE
Change code to not stop on SRP block error and proceed with FE

### DIFF
--- a/EventFilter/EcalRawToDigi/src/DCCSRPBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCSRPBlock.cc
@@ -56,8 +56,10 @@ int DCCSRPBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned
   event_->setSRPSyncNumbers(l1_,bx_);
  
   if( ! checkSrpIdAndNumbSRFlags() ){ 
-    // SRP flags are required to check FE data 
-	return  STOP_EVENT_UNPACKING; 
+    //// SRP flags are required to check FE data 
+    //return  STOP_EVENT_UNPACKING;
+    updateEventPointers();
+    return SKIP_BLOCK_UNPACKING;
   }
 	 
   // Check synchronization
@@ -75,8 +77,10 @@ int DCCSRPBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned
           << "  => Stop event unpacking";
       }
        //Note : add to error collection ?		 
-       // SRP flags are required to check FE , better using synchronized data...
-	   return STOP_EVENT_UNPACKING;
+       //// SRP flags are required to check FE , better using synchronized data...
+      //	   return STOP_EVENT_UNPACKING;
+      updateEventPointers();
+      return SKIP_BLOCK_UNPACKING;
     }
   } 
 


### PR DESCRIPTION
Fix for a problem seen in run  274157 with corrupted SRP block from EB-11 FED.
The SRP block will be ignored, the consequence on reconstruction will be that no recovery of bad channels will be attempted for that FED.
DQM is being updated to set an alarm in case this situation is encountered again
