### PR TITLE
retuning of top Summary plot

### DIFF
--- a/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
+++ b/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
@@ -199,7 +199,7 @@
      <PARAM name="error">0.75</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
      <PARAM name="ymin">3.5</PARAM> 
-     <PARAM name="ymax">6.0</PARAM> 
+     <PARAM name="ymax">8.0</PARAM> 
 </QTEST>
 <!-- nclusters in PixelEndcap: -->
 <QTEST name="Yrange:Endcap:nclusters" activate="true"> 


### PR DESCRIPTION
Adapting the Quality test limit on FPix number of digis to the actual level of PU (see #14883)  
