### PR TITLE
Add run numbers to DQM output

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -5,6 +5,7 @@ from CondTools.DQM.DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi import *
 from DQMServices.Components.DQMMessageLoggerClient_cff import *
 from DQMServices.Components.DQMDcsInfoClient_cfi import *
 from DQMServices.Components.DQMFastTimerServiceClient_cfi import *
+from DQMServices.Components.RunInfoAdder_cfi import *
 
 from DQMOffline.Ecal.ecal_dqm_client_offline_cff import *
 from DQM.SiStripMonitorClient.SiStripClientConfig_Tier0_cff import *
@@ -29,7 +30,8 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                              es_dqm_client_offline *
 											 hcalOfflineHarvesting *
                                              HcalDQMOfflinePostProcessor * 
-                                             dqmFEDIntegrityClient )
+                                             dqmFEDIntegrityClient *
+                                             RunInfoAdder)
 
 DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PreDPG *
@@ -96,7 +98,8 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  dqmFEDIntegrityClient *
                                  alcaBeamMonitorClient *
                                  runTauEff *
-                                 dqmFastTimerServiceClient
+                                 dqmFastTimerServiceClient *
+                                 RunInfoAdder
                                 )
 DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                DQMMessageLoggerClientSeq *

--- a/DQMServices/Components/plugins/RunInfoAdder.cc
+++ b/DQMServices/Components/plugins/RunInfoAdder.cc
@@ -1,14 +1,11 @@
 #include "DQMServices/Components/plugins/RunInfoAdder.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include <iostream>
-#include <iomanip>
-#include <stdio.h>
 #include <string>
 #include <sstream>
-#include <math.h>
 
 RunInfoAdder::RunInfoAdder(const edm::ParameterSet& ps)
 {
@@ -17,6 +14,8 @@ RunInfoAdder::RunInfoAdder(const edm::ParameterSet& ps)
   addRunNumber_  =  ps.getParameter<bool>("addRunNumber");
   addLumi_       =  ps.getParameter<bool>("addLumi");
   folder_        =  ps.getParameter<std::vector<std::string>>("folder");
+
+  run_ = 0;
 
   edm::LogInfo("RunInfoAdder") <<  "Constructor RunInfoAdder addRunNumber_ " 
       << addRunNumber_ << " addLumi_ " << addLumi_ << std::endl;
@@ -54,10 +53,11 @@ void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& ige
         std::stringstream newtitle;
         newtitle << title;
         if (addRunNumber_) {
-          // we use data from the ME, we could also track it in endlumi.
-          newtitle << " (Run " << me->run();
+          // we use data from endLumi, value in ME seems broken.
+          newtitle << " (Run " << run_;
         }
         if (addLumi_) {
+          // does this work? Not sure.
           newtitle << " Lumi " << me->lumi();
         }
         newtitle << ")";
@@ -69,6 +69,9 @@ void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& ige
 
 void RunInfoAdder::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker_, DQMStore::IGetter & igetter_, edm::LuminosityBlock const & iLumi, edm::EventSetup const& iSetup) 
 {
+  // Disable in multi-run case (maybe use ME value then?)
+  if (run_ != 0 && iLumi.run() != run_) addRunNumber_ = false; 
+  run_ = iLumi.run();
   // TODO: See what we can do here in terms of harvesting.
 }
 

--- a/DQMServices/Components/plugins/RunInfoAdder.cc
+++ b/DQMServices/Components/plugins/RunInfoAdder.cc
@@ -1,0 +1,64 @@
+#include "DQMServices/Components/plugins/RunInfoAdder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <math.h>
+
+RunInfoAdder::RunInfoAdder(const edm::ParameterSet& ps)
+{
+
+  // Get parameters from configuration file
+  addRunNumber_  =  ps.getParameter<bool>("addRunNumber");
+  addLumi_       =  ps.getParameter<bool>("addLumi");
+  folder_        =  ps.getParameter<std::string>("folder");
+
+  edm::LogInfo("RunInfoAdder") <<  "Constructor RunInfoAdder addRunNumber_ " 
+      << addRunNumber_ << " addLumi_ " << addLumi_ << std::endl;
+}
+
+RunInfoAdder::~RunInfoAdder() {};
+
+void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_)
+{
+  // TODO: add recursive search here.
+  std::vector<MonitorElement*> mes = igetter_.getContents(folder_);
+  for (auto me : mes) {
+    // This is what the ME uses to check for a root thing...
+    if (me->kind() < MonitorElement::DQM_KIND_TH1F) continue;
+    TH1* th1 = me->getTH1();
+    if (!th1) {
+      edm::LogError("RunInfoAdder") << "Not a TH1: " << me->getFullname() << std::endl;
+      continue;
+    }
+
+    std::string title(th1->GetTitle());
+    if (title.find("(Run") == std::string::npos) {
+      std::stringstream newtitle;
+      newtitle << title;
+      if (addRunNumber_) {
+        // we use data from the ME, we could also track it in endlumi.
+        newtitle << " (Run " << me->run();
+      }
+      if (addLumi_) {
+        newtitle << " Lumi " << me->lumi();
+      }
+      newtitle << ")";
+      th1->SetTitle(newtitle.str().c_str());
+    }
+  }
+}
+
+void RunInfoAdder::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker_, DQMStore::IGetter & igetter_, edm::LuminosityBlock const & iLumi, edm::EventSetup const& iSetup) 
+{
+  // TODO: See what we can do here in terms of harvesting.
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(RunInfoAdder);

--- a/DQMServices/Components/plugins/RunInfoAdder.cc
+++ b/DQMServices/Components/plugins/RunInfoAdder.cc
@@ -16,7 +16,7 @@ RunInfoAdder::RunInfoAdder(const edm::ParameterSet& ps)
   // Get parameters from configuration file
   addRunNumber_  =  ps.getParameter<bool>("addRunNumber");
   addLumi_       =  ps.getParameter<bool>("addLumi");
-  folder_        =  ps.getParameter<std::string>("folder");
+  folder_        =  ps.getParameter<std::vector<std::string>>("folder");
 
   edm::LogInfo("RunInfoAdder") <<  "Constructor RunInfoAdder addRunNumber_ " 
       << addRunNumber_ << " addLumi_ " << addLumi_ << std::endl;
@@ -31,8 +31,11 @@ void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& ige
   igetter_.getContents(dirs, false);
   for (auto& d : dirs) {
 
-    // limit to folder
-    if (d.substr(0, folder_.size()) != folder_) continue;
+    // limit to given folders
+    bool apply = false;
+    for (auto& f : folder_)
+      if (d.substr(0, f.size()) == f) apply = true;
+    if (!apply) continue;
 
     auto dir = d.substr(0, d.size() - 1); // getContents appends a ':'.
     std::vector<MonitorElement*> mes = igetter_.getContents(dir);

--- a/DQMServices/Components/plugins/RunInfoAdder.cc
+++ b/DQMServices/Components/plugins/RunInfoAdder.cc
@@ -25,7 +25,6 @@ RunInfoAdder::~RunInfoAdder() {};
 
 void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_)
 {
-  // TODO: add recursive search here.
   std::vector<std::string> dirs;
   igetter_.getContents(dirs, false);
   for (auto& d : dirs) {
@@ -49,6 +48,7 @@ void RunInfoAdder::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& ige
       }
 
       std::string title(th1->GetTitle());
+      // Check to prevent double adding. This _should_ not be needed.
       if (title.find("(Run") == std::string::npos) {
         std::stringstream newtitle;
         newtitle << title;
@@ -73,6 +73,7 @@ void RunInfoAdder::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker_, DQMStore:
   if (run_ != 0 && iLumi.run() != run_) addRunNumber_ = false; 
   run_ = iLumi.run();
   // TODO: See what we can do here in terms of harvesting.
+  // Maybe call dqmEndJob to do the work when we do online harvesting.
 }
 
 // Define this as a plug-in

--- a/DQMServices/Components/plugins/RunInfoAdder.h
+++ b/DQMServices/Components/plugins/RunInfoAdder.h
@@ -30,6 +30,10 @@ private:
   bool addLumi_;
   std::vector<std::string> folder_;
 
+
+  // information to add, has to be saved from endLumi
+  uint32_t run_;
+
 };
 
 

--- a/DQMServices/Components/plugins/RunInfoAdder.h
+++ b/DQMServices/Components/plugins/RunInfoAdder.h
@@ -28,7 +28,7 @@ private:
   //variables from config file
   bool addRunNumber_;
   bool addLumi_;
-  std::string folder_;
+  std::vector<std::string> folder_;
 
 };
 

--- a/DQMServices/Components/plugins/RunInfoAdder.h
+++ b/DQMServices/Components/plugins/RunInfoAdder.h
@@ -1,0 +1,36 @@
+#ifndef RunInfoAdder_H
+#define RunInfoAdder_H
+
+//Framework
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+ 
+class RunInfoAdder : public DQMEDHarvester{
+
+public:
+
+  RunInfoAdder(const edm::ParameterSet& ps);
+  virtual ~RunInfoAdder();
+  
+protected:
+
+  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
+
+private:
+
+  //variables from config file
+  bool addRunNumber_;
+  bool addLumi_;
+  std::string folder_;
+
+};
+
+
+#endif

--- a/DQMServices/Components/plugins/RunInfoAdder.h
+++ b/DQMServices/Components/plugins/RunInfoAdder.h
@@ -1,12 +1,21 @@
 #ifndef RunInfoAdder_H
 #define RunInfoAdder_H
 
-//Framework
+/** \class RunInfoAdder
+ *
+ * A Harvester plugin that adds information about the run (mainly the run
+ * number) to every histogram, to prevent losing or confusing this information
+ * when histograms are handled as graphics files.
+ *
+ *  \author Marcel Schneider (marcel.andre.schneider@cern.ch)
+ */
+
+// Framework
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-//DQM
+// DQM
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -14,27 +23,21 @@
 class RunInfoAdder : public DQMEDHarvester{
 
 public:
-
   RunInfoAdder(const edm::ParameterSet& ps);
   virtual ~RunInfoAdder();
   
 protected:
-
-  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
-  virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
+  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;
+  virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
 private:
-
   //variables from config file
   bool addRunNumber_;
   bool addLumi_;
   std::vector<std::string> folder_;
 
-
   // information to add, has to be saved from endLumi
   uint32_t run_;
-
 };
-
 
 #endif

--- a/DQMServices/Components/python/RunInfoAdder_cfi.py
+++ b/DQMServices/Components/python/RunInfoAdder_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 RunInfoAdder = cms.EDAnalyzer("RunInfoAdder",
     addRunNumber = cms.bool(True),
-    addLumi = cms.bool(True),
-    folder = cms.string("PixelPhase1/")
+    addLumi = cms.bool(False),
+    # apply only to these folders. Add "" for all.
+    folder = cms.vstring("Pixel", "SiStrip", "Tracking")
 )

--- a/DQMServices/Components/python/RunInfoAdder_cfi.py
+++ b/DQMServices/Components/python/RunInfoAdder_cfi.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 RunInfoAdder = cms.EDAnalyzer("RunInfoAdder",
     addRunNumber = cms.bool(True),
     addLumi = cms.bool(True),
-    folder = cms.string("PixelPhase1/PXBarrel")
+    folder = cms.string("PixelPhase1/")
 )

--- a/DQMServices/Components/python/RunInfoAdder_cfi.py
+++ b/DQMServices/Components/python/RunInfoAdder_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+RunInfoAdder = cms.EDAnalyzer("RunInfoAdder",
+    addRunNumber = cms.bool(True),
+    addLumi = cms.bool(True),
+    folder = cms.string("PixelPhase1/PXBarrel")
+)

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -519,7 +519,7 @@ class DQMStore
   std::vector<MonitorElement *> get(unsigned int tag) const;
   std::vector<MonitorElement *> getContents(const std::string &path) const;
   std::vector<MonitorElement *> getContents(const std::string &path, unsigned int tag) const;
-  void                          getContents(std::vector<std::string> &into, bool showContents = true) const;
+  std::vector<MonitorElement *> getContents(std::vector<std::string> &into, bool showContents = true) const;
 
   // ---------------------- softReset methods -------------------------------
   void                          softReset(MonitorElement *me);

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1849,7 +1849,8 @@ DQMStore::getContents(const std::string &path, unsigned int tag) const
 /// return vector<string> of the form <dir pathname>:<obj1>,<obj2>,<obj3>;
 /// if showContents = false, change form to <dir pathname>:
 /// (useful for subscription requests; meant to imply "all contents")
-void
+/// return value is unused, needed to be compatible with IGetter interface
+std::vector<MonitorElement *>
 DQMStore::getContents(std::vector<std::string> &into, bool showContents /* = true */) const
 {
   into.clear();
@@ -1903,6 +1904,7 @@ DQMStore::getContents(std::vector<std::string> &into, bool showContents /* = tru
       *istr += ':';
     }
   }
+  return std::vector<MonitorElement *>(); // unused
 }
 
 /// get MonitorElement <name> in directory <dir>


### PR DESCRIPTION
This is an attempt to fix the long-standing issue of mislabeled DQM plots on meeting slides. (Once discussion here settles, this should also be backported to 80X.) 

The solution is to simply put the run number onto the plot itself. However this is not that easy in the obvious place (the DQM GUI) since the rendering is not aware of runs and such. So, I tried a simple solution here: just add it to the histogram title in an additional harvesting step.

At the moment this is only applied to tracker-related plots, but we might want to turn it on for everything. (Nothing obviously breaks from changing all histogram titles, but probably something will.)

Implemetation issues are that the run number in the ME seems to be 0 in the relevant places (is this only used for step1 or multi-run harvesting or something?) and that dqmEndJob does not know the run, with the usual fix of storing the value in endLumi. Another is that this plugin should run once at the very end of the harvesting sequence, which I don't see how to do. The current solution works but is not optimal.

The change to the `DQMStore` is needed to access the `getContents` method via the `IGetter`, which I would call a bug fix. My solution is moderately elegant, others are possible but not much better.
