### PR TITLE
Bugfix: Ensure by force that the deepest root of the connected graph is always found in PFBA

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -165,7 +165,7 @@ void PFBlockAlgo::findBlocks() {
   const auto elem_size = bare_elements_.size();
   for( unsigned i = 0; i < elem_size; ++i ) {
     for( unsigned j = 0; j < elem_size; ++j ) {
-      if( j == i ) continue;
+      if( qu.connected(i,j) || j == i ) continue;
       if( !_linkTests[_linkTestSquare[bare_elements_[i]->type()][bare_elements_[j]->type()]] ) {
         j = ranges_[bare_elements_[j]->type()].second;
         continue;
@@ -188,7 +188,8 @@ void PFBlockAlgo::findBlocks() {
   std::vector<unsigned> keys;
   keys.reserve(elements_.size());
   for( unsigned i = 0; i < elements_.size(); ++i ) {
-    unsigned key = qu.find(i);
+    unsigned key = i; 
+    while( key != qu.find(key) ) key = qu.find(key); // make sure we always find the root node...
     auto pos  = std::lower_bound(keys.begin(),keys.end(),key);
     if( pos == keys.end() || *pos != key ) {
       keys.insert(pos,key);      


### PR DESCRIPTION
Quick Union algorithm was not always returning the deepest root available in a connected graph.
This is a deficiency in the underlying algorithm, luckily it is easy to patch out (just keep looking for roots of roots).
I'll fix the underlying cause in the future, thankfully it's iterlog-N on average.

I also added in a clause to skip direct connection tests if two nodes are already connected. Should help with speed. If there is incidental slow down compared to yesterday's IB I will remove it.
