### PR TITLE
DDL Parser Cleanup

### DIFF
--- a/DetectorDescription/Parser/interface/DDLParser.h
+++ b/DetectorDescription/Parser/interface/DDLParser.h
@@ -1,32 +1,24 @@
-#ifndef DDL_Parser_H
-#define DDL_Parser_H
+#ifndef DETECTOR_DESCRIPTION_PARSER_DDL_PARSER_H
+#define DETECTOR_DESCRIPTION_PARSER_DDL_PARSER_H
 
-#include <stddef.h>
+#include "DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h"
+#include "DetectorDescription/Parser/interface/DDLSAX2FileHandler.h"
+#include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
+#include "FWCore/Concurrency/interface/Xerces.h"
 #include <xercesc/sax/SAXException.hpp>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
-// Xerces C++ dependencies
 #include <xercesc/util/XercesDefs.hpp>
+#include <xercesc/util/XercesVersion.hpp>
 #include <iosfwd>
 #include <map>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h"
-#include "DetectorDescription/Parser/interface/DDLSAX2FileHandler.h"
-// ---------------------------------------------------------------------------
-//  Includes
-// ---------------------------------------------------------------------------
-#include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
-#include "FWCore/Concurrency/interface/Xerces.h"
-#include "xercesc/util/XercesVersion.hpp"
+#include <cstddef>
 
 class DDCompactView;
 class DDLDocumentProvider;
-class DDLSAX2ExpressionHandler;
-class DDLSAX2FileHandler;
-class DDLSAX2Handler;
 
 /// DDLParser is the main class of Detector Description Language Parser.
 /** @class DDLParser
@@ -67,20 +59,17 @@ class DDLSAX2Handler;
  *         for CMSSW Framework example see XMLIdealGeometryESSource (different
  *         DDLDocumentProvider completely
  */
-class DDLParser 
-
+class DDLParser
 {
  public:
   typedef XERCES_CPP_NAMESPACE::SAX2XMLReader SAX2XMLReader;
 
   typedef std::map< int, std::pair<std::string, std::string> > FileNameHolder;
   
-  DDLParser ( DDCompactView& cpv );
+  DDLParser( DDCompactView& cpv );
 
- protected:
-  DDLParser( );
+  DDLParser() = delete; 
   
- public:
   ~DDLParser();
 
   /// Parse all files. Return is meaningless.
@@ -114,9 +103,6 @@ class DDLParser
   //old way  void parse( const std::vector<unsigned char>& ablob, unsigned int bsize ) ;
   void parse( const std::vector<unsigned char>& ablob, unsigned int bsize ) ;
 
-  /// Return list of files
-  std::vector<std::string> getFileList();
-
   /// Get the SAX2Parser from the DDLParser.  USE WITH CAUTION.  Set your own handler, etc.
   SAX2XMLReader* getXMLParser();
 
@@ -126,28 +112,26 @@ class DDLParser
    */
   DDLSAX2FileHandler* getDDLSAX2FileHandler();
   
+  /// Clear the file list - see Warning!
+  /**
+   *  This could result in mangled geometry if the Core has not been cleared.
+   **/
+  void clearFiles();
+
+ private:
+  /// Parse File.  Just to hold some common looking code.
+  void parseFile (const int& numtoproc);
+
   /// Is the file already known by the DDLParser?  Returns 0 if not found, and index if found.
   size_t isFound(const std::string& filename);
   
   /// Is the file already parsed?
   bool isParsed(const std::string& filename);
 
-  /// Clear the file list - see Warning!
-  /**
-   *  This could result in mangled geometry if the Core has not been cleared.
-   **/
-  void clearFiles () ;
+  std::string const extractFileName( const std::string& fullname );
 
-  std::string extractFileName(std::string fullname);
-  std::string getNameSpace(const std::string& fname);
-
- protected:
+  std::string const getNameSpace( const std::string& fname );
   
-  /// Parse File.  Just to hold some common looking code.
-  void parseFile (const int& numtoproc);
-
- private:
-
   /// reference to storage
   DDCompactView& cpv_;
 
@@ -158,7 +142,7 @@ class DDLParser
   std::map<int, bool> parsed_;
 
   /// Number of files + 1.
-  int nFiles_;
+  size_t nFiles_;
 
   /// Which file is currently being processed.
   std::string currFileName_;
@@ -169,8 +153,6 @@ class DDLParser
   DDLSAX2FileHandler* fileHandler_;
   DDLSAX2ExpressionHandler* expHandler_;
   DDLSAX2Handler* errHandler_;
-  
-  
 };
 
 #endif

--- a/DetectorDescription/Parser/interface/XercesString.h
+++ b/DetectorDescription/Parser/interface/XercesString.h
@@ -1,0 +1,33 @@
+#ifndef DETECTOR_DESCRIPTION_PARSER_XERCEC_STRING_H
+# define DETECTOR_DESCRIPTION_PARSER_XERCEC_STRING_H
+
+#include <xercesc/util/XercesDefs.hpp>
+#include <xercesc/util/XMLString.hpp>
+#include <memory>
+
+#ifdef XERCES_CPP_NAMESPACE_USE
+XERCES_CPP_NAMESPACE_USE
+#endif
+
+class XercesString
+{
+ public:
+  XercesString() : _wstr(nullptr) { };
+  XercesString(const char *str);
+  XercesString(XMLCh *wstr);
+  XercesString(const XMLCh *wstr);
+  XercesString(const XercesString &copy);
+  ~XercesString();
+  bool append(const XMLCh *tail);
+  bool erase(const XMLCh *head, const XMLCh *tail);
+  const XMLCh* begin() const;
+  const XMLCh* end() const;
+  int size() const;
+  XMLCh & operator [] (const int i);
+  const XMLCh operator [] (const int i) const;
+  operator const XMLCh * () const { return _wstr; };
+ private:
+  XMLCh* _wstr;
+};
+
+#endif 

--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -1,31 +1,16 @@
-/***************************************************************************
-                          DDLParser.cc  -  description
-                             -------------------
-    begin                : Mon Oct 22 2001
-    email                : case@ucdhep.ucdavis.edu
-***************************************************************************/
-
-/***************************************************************************
- *                                                                         *
- *           DDDParser sub-component of DDD                                *
- *                                                                         *
- ***************************************************************************/
-
 #include "DetectorDescription/Parser/interface/DDLParser.h"
-
-#include <xercesc/framework/MemBufInputSource.hpp>
-#include <iostream>
-
-#include "DetectorDescription/Base/interface/DDdebug.h"
 #include "DetectorDescription/Parser/interface/DDLDocumentProvider.h"
 #include "DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h"
 #include "DetectorDescription/Parser/interface/DDLSAX2FileHandler.h"
 #include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
+#include "DetectorDescription/Base/interface/DDdebug.h"
 #include "FWCore/Concurrency/interface/Xerces.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "xercesc/sax2/XMLReaderFactory.hpp"
-#include "xercesc/util/XMLUni.hpp"
+#include <xercesc/framework/MemBufInputSource.hpp>
+#include <xercesc/sax2/XMLReaderFactory.hpp>
+#include <xercesc/util/XMLUni.hpp>
+#include <iostream>
 
 class DDCompactView;
 
@@ -43,8 +28,6 @@ DDLParser::DDLParser( DDCompactView& cpv )
   
   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreValidation, false);   // optional
   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreNameSpaces, false);   // optional
-  // Specify other parser features, e.g.
-  //  SAX2Parser_->setFeature(XMLUni::fgXercesSchemaFullChecking, false);
   
   expHandler_  = new DDLSAX2ExpressionHandler(cpv);
   fileHandler_ = new DDLSAX2FileHandler(cpv);
@@ -114,69 +97,38 @@ DDLParser::isParsed( const std::string& filename )
 // Must receive a filename and path relative to the src directory of a CMSSW release
 // e.g. DetectorDescription/test/myfile.xml
 bool
-DDLParser::parseOneFile( const std::string& fullname ) //, const std::string& url)
+DDLParser::parseOneFile( const std::string& fullname )
 {
-  //  std::string filename = expHandler_->extractFileName(fullname);
-  std::string filename = extractFileName(fullname);
-  //  std::cout << "parseOneFile - fullname = " << fullname << std::endl;
-  //  std::cout << "parseOneFile - filename = " << filename << std::endl;
-  edm::FileInPath fp(fullname);
+  std::string filename = extractFileName( fullname );
+  edm::FileInPath fp( fullname );
   std::string absoluteFileName = fp.fullPath();
-  size_t foundFile = isFound(filename);
-  if (!foundFile)
+  size_t foundFile = isFound( filename );
+  if( !foundFile )
   {
-    pair <std::string, std::string> pss;
+    pair< std::string, std::string > pss;
     pss.first = filename;
     pss.second = absoluteFileName; //url+filename;
     int fIndex = nFiles_;
     fileNames_[nFiles_] = pss;
     ++nFiles_;
-    parsed_[fIndex]=false;
+    parsed_[fIndex] = false;
 
     currFileName_ = fileNames_[fIndex].second;
 
-    // in cleaning up try-catch blocks 2007-06-26 I decided to remove
-    // this because of CMSSW rules. but keep the commented way I used to
-    // do it...
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! try
-    //         {
-    SAX2Parser_->setContentHandler(expHandler_);
-    expHandler_->setNameSpace( getNameSpace(filename) );
-    //	  std::cout << "0) namespace = " << getNameSpace(filename) << std::endl;
-    LogDebug ("DDLParser") << "ParseOneFile() Parsing: " << fileNames_[fIndex].second << std::endl;
-    parseFile ( fIndex );
+    SAX2Parser_->setContentHandler( expHandler_ );
+    expHandler_->setNameSpace( getNameSpace( filename ));
 
-    //         }
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! catch (const XMLException& toCatch) {
-    //         edm::LogError ("DDLParser") << "\nDDLParser::ParseOneFile, PASS1: XMLException while processing files... \n"
-    //              << "Exception message is: \n"
-    //              << StrX(toCatch.getMessage()) << "\n" ;
-    //         cms::concurrency::xercesTerminate();
-    //         throw (DDException("  See XMLException above. "));
-    //       }
+    LogDebug ("DDLParser") << "ParseOneFile() Parsing: " << fileNames_[fIndex].second << std::endl;
+    parseFile( fIndex );
 
     // PASS 2:
 
     DCOUT_V('P', "DDLParser::ParseOneFile(): PASS2: Just before setting Xerces content and error handlers... ");
 
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! try
-    //         {
-
     SAX2Parser_->setContentHandler(fileHandler_);
-    //      std::cout << "currFileName = " << currFileName_ << std::endl;
-    fileHandler_->setNameSpace( getNameSpace(extractFileName(currFileName_)) );
-    //      std::cout << "1)  namespace = " << getNameSpace(currFileName_) << std::endl;
+    fileHandler_->setNameSpace( getNameSpace( extractFileName( currFileName_ )));
     parseFile ( fIndex );
     parsed_[fIndex] = true;
-
-    //         }
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! catch (const XMLException& toCatch) {
-    //         edm::LogError ("DDLParser") << "\nDDLParser::ParseOneFile, PASS2: XMLException while processing files... \n"
-    //              << "Exception message is: \n"
-    //              << StrX(toCatch.getMessage()) << "\n" ;
-    //         cms::concurrency::xercesTerminate();
-    //         throw (DDException("  See XMLException above."));
-    //       }
   }
   else // was found and is parsed...
   {
@@ -196,49 +148,24 @@ DDLParser::parse( const std::vector<unsigned char>& ablob, unsigned int bsize )
   SAX2Parser_->parse(mbis);
 }
 
-std::vector < std::string >
-DDLParser::getFileList( void ) 
-{
-  std::vector<std::string> flist;
-  for (FileNameHolder::const_iterator fit = fileNames_.begin(); fit != fileNames_.end(); ++fit)
-  {
-    flist.push_back(fit->second.first); // was .second (mec: 2003:02:19
-  }
-  return flist;
-}
-
 int
 DDLParser::parse( const DDLDocumentProvider& dp )
 {
-  //  edm::LogInfo ("DDLParser") << "Start Parsing.  Validation is set to " << dp.doValidation() << "." << std::endl;
   edm::LogInfo ("DDLParser") << "Start Parsing.  Validation is set off for the time being." << std::endl;
   // prep for pass 1 through DDD XML
-  //   // Since this block does nothing for CMSSW right now, I have taken it all out
-  //   This clean-up involves interface changes such as the removal of doValidation() everywhere (OR NOT 
-  //   if I decide to keep it for other testing reasons.)
-  //    if (dp.doValidation())
-  //      { 
-  // //       DCOUT_V('P', "WARNING:  PARSER VALIDATION IS TURNED OFF REGARDLESS OF <Schema... ELEMENT");
-  //   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreValidation, true);
-  //   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreNameSpaces, true);
-  // //       //  SAX2Parser_->setFeature(XMLUni::fgXercesSchemaFullChecking, true);
-  //      }
-  //    else
-  //     {
-  SAX2Parser_->setFeature(XMLUni::fgSAX2CoreValidation, false);
-  SAX2Parser_->setFeature(XMLUni::fgSAX2CoreNameSpaces, false);
-  //       //  SAX2Parser_->setFeature(XMLUni::fgXercesSchemaFullChecking, false);
-
-  //     }
+  SAX2Parser_->setFeature( XMLUni::fgSAX2CoreValidation, false );
+  SAX2Parser_->setFeature( XMLUni::fgSAX2CoreNameSpaces, false );
 
   //  This need be only done once, so might as well to it here.
   size_t fileIndex = 0;
   std::vector<std::string> fullFileName;
-
-  for (; fileIndex < (dp.getFileList()).size(); ++fileIndex)
+  const std::vector < std::string >& fileList = dp.getFileList();
+  const std::vector < std::string >& urlList = dp.getURLList();
+  
+  for(; fileIndex < fileList.size(); ++fileIndex )
   { 
-    std::string ts = dp.getURLList()[fileIndex];
-    std::string tf = dp.getFileList()[fileIndex];
+    std::string ts = urlList[fileIndex];
+    std::string tf = fileList[fileIndex];
     if ( ts.size() > 0 ) {
       if ( ts[ts.size() - 1] == '/') {
 	fullFileName.push_back( ts + tf );
@@ -250,98 +177,61 @@ DDLParser::parse( const DDLDocumentProvider& dp )
     }
   }
 
-  for (std::vector<std::string>::const_iterator fnit = fullFileName.begin(); 
-       fnit != fullFileName.end();
-       ++fnit)
+  for( const auto& fnit : fullFileName ) 
   {
-    size_t foundFile = isFound(extractFileName( *fnit )); 
+    size_t foundFile = isFound( extractFileName( fnit )); 
 	
-    if (!foundFile)
+    if( !foundFile )
     {
       pair <std::string, std::string> pss;
-      pss.first = extractFileName( *fnit );
-      pss.second = *fnit;
+      pss.first = extractFileName( fnit );
+      pss.second = fnit;
       fileNames_[nFiles_++] = pss;
-      parsed_[nFiles_ - 1]=false;
+      parsed_[nFiles_ - 1] = false;
     }
   }
     
   // Start processing the files found in the config file.
-  
+  assert( fileNames_.size() == nFiles_ );
+
   // PASS 1:  This was added later (historically) to implement the DDD
   // requirement for Expressions.
   DCOUT('P', "DDLParser::parse(): PASS1: Just before setting Xerces content and error handlers... ");
   
-  
-  // in cleaning up try-catch blocks 2007-06-26 I decided to remove
-  // this because of CMSSW rules. but keep the commented way I used to
-  // do it...
-  //   DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! try
-  //     {
   SAX2Parser_->setContentHandler(expHandler_);
-  for (size_t i = 0; i < fileNames_.size(); ++i)
+  for( size_t i = 0; i < nFiles_; ++i )
   {
-    if (!parsed_[i])
+    if( !parsed_[i])
     {
       currFileName_ = fileNames_[i].second;
-      //	      std::cout << "currFileName = " << currFileName_ << std::endl;
-      expHandler_->setNameSpace( getNameSpace(extractFileName(currFileName_)) );
-      //	      std::cout << "2)  namespace = " << getNameSpace(extractFileName(currFileName_)) << std::endl;
+      expHandler_->setNameSpace( getNameSpace( extractFileName( currFileName_ )));
       parseFile(i);
     }
   }
   expHandler_->dumpElementTypeCounter();
-  //     }
-  //   DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! catch (const XMLException& toCatch) {
-  //     edm::LogInfo ("DDLParser") << "\nPASS1: XMLException while processing files... \n"
-  // 	 << "Exception message is: \n"
-  // 	 << StrX(toCatch.getMessage()) << "\n" ;
-  //     cms::concurrency::xercesTerminate();
-  //     // FIX use this after DEPRECATED stuff removed:    throw(DDException("See XML Exception above"));
-  //     return -1;
-  //   }
+
   // PASS 2:
 
   DCOUT('P', "DDLParser::parse(): PASS2: Just before setting Xerces content and error handlers... ");
 
-  // in cleaning up try-catch blocks 2007-06-26 I decided to remove
-  // this because of CMSSW rules. but keep the commented way I used to
-  // do it...
-  //   DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! try
-  //     {
   SAX2Parser_->setContentHandler(fileHandler_);
 
   // No need to validate (regardless of user's doValidation
   // because the files have already been validated on the first pass.
   // This optimization suggested by Martin Liendl.
-  //       SAX2Parser_->setFeature(StrX("http://xml.org/sax/features/validation"), false);   // optional
-  //       SAX2Parser_->setFeature(StrX("http://xml.org/sax/features/namespaces"), false);   // optional
-  //       SAX2Parser_->setFeature(StrX("http://apache.org/xml/features/validation/dynamic"), false);
-
 
   // Process files again.
-  for (size_t i = 0; i < fileNames_.size(); ++i)
+  for( size_t i = 0; i < nFiles_; ++i )
   {
-    // 	  seal::SealTimer t("DDLParser: parsing all elements of file " +fileNames_[i].first);
-    if (!parsed_[i]) {
+    if( !parsed_[i]) {
       currFileName_ = fileNames_[i].second;
-      //	    std::cout << "currFileName = " << currFileName_ << std::endl;
-      fileHandler_->setNameSpace( getNameSpace(extractFileName(currFileName_)) );
-      //	    std::cout << "3)  namespace = " << getNameSpace(extractFileName(currFileName_)) << std::endl;
+      fileHandler_->setNameSpace( getNameSpace( extractFileName( currFileName_ )));
       parseFile(i);
       parsed_[i] = true;
       pair<std::string, std::string> namePair = fileNames_[i];
       LogDebug ("DDLParser") << "Completed parsing file " << namePair.second << std::endl;
     }
   }
-  //     }
-  //   DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! catch (const XMLException& toCatch) {
-  //     edm::LogError ("DDLParser") << "\nPASS2: XMLException while processing files... \n"
-  // 	 << "Exception message is: \n"
-  // 	 << StrX(toCatch.getMessage()) << "\n" ;
-  //     cms::concurrency::xercesTerminate();
-  //     return -1;
-  //   }
   return 0;
 }
 
@@ -352,22 +242,8 @@ DDLParser::parseFile( const int& numtoproc )
   {
     const std::string & fname = fileNames_[numtoproc].second;
 
-    // in cleaning up try-catch blocks 2007-06-26 I decided to remove
-    // this because of CMSSW rules. but keep the commented way I used to
-    // do it...
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! try
-    // 	{
     currFileName_ = fname;
     SAX2Parser_->parse(currFileName_.c_str());
-    // 	}
-    //       DO NOT UNCOMMENT FOR ANY RELEASE; ONLY FOR DEBUGGING! catch (const XMLException& toCatch)
-    // 	{
-    // 	  std::string e("\nWARNING: DDLParser::parseFile, File: '");
-    // 	  e += currFileName_ + "'\n"
-    // 	    + "Exception message is: \n"
-    // 	    + std::string(StrX(toCatch.getMessage()).localForm()) + "\n";
-    // 	  throw(DDException(e));
-    // 	}
   }
   else
   {
@@ -383,18 +259,13 @@ DDLParser::clearFiles( void )
   parsed_.clear();
 }
 
-std::string
-DDLParser::extractFileName( std::string fullname )
+std::string const
+DDLParser::extractFileName( const std::string& fullname )
 {
-  std::string ret = "";
-  size_t bit = fullname.rfind('/');
-  if ( bit < fullname.size() - 2 ) {
-    ret=fullname.substr(bit+1);
-  }
-  return ret;
+  return( fullname.substr( fullname.rfind( '/' ) + 1 ));
 }
 
-std::string
+std::string const
 DDLParser::getNameSpace( const std::string& fname )
 {
   size_t j = 0;

--- a/DetectorDescription/Parser/src/XercesString.cc
+++ b/DetectorDescription/Parser/src/XercesString.cc
@@ -1,0 +1,107 @@
+#include "DetectorDescription/Parser/interface/XercesString.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <iostream>
+
+#ifdef XERCES_CPP_NAMESPACE_USE
+XERCES_CPP_NAMESPACE_USE
+#endif
+
+XercesString::XercesString( const char *str )
+  : _wstr( nullptr )
+{
+  _wstr = XMLString::transcode( str );
+}
+
+XercesString::XercesString( XMLCh *wstr )
+  : _wstr( wstr )
+{}
+
+XercesString::XercesString( const XMLCh *wstr )
+  : _wstr( nullptr )
+{
+  _wstr = XMLString::replicate( wstr );
+}
+
+XercesString::XercesString( const XercesString &right )
+  : _wstr( nullptr )
+{
+  _wstr = XMLString::replicate( right._wstr );
+}
+
+XercesString::~XercesString()
+{
+  std::cout << "~XercesString()" <<  _wstr << ".\n";
+  if( _wstr ) XMLString::release( &_wstr );
+}
+
+bool
+XercesString::append( const XMLCh *tail )
+{
+  int iTailLen = XMLString::stringLen(tail);
+  int iWorkLen = XMLString::stringLen(_wstr);
+  XMLCh *result = new XMLCh[ iWorkLen + iTailLen + 1 ];
+  bool bOK = result != nullptr;
+  if( bOK )
+  {
+    XMLCh *target = result;
+    XMLString::moveChars(target, _wstr, iWorkLen);
+    target += iWorkLen;
+    XMLString::moveChars(target, tail, iTailLen);
+    target += iTailLen;
+    *target++ = 0;
+    XMLString::release(&_wstr);
+    _wstr = result;
+  }
+  return bOK;
+}
+
+bool
+XercesString::erase(const XMLCh *head, const XMLCh *tail)
+{
+  bool bOK = head <= tail && head >= begin() && tail <= end();
+  if (bOK)
+  {
+    XMLCh *result = new XMLCh[ size() - (tail - head) + 1 ];
+    XMLCh *target = result;
+    bOK = target != nullptr;
+    if (bOK)
+    {
+      const XMLCh *cursor = begin();
+
+      while (cursor != head) *target++ = *cursor++;
+      cursor = tail;
+      while ( cursor != end() ) *target++ = *cursor++;
+      *target ++ = 0;
+      XMLString::release(&_wstr);
+      _wstr = result;
+    }
+  }
+  return bOK;
+}
+
+const XMLCh* XercesString::begin() const
+{
+  return _wstr;
+}
+
+const XMLCh* XercesString::end() const
+{
+  return _wstr + size();
+}
+
+int XercesString::size() const
+{
+  return XMLString::stringLen(_wstr);
+}
+
+XMLCh & XercesString::operator [] (const int i)
+{
+  return _wstr[i];
+}
+
+const XMLCh XercesString::operator [] (const int i) const
+{
+  return _wstr[i];
+}


### PR DESCRIPTION
- Remove unused member functions
- Do not expose private member functions
- Optimize iterations
- Add a new XercesString class to better handle native to char\* conversion and vice versa 
