### PR TITLE
use a online and Prompt-like GT for pre7 relvals: will go away in July

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -23,12 +23,16 @@ autoCond = {
     'run1_data'         :   '81X_dataRun2_v0',
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '81X_dataRun2_v0',
+    # GlobalTag for Run2 data (as Prompt) WILL DISAPPEAR ONCE RERECO UPDATED
+    'run2_prompt_WillDisappearInJul16' :   '81X_dataRun2_Run2016B_Prompt_frozen_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '81X_dataRun2_relval_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
+    # GlobalTag for Run2 data (as HLT) WILL DISAPPEAR ONCE RERECO UPDATED
+    'run2_hlt_WillDisappearInJul16'    :   '81X_dataRun2_Run2016B_HLT_frozen_v1',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v11',
     # GlobalTag for Run2 HLT for HI: it points to the online GT

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1012,7 +1012,7 @@ steps['HLTDR2_25ns']=merge( [ {'-s':'L1REPACK:GT2,HLT:@%s'%hltKey25ns,},{'--cond
 
 hltKey2016='relval2016'
 menuR2_2016 = autoHLT[hltKey2016]
-steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
+steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_WillDisappearInJul16'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
 # use --era 
 steps['RECODR2_50ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_50ns',},dataReco])
@@ -1152,7 +1152,7 @@ steps['RECODreHLTAlCaCalo']=merge([{'--hltProcess':'reHLT','--conditions':'auto:
 
 steps['RECODR2_25nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_25ns']])
 steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']])
-steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_2016']])
+steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_prompt_WillDisappearInJul16'},steps['RECODR2_2016']])
 steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
 
 steps['RECO']=merge([step3Defaults])


### PR DESCRIPTION
Needed to make sure 800_pre7 RelVals won't consume wrong conditions.

**WILL DISAPPEAR ONCE CONDITIONS IN RE-RECO GT ARE FINALIZED**

Differences with respect with HLT and Prompt GT:
- HLT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_v12/81X_dataRun2_Run2016B_HLT_frozen_v1
- RECO: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_Prompt_v8/81X_dataRun2_Run2016B_Prompt_frozen_v1
