### PR TITLE
initialize apparently useless variables in GenMET

### DIFF
--- a/DataFormats/METReco/interface/SpecificGenMETData.h
+++ b/DataFormats/METReco/interface/SpecificGenMETData.h
@@ -25,7 +25,9 @@ struct SpecificGenMETData
   SpecificGenMETData()
     : NeutralEMEtFraction(0.0), NeutralHadEtFraction(0.0)
     , ChargedEMEtFraction(0.0), ChargedHadEtFraction(0.0)
-    , MuonEtFraction(0.0), InvisibleEtFraction(0.0) { }
+    , MuonEtFraction(0.0), InvisibleEtFraction(0.0)
+    , m_EmEnergy(0.0), m_HadEnergy(0.0)
+    , m_InvisibleEnergy(0.0), m_AuxiliaryEnergy(0.0) { }
 
   float NeutralEMEtFraction;
   float NeutralHadEtFraction;


### PR DESCRIPTION
 the goal is to avoid random numbers saved on disk to save space in compression and to minimize spurious differences in product size comparisons
