### PR TITLE
double the reserve for on-demand strip cluster from raw 

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -222,7 +222,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     
     if(onDemand) assert(output->onDemand());
 
-    output->reserve(15000,12*10000);
+    output->reserve(15000,24*10000);
 
 
     if (!onDemand) {


### PR DESCRIPTION
This is  a cheap temporary solution (about 2.7 MB cost per stream).
It resolves several crashes reported in HLT step of 810pre7 relvals
https://hypernews.cern.ch/HyperNews/CMS/get/relval/5231.html

The problematic  "Run 274199, Event 268225325, LumiSection 137"  had a total of 132,303 clusters to be unpacked, while the previous limit was 132,303.

A configurable and possibly more graceful solution is expected with 
https://its.cern.ch/jira/browse/CMSTRACK-145

@fwyzard @VinInn @venturia 
