### PR TITLE
SUSY HLT DQM path and filter name fixes for various paths, 80X

### DIFF
--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
@@ -68,7 +68,7 @@ SUSY_HLT_Ele8_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v'),
-  TriggerFilter = cms.InputTag('hltEle8CaloIdMTrkIdMDPhiFilter', '', 'HLT'), #the last filter in the path
+  TriggerFilter = cms.InputTag('hltEle8CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle8NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
 SUSY_HLT_Ele8_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
@@ -83,7 +83,7 @@ SUSY_HLT_Ele12_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Ele12_CaloIdM_TrackIdM_PFJet30_v'),
-  TriggerFilter = cms.InputTag('hltEle12CaloIdMTrkIdMDPhiFilter', '', 'HLT'), #the last filter in the path
+  TriggerFilter = cms.InputTag('hltEle12CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle12NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
 SUSY_HLT_Ele12_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
@@ -98,7 +98,7 @@ SUSY_HLT_Ele17_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v'),
-  TriggerFilter = cms.InputTag('hltEle17CaloIdMTrkIdMDPhiFilter', '', 'HLT'), #the last filter in the path
+  TriggerFilter = cms.InputTag('hltEle17CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle17NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
 SUSY_HLT_Ele17_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
@@ -113,7 +113,7 @@ SUSY_HLT_Ele23_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v'),
-  TriggerFilter = cms.InputTag('hltEle23CaloIdMTrkIdMDPhiFilter', '', 'HLT'), #the last filter in the path
+  TriggerFilter = cms.InputTag('hltEle23CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle23NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
 SUSY_HLT_Ele23_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
@@ -8,8 +8,8 @@ SUSY_HLT_Electron_BJet = cms.EDAnalyzer("SUSY_HLT_Electron_BJet",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Ele10_CaloIdM_TrackIdM_CentralPFJet30_BTagCSV_p13_v'),
-  TriggerFilterEle = cms.InputTag('hltSingleEle10CaloIdTrackIdVLDphiFilter', '', 'HLT'), #the last filter in the path hltSingleEle10CaloIdTrackIdVLOneOEMinusOneOPFilterRegional
-  TriggerFilterJet = cms.InputTag('hltCSVFilterSingleEle10', '', 'HLT'), #the last filter in the path
+  TriggerFilterEle = cms.InputTag('hltSingleEle10CaloIdMTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path hltSingleEle10CaloIdTrackIdVLOneOEMinusOneOPFilterRegional
+  TriggerFilterJet = cms.InputTag('hltBTagPFCSVp13Single', '', 'HLT'), #the last filter in the path
   PtThrJet = cms.untracked.double(30.0),
   EtaThrJet = cms.untracked.double(3.0)
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
@@ -13,7 +13,7 @@ SUSY_HLT_HT_MuEle = cms.EDAnalyzer("SUSY_HLT_MuEle_Hadronic",
   TriggerPath = cms.string('HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300_v'),
   TriggerPathAuxiliaryForMuEle = cms.string('HLT_PFHT800_v'),
   TriggerPathAuxiliaryForHadronic = cms.string('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v1'),
-  TriggerFilter = cms.InputTag('HLTElectronMuonInvMassFilter', '', 'HLT'), #the last filter in the path 
+  TriggerFilter = cms.InputTag('hltElectronMuonInvMassFilter8', '', 'HLT'), #the last filter in the path 
   PtThrJet = cms.untracked.double(30.0),
   EtaThrJet = cms.untracked.double(3.0)
 )
@@ -31,7 +31,7 @@ SUSY_HLT_HT250_MuEle = cms.EDAnalyzer("SUSY_HLT_MuEle_Hadronic",
   TriggerPath = cms.string('HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT250_v'),
   TriggerPathAuxiliaryForMuEle = cms.string('HLT_PFHT800_v'),
   TriggerPathAuxiliaryForHadronic = cms.string('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v1'),
-  TriggerFilter = cms.InputTag('HLTElectronMuonInvMassFilter', '', 'HLT'), #the last filter in the path 
+  TriggerFilter = cms.InputTag('hltElectronMuonInvMassFilter8', '', 'HLT'), #the last filter in the path 
   PtThrJet = cms.untracked.double(30.0),
   EtaThrJet = cms.untracked.double(3.0)
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
@@ -8,8 +8,8 @@ SUSY_HLT_Muon_BJet = cms.EDAnalyzer("SUSY_HLT_Muon_BJet",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Mu10_CentralPFJet30_BTagCSV_p13_v'),
-  TriggerFilterMuon = cms.InputTag('hltL3fL1sMu16L1f0L2f3QL3Filtered10Q', '','HLT'),
-  TriggerFilterJet = cms.InputTag('hltCSVFilterSingleMu10', '', 'HLT'), #the last filter in the path
+  TriggerFilterMuon = cms.InputTag('hltL3fL1sMu0L1f0L2f3QL3Filtered10Q', '','HLT'),
+  TriggerFilterJet = cms.InputTag('hltBTagPFCSVp13Single', '', 'HLT'), #the last filter in the path
   PtThrJet = cms.untracked.double(30.0),
   EtaThrJet = cms.untracked.double(3.0)
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
@@ -23,7 +23,7 @@ SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
 
                                                      hltProcess = cms.string('HLT'),
 
-                                                     triggerPath = cms.string('HLT_Mu15_IsoVVL_PFHT350_v'),
+                                                     triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT350_v'),
                                                      triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
                                                      triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
@@ -43,7 +43,7 @@ SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                      )
 
 SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
-                                                                    subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVL_PFHT350_v'),
+                                                                    subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_v'),
                                                                     efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
         "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
@@ -35,7 +35,7 @@ SUSY_HLT_Mu17_TrkIsoVVL = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Mu17_TrkIsoVVL_v'),
-  TriggerFilter = cms.InputTag('hltL3fL1sMu12L1f0L2f12L3Filtered17TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                 
+  TriggerFilter = cms.InputTag('hltL3fL1sMu1lqL1f0L2f10L3Filtered17TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                 
 )
 
 SUSY_HLT_Mu17_TrkIsoVVL_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
@@ -50,7 +50,7 @@ SUSY_HLT_Mu17 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
   TriggerPath = cms.string('HLT_Mu17_v'),
-  TriggerFilter = cms.InputTag('hltL3fL1sMu12L1f0L2f12L3Filtered17', '', 'HLT'), #the last filter in the path                                 
+  TriggerFilter = cms.InputTag('hltL3fL1sMu10lqL1f0L2f10L3Filtered17', '', 'HLT'), #the last filter in the path                                 
 )
 
 SUSY_HLT_Mu17_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
@@ -6,16 +6,16 @@ SUSY_HLT_PhotonHT = cms.EDAnalyzer("SUSY_HLT_PhotonHT",
   photonCollection = cms.InputTag("gedPhotons"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_Photon90_CaloId_PFHT500_v'),
+  TriggerPath = cms.string('HLT_Photon90_CaloIdL_PFHT500_v'),
   TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_IterTrk02_v'),
-  TriggerFilterPhoton = cms.InputTag('hltEG90HEFilter', '', 'HLT'),
+  TriggerFilterPhoton = cms.InputTag('hltEG90CaloIdLHEFilter', '', 'HLT'),
   TriggerFilterHt = cms.InputTag('hltPFHT500Jet30', '', 'HLT'),
   ptThrOffline = cms.untracked.double( 100 ),
   htThrOffline = cms.untracked.double( 600 ),
 )
 
 SUSY_HLT_PhotonHT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon90_CaloId_PFHT500_v"),
+    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon90_CaloIdL_PFHT500_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(


### PR DESCRIPTION
This is a fix in the SUSY HLT DQM python config for various path and filter names which have changed in the HLT menu but weren't updated here.

80x version of this PR: #14751 
