### PR TITLE
add a nan protection to avoid crash in fastjet call from pvsorter (81X version)

### DIFF
--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -9,6 +9,7 @@
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/Selector.hh"
 #include "fastjet/PseudoJet.hh"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 using namespace fastjet;
 using namespace std;
@@ -30,7 +31,7 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
 	if(c->pt()!=0) {
        		 scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
 	}
- 	if(isnan(scale)) { 
+ 	if(edm::isNotFinite(scale)) { 
 		edm::LogWarning("PrimaryVertexSorting") << "Scaling is NAN ignoring this candidate/track" << std::endl;
 		scale=0; 
         }

--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -27,7 +27,13 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
     float scale=1.;
     if(c->bestTrack() != 0)
       {
-        scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
+	if(c->pt()!=0) {
+       		 scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
+	}
+ 	if(isnan(scale)) { 
+		edm::LogWarning("PrimaryVertexSorting") << "Scaling is NAN ignoring this candidate/track" << std::endl;
+		scale=0; 
+        }
         if(scale<0){ 
 	  scale=0; 
 	  countScale0++;


### PR DESCRIPTION
same as #14846 
this is the 81X version

it addresses
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1451/2/1/1/1.html
by adding a protection on "nan" being passed to fastjet.

the nan seems to be coming from ptError and should be further investigated
