### PR TITLE
Consumes migration and GenHIEventProducer forward port from 75X

### DIFF
--- a/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/GenHIEventProducer.cc
@@ -35,6 +35,7 @@ Implementation:
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/HiGenData/interface/GenHIEvent.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 #include "HepMC/HeavyIon.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -52,7 +53,7 @@ class GenHIEventProducer : public edm::EDProducer {
 
     private:
         virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        std::vector<std::string> hepmcSrc_;
+        edm::EDGetTokenT<CrossingFrame<edm::HepMCProduct> > hepmcSrc_;
         edm::ESHandle < ParticleDataTable > pdt;
 
   double ptCut_;
@@ -74,10 +75,10 @@ class GenHIEventProducer : public edm::EDProducer {
 GenHIEventProducer::GenHIEventProducer(const edm::ParameterSet& iConfig)
 {
     produces<edm::GenHIEvent>();
-    hepmcSrc_ = iConfig.getParameter<std::vector<std::string> >("generators");
+    hepmcSrc_ = consumes<CrossingFrame<edm::HepMCProduct> >(iConfig.getParameter<edm::InputTag>("src"));
     doParticleInfo_ = iConfig.getUntrackedParameter<bool>("doParticleInfo",false);
     if(doParticleInfo_){
-      ptCut_ = iConfig.getUntrackedParameter<double> ("ptCut",1.);
+      ptCut_ = iConfig.getParameter<double> ("ptCut");
     }
 }
 
@@ -120,11 +121,18 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     double EtMR = 0; // Normalized of total energy bym
     double TotEnergy = 0; // Total energy bym
 
-    for(size_t ihep = 0; ihep < hepmcSrc_.size(); ++ihep){
-        Handle<edm::HepMCProduct> hepmc;
-        iEvent.getByLabel(hepmcSrc_[ihep],hepmc);
+    Handle<CrossingFrame<edm::HepMCProduct> > hepmc;
+    iEvent.getByToken(hepmcSrc_,hepmc);
+    MixCollection<HepMCProduct> mix(hepmc.product());
+    
+    if(mix.size() < 1){
+      throw cms::Exception("MatchVtx")
+	<<"Mixing has "<<mix.size()<<" sub-events, should have been at least 1"
+	<<endl;
+    }
 
-        const HepMC::GenEvent* evt = hepmc->GetEvent();
+    const HepMCProduct& hievt = mix.getObject(mix.size()-1);
+    const HepMC::GenEvent* evt = hievt.GetEvent();
 	if(doParticleInfo_){
 	  HepMC::GenEvent::particle_const_iterator begin = evt->particles_begin();
 	  HepMC::GenEvent::particle_const_iterator end = evt->particles_end();
@@ -171,7 +179,7 @@ GenHIEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		ecc = hi->eccentricity();
             }
         }
-    }
+
     // Get the normalized total energy bym
     if(TotEnergy != 0){
         EtMR = TotEnergy/2;

--- a/GeneratorInterface/HiGenCommon/plugins/HiCentralityBiasFilter.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/HiCentralityBiasFilter.cc
@@ -29,6 +29,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
@@ -57,7 +58,7 @@ class HiCentralityBiasFilter : public edm::EDFilter {
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() override ;
       
-  edm::InputTag hepmcSrc_;
+  edm::EDGetTokenT<edm::HepMCProduct> hepmcSrc_;
 
    edm::Service<edm::RandomNumberGenerator> rng_;
 
@@ -81,9 +82,9 @@ class HiCentralityBiasFilter : public edm::EDFilter {
 HiCentralityBiasFilter::HiCentralityBiasFilter(const edm::ParameterSet& iConfig)
 {
    //now do what ever initialization is needed
-   hepmcSrc_ = iConfig.getUntrackedParameter<edm::InputTag>("src", edm::InputTag("generatorSmeared"));
-   func_ = iConfig.getParameter<string>("function");
-   par_ = iConfig.getParameter<vector<double> >("parameters");
+  hepmcSrc_ = consumes<edm::HepMCProduct>(iConfig.getParameter< edm::InputTag > ("generatorSmeared"));
+  func_ = iConfig.getParameter<string>("function");
+  par_ = iConfig.getParameter<vector<double> >("parameters");
 }
 
 
@@ -111,7 +112,7 @@ HiCentralityBiasFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
    CLHEP::HepRandomEngine& engine = rng_->getEngine(iEvent.streamID());
 
    Handle<HepMCProduct> mc;
-   iEvent.getByLabel(hepmcSrc_,mc);
+   iEvent.getByToken(hepmcSrc_,mc);
    const HepMC::GenEvent* evt = mc->GetEvent();
 
    const HepMC::HeavyIon* hi = evt->heavy_ion();

--- a/GeneratorInterface/HiGenCommon/plugins/HighMultiplicityGenFilter.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/HighMultiplicityGenFilter.cc
@@ -46,6 +46,7 @@ class HighMultiplicityGenFilter : public edm::EDFilter {
       
       // ----------member data ---------------------------
       edm::ESHandle <ParticleDataTable> pdt; 
+      edm::EDGetTokenT<edm::HepMCProduct> hepmcSrc;
       double etaMax;
       double ptMin;
       int nMin; 
@@ -64,9 +65,10 @@ class HighMultiplicityGenFilter : public edm::EDFilter {
 // constructors and destructor
 //
 HighMultiplicityGenFilter::HighMultiplicityGenFilter(const edm::ParameterSet& iConfig) :
-etaMax(iConfig.getUntrackedParameter<double>("etaMax")),
-ptMin(iConfig.getUntrackedParameter<double>("ptMin")),
-nMin(iConfig.getUntrackedParameter<int>("nMin"))
+  hepmcSrc(consumes<edm::HepMCProduct>(iConfig.getParameter< edm::InputTag > ("generatorSmeared"))),
+  etaMax(iConfig.getUntrackedParameter<double>("etaMax")),
+  ptMin(iConfig.getUntrackedParameter<double>("ptMin")),
+  nMin(iConfig.getUntrackedParameter<int>("nMin"))
 {
   //now do what ever initialization is needed
   nAccepted = 0; 
@@ -93,7 +95,7 @@ HighMultiplicityGenFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
   bool accepted = false;
   edm::Handle<edm::HepMCProduct> evt;
-  iEvent.getByLabel("generatorSmeared", evt);
+  iEvent.getByToken(hepmcSrc,evt);
 
   iSetup.getData(pdt);
 

--- a/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
@@ -26,6 +26,8 @@ ________________________________________________________________________
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -102,22 +104,21 @@ private:
   TMatrixD *boost_;
   double fTimeOffset;
   
-  edm::InputTag            sourceLabel;
-
   CLHEP::RandGaussQ*  fRandom ;
 
-  edm::InputTag            signalLabel;
-  edm::InputTag            hiLabel;
+  edm::EDGetTokenT<reco::VertexCollection>   vtxLabel;
+  edm::EDGetTokenT<HepMCProduct>  signalLabel;
+  edm::EDGetTokenT<CrossingFrame<HepMCProduct> >   mixLabel;
   bool                     useRecVertex;
   std::vector<double>      vtxOffset;
 
 };
 
-
 MixBoostEvtVtxGenerator::MixBoostEvtVtxGenerator(const edm::ParameterSet & pset ):
   fVertex(0), boost_(0), fTimeOffset(0),
-  signalLabel(pset.getParameter<edm::InputTag>("signalLabel")),
-  hiLabel(pset.getParameter<edm::InputTag>("heavyIonLabel")),
+  vtxLabel(mayConsume<reco::VertexCollection>(pset.getParameter<edm::InputTag>("vtxLabel"))),
+  signalLabel(consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("signalLabel"))),
+  mixLabel(consumes<CrossingFrame<HepMCProduct> >(pset.getParameter<edm::InputTag>("mixLabel"))),
   useRecVertex(pset.exists("useRecVertex")?pset.getParameter<bool>("useRecVertex"):false)
 { 
 
@@ -249,10 +250,19 @@ TMatrixD* MixBoostEvtVtxGenerator::GetInvLorentzBoost() {
 
 HepMC::FourVector* MixBoostEvtVtxGenerator::getVertex( Event& evt){
   
-  Handle<HepMCProduct> input;
-  evt.getByLabel(hiLabel,input);
+  const HepMC::GenEvent* inev = 0;
 
-  const HepMC::GenEvent* inev = input->GetEvent();
+  Handle<CrossingFrame<HepMCProduct> > cf;
+  evt.getByToken(mixLabel,cf);
+  MixCollection<HepMCProduct> mix(cf.product());
+
+  const HepMCProduct& bkg = mix.getObject(1);
+  if(!(bkg.isVtxGenApplied())){
+    throw cms::Exception("MatchVtx")<<"Input background does not have smeared vertex!"<<endl;
+  }else{
+    inev = bkg.GetEvent();
+  }
+
   HepMC::GenVertex* genvtx = inev->signal_process_vertex();
   if(!genvtx){
     cout<<"No Signal Process Vertex!"<<endl;
@@ -282,8 +292,9 @@ HepMC::FourVector* MixBoostEvtVtxGenerator::getVertex( Event& evt){
  
 HepMC::FourVector* MixBoostEvtVtxGenerator::getRecVertex( Event& evt){
  
+
   Handle<reco::VertexCollection> input;
-  evt.getByLabel(hiLabel,input);
+  evt.getByToken(vtxLabel,input);
 
   double aX,aY,aZ;
  
@@ -302,7 +313,7 @@ HepMC::FourVector* MixBoostEvtVtxGenerator::getRecVertex( Event& evt){
 void MixBoostEvtVtxGenerator::produce( Event& evt, const EventSetup& )
 {
   Handle<HepMCProduct> HepUnsmearedMCEvt;
-  evt.getByLabel(signalLabel, HepUnsmearedMCEvt);
+  evt.getByToken(signalLabel, HepUnsmearedMCEvt);
     
   // Copy the HepMC::GenEvent
   HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
@@ -5,6 +5,6 @@ VtxSmeared = cms.EDProducer("MixBoostEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
                             mixLabel = cms.InputTag("mix","generatorSmeared"),
-                            vtxLabel = cms.InputTag("offlinePrimaryVertices")
+                            vtxLabel = cms.InputTag("offlinePrimaryVertices"),
                             Beta=cms.double(0.434)                          
                             )

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoostReversed_cff.py
@@ -5,5 +5,6 @@ VtxSmeared = cms.EDProducer("MixBoostEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
                             mixLabel = cms.InputTag("mix","generatorSmeared"),
+                            vtxLabel = cms.InputTag("offlinePrimaryVertices")
                             Beta=cms.double(0.434)                          
                             )

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoost_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatch5TeVPPbBoost_cff.py
@@ -5,5 +5,6 @@ VtxSmeared = cms.EDProducer("MixBoostEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
                             mixLabel = cms.InputTag("mix","generatorSmeared"),
+                            vtxLabel = cms.InputTag("offlinePrimaryVertices"),
                             Beta=cms.double(-0.434)
                             )

--- a/GeneratorInterface/HiGenCommon/python/VtxSmearedMatchHI_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/VtxSmearedMatchHI_cff.py
@@ -4,5 +4,6 @@ from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("MixEvtVtxGenerator",
                             useCF = cms.untracked.bool(True),
                             signalLabel = cms.InputTag("generator","unsmeared"),
-                            mixLabel = cms.InputTag("mix","generatorSmeared")
+                            mixLabel = cms.InputTag("mix","generatorSmeared"),
+                            vtxLabel = cms.InputTag("offlinePrimaryVertices")
                             )


### PR DESCRIPTION
This package seems to have escaped consumes migration, presumably as these filters weren't being used. 
Two of these filters are now needed again:
BetaBoostEvtVtxGenerator 
MixBoostEvtVtxGenerator 
which are used to apply a boost to HepMCProducts for generators that are not configured to produce asymmetric collisions, as is needed for proton-lead.  
They correspond to standard and embedded workflows, respectively.  
These are currently run in the relval matrix, so I modified wf's 280 and 301 as follows to test them:

cmsDriver.py AMPT_PPb_5020GeV_MinimumBias_cfi  --conditions auto:run2_mc  --eventcontent RAWSIM -s GEN,SIM --datatier GEN-SIM --beamspot Realistic5TeVPPbBoost

cmsDriver.py Pyquen_DiJet_pt80to120_2760GeV_cfi  --conditions auto:run2_mc_hi -s GEN,SIM --pileup_input das:/RelValHydjetQ_MinBias_5020GeV/CMSSW_7_6_0_pre6-76X_mcRun2_HeavyIon_v4-v1/GEN-SIM --era Run2_2016,Run2_HI --eventcontent FEVTDEBUG --scenario HeavyIons --pileup HiMixGEN --datatier GEN-SIM --beamspot Match5TeVPPbBoost

Note that for that for these wf's the vertex smearing parameters get loaded in this package instead of IOMC.EventVertexGenerators which is not so nice.  These parameters still correspond to 2013 pPb collisions, but I propose to clean this up in a different PR, once we have a guess for the 2016 pPb beam parameters.  

While I was touching this package I also forward ported GenHIEventProducer, which was patched into 75X but never made it into CMSSW8.  This will eventually need to be (re)added to heavy ion workflows (as was done in 75X), which will require updating the configBuilder, but I again propose to leave this as separate PR. 

I will also make this PR in 80X, as it's not yet clear which release we'll use for pPb GEN-SIM. 
