### PR TITLE
Update JECs to `Spring15_v3` and enable new key for Ecal AlCaReco

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v0',
+    'run1_design'       :   '81X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v0',
+    'run1_mc'           :   '81X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v0',
+    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v0',
+    'run1_mc_pa'        :   '81X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v0',
+    'run2_design'       :   '81X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v0',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v0',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v0',
+    'run1_data'         :   '81X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v0',
+    'run2_data'         :   '81X_dataRun2_v1',
     # GlobalTag for Run2 data (as Prompt) WILL DISAPPEAR ONCE RERECO UPDATED
-    'run2_prompt_WillDisappearInJul16' :   '81X_dataRun2_Run2016B_Prompt_frozen_v1',
+    'run2_prompt_WillDisappearInJul16' :   '81X_dataRun2_Run2016B_Prompt_frozen_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v0',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,9 +38,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v2',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v3',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v2',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
## RunI simulation
- **RunI Ideal scenario** : [81X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v1) as [81X_mcRun1_design_v0](https://cms-conddb.cern.c
  h/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_design_v1/81X_mcRun1_design_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
- **RunI Heavy Ions scenario** : [81X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v1) as [81X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_HeavyIon_v1/81X_mcRun1_HeavyIon_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
- **RunI Realistic scenario** : [81X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v1) as [81X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_realistic_v1/81X_mcRun1_realistic_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
- **RunI Proton-Lead scenario** : [81X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v1) as [81X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_pA_v1/81X_mcRun1_pA_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v1) as [81X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v1/81X_mcRun2_design_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
  - updated Jet Energy corrections to version `Spring16_25nsV3` 
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v1) as [81X_mcRun2cosmics_startup_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v1/81X_mcRun2cosmics_startup_peak_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
  - updated Jet Energy corrections to version `Spring16_25nsV3`
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v1) as [81X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v1/81X_mcRun2_asymptotic_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
  - updated Jet Energy corrections to version `Spring16_25nsV3`
- **RunII Startup scenario** : [81X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v1) as [81X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v1/81X_mcRun2_startup_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v1) as [81X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v1/81X_mcRun2_HeavyIon_v0): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v1) as [81X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v1/81X_dataRun2_v0): 
  - updated Jet Energy corrections to version `Spring16_25nsV3`
- **RunII Psuedo-Prompt processing** : [81X_dataRun2_Run2016B_Prompt_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_Run2016B_Prompt_frozen_v2) as [81X_dataRun2_Run2016B_Prompt_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_Run2016B_Prompt_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_Run2016B_Prompt_frozen_v2/81X_dataRun2_Run2016B_Prompt_frozen_v1): 
  - updated Jet Energy corrections to version `Spring16_25nsV3`
- **RunII Offline relval processing** : [81X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v1) as [81X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v1/81X_dataRun2_relval_v0): 
  - updated Jet Energy corrections to version `Spring16_25nsV3`
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v3) as [81X_upgrade2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v3/81X_upgrade2017_realistic_v2): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
  - update phase-I geometry for new BPIX module cable materials, new FPIX portcard material and dimensions as in #14700
- **PhaseI design scenario** : [81X_upgrade2017_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v3) as [81X_upgrade2017_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v3/81X_upgrade2017_design_v2): 
  - updated `AlCaRecoTriggerBits` with `AlCaEcalTrg`
  -  update phase-I geometry for new BPIX module cable materials, new FPIX portcard material and dimensions as in #14700
