### PR TITLE
Fix array bounds overrun in DetectPatterns()

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
@@ -9,16 +9,16 @@
 
 //hardcoded pattern definitions
 #define PATTERN_SIZE 9
-PhiMemoryImage pattern1 (0x8000,0,0,0x8000,0,0,0x8000,0,0,0x8000,0,0);
-PhiMemoryImage pattern2 (0x10000,0,0,0x8000,0,0,0xc000,0,0,0xc000,0,0);
-PhiMemoryImage pattern3 (0x4000,0,0,0x8000,0,0,0x18000,0,0,0x18000,0,0);
-PhiMemoryImage pattern4 (0x60000,0,0,0x8000,0,0,0xe000,0,0,0xe000,0,0);
-PhiMemoryImage pattern5 (0x3000,0,0,0x8000,0,0,0x78000,0,0,0x78000,0,0);
-PhiMemoryImage pattern6 (0x780000,0,0,0x8000,0,0,0xff00,0,0,0xff00,0,0);
-PhiMemoryImage pattern7 (0xf00,0,0,0x8000,0,0,0x7f8000,0,0,0x7f8000,0,0);
-PhiMemoryImage pattern8 (0x7f800000,0,0,0x8000,0,0,0xff00,0,0,0xff00,0,0);//
-PhiMemoryImage pattern9 (0xff,0,0,0x8000,0,0,0x7f8000,0,0,0x7f8000,0,0);
-PhiMemoryImage patterns[PATTERN_SIZE] = {pattern8, pattern9, pattern6, pattern7, pattern4, pattern5, pattern2, pattern3, pattern1};
+const PhiMemoryImage pattern1 (0x8000,0,0,0x8000,0,0,0x8000,0,0,0x8000,0,0);
+const PhiMemoryImage pattern2 (0x10000,0,0,0x8000,0,0,0xc000,0,0,0xc000,0,0);
+const PhiMemoryImage pattern3 (0x4000,0,0,0x8000,0,0,0x18000,0,0,0x18000,0,0);
+const PhiMemoryImage pattern4 (0x60000,0,0,0x8000,0,0,0xe000,0,0,0xe000,0,0);
+const PhiMemoryImage pattern5 (0x3000,0,0,0x8000,0,0,0x78000,0,0,0x78000,0,0);
+const PhiMemoryImage pattern6 (0x780000,0,0,0x8000,0,0,0xff00,0,0,0xff00,0,0);
+const PhiMemoryImage pattern7 (0xf00,0,0,0x8000,0,0,0x7f8000,0,0,0x7f8000,0,0);
+const PhiMemoryImage pattern8 (0x7f800000,0,0,0x8000,0,0,0xff00,0,0,0xff00,0,0);//
+const PhiMemoryImage pattern9 (0xff,0,0,0x8000,0,0,0x7f8000,0,0,0x7f8000,0,0);
+const PhiMemoryImage patterns[PATTERN_SIZE] = {pattern8, pattern9, pattern6, pattern7, pattern4, pattern5, pattern2, pattern3, pattern1};
  
  
  PatternOutput DetectPatterns(ZonesOutput Eout){
@@ -110,13 +110,13 @@ PhiMemoryImage patterns[PATTERN_SIZE] = {pattern8, pattern9, pattern6, pattern7,
  
  		for(int k=0;k<192;k++){//was 128
 	
-			int qr = ranka_t[zone][k-1], ql = ranka_t[zone][k+1], qc = ranka_t[zone][k];
+			int qr = 0, ql = 0, qc = ranka_t[zone][k];
 			
 			//if(qc && verbose)
 			//	std::cout<<"\n"<<k<<":qc = "<<qc<<" straight: "<<stra[zone][k]<<"  lya: "<<lya[zone][k]<<std::endl; 
 		
-			if(k==0){qr=0;}
-			if(k==191){ql=0;}//was 127
+			if(k>0){qr=ranka_t[zone][k-1];}
+			if(k<191){ql=ranka_t[zone][k+1];}//was 127
 		
 			if((qc <= ql) || (qc < qr)){qc = 0;}
 		


### PR DESCRIPTION
The DetectPatterns() routine was running off both ends of the ranka_t vector due to a misplaced bounds check.  This was causing occasional crashes, particularly in the multi-threaded integration builds where the memory layout is more scattered.

I also added "const" to some file-level statics that our static code analyzer complains about.
