### PR TITLE
HEPTopTagger Version 2

### DIFF
--- a/DataFormats/JetReco/interface/HTTTopJetTagInfo.h
+++ b/DataFormats/JetReco/interface/HTTTopJetTagInfo.h
@@ -1,0 +1,100 @@
+#ifndef AnalysisDataFormats_TopObjects_interface_HTTTopJetTagInfo_h
+#define AnalysisDataFormats_TopObjects_interface_HTTTopJetTagInfo_h
+
+
+// \class HTTTopJetTagInfo
+// 
+// \short specific tag info for HEPTopTagger tagging algorithm
+// HTTTopJetTagInfo is a class to hold the discriminator variables for the
+// HEPTopTagger algorithm.
+// 
+//
+// \author Gregor Kasieczka (based on  CATopJetTagInfo by Salvatore Rappoccio)
+// \version first version on 25 Sep 2014
+
+#include "DataFormats/BTauReco/interface/RefMacros.h"
+#include "DataFormats/BTauReco/interface/JetTagInfo.h"
+#include "DataFormats/BTauReco/interface/TaggingVariable.h"
+#include <vector>
+
+namespace reco {
+ 
+class HTTTopJetProperties {
+public:
+  HTTTopJetProperties() {
+    fjPt            = 0.;
+    fjMass          = 0.;
+    fjEta           = 0.;
+    fjPhi           = 0.;
+    topMass         = 0.;
+    unfilteredMass  = 0.;
+    prunedMass	    = 0.;
+    fRec	    = 0.;
+    massRatioPassed = 0.;
+    Ropt	    = 0.;
+    RoptCalc	    = 0.;
+    ptForRoptCalc   = 0.;
+    tau1Unfiltered  = 0.;
+    tau2Unfiltered  = 0.;
+    tau3Unfiltered  = 0.;
+    tau1Filtered    = 0.;
+    tau2Filtered    = 0.;
+    tau3Filtered    = 0.;
+    QWeight	    = 0.;
+    QEpsilon        = 0.;
+    QSigmaM         = 0.;
+
+  }
+  double              fjPt;             //<! Mass of the inital Fatjet passed to the TT
+  double              fjMass;           //<! Mass of the inital Fatjet passed to the TT
+  double              fjEta;            //<! Mass of the inital Fatjet passed to the TT
+  double              fjPhi;            //<! Mass of the inital Fatjet passed to the TT
+  double              topMass;          //<! Mass of the HTT top quark candidate [GeV]
+  double              unfilteredMass;   //<! Unfiltered mass of the triplet [GeV]
+  double              prunedMass;       //<! Mass of the pruned fat jet [GeV]
+  double              fRec;             //<! Minimum distance of m_ij/m_123 from m_W/m_top
+  double              massRatioPassed;  //<! Did the candidate pass the default mass ratio? 
+  double              Ropt;             //<! R_opt found in Optimal procedure. 
+  double              RoptCalc;         //<! R_opt calc for a top quark based on filtered fat-jet pT.
+  double              ptForRoptCalc;    //<! Filtered initial fatjet pT calculation of Ropt 
+  double              tau1Unfiltered;   //<! 1-subjettiness, no filtering
+  double              tau2Unfiltered;   //<! 2-subjettiness, no filtering
+  double              tau3Unfiltered;   //<! 3-subjettiness, no filtering
+  double              tau1Filtered;     //<! 1-subjettiness, with filtering
+  double              tau2Filtered;     //<! 2-subjettiness, with filtering
+  double              tau3Filtered;     //<! 3-subjettiness, with filtering
+  double              QWeight;          //<! maximal weight of jet using Q-jet approach
+  double              QEpsilon;         //<! fraction of jets tagged with Q-jets
+  double              QSigmaM;          //<! Width of Q-jet mass distribution
+};
+
+ class HTTTopJetTagInfo : public JetTagInfo {
+public:
+  typedef edm::RefToBase<Jet> jet_type;
+  typedef HTTTopJetProperties  properties_type;
+    
+    HTTTopJetTagInfo(void) {}
+
+    virtual ~HTTTopJetTagInfo(void) {}
+  
+    virtual HTTTopJetTagInfo* clone(void) const { return new HTTTopJetTagInfo(*this); }
+    
+    const properties_type & properties() const {
+      return properties_;
+    }
+
+    void insert(const edm::RefToBase<Jet> & jet, const HTTTopJetProperties & properties) {
+      setJetRef(jet);
+      properties_ = properties;
+    }
+
+protected:
+    properties_type properties_;
+
+};
+
+DECLARE_EDM_REFS( HTTTopJetTagInfo )
+
+}
+
+#endif // AnalysisDataFormats_TopObjects_interface_HTTTopJetTagInfo_h

--- a/DataFormats/JetReco/src/classes_4.h
+++ b/DataFormats/JetReco/src/classes_4.h
@@ -36,6 +36,9 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
+#include "DataFormats/JetReco/interface/HTTTopJetTagInfo.h"
+
+
 namespace DataFormats_JetReco {
   struct dictionary4 {
     // jet id stuff
@@ -174,6 +177,18 @@ namespace DataFormats_JetReco {
     edm::PtrVector<reco::FFTCaloJet> ptrvgj_fft_2;
     edm::Association<reco::FFTCaloJetCollection> a_gj_fft_2;
     edm::Wrapper<edm::Association<reco::FFTCaloJetCollection> > w_a_gj_fft_2;
+
+    reco::HTTTopJetProperties                                            htttopjetp;
+    std::pair<edm::RefToBase<reco::Jet>, reco::HTTTopJetProperties>      htttopjetp_p;
+
+    reco::HTTTopJetTagInfo                                               htttopjet;
+    reco::HTTTopJetTagInfoCollection                                     htttopjet_c;
+    reco::HTTTopJetTagInfoRef                                            htttopjet_r;
+    reco::HTTTopJetTagInfoRefProd                                        htttopjet_rp;
+    reco::HTTTopJetTagInfoRefVector                                      htttopjet_rv;
+    edm::Wrapper<reco::HTTTopJetTagInfoCollection>                       htttopjet_wc;
+    edm::reftobase::Holder<reco::BaseTagInfo, reco::HTTTopJetTagInfoRef> rb_htttopjet;
+    edm::reftobase::RefHolder<reco::HTTTopJetTagInfoRef>                 rbh_htttopjet; 
 
   };
 }

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -162,8 +162,8 @@
   </class>
   <class name="std::pair<edm::RefToBase<reco::Jet>, reco::HTTTopJetProperties>"/>
  
-  <class name="reco::HTTTopJetTagInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="1184606281"/>
+  <class name="reco::HTTTopJetTagInfo" ClassVersion="12">
+   <version ClassVersion="12" checksum="3013029993"/>
   </class>
   <class name="reco::HTTTopJetTagInfoCollection"/>
   <class name="reco::HTTTopJetTagInfoRef"/>

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -138,22 +138,7 @@
    <class name="edm::PtrVector<reco::FFTCaloJet>" />
    <class name="edm::Association<reco::FFTCaloJetCollection>" />
    <class name="edm::Wrapper<edm::Association<reco::FFTCaloJetCollection> >" />
-   <class name="reco::CATopJetProperties" ClassVersion="10">
-   <version ClassVersion="10" checksum="4096516518"/>
-   </class>
-   <class name="std::pair<edm::RefToBase<reco::Jet>, reco::CATopJetProperties>"/>
- 
-   <class name="reco::CATopJetTagInfo" ClassVersion="11">
-    <version ClassVersion="11" checksum="241737491"/>
-    <version ClassVersion="10" checksum="3059833435"/>
-   </class>
-   <class name="reco::CATopJetTagInfoCollection"/>
-   <class name="reco::CATopJetTagInfoRef"/>
-   <class name="reco::CATopJetTagInfoRefProd"/>
-   <class name="reco::CATopJetTagInfoRefVector"/>
-   <class name="edm::Wrapper<reco::CATopJetTagInfoCollection>"/>
-   <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CATopJetTagInfoRef>" />
-   <class name="edm::reftobase::RefHolder<reco::CATopJetTagInfoRef>" />
+
    <class name="reco::HTTTopJetProperties" ClassVersion="14">
     <version ClassVersion="14" checksum="427903012"/>
    </class>

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -156,4 +156,21 @@
   <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::CATopJetTagInfoRef>" />
   <class name="edm::reftobase::RefHolder<reco::CATopJetTagInfoRef>" />
 
+
+  <class name="reco::HTTTopJetProperties" ClassVersion="14">
+   <version ClassVersion="14" checksum="427903012"/>
+  </class>
+  <class name="std::pair<edm::RefToBase<reco::Jet>, reco::HTTTopJetProperties>"/>
+ 
+  <class name="reco::HTTTopJetTagInfo" ClassVersion="10">
+   <version ClassVersion="10" checksum="1184606281"/>
+  </class>
+  <class name="reco::HTTTopJetTagInfoCollection"/>
+  <class name="reco::HTTTopJetTagInfoRef"/>
+  <class name="reco::HTTTopJetTagInfoRefProd"/>
+  <class name="reco::HTTTopJetTagInfoRefVector"/>
+  <class name="edm::Wrapper<reco::HTTTopJetTagInfoCollection>"/>
+  <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::HTTTopJetTagInfoRef>" />
+  <class name="edm::reftobase::RefHolder<reco::HTTTopJetTagInfoRef>" />
+
 </lcgdict>

--- a/RecoJets/JetAlgorithms/interface/HEPTopTaggerV2.h
+++ b/RecoJets/JetAlgorithms/interface/HEPTopTaggerV2.h
@@ -1,0 +1,347 @@
+#ifndef __HEPTOPTAGGERV2_HH__
+#define __HEPTOPTAGGERV2_HH__
+
+#include <vector>
+#include <algorithm>
+#include <math.h>
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/tools/Pruner.hh"
+#include "fastjet/tools/Filter.hh"
+#include "fastjet/contrib/Njettiness.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "QjetsPlugin.h"
+#include "CLHEP/Random/RandomEngine.h"
+
+// Allow putting evertything into a separate namepsace
+// Do not change next line, it's needed by the sed-code that makes the tagger CMSSW-compatible.
+namespace external {
+
+using namespace std;
+using namespace fastjet;
+
+ enum Mode {EARLY_MASSRATIO_SORT_MASS, 
+	     LATE_MASSRATIO_SORT_MASS, 
+	     EARLY_MASSRATIO_SORT_MODDJADE,
+	     LATE_MASSRATIO_SORT_MODDJADE,
+	     TWO_STEP_FILTER};
+
+
+class HEPTopTaggerV2_fixed_R {
+public:
+  typedef fastjet::ClusterSequence ClusterSequence;
+  typedef fastjet::JetAlgorithm JetAlgorithm;
+  typedef fastjet::JetDefinition JetDefinition;
+  typedef fastjet::PseudoJet PseudoJet;
+
+  HEPTopTaggerV2_fixed_R();
+  
+  HEPTopTaggerV2_fixed_R(fastjet::PseudoJet jet);
+  
+  HEPTopTaggerV2_fixed_R(fastjet::PseudoJet jet,
+	       double mtmass, double mwmass);
+
+  //run tagger
+  void run();
+
+  //settings
+  void do_qjets(bool qjets) {_do_qjets = qjets;}
+
+  void set_mass_drop_threshold(double x) {_mass_drop_threshold = x;}
+  void set_max_subjet_mass(double x) {_max_subjet_mass = x;}
+  
+  void set_filtering_n(unsigned nfilt) {_nfilt = nfilt;}
+  void set_filtering_R(double Rfilt) {_Rfilt = Rfilt;}
+  void set_filtering_minpt_subjet(double x) {_minpt_subjet = x;}
+  void set_filtering_jetalgorithm(JetAlgorithm jet_algorithm) {_jet_algorithm_filter = jet_algorithm;}
+  
+  void set_reclustering_jetalgorithm(JetAlgorithm jet_algorithm) {_jet_algorithm_recluster = jet_algorithm;}
+
+  void set_mode(enum Mode mode) {_mode = mode;}
+  void set_mt(double x) {_mtmass = x;}
+  void set_mw(double x) {_mwmass = x;}
+  void set_top_mass_range(double xmin, double xmax) {_mtmin = xmin; _mtmax = xmax;}
+  void set_fw(double fw) {_rmin = (1.-fw)*_mwmass/_mtmass; _rmax=(1.+fw)*_mwmass/_mtmass;}
+  void set_mass_ratio_range(double rmin, double rmax) {_rmin = rmin; _rmax = rmax;}
+  void set_mass_ratio_cut(double m23cut, double m13cutmin,double m13cutmax) {_m23cut = m23cut; _m13cutmin = m13cutmin; _m13cutmax = m13cutmax;}
+  void set_top_minpt(double x) {_minpt_tag = x;}
+  
+  void set_pruning_zcut(double zcut) {_zcut = zcut;}
+  void set_pruning_rcut_factor(double rcut_factor) {_rcut_factor = rcut_factor;}
+
+  void set_debug(bool debug) {_debug = debug;}
+  void set_qjets(double q_zcut, double q_dcut_fctr, double q_exp_min, double q_exp_max, double q_rigidity, double q_truncation_fctr) {
+    _q_zcut = q_zcut; _q_dcut_fctr = q_dcut_fctr; _q_exp_min = q_exp_min; _q_exp_max = q_exp_max; _q_rigidity =  q_rigidity; _q_truncation_fctr =  q_truncation_fctr;
+  }
+  void set_qjets_rng(CLHEP::HepRandomEngine* engine){ _rnEngine = engine;}
+
+  //get information
+  bool is_maybe_top() const {return _is_maybe_top;}
+  bool is_masscut_passed() const {return _is_masscut_passed;}
+  bool is_minptcut_passed() const {return _is_ptmincut_passed;}
+  bool is_tagged() const {return (_is_masscut_passed && _is_ptmincut_passed);}
+
+  double delta_top() const {return _delta_top;}
+  double djsum() const {return _djsum;}
+  double pruned_mass() const {return _pruned_mass;}
+  double unfiltered_mass() const {return _unfiltered_mass;}
+
+  double f_rec();
+  const PseudoJet & t() const {return _top_candidate;}
+  const PseudoJet & b() const {return _top_subjets[0];}
+  const PseudoJet & W() const {return _W;}
+  const PseudoJet & W1() const {return _top_subjets[1];}
+  const PseudoJet & W2() const {return _top_subjets[2];}
+  const std::vector<PseudoJet> & top_subjets() const {return _top_subjets;}
+  const PseudoJet & j1() const {return _top_subs[0];}
+  const PseudoJet & j2() const {return _top_subs[1];}
+  const PseudoJet & j3() const {return _top_subs[2];}
+  const std::vector<PseudoJet> & top_hadrons() const {return _top_hadrons;}
+  const std::vector<PseudoJet> & hardparts() const {return _top_parts;}
+  const PseudoJet & fat_initial() {return _fat;}
+  
+  void get_setting() const;
+  void get_info() const;
+
+  double nsub(fastjet::PseudoJet jet, int order, fastjet::contrib::Njettiness::AxesMode axes = fastjet::contrib::Njettiness::kt_axes, double beta = 1., double R0 = 1.);
+  double q_weight() {return _qweight;}
+   
+private:
+  bool _do_qjets;
+
+  PseudoJet _jet;
+  PseudoJet _initial_jet;
+
+  double _mass_drop_threshold;
+  double _max_subjet_mass;
+
+  Mode _mode;
+  double _mtmass, _mwmass;
+  double _mtmin, _mtmax;
+  double _rmin, _rmax;
+  double _m23cut, _m13cutmin, _m13cutmax;
+  double _minpt_tag;
+  
+  unsigned _nfilt;
+  double _Rfilt;
+  JetAlgorithm _jet_algorithm_filter;
+  double _minpt_subjet;
+  
+  JetAlgorithm _jet_algorithm_recluster;
+
+  double _zcut;
+  double _rcut_factor;
+
+  double _q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr;
+  JetDefinition _qjet_def;
+  
+  PseudoJet _fat;
+
+  CLHEP::HepRandomEngine* _rnEngine;
+
+  bool _debug;
+  
+  bool _is_masscut_passed;
+  bool _is_ptmincut_passed;
+  bool _is_maybe_top;
+
+  double _delta_top;
+  double _djsum;
+
+  double _pruned_mass;
+  double _unfiltered_mass;
+
+  double _fw;
+  unsigned _parts_size;
+
+  PseudoJet _top_candidate;
+  PseudoJet _W;
+  std::vector<PseudoJet> _top_subs;
+  std::vector<PseudoJet> _top_subjets;
+  std::vector<PseudoJet> _top_hadrons;
+  std::vector<PseudoJet> _top_parts;
+
+  static bool _first_time;
+  double _qweight;
+  
+  //internal functions
+  void FindHardSubst(const PseudoJet& jet, std::vector<fastjet::PseudoJet>& t_parts);
+  std::vector<PseudoJet> Filtering(const std::vector <PseudoJet> & top_constits, const JetDefinition & filtering_def);
+  void store_topsubjets(const std::vector<PseudoJet>& top_subs);
+  bool check_mass_criteria(const std::vector<fastjet::PseudoJet> & top_subs) const;
+  double perp(const PseudoJet & vec, const fastjet::PseudoJet & ref);
+  double djademod (const fastjet::PseudoJet & subjet_i, const fastjet::PseudoJet & subjet_j, const fastjet::PseudoJet & ref);
+
+  void print_banner();
+  
+};
+
+class HEPTopTaggerV2 {
+public:
+  HEPTopTaggerV2();
+  
+  HEPTopTaggerV2(const fastjet::PseudoJet & jet);
+
+
+  HEPTopTaggerV2(const fastjet::PseudoJet & jet, 
+      double mtmass, double mwmass
+      );
+
+  ~HEPTopTaggerV2();
+
+  //run tagger
+  void run();
+
+   //get information
+  bool is_maybe_top() const {return _HEPTopTaggerV2_opt.is_maybe_top();}
+  bool is_masscut_passed() const {return _HEPTopTaggerV2_opt.is_masscut_passed();}
+  bool is_minptcut_passed() const {return _HEPTopTaggerV2_opt.is_minptcut_passed();}
+  bool is_tagged() const {return _HEPTopTaggerV2_opt.is_tagged();}
+
+  double delta_top() const {return _HEPTopTaggerV2_opt.delta_top();}
+  double djsum() const {return _HEPTopTaggerV2_opt.djsum();}
+  double pruned_mass() const {return _HEPTopTaggerV2_opt.pruned_mass();}
+  double unfiltered_mass() const {return _HEPTopTaggerV2_opt.unfiltered_mass();}
+
+  double f_rec() {return _HEPTopTaggerV2_opt.f_rec();}
+  const PseudoJet & t() const {return _HEPTopTaggerV2_opt.t();}
+  const PseudoJet & b() const {return _HEPTopTaggerV2_opt.b();}
+  const PseudoJet & W() const {return _HEPTopTaggerV2_opt.W();}
+  const PseudoJet & W1() const {return _HEPTopTaggerV2_opt.W1();}
+  const PseudoJet & W2() const {return _HEPTopTaggerV2_opt.W2();}
+  const std::vector<PseudoJet> & top_subjets() const {return _HEPTopTaggerV2_opt.top_subjets();}
+  const PseudoJet & j1() const {return _HEPTopTaggerV2_opt.j1();}
+  const PseudoJet & j2() const {return _HEPTopTaggerV2_opt.j2();}
+  const PseudoJet & j3() const {return _HEPTopTaggerV2_opt.j3();}
+  const std::vector<PseudoJet> & top_hadrons() const {return _HEPTopTaggerV2_opt.top_hadrons();}
+  const std::vector<PseudoJet> & hardparts() const {return _HEPTopTaggerV2_opt.hardparts();}
+  const PseudoJet & fat_initial() {return _fat;}
+  const PseudoJet & fat_Ropt() {return _HEPTopTaggerV2_opt.fat_initial();}
+  //HEPTopTaggerV2_fixed_R cand_Ropt(){return _HEPTopTaggerV2[_Ropt];}
+  HEPTopTaggerV2_fixed_R HEPTopTaggerV2agger(int i)  {return _HEPTopTaggerV2[i];}
+  
+  double Ropt() const {return _Ropt/10.;}
+  double Ropt_calc() const {return _R_opt_calc;}
+  double pt_for_Ropt_calc() const {return _pt_for_R_opt_calc;}
+
+  int optimalR_type();
+  double nsub_unfiltered(int order, fastjet::contrib::Njettiness::AxesMode axes = fastjet::contrib::Njettiness::kt_axes, double beta = 1., double R0 = 1.);
+  double nsub_filtered(int order, fastjet::contrib::Njettiness::AxesMode axes = fastjet::contrib::Njettiness::kt_axes, double beta = 1., double R0 = 1.);
+
+  void get_setting() const {return _HEPTopTaggerV2_opt.get_setting();};
+  void get_info() const {return _HEPTopTaggerV2_opt.get_info();};
+  
+  double q_weight() {return _qweight;}
+  
+  //settings
+  void do_optimalR(bool optimalR) {_do_optimalR = optimalR;}
+
+  void set_mass_drop_threshold(double x) {_mass_drop_threshold = x;}
+  void set_max_subjet_mass(double x) {_max_subjet_mass = x;}
+ 
+  void set_filtering_n(unsigned nfilt) {_nfilt = nfilt;}
+  void set_filtering_R(double Rfilt) {_Rfilt = Rfilt;}
+  void set_filtering_minpt_subjet(double x) {_minpt_subjet = x;}
+  void set_filtering_jetalgorithm(JetAlgorithm jet_algorithm) {_jet_algorithm_filter = jet_algorithm;}
+  
+  void set_reclustering_jetalgorithm(JetAlgorithm jet_algorithm) {_jet_algorithm_recluster = jet_algorithm;}
+
+  void set_mode(enum Mode mode) {_mode = mode;}
+  void set_mt(double x) {_mtmass = x;}
+  void set_mw(double x) {_mwmass = x;}
+  void set_top_mass_range(double xmin, double xmax) {_mtmin = xmin; _mtmax = xmax;}
+  void set_fw(double fw) {_rmin = (1.-fw)*_mwmass/_mtmass; _rmax=(1.+fw)*_mwmass/_mtmass;}
+  void set_mass_ratio_range(double rmin, double rmax) {_rmin = rmin; _rmax = rmax;}
+  void set_mass_ratio_cut(double m23cut, double m13cutmin,double m13cutmax) {_m23cut = m23cut; _m13cutmin = m13cutmin; _m13cutmax = m13cutmax;}
+  void set_top_minpt(double x) {_minpt_tag = x;}
+  
+  void set_optimalR_max(double x) {_max_fatjet_R = x;}
+  void set_optimalR_min(double x) {_min_fatjet_R = x;}
+  void set_optimalR_step(double x) {_step_R = x;}
+  void set_optimalR_threshold(double x) {_optimalR_threshold = x;}
+
+  void set_filtering_optimalR_calc_R(double x) {_R_filt_optimalR_calc = x;}
+  void set_filtering_optimalR_calc_n(unsigned x) {_N_filt_optimalR_calc = x;}
+  void set_optimalR_calc_fun(double (*f)(double)) {_r_min_exp_function = f;}
+
+  void set_optimalR_type_top_mass_range(double x, double y) {_optimalR_mmin = x; _optimalR_mmax = y;}
+  void set_optimalR_type_fw(double x) {_optimalR_fw = x;}
+  void set_optimalR_type_max_diff(double x) {_R_opt_diff = x;}
+  
+  void set_optimalR_reject_minimum(bool x) {_R_opt_reject_min = x;}
+
+  void set_filtering_optimalR_pass_R(double x) {_R_filt_optimalR_pass = x;}
+  void set_filtering_optimalR_pass_n(unsigned x) {_N_filt_optimalR_pass = x;}
+  void set_filtering_optimalR_fail_R(double x) {_R_filt_optimalR_fail = x;}
+  void set_filtering_optimalR_fail_n(unsigned x) {_N_filt_optimalR_fail = x;}
+  
+  void set_pruning_zcut(double zcut) {_zcut = zcut;}
+  void set_pruning_rcut_factor(double rcut_factor) {_rcut_factor = rcut_factor;}
+
+  void set_debug(bool debug) {_debug = debug;}
+  void do_qjets(bool qjets) {_do_qjets = qjets;}
+  void set_qjets(double q_zcut, double q_dcut_fctr, double q_exp_min, double q_exp_max, double q_rigidity, double q_truncation_fctr) {
+    _q_zcut = q_zcut; _q_dcut_fctr = q_dcut_fctr; _q_exp_min = q_exp_min; _q_exp_max = q_exp_max; _q_rigidity =  q_rigidity; _q_truncation_fctr =  q_truncation_fctr;
+  }
+  void set_qjets_rng(CLHEP::HepRandomEngine* engine){ _rnEngine = engine;}
+
+   
+private:
+  bool _do_optimalR, _do_qjets;
+ 
+  PseudoJet _jet;
+  PseudoJet _initial_jet;
+  
+  double _mass_drop_threshold;
+  double _max_subjet_mass;
+  
+  Mode _mode;
+  double _mtmass, _mwmass;
+  double _mtmin, _mtmax;
+  double _rmin, _rmax;
+  double _m23cut, _m13cutmin, _m13cutmax;
+  double _minpt_tag;
+ 
+  unsigned _nfilt;
+  double _Rfilt;
+  fastjet::JetAlgorithm _jet_algorithm_filter;
+  double _minpt_subjet;
+ 
+  fastjet::JetAlgorithm _jet_algorithm_recluster;
+
+  double _zcut;
+  double _rcut_factor;
+ 
+  double _max_fatjet_R, _min_fatjet_R, _step_R, _optimalR_threshold;
+
+  double  _R_filt_optimalR_calc, _N_filt_optimalR_calc;
+  double (*_r_min_exp_function)(double);
+  
+  double _optimalR_mmin, _optimalR_mmax, _optimalR_fw, _R_opt_calc, _pt_for_R_opt_calc, _R_opt_diff;
+  bool _R_opt_reject_min;
+  double _R_filt_optimalR_pass, _N_filt_optimalR_pass, _R_filt_optimalR_fail, _N_filt_optimalR_fail;
+
+  double _q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr;
+  JetDefinition _qjet_def;
+  
+  PseudoJet _fat, _filt_fat;
+  map<int,int> _n_small_fatjets;
+  map<int,HEPTopTaggerV2_fixed_R> _HEPTopTaggerV2;
+  HEPTopTaggerV2_fixed_R _HEPTopTaggerV2_opt;
+
+  int _Ropt;
+
+  CLHEP::HepRandomEngine* _rnEngine;
+  
+  bool _debug;
+  double _qweight;
+
+  void UnclusterFatjets(const vector<fastjet::PseudoJet> & big_fatjets, vector<fastjet::PseudoJet> & small_fatjets, const ClusterSequence & cs, const double small_radius);
+
+};
+//--------------------------------------------------------------------
+// Do not change next line, it's needed by the sed-code that makes the tagger CMSSW-compatible.
+};
+
+#endif // __HEPTOPTAGGERV2_HH__
+

--- a/RecoJets/JetAlgorithms/interface/HEPTopTaggerWrapperV2.h
+++ b/RecoJets/JetAlgorithms/interface/HEPTopTaggerWrapperV2.h
@@ -1,0 +1,300 @@
+//  2011 Christopher Vermilion
+//
+//----------------------------------------------------------------------
+//  This file is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  The GNU General Public License is available at
+//  http://www.gnu.org/licenses/gpl.html or you can write to the Free Software
+//  Foundation, Inc.:
+//      59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//----------------------------------------------------------------------
+
+#ifndef __HEPTOPTAGGER_WRAPPERV2_HH__
+#define __HEPTOPTAGGER_WRAPPERV2_HH__
+
+#include <fastjet/tools/TopTaggerBase.hh>
+#include <fastjet/CompositeJetStructure.hh>
+#include "CLHEP/Random/RandomEngine.h"
+#include <sstream>
+
+FASTJET_BEGIN_NAMESPACE
+
+/// A fastjet::Transformer wrapper for the HEP top tagger.  All of the work
+/// is done by the HEPTopTagger class in HEPTopTagger.hh, written by
+/// Tilman Plehn, Gavin Salam, Michael Spannowsky, and Michihisa Takeuchi.  The
+/// HEP top tagger was described in Phys. Rev. Lett. 104 (2010) 111801
+/// [arXiv:0910.5472] and JHEP 1010 (2010) 078 [arXiv:1006.2833].
+/// 
+///
+/// This code is based on JHTopTagger.{hh,cc}, part of the FastJet package,
+/// written by Matteo Cacciari, Gavin P. Salam and Gregory Soyez, and released
+/// under the GNU General Public License.
+///
+/// The HEP top tagger produces information similar to the Johns Hopkins tagger.
+///  Accordingly I simply reuse the JHTopTaggerStructure.
+
+// Removed legacy comments by CHRISTOPHER SILKWORTH
+
+class HEPTopTaggerV2Structure;
+
+
+class HEPTopTaggerV2 : public TopTaggerBase {
+public:
+ HEPTopTaggerV2(bool DoOptimalR,
+		bool DoQjets,
+		double minSubjetPt, 
+		double minCandPt, 
+		double subjetMass, 
+		double muCut, 
+		double filtR,
+		int filtN,
+		int mode, 
+		double minCandMass, 
+		double maxCandMass, 
+		double massRatioWidth, 
+		double minM23Cut, 
+		double minM13Cut, 
+		double maxM13Cut,
+		bool optRrejectMin) : DoOptimalR_(DoOptimalR),
+    DoQjets_(DoQjets),
+    minSubjetPt_(minSubjetPt),
+    minCandPt_(minCandPt),
+    subjetMass_(subjetMass),
+    muCut_(muCut),
+    filtR_(filtR),
+    filtN_(filtN),
+    mode_(mode),
+    minCandMass_(minCandMass),
+    maxCandMass_(maxCandMass),
+    massRatioWidth_(massRatioWidth),
+    minM23Cut_(minM23Cut),
+    minM13Cut_(minM13Cut),
+    maxM13Cut_(maxM13Cut),
+    optRrejectMin_(optRrejectMin),
+    engine_(0)
+  {}
+
+  /// returns a textual description of the tagger
+  virtual std::string description() const;
+
+  /// runs the tagger on the given jet and
+  /// returns the tagged PseudoJet if successful, or a PseudoJet==0 otherwise
+  /// (standard access is through operator()).
+  ///  \param jet   the PseudoJet to tag
+  virtual PseudoJet result(const PseudoJet & jet) const;
+
+  void set_rng(CLHEP::HepRandomEngine* engine){ engine_ = engine;}
+
+  // the type of the associated structure
+  typedef HEPTopTaggerV2Structure StructureType;
+
+private:
+    bool DoOptimalR_; // Use optimalR mode
+    bool DoQjets_; // Use qjet mode
+
+    double minSubjetPt_; // Minimal pT for subjets [GeV]
+    double minCandPt_;   // Minimal pT to return a candidate [GeV]
+ 
+    double subjetMass_; // Mass above which subjets are further unclustered
+    double muCut_; // Mass drop threshold
+    
+    double filtR_; // maximal filtering radius
+    int filtN_; // number of filtered subjets to use
+
+    // HEPTopTagger Mode
+    // 0: do 2d-plane, return candidate with delta m_top minimal
+    // 1: return candidate with delta m_top minimal IF passes 2d plane
+    // 2: do 2d-plane, return candidate with max dj_sum
+    // 3: return candidate with max dj_sum IF passes 2d plane
+    // 4: return candidate built from leading three subjets after unclustering IF passes 2d plane
+    // Note: Original HTT was mode==1    
+    int mode_; 
+
+    // Top Quark mass window in GeV
+    double minCandMass_;
+    double maxCandMass_;
+    
+    double massRatioWidth_; // One sided width of the A-shaped window around m_W/m_top in %
+    double minM23Cut_; // minimal value of m23/m123
+    double minM13Cut_; // minimal value of atan(m13/m12)
+    double maxM13Cut_; // maximal value of atan(m13/m12)
+  
+    bool optRrejectMin_; // set Ropt to zero for candidates that never leave the window around the initial mass
+                         // otherwise (default) set them to R=0.5
+
+    // Random engine for Q-jet HTT
+    CLHEP::HepRandomEngine* engine_;
+};
+
+
+class HEPTopTaggerV2Structure : public CompositeJetStructure, public TopTaggerBaseStructure {
+
+ public:
+   /// ctor with pieces initialisation
+   HEPTopTaggerV2Structure(const std::vector<PseudoJet>& pieces_in,
+                  const JetDefinition::Recombiner *recombiner = 0) : CompositeJetStructure(pieces_in, recombiner),
+    _fj_mass(0.0),
+    _fj_pt(0.0),
+    _fj_eta(0.0),
+    _fj_phi(0.0),
+    _top_mass(0.0),
+    _unfiltered_mass(0.0),
+    _pruned_mass(0.0),
+    _fRec(-1.),
+    _mass_ratio_passed(-1),
+    _ptForRoptCalc(-1),
+    _tau1Unfiltered(-1.),
+    _tau2Unfiltered(-1.),
+    _tau3Unfiltered(-1.),
+    _tau1Filtered(-1.),
+    _tau2Filtered(-1.),
+    _tau3Filtered(-1.),
+    _Qweight(-1.),    
+    _Qepsilon(-1.),    
+    _QsigmaM(-1.),    
+    W_rec(recombiner), 
+    rW_(){}
+  
+   // Return W subjet
+   inline PseudoJet const & W() const{ 
+     rW_ = join(_pieces[0], _pieces[1], *W_rec);
+     return rW_;
+   }
+     
+   // Return leading subjet in W
+   inline PseudoJet  W1() const{
+     assert(W().pieces().size()>0);
+     return W().pieces()[0];
+   }
+       
+   /// returns the second W subjet
+   inline PseudoJet W2() const{
+     assert(W().pieces().size()>1);
+     return W().pieces()[1];
+   }
+ 
+
+   /// returns the non-W subjet
+   /// It will have 1 or 2 pieces depending on whether the tagger has
+   /// found 3 or 4 pieces
+   inline const PseudoJet & non_W() const{ 
+     return _pieces[2];
+   }
+ 
+   /// return the mass of the initial fatjet
+   inline double fj_mass() const {return _fj_mass;}
+
+   /// return the pt of the initial fatjet
+   inline double fj_pt() const {return _fj_pt;}
+
+   /// return the eta of the initial fatjet
+   inline double fj_eta() const {return _fj_eta;}
+
+   /// return the phi of the initial fatjet
+   inline double fj_phi() const {return _fj_phi;}
+
+   /// returns the candidate mass
+   inline double top_mass() const {return _top_mass;}
+
+   /// returns the unfiltered mass
+   inline double unfiltered_mass() const {return _unfiltered_mass;}
+
+   /// returns the pruned mass
+   inline double pruned_mass() const {return _pruned_mass;}
+
+   /// returns fRec
+   inline double fRec() const {return _fRec;}
+
+   /// returns if 2d-mass plane cuts were passed
+   inline double mass_ratio_passed() const {return _mass_ratio_passed;}
+
+   /// returns Ropt
+   inline double Ropt() const {return _Ropt;}
+
+   /// returns calculated Ropt
+   inline double RoptCalc() const {return _RoptCalc;}
+
+   /// returns the filtered pT for calculating R_opt
+   inline double ptForRoptCalc() const {return _ptForRoptCalc;}
+
+   // Nsubjettiness and Q-jet variables
+   inline double Tau1Unfiltered() const {return _tau1Unfiltered;}
+   inline double Tau2Unfiltered() const {return _tau2Unfiltered;}
+   inline double Tau3Unfiltered() const {return _tau3Unfiltered;}
+   inline double Tau1Filtered() const {return _tau1Filtered;}
+   inline double Tau2Filtered() const {return _tau2Filtered;}
+   inline double Tau3Filtered() const {return _tau3Filtered;}
+
+   inline double Qweight() const {return _Qweight;}
+   inline double Qepsilon() const {return _Qepsilon;}
+   inline double QsigmaM() const {return _QsigmaM;}   
+    
+ protected:
+
+      double _fj_mass;
+      double _fj_pt;
+      double _fj_eta;
+      double _fj_phi;
+
+      double _top_mass;
+      double _unfiltered_mass;
+      double _pruned_mass;
+      double _fRec;
+      int _mass_ratio_passed;
+      double _ptForRoptCalc;
+      double _Ropt;
+      double _RoptCalc;
+
+      double _tau1Unfiltered;
+      double _tau2Unfiltered;
+      double _tau3Unfiltered;
+      double _tau1Filtered;
+      double _tau2Filtered;
+      double _tau3Filtered;
+      double _Qweight;
+      double _Qepsilon;
+      double _QsigmaM;
+
+      const JetDefinition::Recombiner  * W_rec;
+ 
+      mutable PseudoJet rW_;
+
+   // allow the tagger to set these
+   friend class HEPTopTaggerV2;
+ };
+
+
+//------------------------------------------------------------------------
+// description of the tagger
+inline std::string HEPTopTaggerV2::description() const{ 
+
+  std::ostringstream oss;
+  oss << "HEPTopTaggerV2 with: "
+      << "minSubjetPt = " << minSubjetPt_ 
+      << "minCandPt = " << minCandPt_ 
+      << "subjetMass = " << subjetMass_ 
+      << "muCut = " << muCut_ 
+      << "filtR = " << filtR_ 
+      << "filtN = " << filtN_     
+      << "mode = " << mode_ 
+      << "minCandMass = " << minCandMass_ 
+      << "maxCandMass = " << maxCandMass_ 
+      << "massRatioWidth = " << massRatioWidth_ 
+      << "minM23Cut = " << minM23Cut_ 
+      << "minM13Cut = " << minM13Cut_ 
+      << "maxM13Cut = " << maxM13Cut_ << std::endl;
+  return oss.str();
+}
+
+
+FASTJET_END_NAMESPACE
+
+#endif // __HEPTOPTAGGER_HH__

--- a/RecoJets/JetAlgorithms/interface/Qjets.h
+++ b/RecoJets/JetAlgorithms/interface/Qjets.h
@@ -2,6 +2,8 @@
 #define RecoJets_JetAlgorithms_QJets_h
 #include <queue>
 #include <vector>
+#include <list>
+#include <algorithm>
 #include "fastjet/JetDefinition.hh"
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequence.hh"
@@ -25,6 +27,7 @@ class JetDistanceCompare{
 
 class Qjets{
  private:
+  double Omega;
   bool _rand_seed_set;
   unsigned int _seed;
   double _zcut, _dcut, _dcut_fctr, _exp_min, _exp_max, _rigidity, _truncation_fctr;
@@ -61,4 +64,17 @@ class Qjets{
   void Cluster(fastjet::ClusterSequence & cs);
   void SetRandSeed(unsigned int seed); /* In case you want reproducible behavior */
 };
+
+
+class QjetsBaseExtras : public fastjet::ClusterSequence::Extras {
+public:
+ QjetsBaseExtras():_wij(-1.) {}
+  virtual ~QjetsBaseExtras() {};
+  virtual double weight() const {return _wij;};
+  friend class Qjets;
+
+  protected:
+  double _wij;
+};
+
 #endif

--- a/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
+++ b/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
@@ -1,0 +1,651 @@
+#include "../interface/HEPTopTaggerV2.h"
+
+// Do not change next line, it's needed by the sed-code that makes the tagger CMSSW-compatible.
+namespace external {
+
+//optimal_R fit
+double R_opt_calc_funct(double pt_filt) {
+  return 327./pt_filt;
+}
+
+bool HEPTopTaggerV2_fixed_R::_first_time = true;
+
+void HEPTopTaggerV2_fixed_R::print_banner() {
+  if (!_first_time) {return;}
+  _first_time = false;
+
+  std::cout << "#--------------------------------------------------------------------------\n";
+  std::cout << "#                   HEPTopTaggerV2 - under construction                      \n";
+  std::cout << "#                                                                          \n";
+  std::cout << "# Please cite JHEP 1010 (2010) 078 [arXiv:1006.2833 [hep-ph]]              \n";
+  std::cout << "# and Phys.Rev. D89 (2014) 074047 [arXiv:1312.1504 [hep-ph]]               \n";
+  std::cout << "#--------------------------------------------------------------------------\n";
+}
+
+//pt wrt a reference vector
+double HEPTopTaggerV2_fixed_R::perp(const fastjet::PseudoJet & vec, const fastjet::PseudoJet & ref) {
+  double ref_ref = ref.px() * ref.px() + ref.py() * ref.py() + ref.pz() * ref.pz();
+  double vec_ref = vec.px() * ref.px() + vec.py() * ref.py() + vec.pz() * ref.pz();
+  double per_per = vec.px() * vec.px() + vec.py() * vec.py() + vec.pz() * vec.pz();
+  if (ref_ref > 0.) 
+    per_per -= vec_ref * vec_ref / ref_ref;
+  if (per_per < 0.) 
+    per_per = 0.;
+  return sqrt(per_per);
+}
+
+//modified Jade distance
+double HEPTopTaggerV2_fixed_R::djademod (const fastjet::PseudoJet& subjet_i, const fastjet::PseudoJet& subjet_j, const fastjet::PseudoJet& ref) {
+  double dj = -1.0;
+  double delta_phi = subjet_i.delta_phi_to(subjet_j);
+  double delta_eta = subjet_i.eta() - subjet_j.eta();
+  double delta_R = sqrt(delta_eta * delta_eta + delta_phi * delta_phi);	
+  dj = perp(subjet_i, ref) * perp(subjet_j, ref) * pow(delta_R, 4.);
+  return dj;
+}
+
+//minimal |(m_ij / m_123) / (m_w/ m_t) - 1|
+double HEPTopTaggerV2_fixed_R::f_rec() {
+  double m12 = (_top_subs[0] + _top_subs[1]).m();
+  double m13 = (_top_subs[0] + _top_subs[2]).m();
+  double m23 = (_top_subs[1] + _top_subs[2]).m();
+  double m123 = (_top_subs[0] + _top_subs[1] + _top_subs[2]).m();
+
+  double fw12 = fabs( (m12/m123) / (_mwmass/_mtmass) - 1);
+  double fw13 = fabs( (m13/m123) / (_mwmass/_mtmass) - 1);
+  double fw23 = fabs( (m23/m123) / (_mwmass/_mtmass) - 1);
+  
+  return std::min(fw12, std::min(fw13, fw23));  
+}
+
+//find hard substructures
+void HEPTopTaggerV2_fixed_R::FindHardSubst(const PseudoJet & this_jet, std::vector<fastjet::PseudoJet> & t_parts) {
+  PseudoJet parent1(0, 0, 0, 0), parent2(0, 0, 0, 0);
+  if (this_jet.m() < _max_subjet_mass || !this_jet.validated_cs()->has_parents(this_jet, parent1, parent2)) {
+    t_parts.push_back(this_jet);
+  } else {
+    if (parent1.m() < parent2.m()) 
+      std::swap(parent1, parent2);   
+    FindHardSubst(parent1, t_parts);
+    if (parent1.m() < _mass_drop_threshold * this_jet.m())
+      FindHardSubst(parent2, t_parts);   
+  }
+}
+
+//store subjets as vector<PseudoJet> with [0]->b [1]->W-jet 1 [2]->W-jet 2
+void HEPTopTaggerV2_fixed_R::store_topsubjets(const std::vector<PseudoJet>& top_subs) {
+  _top_subjets.resize(0);
+  double m12 = (top_subs[0] + top_subs[1]).m();
+  double m13 = (top_subs[0] + top_subs[2]).m();
+  double m23 = (top_subs[1] + top_subs[2]).m();
+  double dm12 = fabs(m12 - _mwmass);
+  double dm13 = fabs(m13 - _mwmass);
+  double dm23 = fabs(m23 - _mwmass);
+  
+  if (dm23 <= dm12 && dm23 <= dm13) {
+    _top_subjets.push_back(top_subs[0]); 
+    _top_subjets.push_back(top_subs[1]); 
+    _top_subjets.push_back(top_subs[2]);	
+  } else if (dm13 <= dm12 && dm13 < dm23) {
+    _top_subjets.push_back(top_subs[1]);
+    _top_subjets.push_back(top_subs[0]);
+    _top_subjets.push_back(top_subs[2]);
+  } else if (dm12 < dm23 && dm12 < dm13) {
+    _top_subjets.push_back(top_subs[2]);
+    _top_subjets.push_back(top_subs[0]);
+    _top_subjets.push_back(top_subs[1]);
+  }
+  _W = _top_subjets[1] + _top_subjets[2];
+  return;
+}
+
+//check mass plane cuts
+bool HEPTopTaggerV2_fixed_R::check_mass_criteria(const std::vector<PseudoJet> & top_subs) const {
+  bool is_passed = false;
+  double m12 = (top_subs[0] + top_subs[1]).m();
+  double m13 = (top_subs[0] + top_subs[2]).m();
+  double m23 = (top_subs[1] + top_subs[2]).m();
+  double m123 = (top_subs[0] + top_subs[1] + top_subs[2]).m();
+  if (
+      (atan(m13/m12) > _m13cutmin && _m13cutmax > atan(m13/m12)
+       && (m23/m123 > _rmin && _rmax > m23/m123))
+      ||
+      (((m23/m123) * (m23/m123) < 1 - _rmin * _rmin* (1 + (m13/m12) * (m13/m12)))
+       &&
+       ((m23/m123) * (m23/m123) > 1 - _rmax * _rmax * (1 + (m13/m12) * (m13/m12)))
+       && 
+       (m23/m123 > _m23cut))
+      ||
+      (((m23/m123) * (m23/m123) < 1 - _rmin * _rmin * (1 + (m12/m13) * (m12/m13)))
+       &&
+       ((m23/m123) * (m23/m123) > 1 - _rmax * _rmax * (1 + (m12/m13) * (m12/m13)))
+       && 
+       (m23/m123 > _m23cut))
+      ) { 
+    is_passed = true;
+  }
+  return is_passed;
+}
+
+double HEPTopTaggerV2_fixed_R::nsub(fastjet::PseudoJet jet, int order, fastjet::contrib::Njettiness::AxesMode axes, double beta, double R0) {
+  fastjet::contrib::Nsubjettiness nsub(order, axes, beta, R0);
+  return nsub.result(jet);
+}
+
+HEPTopTaggerV2_fixed_R::HEPTopTaggerV2_fixed_R() : _do_qjets(0),
+					       _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+					       _mode(Mode(0)), _mtmass(172.3), _mwmass(80.4), _mtmin(150.), _mtmax(200.), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+					       _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+					       _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+					       _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+					       _zcut(0.1), _rcut_factor(0.5),
+					       _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0), _rnEngine(0),
+					       //_qjet_plugin(_q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr),
+					       _debug(false)
+{
+  _djsum = 0.;
+  _delta_top = 1000000000000.0;
+  _pruned_mass = 0.;
+  _unfiltered_mass = 0.;
+  _top_candidate.reset(0., 0., 0., 0.);
+  _parts_size = 0;
+  _is_maybe_top = _is_masscut_passed = _is_ptmincut_passed = false;
+  _top_subs.clear();
+  _top_subjets.clear();
+  _top_hadrons.clear();
+  _top_parts.clear();
+  _qweight= -1.;
+  
+}
+						
+HEPTopTaggerV2_fixed_R::HEPTopTaggerV2_fixed_R(const fastjet::PseudoJet jet) : _do_qjets(0),
+									   _jet(jet), _initial_jet(jet),
+									   _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+									   _mode(Mode(0)), _mtmass(172.3), _mwmass(80.4),  _mtmin(150.), _mtmax(200.), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+									   _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+									   _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+									   _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+									   _zcut(0.1), _rcut_factor(0.5),
+									   _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0),
+									   _fat(jet), _rnEngine(0),
+									   _debug(false)
+{}
+
+HEPTopTaggerV2_fixed_R::HEPTopTaggerV2_fixed_R(const fastjet::PseudoJet jet, 
+					   double mtmass, double mwmass) : _do_qjets(0),
+									   _jet(jet), _initial_jet(jet),
+									   _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+									   _mode(Mode(0)), _mtmass(mtmass), _mwmass(mwmass), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+									   _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+									   _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+									   _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+									   _zcut(0.1), _rcut_factor(0.5),
+									   _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0),
+									   _fat(jet), _rnEngine(0),
+									   _debug(false)
+{}
+
+void HEPTopTaggerV2_fixed_R::run() {
+  print_banner();
+  
+  if ((_mode != EARLY_MASSRATIO_SORT_MASS) 
+      && (_mode != LATE_MASSRATIO_SORT_MASS) 
+      && (_mode != EARLY_MASSRATIO_SORT_MODDJADE)
+      && (_mode != LATE_MASSRATIO_SORT_MODDJADE)
+      && (_mode != TWO_STEP_FILTER) ) {
+    std::cout << "ERROR: UNKNOWN MODE" << std::endl;
+    return;
+  }
+  
+  //Qjets
+  QjetsPlugin _qjet_plugin(_q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr);
+  _qjet_def = fastjet::JetDefinition(&_qjet_plugin);
+  _qweight=-1;
+  vector<fastjet::PseudoJet> _q_constits;
+  ClusterSequence* _qjet_seq;
+  PseudoJet _qjet;
+  if (_do_qjets){
+    _q_constits = _initial_jet.associated_cluster_sequence()->constituents(_initial_jet);
+    _qjet_seq = new ClusterSequence(_q_constits, _qjet_def);
+    _qjet = sorted_by_pt(_qjet_seq->inclusive_jets())[0];
+    _qjet_seq->delete_self_when_unused();
+    const QjetsBaseExtras* ext =
+      dynamic_cast<const QjetsBaseExtras*>(_qjet_seq->extras());
+    _qweight=ext->weight();
+    _jet = _qjet;
+    _fat = _qjet;
+    _qjet_plugin.SetRNEngine(_rnEngine);
+  }
+  
+  //initialization
+  _djsum = 0.;
+  _delta_top = 1000000000000.0;
+  _pruned_mass = 0.;
+  _unfiltered_mass = 0.;
+  _top_candidate.reset(0., 0., 0., 0.);
+  _parts_size = 0;
+  _is_maybe_top = _is_masscut_passed = _is_ptmincut_passed = false;
+  _top_subs.clear();
+  _top_subjets.clear();
+  _top_hadrons.clear();
+  _top_parts.clear();
+   
+  //find hard substructures
+  FindHardSubst(_jet, _top_parts);
+    
+  if (_top_parts.size() < 3) { 
+    if (_debug) {std::cout << "< 3 hard substructures " << std::endl;}
+    return; //such events are not interesting   
+  }
+  
+  // Sort subjets-after-unclustering by pT.
+  // Necessary so that two-step-filtering can use the leading-three.
+  _top_parts=sorted_by_pt(_top_parts);
+
+  // loop over triples
+  _top_parts = sorted_by_pt(_top_parts);
+  for (unsigned rr = 0; rr < _top_parts.size(); rr++) {
+    for (unsigned ll = rr + 1; ll < _top_parts.size(); ll++) {
+      for (unsigned kk = ll + 1; kk < _top_parts.size(); kk++) {
+	
+	// two-step filtering 
+	// This means that we only look at the triplet formed by the
+	// three leading-in-pT subjets-after-unclustering.
+	if((_mode==TWO_STEP_FILTER) && rr>0)
+	  continue;
+	if((_mode==TWO_STEP_FILTER) && ll>1)
+	  continue;
+	if((_mode==TWO_STEP_FILTER) && kk>2)
+	  continue;
+
+      	//pick triple
+	PseudoJet triple = join(_top_parts[rr], _top_parts[ll], _top_parts[kk]);
+	
+	//filtering 
+	double filt_top_R 
+	  = std::min(_Rfilt, 0.5*sqrt(std::min(_top_parts[kk].squared_distance(_top_parts[ll]), 
+					       std::min(_top_parts[rr].squared_distance(_top_parts[ll]), 
+							_top_parts[kk].squared_distance(_top_parts[rr])))));
+	JetDefinition filtering_def(_jet_algorithm_filter, filt_top_R);
+	fastjet::Filter filter(filtering_def, fastjet::SelectorNHardest(_nfilt) * fastjet::SelectorPtMin(_minpt_subjet));
+	PseudoJet topcandidate = filter(triple);
+
+	//mass window cut
+  	if (topcandidate.m() < _mtmin || _mtmax < topcandidate.m()) continue;
+
+	// Sanity cut: can't recluster less than 3 objects into three subjets
+	if (topcandidate.pieces().size() < 3)
+	  continue;
+       
+	// Recluster to 3 subjets and apply mass plane cuts
+	JetDefinition reclustering(_jet_algorithm_recluster, 3.14);
+	ClusterSequence *  cs_top_sub = new ClusterSequence(topcandidate.pieces(), reclustering);
+        std::vector <PseudoJet> top_subs = sorted_by_pt(cs_top_sub->exclusive_jets(3));         
+	cs_top_sub->delete_self_when_unused();
+
+	// Require the third subjet to be above the pT threshold
+	if (top_subs[2].perp() < _minpt_subjet)
+	  continue;
+
+	// Modes with early 2d-massplane cuts
+	if (_mode == EARLY_MASSRATIO_SORT_MASS      && !check_mass_criteria(top_subs)) {continue;}
+	if (_mode == EARLY_MASSRATIO_SORT_MODDJADE  && !check_mass_criteria(top_subs)) {continue;}
+
+	//is this candidate better than the other? -> update
+	double deltatop = fabs(topcandidate.m() - _mtmass);
+	double djsum = djademod(top_subs[0], top_subs[1], topcandidate) 
+	  + djademod(top_subs[0], top_subs[2], topcandidate)
+	  + djademod(top_subs[1], top_subs[2], topcandidate);
+	bool better = false;
+
+	// Modes 0 and 1 sort by top mass
+	if ( (_mode == EARLY_MASSRATIO_SORT_MASS) 
+	     || (_mode == LATE_MASSRATIO_SORT_MASS)) {
+	  if (deltatop < _delta_top) 
+	    better = true;
+	}
+	// Modes 2 and 3 sort by modified jade distance
+	else if ( (_mode == EARLY_MASSRATIO_SORT_MODDJADE) 
+		  || (_mode == LATE_MASSRATIO_SORT_MODDJADE)) {
+	  if (djsum > _djsum) 
+	    better = true;
+	}
+	// Mode 4 is the two-step filtering. No sorting necessary as
+	// we just look at the triplet of highest pT objects after
+	// unclustering
+	else if (_mode == TWO_STEP_FILTER) {
+	  better = true;
+	} 
+	else {
+	  std::cout << "ERROR: UNKNOWN MODE (IN DISTANCE MEASURE SELECTION)" << std::endl;
+	  return;
+	}
+
+	if (better) {
+	  _djsum = djsum;
+	  _delta_top = deltatop; 
+	  _is_maybe_top = true;
+	  _top_candidate = topcandidate;
+	  _top_subs = top_subs;
+	  store_topsubjets(top_subs);
+	  _top_hadrons = topcandidate.constituents();
+	  // Pruning
+	  double _Rprun = _initial_jet.validated_cluster_sequence()->jet_def().R(); 
+	  JetDefinition jet_def_prune(fastjet::cambridge_algorithm, _Rprun);
+	  fastjet::Pruner pruner(jet_def_prune, _zcut, _rcut_factor);
+	  PseudoJet prunedjet = pruner(triple);
+	  _pruned_mass = prunedjet.m();
+	  _unfiltered_mass = triple.m();
+	  
+	  //are all criteria fulfilled?
+	  _is_masscut_passed = false;
+	  if (check_mass_criteria(top_subs)) {
+	    _is_masscut_passed = true;
+	  }
+	  _is_ptmincut_passed = false;
+	  if (_top_candidate.pt() > _minpt_tag) {
+	    _is_ptmincut_passed = true;
+	  }
+	}//end better
+      }//end kk
+    }//end ll
+  }//end rr
+   
+  return;
+}
+
+void HEPTopTaggerV2_fixed_R::get_info() const {  
+  std::cout << "#--------------------------------------------------------------------------\n";
+  std::cout << "#                          HEPTopTaggerV2 Result" << std::endl;
+  std::cout << "#" << std::endl;
+  std::cout << "# is top candidate: " << _is_maybe_top << std::endl;
+  std::cout << "# mass plane cuts passed: " << _is_masscut_passed << std::endl;
+  std::cout << "# top candidate mass: " << _top_candidate.m() << std::endl;
+  std::cout << "# top candidate (pt, eta, phi): (" 
+	    << _top_candidate.perp() << ", "
+	    << _top_candidate.eta() << ", "
+	    << _top_candidate.phi_std() << ")" << std::endl;
+  std::cout << "# top hadrons: " << _top_hadrons.size() << std::endl;
+  std::cout << "# hard substructures: " << _parts_size << std::endl;
+  std::cout << "# |m - mtop| : " << _delta_top << std::endl; 
+  std::cout << "# djsum : " << _djsum << std::endl;
+  std::cout << "# is consistency cut passed: " << _is_ptmincut_passed << std::endl; 
+  std::cout << "#--------------------------------------------------------------------------\n";
+  return;
+}
+
+void HEPTopTaggerV2_fixed_R::get_setting() const {
+  std::cout << "#--------------------------------------------------------------------------\n";
+  std::cout << "#                         HEPTopTaggerV2 Settings" << std::endl;
+  std::cout << "#" << std::endl;
+  std::cout << "# mode: " << _mode << " (0 = EARLY_MASSRATIO_SORT_MASS) " << std::endl;
+  std::cout << "#        "         << " (1 = LATE_MASSRATIO_SORT_MASS)  " << std::endl;
+  std::cout << "#        "         << " (2 = EARLY_MASSRATIO_SORT_MODDJADE)  " << std::endl;
+  std::cout << "#        "         << " (3 = LATE_MASSRATIO_SORT_MODDJADE)  " << std::endl;
+  std::cout << "#        "         << " (4 = TWO_STEP_FILTER)  " << std::endl;
+  std::cout << "# top mass: " << _mtmass << "    ";
+  std::cout << "W mass: " << _mwmass << std::endl;
+  std::cout << "# top mass window: [" << _mtmin << ", " << _mtmax << "]" << std::endl;
+  std::cout << "# W mass ratio: [" << _rmin << ", " << _rmax << "] (["
+	    <<_rmin*_mtmass/_mwmass<< "%, "<< _rmax*_mtmass/_mwmass << "%])"<< std::endl;
+  std::cout << "# mass plane cuts: (m23cut, m13min, m13max) = (" 
+	    << _m23cut << ", " << _m13cutmin << ", " << _m13cutmax << ")" << std::endl;
+  std::cout << "# mass_drop_threshold: " << _mass_drop_threshold << "    ";
+  std::cout << "max_subjet_mass: " << _max_subjet_mass << std::endl;
+  std::cout << "# R_filt: " << _Rfilt << "    ";
+  std::cout << "n_filt: " << _nfilt << std::endl;
+  std::cout << "# minimal subjet pt: " << _minpt_subjet << std::endl;
+  std::cout << "# minimal reconstructed pt: " << _minpt_tag << std::endl;
+  std::cout << "# internal jet algorithms (0 = kt, 1 = C/A, 2 = anti-kt): " << std::endl; 
+  std::cout << "#   filtering: "<< _jet_algorithm_filter << std::endl;
+  std::cout << "#   reclustering: "<< _jet_algorithm_recluster << std::endl;
+  std::cout << "#--------------------------------------------------------------------------\n";
+  
+  return;
+}
+
+//uncluster a fat jet to subjets of given cone size
+void HEPTopTaggerV2::UnclusterFatjets(const vector<fastjet::PseudoJet> & big_fatjets, 
+				    vector<fastjet::PseudoJet> & small_fatjets, 
+				    const ClusterSequence & cseq, 
+				    const double small_radius) {
+  for (unsigned i=0; i < big_fatjets.size(); i++) {
+    PseudoJet this_jet = big_fatjets[i];
+    PseudoJet parent1(0, 0, 0, 0), parent2(0, 0, 0, 0);
+    bool test = cseq.has_parents(this_jet, parent1, parent2);
+    double dR = 100;
+
+    if(test) dR = sqrt(parent1.squared_distance(parent2));
+
+    if (!test || dR<small_radius) {
+      small_fatjets.push_back(this_jet);
+    } else {
+      vector<fastjet::PseudoJet> parents;
+      parents.push_back(parent1);
+      parents.push_back(parent2);
+      UnclusterFatjets(parents, small_fatjets, cseq, small_radius);
+    }
+  }
+}
+
+HEPTopTaggerV2::HEPTopTaggerV2() : _do_optimalR(0), _do_qjets(0),
+			       _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+			       _mode(Mode(0)), _mtmass(172.3), _mwmass(80.4), _mtmin(150.), _mtmax(200.), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+			       _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+			       _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+			       _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+			       _zcut(0.1), _rcut_factor(0.5),
+			       _max_fatjet_R(1.8), _min_fatjet_R(0.5), _step_R(0.1), _optimalR_threshold(0.2),
+			       _R_filt_optimalR_calc(0.2), _N_filt_optimalR_calc(10), _r_min_exp_function(&R_opt_calc_funct),
+                               _optimalR_mmin(150.), _optimalR_mmax(200.), _optimalR_fw(0.175), _R_opt_diff(0.3), _R_opt_reject_min(false),
+			       _R_filt_optimalR_pass(0.2), _N_filt_optimalR_pass(5), _R_filt_optimalR_fail(0.3), _N_filt_optimalR_fail(3),
+  _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0), _rnEngine(0),
+			       _debug(false)
+{}
+
+HEPTopTaggerV2::HEPTopTaggerV2(const fastjet::PseudoJet & jet 
+			   ) : _do_optimalR(0), _do_qjets(0),
+			       _jet(jet), _initial_jet(jet),
+			       _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+			       _mode(Mode(0)), _mtmass(172.3), _mwmass(80.4), _mtmin(150.), _mtmax(200.), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+			       _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+			       _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+			       _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+			       _zcut(0.1), _rcut_factor(0.5),
+			       _max_fatjet_R(jet.validated_cluster_sequence()->jet_def().R()), _min_fatjet_R(0.5), _step_R(0.1), _optimalR_threshold(0.2),
+			       _R_filt_optimalR_calc(0.2), _N_filt_optimalR_calc(10), _r_min_exp_function(&R_opt_calc_funct),
+			       _optimalR_mmin(150.), _optimalR_mmax(200.), _optimalR_fw(0.175), _R_opt_diff(0.3), _R_opt_reject_min(false),
+			       _R_filt_optimalR_pass(0.2), _N_filt_optimalR_pass(5), _R_filt_optimalR_fail(0.3), _N_filt_optimalR_fail(3),
+			       _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0),
+			       _fat(jet),_rnEngine(0),
+			       _debug(false)
+{}
+
+HEPTopTaggerV2::HEPTopTaggerV2(const fastjet::PseudoJet & jet, 
+			   double mtmass, double mwmass
+			   ) : _do_optimalR(0), _do_qjets(0),
+			       _jet(jet), _initial_jet(jet),
+			       _mass_drop_threshold(0.8), _max_subjet_mass(30.),
+			       _mode(Mode(0)), _mtmass(mtmass), _mwmass(mwmass), _mtmin(150.), _mtmax(200.), _rmin(0.85*80.4/172.3), _rmax(1.15*80.4/172.3),
+			       _m23cut(0.35), _m13cutmin(0.2), _m13cutmax(1.3), _minpt_tag(200.),
+			       _nfilt(5), _Rfilt(0.3), _jet_algorithm_filter(fastjet::cambridge_algorithm), _minpt_subjet(0.),
+			       _jet_algorithm_recluster(fastjet::cambridge_algorithm),
+			       _zcut(0.1), _rcut_factor(0.5),
+			       _max_fatjet_R(jet.validated_cluster_sequence()->jet_def().R()), _min_fatjet_R(0.5), _step_R(0.1), _optimalR_threshold(0.2),
+			       _R_filt_optimalR_calc(0.2), _N_filt_optimalR_calc(10), _r_min_exp_function(&R_opt_calc_funct),
+			       _optimalR_mmin(150.), _optimalR_mmax(200.), _optimalR_fw(0.175), _R_opt_diff(0.3), _R_opt_reject_min(false),
+			       _R_filt_optimalR_pass(0.2), _N_filt_optimalR_pass(5), _R_filt_optimalR_fail(0.3), _N_filt_optimalR_fail(3),
+			       _q_zcut(0.1), _q_dcut_fctr(0.5), _q_exp_min(0.), _q_exp_max(0.), _q_rigidity(0.1), _q_truncation_fctr(0.0),
+			       _fat(jet), _rnEngine(0),
+			       _debug(false)
+{}
+
+void HEPTopTaggerV2::run() {
+  //cout << "--- new Tagger run ---" << endl;
+
+  QjetsPlugin _qjet_plugin(_q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr);
+  int maxR = int(_max_fatjet_R * 10);
+  int minR = int(_min_fatjet_R * 10);
+  int stepR = int(_step_R * 10);
+  _qweight=-1;
+  _qjet_plugin.SetRNEngine(_rnEngine);
+
+  if (!_do_optimalR) {
+    HEPTopTaggerV2_fixed_R htt(_jet);   
+    htt.set_mass_drop_threshold(_mass_drop_threshold);
+    htt.set_max_subjet_mass(_max_subjet_mass);
+    htt.set_filtering_n(_nfilt);
+    htt.set_filtering_R(_Rfilt);
+    htt.set_filtering_minpt_subjet(_minpt_subjet);
+    htt.set_filtering_jetalgorithm(_jet_algorithm_filter);
+    htt.set_reclustering_jetalgorithm(_jet_algorithm_recluster);
+    htt.set_mode(_mode );
+    htt.set_mt(_mtmass);
+    htt.set_mw(_mwmass);
+    htt.set_top_mass_range(_mtmin, _mtmax);
+    htt.set_mass_ratio_range(_rmin, _rmax);
+    htt.set_mass_ratio_cut(_m23cut, _m13cutmin, _m13cutmax);
+    htt.set_top_minpt(_minpt_tag);
+    htt.set_pruning_zcut(_zcut);
+    htt.set_pruning_rcut_factor(_rcut_factor);
+    htt.set_debug(_debug);
+    htt.set_qjets(_q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr);
+    htt.run();
+    
+    _HEPTopTaggerV2[maxR] = htt;
+    _Ropt = maxR;
+    _qweight = htt.q_weight();
+    _HEPTopTaggerV2_opt = _HEPTopTaggerV2[_Ropt];
+  } else {
+    _qjet_def = fastjet::JetDefinition(&_qjet_plugin);
+    vector<fastjet::PseudoJet> _q_constits;
+    ClusterSequence* _qjet_seq;
+    PseudoJet _qjet;
+    const ClusterSequence* _seq;
+    _seq = _initial_jet.validated_cluster_sequence();
+    if (_do_qjets){
+      _q_constits = _initial_jet.associated_cluster_sequence()->constituents(_initial_jet);
+      _qjet_seq = new ClusterSequence(_q_constits, _qjet_def);
+      _qjet = sorted_by_pt(_qjet_seq->inclusive_jets())[0];
+      _qjet_seq->delete_self_when_unused();
+      const QjetsBaseExtras* ext =
+	dynamic_cast<const QjetsBaseExtras*>(_qjet_seq->extras());
+      _qweight=ext->weight();
+      _jet = _qjet;
+      _seq = _qjet_seq;
+      _fat = _qjet;
+    }
+ 
+    // Do MultiR procedure  
+    vector<fastjet::PseudoJet> big_fatjets;
+    vector<fastjet::PseudoJet> small_fatjets;
+  
+    big_fatjets.push_back(_jet);
+    _Ropt = 0;
+    
+    for (int R = maxR; R >= minR; R -= stepR) {
+      UnclusterFatjets(big_fatjets, small_fatjets, *_seq, R / 10.);
+          
+      if (_debug) {cout << "R = " << R << " -> n_small_fatjets = " << small_fatjets.size() << endl;}
+    
+      _n_small_fatjets[R] = small_fatjets.size();
+
+      // We are sorting by pt - so start with a negative dummy
+      double dummy = -99999;
+
+      for (unsigned i = 0; i < small_fatjets.size(); i++) {
+	HEPTopTaggerV2_fixed_R htt(small_fatjets[i]);
+	htt.set_mass_drop_threshold(_mass_drop_threshold);
+	htt.set_max_subjet_mass(_max_subjet_mass);
+	htt.set_filtering_n(_nfilt);
+	htt.set_filtering_R(_Rfilt);
+	htt.set_filtering_minpt_subjet(_minpt_subjet);
+	htt.set_filtering_jetalgorithm(_jet_algorithm_filter);
+	htt.set_reclustering_jetalgorithm(_jet_algorithm_recluster);
+	htt.set_mode(_mode );
+	htt.set_mt(_mtmass);
+	htt.set_mw(_mwmass);
+	htt.set_top_mass_range(_mtmin, _mtmax);
+	htt.set_mass_ratio_range(_rmin, _rmax);
+	htt.set_mass_ratio_cut(_m23cut, _m13cutmin, _m13cutmax);
+	htt.set_top_minpt(_minpt_tag);
+	htt.set_pruning_zcut(_zcut);
+	htt.set_pruning_rcut_factor(_rcut_factor);
+	htt.set_debug(_debug);
+	htt.set_qjets(_q_zcut, _q_dcut_fctr, _q_exp_min, _q_exp_max, _q_rigidity, _q_truncation_fctr);
+
+	htt.run();
+     
+	if (htt.t().perp() > dummy) {
+	  dummy = htt.t().perp();
+	  _HEPTopTaggerV2[R] = htt;
+	}
+      } //End of loop over small_fatjets
+    
+      // Only check if we have not found Ropt yet
+      if (_Ropt == 0 && R < maxR) {                 
+	// If the new mass is OUTSIDE the window ..
+	if (_HEPTopTaggerV2[R].t().m() < (1-_optimalR_threshold)*_HEPTopTaggerV2[maxR].t().m())
+	  // .. set _Ropt to the previous mass 
+	  _Ropt = R + stepR;
+      }
+    
+      big_fatjets = small_fatjets;
+      small_fatjets.clear();
+    }//End of loop over R
+
+    // if we did not find Ropt in the loop:
+    if (_Ropt == 0 && _HEPTopTaggerV2[maxR].t().m() > 0){
+      // either pick the last value (_R_opt_reject_min=false)
+      // or leace Ropt at zero (_R_opt_reject_min=true)
+      if (_R_opt_reject_min==false)
+	_Ropt = minR;            
+    }
+
+    //for the case that there is no tag at all (< 3 hard substructures)
+    if (_Ropt == 0 && _HEPTopTaggerV2[maxR].t().m() == 0)
+      _Ropt = maxR;
+  
+    _HEPTopTaggerV2_opt = _HEPTopTaggerV2[_Ropt];
+  
+    Filter filter_optimalR_calc(_R_filt_optimalR_calc, SelectorNHardest(_N_filt_optimalR_calc));
+    _R_opt_calc = _r_min_exp_function(filter_optimalR_calc(_fat).pt());
+    _pt_for_R_opt_calc = filter_optimalR_calc(_fat).pt();
+
+    Filter filter_optimalR_pass(_R_filt_optimalR_pass, SelectorNHardest(_N_filt_optimalR_pass));
+    Filter filter_optimalR_fail(_R_filt_optimalR_fail, SelectorNHardest(_N_filt_optimalR_fail));
+    if(optimalR_type() == 1) {
+      _filt_fat = filter_optimalR_pass(_fat);
+    } else {
+      _filt_fat = filter_optimalR_fail(_fat);
+    }
+  }
+}
+
+//optimal_R type
+int HEPTopTaggerV2::optimalR_type() {
+  if(_HEPTopTaggerV2_opt.t().m() < _optimalR_mmin || _HEPTopTaggerV2_opt.t().m() > _optimalR_mmax) {
+    return 0;
+  }
+  if(_HEPTopTaggerV2_opt.f_rec() > _optimalR_fw) {
+    return 0;
+  }
+  if(_Ropt/10. - _R_opt_calc > _R_opt_diff) {
+    return 0;
+  }
+  return 1;
+}
+
+double HEPTopTaggerV2::nsub_unfiltered(int order, fastjet::contrib::Njettiness::AxesMode axes, double beta, double R0) {
+  fastjet::contrib::Nsubjettiness nsub(order, axes, beta, R0);
+  return nsub.result(_fat);
+}
+
+double HEPTopTaggerV2::nsub_filtered(int order, fastjet::contrib::Njettiness::AxesMode axes, double beta, double R0) {
+  fastjet::contrib::Nsubjettiness nsub(order, axes, beta, R0);
+  return nsub.result(_filt_fat);
+}
+
+HEPTopTaggerV2::~HEPTopTaggerV2(){}
+// Do not change next line, it's needed by the sed-code that makes the tagger CMSSW-compatible.
+};

--- a/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
+++ b/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
@@ -279,7 +279,7 @@ void HEPTopTaggerV2_fixed_R::run() {
        
 	// Recluster to 3 subjets and apply mass plane cuts
 	JetDefinition reclustering(_jet_algorithm_recluster, 3.14);
-	ClusterSequence *  cs_top_sub = new ClusterSequence(topcandidate.pieces(), reclustering);
+	ClusterSequence *  cs_top_sub = new ClusterSequence(topcandidate.constituents(), reclustering);
         std::vector <PseudoJet> top_subs = sorted_by_pt(cs_top_sub->exclusive_jets(3));         
 	cs_top_sub->delete_self_when_unused();
 

--- a/RecoJets/JetAlgorithms/src/HEPTopTaggerWrapperV2.cc
+++ b/RecoJets/JetAlgorithms/src/HEPTopTaggerWrapperV2.cc
@@ -44,14 +44,16 @@ FASTJET_BEGIN_NAMESPACE
 // Input objects are packed pfCandidates with CHS
 double R_min_expected_function(double x){
 
-  if (x>1000)
-    x=1000;
+
+  if (x>700)
+    x=700;
     
-  double A = -4.02290e+00;
-  double B =  8.97577e-02;
-  double C =  2.10638e+03;
-  double D = -4.19572e+05;
-  double E =  3.20825e+07;
+  double A =      -9.42052;
+  double B =      0.202773;
+  double C =       4498.45;
+  double D =  -1.05737e+06;
+  double E =   9.95494e+07;
+
   return A+B*sqrt(x)+C/x+D/(x*x)+E/(x*x*x);
 }
 
@@ -193,13 +195,14 @@ PseudoJet HEPTopTaggerV2::result(const PseudoJet & jet) const{
   s->_fRec = tagger.f_rec();
   s->_mass_ratio_passed = tagger.is_masscut_passed();
 
-
-  s->_tau1Unfiltered = tagger.nsub_unfiltered(1);
-  s->_tau2Unfiltered = tagger.nsub_unfiltered(2);
-  s->_tau3Unfiltered = tagger.nsub_unfiltered(3);
-  s->_tau1Filtered = tagger.nsub_filtered(1);
-  s->_tau2Filtered = tagger.nsub_filtered(2);
-  s->_tau3Filtered = tagger.nsub_filtered(3);
+  if (DoOptimalR_){
+    s->_tau1Unfiltered = tagger.nsub_unfiltered(1);
+    s->_tau2Unfiltered = tagger.nsub_unfiltered(2);
+    s->_tau3Unfiltered = tagger.nsub_unfiltered(3);
+    s->_tau1Filtered = tagger.nsub_filtered(1);
+    s->_tau2Filtered = tagger.nsub_filtered(2);
+    s->_tau3Filtered = tagger.nsub_filtered(3);
+  }
 
   s->_Qweight = Qweight;
   s->_Qepsilon = Qepsilon;

--- a/RecoJets/JetAlgorithms/src/HEPTopTaggerWrapperV2.cc
+++ b/RecoJets/JetAlgorithms/src/HEPTopTaggerWrapperV2.cc
@@ -1,0 +1,225 @@
+// 2011 Christopher Vermilion
+//
+//----------------------------------------------------------------------
+//  This file is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  The GNU General Public License is available at
+//  http://www.gnu.org/licenses/gpl.html or you can write to the Free Software
+//  Foundation, Inc.:
+//      59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//----------------------------------------------------------------------
+
+#include "RecoJets/JetAlgorithms/interface/HEPTopTaggerWrapperV2.h"
+
+#include <fastjet/Error.hh>
+#include <fastjet/JetDefinition.hh>
+#include <fastjet/ClusterSequence.hh>
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/tools/Pruner.hh"
+#include "fastjet/tools/Filter.hh"
+
+#include <math.h>
+#include <limits>
+#include <cassert>
+using namespace std;
+
+#include "RecoJets/JetAlgorithms/interface/HEPTopTaggerV2.h"
+
+
+FASTJET_BEGIN_NAMESPACE
+
+
+// Expected R_min for tops (as function of filtered initial fatjet pT in GeV (using CA, R=0.2, n=10)
+// From ttbar sample, phys14, n20, bx25
+// matched to hadronically decaying top with delta R < 1.2 and true top pT > 200
+// Cuts are: fW < 0.175 and  m_top = 120..220
+// Input objects are packed pfCandidates with CHS
+double R_min_expected_function(double x){
+
+  if (x>1000)
+    x=1000;
+    
+  double A = -4.02290e+00;
+  double B =  8.97577e-02;
+  double C =  2.10638e+03;
+  double D = -4.19572e+05;
+  double E =  3.20825e+07;
+  return A+B*sqrt(x)+C/x+D/(x*x)+E/(x*x*x);
+}
+
+
+
+//------------------------------------------------------------------------
+// returns the tagged PseudoJet if successful, 0 otherwise
+//  - jet   the PseudoJet to tag
+PseudoJet HEPTopTaggerV2::result(const PseudoJet & jet) const{
+
+  // make sure that there is a "regular" cluster sequence associated
+  // with the jet. Note that we also check it is valid (to avoid a
+  // more criptic error later on)
+  if (!jet.has_valid_cluster_sequence()){
+    throw Error("HEPTopTagger can only be applied on jets having an associated (and valid) ClusterSequence");
+  }
+
+  external::HEPTopTaggerV2 tagger(jet);
+  
+  external::HEPTopTaggerV2 best_tagger;
+
+  // translate the massRatioWidth (which should be the half-width given in %) 
+  // to values useful for the A-shape cuts
+  double mw_over_mt = 80.4/172.3;
+  double ratio_min = mw_over_mt * (100.-massRatioWidth_)/100.;
+  double ratio_max = mw_over_mt * (100.+massRatioWidth_)/100.;
+  
+  // Unclustering, Filtering & Subjet Settings
+  tagger.set_max_subjet_mass(subjetMass_);
+  tagger.set_mass_drop_threshold(muCut_);
+  tagger.set_filtering_R(filtR_);
+  tagger.set_filtering_n(filtN_);
+  tagger.set_filtering_minpt_subjet(minSubjetPt_); 
+
+  // Optimal R
+  tagger.do_optimalR(DoOptimalR_);
+  tagger.set_optimalR_reject_minimum(optRrejectMin_);
+
+  // How to select among candidates
+  tagger.set_mode((external::Mode)mode_);
+  
+  // Requirements to accept a candidate
+  tagger.set_top_minpt(minCandPt_); 
+  tagger.set_top_mass_range(minCandMass_, maxCandMass_); 
+  tagger.set_mass_ratio_cut(minM23Cut_, minM13Cut_, maxM13Cut_);
+  tagger.set_mass_ratio_range(ratio_min, ratio_max);
+
+  // Set function to calculate R_min_expected
+  tagger.set_optimalR_calc_fun(R_min_expected_function);
+
+  
+  double Qweight  = -1;
+  double Qepsilon = -1;
+  double QsigmaM  = -1;
+
+  if (DoQjets_){
+    
+    int niter(100);
+    double q_zcut(0.1);
+    double q_dcut_fctr(0.5);
+    double q_exp_min(0.);
+    double q_exp_max(0.);
+    double q_rigidity(0.1);
+    double q_truncation_fctr(0.0);
+           
+    double weight_q1 = -1.;
+    double m_sum = 0.;
+    double m2_sum = 0.;
+    int qtags = 0;
+
+    tagger.set_qjets(q_zcut,
+		     q_dcut_fctr,
+		     q_exp_min,
+		     q_exp_max,
+		     q_rigidity,
+		     q_truncation_fctr);
+    tagger.set_qjets_rng(engine_);    
+    tagger.do_qjets(true);
+    tagger.run();
+
+    for (int iq = 0; iq < niter; iq++) {
+      tagger.run();
+      if (tagger.is_tagged()) {
+	qtags++;
+	m_sum += tagger.t().m();
+	m2_sum += tagger.t().m() * tagger.t().m();
+	if (tagger.q_weight() > weight_q1)
+	  best_tagger = tagger;
+	  weight_q1=tagger.q_weight();             
+      }
+    }
+    
+    tagger = best_tagger;
+    Qweight = weight_q1;
+    Qepsilon = float(qtags)/float(niter);
+    
+    // calculate width of tagged mass distribution if we have at least one candidate
+    if (qtags > 0){
+      double mean_m = m_sum / qtags;
+      double mean_m2 = m2_sum / qtags;
+      QsigmaM = sqrt(mean_m2 - mean_m*mean_m);
+    }
+  }
+  else{
+    tagger.run();
+  }
+
+  // Requires:
+  //   - top mass window
+  //   - mass ratio cuts
+  //   - minimal candidate pT
+  // If this is not intended: use loose top mass and ratio windows
+  if (!tagger.is_tagged())
+    return PseudoJet();
+  
+  // create the result and its structure
+  const JetDefinition::Recombiner *rec
+    = jet.associated_cluster_sequence()->jet_def().recombiner();
+
+  const vector<PseudoJet>& subjets = tagger.top_subjets();
+  assert(subjets.size() == 3);
+
+  PseudoJet non_W = subjets[0];
+  PseudoJet W1 = subjets[1];
+  PseudoJet W2 = subjets[2];
+  PseudoJet W = join(subjets[1], subjets[2], *rec);
+
+  PseudoJet result = join<HEPTopTaggerV2Structure>( W1, W2, non_W, *rec);
+  HEPTopTaggerV2Structure *s = (HEPTopTaggerV2Structure*) result.structure_non_const_ptr();
+
+  s->_fj_mass  = jet.m();
+  s->_fj_pt    = jet.perp();
+  s->_fj_eta   = jet.eta();
+  s->_fj_phi   = jet.phi();
+
+  s->_top_mass = tagger.t().m();
+  s->_pruned_mass = tagger.pruned_mass();
+  s->_unfiltered_mass = tagger.unfiltered_mass();
+  s->_fRec = tagger.f_rec();
+  s->_mass_ratio_passed = tagger.is_masscut_passed();
+
+
+  s->_tau1Unfiltered = tagger.nsub_unfiltered(1);
+  s->_tau2Unfiltered = tagger.nsub_unfiltered(2);
+  s->_tau3Unfiltered = tagger.nsub_unfiltered(3);
+  s->_tau1Filtered = tagger.nsub_filtered(1);
+  s->_tau2Filtered = tagger.nsub_filtered(2);
+  s->_tau3Filtered = tagger.nsub_filtered(3);
+
+  s->_Qweight = Qweight;
+  s->_Qepsilon = Qepsilon;
+  s->_QsigmaM = QsigmaM;
+
+
+  if (DoOptimalR_){
+    s->_Ropt = tagger.Ropt();
+    s->_RoptCalc = tagger.Ropt_calc();
+    s->_ptForRoptCalc = tagger.pt_for_Ropt_calc();
+  }
+  else {
+    s->_Ropt = -1;
+    s->_RoptCalc = -1;
+    s->_ptForRoptCalc = -1;
+  }
+
+  // Removed selectors as all cuts are applied in HTT
+
+  return result;
+}
+
+FASTJET_END_NAMESPACE

--- a/RecoJets/JetAlgorithms/src/Qjets.cc
+++ b/RecoJets/JetAlgorithms/src/Qjets.cc
@@ -46,6 +46,7 @@ JetDistance Qjets::GetNextDistance(){
     tot_weight += (*it).second/norm;
     if(tot_weight >= rand){
       ret = (*it).first;
+      Omega *= ((*it).second);
       break;
     }
   }
@@ -59,6 +60,8 @@ JetDistance Qjets::GetNextDistance(){
 }
 
 void Qjets::Cluster(fastjet::ClusterSequence & cs){
+  Omega = 1.;
+  QjetsBaseExtras * extras = new QjetsBaseExtras();
   computeDCut(cs);
 
   // Populate all the distances
@@ -92,6 +95,9 @@ void Qjets::Cluster(fastjet::ClusterSequence & cs){
     }
     jd = GetNextDistance();
   } 
+
+  extras->_wij = Omega;
+  cs.plugin_associate_extras(std::auto_ptr<fastjet::ClusterSequence::Extras>(extras));
 
   // merge remaining jets with beam
   int num_merged_final(0);

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -1,0 +1,244 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/HTTTopJetTagInfo.h"
+#include "DataFormats/JetReco/interface/BasicJetCollection.h"
+#include "HTTTopJetProducer.h"
+
+using namespace edm;
+using namespace cms;
+using namespace reco;
+using namespace std;
+
+HTTTopJetProducer::HTTTopJetProducer(edm::ParameterSet const& conf):
+       FastjetJetProducer( conf ),
+       optimalR_(false),
+       qJets_(false),
+       minFatjetPt_(200.),
+       minSubjetPt_(20.),
+       minCandPt_(200.),
+       maxFatjetAbsEta_(2.5),
+       subjetMass_(30.),
+       muCut_(0.8),
+       filtR_(0.3),
+       filtN_(5),       
+       mode_(0),
+       minCandMass_(150.),
+       maxCandMass_(200.),
+       massRatioWidth_(15),
+       minM23Cut_(0.35),
+       minM13Cut_(0.2),
+       maxM13Cut_(1.3),
+       maxR_(1.5),
+       minR_(0.5),
+       rejectMinR_(false),
+       verbose_(false )
+{
+  
+  // Read in all the options from the configuration
+  if ( conf.exists("optimalR") ) 
+    optimalR_ = conf.getParameter<bool>("optimalR");
+
+  if ( conf.exists("qJets") ) 
+    qJets_ = conf.getParameter<bool>("qJets");
+
+  if ( conf.exists("minFatjetPt") ) 
+    minFatjetPt_ = conf.getParameter<double>("minFatjetPt");
+  
+  if ( conf.exists("minSubjetPt") ) 
+    minSubjetPt_ = conf.getParameter<double>("minSubjetPt");
+  
+  if ( conf.exists("minCandPt") ) 
+    minCandPt_ = conf.getParameter<double>("minCandPt");
+  
+  if ( conf.exists("maxFatjetAbsEta") )
+    maxFatjetAbsEta_ = conf.getParameter<double>("maxFatjetAbsEta");
+  
+  if ( conf.exists("subjetMass") )
+    subjetMass_ = conf.getParameter<double>("subjetMass");
+  
+  if ( conf.exists("muCut") )
+    muCut_ = conf.getParameter<double>("muCut");
+
+  if ( conf.exists("filtR") )
+    filtR_ = conf.getParameter<double>("filtR");
+
+  if ( conf.exists("filtN") )
+    filtN_ = conf.getParameter<int>("filtN");
+  
+  if ( conf.exists("mode") )
+    mode_ = conf.getParameter<int>("mode");
+  
+  if ( conf.exists("minCandMass") )
+    minCandMass_ = conf.getParameter<double>("minCandMass");
+  
+  if ( conf.exists("maxCandMass") )
+    maxCandMass_ = conf.getParameter<double>("maxCandMass");
+  
+  if ( conf.exists("massRatioWidth") )
+    massRatioWidth_ = conf.getParameter<double>("massRatioWidth");
+  
+  if ( conf.exists("minM23Cut") )
+    minM23Cut_ = conf.getParameter<double>("minM23Cut");
+
+  if ( conf.exists("minM13Cut") )
+    minM13Cut_ = conf.getParameter<double>("minM13Cut");
+  
+  if ( conf.exists("maxM13Cut") )
+    maxM13Cut_ = conf.getParameter<double>("maxM13Cut");
+
+  if ( conf.exists("maxR") )
+    maxR_ = conf.getParameter<double>("maxR");
+
+  if ( conf.exists("minR") )
+    minR_ = conf.getParameter<double>("minR");
+
+  if ( conf.exists("rejectMinR") )
+    rejectMinR_ = conf.getParameter<bool>("rejectMinR");
+
+  if ( conf.exists("verbose") )
+    verbose_ = conf.getParameter<bool>("verbose");
+  
+  // Create the tagger-wrapper
+  produces<HTTTopJetTagInfoCollection>();
+
+  // Signal to the VirtualJetProducer that we have to add HTT information
+  fromHTTTopJetProducer_ = 1;
+  
+  fjHEPTopTagger_ = std::auto_ptr<fastjet::HEPTopTaggerV2>(new fastjet::HEPTopTaggerV2(
+										       optimalR_,
+										       qJets_,
+										       minSubjetPt_, 
+										       minCandPt_,
+										       subjetMass_, 	    
+										       muCut_, 		    
+										       filtR_,
+										       filtN_,
+										       mode_, 		    
+										       minCandMass_, 	    
+										       maxCandMass_, 	    
+										       massRatioWidth_, 	    
+										       minM23Cut_, 	    
+										       minM13Cut_, 	    
+										       maxM13Cut_,
+										       rejectMinR_
+										       )); 
+  
+}
+
+		
+
+
+
+void HTTTopJetProducer::produce(  edm::Event & e, const edm::EventSetup & c ) 
+{
+
+  if (qJets_){
+    edm::Service<edm::RandomNumberGenerator> rng;
+    CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+    fjHEPTopTagger_->set_rng(engine);
+  }
+
+  FastjetJetProducer::produce(e, c);
+}
+
+void HTTTopJetProducer::runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  if ( !doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  } else if (voronoiRfact_ <= 0) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+  } else {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+  }
+
+  //Run the jet clustering
+  vector<fastjet::PseudoJet> inclusiveJets = fjClusterSeq_->inclusive_jets(minFatjetPt_);
+
+  if ( verbose_ ) cout << "Getting central jets" << endl;
+  // Find the transient central jets
+  vector<fastjet::PseudoJet> centralJets;
+  for (unsigned int i = 0; i < inclusiveJets.size(); i++) {
+    
+    if (inclusiveJets[i].perp() > minFatjetPt_ && fabs(inclusiveJets[i].rapidity()) < maxFatjetAbsEta_) {
+      centralJets.push_back(inclusiveJets[i]);
+    }
+  }
+
+  fastjet::HEPTopTaggerV2 & HEPTagger = *fjHEPTopTagger_;
+
+  vector<fastjet::PseudoJet>::iterator jetIt = centralJets.begin(), centralJetsEnd = centralJets.end();
+  if ( verbose_ )cout<<"Loop over jets"<<endl;
+  for ( ; jetIt != centralJetsEnd; ++jetIt ) {
+    
+    if (verbose_) cout << "CMS FJ jet pt: " << (*jetIt).perp() << endl;
+    
+    fastjet::PseudoJet taggedJet;
+
+    taggedJet = HEPTagger.result(*jetIt);
+
+    if (taggedJet != 0){
+      fjJets_.push_back(taggedJet);           
+    }
+  }
+  
+}
+
+void HTTTopJetProducer::addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
+						       const edm::EventSetup& iSetup,
+						       edm::OrphanHandle<reco::BasicJetCollection> & oh){
+
+
+  // Set up output list
+  auto_ptr<HTTTopJetTagInfoCollection> tagInfos(new HTTTopJetTagInfoCollection() );
+
+  // Loop over jets
+  for (size_t ij=0; ij != fjJets_.size(); ij++){
+
+    HTTTopJetProperties properties;
+    HTTTopJetTagInfo tagInfo;
+
+    // Black magic:
+    // In the standard CA treatment the RefToBase is made from the handle directly
+    // Since we only have a OrphanHandle (the JetCollection is created by this process) 
+    // we have to take the detour via the Ref
+    edm::Ref<reco::BasicJetCollection> ref(oh, ij);  
+    edm::RefToBase<reco::Jet> rtb(ref);  
+    
+    fastjet::HEPTopTaggerV2Structure *s = (fastjet::HEPTopTaggerV2Structure*) fjJets_[ij].structure_non_const_ptr();
+      
+    properties.fjMass           = s->fj_mass();
+    properties.fjPt             = s->fj_pt();
+    properties.fjEta            = s->fj_eta();
+    properties.fjPhi            = s->fj_phi();
+    
+    properties.topMass           = s->top_mass();
+    properties.unfilteredMass	 = s->unfiltered_mass();
+    properties.prunedMass	 = s->pruned_mass();
+    properties.fRec		 = s->fRec();
+    properties.massRatioPassed   = s->mass_ratio_passed();
+    
+    properties.Ropt	          = s->Ropt();
+    properties.RoptCalc           = s->RoptCalc();
+    properties.ptForRoptCalc      = s->ptForRoptCalc();
+    
+    properties.tau1Unfiltered     = s->Tau1Unfiltered();
+    properties.tau2Unfiltered	  = s->Tau2Unfiltered();
+    properties.tau3Unfiltered	  = s->Tau3Unfiltered();
+    properties.tau1Filtered	  = s->Tau1Filtered();
+    properties.tau2Filtered	  = s->Tau2Filtered();
+    properties.tau3Filtered	  = s->Tau3Filtered();
+    properties.QWeight		  = s->Qweight();
+    properties.QEpsilon		  = s->Qepsilon(); 
+    properties.QSigmaM            = s->QsigmaM();
+
+    tagInfo.insert(rtb, properties );
+    tagInfos->push_back( tagInfo );   
+  }
+
+  iEvent.put( tagInfos );
+  
+};
+
+ 
+//define this as a plug-in
+DEFINE_FWK_MODULE(HTTTopJetProducer);

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
@@ -1,0 +1,146 @@
+#ifndef RecoJets_JetProducers_HTTTopJetProducer_h
+#define RecoJets_JetProducers_HTTTopJetProducer_h
+
+
+/* *********************************************************
+
+
+ * \class CATopJetProducer
+ * Jet producer to produce top jets using the C-A algorithm to break
+ * jets into subjets as described here:
+ * "Top-tagging: A Method for Identifying Boosted Hadronic Tops"
+ * David E. Kaplan, Keith Rehermann, Matthew D. Schwartz, Brock Tweedie
+ * arXiv:0806.0848v1 [hep-ph] 
+
+  \brief Jet producer to run the CATopJetAlgorithm
+
+  \author   Salvatore Rappoccio
+  \version  
+
+         Notes on implementation:
+
+	 Because the BaseJetProducer only allows the user to produce
+	 one jet collection at a time, this algorithm cannot
+	 fit into that paradigm. 
+
+	 All of the "hard" jets are of type BasicJet, since
+	 they are "jets of jets". The subjets will be either
+	 CaloJets, GenJets, etc.
+
+	 In order to avoid a templatization of the entire
+	 EDProducer itself, we only use a templated method
+	 to write out the subjets to the event record,
+	 and to use that information to write out the
+	 hard jets to the event record.
+
+	 This templated method is called "write_outputs". It
+	 relies on a second templated method called "write_specific",
+	 which relies on some template specialization to create
+	 different specific objects (i.e. CaloJets, BasicJets, GenJets, etc). 
+
+ ************************************************************/
+
+
+
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/BasicJetCollection.h"
+#include "RecoJets/JetAlgorithms/interface/JetAlgoHelper.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "RecoJets/JetProducers/plugins/FastjetJetProducer.h"
+
+#include "RecoJets/JetAlgorithms/interface/HEPTopTaggerWrapperV2.h"
+
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CLHEP/Random/RandomEngine.h"
+
+#include "fastjet/SISConePlugin.hh"
+
+
+namespace cms
+{
+  class HTTTopJetProducer : public FastjetJetProducer
+  {
+  public:
+
+    HTTTopJetProducer(const edm::ParameterSet& ps);
+
+    virtual ~HTTTopJetProducer() {}
+
+    virtual void produce( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+    virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+    virtual void addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
+						const edm::EventSetup& iSetup,
+						edm::OrphanHandle<reco::BasicJetCollection> & oh);
+
+
+  private:
+    std::auto_ptr<fastjet::HEPTopTaggerV2>        fjHEPTopTagger_;
+
+    // Below are all configurable options. 
+    // Parenthesis indicates if this is enforced by the tagger itself or by the producer
+
+    bool optimalR_; // Should the MultiR version of the tagger be used? (tagger)
+    bool qJets_; // Should Q-jets be used? (tagger/producer)
+
+    double minFatjetPt_; // Only process fatjets larger pT with the tagger [GeV] (producer)
+    double minSubjetPt_; // Minimal pT for subjets [GeV] (tagger)
+    double minCandPt_;   // Minimal pT to return a candidate [GeV] (tagger)
+ 
+    double maxFatjetAbsEta_; // Only process fatjets with smaller |eta| with the tagger. (producer)
+
+    double subjetMass_; // Mass above which subjets are further unclustered (tagger)
+    double muCut_; // Mass drop threshold (tagger)
+
+    double filtR_; // maximal filtering radius
+    int filtN_; // number of filtered subjets to use
+    
+    // HEPTopTagger Mode (tagger):
+    // 0: do 2d-plane, return candidate with delta m_top minimal
+    // 1: return candidate with delta m_top minimal IF passes 2d plane
+    // 2: do 2d-plane, return candidate with max dj_sum
+    // 3: return candidate with max dj_sum IF passes 2d plane
+    // 4: return candidate built from leading three subjets after unclustering IF passes 2d plane
+    // Note: Original HTT was mode==1    
+    int mode_; 
+
+    // Top Quark mass window in GeV (tagger)
+    double minCandMass_;
+    double maxCandMass_;
+    
+    double massRatioWidth_; // One sided width of the A-shaped window around m_W/m_top in % (tagger)
+    double minM23Cut_; // minimal value of m23/m123 (tagger)
+    double minM13Cut_; // minimal value of atan(m13/m12) (tagger)
+    double maxM13Cut_; // maximal value of atan(m13/m12) (tagger)
+
+    double maxR_; // maximal fatjet size for MultiR tagger (tagger)
+    double minR_; // minimal fatjet size for MultiR tagger (tagger)
+        
+    bool rejectMinR_; // set Ropt to zero when the candidate never
+		      // leaves the window around the initial mass
+
+    bool verbose_;
+
+  };
+
+}
+
+
+#endif

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -10,6 +10,10 @@
 #include "RecoJets/JetProducers/interface/BackgroundEstimator.h"
 #include "RecoJets/JetProducers/interface/VirtualJetProducerHelper.h"
 
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -136,6 +140,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig)
   , jetCollInstanceName_ ("")
   , writeCompound_ ( false )
   , verbosity_(0)
+  , fromHTTTopJetProducer_(0)
 {
   anomalousTowerDef_ = std::auto_ptr<AnomalousTower>(new AnomalousTower(iConfig));
 
@@ -851,5 +856,11 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
   }
 
   // put hard jets into event record
-  iEvent.put( jetCollection);
+  // Store the Orphan handle for adding HTT information
+  edm::OrphanHandle<reco::BasicJetCollection>  oh = iEvent.put( jetCollection);
+
+  if (fromHTTTopJetProducer_){
+    addHTTTopJetTagInfoCollection( iEvent, iSetup, oh);
+  }
+
 }

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -14,6 +14,8 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
+#include "DataFormats/JetReco/interface/BasicJetCollection.h"
+
 #include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
 #include "RecoJets/JetProducers/interface/AnomalousTower.h"
 
@@ -119,6 +121,11 @@ protected:
   // has no default. 
   virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup) = 0;
 
+  // This will allow making the HTTTopJetTagInfoCollection
+  virtual void addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
+					      const edm::EventSetup& iSetup,
+					      edm::OrphanHandle<reco::BasicJetCollection> & oh){};
+ 
   // Do the offset correction. 
   // Only runs if "doPUOffsetCorrection_" is true.  
   void offsetCorrectJets(std::vector<fastjet::PseudoJet> & orphanInput);
@@ -176,7 +183,6 @@ protected:
   bool                  doPUOffsetCorr_;            // add the pileup calculation from offset correction? 
   std::string           puSubtractorName_;
 
-
   std::vector<edm::Ptr<reco::Candidate> > inputs_;  // input candidates [View, PtrVector and CandCollection have limitations]
   reco::Particle::Point           vertex_;          // Primary vertex 
   ClusterSequencePtr              fjClusterSeq_;    // fastjet cluster sequence
@@ -201,9 +207,9 @@ protected:
   unsigned int                    minSeed_;              // minimum seed to use, useful for MC generation
 
   int                   verbosity_;                 // flag to enable/disable debug output
+  bool                  fromHTTTopJetProducer_;   // for running the v2.0 HEPTopTagger
 
- private:
-
+private:
   std::auto_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition
 
   // tokens for the data access


### PR DESCRIPTION
HEPTopTagger V2 (via this code) was used in different performance studies/physics analyses for a while but so far not included in "CMSSW" proper.
It was studied in PAS-JME-15-002 (https://cds.cern.ch/record/2126325?ln=en). The approval talk for this PAS can be found at: https://indico.cern.ch/event/469439/contributions/1147349/attachments/1204562/1755301/Approval.pdf
(pp23)

PR adds the HTT V2 code + necessary CMSSW bindings and DataFormats
