### PR TITLE
fix CaloTowerTopology for HGCal/BH

### DIFF
--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
@@ -33,7 +33,9 @@
 // constructors and destructor
 //
 CaloTowerConstituentsMapBuilder::CaloTowerConstituentsMapBuilder(const edm::ParameterSet& iConfig) :
-  mapFile_(iConfig.getUntrackedParameter<std::string>("MapFile","")) {
+  mapFile_(iConfig.getUntrackedParameter<std::string>("MapFile","")),
+  mapAuto_(iConfig.getUntrackedParameter<bool>("MapAuto",false)),
+  skipHE_(iConfig.getUntrackedParameter<bool>("SkipHE",false)) {
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
@@ -54,6 +56,8 @@ CaloTowerConstituentsMapBuilder::fillDescriptions(edm::ConfigurationDescriptions
 {
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>( "MapFile", "" );
+  desc.addUntracked<bool>( "MapAuto", false );
+  desc.addUntracked<bool>( "SkipHE", false );
   descriptions.add( "caloTowerConstituents", desc );
 }
 
@@ -77,14 +81,14 @@ CaloTowerConstituentsMapBuilder::produce(const CaloGeometryRecord& iRecord)
   const CaloGeometry* geometry = pG.product();
    
   prod->useStandardHB(true);
-  prod->useStandardHE(true);
+  if(!skipHE_) prod->useStandardHE(true);
   prod->useStandardHF(true);
   prod->useStandardHO(true);
   prod->useStandardEB(true);
    
   if (!mapFile_.empty()) {
     parseTextMap(mapFile_,*prod);
-  } else {
+  } else if (mapAuto_ && !skipHE_) {
     assignEEtoHE(geometry, *prod, &*cttopo);
   }
   prod->sort();

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -51,5 +51,6 @@ private:
   void parseTextMap(const std::string& filename,CaloTowerConstituentsMap& theMap);
   void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology * cttopo);
   std::string mapFile_;
+  bool mapAuto_, skipHE_;
 };
 

--- a/Geometry/CaloTopology/src/CaloTowerTopology.cc
+++ b/Geometry/CaloTopology/src/CaloTowerTopology.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 #include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include <assert.h>
+#include <algorithm>
 
 CaloTowerTopology::CaloTowerTopology(const HcalTopology * topology) : hcaltopo(topology) {
 
@@ -16,22 +17,22 @@ CaloTowerTopology::CaloTowerTopology(const HcalTopology * topology) : hcaltopo(t
   firstHBRing_ = 1;
   lastHBRing_ = firstHBRing_ + nEtaHB - 1;
   firstHERing_ = lastHBRing_; //crossover
-  lastHERing_ = firstHERing_ + nEtaHE_ - 1;
-  firstHFRing_ = (nEtaHE_ == 0) ? hcaltopo->firstHFRing() : (lastHERing_ + 1); //no crossover for CaloTowers; HF crossover cells go in the subsequent non-crossover HF tower
+  lastHERing_ = firstHERing_ + std::max(nEtaHE_ - 1,0); //max = protection for case with no HE
+  firstHFRing_ = lastHERing_ + 1; //no crossover for CaloTowers; HF crossover cells go in the subsequent non-crossover HF tower
   lastHFRing_ = firstHFRing_ + (nEtaHF - 1) - 1; //nEtaHF - 1 to account for no crossover
   firstHORing_ = 1;
   lastHORing_ = firstHORing_ + nEtaHO - 1;
   
   //translate phi segmentation boundaries into continuous ieta
-  if(hcaltopo->firstHEDoublePhiRing()==999) firstHEDoublePhiRing_ = firstHFRing_;
+  if(hcaltopo->firstHEDoublePhiRing()==999 || nEtaHE_ == 0) firstHEDoublePhiRing_ = firstHFRing_;
   else firstHEDoublePhiRing_ = firstHERing_ + (hcaltopo->firstHEDoublePhiRing() - hcaltopo->firstHERing());
   firstHEQuadPhiRing_ = firstHERing_ + (hcaltopo->firstHEQuadPhiRing() - hcaltopo->firstHERing());
   firstHFQuadPhiRing_ = firstHFRing_ - 1 + (hcaltopo->firstHFQuadPhiRing() - hcaltopo->firstHFRing());
   
   //number of etas per phi segmentation type
   int nEtaSinglePhi_, nEtaDoublePhi_, nEtaQuadPhi_;
-  nEtaSinglePhi_ = (nEtaHE_ == 0) ? nEtaHB : (firstHEDoublePhiRing_ - firstHBRing_);
-  nEtaDoublePhi_ = (nEtaHE_ == 0) ? (firstHFQuadPhiRing_- firstHFRing_) : (firstHFQuadPhiRing_ - firstHEDoublePhiRing_);
+  nEtaSinglePhi_ = firstHEDoublePhiRing_ - firstHBRing_;
+  nEtaDoublePhi_ = firstHFQuadPhiRing_ - firstHEDoublePhiRing_;
   nEtaQuadPhi_ = lastHFRing_ - firstHFQuadPhiRing_ + 1; //include lastHFRing
   
   //total number of towers per phi segmentation type

--- a/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
@@ -53,11 +53,11 @@ CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
   int sign=(ieta>0)?(1):(-1);
   double eta1, eta2;
   if (abs(ieta)>m_limits->lastHERing()) {
-    eta1 = theHFEtaBounds[etaRing-m_hcaltopo->firstHFRing()];
-    eta2 = theHFEtaBounds[etaRing-m_hcaltopo->firstHFRing()+1];
+    eta1 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing());
+    eta2 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing()+1);
   } else {
-    eta1 = theHBHEEtaBounds[etaRing-1];
-    eta2 = theHBHEEtaBounds[etaRing];
+    eta1 = theHBHEEtaBounds.at(etaRing-1);
+    eta2 = theHBHEEtaBounds.at(etaRing);
   }
   double eta = 0.5*(eta1+eta2);
   double deta = (eta2-eta1);  

--- a/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
@@ -3,6 +3,11 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CaloGeometry/interface/IdealObliquePrism.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+#include <iterator>
+#include <algorithm>
+
+//#define DebugLog
 
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
@@ -15,6 +20,15 @@ std::auto_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(con
   //get eta limits from hcal rec constants
   theHFEtaBounds   = m_hcons->getEtaTableHF();
   theHBHEEtaBounds = m_hcons->getEtaTable();
+
+#ifdef DebugLog
+  std::cout << "CaloTowerHardcodeGeometryLoader: theHBHEEtaBounds = ";
+  std::copy(theHBHEEtaBounds.begin(), theHBHEEtaBounds.end(), std::ostream_iterator<double>(std::cout, ","));
+  std::cout << std::endl;
+
+  std::cout << "CaloTowerHardcodeGeometryLoader: lastHBRing = " << m_limits->lastHBRing() << ", lastHERing = " << m_limits->lastHERing() << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: HcalTopology: firstHBRing = " << hcaltopo->firstHBRing() << ", lastHBRing = " << hcaltopo->lastHBRing() << ", firstHERing = " << hcaltopo->firstHERing() << ", lastHERing = " << hcaltopo->lastHERing() << ", firstHFRing = " << hcaltopo->firstHFRing() << ", lastHFRing = " << hcaltopo->lastHFRing() << std::endl;
+#endif
 
   CaloTowerGeometry* geom=new CaloTowerGeometry(m_limits);
 
@@ -52,6 +66,11 @@ CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
   int etaRing=m_limits->convertCTtoHcal(abs(ieta));
   int sign=(ieta>0)?(1):(-1);
   double eta1, eta2;
+
+#ifdef DebugLog
+  std::cout << "CaloTowerHardcodeGeometryLoader: ieta = " << ieta << ", iphi = " << iphi << ", etaRing = " << etaRing << std::endl;
+#endif
+
   if (abs(ieta)>m_limits->lastHERing()) {
     eta1 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing());
     eta2 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing()+1);
@@ -68,6 +87,10 @@ CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
   
   double phi_low = dphi_nominal*(iphi-1); // low-edge boundaries are constant...
   double phi = phi_low+dphi_half;
+
+#ifdef DebugLog
+  std::cout << "CaloTowerHardcodeGeometryLoader: eta1 = " << eta1 << ", eta2 = " << eta2 <<", eta = " << eta << ", phi = " << phi << std::endl;
+#endif
 
   double x,y,z,thickness;
   bool alongZ=true;
@@ -103,6 +126,10 @@ CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
 
   hh.push_back( fabs( eta ) ) ;
   hh.push_back( fabs( z ) ) ;
+
+#ifdef DebugLog
+  std::cout << "CaloTowerHardcodeGeometryLoader: x = " << x << ", y = " << y << ", z = " << z << ", thickness = " << thickness << std::endl;
+#endif
 
   geom->newCell( point, point, point,
 		 CaloCellGeometry::getParmPtr( hh, 

--- a/RecoJets/Configuration/python/CaloTowersES_cfi.py
+++ b/RecoJets/Configuration/python/CaloTowersES_cfi.py
@@ -5,15 +5,5 @@ import Geometry.CaloEventSetup.caloTowerConstituents_cfi
 CaloTowerConstituentsMapBuilder = Geometry.CaloEventSetup.caloTowerConstituents_cfi.caloTowerConstituents.clone()
 CaloTowerConstituentsMapBuilder.MapFile = "Geometry/CaloTopology/data/CaloTowerEEGeometric.map.gz"
 
-## import Geometry.HcalEventSetup.hcalTopologyConstants_cfi as hcalTopologyConstants_cfi
-## caloTowerConstituentsMapBuilder.hcalTopologyConstants = cms.PSet(hcalTopologyConstants_cfi.hcalTopologyConstants)
-
-#
-# Event Setup necessary for CaloTowers reconstruction
-#
-#include "Geometry/CaloEventSetup/data/CaloTowerConstituents.cfi"
-## CaloTowerConstituentsMapBuilder = cms.ESProducer("CaloTowerConstituentsMapBuilder",
-##     MapFile = cms.untracked.string('Geometry/CaloTopology/data/CaloTowerEEGeometric.map.gz')
-## )
-
-
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_hgcal.toModify( CaloTowerConstituentsMapBuilder, MapFile = "", SkipHE = True )


### PR DESCRIPTION
Testing #14713 revealed an issue with `CaloTowerHardcodeGeometryLoader`. This was fixed by modifying the definition of `CaloTowerTopology::lastHERing_` for correct handling of the case where HE is skipped (currently, no CaloTowers are desired for the Phase2 endcap with HGCal). I also switched to using `std::vector::at()` in `CaloTowerHardcodeGeometryLoader` to make the proximate cause of the issue more visible in case something similar pops up in the future, and added a bunch of debug statements behind a preprocessor flag.

I noticed that some of the changes in #14713 messed up the dense indexing for CaloTowers, because the CaloTower ieta was not continuous. This is fixed now, even though it leads to the somewhat strange convention of Phase2 HF CaloTowers starting at ieta=17.

NB: To test Phase2 workflows (I used 11000.0) in the latest IB, #14755 is also needed.

attn: @bsunanda
