### PR TITLE
81X update phase-I with Hcal geometry fix

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,9 +34,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v0',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v1',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v0',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -12,7 +12,7 @@ upgradeKeys=['2017',
 	     ]
 
 
-upgradeGeoms={ '2017' : 'Extended2017',
+upgradeGeoms={ '2017' : 'DB:Extended',
                '2023' : 'Extended2023',   
                '2023tilted' : 'Extended2023tilted', 
                '2023sim' : 'Extended2023sim',


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v1) as [81X_upgrade2017_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v1/81X_upgrade2017_realistic_v0): 
  - updates to the Hcal geometry from 2015 Hcal to 2016a Hcal to fix the issue reported in https://github.com/cms-sw/cmssw/pull/14545#issuecomment-220594312
- **PhaseI design scenario** : [81X_upgrade2017_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v1) as [81X_upgrade2017_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v1/81X_upgrade2017_design_v0): 
  - updates to the Hcal geometry from 2015 Hcal to 2016a Hcal to fix the issue reported in https://github.com/cms-sw/cmssw/pull/14545#issuecomment-220594312

attn: @makortel @ianna @boudoul @veszpv.

@boudoul @hengne, please let me know if there is any smarter way of consuming the geometry from DB without destroying the loop logic in `Configuration/PyReleaseValidation/python/relval_steps.py`.
