### PR TITLE
remove unnecessary cloning of  particleFlowDisplacedVertex and pfCandidateToVertexAssociation in met corrections  (backport of #14744)

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/helpers.py
+++ b/PhysicsTools/PatAlgos/python/tools/helpers.py
@@ -190,10 +190,11 @@ class GatherAllModulesVisitor(object):
 class CloneSequenceVisitor(object):
     """Visitor that travels within a cms.Sequence, and returns a cloned version of the Sequence.
     All modules and sequences are cloned and a postfix is added"""
-    def __init__(self, process, label, postfix, removePostfix=""):
+    def __init__(self, process, label, postfix, removePostfix="", noClones = []):
         self._process = process
         self._postfix = postfix
         self._removePostfix = removePostfix
+        self._noClones = noClones
         self._moduleLabels = []
         self._clonedSequence = cms.Sequence()
         setattr(process, self._newLabel(label), self._clonedSequence)
@@ -202,7 +203,9 @@ class CloneSequenceVisitor(object):
         if isinstance(visitee, cms._Module):
             label = visitee.label()
             newModule = None
-            if label in self._moduleLabels: # has the module already been cloned ?
+            if label in self._noClones: #keep unchanged
+                newModule = getattr(self._process, label)
+            elif label in self._moduleLabels: # has the module already been cloned ?
                 newModule = getattr(self._process, self._newLabel(label))
             else:
                 self._moduleLabels.append(label)
@@ -303,7 +306,7 @@ def contains(sequence, moduleName):
 
 
 
-def cloneProcessingSnippet(process, sequence, postfix, removePostfix=""):
+def cloneProcessingSnippet(process, sequence, postfix, removePostfix="", noClones = []):
    """
    ------------------------------------------------------------------
    copy a sequence plus the modules and sequences therein
@@ -313,7 +316,7 @@ def cloneProcessingSnippet(process, sequence, postfix, removePostfix=""):
    """
    result = sequence
    if not postfix == "":
-       visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix)
+       visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix, noClones)
        sequence.visit(visitor)
        result = visitor.clonedSequence()
    return result

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -384,7 +384,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
             
         if postfix != "" and metType == "PF" and not hasattr(process, 'pat'+metType+'Met'+postfix):
-            configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix)
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
+            configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp)
             setattr(process, 'pat'+metType+'Met'+postfix, getattr(process,'patPFMet' ).clone() )
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, "patPFMet"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
@@ -442,7 +443,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             }
 
         if postfix != "":
-            configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT0CorrSequence"), postfix)
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
+            configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT0CorrSequence"), postfix, noClones = noClonesTmp)
             configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT1T2CorrSequence"), postfix)
             configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT2CorrSequence"), postfix)
             configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetTxyCorrSequence"), postfix)


### PR DESCRIPTION
(copied from 81X description)
modules with (currently) identical PSets independent of MET correction settings were cloned unnecessarily: particleFlowDisplacedVertex and pfCandidateToVertexAssociation were cloned to 
*Puppi and *NoHF instances.
The extra CPU consumed by these in PU35 ttbar MC is about 3% of total event processing time.

If future implementations need these to be different, cloning of these modules can be re-enabled.
If there was no lingering need to support scheduled execution and if these modules were not in endpaths,
a solution could have been easier (just drop from the original sequence definition).

No changes in final results are expected (none were observed in local tests)
