### PR TITLE
HGCal "EM Scale" Calibrations

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
@@ -24,6 +24,7 @@ class HGCalRecHitAbsAlgo
   virtual ~HGCalRecHitAbsAlgo() { };
 
   /// make rechits from dataframes
+  virtual void setLayerWeights(const std::vector<float>& weights) {};
 
   virtual void setADCToGeVConstant(const float value) = 0;
   virtual HGCRecHit makeRecHit(const HGCUncalibratedRecHit& uncalibRH, const uint32_t &flags) const = 0;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -46,7 +46,7 @@ class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
     HGCalDetId hid(uncalibRH.id());
 
     //    float clockToNsConstant = 25;
-    float energy = uncalibRH.amplitude() * weights_[hid.layer()] * 1.0f-3;
+    float energy = uncalibRH.amplitude() * weights_[hid.layer()] * 0.001f;
     float time   = uncalibRH.jitter();
 
     //if(time<0) time   = 0; // fast-track digi conversion

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -10,6 +10,7 @@
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h"
 #include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include <iostream>
 
 class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
@@ -18,6 +19,10 @@ class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
   HGCalRecHitSimpleAlgo() {
     adcToGeVConstant_ = -1;
     adcToGeVConstantIsSet_ = false;
+  }
+
+  virtual void setLayerWeights(const std::vector<float>& weights) override {
+    weights_ = weights;
   }
   
   virtual void setADCToGeVConstant(const float value) override {
@@ -38,8 +43,10 @@ class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
         << "makeRecHit: adcToGeVConstant_ not set before calling this method!";
     }
     
+    HGCalDetId hid(uncalibRH.id());
+
     //    float clockToNsConstant = 25;
-    float energy = uncalibRH.amplitude() * adcToGeVConstant_;
+    float energy = uncalibRH.amplitude() * weights_[hid.layer()] * 1.0f-3;
     float time   = uncalibRH.jitter();
 
     //if(time<0) time   = 0; // fast-track digi conversion
@@ -56,5 +63,6 @@ class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
 private:
   float adcToGeVConstant_;
   bool  adcToGeVConstantIsSet_;
+  std::vector<float> weights_;
 };
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -28,11 +28,19 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
   HGCHEB_isSiFE_     =  ps.getParameter<bool>("HGCHEB_isSiFE");
   hgchebUncalib2GeV_ = keV2GeV/HGCHEB_keV2DIGI_;
 
-  // layer weights
+  // layer weights (from Valeri/Arabella)
   std::vector<float> weights;
   const auto& dweights = ps.getParameter<std::vector<double> >("layerWeights");
   for( auto weight : dweights ) {
     weights.push_back(weight);
+  }
+
+  // residual correction for cell thickness
+  const auto& rcorr = ps.getParameter<std::vector<double> >("layerCorrection");
+  rcorr_.clear();
+  rcorr_.push_back(1.f);
+  for( auto corr : rcorr ) {
+    rcorr_.push_back(1.0/corr);
   }
   
 }
@@ -62,16 +70,16 @@ HGCalRecHitWorkerSimple::run( const edm::Event & evt,
                               HGCRecHitCollection & result ) {
   DetId detid=uncalibRH.id();  
   uint32_t recoFlag = 0;
-  const std::vector<double>* fCPerMIP = nullptr;
+  //const std::vector<double>* fCPerMIP = nullptr;
     
   switch( detid.subdetId() ) {
   case HGCEE:
     rechitMaker_->setADCToGeVConstant(float(hgceeUncalib2GeV_) );
-    fCPerMIP = &HGCEE_fCPerMIP_;
+    //fCPerMIP = &HGCEE_fCPerMIP_;
     break;
   case HGCHEF:
     rechitMaker_->setADCToGeVConstant(float(hgchefUncalib2GeV_) );
-    fCPerMIP = &HGCHEF_fCPerMIP_;
+    //fCPerMIP = &HGCHEF_fCPerMIP_;
     break;
   case HGCHEB:
     rechitMaker_->setADCToGeVConstant(float(hgchebUncalib2GeV_) );
@@ -85,13 +93,11 @@ HGCalRecHitWorkerSimple::run( const edm::Event & evt,
   if (recoFlag == 0) {    
     HGCRecHit myrechit( rechitMaker_->makeRecHit(uncalibRH, 0) );    
     HGCalDetId hid(detid);
-    if( fCPerMIP != nullptr ) {
-      //const int thk = ddds_[hid.subdetId()-3]->waferTypeL(hid.wafer());
-      // units out of rechit maker are MIP * (GeV/fC)
-      // so multiple
-      const double new_E = myrechit.energy();//*(*fCPerMIP)[thk-1];
-      myrechit.setEnergy(new_E);
-    }    
+    const int thk = ddds_[hid.subdetId()-3]->waferTypeL(hid.wafer());
+    // units out of rechit maker are MIP * (GeV/fC)
+    // so multiple
+    const double new_E = myrechit.energy()*rcorr_[thk];
+    myrechit.setEnergy(new_E);
     result.push_back(myrechit);
   }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -27,6 +27,14 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
   HGCHEB_keV2DIGI_   =  ps.getParameter<double>("HGCHEB_keV2DIGI");
   HGCHEB_isSiFE_     =  ps.getParameter<bool>("HGCHEB_isSiFE");
   hgchebUncalib2GeV_ = keV2GeV/HGCHEB_keV2DIGI_;
+
+  // layer weights
+  std::vector<float> weights;
+  const auto& dweights = ps.getParameter<std::vector<double> >("layerWeights");
+  for( auto weight : dweights ) {
+    weights.push_back(weight);
+  }
+  
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
@@ -78,10 +86,10 @@ HGCalRecHitWorkerSimple::run( const edm::Event & evt,
     HGCRecHit myrechit( rechitMaker_->makeRecHit(uncalibRH, 0) );    
     HGCalDetId hid(detid);
     if( fCPerMIP != nullptr ) {
-      const int thk = ddds_[hid.subdetId()-3]->waferTypeL(hid.wafer());
+      //const int thk = ddds_[hid.subdetId()-3]->waferTypeL(hid.wafer());
       // units out of rechit maker are MIP * (GeV/fC)
       // so multiple
-      const double new_E = myrechit.energy()*(*fCPerMIP)[thk-1];
+      const double new_E = myrechit.energy();//*(*fCPerMIP)[thk-1];
       myrechit.setEnergy(new_E);
     }    
     result.push_back(myrechit);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -34,9 +34,10 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
   for( auto weight : dweights ) {
     weights.push_back(weight);
   }
+  rechitMaker_->setLayerWeights(weights);
 
   // residual correction for cell thickness
-  const auto& rcorr = ps.getParameter<std::vector<double> >("layerCorrection");
+  const auto& rcorr = ps.getParameter<std::vector<double> >("thicknessCorrection");
   rcorr_.clear();
   rcorr_.push_back(1.f);
   for( auto corr : rcorr ) {

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -38,6 +38,8 @@ class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
   
   std::vector<int> v_DB_reco_flags_;
   bool killDeadChannels_;
+
+  std::vector<float> rcorr_;
   
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;
 };

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -3,6 +3,60 @@ import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import *
 
+dEdX_weights = cms.vdouble(0.0,   # there is no layer zero
+                           8.603, # Mev
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.0675, 
+                           8.9515, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           10.135, 
+                           11.682, 
+                           13.654, 
+                           13.654, 
+                           13.654, 
+                           13.654, 
+                           13.654, 
+                           13.654, 
+                           13.654, 
+                           38.2005, 
+                           55.0265, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           49.871, 
+                           62.005, 
+                           83.1675, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           92.196, 
+                           46.098)
+
 # HGCAL rechit producer
 HGCalRecHit = cms.EDProducer(
     "HGCalRecHitProducer",
@@ -22,6 +76,10 @@ HGCalRecHit = cms.EDProducer(
     HGCHEF_fCPerMIP = HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP,
     HGCHEB_keV2DIGI = hgchebackDigitizer.digiCfg.keV2MIP,
     HGCHEB_isSiFE   = HGCalUncalibRecHit.HGCHEBConfig.isSiFE,
+
+    # EM Scale calibrations
+    layerWeights = dEdX_weights,
+    EM_scale_corr   = cms.vdouble(0.964,0.920,0.909), # 100, 200, 300 um
     
     # algo
     algo = cms.string("HGCalRecHitWorkerSimple")

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -79,7 +79,7 @@ HGCalRecHit = cms.EDProducer(
 
     # EM Scale calibrations
     layerWeights = dEdX_weights,
-    EM_scale_corr   = cms.vdouble(0.964,0.920,0.909), # 100, 200, 300 um
+    thicknessCorrection = cms.vdouble(0.964,0.920,0.909), # 100, 200, 300 um
     
     # algo
     algo = cms.string("HGCalRecHitWorkerSimple")


### PR DESCRIPTION
Change RecHit producer to generate hits that are calibrated (roughly) to the electromagnetic shower scale to produce some "human readable" rec hit energies and to provide an estimate of cluster energies during cluster building.
