### PR TITLE
Fix RPCGeometryBuilder to set correct chamber surface

### DIFF
--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
@@ -123,7 +123,7 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
       // First set the baseline plane to calculate relative poisions
       const auto& refSurf = (*rls.begin())->surface();
       if ( chid.region() == 0 ) {
-        float corners[4] = {0,0,0,0};
+        float corners[6] = {0,0,0,0,0,0};
         for ( auto rl : rls ) {
           const double h2 = rl->surface().bounds().length()/2;
           const double w2 = rl->surface().bounds().width()/2;
@@ -133,14 +133,18 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
           corners[1] = std::min(corners[1], x1y1AtRef.y());
           corners[2] = std::max(corners[2], x2y2AtRef.x());
           corners[3] = std::max(corners[3], x2y2AtRef.y());
+
+          corners[4] = std::min(corners[4], x1y1AtRef.z());
+          corners[5] = std::max(corners[5], x1y1AtRef.z());
         }
         const LocalPoint lpOfCentre((corners[0]+corners[2])/2, (corners[1]+corners[3])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new RectangularPlaneBounds((corners[2]-corners[0])/2, (corners[3]-corners[1])/2, 0);
+        auto bounds = new RectangularPlaneBounds((corners[2]-corners[0])/2, (corners[3]-corners[1])/2, (corners[5]-corners[4])+0.5);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
       else {
         float cornersLo[3] = {0,}, cornersHi[3] = {0,};
+        float cornersZ[2] = {0,};
         for ( auto rl : rls ) {
           const double h2 = rl->surface().bounds().length()/2;
           const double w2 = rl->surface().bounds().width()/2;
@@ -161,10 +165,13 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
           cornersHi[0] = std::min(cornersHi[0], x1y2AtRef.x());
           cornersHi[1] = std::max(cornersHi[1], x2y2AtRef.x());
           cornersHi[2] = std::max(cornersHi[2], x1y2AtRef.y());
+
+          cornersZ[0] = std::min(cornersZ[0], x1y1AtRef.z());
+          cornersZ[1] = std::max(cornersZ[1], x1y1AtRef.z());
         }
         const LocalPoint lpOfCentre((cornersHi[0]+cornersHi[1])/2, (cornersLo[2]+cornersHi[2])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, 0);
+        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, (cornersZ[1]-cornersZ[0])+0.5);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
     }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
@@ -140,7 +140,7 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
       else {
-        float cornersLo[3] = {0,}, cornersHi[3] = {4};
+        float cornersLo[3] = {0,}, cornersHi[3] = {0,};
         for ( auto rl : rls ) {
           const double h2 = rl->surface().bounds().length()/2;
           const double w2 = rl->surface().bounds().width()/2;

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
@@ -164,7 +164,7 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
         }
         const LocalPoint lpOfCentre((cornersHi[0]+cornersHi[1])/2, (cornersLo[2]+cornersHi[2])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2]), 0);
+        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, 0);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
     }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
@@ -36,45 +36,34 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
   const std::vector<DetId>& detids(rgeo.detIds());
   RPCGeometry* geometry = new RPCGeometry();
 
-  std::string name;
-  std::vector<double>::const_iterator tranStart;
-  std::vector<double>::const_iterator shapeStart;
-  std::vector<double>::const_iterator rotStart;
-  std::vector<std::string>::const_iterator strStart;
-
   for (unsigned int id=0; id<detids.size(); id++){
-
     RPCDetId rpcid(detids[id]);
     RPCDetId chid(rpcid.region(),rpcid.ring(),rpcid.station(),
                   rpcid.sector(),rpcid.layer(),rpcid.subsector(),0);
 
-    tranStart=rgeo.tranStart(id);
-    shapeStart=rgeo.shapeStart(id);
-    rotStart=rgeo.rotStart(id);
-    strStart=rgeo.strStart(id);
-    name=*(strStart);
+    const auto tranStart  = rgeo.tranStart(id);
+    const auto shapeStart = rgeo.shapeStart(id);
+    const auto rotStart   = rgeo.rotStart(id);
+    const std::string& name = *rgeo.strStart(id);
 
     Surface::PositionType pos(*(tranStart)/cm,*(tranStart+1)/cm, *(tranStart+2)/cm);
     // CLHEP way
     Surface::RotationType rot(*(rotStart+0),*(rotStart+1),*(rotStart+2),
-			      *(rotStart+3),*(rotStart+4),*(rotStart+5),
-			      *(rotStart+6),*(rotStart+7),*(rotStart+8));
+                              *(rotStart+3),*(rotStart+4),*(rotStart+5),
+                              *(rotStart+6),*(rotStart+7),*(rotStart+8));
 
-    std::vector<float> pars;
     RPCRollSpecs* rollspecs= 0;
     Bounds* bounds = 0;
 
     //    if (dpar.size()==4){
     if ( rgeo.shapeEnd(id) - shapeStart == 4 ) {
-      float width     = *(shapeStart+0)/cm;
-      float length    = *(shapeStart+1)/cm;
-      float thickness = *(shapeStart+2)/cm;
-      float nstrip    = *(shapeStart+3);
+      const float width     = *(shapeStart+0)/cm;
+      const float length    = *(shapeStart+1)/cm;
+      const float thickness = *(shapeStart+2)/cm;
+      const float nstrip    = *(shapeStart+3);
       //RectangularPlaneBounds*
       bounds = new RectangularPlaneBounds(width,length,thickness);
-      pars.push_back(width);
-      pars.push_back(length);
-      pars.push_back(nstrip);
+      const std::vector<float> pars = {width, length, nstrip};
 
       if (!theComp11Flag) {
         //Correction of the orientation to get the REAL geometry.
@@ -92,17 +81,14 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
 
     }
     else {
-      float be = *(shapeStart+0)/cm;
-      float te = *(shapeStart+1)/cm;
-      float ap = *(shapeStart+2)/cm;
-      float ti = *(shapeStart+3)/cm;
-      float nstrip = *(shapeStart+4);
+      const float be = *(shapeStart+0)/cm;
+      const float te = *(shapeStart+1)/cm;
+      const float ap = *(shapeStart+2)/cm;
+      const float ti = *(shapeStart+3)/cm;
+      const float nstrip = *(shapeStart+4);
       //  TrapezoidalPlaneBounds*
       bounds = new TrapezoidalPlaneBounds(be,te,ap,ti);
-      pars.push_back(be); //b/2;
-      pars.push_back(te); //B/2;
-      pars.push_back(ap); //h/2;
-      pars.push_back(nstrip);
+      const std::vector<float> pars = {be /*b/2*/, te /*B/2*/, ap /*h/2*/, nstrip};
 
       rollspecs = new RPCRollSpecs(GeomDetEnumerators::RPCEndcap,name,pars);
 
@@ -117,7 +103,7 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
 
     BoundPlane* bp = new BoundPlane(pos,rot,bounds);
     ReferenceCountingPointer<BoundPlane> surf(bp);
-    RPCRoll* r=new RPCRoll(rpcid,surf,rollspecs);
+    RPCRoll* r = new RPCRoll(rpcid,surf,rollspecs);
     geometry->add(r);
 
     auto rls = chids.find(chid);

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.cc
@@ -28,26 +28,26 @@ RPCGeometryBuilderFromCondDB::RPCGeometryBuilderFromCondDB(bool comp11) :
   theComp11Flag(comp11)
 { }
 
-RPCGeometryBuilderFromCondDB::~RPCGeometryBuilderFromCondDB() 
+RPCGeometryBuilderFromCondDB::~RPCGeometryBuilderFromCondDB()
 { }
 
 RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
 {
   const std::vector<DetId>& detids(rgeo.detIds());
   RPCGeometry* geometry = new RPCGeometry();
-  
+
   std::string name;
   std::vector<double>::const_iterator tranStart;
   std::vector<double>::const_iterator shapeStart;
   std::vector<double>::const_iterator rotStart;
   std::vector<std::string>::const_iterator strStart;
-  
+
   for (unsigned int id=0; id<detids.size(); id++){
-    
+
     RPCDetId rpcid(detids[id]);
     RPCDetId chid(rpcid.region(),rpcid.ring(),rpcid.station(),
-		  rpcid.sector(),rpcid.layer(),rpcid.subsector(),0);
-    
+                  rpcid.sector(),rpcid.layer(),rpcid.subsector(),0);
+
     tranStart=rgeo.tranStart(id);
     shapeStart=rgeo.shapeStart(id);
     rotStart=rgeo.rotStart(id);
@@ -59,26 +59,25 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
     Surface::RotationType rot(*(rotStart+0),*(rotStart+1),*(rotStart+2),
 			      *(rotStart+3),*(rotStart+4),*(rotStart+5),
 			      *(rotStart+6),*(rotStart+7),*(rotStart+8));
-      
+
     std::vector<float> pars;
     RPCRollSpecs* rollspecs= 0;
     Bounds* bounds = 0;
-    
+
     //    if (dpar.size()==4){
     if ( rgeo.shapeEnd(id) - shapeStart == 4 ) {
       float width     = *(shapeStart+0)/cm;
       float length    = *(shapeStart+1)/cm;
       float thickness = *(shapeStart+2)/cm;
       float nstrip    = *(shapeStart+3);
-      //RectangularPlaneBounds* 
-      bounds = 
-	new RectangularPlaneBounds(width,length,thickness);
+      //RectangularPlaneBounds*
+      bounds = new RectangularPlaneBounds(width,length,thickness);
       pars.push_back(width);
       pars.push_back(length);
-      pars.push_back(nstrip); 
+      pars.push_back(nstrip);
 
       if (!theComp11Flag) {
-	//Correction of the orientation to get the REAL geometry.
+        //Correction of the orientation to get the REAL geometry.
         //Change of axes for the +z part only.
         //Including the 0 whell
         if ( *(tranStart+2) > -1500.) {   //tran[2] >-1500. ){
@@ -89,68 +88,61 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
         }
       }
 
-      
       rollspecs = new RPCRollSpecs(GeomDetEnumerators::RPCBarrel,name,pars);
-      
-      
-    }else{
+
+    }
+    else {
       float be = *(shapeStart+0)/cm;
       float te = *(shapeStart+1)/cm;
       float ap = *(shapeStart+2)/cm;
       float ti = *(shapeStart+3)/cm;
       float nstrip = *(shapeStart+4);
-      //  TrapezoidalPlaneBounds* 
-      bounds = 
-	new TrapezoidalPlaneBounds(be,te,ap,ti);
+      //  TrapezoidalPlaneBounds*
+      bounds = new TrapezoidalPlaneBounds(be,te,ap,ti);
       pars.push_back(be); //b/2;
       pars.push_back(te); //B/2;
       pars.push_back(ap); //h/2;
-      pars.push_back(nstrip); 
-      
+      pars.push_back(nstrip);
+
       rollspecs = new RPCRollSpecs(GeomDetEnumerators::RPCEndcap,name,pars);
-      
+
       //Change of axes for the forward
       Basic3DVector<float> newX(1.,0.,0.);
       Basic3DVector<float> newY(0.,0.,1.);
       //      if (tran[2] > 0. )
       newY *= -1;
       Basic3DVector<float> newZ(0.,1.,0.);
-      rot.rotateAxes (newX, newY,newZ);	
+      rot.rotateAxes (newX, newY,newZ);
     }
-    
+
     BoundPlane* bp = new BoundPlane(pos,rot,bounds);
     ReferenceCountingPointer<BoundPlane> surf(bp);
     RPCRoll* r=new RPCRoll(rpcid,surf,rollspecs);
     geometry->add(r);
-    
-    std::list<RPCRoll *> rls;
-    if (chids.find(chid)!=chids.end()){
-      rls = chids[chid];
-    }
-    rls.push_back(r);
-    chids[chid]=rls;
-  }
-  // Create the RPCChambers and store them on the Geometry 
-  for( std::map<RPCDetId, std::list<RPCRoll *> >::iterator ich=chids.begin();
-       ich != chids.end(); ich++){
-    RPCDetId chid = ich->first;
-    std::list<RPCRoll * > rls = ich->second;
 
-    // compute the overall boundplane. At the moment we use just the last
-    // surface
+    auto rls = chids.find(chid);
+    if ( rls == chids.end() ) rls = chids.insert(std::make_pair(chid, std::set<RPCRoll*>())).first;
+    rls->second.insert(r);
+  }
+
+  // Create the RPCChambers and store them on the Geometry
+  for( auto ich=chids.begin(); ich != chids.end(); ich++){
+    const RPCDetId& chid = ich->first;
+    const auto& rls = ich->second;
+
+    // compute the overall boundplane.
     BoundPlane* bp=0;
-    for(std::list<RPCRoll *>::iterator rl=rls.begin();
-    rl!=rls.end(); rl++){
+
+    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
       const BoundPlane& bps = (*rl)->surface();
       bp = const_cast<BoundPlane *>(&bps);
     }
 
     ReferenceCountingPointer<BoundPlane> surf(bp);
-    // Create the chamber 
-    RPCChamber* ch = new RPCChamber (chid, surf); 
+    // Create the chamber
+    RPCChamber* ch = new RPCChamber (chid, surf);
     // Add the rolls to rhe chamber
-    for(std::list<RPCRoll *>::iterator rl=rls.begin();
-    rl!=rls.end(); rl++){
+    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
       ch->add(*rl);
     }
     // Add the chamber to the geometry
@@ -159,6 +151,4 @@ RPCGeometry* RPCGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
   }
   return geometry;
 }
-
-    
 

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.h
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromCondDB.h
@@ -11,7 +11,7 @@
 #include <CondFormats/GeometryObjects/interface/RecoIdealGeometry.h>
 #include <string>
 #include <map>
-#include <list>
+#include <set>
 
 
 class RPCGeometry;
@@ -30,7 +30,7 @@ class RPCGeometryBuilderFromCondDB
 
 
  private:
-  std::map<RPCDetId,std::list<RPCRoll *> > chids;
+  std::map<RPCDetId,std::set<RPCRoll *> > chids;
   bool theComp11Flag;
 
 };

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -204,7 +204,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
         }
         const LocalPoint lpOfCentre((corners[0]+corners[2])/2, (corners[1]+corners[3])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new RectangularPlaneBounds((corners[2]-corners[0])/2, (corners[3]-corners[1])/2, 0);
+        auto bounds = new RectangularPlaneBounds((corners[2]-corners[0])/2, (corners[3]-corners[1])/2, 1);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
       else {
@@ -232,7 +232,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
         }
         const LocalPoint lpOfCentre((cornersHi[0]+cornersHi[1])/2, (cornersLo[2]+cornersHi[2])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, 0);
+        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, 1);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
     }
@@ -244,6 +244,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     for ( auto rl : rls ) ch->add(rl);
     // Add the chamber to the geometry
     geometry->add(ch);
+
   }
   return geometry;
 }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -14,6 +14,7 @@
 #include "Geometry/MuonNumbering/interface/MuonDDDNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/RPCNumberingScheme.h"
+#include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
@@ -141,7 +142,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
 					    <<" par "<<width
 					    <<" "<<length<<" "<<thickness;
     }
-    else{
+    else {
       const float be = dpar[4]/cm;
       const float te = dpar[8]/cm;
       const float ap = dpar[0]/cm;
@@ -180,25 +181,67 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     doSubDets = fview.nextSibling(); // go to next layer
   }
   // Create the RPCChambers and store them on the Geometry
-  for( auto ich=chids.begin(); ich != chids.end(); ich++){
+  for ( auto ich=chids.begin(); ich != chids.end(); ++ich ) {
     const RPCDetId& chid = ich->first;
     const auto& rls = ich->second;
 
-    // compute the overall boundplane. At the moment we use just the last
-    // surface
+    // compute the overall boundplane.
     BoundPlane* bp=0;
-    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
-      const BoundPlane& bps = (*rl)->surface();
-      bp = const_cast<BoundPlane *>(&bps);
+    if ( !rls.empty() ) {
+      // First set the baseline plane to calculate relative poisions
+      const auto& refSurf = (*rls.begin())->surface();
+      if ( chid.region() == 0 ) {
+        float corners[4] = {0,0,0,0};
+        for ( auto rl : rls ) {
+          const double h2 = rl->surface().bounds().length()/2;
+          const double w2 = rl->surface().bounds().width()/2;
+          const auto x1y1AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(-w2,-h2,0)));
+          const auto x2y2AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(+w2,+h2,0)));
+          corners[0] = std::min(corners[0], x1y1AtRef.x());
+          corners[1] = std::min(corners[1], x1y1AtRef.y());
+          corners[2] = std::max(corners[2], x2y2AtRef.x());
+          corners[3] = std::max(corners[3], x2y2AtRef.y());
+        }
+        const LocalPoint lpOfCentre((corners[0]+corners[2])/2, (corners[1]+corners[3])/2, 0);
+        const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
+        auto bounds = new RectangularPlaneBounds((corners[2]-corners[0])/2, (corners[3]-corners[1])/2, 0);
+        bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
+      }
+      else {
+        float cornersLo[3] = {0,}, cornersHi[3] = {4};
+        for ( auto rl : rls ) {
+          const double h2 = rl->surface().bounds().length()/2;
+          const double w2 = rl->surface().bounds().width()/2;
+          const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(rl->specificTopology());
+          const double r = topo.radius();
+          const double wAtLo = w2/r*(r-h2); // tan(theta/2) = (w/2)/r = x/(r-h/2)
+          const double wAtHi = w2/r*(r+h2);
+
+          const auto x1y1AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(-wAtLo, -h2, 0)));
+          const auto x2y1AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(+wAtLo, -h2, 0)));
+          const auto x1y2AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(-wAtHi, +h2, 0)));
+          const auto x2y2AtRef = refSurf.toLocal(rl->toGlobal(LocalPoint(+wAtHi, +h2, 0)));
+
+          cornersLo[0] = std::min(cornersLo[0], x1y1AtRef.x());
+          cornersLo[1] = std::max(cornersLo[1], x2y1AtRef.x());
+          cornersLo[2] = std::min(cornersLo[2], x1y1AtRef.y());
+
+          cornersHi[0] = std::min(cornersHi[0], x1y2AtRef.x());
+          cornersHi[1] = std::max(cornersHi[1], x2y2AtRef.x());
+          cornersHi[2] = std::max(cornersHi[2], x1y2AtRef.y());
+        }
+        const LocalPoint lpOfCentre((cornersHi[0]+cornersHi[1])/2, (cornersLo[2]+cornersHi[2])/2, 0);
+        const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
+        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2]), 0);
+        bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
+      }
     }
 
     ReferenceCountingPointer<BoundPlane> surf(bp);
     // Create the chamber
     RPCChamber* ch = new RPCChamber (chid, surf);
     // Add the rolls to rhe chamber
-    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
-      ch->add(*rl);
-    }
+    for ( auto rl : rls ) ch->add(rl);
     // Add the chamber to the geometry
     geometry->add(ch);
   }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -232,7 +232,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
         }
         const LocalPoint lpOfCentre((cornersHi[0]+cornersHi[1])/2, (cornersLo[2]+cornersHi[2])/2, 0);
         const auto gpOfCentre = refSurf.toGlobal(lpOfCentre);
-        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2]), 0);
+        auto bounds = new TrapezoidalPlaneBounds((cornersLo[1]-cornersLo[0])/2, (cornersHi[1]-cornersHi[0])/2, (cornersHi[2]-cornersLo[2])/2, 0);
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
     }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -208,7 +208,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
         bp = new BoundPlane(gpOfCentre, refSurf.rotation(), bounds);
       }
       else {
-        float cornersLo[3] = {0,}, cornersHi[3] = {4};
+        float cornersLo[3] = {0,}, cornersHi[3] = {0,};
         for ( auto rl : rls ) {
           const double h2 = rl->surface().bounds().length()/2;
           const double w2 = rl->surface().bounds().width()/2;

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -28,7 +28,7 @@
 RPCGeometryBuilderFromDDD::RPCGeometryBuilderFromDDD(bool comp11) : theComp11Flag(comp11)
 { }
 
-RPCGeometryBuilderFromDDD::~RPCGeometryBuilderFromDDD() 
+RPCGeometryBuilderFromDDD::~RPCGeometryBuilderFromDDD()
 { }
 
 RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const MuonDDDConstants& muonConstants)
@@ -39,12 +39,12 @@ RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
 
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true // use merged-specifics or simple-specifics
-		     );
+  filter.setCriteria(val, // name & value of a variable
+                     DDCompOp::matches,
+                     DDLogOp::AND,
+                     true, // compare strings otherwise doubles
+                     true // use merged-specifics or simple-specifics
+                     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);
 
@@ -56,21 +56,21 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
   LogDebug("RPCGeometryBuilderFromDDD") <<"Building the geometry service";
   RPCGeometry* geometry = new RPCGeometry();
 
-  LogDebug("RPCGeometryBuilderFromDDD") << "About to run through the RPC structure\n" 
+  LogDebug("RPCGeometryBuilderFromDDD") << "About to run through the RPC structure\n"
 					<<" First logical part "
 					<<fview.logicalPart().name().name();
   bool doSubDets = fview.firstChild();
 
   LogDebug("RPCGeometryBuilderFromDDD") << "doSubDets = " << doSubDets;
   while (doSubDets){
-    LogDebug("RPCGeometryBuilderFromDDD") <<"start the loop"; 
+    LogDebug("RPCGeometryBuilderFromDDD") <<"start the loop";
 
     // Get the Base Muon Number
     MuonDDDNumbering mdddnum(muonConstants);
     LogDebug("RPCGeometryBuilderFromDDD") <<"Getting the Muon base Number";
     MuonBaseNumber   mbn=mdddnum.geoHistoryToBaseNumber(fview.geoHistory());
     LogDebug("RPCGeometryBuilderFromDDD") <<"Start the Rpc Numbering Schema";
-    // Get the The Rpc det Id 
+    // Get the The Rpc det Id
     RPCNumberingScheme rpcnum(muonConstants);
     int detid = 0;
 
@@ -86,16 +86,15 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     DDValue numbOfStrips("nStrips");
 
     std::vector<const DDsvalues_type* > specs(fview.specifics());
-    std::vector<const DDsvalues_type* >::iterator is=specs.begin();
     int nStrips=0;
-    for (;is!=specs.end(); is++){
+    for (auto is=specs.begin();is!=specs.end(); ++is){
       if (DDfetch( *is, numbOfStrips)){
-	nStrips=int(numbOfStrips.doubles()[0]);	
+        nStrips=int(numbOfStrips.doubles()[0]);
       }
     }
 
     LogDebug("RPCGeometryBuilderFromDDD") << ((nStrips == 0 ) ? ("No strip found!!") : (""));
-    
+
     std::vector<double> dpar=fview.logicalPart().solid().parameters();
     std::string name=fview.logicalPart().name().name();
     DDTranslation tran    = fview.translation();
@@ -103,47 +102,44 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     DDRotationMatrix rota = fview.rotation();//.Inverse();
     Surface::PositionType pos(tran.x()/cm,tran.y()/cm, tran.z()/cm);
     // CLHEP way
-//     Surface::RotationType rot(rota.xx(),rota.xy(),rota.xz(),
-// 			      rota.yx(),rota.yy(),rota.yz(),
-// 			      rota.zx(),rota.zy(),rota.zz());
+    // Surface::RotationType rot(rota.xx(),rota.xy(),rota.xz(),
+    // 			                     rota.yx(),rota.yy(),rota.yz(),
+    // 			                     rota.zx(),rota.zy(),rota.zz());
 
-//ROOT::Math way
+    //ROOT::Math way
     DD3Vector x, y, z;
     rota.GetComponents(x,y,z);
     // doesn't this just re-inverse???
     Surface::RotationType rot (float(x.X()),float(x.Y()),float(x.Z()),
-			       float(y.X()),float(y.Y()),float(y.Z()),
-			       float(z.X()),float(z.Y()),float(z.Z())); 
-    
+                               float(y.X()),float(y.Y()),float(y.Z()),
+                               float(z.X()),float(z.Y()),float(z.Z()));
+
     std::vector<float> pars;
     RPCRollSpecs* rollspecs= 0;
     Bounds* bounds = 0;
 
-
-
     if (dpar.size()==3){
-      float width     = dpar[0]/cm;
-      float length    = dpar[1]/cm;
-      float thickness = dpar[2]/cm;
-      //RectangularPlaneBounds* 
-      bounds = 
-	new RectangularPlaneBounds(width,length,thickness);
+      const float width     = dpar[0]/cm;
+      const float length    = dpar[1]/cm;
+      const float thickness = dpar[2]/cm;
+      //RectangularPlaneBounds*
+      bounds = new RectangularPlaneBounds(width,length,thickness);
       pars.push_back(width);
       pars.push_back(length);
       pars.push_back(numbOfStrips.doubles()[0]); //h/2;
 
       if (!theComp11Flag) {
-	//Correction of the orientation to get the REAL geometry.
+        //Correction of the orientation to get the REAL geometry.
         //Change of axes for the +z part only.
-        //Including the 0 whell
+        //Including the 0 wheel
         if (tran.z() >-1500. ){
           Basic3DVector<float> newX(-1.,0.,0.);
           Basic3DVector<float> newY(0.,-1.,0.);
           Basic3DVector<float> newZ(0.,0.,1.);
-          rot.rotateAxes (newX, newY,newZ);
+          rot.rotateAxes(newX, newY,newZ);
         }
       }
-      
+
       rollspecs = new RPCRollSpecs(GeomDetEnumerators::RPCBarrel,name,pars);
       LogDebug("RPCGeometryBuilderFromDDD") <<"Barrel "<<name
 					    <<" par "<<width
@@ -154,14 +150,13 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
       float te = dpar[8]/cm;
       float ap = dpar[0]/cm;
       float ti = 0.4/cm;
-      //  TrapezoidalPlaneBounds* 
-      bounds = 
-	new TrapezoidalPlaneBounds(be,te,ap,ti);
+      //  TrapezoidalPlaneBounds*
+      bounds = new TrapezoidalPlaneBounds(be,te,ap,ti);
       pars.push_back(dpar[4]/cm); //b/2;
       pars.push_back(dpar[8]/cm); //B/2;
       pars.push_back(dpar[0]/cm); //h/2;
       pars.push_back(numbOfStrips.doubles()[0]); //h/2;
-      
+
       LogDebug("RPCGeometryBuilderFromDDD") <<"Forward "<<name
 					    <<" par "<<dpar[4]/cm
 					    <<" "<<dpar[8]/cm<<" "<<dpar[3]/cm<<" "
@@ -176,49 +171,42 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
       newY *= -1;
       Basic3DVector<float> newZ(0.,1.,0.);
       rot.rotateAxes (newX, newY,newZ);
-      
     }
     LogDebug("RPCGeometryBuilderFromDDD") <<"   Number of strips "<<nStrips;
-    
+
     BoundPlane* bp = new BoundPlane(pos,rot,bounds);
     ReferenceCountingPointer<BoundPlane> surf(bp);
     RPCRoll* r=new RPCRoll(rpcid,surf,rollspecs);
     geometry->add(r);
 
-    std::list<RPCRoll *> rls;
-    if (chids.find(chid)!=chids.end()){
-      rls = chids[chid];
-    }
-    rls.push_back(r);
-    chids[chid]=rls;
+    auto rls = chids.find(chid);
+    if ( rls == chids.end() ) rls = chids.insert(std::make_pair(chid, std::set<RPCRoll*>())).first;
+    rls->second.insert(r);
 
     doSubDets = fview.nextSibling(); // go to next layer
   }
-  // Create the RPCChambers and store them on the Geometry 
-  for( std::map<RPCDetId, std::list<RPCRoll *> >::iterator ich=chids.begin();
-       ich != chids.end(); ich++){
-    RPCDetId chid = ich->first;
-    std::list<RPCRoll * > rls = ich->second;
+  // Create the RPCChambers and store them on the Geometry
+  for( auto ich=chids.begin(); ich != chids.end(); ich++){
+    const RPCDetId& chid = ich->first;
+    const auto& rls = ich->second;
 
     // compute the overall boundplane. At the moment we use just the last
     // surface
     BoundPlane* bp=0;
-    for(std::list<RPCRoll *>::iterator rl=rls.begin();
-    rl!=rls.end(); rl++){
+    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
       const BoundPlane& bps = (*rl)->surface();
       bp = const_cast<BoundPlane *>(&bps);
     }
 
     ReferenceCountingPointer<BoundPlane> surf(bp);
-    // Create the chamber 
-    RPCChamber* ch = new RPCChamber (chid, surf); 
+    // Create the chamber
+    RPCChamber* ch = new RPCChamber (chid, surf);
     // Add the rolls to rhe chamber
-    for(std::list<RPCRoll *>::iterator rl=rls.begin();
-    rl!=rls.end(); rl++){
+    for(auto rl=rls.begin(); rl!=rls.end(); rl++){
       ch->add(*rl);
     }
     // Add the chamber to the geometry
     geometry->add(ch);
-  } 
+  }
   return geometry;
 }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -33,8 +33,8 @@ RPCGeometryBuilderFromDDD::~RPCGeometryBuilderFromDDD()
 
 RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const MuonDDDConstants& muonConstants)
 {
-  std::string attribute = "ReadOutName"; // could come from .orcarc
-  std::string value     = "MuonRPCHits";    // could come from .orcarc
+  const std::string attribute = "ReadOutName"; // could come from .orcarc
+  const std::string value     = "MuonRPCHits";    // could come from .orcarc
   DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonRPC's
@@ -72,10 +72,9 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     LogDebug("RPCGeometryBuilderFromDDD") <<"Start the Rpc Numbering Schema";
     // Get the The Rpc det Id
     RPCNumberingScheme rpcnum(muonConstants);
-    int detid = 0;
 
     LogDebug("RPCGeometryBuilderFromDDD") <<"Getting the Unit Number";
-    detid = rpcnum.baseNumberToUnitNumber(mbn);
+    const int detid = rpcnum.baseNumberToUnitNumber(mbn);
     LogDebug("RPCGeometryBuilderFromDDD") <<"Getting the RPC det Id "<<detid;
 
     RPCDetId rpcid(detid);
@@ -114,7 +113,6 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
                                float(y.X()),float(y.Y()),float(y.Z()),
                                float(z.X()),float(z.Y()),float(z.Z()));
 
-    std::vector<float> pars;
     RPCRollSpecs* rollspecs= 0;
     Bounds* bounds = 0;
 
@@ -124,9 +122,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
       const float thickness = dpar[2]/cm;
       //RectangularPlaneBounds*
       bounds = new RectangularPlaneBounds(width,length,thickness);
-      pars.push_back(width);
-      pars.push_back(length);
-      pars.push_back(numbOfStrips.doubles()[0]); //h/2;
+      const std::vector<float> pars = {width, length, float(numbOfStrips.doubles()[0]) /*h/2*/};
 
       if (!theComp11Flag) {
         //Correction of the orientation to get the REAL geometry.
@@ -146,16 +142,14 @@ RPCGeometry* RPCGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
 					    <<" "<<length<<" "<<thickness;
     }
     else{
-      float be = dpar[4]/cm;
-      float te = dpar[8]/cm;
-      float ap = dpar[0]/cm;
-      float ti = 0.4/cm;
+      const float be = dpar[4]/cm;
+      const float te = dpar[8]/cm;
+      const float ap = dpar[0]/cm;
+      const float ti = 0.4/cm;
       //  TrapezoidalPlaneBounds*
       bounds = new TrapezoidalPlaneBounds(be,te,ap,ti);
-      pars.push_back(dpar[4]/cm); //b/2;
-      pars.push_back(dpar[8]/cm); //B/2;
-      pars.push_back(dpar[0]/cm); //h/2;
-      pars.push_back(numbOfStrips.doubles()[0]); //h/2;
+      const std::vector<float> pars = {float(dpar[4]/cm) /*b/2*/, float(dpar[8]/cm) /*B/2*/,
+                                       float(dpar[0]/cm) /*h/2*/, float(numbOfStrips.doubles()[0]) /*h/2*/};
 
       LogDebug("RPCGeometryBuilderFromDDD") <<"Forward "<<name
 					    <<" par "<<dpar[4]/cm

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.h
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.h
@@ -11,7 +11,7 @@
 
 #include <string>
 #include <map>
-#include <list>
+#include <set>
 
 class DDCompactView;
 class DDFilteredView;
@@ -33,7 +33,7 @@ class RPCGeometryBuilderFromDDD
 
  private:
   RPCGeometry* buildGeometry(DDFilteredView& fview, const MuonDDDConstants& muonConstants);
-  std::map<RPCDetId,std::list<RPCRoll *> > chids;
+  std::map<RPCDetId,std::set<RPCRoll *> > chids;
 
   bool theComp11Flag;
 

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -22,110 +22,87 @@
 #include <iostream>
 #include <algorithm>
 
-RPCGeometryParsFromDD::RPCGeometryParsFromDD() 
+RPCGeometryParsFromDD::RPCGeometryParsFromDD()
 { }
 
-RPCGeometryParsFromDD::~RPCGeometryParsFromDD() 
+RPCGeometryParsFromDD::~RPCGeometryParsFromDD()
 { }
 
-void
-RPCGeometryParsFromDD::build(const DDCompactView* cview, 
-      const MuonDDDConstants& muonConstants, RecoIdealGeometry& rgeo )
+void RPCGeometryParsFromDD::build(const DDCompactView* cview,
+                                  const MuonDDDConstants& muonConstants, RecoIdealGeometry& rgeo )
 {
-  std::string attribute = "ReadOutName";
-  std::string value     = "MuonRPCHits";
+  const std::string attribute = "ReadOutName";
+  const std::string value     = "MuonRPCHits";
   DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true // use merged-specifics or simple-specifics
-		     );
+  filter.setCriteria(val, // name & value of a variable
+                     DDCompOp::matches,
+                     DDLogOp::AND,
+                     true, // compare strings otherwise doubles
+                     true // use merged-specifics or simple-specifics
+                     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);
 
   this->buildGeometry(fview, muonConstants, rgeo);
 }
 
-void
-RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview, const MuonDDDConstants& muonConstants, RecoIdealGeometry& rgeo)
+void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
+                                          const MuonDDDConstants& muonConstants, RecoIdealGeometry& rgeo)
 {
-
-  bool doSubDets = fview.firstChild();
-
-  while (doSubDets){
+  for ( bool doSubDets = fview.firstChild(); doSubDets==true; doSubDets = fview.nextSibling() ) {
 
     // Get the Base Muon Number
     MuonDDDNumbering mdddnum(muonConstants);
     MuonBaseNumber   mbn=mdddnum.geoHistoryToBaseNumber(fview.geoHistory());
 
-    // Get the The Rpc det Id 
+    // Get the The Rpc det Id
     RPCNumberingScheme rpcnum(muonConstants);
-    int detid = 0;
-
-    detid = rpcnum.baseNumberToUnitNumber(mbn);
+    const int detid = rpcnum.baseNumberToUnitNumber(mbn);
     RPCDetId rpcid(detid);
 
     DDValue numbOfStrips("nStrips");
 
     std::vector<const DDsvalues_type* > specs(fview.specifics());
-    std::vector<const DDsvalues_type* >::iterator is=specs.begin();
     int nStrips=0;
-    for (;is!=specs.end(); is++){
+    for (auto is=specs.begin();is!=specs.end(); is++){
       if (DDfetch( *is, numbOfStrips)){
-	nStrips=int(numbOfStrips.doubles()[0]);	
+        nStrips=int(numbOfStrips.doubles()[0]);
       }
     }
-    if (nStrips == 0 )
-      std::cout <<"No strip found!!"<<std::endl;
-    
-    std::vector<double> dpar=fview.logicalPart().solid().parameters();
+    if (nStrips == 0 ) std::cout <<"No strip found!!"<<std::endl;
 
-    std::vector<std::string> strpars;
-    std::string name=fview.logicalPart().name().name();
-    strpars.push_back(name);
-    DDTranslation tran    = fview.translation();
+    const std::vector<double> dpar = fview.logicalPart().solid().parameters();
+
+    const std::string name=fview.logicalPart().name().name();
+    const std::vector<std::string> strpars = {name};
+    DDTranslation tran = fview.translation();
 
     DDRotationMatrix rota = fview.rotation();//.Inverse();
     DD3Vector x, y, z;
     rota.GetComponents(x,y,z);
-    std::vector<double> pars;    
+    std::vector<double> pars;
     if (dpar.size()==3){
-      double width     = dpar[0];
-      double length    = dpar[1];
-      double thickness = dpar[2];
-      pars.push_back(width);
-      pars.push_back(length);
-      pars.push_back(thickness);
-      pars.push_back(numbOfStrips.doubles()[0]); 
-    }else{
-      pars.push_back(dpar[4]); //b/2;
-      pars.push_back(dpar[8]); //B/2;
-      pars.push_back(dpar[0]); //h/2;
-      pars.push_back(0.4);
-      pars.push_back(numbOfStrips.doubles()[0]); //h/2;
+      const double width     = dpar[0];
+      const double length    = dpar[1];
+      const double thickness = dpar[2];
+      pars = {width, length, thickness, numbOfStrips.doubles()[0]};
+    }
+    else{
+      pars = {
+        dpar[4] /*b/2*/, dpar[8] /*B/2*/, dpar[0] /*h/2*/,
+        0.4,
+        numbOfStrips.doubles()[0] /*h/2*/
+      };
     }
 
-    
-    std::vector<double> vtra(3);
-    std::vector<double> vrot(9);
-    vtra[0]=(float) 1.0 * (tran.x());
-    vtra[1]=(float) 1.0 * (tran.y());
-    vtra[2]=(float) 1.0 * (tran.z());
-    vrot[0]=(float) 1.0 * x.X();
-    vrot[1]=(float) 1.0 * x.Y();
-    vrot[2]=(float) 1.0 * x.Z();
-    vrot[3]=(float) 1.0 * y.X();
-    vrot[4]=(float) 1.0 * y.Y();
-    vrot[5]=(float) 1.0 * y.Z();
-    vrot[6]=(float) 1.0 * z.X();
-    vrot[7]=(float) 1.0 * z.Y();
-    vrot[8]=(float) 1.0 * z.Z();
+    const std::vector<double> vtra = {tran.x(), tran.y(), tran.z()};
+    const std::vector<double> vrot = {x.X(), x.Y(), x.Z(),
+                                      y.X(), y.Y(), y.Z(),
+                                      z.X(), z.Y(), z.Z()};
     rgeo.insert(rpcid.rawId(),vtra,vrot, pars,strpars);
-    doSubDets = fview.nextSibling(); // go to next layer
   }
-  
+
 }


### PR DESCRIPTION
The surface object from RPCChamber was not correspond to the whole chamber, it was the copy from one of the rolls associated to the chamber.

This PR modifies the RPCGeometryBuilderFromCondDB and RPCGeometryBuilderFromDDD ESProducers to construct surface which can contain all rolls in the chamber thus one can properly do the global<->local coordinate transformation from the chamber and bounding checks as well.
