### PR TITLE
Implement trigger matching for stage-2 L1 trigger in MuonAssociators

### DIFF
--- a/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
+++ b/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
@@ -179,6 +179,8 @@ class L1MuonMatcherAlgo {
     private:
         PropagateToMuon prop_;
 
+	bool useStage2L1_;
+
         typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
         /// Preselection cut to apply to L1 candidates before matching
         L1Selector preselectionCutL1_;

--- a/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
+++ b/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
@@ -181,13 +181,9 @@ class L1MuonMatcherAlgo {
 
 	bool useStage2L1_;
 
-        typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
+        typedef StringCutObjectSelector<reco::Candidate,true> L1Selector;
         /// Preselection cut to apply to L1 candidates before matching
-        L1Selector preselectionCutL1_;
-
-        typedef StringCutObjectSelector<l1t::Muon> L1TSelector;
-        /// Preselection cut to apply to L1 candidates before matching
-        L1TSelector preselectionCutL1T_;
+        L1Selector preselectionCut_;
 
         /// Matching cuts
         double deltaR2_, deltaPhi_, deltaEta_;

--- a/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
+++ b/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
@@ -18,6 +18,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
@@ -70,10 +71,13 @@ class L1MuonMatcherAlgo {
             return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
         }
 
-
         /// Try to match one track to one L1. Return true if succeeded (and update deltaR, deltaPhi accordingly)
         /// The preselection cut on L1, if specified in the config, is applied before the match
         bool match(TrajectoryStateOnSurface & propagated, const l1extra::L1MuonParticle &l1, float &deltaR, float &deltaPhi) const ;
+
+
+
+	// Methods to match with vectors of legacy L1 muon trigger objects
 
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
         /// Returns -1 if the match fails
@@ -99,12 +103,48 @@ class L1MuonMatcherAlgo {
             return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
         }
 
-
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi accordingly)
         /// Returns -1 if the match fails
         /// The preselection cut on L1, if specified in the config, is applied before the match
         int match(TrajectoryStateOnSurface &propagated, const std::vector<l1extra::L1MuonParticle> &l1, float &deltaR, float &deltaPhi) const ;
 
+
+
+
+	// Methods to match with vectors of stage2 L1 muon trigger objects
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage2 L1, if specified in the config, is applied before the match
+        int match(const reco::Track &tk, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(tk);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage2 L1, if specified in the config, is applied before the match
+        int match(const reco::Candidate &c, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(c);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage 2 L1, if specified in the config, is applied before the match
+        int match(const SimTrack &tk, const edm::SimVertexContainer &vtxs, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(tk, vtxs);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage 2 L1, and return its index in the vector (and update deltaR, deltaPhi accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage 2 L1, if specified in the config, is applied before the match
+        int match(TrajectoryStateOnSurface &propagated, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi) const ;
+
+
+
+	// Generic matching
 
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
         /// Returns -1 if the match fails
@@ -133,7 +173,6 @@ class L1MuonMatcherAlgo {
         template<typename Collection, typename Selector>
         int matchGeneric(TrajectoryStateOnSurface &propagated, const Collection &l1, const Selector &sel, float &deltaR, float &deltaPhi) const ;
 
-
         /// Add this offset to the L1 phi before doing the match, to correct for different scales in L1 vs offline
         void setL1PhiOffset(double l1PhiOffset) { l1PhiOffset_ = l1PhiOffset; }
 
@@ -142,7 +181,11 @@ class L1MuonMatcherAlgo {
 
         typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
         /// Preselection cut to apply to L1 candidates before matching
-        L1Selector preselectionCut_;
+        L1Selector preselectionCutL1_;
+
+        typedef StringCutObjectSelector<l1t::Muon> L1TSelector;
+        /// Preselection cut to apply to L1 candidates before matching
+        L1TSelector preselectionCutL1T_;
 
         /// Matching cuts
         double deltaR2_, deltaPhi_, deltaEta_;
@@ -153,6 +196,7 @@ class L1MuonMatcherAlgo {
 
         /// offset to be added to the L1 phi before the match
         double l1PhiOffset_;
+
 };
 
 template<typename Collection, typename Selector>

--- a/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
+++ b/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
@@ -70,6 +70,8 @@ class PropagateToMuon {
         /// for cosmics, some things change: the along-opposite is not in-out, nor the innermost/outermost states are in-out really
         bool cosmicPropagation_;
 
+	bool useMB2InOverlap_;
+
         // needed services for track propagation
         edm::ESHandle<MagneticField> magfield_;
         edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -132,7 +132,6 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	for (int ibx = l1tBX->getFirstBX(); ibx <= l1tBX->getLastBX(); ++ibx)
 	  {
 	    bxIdxs.push_back(l1tBX->end(ibx) - l1tBX->begin());
-	    std::cout << (l1tBX->end(ibx) - l1tBX->begin()) << " " << ibx << std::endl; 
 	  }
       }
     else
@@ -195,7 +194,6 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	      bx[i] = l1tBX->getFirstBX() + (std::upper_bound(bxIdxs.begin(),bxIdxs.end(), minBxIdx + match) - bxIdxs.begin()); 
 	      isolated[i] = l1t.hwIso();
 	      l1rawMatches[i] = edm::Ptr<reco::Candidate>(l1tBX, size_t(minBxIdx + match));
-	      std::cout << "Filling match: " << match << " BX : " << bx[i] << " " << (minBxIdx + match) << std::endl;
 	    }
 	    else {
 	      const L1MuGMTCand & gmt = (*l1s)[match].gmtMuonCand();
@@ -216,8 +214,6 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     propFiller.fill();
     iEvent.put(propAss, "propagatedReco");
 
-    std::cout << "pippo" << std::endl;
-
     auto_ptr<PATTriggerAssociation> fullAss(new PATTriggerAssociation(  l1Done));
     PATTriggerAssociation::Filler fullFiller(*fullAss);
     fullFiller.insert(reco, fullMatches.begin(), fullMatches.end());
@@ -236,8 +232,6 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	else
 	  storeExtraInfo(iEvent, l1s,  whichRecoMatch, "l1ToReco");
     }
-
-    std::cout << "pluto" << std::endl;
 
 }
 

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -117,7 +117,7 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     
     iEvent.getByToken(recoToken_, reco);
 
-    if (Usestage2l1_) {
+    if (useStage2L1_) {
       iEvent.getByToken(l1tToken_, l1tBX);
       l1size = l1tBX->size();
 	

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -48,13 +48,21 @@ namespace pat {
       /// Tokens for input collections
       edm::EDGetTokenT<edm::View<reco::Candidate> > recoToken_;
       edm::EDGetTokenT<std::vector<l1extra::L1MuonParticle> > l1Token_;
-
+      edm::EDGetTokenT<l1t::MuonBxCollection> l1tToken_;
+    
       /// Labels to set as filter names in the output
       std::string labelL1_, labelProp_;
 
       /// Write out additional info as ValueMaps
       bool writeExtraInfo_;
 
+      /// Allow to run both on legacy or stage2 (2016) L1 Muon trigger output
+      bool useStage2L1_;
+
+      /// Skim stage2 BX vector
+      int firstBX_;
+      int lastBX_;
+    
       /// Store extra information in a ValueMap
       template<typename Hand, typename T>
       void storeExtraInfo(edm::Event &iEvent,
@@ -69,9 +77,13 @@ pat::L1MuonMatcher::L1MuonMatcher(const edm::ParameterSet & iConfig) :
     matcher_(iConfig),
     recoToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
     l1Token_(consumes<std::vector<l1extra::L1MuonParticle> >(iConfig.getParameter<edm::InputTag>("matched"))),
-    labelL1_(iConfig.getParameter<std::string>(  "setL1Label")),
+    l1tToken_(consumes<l1t::MuonBxCollection>(iConfig.getParameter<edm::InputTag>("matched"))),
+    labelL1_(iConfig.getParameter<std::string>("setL1Label")),
     labelProp_(iConfig.getParameter<std::string>("setPropLabel")),
-    writeExtraInfo_(iConfig.getParameter<bool>("writeExtraInfo"))
+    writeExtraInfo_(iConfig.getParameter<bool>("writeExtraInfo")),
+    useStage2L1_(iConfig.getParameter<bool>("useStage2L1")),
+    firstBX_(iConfig.getParameter<int>("firstBX")),
+    lastBX_(iConfig.getParameter<int>("lastBX"))
 {
     produces<PATPrimitiveCollection>("l1muons");        // l1 in PAT format
     produces<PATPrimitiveCollection>("propagatedReco"); // reco to muon station 2
@@ -95,15 +107,40 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 
     Handle<View<reco::Candidate> > reco;
     Handle<vector<l1extra::L1MuonParticle> > l1s;
+    Handle<l1t::MuonBxCollection> l1tBX;
+  
+    std::vector<l1t::Muon> l1ts;
+    std::map<size_t,int> bxMap;
 
+    
     iEvent.getByToken(recoToken_, reco);
-    iEvent.getByToken(l1Token_, l1s);
+
+    size_t l1size = 0;
+    if (useStage2L1_)
+      {
+	iEvent.getByToken(l1tToken_, l1tBX);
+	
+	int minBX = max(firstBX_,l1tBX->getFirstBX());
+	int maxBX = min(lastBX_,l1tBX->getLastBX());
+	std::copy(l1tBX->begin(minBX), l1tBX->end(maxBX), std::back_inserter(l1ts));
+	for (int ibx = minBX; ibx <= maxBX; ++ibx)
+	  {
+	    std::vector<l1t::Muon>::const_iterator bxBegin  = l1tBX->begin(ibx);
+	    bxMap[l1tBX->key(bxBegin)] = ibx;
+	    l1size = l1ts.size();
+	  }
+      }
+    else
+      {
+	iEvent.getByToken(l1Token_, l1s);
+	l1size = l1s->size();
+      }
 
     auto_ptr<PATPrimitiveCollection> propOut(new PATPrimitiveCollection());
     auto_ptr<PATPrimitiveCollection> l1Out(new PATPrimitiveCollection());
     std::vector<edm::Ptr<reco::Candidate> > l1rawMatches(reco->size());
-    vector<int>   isSelected(l1s->size(), -1);
-    std::vector<edm::Ptr<reco::Candidate> > whichRecoMatch(l1s->size());
+    vector<int>   isSelected(l1size, -1);
+    std::vector<edm::Ptr<reco::Candidate> > whichRecoMatch(l1size);
     vector<int>   propMatches(reco->size(), -1);
     vector<int>   fullMatches(reco->size(), -1);
     vector<float> deltaRs(reco->size(), 999), deltaPhis(reco->size(), 999);
@@ -111,7 +148,9 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     for (int i = 0, n = reco->size(); i < n; ++i) {
         TrajectoryStateOnSurface propagated;
         const reco::Candidate &mu = (*reco)[i];
-        int match = matcher_.match(mu, *l1s, deltaRs[i], deltaPhis[i], propagated);
+        int match = useStage2L1_ ? 
+	  matcher_.match(mu, l1ts, deltaRs[i], deltaPhis[i], propagated) :
+	  matcher_.match(mu, *l1s, deltaRs[i], deltaPhis[i], propagated);
         if (propagated.isValid()) {
             GlobalPoint pos = propagated.globalPosition();
             propMatches[i] = propOut->size();
@@ -120,21 +159,45 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
             propOut->back().setCharge(mu.charge());
         }
         if (match != -1) {
-            const l1extra::L1MuonParticle & l1 = (*l1s)[match];
             whichRecoMatch[match] = reco->ptrAt(i);
+  	 
+	    int charge = 0;
+	    math::PtEtaPhiMLorentzVector p4;
+	    
+	    if (useStage2L1_) {
+	      const l1t::Muon & l1t = l1ts[match];
+	      charge = l1t.charge();
+	      p4     = l1t.polarP4();
+	    }
+	    else {
+	      const l1extra::L1MuonParticle & l1 = (*l1s)[match];
+	      charge = l1.charge();
+	      p4     = l1.polarP4();
+	    }
+	    
             if (isSelected[match] == -1) { // copy to output if needed
                 isSelected[match] = l1Out->size();
-                l1Out->push_back(PATPrimitive(l1.polarP4()));
+                l1Out->push_back(PATPrimitive(p4));
                 l1Out->back().addFilterLabel(labelL1_);
-                l1Out->back().setCharge(l1.charge());
+                l1Out->back().setCharge(charge);
             }
             fullMatches[i] = isSelected[match]; // index in the output collection
-            const L1MuGMTCand & gmt = l1.gmtMuonCand();
-            quality[i]  = gmt.quality();
-            bx[i]       = gmt.bx();
-            isolated[i] = gmt.isol();
-            l1rawMatches[i] = edm::Ptr<reco::Candidate>(l1s, size_t(match));
-        }
+	    
+	    if (useStage2L1_) {
+	      const l1t::Muon & l1t = l1ts[match];
+	      quality[i]  = l1t.hwQual();
+	      bx[i] = bxMap.upper_bound(i)->second; 
+	      isolated[i] = l1t.hwIso();
+	      l1rawMatches[i] = edm::Ptr<reco::Candidate>(l1tBX, size_t(bxMap.upper_bound(i)->first + match));
+	    }
+	    else {
+	      const L1MuGMTCand & gmt = (*l1s)[match].gmtMuonCand();
+	      quality[i]  = gmt.quality();
+	      bx[i]       = gmt.bx();
+	      isolated[i] = gmt.isol();
+	      l1rawMatches[i] = edm::Ptr<reco::Candidate>(l1s, size_t(match));
+	    }
+	}
     }
 
     OrphanHandle<PATPrimitiveCollection> l1Done = iEvent.put(l1Out, "l1muons");

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -117,28 +117,23 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     
     iEvent.getByToken(recoToken_, reco);
 
-    if (useStage2L1_)
-      {
-	iEvent.getByToken(l1tToken_, l1tBX);
-	l1size = l1tBX->size();
+    if (Usestage2l1_) {
+      iEvent.getByToken(l1tToken_, l1tBX);
+      l1size = l1tBX->size();
 	
-	int minBX = max(firstBX_,l1tBX->getFirstBX());
-	int maxBX = min(lastBX_,l1tBX->getLastBX());
+      int minBX = max(firstBX_,l1tBX->getFirstBX());
+      int maxBX = min(lastBX_,l1tBX->getLastBX());
 
-	minBxIdx = l1tBX->begin(minBX) - l1tBX->begin();
-	std::copy(l1tBX->begin(minBX), l1tBX->end(maxBX), std::back_inserter(l1ts));
+      minBxIdx = l1tBX->begin(minBX) - l1tBX->begin();
+      std::copy(l1tBX->begin(minBX), l1tBX->end(maxBX), std::back_inserter(l1ts));
 
-	for (int ibx = l1tBX->getFirstBX(); ibx <= l1tBX->getLastBX(); ++ibx)
-	  {
-	    bxIdxs.push_back(l1tBX->end(ibx) - l1tBX->begin());
-	    //std::cout << "BX transitions" << ibx << " " << l1tBX->end(ibx) - l1tBX->begin() << std::endl;
-	  }
-      }
-    else
-      {
-	iEvent.getByToken(l1Token_, l1s);
-	l1size = l1s->size();
-      }
+      for (int ibx = l1tBX->getFirstBX(); ibx <= l1tBX->getLastBX(); ++ibx)
+	bxIdxs.push_back(l1tBX->end(ibx) - l1tBX->begin());
+    }
+    else {
+      iEvent.getByToken(l1Token_, l1s);
+      l1size = l1s->size();
+    }
 
     auto_ptr<PATPrimitiveCollection> propOut(new PATPrimitiveCollection());
     auto_ptr<PATPrimitiveCollection> l1Out(new PATPrimitiveCollection());
@@ -196,7 +191,6 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	      const l1t::Muon & l1t = (*l1tBX)[match];
 	      quality[i]  = l1t.hwQual();
 	      bx[i] = l1tBX->getFirstBX() + (std::upper_bound(bxIdxs.begin(),bxIdxs.end(), match) - bxIdxs.begin()); 
-	      //std::cout << "Matching found" << bx[i] << " " << size_t(match) << std::endl;
 	      isolated[i] = l1t.hwIso();
 	      l1rawMatches[i] = edm::Ptr<reco::Candidate>(l1tBX, size_t(match));
 	    }

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -127,10 +127,10 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
       minBxIdx = l1tBX->begin(minBX) - l1tBX->begin();
       std::copy(l1tBX->begin(minBX), l1tBX->end(maxBX), std::back_inserter(l1ts));
 
-      for (int ibx = l1tBX->getFirstBX(); ibx <= l1tBX->getLastBX(); ++ibx)
+      for (int ibx = l1tBX->getFirstBX(); ibx <= l1tBX->getLastBX(); ++ibx) {
 	bxIdxs.push_back(l1tBX->end(ibx) - l1tBX->begin());
-    }
-    else {
+      } 
+    } else {
       iEvent.getByToken(l1Token_, l1s);
       l1size = l1s->size();
     }
@@ -159,10 +159,11 @@ pat::L1MuonMatcher::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
         }
         if (match != -1) {
 
-	  if(useStage2L1_)
-	    match += minBxIdx;
+	    if(useStage2L1_) {
+	      match += minBxIdx;
+	    }
 
-            whichRecoMatch[match] = reco->ptrAt(i);
+	    whichRecoMatch[match] = reco->ptrAt(i);
   	 
 	    int charge = 0;
 	    math::PtEtaPhiMLorentzVector p4;

--- a/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
+++ b/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
@@ -8,11 +8,13 @@ from math import pi
 
 muonL1MatcherParameters = cms.PSet(
     # Choice of matching algorithm
-    useTrack = cms.string("tracker"),  # 'none' to use Candidate P4; or 'tracker', 'muon', 'global'
-    useState = cms.string("atVertex"), # 'innermost' and 'outermost' require the TrackExtra
-    useSimpleGeometry = cms.bool(True), # just use a cylinder plus two disks.
-    fallbackToME1 = cms.bool(False),    # If propagation to ME2 fails, propagate to ME1
-    useMB2inOverlap =  cms.bool(False),  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
+    useTrack = cms.string("tracker"),   # 'none' to use Candidate P4; or 'tracker', 'muon', 'global'
+    useState = cms.string("atVertex"),  # 'innermost' and 'outermost' require the TrackExtra
+    useSimpleGeometry = cms.bool(True),  # just use a cylinder plus two disks.
+    fallbackToME1 = cms.bool(False),     # If propagation to ME2 fails, propagate to ME1
+
+    useMB2InOverlap =  cms.bool(False),  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
+    useStage2L1 = cms.bool(False),       # Use stage2 L1 instead of legacy one
 
     sortBy = cms.string("pt"),          # among compatible candidates, pick the highest pt one
 
@@ -41,9 +43,6 @@ muonL1Match = cms.EDProducer("L1MuonMatcher",
 
     # Write extra ValueMaps
     writeExtraInfo = cms.bool(True),
-
-    # Use stage2 L1 instead of legacy one
-    useStage2L1 = cms.bool(False),
 
     # Min and Max BXs from l1t::BxVector (applies to stage 2 only)
     firstBX = cms.int32(0),

--- a/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
+++ b/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
@@ -12,7 +12,7 @@ muonL1MatcherParameters = cms.PSet(
     useState = cms.string("atVertex"), # 'innermost' and 'outermost' require the TrackExtra
     useSimpleGeometry = cms.bool(True), # just use a cylinder plus two disks.
     fallbackToME1 = cms.bool(False),    # If propagation to ME2 fails, propagate to ME1
-    useMB2inOverlap =  cms.bool(False)  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
+    useMB2inOverlap =  cms.bool(False),  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
 
     sortBy = cms.string("pt"),          # among compatible candidates, pick the highest pt one
 

--- a/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
+++ b/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
@@ -12,6 +12,8 @@ muonL1MatcherParameters = cms.PSet(
     useState = cms.string("atVertex"), # 'innermost' and 'outermost' require the TrackExtra
     useSimpleGeometry = cms.bool(True), # just use a cylinder plus two disks.
     fallbackToME1 = cms.bool(False),    # If propagation to ME2 fails, propagate to ME1
+    useMB2inOverlap =  cms.bool(False)  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
+
     sortBy = cms.string("pt"),          # among compatible candidates, pick the highest pt one
 
     # Matching Criteria
@@ -39,4 +41,12 @@ muonL1Match = cms.EDProducer("L1MuonMatcher",
 
     # Write extra ValueMaps
     writeExtraInfo = cms.bool(True),
+
+    # Use stage2 L1 instead of legacy one
+    useStage2L1 = cms.bool(False),
+
+    # Min and Max BXs from l1t::BxVector (applies to stage 2 only)
+    firstBX = cms.int32(0),
+    lastBX  = cms.int32(0),
+
 )

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -238,3 +238,12 @@ def useL1MatchingWindowForSinglets(process):
         process.muonMatchHLTL1.maxDeltaEta   = 0.2
         process.muonMatchHLTL1.fallbackToME1 = True
 
+
+def useL1Stage2Candidates(process):
+    if hasattr(process, 'muonL1Info'):
+         process.muonL1Info.muonL1MatcherParametersl1PhiOffset = cms.double(1.25) # CB to be checked with experts
+         process.muonL1Info.muonL1MatcherParametersuseMB2inOverlap = cms.bool(True)
+         process.muonL1Info.useStage2L1 = cms.bool(True)
+         process.muonL1Info.preselection = cms.string("b")
+         
+

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from math import pi
 
 ##    __  __       _          ____   _  _____   __  __                       
 ##   |  \/  | __ _| | _____  |  _ \ / \|_   _| |  \/  |_   _  ___  _ __  ___ 
@@ -246,13 +247,15 @@ def useL1MatchingWindowForSinglets(process):
 
 
 def useL1Stage2Candidates(process):
-    if hasattr(process, 'muonL1Info'):
-         # CB to be checked if a customisation is needed
-         #process.muonL1Info.l1PhiOffset = cms.double(??) 
-         process.muonL1Info.useMB2InOverlap = cms.bool(True)
-         process.muonL1Info.useStage2L1 = cms.bool(True)
-         process.muonL1Info.preselection = cms.string("")
-         process.muonL1Info.matched = cms.InputTag("gmtStage2Digis:Muon:")
+    if hasattr(process, 'muonL1Info'): 
+        # l1PhiOffest might need a second look 
+        # barrel seems not to requre it, whereas encaps do
+        # anyhow the effect is of the order of 0.02
+        #process.muonL1Info.l1PhiOffset = cms.double() 
+        process.muonL1Info.useMB2InOverlap = cms.bool(True)
+        process.muonL1Info.useStage2L1 = cms.bool(True)
+        process.muonL1Info.preselection = cms.string("")
+        process.muonL1Info.matched = cms.InputTag("gmtStage2Digis:Muon:")
 
          
 

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -51,6 +51,12 @@ def addL1UserData(patMuonProducer, l1ModuleLabel = "muonL1Info"):
     patMuonProducer.userData.userFloats.src += [  
         cms.InputTag(l1ModuleLabel, "deltaR"),  # will be 999 in case of no match
     ]
+    patMuonProducer.userData.userFloats.src += [  
+        cms.InputTag(l1ModuleLabel, "deltaPhi"),  # will be 999 in case of no match
+    ]
+    patMuonProducer.userData.userInts.src += [  
+        cms.InputTag(l1ModuleLabel, "bx"),  # will be 999 in case of no match
+    ]
     patMuonProducer.userData.userCands.src += [
         cms.InputTag(l1ModuleLabel)
     ]

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -241,7 +241,8 @@ def useL1MatchingWindowForSinglets(process):
 
 def useL1Stage2Candidates(process):
     if hasattr(process, 'muonL1Info'):
-         process.muonL1Info.l1PhiOffset = cms.double(1.25) # CB to be checked with experts
+         #process.muonL1Info.l1PhiOffset = cms.double(??) 
+         # CB to be checked with experts
          process.muonL1Info.useMB2InOverlap = cms.bool(True)
          process.muonL1Info.useStage2L1 = cms.bool(True)
          process.muonL1Info.preselection = cms.string("")

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from math import pi
 
 ##    __  __       _          ____   _  _____   __  __                       
 ##   |  \/  | __ _| | _____  |  _ \ / \|_   _| |  \/  |_   _  ___  _ __  ___ 

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -55,7 +55,7 @@ def addL1UserData(patMuonProducer, l1ModuleLabel = "muonL1Info"):
         cms.InputTag(l1ModuleLabel, "deltaPhi"),  # will be 999 in case of no match
     ]
     patMuonProducer.userData.userInts.src += [  
-        cms.InputTag(l1ModuleLabel, "bx"),  # will be 999 in case of no match
+        cms.InputTag(l1ModuleLabel, "bx"),  # will be -999 in case of no match
     ]
     patMuonProducer.userData.userCands.src += [
         cms.InputTag(l1ModuleLabel)
@@ -247,8 +247,8 @@ def useL1MatchingWindowForSinglets(process):
 
 def useL1Stage2Candidates(process):
     if hasattr(process, 'muonL1Info'):
+         # CB to be checked if a customisation is needed
          #process.muonL1Info.l1PhiOffset = cms.double(??) 
-         # CB to be checked with experts
          process.muonL1Info.useMB2InOverlap = cms.bool(True)
          process.muonL1Info.useStage2L1 = cms.bool(True)
          process.muonL1Info.preselection = cms.string("")

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -241,9 +241,11 @@ def useL1MatchingWindowForSinglets(process):
 
 def useL1Stage2Candidates(process):
     if hasattr(process, 'muonL1Info'):
-         process.muonL1Info.muonL1MatcherParametersl1PhiOffset = cms.double(1.25) # CB to be checked with experts
-         process.muonL1Info.muonL1MatcherParametersuseMB2inOverlap = cms.bool(True)
+         process.muonL1Info.l1PhiOffset = cms.double(1.25) # CB to be checked with experts
+         process.muonL1Info.useMB2InOverlap = cms.bool(True)
          process.muonL1Info.useStage2L1 = cms.bool(True)
-         process.muonL1Info.preselection = cms.string("b")
+         process.muonL1Info.preselection = cms.string("")
+         process.muonL1Info.matched = cms.InputTag("gmtStage2Digis:Muon:")
+
          
 

--- a/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
+++ b/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
@@ -4,8 +4,9 @@
 
 L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet & iConfig) :
     prop_(iConfig),
-    preselectionCutL1_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
-    preselectionCutL1T_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
+    useStage2L1_(iConfig.existsAs<bool>("useStage2L1") ? iConfig.getParameter<bool>("useStage2L1") : false),
+    preselectionCutL1_((iConfig.existsAs<std::string>("preselection") && !useStage2L1_) ? iConfig.getParameter<std::string>("preselection") : ""),
+    preselectionCutL1T_((iConfig.existsAs<std::string>("preselection") &&  useStage2L1_) ? iConfig.getParameter<std::string>("preselection") : ""),
     deltaR2_(std::pow(iConfig.getParameter<double>("maxDeltaR"),2)),
     deltaPhi_(iConfig.existsAs<double>("maxDeltaPhi") ? iConfig.getParameter<double>("maxDeltaPhi") : 10),
     deltaEta_(iConfig.existsAs<double>("maxDeltaEta") ? iConfig.getParameter<double>("maxDeltaEta") : 10),

--- a/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
+++ b/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
@@ -4,7 +4,8 @@
 
 L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet & iConfig) :
     prop_(iConfig),
-    preselectionCut_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
+    preselectionCutL1_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
+    preselectionCutL1T_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
     deltaR2_(std::pow(iConfig.getParameter<double>("maxDeltaR"),2)),
     deltaPhi_(iConfig.existsAs<double>("maxDeltaPhi") ? iConfig.getParameter<double>("maxDeltaPhi") : 10),
     deltaEta_(iConfig.existsAs<double>("maxDeltaEta") ? iConfig.getParameter<double>("maxDeltaEta") : 10),
@@ -51,7 +52,7 @@ L1MuonMatcherAlgo::init(const edm::EventSetup & iSetup) {
 
 bool
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const l1extra::L1MuonParticle &l1, float &deltaR, float &deltaPhi) const {
-    if (preselectionCut_(l1)) {
+    if (preselectionCutL1_(l1)) {
         GlobalPoint pos = propagated.globalPosition();
         double thisDeltaPhi = ::deltaPhi(double(pos.phi()),  l1.phi()+l1PhiOffset_);
         double thisDeltaEta = pos.eta() - l1.eta();
@@ -67,7 +68,12 @@ L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const l1extra::L
 
 int
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1extra::L1MuonParticle> &l1s, float &deltaR, float &deltaPhi) const {
-    return matchGeneric(propagated, l1s, preselectionCut_, deltaR, deltaPhi);
+    return matchGeneric(propagated, l1s, preselectionCutL1_, deltaR, deltaPhi);
+}
+
+int
+L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1t::Muon> &l1s, float &deltaR, float &deltaPhi) const {
+    return matchGeneric(propagated, l1s, preselectionCutL1T_, deltaR, deltaPhi);
 }
 
 

--- a/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
+++ b/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
@@ -5,8 +5,7 @@
 L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet & iConfig) :
     prop_(iConfig),
     useStage2L1_(iConfig.existsAs<bool>("useStage2L1") ? iConfig.getParameter<bool>("useStage2L1") : false),
-    preselectionCutL1_((iConfig.existsAs<std::string>("preselection") && !useStage2L1_) ? iConfig.getParameter<std::string>("preselection") : ""),
-    preselectionCutL1T_((iConfig.existsAs<std::string>("preselection") &&  useStage2L1_) ? iConfig.getParameter<std::string>("preselection") : ""),
+    preselectionCut_((iConfig.existsAs<std::string>("preselection")) ? iConfig.getParameter<std::string>("preselection") : ""),
     deltaR2_(std::pow(iConfig.getParameter<double>("maxDeltaR"),2)),
     deltaPhi_(iConfig.existsAs<double>("maxDeltaPhi") ? iConfig.getParameter<double>("maxDeltaPhi") : 10),
     deltaEta_(iConfig.existsAs<double>("maxDeltaEta") ? iConfig.getParameter<double>("maxDeltaEta") : 10),
@@ -53,7 +52,7 @@ L1MuonMatcherAlgo::init(const edm::EventSetup & iSetup) {
 
 bool
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const l1extra::L1MuonParticle &l1, float &deltaR, float &deltaPhi) const {
-    if (preselectionCutL1_(l1)) {
+    if (preselectionCut_(l1)) {
         GlobalPoint pos = propagated.globalPosition();
         double thisDeltaPhi = ::deltaPhi(double(pos.phi()),  l1.phi()+l1PhiOffset_);
         double thisDeltaEta = pos.eta() - l1.eta();
@@ -69,12 +68,12 @@ L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const l1extra::L
 
 int
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1extra::L1MuonParticle> &l1s, float &deltaR, float &deltaPhi) const {
-    return matchGeneric(propagated, l1s, preselectionCutL1_, deltaR, deltaPhi);
+    return matchGeneric(propagated, l1s, preselectionCut_, deltaR, deltaPhi);
 }
 
 int
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1t::Muon> &l1s, float &deltaR, float &deltaPhi) const {
-    return matchGeneric(propagated, l1s, preselectionCutL1T_, deltaR, deltaPhi);
+    return matchGeneric(propagated, l1s, preselectionCut_, deltaR, deltaPhi);
 }
 
 

--- a/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
+++ b/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
@@ -62,11 +62,11 @@ PropagateToMuon::init(const edm::EventSetup & iSetup) {
         endcapDiskPos_[i] = dynamic_cast<const BoundDisk *>(& muonGeometry_->forwardCSCLayers()[i]->surface());
         endcapDiskNeg_[i] = dynamic_cast<const BoundDisk *>(& muonGeometry_->backwardCSCLayers()[i]->surface());
         endcapRadii_[i] = std::make_pair(endcapDiskPos_[i]->innerRadius(), endcapDiskPos_[i]->outerRadius());
-        std::cout << "L1MuonMatcher: endcap " << i << " Z = " << endcapDiskPos_[i]->position().z() << ", radii = " << endcapRadii_[i].first << "," << endcapRadii_[i].second << std::endl;
+        //std::cout << "L1MuonMatcher: endcap " << i << " Z = " << endcapDiskPos_[i]->position().z() << ", radii = " << endcapRadii_[i].first << "," << endcapRadii_[i].second << std::endl;
     }
 
     if (useMB2_ && useMB2InOverlap_)
-      barrelHalfLength_ = endcapDiskPos_[0]->position().z() - endcapDiskNeg_[0]->position().z();
+      barrelHalfLength_ = endcapDiskPos_[2]->position().z();
 }
 
 FreeTrajectoryState 

--- a/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
+++ b/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
@@ -19,7 +19,9 @@ PropagateToMuon::PropagateToMuon(const edm::ParameterSet & iConfig) :
   useMB2_(iConfig.existsAs<bool>("useStation2") ? iConfig.getParameter<bool>("useStation2") : true),
   fallbackToME1_(iConfig.existsAs<bool>("fallbackToME1") ? iConfig.getParameter<bool>("fallbackToME1") : false),
   whichTrack_(None), whichState_(AtVertex),
-  cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis") ? iConfig.getParameter<bool>("cosmicPropagationHypothesis") : false)
+  cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis") ? iConfig.getParameter<bool>("cosmicPropagationHypothesis") : false),
+  useMB2InOverlap_(iConfig.existsAs<bool>("useMB2inOverlap") ? iConfig.getParameter<bool>("useMB2InOverlap") : false)
+
 {
     std::string whichTrack = iConfig.getParameter<std::string>("useTrack");
     if      (whichTrack == "none")    { whichTrack_ = None; }
@@ -60,8 +62,11 @@ PropagateToMuon::init(const edm::EventSetup & iSetup) {
         endcapDiskPos_[i] = dynamic_cast<const BoundDisk *>(& muonGeometry_->forwardCSCLayers()[i]->surface());
         endcapDiskNeg_[i] = dynamic_cast<const BoundDisk *>(& muonGeometry_->backwardCSCLayers()[i]->surface());
         endcapRadii_[i] = std::make_pair(endcapDiskPos_[i]->innerRadius(), endcapDiskPos_[i]->outerRadius());
-        //std::cout << "L1MuonMatcher: endcap " << i << " Z = " << endcapDiskPos_[i]->position().z() << ", radii = " << endcapRadii_[i].first << "," << endcapRadii_[i].second << std::endl;
+        std::cout << "L1MuonMatcher: endcap " << i << " Z = " << endcapDiskPos_[i]->position().z() << ", radii = " << endcapRadii_[i].first << "," << endcapRadii_[i].second << std::endl;
     }
+
+    if (useMB2_ && useMB2InOverlap_)
+      barrelHalfLength_ = endcapDiskPos_[0]->position().z() - endcapDiskNeg_[0]->position().z();
 }
 
 FreeTrajectoryState 

--- a/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
+++ b/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
@@ -20,7 +20,7 @@ PropagateToMuon::PropagateToMuon(const edm::ParameterSet & iConfig) :
   fallbackToME1_(iConfig.existsAs<bool>("fallbackToME1") ? iConfig.getParameter<bool>("fallbackToME1") : false),
   whichTrack_(None), whichState_(AtVertex),
   cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis") ? iConfig.getParameter<bool>("cosmicPropagationHypothesis") : false),
-  useMB2InOverlap_(iConfig.existsAs<bool>("useMB2inOverlap") ? iConfig.getParameter<bool>("useMB2InOverlap") : false)
+  useMB2InOverlap_(iConfig.existsAs<bool>("useMB2InOverlap") ? iConfig.getParameter<bool>("useMB2InOverlap") : false)
 
 {
     std::string whichTrack = iConfig.getParameter<std::string>("useTrack");
@@ -67,6 +67,7 @@ PropagateToMuon::init(const edm::EventSetup & iSetup) {
 
     if (useMB2_ && useMB2InOverlap_)
       barrelHalfLength_ = endcapDiskPos_[2]->position().z();
+
 }
 
 FreeTrajectoryState 


### PR DESCRIPTION
This PR makes the L1MuonMatcher code work also with the stage L1 trigger (and the BXVector format).
Upon suggestion of the OMT experts, the propagation is also slightly adjusted to cope with the RF changes in the overlap region between the legacy trigger and OMTF.
A function to enable the switch is implemented in patMuonsWithTrigger_cff.
