### PR TITLE
Mostly changes related to handling TDC info

### DIFF
--- a/DataFormats/HcalRecHit/interface/HFQIE10Info.h
+++ b/DataFormats/HcalRecHit/interface/HFQIE10Info.h
@@ -21,6 +21,14 @@ public:
     static const unsigned N_RAW_MAX = 5;
     static const raw_type INVALID_RAW = std::numeric_limits<raw_type>::max();
 
+    // Special value for the rise time used in case the QIE10 pulse
+    // is always below the discriminator
+    static constexpr float UNKNOWN_T_UNDERSHOOT = -100.f;
+
+    // Special value for the rise time used in case the QIE10 pulse
+    // is always above the discriminator
+    static constexpr float UNKNOWN_T_OVERSHOOT = -101.f;
+
     HFQIE10Info();
 
     // Argument "soi" provides the index of the sample of interest

--- a/DataFormats/HcalRecHit/interface/HFQIE10Info.h
+++ b/DataFormats/HcalRecHit/interface/HFQIE10Info.h
@@ -27,7 +27,7 @@ public:
 
     // Special value for the rise time used in case the QIE10 pulse
     // is always above the discriminator
-    static constexpr float UNKNOWN_T_OVERSHOOT = -101.f;
+    static constexpr float UNKNOWN_T_OVERSHOOT = -110.f;
 
     HFQIE10Info();
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/AbsHFPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/AbsHFPhase1Algo.h
@@ -41,7 +41,8 @@ public:
     // should have its id (of type HcalDetId) set to 0.
     virtual HFRecHit reconstruct(const HFPreRecHit& prehit,
                                  const HcalCalibrations& calibs,
-                                 const bool flaggedBadInDB[2]) = 0;
+                                 const bool flaggedBadInDB[2],
+                                 bool expectSingleAnodePMT) = 0;
 };
 
 #endif // RecoLocalCalo_HcalRecAlgos_AbsHFPhase1Algo_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
@@ -37,6 +37,15 @@ public:
     // aux words of the HFRecHit. For more detail, see comments
     // inside the HFRecHitAuxSetter.h header.
     //
+    // "timeShift" value (in ns) will be added to all valid times
+    // returned by QIE10 TDCs. This shift is used both for applying
+    // the timing cuts and for rechit construction.
+    //
+    // "triseIfNoTDC" and "tfallIfNoTDC": the rechit rise and
+    // fall times will be set to these values in case meaningful
+    // TDC information is not available for any of the PMT anodes
+    // (time shift is not added to these numbers).
+    //
     // For monitoring purposes, "rejectAllFailures" can be set to
     // "false". In this case, for the energy reconstruction purposes,
     // all status values indicating that the anode is not passing
@@ -45,7 +54,8 @@ public:
     //
     HFSimpleTimeCheck(const std::pair<float,float> tlimits[2],
                       const float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2],
-                      unsigned soiPhase,
+                      unsigned soiPhase, float timeShift,
+                      float triseIfNoTDC, float tfallIfNoTDC,
                       bool rejectAllFailures = true);
 
     inline virtual ~HFSimpleTimeCheck() {}
@@ -54,9 +64,13 @@ public:
 
     virtual HFRecHit reconstruct(const HFPreRecHit& prehit,
                                  const HcalCalibrations& calibs,
-                                 const bool flaggedBadInDB[2]) override;
+                                 const bool flaggedBadInDB[2],
+                                 bool expectSingleAnodePMT) override;
 
     inline unsigned soiPhase() const {return soiPhase_;}
+    inline float timeShift() const {return timeShift_;}
+    inline float triseIfNoTDC() const {return triseIfNoTDC_;}
+    inline float tfallIfNoTDC() const {return tfallIfNoTDC_;}
     inline bool rejectingAllFailures() const {return rejectAllFailures_;}
 
 protected:
@@ -69,6 +83,9 @@ private:
     std::pair<float,float> tlimits_[2];
     float energyWeights_[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2];
     unsigned soiPhase_;
+    float timeShift_;
+    float triseIfNoTDC_;
+    float tfallIfNoTDC_;
     bool rejectAllFailures_;
 };
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/parseHFPhase1AlgoDescription.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/parseHFPhase1AlgoDescription.h
@@ -1,0 +1,21 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_parseHFPhase1AlgoDescription_h
+#define RecoLocalCalo_HcalRecAlgos_parseHFPhase1AlgoDescription_h
+
+#include <memory>
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsHFPhase1Algo.h"
+
+namespace edm {
+    class ParameterSet;
+}
+
+//
+// Factory function for creating objects of types
+// inheriting from AbsHFPhase1Algo out of parameter sets.
+//
+// Update the implementation of this function if you need
+// to add a new algorithm to HFPhase1Reconstructor.
+//
+std::unique_ptr<AbsHFPhase1Algo>
+parseHFPhase1AlgoDescription(const edm::ParameterSet& ps);
+
+#endif // RecoLocalCalo_HcalRecAlgos_parseHFPhase1AlgoDescription_h

--- a/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
@@ -4,11 +4,20 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFRecHitAuxSetter.h"
 
+// Rechit status bit assignments
+// #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+
 HFSimpleTimeCheck::HFSimpleTimeCheck(const std::pair<float,float> tlimits[2],
                                      const float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2],
                                      const unsigned i_soiPhase,
+                                     const float i_timeShift,
+                                     const float i_triseIfNoTDC,
+                                     const float i_tfallIfNoTDC,
                                      const bool rejectAllFailures)
     : soiPhase_(i_soiPhase),
+      timeShift_(i_timeShift),
+      triseIfNoTDC_(i_triseIfNoTDC),
+      tfallIfNoTDC_(i_tfallIfNoTDC),
       rejectAllFailures_(rejectAllFailures)
 {
     tlimits_[0] = tlimits[0];
@@ -25,14 +34,35 @@ unsigned HFSimpleTimeCheck::determineAnodeStatus(
     const unsigned nRaw = anode.nRaw();
     if (nRaw)
     {
-        const QIE10DataFrame::Sample s(anode.getRaw(nRaw - 1));
-        if (!s.ok())
+        bool hardwareOK = true;
+        unsigned sampleToCheck = anode.soi();
+        if (sampleToCheck < nRaw)
+        {
+            const QIE10DataFrame::Sample s(anode.getRaw(sampleToCheck));
+            hardwareOK = s.ok();
+        }
+        else
+        {
+            // This should not normally happen, but we still
+            // need to do something reasonable here
+            for (sampleToCheck = 0; sampleToCheck < nRaw; ++sampleToCheck)
+            {
+                const QIE10DataFrame::Sample s(anode.getRaw(sampleToCheck));
+                if (!s.ok())
+                    hardwareOK = false;
+            }
+        }
+        if (!hardwareOK)
             return HFAnodeStatus::HARDWARE_ERROR;
     }
 
     // Check the time limits
-    const float trise = anode.timeRising();
-    if (tlimits_[ianode].first <= trise && trise <= tlimits_[ianode].second)
+    float trise = anode.timeRising();
+    const bool timeIsKnown = !(trise == HFQIE10Info::UNKNOWN_T_UNDERSHOOT ||
+                               trise == HFQIE10Info::UNKNOWN_T_OVERSHOOT);
+    trise += timeShift_;
+    if (timeIsKnown &&
+        tlimits_[ianode].first <= trise && trise <= tlimits_[ianode].second)
         return HFAnodeStatus::OK;
     else
         return HFAnodeStatus::FAILED_TIMING;
@@ -58,12 +88,16 @@ unsigned HFSimpleTimeCheck::mapStatusIntoIndex(const unsigned states[2]) const
 
 HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
                                         const HcalCalibrations& /* calibs */,
-                                        const bool flaggedBadInDB[2])
+                                        const bool flaggedBadInDB[2],
+                                        const bool expectSingleAnodePMT)
 {
     HFRecHit rh;
 
     // Determine the status of each anode
     unsigned states[2] = {HFAnodeStatus::NOT_READ_OUT, HFAnodeStatus::NOT_READ_OUT};
+    if (expectSingleAnodePMT)
+        states[1] = HFAnodeStatus::NOT_DUAL;
+
     for (unsigned ianode=0; ianode<2; ++ianode)
     {
         const HFQIE10Info* anodeInfo = prehit.getHFQIE10Info(ianode);
@@ -86,7 +120,7 @@ HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
         const float* weights = &energyWeights_[lookupInd][0];
         float energy = 0.f, t = 0.f, tfall = 0.f, weightedEnergySum = 0.f;
         float tsum = 0.f, tfallsum = 0.f;
-        unsigned anodeCount = 0;
+        unsigned knownTimeCount = 0;
 
         for (unsigned ianode=0; ianode<2; ++ianode)
         {
@@ -95,22 +129,29 @@ HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
             {
                 const float weightedEnergy = weights[ianode]*anodeInfo->energy();
                 energy += weightedEnergy;
-                const float trising = anodeInfo->timeRising();
-                tsum += trising;
-                const float tfalling = anodeInfo->timeFalling();
-                tfallsum += tfalling;
-
-                if (weightedEnergy > 0.f)
+                float trising = anodeInfo->timeRising();
+                const bool timeIsKnown = !(trising == HFQIE10Info::UNKNOWN_T_UNDERSHOOT ||
+                                           trising == HFQIE10Info::UNKNOWN_T_OVERSHOOT);
+                if (timeIsKnown)
                 {
-                    weightedEnergySum += weightedEnergy;
-                    t += trising*weightedEnergy;
-                    tfall += tfalling*weightedEnergy;
-                }
+                    trising += timeShift_;
+                    tsum += trising;
+                    const float tfalling = anodeInfo->timeFalling() + timeShift_;
+                    tfallsum += tfalling;
 
-                ++anodeCount;
+                    if (weightedEnergy > 0.f)
+                    {
+                        weightedEnergySum += weightedEnergy;
+                        t += trising*weightedEnergy;
+                        tfall += tfalling*weightedEnergy;
+                    }
+
+                    ++knownTimeCount;
+                }
             }
         }
 
+        // uint32_t timingFromTDC = 1;
         if (weightedEnergySum > 0.f)
         {
             // Normally, determine TDC rise and fall time
@@ -118,15 +159,28 @@ HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
             t /= weightedEnergySum;
             tfall /= weightedEnergySum;
         }
-        else
+        else if (knownTimeCount)
         {
             // But if energies are negative, use simple averages
-            t = tsum/anodeCount;
-            tfall = tfallsum/anodeCount;
+            t = tsum/knownTimeCount;
+            tfall = tfallsum/knownTimeCount;
+        }
+        else
+        {
+            // If we are here, neither anode provided valid time
+            // information
+            t = triseIfNoTDC_;
+            tfall = tfallIfNoTDC_;
+            // timingFromTDC = 0;
         }
 
         rh = HFRecHit(prehit.id(), energy, t, tfall);
         HFRecHitAuxSetter::setAux(prehit, states, soiPhase_, &rh);
+
+        // When Phase 1 rechit status bit assignments are understood,
+        // set the "timing from TDC" flag as follows:
+        //
+        // rh.setFlagField(timingFromTDC, HcalCaloFlagLabels::?properFlagName?);
     }
 
     return rh;

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
@@ -1,0 +1,53 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/parseHFPhase1AlgoDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// Phase 1 HF reco algorithm headers
+#include "RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h"
+
+std::unique_ptr<AbsHFPhase1Algo>
+parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
+{
+    std::unique_ptr<AbsHFPhase1Algo> algo;
+
+    const std::string& className = ps.getParameter<std::string>("Class");
+
+    if (className == "HFSimpleTimeCheck")
+    {
+        const std::vector<double>& tlimitsVec =
+            ps.getParameter<std::vector<double> >("tlimits");
+        const std::vector<double>& energyWeightsVec =
+            ps.getParameter<std::vector<double> >("energyWeights");
+        const unsigned soiPhase =
+            ps.getParameter<unsigned>("soiPhase");
+        const float timeShift =
+            ps.getParameter<double>("timeShift");
+        const float triseIfNoTDC =
+            ps.getParameter<double>("triseIfNoTDC");
+        const float tfallIfNoTDC =
+            ps.getParameter<double>("tfallIfNoTDC");
+        const bool rejectAllFailures =
+            ps.getParameter<bool>("rejectAllFailures");
+
+        std::pair<float,float> tlimits[2];
+        float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2];
+        const unsigned sz = sizeof(energyWeights)/sizeof(energyWeights[0][0]);
+
+        if (tlimitsVec.size() == 4 && energyWeightsVec.size() == sz)
+        {
+            tlimits[0] = std::pair<float,float>(tlimitsVec[0], tlimitsVec[1]);
+            tlimits[1] = std::pair<float,float>(tlimitsVec[2], tlimitsVec[3]);
+
+            // Same order of elements as in the natural C array mapping
+            float* to = &energyWeights[0][0];
+            for (unsigned i=0; i<sz; ++i)
+                to[i] = energyWeightsVec[i];
+
+            algo = std::unique_ptr<AbsHFPhase1Algo>(
+                new HFSimpleTimeCheck(tlimits, energyWeights, soiPhase,
+                                      timeShift, triseIfNoTDC, tfallIfNoTDC,
+                                      rejectAllFailures));
+        }
+    }
+
+    return algo;
+}

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -40,8 +40,17 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
             0.0, 1.0   # {FAILED_OTHER, OK}
         ),
 
-        # Into which byte the sample of interest ADC will be placed?
+        # Into which byte (0, 1, or 2) of the aux word the sample
+        # of interest ADC will be placed?
         soiPhase = cms.uint32(1),
+
+        # Time shift added to all "normal" QIE10 TDC time measurements
+        timeShift = cms.double(0.0),
+
+        # Rise and fall time of the rechit will be set to these values
+        # if neither anode has valid TDC info
+        triseIfNoTDC = cms.double(-100.0),
+        tfallIfNoTDC = cms.double(-101.0),
 
         # Do not construct rechits with problems
         rejectAllFailures = cms.bool(True)


### PR DESCRIPTION
HFQIE10Info and rechit timing is now in ns instead of TDC units.
Correct handling of special QIE10 TDC values 62 and 63.
Made provisions for proper handing of single-anode PMTs in the mixed-readout scenario.
Use "sample-of-interest" time slice for setting "HARDWARE_ERROR" algorithm status.

The code is checked with the Phase 1 recipe described at
https://twiki.cern.ch/twiki/bin/viewauth/CMS/HcalPhase1SoftwareSimulationRecipe
