### PR TITLE
Update the fall-back Express GT for Event Display after the Era change in Tier0 (81X)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
 
-# Deafult Express GT: it is the GT that will be used in case we are not able
+# Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.
-GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v8" )
+GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v10" )
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.


### PR DESCRIPTION
This PR updates the "default" Express GT, i.e. the fall-back to be used in case we are not able to retrieve the one used at Tier0, in `DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py` for the Event Display online application, to keep it synchronized with the Era change in Tier0 processing.
Forward port of #14946 
