### PR TITLE
Phase1 Pixel DQM Bugfixes

### DIFF
--- a/DQM/SiPixelPhase1Common/README.md
+++ b/DQM/SiPixelPhase1Common/README.md
@@ -9,6 +9,8 @@ This document decomposes into three sections:
    2. *How to actually use it* -- practical examples with explanation.
    3. *How it really works* -- explanations on the implementation.
 
+Further information can be found on the TWiki page: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PixelDQMPhaseI . Note that parts migh be historical and not reflect the current state.
+
 The Concept
 -----------
 

--- a/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
@@ -146,4 +146,7 @@ class Specification(cms.PSet):
       self.groupBy("/".join(cols), self._lastMode)
       self.save()
     return self
-    
+
+  # this is used for serialization, and for that this is just a PSet.
+  def pythonTypeName(self):
+    return 'cms.PSet';

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -175,7 +175,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   std::vector<ID> geomquantities;
 
   struct TTField {
-    edm::ESHandle<TrackerTopology> tt;
+    const TrackerTopology* tt;
     TrackerTopology::DetIdFields field;
     Value operator()(InterestingQuantities const& iq) {
       if (tt->hasField(iq.sourceModule, field)) 
@@ -185,17 +185,20 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
     };
   };
 
-   std::vector<std::pair<std::string, TTField>> namedPartitions {
-    {"PXEndcap" , {trackerTopologyHandle, TrackerTopology::PFSide}},
+  const TrackerTopology* tt = trackerTopologyHandle.operator->();
 
-    {"PXLayer"  , {trackerTopologyHandle, TrackerTopology::PBLayer}},
-    {"PXLadder" , {trackerTopologyHandle, TrackerTopology::PBLadder}},
-    {"PXBModule", {trackerTopologyHandle, TrackerTopology::PBModule}},
 
-    {"PXBlade"  , {trackerTopologyHandle, TrackerTopology::PFBlade}},
-    {"PXDisk"   , {trackerTopologyHandle, TrackerTopology::PFDisk}},
-    {"PXPanel"  , {trackerTopologyHandle, TrackerTopology::PFPanel}},
-    {"PXFModule", {trackerTopologyHandle, TrackerTopology::PFModule}},
+  std::vector<std::pair<std::string, TTField>> namedPartitions {
+    {"PXEndcap" , {tt, TrackerTopology::PFSide}},
+
+    {"PXLayer"  , {tt, TrackerTopology::PBLayer}},
+    {"PXLadder" , {tt, TrackerTopology::PBLadder}},
+    {"PXBModule", {tt, TrackerTopology::PBModule}},
+
+    {"PXBlade"  , {tt, TrackerTopology::PFBlade}},
+    {"PXDisk"   , {tt, TrackerTopology::PFDisk}},
+    {"PXPanel"  , {tt, TrackerTopology::PFPanel}},
+    {"PXFModule", {tt, TrackerTopology::PFModule}},
   };
 
   for (auto& e : namedPartitions) {

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -212,7 +212,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   addExtractor(intern("PXForward"), pxforward, 0, 0);
 
   // Redefine the disk numbering to use the sign
-  auto& pxendcap = extractors[intern("PXEndcap")];
+  auto pxendcap = extractors[intern("PXEndcap")];
   auto diskid = intern("PXDisk");
   auto pxdisk = extractors[diskid];
   extractors[diskid] = [pxdisk, pxendcap] (InterestingQuantities const& iq) {
@@ -228,8 +228,8 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   assert(trackerGeometryHandle.isValid());
   
   // We need to track some extra stuff here for the Shells later.
-  auto& pxlayer  = extractors[intern("PXLayer")];
-  auto& pxladder = extractors[intern("PXLadder")];
+  auto pxlayer  = extractors[intern("PXLayer")];
+  auto pxladder = extractors[intern("PXLadder")];
   std::vector<Value> maxladders;
 
   // Now travrse the detector and collect whatever we need.
@@ -260,7 +260,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   // of the code, but it might work for Phase0 as well.
   Value innerring = iConfig.getParameter<int>("n_inner_ring_blades");
   Value outerring = max_value[intern("PXBlade")] - innerring;
-  auto& pxblade  = extractors[intern("PXBlade")];
+  auto pxblade  = extractors[intern("PXBlade")];
   addExtractor(intern("PXRing"), 
     [pxblade, innerring] (InterestingQuantities const& iq) {
       auto blade = pxblade(iq);
@@ -270,7 +270,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
     }, 1, 2
   );
 
-  auto& pxmodule = extractors[intern("PXBModule")];
+  auto pxmodule = extractors[intern("PXBModule")];
   Value maxmodule = max_value[intern("PXBModule")];
   addExtractor(intern("HalfCylinder"),
     [pxendcap, pxblade, innerring, outerring] (InterestingQuantities const& iq) {

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -494,7 +494,8 @@ void HistogramManager::executeReduce(SummationStep& step, Table& t) {
       edm::LogError("HistogramManager") << "+++ Reduction '" << step.arg
                                         << " not yet implemented\n";
     }
-    new_histo.th1 = new TH1D(name.c_str(), (";;" + label).c_str(), 1, 0, 1);
+    new_histo.th1 = new TH1F(name.c_str(), (std::string("") + th1->GetTitle() 
+                                            + ";;" + label).c_str(), 1, 0, 1);
     new_histo.th1->SetBinContent(1, reduced_quantity);
   }
   t.swap(out);

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -224,10 +224,10 @@ std::string HistogramManager::makePath(
 
 void HistogramManager::book(DQMStore::IBooker& iBooker,
                             edm::EventSetup const& iSetup) {
-  if (!enabled) return;
   if (!geometryInterface.loaded()) {
     geometryInterface.load(iSetup);
   }
+  if (!enabled) return;
 
   for (unsigned int i = 0; i < specs.size(); i++) {
     auto& s = specs[i];

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -4,7 +4,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
 SiPixelPhase1DigisADC = DefaultHisto.clone(
-  enabled = True, # ADC
   name = "adc",
   title = "Digi ADC values",
   xlabel = "adc readout",
@@ -24,7 +23,6 @@ SiPixelPhase1DigisADC = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisNdigis = DefaultHisto.clone(
-  enabled = True, # Ndigis
   name = "digis", # 'Count of' added automatically
   title = "Digis",
   xlabel = "digis",
@@ -51,7 +49,6 @@ SiPixelPhase1DigisNdigis = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
-  enabled = True,  # Ndigis per FED
   name = "digis",  # This is the same as above up to the ranges. maybe we 
   title = "Digis", # should allow setting the range per spec, but OTOH a 
   xlabel = "digis",# HistogramManager is almost free.
@@ -73,7 +70,6 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisEvents = DefaultHisto.clone(
-  enabled = True, # Event Rate
   name = "eventrate",
   title = "Rate of Pixel Events",
   xlabel = "Lumisection",
@@ -88,7 +84,6 @@ SiPixelPhase1DigisEvents = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisHitmap = DefaultHisto.clone(
-  enabled = True, # hitmaps
   name = "hitmap",
   title = "Position of digis on module",
   ylabel = "#digis",
@@ -128,7 +123,6 @@ SiPixelPhase1DigisHitmap = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisDebug = DefaultHisto.clone(
-  enabled = True, # Geometry Debug
   name = "debug",
   xlabel = "ladder #",
   range_min = 1,
@@ -141,7 +135,8 @@ SiPixelPhase1DigisDebug = DefaultHisto.clone(
                    .groupBy(parent(DefaultHisto.defaultGrouping), "EXTEND_X")
                    .saveAll(),
     Specification().groupBy(parent(DefaultHisto.defaultGrouping)) # per-layer
-                   .save()
+                   .save(),
+    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule).save(),
   )
 )
 

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -66,8 +66,8 @@ SiPixelPhase1RecHitsErrorX = DefaultHisto.clone(
   )
 )
 
-SiPixelPhase1RecHitsErrorY = DefaultHisto.clone(
-  name = "rechiterror_x",
+SiPixelPhase1RecHitsErrorY = SiPixelPhase1RecHitsErrorX.clone(
+  name = "rechiterror_y",
   title = "RecHit Error in Y-direction",
   xlabel = "Y error"
 )
@@ -79,6 +79,7 @@ SiPixelPhase1RecHitsPosition = DefaultHisto.clone(
   range_y_min = -4, range_y_max = 4, range_y_nbins = 100,
   xlabel = "x offset",
   ylabel = "y offset",
+  dimensions = 2,
   specs = cms.VPSet(
     Specification().groupBy(DefaultHisto.defaultGrouping).save(),
     Specification(PerModule).groupBy(DefaultHisto.defaultPerModule).save(),


### PR DESCRIPTION
This PR fixes some smaller bugs that were found in the first version merged in #14586 (also @fioriNTU ).
- (UPDATE: the explanation here is wrong, it seems this was all caused by the invalid refs fixed by [this](https://github.com/cms-sw/cmssw/pull/14760/commits/5b03e23a33ee37d8c44b8e2b0f710eb78ba7d2f7). I still don't understand why this happens, but it is undefined behaviour and therefore totally fine.) The most critical one was caused by the last-minute changes to TrackerTopology ( @davidlange6 ). The new code stored a `edm::ESHandle` to TT, and that seemed to silently become invalid on rare occasions. The fix is to use a bare pointer, which is a bad solution but works. While I can understand that the Handle or also the pointer gets invalid, what I do NOT understand is why this happens during the DQM booking phase (maybe also elsewhere, but definitely there) and only in one out of 6 plugins, that all run the same code. Maybe there is more to it. (The plugin in question is SiPixelPhase1RecHits, the symptom is that many histograms are not booked, and changing to pointers fixes it).
- the other commits fix a crash on configurations with all MEs turned off and some cosmetic changes
- finally there is a a fix for the issue reported by @slava77 today in #14586 . With this fix the given command does still crash, but it is no longer the Phase1 Pixel DQMs fault (I hope).
- I have no idea how @mtosi 's commit ends up in this PR. It is totally unrelated. (Update: fixed by rebase & force push)
