### PR TITLE
Fix memory blowup in ALCAHARVEST 80X (backport of #14721)

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
@@ -99,6 +99,7 @@ SiPixelAliMilleAlignmentProducer.tjTkAssociationMapTag = 'SiPixelAliTrackRefitte
 
 SiPixelAliMilleAlignmentProducer.algoConfig = MillePedeAlignmentAlgorithm
 SiPixelAliMilleAlignmentProducer.algoConfig.mode = 'mille'
+SiPixelAliMilleAlignmentProducer.algoConfig.runAtPCL = True
 SiPixelAliMilleAlignmentProducer.algoConfig.mergeBinaryFiles = cms.vstring()
 SiPixelAliMilleAlignmentProducer.algoConfig.binaryFile = 'milleBinary_0.dat'
 SiPixelAliMilleAlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -97,6 +97,7 @@ SiPixelAliMilleAlignmentProducer.tjTkAssociationMapTag = 'SiPixelAliTrackRefitte
 
 SiPixelAliMilleAlignmentProducer.algoConfig = MillePedeAlignmentAlgorithm
 SiPixelAliMilleAlignmentProducer.algoConfig.mode = 'mille'
+SiPixelAliMilleAlignmentProducer.algoConfig.runAtPCL = True
 SiPixelAliMilleAlignmentProducer.algoConfig.mergeBinaryFiles = cms.vstring()
 SiPixelAliMilleAlignmentProducer.algoConfig.binaryFile = 'milleBinary_0.dat'
 SiPixelAliMilleAlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
@@ -260,6 +260,8 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   // CHK for GBL
   std::unique_ptr<gbl::MilleBinary> theBinary;
   bool                      theGblDoubleBinary;
+
+  const bool                runAtPCL_;
 };
 
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
@@ -90,6 +90,12 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   // This one will be called since it matches the interface of the base class
   virtual void endRun(const EndRunInfo &runInfo, const edm::EventSetup &setup);
 
+  /// called at begin of luminosity block (resets Mille binary in mille mode)
+  virtual void beginLuminosityBlock(const edm::EventSetup&) override;
+
+  /// called at end of luminosity block
+  virtual void endLuminosityBlock(const edm::EventSetup&) override;
+
 
 /*   virtual void beginLuminosityBlock(const edm::EventSetup &setup) {} */
 /*   virtual void endLuminosityBlock(const edm::EventSetup &setup) {} */

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
@@ -10,41 +10,40 @@
 #include <fstream>
 
 MillePedeFileConverter::MillePedeFileConverter(const edm::ParameterSet& iConfig)
-    : theInputDir(iConfig.getParameter<std::string>("fileDir")),
-      theInputFileName(iConfig.getParameter<std::string>("inputBinaryFile")),
-      theFileBlobLabel(iConfig.getParameter<std::string>("fileBlobLabel")) {
+    : inputDir_(iConfig.getParameter<std::string>("fileDir")),
+      inputFileName_(iConfig.getParameter<std::string>("inputBinaryFile")),
+      fileBlobLabel_(iConfig.getParameter<std::string>("fileBlobLabel")) {
   // We define what this producer produces: A FileBlobCollection
-  produces<FileBlobCollection, edm::InRun>(theFileBlobLabel);
+  produces<FileBlobCollection, edm::InLumi>(fileBlobLabel_);
 }
 
 MillePedeFileConverter::~MillePedeFileConverter() {}
 
-void MillePedeFileConverter::endRunProduce(edm::Run& iRun,
-                                           const edm::EventSetup& iSetup) {
+void MillePedeFileConverter::endLuminosityBlockProduce(edm::LuminosityBlock& iLumi,
+                                                       const edm::EventSetup& iSetup) {
   edm::LogInfo("MillePedeFileActions")
-      << "Inserting all data from file " << theInputDir + theInputFileName
-      << " as a FileBlob to the run, using label \"" << theFileBlobLabel
+      << "Inserting all data from file " << inputDir_ + inputFileName_
+      << " as a FileBlob to the lumi, using label \"" << fileBlobLabel_
       << "\".";
   // Preparing the FileBlobCollection:
-  std::unique_ptr<FileBlobCollection> theFileBlobCollection(
-      new FileBlobCollection());
-  FileBlob theFileBlob;
+  auto fileBlobCollection = std::make_unique<FileBlobCollection>();
+  FileBlob fileBlob;
   try {
     // Creating the FileBlob:
     // (The FileBlob will signal problems with the file itself.)
-    theFileBlob = FileBlob(theInputDir + theInputFileName, true);
+    fileBlob = FileBlob(inputDir_ + inputFileName_, true);
   }
   catch (...) {
     // When creation of the FileBlob fails:
     edm::LogError("MillePedeFileActions")
         << "Error: No FileBlob could be created from the file \""
-        << theInputDir + theInputFileName << "\".";
+        << inputDir_ + inputFileName_ << "\".";
     throw;
   }
-  if (theFileBlob.size() > 0) {
-    // Adding the FileBlob to the run:
-    theFileBlobCollection->addFileBlob(theFileBlob);
-    iRun.put(std::move(theFileBlobCollection), theFileBlobLabel);
+  if (fileBlob.size() > 0) {
+    // Adding the FileBlob to the lumi:
+    fileBlobCollection->addFileBlob(fileBlob);
+    iLumi.put(std::move(fileBlobCollection), fileBlobLabel_);
   }
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
@@ -43,8 +43,8 @@ void MillePedeFileConverter::endLuminosityBlockProduce(edm::LuminosityBlock& iLu
   if (fileBlob.size() > 0) {
     // Adding the FileBlob to the lumi:
     fileBlobCollection->addFileBlob(fileBlob);
-    iLumi.put(std::move(fileBlobCollection), fileBlobLabel_);
   }
+  iLumi.put(std::move(fileBlobCollection), fileBlobLabel_);
 }
 
 // Manage the parameters for the module:

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.h
@@ -26,7 +26,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class MillePedeFileConverter
-    : public edm::one::EDProducer<edm::EndRunProducer> {
+    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer> {
  public:
   explicit MillePedeFileConverter(const edm::ParameterSet&);
   ~MillePedeFileConverter();
@@ -34,12 +34,12 @@ class MillePedeFileConverter
 
  private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override {}
-  virtual void endRunProduce(edm::Run& run,
-                             const edm::EventSetup& iSetup) override final;
+  virtual void endLuminosityBlockProduce(edm::LuminosityBlock&,
+                                         const edm::EventSetup&) override final;
 
-  std::string theInputDir;
-  std::string theInputFileName;
-  std::string theFileBlobLabel;
+  const std::string inputDir_;
+  const std::string inputFileName_;
+  const std::string fileBlobLabel_;
 };
 
 // define this as a plug-in

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.cc
@@ -27,28 +27,25 @@ void MillePedeFileExtractor::endLuminosityBlock(const edm::LuminosityBlock& iLum
   iLumi.getByToken(fileBlobToken_, fileBlobCollection);
   if (fileBlobCollection.isValid()) {
     // Logging the amount of FileBlobs in the vector
-    int theVectorSize = fileBlobCollection->size();
-    edm::LogInfo("MillePedeFileActions") << "Root file contains "
-                                         << theVectorSize << " FileBlob(s).";
+    edm::LogInfo("MillePedeFileActions")
+      << "Root file contains " << fileBlobCollection->size() << " FileBlob(s).";
     // Loop over the FileBlobs in the vector, and write them to files:
-    for (std::vector<FileBlob>::const_iterator it =
-             fileBlobCollection->begin();
-         it != fileBlobCollection->end(); ++it) {
+    for (const auto& blob: *fileBlobCollection) {
       // We format the filename with a number, starting from 0 to the size of
       // our vector.
       // For this to work, the outputBinaryFile config parameter must contain a
       // formatting directive for a number, like %04d.
       char theNumberedOutputFileName[200];
-      int theNumber = it - fileBlobCollection->begin();
-      sprintf(theNumberedOutputFileName, outputFileName_.c_str(), theNumber);
+      sprintf(theNumberedOutputFileName, outputFileName_.c_str(), nBinaries_);
       // Log the filename to which we will write...
       edm::LogInfo("MillePedeFileActions")
           << "Writing FileBlob file to file "
           << outputDir_ + theNumberedOutputFileName << ".";
       // ...and perform the writing operation.
-      it->write(outputDir_ + theNumberedOutputFileName);
-      // Carefull, it seems that when writing to an impossible file, this is
-      // swallowed by the FileBlob->write operation and no error is thrown.
+      blob.write(outputDir_ + theNumberedOutputFileName);
+      // Careful, it seems that when writing to an impossible file, this is
+      // swallowed by the FileBlob.write operation and no error is thrown.
+      ++nBinaries_;
     }
   } else {
     edm::LogError("MillePedeFileActions")

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
@@ -22,26 +22,29 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/Common/interface/FileBlobCollection.h"
 
-class MillePedeFileExtractor : public edm::EDAnalyzer {
+class MillePedeFileExtractor : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
  public:
   explicit MillePedeFileExtractor(const edm::ParameterSet&);
   ~MillePedeFileExtractor();
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  void analyze(const edm::Event&, const edm::EventSetup&) {}
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&,
+                                    const edm::EventSetup&) override {}
+  virtual void endLuminosityBlock(const edm::LuminosityBlock&,
+                                  const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
 
-  std::string theOutputDir;
-  std::string theOutputFileName;
+  const std::string outputDir_;
+  const std::string outputFileName_;
 
-  edm::EDGetTokenT<FileBlobCollection> theFileBlobToken;
+  edm::EDGetTokenT<FileBlobCollection> fileBlobToken_;
 
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
@@ -42,11 +42,16 @@ class MillePedeFileExtractor :
                                   const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
 
+  bool enoughBinaries() {
+    return (nBinaries_ >= maxNumberOfBinaries_) && hasBinaryNumberLimit(); }
+  bool hasBinaryNumberLimit() { return maxNumberOfBinaries_ > -1; }
+
   const std::string outputDir_;
   const std::string outputFileName_;
 
   edm::EDGetTokenT<FileBlobCollection> fileBlobToken_;
 
+  const int maxNumberOfBinaries_;
   int nBinaries_{0};
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
@@ -28,7 +28,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/Common/interface/FileBlobCollection.h"
 
-class MillePedeFileExtractor : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class MillePedeFileExtractor :
+  public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
  public:
   explicit MillePedeFileExtractor(const edm::ParameterSet&);
   ~MillePedeFileExtractor();
@@ -46,6 +47,7 @@ class MillePedeFileExtractor : public edm::one::EDAnalyzer<edm::one::WatchLumino
 
   edm::EDGetTokenT<FileBlobCollection> fileBlobToken_;
 
+  int nBinaries_{0};
 };
 
 // define this as a plug-in

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -21,6 +21,8 @@ MillePedeAlignmentAlgorithm = cms.PSet(
 
     monitorFile = cms.untracked.string('millePedeMonitor.root'), ## if empty: no monitoring...
 
+    runAtPCL = cms.bool(False), # at the PCL the mille binaries are reset at lumi-section boundaries
+
     # PSet that allows to configure the pede labeler, i.e. select the actual
     # labeler plugin to use and parameters for the selected plugin
     pedeLabeler = cms.PSet(

--- a/Alignment/MillePedeAlignmentAlgorithm/src/Mille.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/Mille.h
@@ -9,11 +9,11 @@
  *  Class to write a C binary (cf. below) file of a given name and to fill it
  *  with information used as input to pede.
  *  Use its member functions mille(...), special(...), kill() and end() as you would
- *  use the fortran MILLE and its entry points MILLSP, KILLE and ENDLE. 
+ *  use the fortran MILLE and its entry points MILLSP, KILLE and ENDLE.
  *
  *  For debugging purposes constructor flags enable switching to text output and/or
  *  to write also derivatives and lables which are ==0.
- *  But note that pede will not be able to read text output and has not been tested with 
+ *  But note that pede will not be able to read text output and has not been tested with
  *  derivatives/labels ==0.
  *
  *  \author    : Gero Flucke
@@ -23,33 +23,36 @@
  *  (last update by $Author: flucke $)
  */
 
-class Mille 
+class Mille
 {
  public:
   Mille(const char *outFileName, bool asBinary = true, bool writeZero = false);
   ~Mille();
 
   void mille(int NLC, const float *derLc, int NGL, const float *derGl,
-	     const int *label, float rMeas, float sigma);
+             const int *label, float rMeas, float sigma);
   void special(int nSpecial, const float *floatings, const int *integers);
   void kill();
-  void flushOutputFile(); 
+  void flushOutputFile();
+  void resetOutputFile();
   void end();
 
  private:
   void newSet();
   bool checkBufferSize(int nLocal, int nGlobal);
 
-  std::ofstream myOutFile; // C-binary for output
-  bool myAsBinary;         // if false output as text
-  bool myWriteZero;        // if true also write out derivatives/lables ==0
+  const std::ios_base::openmode fileMode_; // file open mode of the binary
+  const std::string fileName_;             // file name of the binary
+  std::ofstream outFile_; // C-binary for output
+  bool asBinary_;         // if false output as text
+  bool writeZero_;        // if true also write out derivatives/lables ==0
 
-  enum {myBufferSize = 5000};
-  int   myBufferInt[myBufferSize];   // to collect labels etc.
-  float myBufferFloat[myBufferSize]; // to collect derivatives etc.
-  int   myBufferPos;
-  bool  myHasSpecial; // if true, special(..) already called for this record
+  enum {bufferSize_ = 5000};
+  int   bufferInt_[bufferSize_];   // to collect labels etc.
+  float bufferFloat_[bufferSize_]; // to collect derivatives etc.
+  int   bufferPos_;
+  bool  hasSpecial_; // if true, special(..) already called for this record
 
-  enum {myMaxLabel = (0xFFFFFFFF - (1 << 31))}; // largest label allowed: 2^31 - 1
+  enum {maxLabel_ = (0xFFFFFFFF - (1 << 31))}; // largest label allowed: 2^31 - 1
 };
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
@@ -351,10 +351,13 @@ std::vector<std::string> MillePedeAlignmentAlgorithm::getExistingFormattedFiles(
         }
       } else {
         // The file doesn't exist, break out of the loop
-	edm::LogWarning("Alignment")
-	  << "The input file '" << strippedInputFileName << "' does not exist.";
         break;
       }
+    }
+    // warning if unformatted (-> theNumber stays at 0) does not exist
+    if (theNumber == 0 && (files.size() == 0 || files.back() != plainFile)) {
+      edm::LogWarning("Alignment")
+	<< "The input file '" << plainFile << "' does not exist.";
     }
   }
   return files;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
@@ -95,7 +95,8 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
   theMinNumHits(cfg.getParameter<unsigned int>("minNumHits")),
   theMaximalCor2D(cfg.getParameter<double>("max2Dcorrelation")),
   theLastWrittenIov(0),
-  theGblDoubleBinary(cfg.getParameter<bool>("doubleBinary"))
+  theGblDoubleBinary(cfg.getParameter<bool>("doubleBinary")),
+  runAtPCL_(cfg.getParameter<bool>("runAtPCL"))
 {
   if (!theDir.empty() && theDir.find_last_of('/') != theDir.size()-1) theDir += '/';// may need '/'
   edm::LogInfo("Alignment") << "@SUB=MillePedeAlignmentAlgorithm" << "Start in mode '"
@@ -533,12 +534,14 @@ void MillePedeAlignmentAlgorithm::endRun(const EndRunInfo &runInfo, const edm::E
 //____________________________________________________
 void MillePedeAlignmentAlgorithm::beginLuminosityBlock(const edm::EventSetup&)
 {
+  if (!runAtPCL_) return;
   if(this->isMode(myMilleBit)) theMille->resetOutputFile();
 }
 
 //____________________________________________________
 void MillePedeAlignmentAlgorithm::endLuminosityBlock(const edm::EventSetup&)
 {
+  if (!runAtPCL_) return;
   if(this->isMode(myMilleBit)) theMille->flushOutputFile();
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
@@ -530,6 +530,18 @@ void MillePedeAlignmentAlgorithm::endRun(const EndRunInfo &runInfo, const edm::E
   if(this->isMode(myMilleBit)) theMille->flushOutputFile();
 }
 
+//____________________________________________________
+void MillePedeAlignmentAlgorithm::beginLuminosityBlock(const edm::EventSetup&)
+{
+  if(this->isMode(myMilleBit)) theMille->resetOutputFile();
+}
+
+//____________________________________________________
+void MillePedeAlignmentAlgorithm::endLuminosityBlock(const edm::EventSetup&)
+{
+  if(this->isMode(myMilleBit)) theMille->flushOutputFile();
+}
+
 
 //____________________________________________________
 int MillePedeAlignmentAlgorithm::addMeasurementData(const edm::EventSetup &setup,


### PR DESCRIPTION
Fixes Memory blowup reported in [Reconstruction Development HN](https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1445.html).
- the blowup was caused by the merging of the FileBlobCollections at the end of the run
- making this collection a lumi product instead of a run product keeps the memory consumption stable without changing the alignment result (see plots below for the first 600 files of run 273730)

Memory consumption of SiPixelAli workflow:
![pede_memory_usage_log](https://cloud.githubusercontent.com/assets/4136328/15703263/9efd4e80-27e4-11e6-903e-be4ce582eadf.png)

Geometry comparison:
![global_tracker_2_final](https://cloud.githubusercontent.com/assets/4136328/15703384/3992f256-27e5-11e6-80cc-e5a9f149d41a.png)

Backport of #14721
