### PR TITLE
Phase2 tracking validation in 81X

### DIFF
--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -17,6 +17,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -74,6 +75,8 @@ namespace helper {
     typedef ClusterHitRecord<SiPixelRecHit::ClusterRef>   PixelClusterHitRecord;
     /// Assuming that the ClusterRef is the same for all SiStripRecHit*:
     typedef ClusterHitRecord<SiStripRecHit2D::ClusterRef> StripClusterHitRecord;
+ 
+    typedef ClusterHitRecord<Phase2TrackerRecHit1D::CluRef> Phase2OTClusterHitRecord;
 
     //------------------------------------------------------------------
     //!  Processes all the clusters of a specific type
@@ -88,6 +91,7 @@ namespace helper {
     //--- Information about the cloned clusters
     std::vector<PixelClusterHitRecord>                  pixelClusterRecords_;
     std::vector<StripClusterHitRecord>                  stripClusterRecords_;
+    std::vector<Phase2OTClusterHitRecord>               phase2OTClusterRecords_;
   };
 
 }

--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -75,7 +75,8 @@ namespace helper {
     typedef ClusterHitRecord<SiPixelRecHit::ClusterRef>   PixelClusterHitRecord;
     /// Assuming that the ClusterRef is the same for all SiStripRecHit*:
     typedef ClusterHitRecord<SiStripRecHit2D::ClusterRef> StripClusterHitRecord;
- 
+    //FIXME:: this is just temporary solution for phase2,
+    //probably is good to add a Phase2ClusterStorer?
     typedef ClusterHitRecord<Phase2TrackerRecHit1D::CluRef> Phase2OTClusterHitRecord;
 
     //------------------------------------------------------------------

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -8,6 +8,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 // FastSim hits:
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/FastProjectedTrackerRecHit.h"
@@ -45,6 +46,10 @@ namespace helper {
       //std::cout << "|   It is a ProjectedSiStripRecHit2D hit !!" << std::endl;
       ProjectedSiStripRecHit2D &phit = static_cast<ProjectedSiStripRecHit2D&>(newHit);
       stripClusterRecords_.push_back(StripClusterHitRecord(phit.originalHit(), hits, index));
+    } else if (hit_type == typeid(Phase2TrackerRecHit1D)) {
+      std::cout << "|   It is a Phase2TrackerRecHit1D hit and it cannot be recorded because it does not have two recHit but just two clusters !!" << std::endl;
+//      Phase2TrackerRecHit1D &vhit = static_cast<Phase2TrackerRecHit1D&>(newHit);
+//      phase2ClusterRecords_.push_back(Phase2ClusterHitRecord(static_cast<Phase2TrackerRecHit1D&>(newHit), hits, index));
     } else {
       if (hit_type == typeid(FastTrackerRecHit)
  	  || hit_type == typeid(FastProjectedTrackerRecHit)

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -47,9 +47,9 @@ namespace helper {
       ProjectedSiStripRecHit2D &phit = static_cast<ProjectedSiStripRecHit2D&>(newHit);
       stripClusterRecords_.push_back(StripClusterHitRecord(phit.originalHit(), hits, index));
     } else if (hit_type == typeid(Phase2TrackerRecHit1D)) {
-      std::cout << "|   It is a Phase2TrackerRecHit1D hit and it cannot be recorded because it does not have two recHit but just two clusters !!" << std::endl;
-//      Phase2TrackerRecHit1D &vhit = static_cast<Phase2TrackerRecHit1D&>(newHit);
-//      phase2ClusterRecords_.push_back(Phase2ClusterHitRecord(static_cast<Phase2TrackerRecHit1D&>(newHit), hits, index));
+//      std::cout << "|   It is a Phase2TrackerRecHit1D hit and it cannot be recorded because it does not have two recHit but just two clusters !!" << std::endl;
+//      Phase2TrackerRecHit1D &ph2OThit = static_cast<Phase2TrackerRecHit1D&>(newHit);
+      phase2OTClusterRecords_.push_back(Phase2OTClusterHitRecord(static_cast<Phase2TrackerRecHit1D&>(newHit), hits, index));
     } else {
       if (hit_type == typeid(FastTrackerRecHit)
  	  || hit_type == typeid(FastProjectedTrackerRecHit)

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -47,8 +47,9 @@ namespace helper {
       ProjectedSiStripRecHit2D &phit = static_cast<ProjectedSiStripRecHit2D&>(newHit);
       stripClusterRecords_.push_back(StripClusterHitRecord(phit.originalHit(), hits, index));
     } else if (hit_type == typeid(Phase2TrackerRecHit1D)) {
-//      std::cout << "|   It is a Phase2TrackerRecHit1D hit and it cannot be recorded because it does not have two recHit but just two clusters !!" << std::endl;
-//      Phase2TrackerRecHit1D &ph2OThit = static_cast<Phase2TrackerRecHit1D&>(newHit);
+      //FIXME:: this is just temporary solution for phase2,
+      //it is not really running in the phase2 tracking wf - yet...
+      //std::cout << "|   It is a Phase2TrackerRecHit1D hit !!" << std::endl;
       phase2OTClusterRecords_.push_back(Phase2OTClusterHitRecord(static_cast<Phase2TrackerRecHit1D&>(newHit), hits, index));
     } else {
       if (hit_type == typeid(FastTrackerRecHit)

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1613,11 +1613,11 @@ for k in upgradeKeys:
     if cust!=None : upgradeStepDict['RecoFullLocal'][k]['--customise']=cust
     if era is not None: upgradeStepDict['RecoFullLocal'][k]['--era']=era
 
-    upgradeStepDict['RecoFullTracking'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly',
+    upgradeStepDict['RecoFullTracking'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM',
                                       '--conditions':gt,
-                                      '--datatier':'GEN-SIM-RECO',
+                                      '--datatier':'GEN-SIM-RECO,DQMIO',
                                       '-n':'10',
-                                      '--eventcontent':'RECOSIM',
+                                      '--eventcontent':'RECOSIM,DQM',
                                       '--geometry' : geom
                                       }
     if cust!=None : upgradeStepDict['RecoFullTracking'][k]['--customise']=cust
@@ -1639,6 +1639,20 @@ for k in upgradeKeys:
 
     if k2 in PUDataSets:
         upgradeStepDict['RecoFullPUHGCAL'][k]=merge([PUDataSets[k2],{'-s':'RAW2DIGI,L1Reco,RECO'},upgradeStepDict['RecoFullHGCAL'][k]])
+
+    upgradeStepDict['HARVESTFullTracking'][k]={'-s':'HARVESTING:@trackingOnlyValidation',
+                                    '--conditions':gt,
+                                    '--mc':'',
+                                    '--geometry' : geom,
+                                    '--scenario' : 'pp',
+                                    '--filetype':'DQM'
+                                    }
+    if cust!=None : upgradeStepDict['HARVESTFullTracking'][k]['--customise']=cust
+    if era is not None: upgradeStepDict['HARVESTFullTracking'][k]['--era']=era
+
+    if k2 in PUDataSets:
+        upgradeStepDict['HARVESTFullTrackingPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFullTracking'][k]])
+
 
     upgradeStepDict['HARVESTFull'][k]={'-s':'HARVESTING:@standardValidation+@standardDQM+@miniAODValidation+@miniAODDQM',
                                     '--conditions':gt,

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -99,16 +99,16 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
 # step5 is digi+l1tracktrigger
 # step6 is fastsim
 # step7 is fastsim harvesting
-upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','RecoFullLocal','RecoFull','RecoFullHGCAL','RecoFullTracking','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','RecoFullPUTracking','HARVESTFullPU','DigiFullTrigger']
+upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','DigiFull','RecoFullLocal','RecoFull','RecoFullHGCAL','RecoFullTracking','HARVESTFullTracking','HARVESTFullTrackingPU','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','RecoFullPUTracking','HARVESTFullPU','DigiFullTrigger']
 
 upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    #'2017':['GenSimFull'],
 		   '2017PU':['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],#full sequence
 		   '2023':['GenSimFull','DigiFull','RecoFull'],#full sequence
-		   '2023tilted':['GenSimFull','DigiFull','RecoFullTracking'],#full (or almost..) reco tilted scenario
+		   '2023tilted':['GenSimFull','DigiFull','RecoFullTracking','HARVESTFullTracking'],#full (or almost..) reco tilted scenario + tracking valdqm
 		   '2023sim':['GenSimFull'],#sim scenario
 		   '2023LReco':['GenSimFull','DigiFull','RecoFullLocal'],#local reco scenario
-		   '2023GReco':['GenSimFull','DigiFull','RecoFullTracking']#full (or almost..)  reco scenario
+		   '2023GReco':['GenSimFull','DigiFull','RecoFullTracking','HARVESTFullTracking']#full (or almost..)  reco scenario + tracking valdqm
                    }
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -41,6 +41,7 @@ class Eras (object):
         self.trackingPhase1 = cms.Modifier()
         self.trackingPhase1PU70 = cms.Modifier()
         self.trackingLowPU = cms.Modifier()
+        self.trackingPhase2PU140 = cms.Modifier()
         
         # This era should not be set by the user with the "--era" command, it's
         # activated automatically if the "--fast" command is used.
@@ -64,9 +65,9 @@ class Eras (object):
         self.Run3 = cms.ModifierChain( self.Run2_2017,self.run3_GEM )
         # Phase2 is everything for the 2023 (2026?) detector that works so far in this release.
         # include phase 1 stuff until phase 2 tracking is fully defined....
-        self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.phase2_hgcal, self.phase2_muon, self.run3_GEM )
+        self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.trackingPhase2PU140, self.phase2_hgcal, self.phase2_muon, self.run3_GEM )
         # Phase2dev is everything for the 2023 (2026?) detector that is still in development.
-        self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.phase2dev_hgcal, self.phase2dev_muon )
+        self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.trackingPhase2PU140, self.phase2dev_hgcal, self.phase2dev_muon )
 
         # Scenarios with low-PU tracking (for B=0T reconstruction)
         self.Run2_2016_trackingLowPU = cms.ModifierChain(self.Run2_2016, self.trackingLowPU)

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -67,7 +67,7 @@ class Eras (object):
         # include phase 1 stuff until phase 2 tracking is fully defined....
         self.Phase2 = cms.ModifierChain( self.phase2_common, self.phase2_tracker, self.trackingPhase2PU140, self.phase2_hgcal, self.phase2_muon, self.run3_GEM )
         # Phase2dev is everything for the 2023 (2026?) detector that is still in development.
-        self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.trackingPhase2PU140, self.phase2dev_hgcal, self.phase2dev_muon )
+        self.Phase2dev = cms.ModifierChain( self.Phase2, self.phase2dev_common, self.phase2dev_tracker, self.phase2dev_hgcal, self.phase2dev_muon )
 
         # Scenarios with low-PU tracking (for B=0T reconstruction)
         self.Run2_2016_trackingLowPU = cms.ModifierChain(self.Run2_2016, self.trackingLowPU)

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -140,3 +140,14 @@ for era in _cfg.allEras():
     pf = _cfg.postfix(era)
     locals()["selectedIterTrackingStep"+pf] = _cfg.iterationAlgos(era)
 #selectedIterTrackingStep.append('muonSeededStepOutInDisplaced')
+
+# FIXME ::  this part will be removed when phase2 tracking is migrated to eras
+selectedIterTrackingStep_trackingPhase2PU140 = [
+    "initialStep",
+    "highPtTripletStep",
+    "lowPtQuadStep",
+    "lowPtTripletStep",
+    "detachedQuadStep",
+    "pixelPairStep",
+    "muonSeededStepInOut",
+]

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -178,7 +178,7 @@ for tracks in selectedTracks :
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0 += locals()[label]
 # seeding monitoring
-for era in _cfg.allEras():
+for era in _cfg.allEras() + ["trackingPhase2PU140"]: # FIXME:: allEras() extension should be removed when phase2 tracking is migrated to eras
     postfix = _cfg.postfix(era)
     _seq = cms.Sequence()
     for step in locals()["selectedIterTrackingStep"+postfix]:

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -21,10 +21,6 @@ def customise(process):
         process=customise_Reco(process,float(n))
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
-    if hasattr(process,'dqmoffline_step'):
-        process=customise_DQM(process,n)
-    if hasattr(process,'dqmHarvesting'):
-        process=customise_harvesting(process)
     if hasattr(process,'validation_step'):
         process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
@@ -338,9 +334,6 @@ def customise_condOverRides(process):
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkFlat_cff')
     return process
 
-
-def customise_DQM(process,pileup):
-    return process
 
 def customise_Validation(process,pileup):
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -21,6 +21,12 @@ def customise(process):
         process=customise_Reco(process,float(n))
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
+    if hasattr(process,'dqmoffline_step'):
+        process=customise_DQM(process,n)
+    if hasattr(process,'dqmHarvesting'):
+        process=customise_harvesting(process)
+    if hasattr(process,'validation_step'):
+        process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
 
     return process
@@ -332,3 +338,23 @@ def customise_condOverRides(process):
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkFlat_cff')
     return process
 
+
+def customise_DQM(process,pileup):
+    return process
+
+def customise_Validation(process,pileup):
+
+    process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
+    if hasattr(process,'tpClusterProducer'):
+        process.tpClusterProducer.pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel")
+        process.tpClusterProducer.phase2OTSimLinkSrc  = cms.InputTag("simSiPixelDigis","Tracker")
+
+    if hasattr(process,'simHitTPAssocProducer'):
+        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+
+    if hasattr(process,'trackingParticleNumberOfLayersProducer'):
+        process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+
+    return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -21,10 +21,6 @@ def customise(process):
         process=customise_Reco(process,float(n))
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
-    if hasattr(process,'dqmoffline_step'):
-        process=customise_DQM(process,n)
-    if hasattr(process,'dqmHarvesting'):
-        process=customise_harvesting(process)
     if hasattr(process,'validation_step'):
         process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
@@ -338,9 +334,6 @@ def customise_condOverRides(process):
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted_cff')
     return process
 
-
-def customise_DQM(process,pileup):
-    return process
 
 def customise_Validation(process,pileup):
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -21,6 +21,12 @@ def customise(process):
         process=customise_Reco(process,float(n))
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
+    if hasattr(process,'dqmoffline_step'):
+        process=customise_DQM(process,n)
+    if hasattr(process,'dqmHarvesting'):
+        process=customise_harvesting(process)
+    if hasattr(process,'validation_step'):
+        process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
 
     return process
@@ -330,4 +336,25 @@ def customise_Reco(process,pileup):
 
 def customise_condOverRides(process):
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted_cff')
+    return process
+
+
+def customise_DQM(process,pileup):
+    return process
+
+def customise_Validation(process,pileup):
+
+    process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
+    if hasattr(process,'tpClusterProducer'):
+        process.tpClusterProducer.pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel")
+        process.tpClusterProducer.phase2OTSimLinkSrc  = cms.InputTag("simSiPixelDigis","Tracker")
+
+    if hasattr(process,'simHitTPAssocProducer'):
+        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+
+    if hasattr(process,'trackingParticleNumberOfLayersProducer'):
+        process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+
     return process

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -9,6 +9,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -417,6 +418,12 @@ template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHitsIm
 	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
 	  returnValue.push_back(sRHit->omniClusterRef());
 	}
+	else if (tid == typeid(Phase2TrackerRecHit1D)) {
+	  const Phase2TrackerRecHit1D* ph2Hit = dynamic_cast<const Phase2TrackerRecHit1D*>(rhit);
+          if (!ph2Hit->cluster().isNonnull() )
+	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+	  returnValue.push_back(ph2Hit->omniClusterRef());
+        }
 	else {
 	  auto const & thit = static_cast<BaseTrackerRecHit const&>(*rhit);
 	  if ( thit.isProjected() ) {

--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -128,3 +128,4 @@ def _modifyForPhase1(pset):
     pset.maxEta = 3
     pset.nintEta = 60
 eras.phase1Pixel.toModify(MTVHistoProducerAlgoForTrackerBlock, _modifyForPhase1)
+eras.phase2_tracker.toModify(MTVHistoProducerAlgoForTrackerBlock, minEta=-4.5, maxEta=4.5)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -138,6 +138,7 @@ _relevantEras = [
     _eraPostfix("trackingLowPU"),
     _eraPostfix("trackingPhase1"),
     _eraPostfix("trackingPhase1PU70"),
+    _eraPostfix("trackingPhase2PU140"),
 ]
 _relevantErasAndFastSim = _relevantEras + [_eraPostfix("fastSim")]
 def _translateArgs(args, postfix, modDict):

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -34,6 +34,36 @@ for era in _cfg.allEras():
     locals()["_seedProducers"+pf] = _seedProd + _cfg.seedProducers(era)
     locals()["_trackProducers"+pf] = _trackProd + _cfg.trackProducers(era)
 
+# FIXME ::  this part will be removed when phase2 tracking is migrated to eras
+_algos_trackingPhase2PU140 = [
+    "generalTracks",
+    "initialStep",
+    "highPtTripletStep",
+    "lowPtQuadStep",
+    "lowPtTripletStep",
+    "detachedQuadStep",
+    "pixelPairStep",
+    "muonSeededStepInOut",
+]
+_seedProducers_trackingPhase2PU140 = [
+    "initialStepSeeds",
+    "highPtTripletStepSeeds",
+    "lowPtQuadStepSeeds",
+    "lowPtTripletStepSeeds",
+    "detachedQuadStepSeeds",
+    "pixelPairStepSeeds",
+    "muonSeededSeedsInOut",
+]
+_trackProducers_trackingPhase2PU140 = [
+    "initialStepTracks",
+    "highPtTripletStepTracks",
+    "lowPtQuadStepTracks",
+    "lowPtTripletStepTracks",
+    "detachedQuadStepTracks",
+    "pixelPairStepTracks",
+    "muonSeededTracksInOut",
+]
+
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",
                                  "muonSeededSeedsInOut",

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -19,5 +19,6 @@ def _modifyForPhase1(pset):
     pset.minRapidityTP = -3
     pset.maxRapidityTP = 3
 eras.phase1Pixel.toModify(TrackingParticleSelectionForEfficiency, _modifyForPhase1)
+eras.phase2_tracker.toModify(TrackingParticleSelectionForEfficiency, minRapidityTP = -4.5, maxRapidityTP = 4.5)
 if eras.fastSim.isChosen():
     TrackingParticleSelectionForEfficiency.stableOnlyTP = True

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -29,3 +29,5 @@ def _modifyForPhase1(pset):
     pset.maxRapidity = 3
 eras.phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1)
 eras.phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
+eras.phase2_tracker.toModify(generalTpSelectorBlock, minRapidity=-4.5, maxRapidity=4.5)
+eras.phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, minRapidity=-4.5, maxRapidity=4.5)


### PR DESCRIPTION
In this PR the validation and DQM step has been included in the WF (106xx and 112xx) and fixed for the phase2 tracking. Where it was easy and possible, the customization has already been moved to era (trackingPhase2PU140).
No changes are expected in the standard list of WF for run2. Some checks have been performed locally.

@boudoul @makortel please have a look at the final changes.
@delaere @VinInn @rovere @kpedro88 
