### PR TITLE
add timing VS lumi (for HLT monitoring)

### DIFF
--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -1,0 +1,212 @@
+#include "DQM/HLTEvF/plugins/LumiMonitor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQM/TrackingMonitor/interface/GetLumi.h"
+
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+LumiMonitor::LumiMonitor( const edm::ParameterSet& iConfig ) : 
+  conf_(iConfig) 
+  , doPixelLumi_                  ( conf_.getParameter<bool>  ("doPixelLumi")                 )
+  , useBPixLayer1_                ( conf_.getParameter<bool>  ("useBPixLayer1")               )
+  , minNumberOfPixelsPerCluster_  ( conf_.getParameter<int>   ("minNumberOfPixelsPerCluster") )
+  , minPixelClusterCharge_        ( conf_.getParameter<double>("minPixelClusterCharge")       )
+  
+{
+
+  folderName_ = conf_.getParameter<std::string>("FolderName");
+
+  pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> >(conf_.getParameter<edm::InputTag>("pixelClusters"));
+  lumiscalersToken_   = mayConsume<LumiScalersCollection>(conf_.getParameter<edm::InputTag>("scalers"));
+
+  numberOfPixelClustersVsLS_   = NULL;
+  numberOfPixelClustersVsLumi_ = NULL;
+  lumiVsLS_                    = NULL;
+  pixelLumiVsLS_               = NULL;
+  pixelLumiVsLumi_             = NULL;
+
+  if(useBPixLayer1_) 
+    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::XSEC_PIXEL_CLUSTER  ;
+  else
+    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::rXSEC_PIXEL_CLUSTER  ;
+
+
+}
+
+LumiMonitor::~LumiMonitor() {
+
+}
+
+void LumiMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+				 edm::Run const        & iRun,
+				 edm::EventSetup const & iSetup) 
+{  
+  
+  std::string histname, histtitle;
+
+  edm::ParameterSet histoPSet        = conf_.getParameter<edm::ParameterSet>("histoPSet");
+  edm::ParameterSet pixelClusterPSet = histoPSet.getParameter<edm::ParameterSet>("pixelClusterPSet");
+  edm::ParameterSet lumiPSet         = histoPSet.getParameter<edm::ParameterSet>("lumiPSet");
+  edm::ParameterSet pixellumiPSet    = histoPSet.getParameter<edm::ParameterSet>("pixellumiPSet");
+  edm::ParameterSet lsPSet           = histoPSet.getParameter<edm::ParameterSet>("lsPSet");
+
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder.c_str());
+
+  if ( doPixelLumi_ ) {
+    histname = "numberOfPixelClustersVsLS"; histtitle = "number of pixel clusters vs LS";
+    numberOfPixelClustersVsLS_ = ibooker.book1D(histname, histtitle, 
+						lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")));
+    //    numberOfPixelClustersVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
+    numberOfPixelClustersVsLS_->setAxisTitle("LS",1);
+    numberOfPixelClustersVsLS_->setAxisTitle("number of pixel clusters",2);
+    
+    histname = "numberOfPixelClustersVsLumi"; histtitle = "number of pixel clusters vs lumi";
+    numberOfPixelClustersVsLumi_ = ibooker.bookProfile(histname, histtitle, 
+						       lumiPSet.getParameter<int32_t>("nbins"), lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"),
+						       pixelClusterPSet.getParameter<double>("xmin"), pixelClusterPSet.getParameter<double>("xmax"));
+    numberOfPixelClustersVsLumi_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",1);
+    numberOfPixelClustersVsLumi_->setAxisTitle("number of pixel clusters",2);
+
+    histname = "pixelLumiVsLS"; histtitle = "pixel-lumi vs LS";
+    pixelLumiVsLS_ = ibooker.bookProfile(histname, histtitle, 
+					 lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")),
+					 pixellumiPSet.getParameter<double>("xmin"), pixellumiPSet.getParameter<double>("xmax"));
+    //    pixelLumiVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
+    pixelLumiVsLS_->setAxisTitle("LS",1);
+    pixelLumiVsLS_->setAxisTitle("(pixel-lumi) inst lumi E30 [Hz cm^{-2}]",2);
+    
+    histname = "pixelLumiVsLumi"; histtitle = "pixel-lumi vs lumi";
+    pixelLumiVsLumi_ = ibooker.bookProfile(histname, histtitle, 
+					   lumiPSet.getParameter<int32_t>("nbins"), lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"),
+					   pixellumiPSet.getParameter<double>("xmin"), pixellumiPSet.getParameter<double>("xmax"));
+    pixelLumiVsLumi_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",1);
+    pixelLumiVsLumi_->setAxisTitle("(pixel-lumi) inst lumi E30 [Hz cm^{-2}]",2);
+  }
+
+  histname = "lumiVsLS"; histtitle = "lumi vs LS";
+  lumiVsLS_ = ibooker.bookProfile(histname, histtitle, 
+				  lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")),
+				  lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"));
+  //  lumiVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
+  lumiVsLS_->setAxisTitle("LS",1);
+  lumiVsLS_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",2);
+
+}
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+void LumiMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+
+  //  int bx = iEvent.bunchCrossing();
+  int ls = iEvent.id().luminosityBlock();
+
+  float scal_lumi = -1.;
+  edm::Handle<LumiScalersCollection> lumiScalers;
+  iEvent.getByToken(lumiscalersToken_, lumiScalers);
+  if ( lumiScalers.isValid() && lumiScalers->size() ) {
+    LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
+    scal_lumi = scalit->instantLumi();
+  } else {
+    scal_lumi = -1.;
+  }
+  lumiVsLS_ -> Fill(ls, scal_lumi);
+
+  if ( doPixelLumi_ ) {
+    size_t pixel_clusters = 0;
+    float  pixel_lumi = -1.;
+    edm::Handle< edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
+    iEvent.getByToken(pixelClustersToken_, pixelClusters);
+    if ( pixelClusters.isValid() ) {
+      
+      edm::ESHandle<TrackerTopology> tTopoHandle;
+      iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+      const TrackerTopology* const tTopo = tTopoHandle.product();
+      
+      // Count the number of clusters with at least a minimum
+      // number of pixels per cluster and at least a minimum charge.
+      size_t tot = 0;
+      edmNew::DetSetVector<SiPixelCluster>::const_iterator  pixCluDet = pixelClusters->begin();
+      for ( ; pixCluDet!=pixelClusters->end(); ++pixCluDet) {
+	
+	DetId detid = pixCluDet->detId();
+	size_t subdetid = detid.subdetId();
+	if ( subdetid == (int) PixelSubdetector::PixelBarrel ) 
+	  if ( tTopo->layer(detid)==1 ) 
+	    continue;
+	
+	edmNew::DetSet<SiPixelCluster>::const_iterator  pixClu = pixCluDet->begin();    
+	for ( ; pixClu != pixCluDet->end(); ++pixClu ) {
+	  ++tot;
+	  if ( (pixClu->size()   >= minNumberOfPixelsPerCluster_) &&
+	       (pixClu->charge() >= minPixelClusterCharge_      ) ) {
+	    ++pixel_clusters;
+	  }
+	}
+      }
+      pixel_lumi = lumi_factor_per_bx_ * pixel_clusters / GetLumi::CM2_TO_NANOBARN ; // ?!?!
+    } else
+      pixel_lumi = -1.;
+
+    numberOfPixelClustersVsLS_   -> Fill(ls,       pixel_clusters);
+    numberOfPixelClustersVsLumi_ -> Fill(scal_lumi,pixel_clusters);
+    pixelLumiVsLS_               -> Fill(ls,       pixel_lumi);
+    pixelLumiVsLumi_             -> Fill(scal_lumi,pixel_lumi);
+  }
+
+}
+
+void LumiMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<int>   ( "nbins");
+  pset.add<double>( "xmin" );
+  pset.add<double>( "xmax" );
+}
+
+void LumiMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<int>   ( "nbins", 2500);
+}
+
+void LumiMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>( "pixelClusters",               edm::InputTag("hltSiPixelClusters") );
+  desc.add<edm::InputTag>( "scalers",                     edm::InputTag("hltScalersRawToDigi"));
+  desc.add<std::string>  ( "FolderName",                  "HLT/LumiMonitoring"                );
+  desc.add<bool>         ( "doPixelLumi",                 false                               );
+  desc.add<bool>         ( "useBPixLayer1",               false                               );
+  desc.add<int>          ( "minNumberOfPixelsPerCluster", 2                                   ); // from DQM/PixelLumi/python/PixelLumiDQM_cfi.py
+  desc.add<double>       ( "minPixelClusterCharge",       15000.                              );
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription pixelClusterPSet;
+  LumiMonitor::fillHistoPSetDescription(pixelClusterPSet);
+  histoPSet.add("pixelClusterPSet", pixelClusterPSet);
+
+  edm::ParameterSetDescription lumiPSet;
+  fillHistoPSetDescription(lumiPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lumiPSet", lumiPSet);
+
+  edm::ParameterSetDescription pixellumiPSet;
+  fillHistoPSetDescription(pixellumiPSet);
+  histoPSet.add<edm::ParameterSetDescription>("pixellumiPSet", pixellumiPSet);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoLSPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("lumiMonitor", desc);
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LumiMonitor);

--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -10,35 +10,48 @@
 // -----------------------------
 
 LumiMonitor::LumiMonitor( const edm::ParameterSet& iConfig ) : 
-  conf_(iConfig) 
-  , doPixelLumi_                  ( conf_.getParameter<bool>  ("doPixelLumi")                 )
-  , useBPixLayer1_                ( conf_.getParameter<bool>  ("useBPixLayer1")               )
-  , minNumberOfPixelsPerCluster_  ( conf_.getParameter<int>   ("minNumberOfPixelsPerCluster") )
-  , minPixelClusterCharge_        ( conf_.getParameter<double>("minPixelClusterCharge")       )
-  
+  folderName_             ( iConfig.getParameter<std::string>("FolderName") )
+  , lumiScalersToken_     ( consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("scalers") ) ) 
+  , lumi_binning_         ( getHistoPSet  (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lumiPSet"))         )
+  , ls_binning_           ( getHistoLSPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lsPSet"))           )
+  , doPixelLumi_          ( iConfig.getParameter<bool>("doPixelLumi") )
+  , pixelClustersToken_           ( doPixelLumi_ ? consumes<edmNew::DetSetVector<SiPixelCluster> >(iConfig.getParameter<edm::InputTag>("pixelClusters") ) : edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> () )
+  , useBPixLayer1_                ( doPixelLumi_ ? iConfig.getParameter<bool>   ("useBPixLayer1") : false            )
+  , minNumberOfPixelsPerCluster_  ( doPixelLumi_ ? iConfig.getParameter<int>    ("minNumberOfPixelsPerCluster") : -1 )
+  , minPixelClusterCharge_        ( doPixelLumi_ ? iConfig.getParameter<double> ("minPixelClusterCharge") : -1.      )
+  , pixelCluster_binning_         ( doPixelLumi_ ? getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("pixelClusterPSet")) : MEbinning {} )
+  , pixellumi_binning_            ( doPixelLumi_ ? getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("pixellumiPSet")) : MEbinning {} )
 {
 
-  folderName_ = conf_.getParameter<std::string>("FolderName");
-
-  pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> >(conf_.getParameter<edm::InputTag>("pixelClusters"));
-  lumiscalersToken_   = mayConsume<LumiScalersCollection>(conf_.getParameter<edm::InputTag>("scalers"));
-
-  numberOfPixelClustersVsLS_   = NULL;
-  numberOfPixelClustersVsLumi_ = NULL;
-  lumiVsLS_                    = NULL;
-  pixelLumiVsLS_               = NULL;
-  pixelLumiVsLumi_             = NULL;
+  numberOfPixelClustersVsLS_   = nullptr;
+  numberOfPixelClustersVsLumi_ = nullptr;
+  lumiVsLS_                    = nullptr;
+  pixelLumiVsLS_               = nullptr;
+  pixelLumiVsLumi_             = nullptr;
 
   if(useBPixLayer1_) 
     lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::XSEC_PIXEL_CLUSTER  ;
   else
     lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::rXSEC_PIXEL_CLUSTER  ;
 
-
 }
 
-LumiMonitor::~LumiMonitor() {
+MEbinning LumiMonitor::getHistoPSet(edm::ParameterSet pset)
+{
+  return MEbinning{
+    pset.getParameter<int32_t>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
 
+MEbinning LumiMonitor::getHistoLSPSet(edm::ParameterSet pset)
+{
+  return MEbinning{
+    pset.getParameter<int32_t>("nbins"),
+      0.,
+      double(pset.getParameter<int32_t>("nbins"))
+      };
 }
 
 void LumiMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
@@ -48,53 +61,47 @@ void LumiMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   
   std::string histname, histtitle;
 
-  edm::ParameterSet histoPSet        = conf_.getParameter<edm::ParameterSet>("histoPSet");
-  edm::ParameterSet pixelClusterPSet = histoPSet.getParameter<edm::ParameterSet>("pixelClusterPSet");
-  edm::ParameterSet lumiPSet         = histoPSet.getParameter<edm::ParameterSet>("lumiPSet");
-  edm::ParameterSet pixellumiPSet    = histoPSet.getParameter<edm::ParameterSet>("pixellumiPSet");
-  edm::ParameterSet lsPSet           = histoPSet.getParameter<edm::ParameterSet>("lsPSet");
-
   std::string currentFolder = folderName_ ;
   ibooker.setCurrentFolder(currentFolder.c_str());
 
   if ( doPixelLumi_ ) {
     histname = "numberOfPixelClustersVsLS"; histtitle = "number of pixel clusters vs LS";
     numberOfPixelClustersVsLS_ = ibooker.book1D(histname, histtitle, 
-						lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")));
+						ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax);
     //    numberOfPixelClustersVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
     numberOfPixelClustersVsLS_->setAxisTitle("LS",1);
     numberOfPixelClustersVsLS_->setAxisTitle("number of pixel clusters",2);
     
-    histname = "numberOfPixelClustersVsLumi"; histtitle = "number of pixel clusters vs lumi";
+    histname = "numberOfPixelClustersVsLumi"; histtitle = "number of pixel clusters vs scal lumi";
     numberOfPixelClustersVsLumi_ = ibooker.bookProfile(histname, histtitle, 
-						       lumiPSet.getParameter<int32_t>("nbins"), lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"),
-						       pixelClusterPSet.getParameter<double>("xmin"), pixelClusterPSet.getParameter<double>("xmax"));
-    numberOfPixelClustersVsLumi_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",1);
+						       lumi_binning_.nbins, lumi_binning_.xmin, lumi_binning_.xmax,
+						       pixelCluster_binning_.xmin,pixelCluster_binning_.xmax);
+    numberOfPixelClustersVsLumi_->setAxisTitle("scal inst lumi E30 [Hz cm^{-2}]",1);
     numberOfPixelClustersVsLumi_->setAxisTitle("number of pixel clusters",2);
 
     histname = "pixelLumiVsLS"; histtitle = "pixel-lumi vs LS";
     pixelLumiVsLS_ = ibooker.bookProfile(histname, histtitle, 
-					 lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")),
-					 pixellumiPSet.getParameter<double>("xmin"), pixellumiPSet.getParameter<double>("xmax"));
+					 ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,
+					 pixellumi_binning_.xmin,pixellumi_binning_.xmax);
     //    pixelLumiVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
     pixelLumiVsLS_->setAxisTitle("LS",1);
-    pixelLumiVsLS_->setAxisTitle("(pixel-lumi) inst lumi E30 [Hz cm^{-2}]",2);
+    pixelLumiVsLS_->setAxisTitle("pixel-based inst lumi E30 [Hz cm^{-2}]",2);
     
-    histname = "pixelLumiVsLumi"; histtitle = "pixel-lumi vs lumi";
+    histname = "pixelLumiVsLumi"; histtitle = "pixel-lumi vs scal lumi";
     pixelLumiVsLumi_ = ibooker.bookProfile(histname, histtitle, 
-					   lumiPSet.getParameter<int32_t>("nbins"), lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"),
-					   pixellumiPSet.getParameter<double>("xmin"), pixellumiPSet.getParameter<double>("xmax"));
-    pixelLumiVsLumi_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",1);
-    pixelLumiVsLumi_->setAxisTitle("(pixel-lumi) inst lumi E30 [Hz cm^{-2}]",2);
+					   lumi_binning_.nbins,lumi_binning_.xmin,lumi_binning_.xmax,
+					   pixellumi_binning_.xmin,lumi_binning_.xmax);
+    pixelLumiVsLumi_->setAxisTitle("scal inst lumi E30 [Hz cm^{-2}]",1);
+    pixelLumiVsLumi_->setAxisTitle("pixel-based inst lumi E30 [Hz cm^{-2}]",2);
   }
 
-  histname = "lumiVsLS"; histtitle = "lumi vs LS";
+  histname = "lumiVsLS"; histtitle = "scal lumi vs LS";
   lumiVsLS_ = ibooker.bookProfile(histname, histtitle, 
-				  lsPSet.getParameter<int32_t>("nbins"), 0., double(lsPSet.getParameter<int32_t>("nbins")),
-				  lumiPSet.getParameter<double>("xmin"), lumiPSet.getParameter<double>("xmax"));
+				  ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,
+				  lumi_binning_.xmin, lumi_binning_.xmax);
   //  lumiVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
   lumiVsLS_->setAxisTitle("LS",1);
-  lumiVsLS_->setAxisTitle("(SCAL) inst lumi E30 [Hz cm^{-2}]",2);
+  lumiVsLS_->setAxisTitle("scal inst lumi E30 [Hz cm^{-2}]",2);
 
 }
 
@@ -109,7 +116,7 @@ void LumiMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetu
 
   float scal_lumi = -1.;
   edm::Handle<LumiScalersCollection> lumiScalers;
-  iEvent.getByToken(lumiscalersToken_, lumiScalers);
+  iEvent.getByToken(lumiScalersToken_, lumiScalers);
   if ( lumiScalers.isValid() && lumiScalers->size() ) {
     LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
     scal_lumi = scalit->instantLumi();

--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -1,0 +1,74 @@
+#ifndef LUMIMONITOR_H
+#define LUMIMONITOR_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+//DataFormats
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/Luminosity/interface/LumiDetails.h"
+#include "DataFormats/Luminosity/interface/LumiSummary.h"
+
+
+//
+// class declaration
+//
+
+class LumiMonitor : public DQMEDAnalyzer 
+{
+public:
+  LumiMonitor( const edm::ParameterSet& );
+  ~LumiMonitor();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
+  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
+
+private:
+
+  void bookHistograms();
+
+  edm::ParameterSet conf_;
+
+  std::string folderName_;
+
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
+  edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  edm::EDGetTokenT<LumiSummary> lumiSummaryToken_;
+  
+  MonitorElement* numberOfPixelClustersVsLS_;
+  MonitorElement* numberOfPixelClustersVsLumi_;
+  MonitorElement* lumiVsLS_;
+  MonitorElement* pixelLumiVsLS_;
+  MonitorElement* pixelLumiVsLumi_;
+
+  bool  doPixelLumi_;
+  bool  useBPixLayer1_;
+  int   minNumberOfPixelsPerCluster_;
+  float minPixelClusterCharge_;	
+
+  float lumi_factor_per_bx_;
+
+  unsigned long long m_cacheID_;
+};
+
+#endif // LUMIMONITOR_H

--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -25,6 +25,14 @@
 #include "DataFormats/Luminosity/interface/LumiSummary.h"
 
 
+struct MEbinning {
+  int nbins;
+  double xmin;
+  double xmax;
+  //  MEbinning() {};
+  //  explicit MEbinning(int n, double min, double max) { nbins= n; xmin = min; xmax = max;}
+};
+
 //
 // class declaration
 //
@@ -33,7 +41,7 @@ class LumiMonitor : public DQMEDAnalyzer
 {
 public:
   LumiMonitor( const edm::ParameterSet& );
-  ~LumiMonitor();
+  ~LumiMonitor() = default;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
   static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
@@ -45,14 +53,24 @@ protected:
 
 private:
 
-  void bookHistograms();
-
-  edm::ParameterSet conf_;
+  static MEbinning getHistoPSet  (edm::ParameterSet pset);
+  static MEbinning getHistoLSPSet(edm::ParameterSet pset);
 
   std::string folderName_;
 
+  edm::EDGetTokenT<LumiScalersCollection> lumiScalersToken_;
+  MEbinning lumi_binning_;
+  MEbinning ls_binning_;
+
+  bool  doPixelLumi_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
-  edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  bool  useBPixLayer1_;
+  int   minNumberOfPixelsPerCluster_;
+  float minPixelClusterCharge_;	
+  MEbinning pixelCluster_binning_;
+  MEbinning pixellumi_binning_;
+
+
   edm::EDGetTokenT<LumiSummary> lumiSummaryToken_;
   
   MonitorElement* numberOfPixelClustersVsLS_;
@@ -61,14 +79,8 @@ private:
   MonitorElement* pixelLumiVsLS_;
   MonitorElement* pixelLumiVsLumi_;
 
-  bool  doPixelLumi_;
-  bool  useBPixLayer1_;
-  int   minNumberOfPixelsPerCluster_;
-  float minPixelClusterCharge_;	
-
   float lumi_factor_per_bx_;
 
-  unsigned long long m_cacheID_;
 };
 
 #endif // LUMIMONITOR_H

--- a/DQM/HLTEvF/python/LumiMonitor_cff.py
+++ b/DQM/HLTEvF/python/LumiMonitor_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+lumiMonitor = cms.EDAnalyzer("LumiMonitor",
+   FolderName                  = cms.string("HLT/LumiMonitoring"),
+   doPixelLumi                 = cms.bool(False),
+   useBPixLayer1               = cms.bool(False),
+   minNumberOfPixelsPerCluster = cms.int32(2), # from DQM/PixelLumi/python/PixelLumiDQM_cfi.py
+   minPixelClusterCharge       = cms.double(15000.),
+   pixelClusters               = cms.InputTag("hltSiPixelClusters"),
+   scalers                     = cms.InputTag('scalersRawToDigi'),
+   histoPSet                   = cms.PSet(
+      pixelClusterPSet            = cms.PSet(
+            nbins = cms.int32 (  200  ),
+            xmin  = cms.double(   -0.5),
+            xmax  = cms.double(19999.5),
+      ),
+      lumiPSet                    = cms.PSet(
+            nbins = cms.int32 ( 3600 ),
+            xmin  = cms.double( 3000.),
+            xmax  = cms.double(12000.),
+      ),
+      pixellumiPSet               = cms.PSet(
+            nbins = cms.int32 (300 ),
+            xmin  = cms.double(  0.),
+            xmax  = cms.double(  3.),
+      ),
+      lsPSet                      = cms.PSet(
+            nbins = cms.int32 (2500 ),
+            xmin  = cms.double(   0.),
+            xmax  = cms.double(2500.),
+      ),
+   ),
+)

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -26,5 +26,15 @@ if process.dqmRunConfig.type.value() is "playback":
 # FastTimerService client
 process.load('HLTrigger.Timer.fastTimerServiceClient_cfi')
 process.fastTimerServiceClient.dqmPath = "HLT/TimerService"
+# timing VS lumi
+process.fastTimerServiceClient.doPlotsVsScalLumi  = cms.bool(True)
+process.fastTimerServiceClient.doPlotsVsPixelLumi = cms.bool(False)
+process.fastTimerServiceClient.scalLumiME = cms.PSet(
+    folder = cms.string('HLT/LumiMonitoring'),
+    name   = cms.string('lumiVsLS'),
+    nbins  = cms.int32(6500),
+    xmin   = cms.double(0),
+    xmax   = cms.double(13000)
+)
 
 process.p = cms.EndPath( process.fastTimerServiceClient + process.dqmEnv + process.dqmSaver )

--- a/DQM/TrackingMonitor/interface/GetLumi.h
+++ b/DQM/TrackingMonitor/interface/GetLumi.h
@@ -34,7 +34,7 @@ class GetLumi
 
   static constexpr double INELASTIC_XSEC_7TeV  = 68.0; // mb
   static constexpr double INELASTIC_XSEC_8TeV  = 69.3; // mb
-  static constexpr double INELASTIC_XSEC_13TeV = 71.0; // mb
+  static constexpr double INELASTIC_XSEC_13TeV = 71.3; // mb from http://inspirehep.net/record/1447965/files/FSQ-15-005-pas.pdf
 
   // from http://cmslxr.fnal.gov/source/DQM/PixelLumi/plugins/PixelLumiDQM.h
   // Using all pixel clusters:

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -23,12 +23,21 @@
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
+struct MEPSet {
+  std::string folder;
+  std::string name;
+  int nbins;
+  double xmin;
+  double xmax;
+};
+
 class FastTimerServiceClient : public DQMEDHarvester {
 public:
   explicit FastTimerServiceClient(edm::ParameterSet const &);
   ~FastTimerServiceClient();
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillLumiMePSetDescription(edm::ParameterSetDescription & pset);
 
 private:
   std::string m_dqm_path;
@@ -39,11 +48,25 @@ private:
   void fillSummaryPlots(        DQMStore::IBooker & booker, DQMStore::IGetter & getter);
   void fillProcessSummaryPlots( DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & path);
   void fillPathSummaryPlots(    DQMStore::IBooker & booker, DQMStore::IGetter & getter, double events, std::string const & path);
+  void fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path, std::string const & suffix, MEPSet pset);
+
+  static MEPSet getHistoPSet  (edm::ParameterSet pset);
+
+  bool doPlotsVsScalLumi_;
+  bool doPlotsVsPixelLumi_;
+
+  MEPSet scalLumiMEPSet_;
+  MEPSet pixelLumiMEPSet_;
+
 };
 
 
 FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const & config) :
   m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
+  , doPlotsVsScalLumi_ ( config.getParameter<bool>( "doPlotsVsScalLumi" )  )
+  , doPlotsVsPixelLumi_( config.getParameter<bool>( "doPlotsVsPixelLumi" ) )
+  , scalLumiMEPSet_ ( doPlotsVsScalLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("scalLumiME")) : MEPSet{}  )
+  , pixelLumiMEPSet_( doPlotsVsPixelLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("pixelLumiME")) : MEPSet{} )
 {
 }
 
@@ -87,10 +110,20 @@ FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker & booker, DQMStore::I
 
 void
 FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path) {
+
   MonitorElement * me = getter.get(current_path + "/event");
   if (me == 0)
     // no FastTimerService DQM information
     return;
+
+  if ( doPlotsVsScalLumi_ ) {
+    fillPlotsVsLumi( booker,getter, current_path, "VsScalLumi", scalLumiMEPSet_ );
+  }
+  if ( doPlotsVsPixelLumi_ ) {
+    fillPlotsVsLumi( booker,getter, current_path, "VsPixelLumi", pixelLumiMEPSet_ );
+  }
+
+  getter.setCurrentFolder(current_path);
 
   double events = me->getTH1F()->GetEntries();
 
@@ -132,7 +165,6 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
     paths = me->getTProfile();
     size  = paths->GetXaxis()->GetNbins();
   }
-
   if (paths == nullptr)
     return;
 
@@ -223,12 +255,128 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
 
 }
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+void
+FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path, std::string const & suffix, MEPSet pset ) {
+
+  std::vector<std::string> menames;
+
+  static const boost::regex byls(".*byls");
+  static const boost::regex test(suffix);
+  // get all MEs in the current_path
+  getter.setCurrentFolder(current_path);
+  std::vector<std::string> allmenames = getter.getMEs();
+  for ( auto m : allmenames )
+    // get only MEs vs LS
+    if (boost::regex_match(m, byls))
+      menames.push_back(m);
+
+  // if no MEs available, return
+  if ( menames.size() == 0 )
+    return;
+  
+
+  // get info for getting the lumi VS LS histogram
+  std::string folder = pset.folder;
+  std::string name   = pset.name;
+  int         nbins  = pset.nbins;
+  double      xmin   = pset.xmin;
+  double      xmax   = pset.xmax;
+
+  // get lumi VS LS ME
+  getter.setCurrentFolder(folder);
+  MonitorElement* lumiVsLS = getter.get(folder+"/"+name);
+  // if no ME available, return
+  if ( !lumiVsLS ) {
+    edm::LogWarning("FastTimerServiceClient") << "no " << name << " ME is available in " << folder << std::endl;
+    return;
+  }
+
+  // get range and binning for new MEs x-axis
+  size_t size        = lumiVsLS->getTProfile()->GetXaxis()->GetNbins();
+  std::string xtitle = lumiVsLS->getTProfile()->GetYaxis()->GetTitle();
+
+  std::vector<double> lumi;
+  std::vector<int> LS;
+  for ( size_t ibin=1; ibin <= size; ++ibin ) {
+    // avoid to store points w/ no info
+    if ( lumiVsLS->getTProfile()->GetBinContent(ibin) == 0. ) continue;
+
+    lumi.push_back( lumiVsLS->getTProfile()->GetBinContent(ibin) );
+    LS.push_back  ( lumiVsLS->getTProfile()->GetXaxis()->GetBinCenter(ibin) );
+  }
+
+  booker.setCurrentFolder(current_path);
+  getter.setCurrentFolder(current_path);
+  for ( auto m : menames ) {
+    std::string label = m;
+    label.erase(label.find("_byls"));
+
+    MonitorElement* me = getter.get(current_path + "/" + m);
+    double ymin        = me->getTProfile()->GetMinimum();
+    double ymax        = me->getTProfile()->GetMaximum();
+    std::string ytitle = me->getTProfile()->GetYaxis()->GetTitle();
+
+    MonitorElement* meVsLumi = getter.get( current_path + "/" + label + "_" + suffix );
+    if (meVsLumi) {
+      assert( meVsLumi->getTProfile()->GetXaxis()->GetXmin()  == xmin );
+      assert( meVsLumi->getTProfile()->GetXaxis()->GetXmax()  == xmax );
+      meVsLumi->Reset(); // do I have to do it ?!?!?
+    } else {
+      meVsLumi = booker.bookProfile(label + "_" + suffix, label + "_" + suffix, nbins, xmin, xmax, ymin, ymax);
+      //    TProfile* meVsLumi_p = meVsLumi->getTProfile();
+      meVsLumi->getTProfile()->GetXaxis()->SetTitle(xtitle.c_str());
+      meVsLumi->getTProfile()->GetYaxis()->SetTitle(ytitle.c_str());
+    }
+    for ( size_t ils=0; ils < LS.size(); ++ils ) {
+      int ibin = me->getTProfile()->GetXaxis()->FindBin(LS[ils]);
+      double y = me->getTProfile()->GetBinContent(ibin);
+
+      meVsLumi->Fill(lumi[ils],y);
+    }
+  }
+  
+  
+}
+
+void 
+FastTimerServiceClient::fillLumiMePSetDescription(edm::ParameterSetDescription & pset) {
+  pset.add<std::string>("folder", "HLT/LumiMonitoring");
+  pset.add<std::string>("name"  , "lumiVsLS");
+  pset.add<int>   ("nbins",  6500 );
+  pset.add<double>("xmin",      0.);
+  pset.add<double>("xmax",  13000.);
+}
+
+
+MEPSet FastTimerServiceClient::getHistoPSet(edm::ParameterSet pset)
+{
+  return MEPSet{
+    pset.getParameter<std::string>("folder"),
+      pset.getParameter<std::string>("name"),
+      pset.getParameter<int>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
+
 void
 FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
   // The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>( "dqmPath", "HLT/TimerService");
+  desc.add<bool>( "doPlotsVsScalLumi",  true  );
+  desc.add<bool>( "doPlotsVsPixelLumi", false );
+
+  edm::ParameterSetDescription scalLumiMEPSet;
+  fillLumiMePSetDescription(scalLumiMEPSet);
+  desc.add<edm::ParameterSetDescription>("scalLumiME", scalLumiMEPSet);
+  
+  edm::ParameterSetDescription pixelLumiMEPSet;
+  fillLumiMePSetDescription(pixelLumiMEPSet);
+  desc.add<edm::ParameterSetDescription>("pixelLumiME", pixelLumiMEPSet);
+
   descriptions.add("fastTimerServiceClient", desc);
 }
 


### PR DESCRIPTION
the main goal is to have this update in 80x for monitoring the timing vs lumi @ p5

I added a DQM source which produce the inst lumi vs LS
which has to be run w/in HLT menu
its timing should be ~neglible
![hltlumimonitoring](https://cloud.githubusercontent.com/assets/4946419/16238478/e53ed920-37e0-11e6-9803-e1416eaf735c.png)

then, the timing VS lumi is done by the FastTimerServiceClient

the current configuration makes the lumi profile by using SCAL,
but it can be configured in order to make use of the pixel-based luminosity as well
