### PR TITLE
Add more setters in CSCCorrelatedLCTDigi

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -84,6 +84,15 @@ class CSCCorrelatedLCTDigi
   /// set quality code
   void setQuality(unsigned int q) {quality=q;}
 
+  /// set CLCT pattern
+  void setCLCTPattern(unsigned int p) {pattern=p;}
+
+  /// set valid
+  void setValid(unsigned int v) {valid=v;}
+
+  /// set bending
+  void setBend(unsigned int b) {bend=b;}
+
  private:
   uint16_t trknmb;
   uint16_t valid;


### PR DESCRIPTION
The extra setters will allow us to insert GEM-CSC bending angle information in the  CSCCorrelatedLCTDigi dataformat, without actually changing the dataformat itself. Instead we will reinterpret 4 fields of the dataformat in the EMTF. These fields are pattern, quality, bending and valid.

There should be no change in the workflows for any era. 
