### PR TITLE
Switch upgrade RecoFull event content to RECOSIM

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1659,7 +1659,7 @@ for k in upgradeKeys:
                                       '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',
                                       '-n':'10',
                                       '--runUnscheduled':'',
-                                      '--eventcontent':'FEVTDEBUGHLT,MINIAODSIM,DQM',
+                                      '--eventcontent':'RECOSIM,MINIAODSIM,DQM',
                                       '--geometry' : geom
                                       }
     if cust!=None : upgradeStepDict['RecoFull'][k]['--customise']=cust


### PR DESCRIPTION
I noticed that in 810pre7 (probably earlier too) the 2017 GEN-SIM-RECO datasets are larger than GEN-SIM-DIGI-RAW. After some investigation (out of curiosity) I noticed that the upgrade `RecoFull` workflow is configured for FEVTDEBUGHLT event content. I believe it is bit of an overkill, and probably just a historic remnant (AFAICT has been there always in 81X).

FYI @boudoul @kpedro88 
