### PR TITLE
CTPPS: AOD EventContent update

### DIFF
--- a/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
+++ b/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
@@ -30,6 +30,9 @@ RecoCTPPSRECO = cms.PSet(
 
 RecoCTPPSAOD = cms.PSet(
   outputCommands = cms.untracked.vstring(
+    'keep TotemFEDInfos_totemRPRawToDigi_*_*',
+    'keep TotemTriggerCounters_totemTriggerRawToDigi_*_*',
+    'keep TotemRPDigiedmDetSetVector_totemRPRawToDigi_*_*',
     'keep TotemVFATStatusedmDetSetVector_totemRPRawToDigi_*_*',
     'keep TotemRPClusteredmDetSetVector_totemRPClusterProducer_*_*',
     'keep TotemRPRecHitedmDetSetVector_totemRPRecHitProducer_*_*',

--- a/RecoCTPPS/Configuration/python/recoCTPPS_cff.py
+++ b/RecoCTPPS/Configuration/python/recoCTPPS_cff.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from RecoCTPPS.TotemRPLocal.totemRPLocalReconstruction_cff import *
-recoCTPPS  = cms.Sequence(totemRPLocalReconstruction)

--- a/RecoCTPPS/Configuration/python/recoCTPPS_cff.py
+++ b/RecoCTPPS/Configuration/python/recoCTPPS_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoCTPPS.TotemRPLocal.totemRPLocalReconstruction_cff import *
+recoCTPPS  = cms.Sequence(totemRPLocalReconstruction)

--- a/RecoCTPPS/Configuration/test/raw_data_test.py
+++ b/RecoCTPPS/Configuration/test/raw_data_test.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TotemStandaloneRawDataTest")
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    statistics = cms.untracked.vstring(),
+    destinations = cms.untracked.vstring('cout'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+# raw data source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# raw-to-digi conversion
+process.load("EventFilter.TotemRawToDigi.totemRawToDigi_cff")
+
+# RP reconstruction chain with standard settings
+process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
+
+process.p = cms.Path(
+    process.totemTriggerRawToDigi *
+    process.totemRPRawToDigi *
+    process.recoCTPPS
+)
+
+# output configuration
+from RecoCTPPS.Configuration.RecoCTPPS_EventContent_cff import RecoCTPPSAOD
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("file:./AOD.root"),
+    outputCommands = RecoCTPPSAOD.outputCommands
+)
+
+process.outpath = cms.EndPath(process.output)


### PR DESCRIPTION
- `RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py`: AOD has the same EventContent as RECO. The added products are negligible in size and could be important for commissioning.
- `RecoCTPPS/Configuration/test/raw_data_test.py`: a test config for validating the standard cff files.

This PR should be merged after #14605.
