### PR TITLE
Fix to MultiTrackValidator standalone mode

### DIFF
--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -1184,7 +1184,7 @@ MTVHistoProducerAlgoForTracker::getPt(double pt) {
 }
 
 unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::Track& track, const TrackerTopology& ttopo) {
-  if(track.seedRef().isNull())
+  if(track.seedRef().isNull() || !track.seedRef().isAvailable())
     return seedingLayerSetNames.size()-1;
 
   const TrajectorySeed& seed = *(track.seedRef());


### PR DESCRIPTION
The check for `Track::seedRef()` availability in MultiTrackValidator, added in #14248, was not sufficient. This omission leads to an exception from missing product in the MTV standalone mode ([SWGuideMultiTrackValidator#cmsDriver_MTV_alone_i_e_standalo](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMultiTrackValidator#cmsDriver_MTV_alone_i_e_standalo)). Requiring explicitly the availability of the seed product fixes the exception. Thanks to @ebrondol for reporting the bug.

Tested in CMSSW_8_1_0_pre6, no changes expected in standard workflows.

@rovere @VinInn 
