### PR TITLE
Fpix HitEfficiency Maps per Panel

### DIFF
--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -84,7 +84,8 @@ class SiPixelActionExecutor {
  bool readConfiguration(	    int 			 & tkmap_freq, 
                         	    int 			 & summary_freq);
  void readConfiguration(	    );
-
+ int getLadder(                     const std::string            & dname);
+ int getBlade(                     const std::string             & dname);
 
 private:
   

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -1661,17 +1661,17 @@ void SiPixelActionExecutor::bookEfficiency(DQMStore::IBooker & iBooker, bool isU
   iBooker.cd();
   iBooker.setCurrentFolder("Pixel/Endcap");
   if (!isUpgrade) {
-  if(Tier0Flag_){
-    HitEfficiency_Dp1 = iBooker.book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;",24,-12.,12.,1,0.,1.);
-    HitEfficiency_Dp2 = iBooker.book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;",24,-12.,12.,1,0.,1.);
-    HitEfficiency_Dm1 = iBooker.book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;",24,-12.,12.,1,0.,1.);
-    HitEfficiency_Dm2 = iBooker.book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;",24,-12.,12.,1,0.,1.);
-  }else{
-    HitEfficiency_Dp1 = iBooker.book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;Modules",24,-12.,12.,7,1.,8.);
-    HitEfficiency_Dp2 = iBooker.book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;Modules",24,-12.,12.,7,1.,8.);
-    HitEfficiency_Dm1 = iBooker.book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;Modules",24,-12.,12.,7,1.,8.);
-    HitEfficiency_Dm2 = iBooker.book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;Modules",24,-12.,12.,7,1.,8.);
-  }
+    if(Tier0Flag_){
+      HitEfficiency_Dp1 = iBooker.book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blade;Panel",26,-13.,13.,2,0.5,2.5);
+      HitEfficiency_Dp2 = iBooker.book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blade;Panel",26,-13.,13.,2,0.5,2.5);
+      HitEfficiency_Dm1 = iBooker.book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blade;Panel",26,-13.,13.,2,0.5,2.5);
+      HitEfficiency_Dm2 = iBooker.book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;;Blade;Panel",26,-13.,13.,2,0.5,2.5);   
+    }else{
+      HitEfficiency_Dp1 = iBooker.book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;Modules",24,-12.,12.,7,1.,8.);
+      HitEfficiency_Dp2 = iBooker.book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;Modules",24,-12.,12.,7,1.,8.);
+      HitEfficiency_Dm1 = iBooker.book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;Modules",24,-12.,12.,7,1.,8.);
+      HitEfficiency_Dm2 = iBooker.book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;Modules",24,-12.,12.,7,1.,8.);
+    }
   } else if (isUpgrade) {
     if(Tier0Flag_){
       HitEfficiency_Dp1 = iBooker.book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;",28,-17.,11.,1,0.,1.);
@@ -1708,6 +1708,24 @@ void SiPixelActionExecutor::createEfficiency(DQMStore::IBooker & iBooker, DQMSto
 
 //=============================================================================================================
 
+int SiPixelActionExecutor::getLadder(const std::string & dname_){
+  int biny_= 0;
+  string lad=dname_.substr(dname_.find("Ladder_") + 7, 2);
+  if(dname_.find(lad)!=string::npos){ biny_ = atoi(lad.c_str());}
+  return biny_;
+}
+
+//=============================================================================================================
+
+int SiPixelActionExecutor::getBlade(const std::string & dname_){
+  int binx_= 0;
+  string blad=dname_.substr(dname_.find("Blade_") + 6, 2);
+  if(dname_.find(blad)!=string::npos){ binx_ = atoi(blad.c_str());}
+  return binx_;
+}
+
+//=============================================================================================================
+
 void SiPixelActionExecutor::fillEfficiency(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter, bool isbarrel, bool isUpgrade){
   //cout<<"entering SiPixelActionExecutor::fillEfficiency..."<<std::endl;
   string currDir = iBooker.pwd();
@@ -1729,32 +1747,19 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore::IBooker & iBooker, DQMStore
 	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
 	  MonitorElement * valid = iGetter.get(new_path);
 	  if (!valid) continue;
-	  //int binx = 0; 
+	  int binx = 0; 
 	  int biny = 0;
 	  //get the ladder number
-	  
-	  if(dname.find("01")!=string::npos){ biny = 1;}else if(dname.find("02")!=string::npos){ biny = 2;}
-	  else if(dname.find("03")!=string::npos){ biny = 3;}else if(dname.find("04")!=string::npos){ biny = 4;}
-	  else if(dname.find("05")!=string::npos){ biny = 5;}else if(dname.find("06")!=string::npos){ biny = 6;}
-	  else if(dname.find("07")!=string::npos){ biny = 7;}else if(dname.find("08")!=string::npos){ biny = 8;}
-	  else if(dname.find("09")!=string::npos){ biny = 9;}else if(dname.find("10")!=string::npos){ biny = 10;}
-	  else if(dname.find("11")!=string::npos){ biny = 11;}else if(dname.find("12")!=string::npos){ biny = 12;}
-	  else if(dname.find("13")!=string::npos){ biny = 13;}else if(dname.find("14")!=string::npos){ biny = 14;}
-	  else if(dname.find("15")!=string::npos){ biny = 15;}else if(dname.find("16")!=string::npos){ biny = 16;}
-	  else if(dname.find("17")!=string::npos){ biny = 17;}else if(dname.find("18")!=string::npos){ biny = 18;}
-	  else if(dname.find("19")!=string::npos){ biny = 19;}else if(dname.find("20")!=string::npos){ biny = 20;}
-	  else if(dname.find("21")!=string::npos){ biny = 21;}else if(dname.find("22")!=string::npos){ biny = 22;}
-	  
-	  if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
+	   biny = getLadder(dname);//Current
+	  if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){ 
 	    biny=-biny;
 	  }
-	  
-  	  for(int i=1; i<5;i++){
+	  const int nMod = 4; 
+	  for(int i=1; i<nMod+1;i++){
 	    float hitEfficiency = -1.0;
 	    float missingHits=0;
 	    float validHits=0;
-	    float binx=float(i);
-
+	    binx=i; //Module
 	    if(currDir.find("Shell_m")!=string::npos) binx=-binx;
 
 	    missingHits=missing->getBinContent(i);
@@ -1794,30 +1799,11 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore::IBooker & iBooker, DQMStore
 	    float hitEfficiency = -1.;
 	    if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
 	    int binx = 0; int biny = 0;
-	    if(currDir.find("Shell_m")!=string::npos){ binx = 1;}else{ binx = 2;}
-	    if(dname.find("01")!=string::npos){ biny = 1;}else if(dname.find("02")!=string::npos){ biny = 2;}
-	    else if(dname.find("03")!=string::npos){ biny = 3;}else if(dname.find("04")!=string::npos){ biny = 4;}
-	    else if(dname.find("05")!=string::npos){ biny = 5;}else if(dname.find("06")!=string::npos){ biny = 6;}
-	    else if(dname.find("07")!=string::npos){ biny = 7;}else if(dname.find("08")!=string::npos){ biny = 8;}
-	    else if(dname.find("09")!=string::npos){ biny = 9;}else if(dname.find("10")!=string::npos){ biny = 10;}
-	    else if(dname.find("11")!=string::npos){ biny = 11;}else if(dname.find("12")!=string::npos){ biny = 12;}
-	    else if(dname.find("13")!=string::npos){ biny = 13;}else if(dname.find("14")!=string::npos){ biny = 14;}
-	    else if(dname.find("15")!=string::npos){ biny = 15;}else if(dname.find("16")!=string::npos){ biny = 16;}
-	    else if(dname.find("17")!=string::npos){ biny = 17;}else if(dname.find("18")!=string::npos){ biny = 18;}
-	    else if(dname.find("19")!=string::npos){ biny = 19;}else if(dname.find("20")!=string::npos){ biny = 20;}
-	    else if(dname.find("21")!=string::npos){ biny = 21;}else if(dname.find("22")!=string::npos){ biny = 22;}
-	    else if(dname.find("23")!=string::npos){ biny = 23;}else if(dname.find("24")!=string::npos){ biny = 24;}
-	    else if(dname.find("25")!=string::npos){ biny = 25;}else if(dname.find("25")!=string::npos){ biny = 25;}
-	    else if(dname.find("26")!=string::npos){ biny = 26;}else if(dname.find("27")!=string::npos){ biny = 27;}
-	    else if(dname.find("28")!=string::npos){ biny = 28;}else if(dname.find("29")!=string::npos){ biny = 29;}
-	    else if(dname.find("30")!=string::npos){ biny = 30;}else if(dname.find("31")!=string::npos){ biny = 31;}
-	    else if(dname.find("32")!=string::npos){ biny = 32;}
+	    biny = getLadder(dname);
 	    if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
-	      if(currDir.find("Layer_1")!=string::npos){ biny = biny + 6;}
-	      else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 14;}
-	      else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
-	      else if(currDir.find("Layer_4")!=string::npos){ biny = biny + 32;}
+	      biny=-biny;
 	    }
+	    if(currDir.find("Shell_m")!=string::npos){ binx = 1;}else{ binx = 2;} //x-axis: z-side
 	    if(currDir.find("Layer_1")!=string::npos){
 	      HitEfficiency_L1 = iGetter.get("Pixel/Barrel/HitEfficiency_L1");
 	      if(HitEfficiency_L1) HitEfficiency_L1->setBinContent(binx, biny,(float)hitEfficiency);
@@ -1839,50 +1825,40 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore::IBooker & iBooker, DQMStore
       for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
         string full_path = currDir + "/" + (*it);
         if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
-	  MonitorElement * me = iGetter.get(full_path);
-	  if (!me) continue;
-	  float missingHits = me->getEntries();
+	  MonitorElement * missing = iGetter.get(full_path);
+	  if (!missing) continue;
+	  //float missingHits = missing->getEntries();
 	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
-	  me = iGetter.get(new_path);
-	  if (!me) continue;
-	  float validHits = me->getEntries();
-	  float hitEfficiency = -1.;
-	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
-	  int binx = 0; int biny = 1;
-	  if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
-	  else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
-	  else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
-	  else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
-	  else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
-	  else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
-	  if(currDir.find("HalfCylinder_mI")!=string::npos || currDir.find("HalfCylinder_pI")!=string::npos){ binx = binx + 12;}
-	  else{ 
-	    if(binx==1) binx = 12;
-	    else if(binx==2) binx = 11;
-	    else if(binx==3) binx = 10;
-	    else if(binx==4) binx = 9;
-	    else if(binx==5) binx = 8;
-	    else if(binx==6) binx = 7;
-	    else if(binx==7) binx = 6;
-	    else if(binx==8) binx = 5;
-	    else if(binx==9) binx = 4;
-	    else if(binx==10) binx = 3;
-	    else if(binx==11) binx = 2;
-	    else if(binx==12) binx = 1;
-	  }
-	  if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
-	    HitEfficiency_Dm1 = iGetter.get("Pixel/Endcap/HitEfficiency_Dm1");
-	    if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
-	    HitEfficiency_Dm2 = iGetter.get("Pixel/Endcap/HitEfficiency_Dm2");
-	    if(HitEfficiency_Dm2) HitEfficiency_Dm2->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
-	    HitEfficiency_Dp1 = iGetter.get("Pixel/Endcap/HitEfficiency_Dp1");
-	    if(HitEfficiency_Dp1) HitEfficiency_Dp1->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
-	    HitEfficiency_Dp2 = iGetter.get("Pixel/Endcap/HitEfficiency_Dp2");
-	    if(HitEfficiency_Dp2) HitEfficiency_Dp2->setBinContent(binx, biny, (float)hitEfficiency);
-          }
+	  MonitorElement * valid = iGetter.get(new_path);
+	  if (!valid) continue;
+	  //float validHits = valid->getEntries();
+	  int binx = 0; int biny = 0;
+	  binx = getBlade(dname);
+	  if(currDir.find("HalfCylinder_mI")!=string::npos || currDir.find("HalfCylinder_pI")!=string::npos){ binx = binx + 14;}
+	  else{  binx = 13 -binx;}
+	  const int nPanel=2;
+	  for (int i=1; i<nPanel+1; i++){
+	    float hitEfficiency = -1.;
+	    float missingHits=0;
+	    float validHits=0;
+	    biny=i;
+	    missingHits=missing->getBinContent(i);
+	    validHits=valid->getBinContent(i);
+	    if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
+	    if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	      HitEfficiency_Dm1 = iGetter.get("Pixel/Endcap/HitEfficiency_Dm1");
+	      if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny, (float)hitEfficiency);
+	    }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	      HitEfficiency_Dm2 = iGetter.get("Pixel/Endcap/HitEfficiency_Dm2");
+	      if(HitEfficiency_Dm2) HitEfficiency_Dm2->setBinContent(binx, biny, (float)hitEfficiency);
+	    }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	      HitEfficiency_Dp1 = iGetter.get("Pixel/Endcap/HitEfficiency_Dp1");
+	      if(HitEfficiency_Dp1) HitEfficiency_Dp1->setBinContent(binx, biny, (float)hitEfficiency);
+	    }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	      HitEfficiency_Dp2 = iGetter.get("Pixel/Endcap/HitEfficiency_Dp2");
+	      if(HitEfficiency_Dp2) HitEfficiency_Dp2->setBinContent(binx, biny, (float)hitEfficiency);
+	    }
+	  }//EndOfFor
 	}
       } 
     }else if(!isbarrel && dname.find("Blade_")!=string::npos && isUpgrade){ 
@@ -1900,15 +1876,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore::IBooker & iBooker, DQMStore
 	  float hitEfficiency = -1.;
 	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
 	  int binx = 0; int biny = 1;
-	  if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
-	  else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
-	  else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
-	  else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
-	  else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
-	  else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
-          else if(currDir.find("13")!=string::npos){ binx = 13;}else if(currDir.find("14")!=string::npos){ binx = 14;}
-          else if(currDir.find("15")!=string::npos){ binx = 15;}else if(currDir.find("16")!=string::npos){ binx = 16;}
-          else if(currDir.find("17")!=string::npos){ binx = 17;}
+	  binx = getBlade(dname);
 	  if(currDir.find("HalfCylinder_mI")!=string::npos || currDir.find("HalfCylinder_pI")!=string::npos){ binx = binx + 12;}
 	  else{ 
 	    if(binx==1) binx = 17;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -301,7 +301,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, edm::Eve
     
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hisID = src.label() + "_" + sblade;
-    
+
     if(updateEfficiencies){
       //EFFICIENCY
       meEfficiencyBlade_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
@@ -321,7 +321,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, edm::Eve
     }
     
     //VALID
-    meValidBlade_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidBlade_ = iBooker.book1D("valid_"+hisID,"# Valid hits",2,0.5,2.5);
     meValidBlade_->setAxisTitle("# Valid hits",1);
     
     meValidXBlade_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
@@ -329,7 +329,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, edm::Eve
     
     meValidYBlade_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
     meValidYBlade_->setAxisTitle("# Valid hits in Y",1);
-    
+
     meValidAlphaBlade_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
     meValidAlphaBlade_->setAxisTitle("# Valid hits in Alpha",1);
     
@@ -337,7 +337,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, edm::Eve
     meValidBetaBlade_->setAxisTitle("# Valid hits in Beta",1);
 
     //MISSING
-    meMissingBlade_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingBlade_ = iBooker.book1D("missing_"+hisID,"# Missing hits",2,0.5,2.5);
     meMissingBlade_->setAxisTitle("# Missing hits",1);
     
     meMissingXBlade_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
@@ -486,7 +486,9 @@ void SiPixelHitEfficiencyModule::fill(const TrackerTopology * pTT,const LocalTra
   float prediction_y = ltp.position().y();
  
   PixelBarrelName PBN= PixelBarrelName(DetId(id_), pTT);
-  int imod=PBN.moduleName(); 
+  int imod=PBN.moduleName();
+  PixelEndcapName PEN= PixelEndcapName(DetId(id_),pTT);
+  int ipan=PEN.pannelName(); 
   
   if(isHitValid){
     if(modon){
@@ -515,7 +517,7 @@ void SiPixelHitEfficiencyModule::fill(const TrackerTopology * pTT,const LocalTra
       meValidBetaPhi_->Fill(prediction_beta);
     }
     if(endcap && bladeon){
-      meValidBlade_->Fill(0.5);
+      meValidBlade_->Fill(ipan);
       meValidXBlade_->Fill(prediction_x);
       meValidYBlade_->Fill(prediction_y);
       meValidAlphaBlade_->Fill(prediction_alpha);
@@ -563,7 +565,7 @@ void SiPixelHitEfficiencyModule::fill(const TrackerTopology * pTT,const LocalTra
       meMissingBetaPhi_->Fill(prediction_beta);
     }
     if(endcap && bladeon){
-      meMissingBlade_->Fill(0.5);
+      meMissingBlade_->Fill(ipan);
       meMissingXBlade_->Fill(prediction_x);
       meMissingYBlade_->Fill(prediction_y);
       meMissingAlphaBlade_->Fill(prediction_alpha);


### PR DESCRIPTION
Now for CMSSW_8_0_X: 1. The monitor elements for Endcap: meMissingBlade_ and meValidBlade_ are now filled per panel. This allows to plot the HitEfficiency maps with more Granularity. The Hit Efficiency is showed per blade and panel for every endcap disk.  2. Functions getBlade and getLadder to read the Blade and Ladder with no dependence on detector geometry. Reducing existing hard code.
