### PR TITLE
EP code update

### DIFF
--- a/RecoHI/HiEvtPlaneAlgos/interface/HiEvtPlaneList.h
+++ b/RecoHI/HiEvtPlaneAlgos/interface/HiEvtPlaneList.h
@@ -29,9 +29,8 @@ Index     Name   Detector Order hmin1 hmax1 hmin2 hmax2 minpt maxpt nsub mcw    
    24   trackp4   Tracker     4  1.00  2.00  0.00  0.00  0.30  3.00 3sub  no      HFm4      HFp4
    25    HFm1mc        HF     1 -5.00 -3.00  0.00  0.00  0.01 30.00 3sub yes    HFp1mc trackp1mc
    26    HFp1mc        HF     1  3.00  5.00  0.00  0.00  0.01 30.00 3sub yes    HFm1mc trackm1mc
-   27 trackm1mc   Tracker     1 -2.20 -1.40  0.00  0.00  0.30  3.00 3sub yes    HFm1mc    HFp1mc
-   28 trackp1mc   Tracker     1  1.40  2.20  0.00  0.00  0.30  3.00 3sub yes    HFm1mc    HFp1mc
-   29 Castor1mc    Castor     1 -6.55 -5.10  0.00  0.00  0.01 50.00 3sub yes    HFp1mc trackp1mc
+   27 trackm1mc   Tracker     1 -2.00 -1.00  0.00  0.00  0.30  3.00 3sub yes    HFm1mc    HFp1mc
+   28 trackp1mc   Tracker     1  1.00  2.00  0.00  0.00  0.30  3.00 3sub yes    HFm1mc    HFp1mc
 */
 #include <string>
 
@@ -81,7 +80,7 @@ namespace hi{
          -2.00,        1.00,       -6.55,       -5.00,        3.00,
          -5.00,       -0.75,       -2.00,        1.00,       -5.00,
           3.00,       -5.00,       -0.75,       -2.00,        1.00,
-         -5.00,        3.00,       -2.20,        1.40 
+         -5.00,        3.00,       -2.00,        1.00 
   };
 
   const double  EPEtaMax1[]  = {
@@ -90,7 +89,7 @@ namespace hi{
          -1.00,        2.00,       -5.10,       -3.00,        5.00,
          -3.00,        0.75,       -1.00,        2.00,       -3.00,
           5.00,       -3.00,        0.75,       -1.00,        2.00,
-         -3.00,        5.00,       -1.40,        2.20 
+         -3.00,        5.00,       -1.00,        2.00 
   };
 
   const double  EPEtaMin2[]  = {

--- a/RecoHI/HiEvtPlaneAlgos/src/EvtPlaneProducer.cc
+++ b/RecoHI/HiEvtPlaneAlgos/src/EvtPlaneProducer.cc
@@ -378,7 +378,7 @@ EvtPlaneProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	      if(MomConsWeight[i][0]=='y' && loadDB_ ) {
 		w = flat[i]->getW(tower_energyet, vzr_sell, bin);
 	      }
-	      if(tower_eta<0 ) w=-w;
+	      if(tower_eta<0 && MomConsWeight[i][0]=='n') w=-w;
 	    }
 	    rp[i]->addParticle(w,tower_energyet,sin(EPOrder[i]*tower_phi),cos(EPOrder[i]*tower_phi),tower_eta);
 	  }
@@ -409,7 +409,7 @@ EvtPlaneProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
        	      if(MomConsWeight[i][0]=='y' && loadDB_ ) {
        		w = flat[i]->getW(tower_energyet, vzr_sell, bin);
        	      }
-       	      if(tower_eta<0 ) w=-w;
+       	      if(tower_eta<0 && MomConsWeight[i][0]=='n') w=-w;
        	    }
        	    rp[i]->addParticle(w,tower_energyet,sin(EPOrder[i]*tower_phi),cos(EPOrder[i]*tower_phi),tower_eta);
        	  }
@@ -481,7 +481,7 @@ EvtPlaneProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		if(MomConsWeight[i][0]=='y' && loadDB_) {
 		  w = flat[i]->getW(track_pt, vzr_sell, bin);
 		}
-		if(track_eta<0) w=-w;
+		if(track_eta<0 && MomConsWeight[i][0]=='n') w=-w;
 	      }
 	      rp[i]->addParticle(w,track_pt,sin(EPOrder[i]*track_phi),cos(EPOrder[i]*track_phi),track_eta);
 	    }


### PR DESCRIPTION
Fix table in comment.
Fix eta range for 1st order tracker EP.
Fix 1st order EP momentum conserving weight.
This PR is meant to be integrated with #14819 for a reprocess of 2015 PbPb data with pixel tracks.
@mandrenguyen 
