### PR TITLE
 double the reserve for on-demand strip cluster from raw (backport of #14953 )

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -222,7 +222,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     
     if(onDemand) assert(output->onDemand());
 
-    output->reserve(15000,12*10000);
+    output->reserve(15000,24*10000);
 
 
     if (!onDemand) {


### PR DESCRIPTION
This is a cheap temporary solution (about 2.7 MB cost per stream).
It resolves several crashes reported in HLT step of 810pre7 relvals
https://hypernews.cern.ch/HyperNews/CMS/get/relval/5231.html
