### PR TITLE
Reduce PCL disk space 80X

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
@@ -83,10 +83,10 @@ SiPixelAliMilleAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
         'TrackerTPBHalfBarrel,111111',
         'TrackerTPEHalfCylinder,111111',
 
-        'TrackerTIBHalfBarrel,ffffff',
-        'TrackerTOBHalfBarrel,ffffff',
-        'TrackerTIDEndcap,ffffff',
-        'TrackerTECEndcap,ffffff'
+        'TrackerTIBHalfBarrel,000000',
+        'TrackerTOBHalfBarrel,000000',
+        'TrackerTIDEndcap,000000',
+        'TrackerTECEndcap,000000'
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -81,10 +81,10 @@ SiPixelAliMilleAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
         'TrackerTPBHalfBarrel,111111',
         'TrackerTPEHalfCylinder,111111',
 
-        'TrackerTIBHalfBarrel,ffffff',
-        'TrackerTOBHalfBarrel,ffffff',
-        'TrackerTIDEndcap,ffffff',
-        'TrackerTECEndcap,ffffff'
+        'TrackerTIBHalfBarrel,000000',
+        'TrackerTOBHalfBarrel,000000',
+        'TrackerTIDEndcap,000000',
+        'TrackerTECEndcap,000000'
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
@@ -18,10 +18,10 @@ SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
         'TrackerTPBHalfBarrel,111111',
         'TrackerTPEHalfCylinder,111111',
 
-        'TrackerTIBHalfBarrel,ffffff',
-        'TrackerTOBHalfBarrel,ffffff',
-        'TrackerTIDEndcap,ffffff',
-        'TrackerTECEndcap,ffffff'
+        'TrackerTIBHalfBarrel,000000',
+        'TrackerTOBHalfBarrel,000000',
+        'TrackerTIDEndcap,000000',
+        'TrackerTECEndcap,000000'
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -21,10 +21,10 @@ SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
         'TrackerTPBHalfBarrel,111111',
         'TrackerTPEHalfCylinder,111111',
 
-        'TrackerTIBHalfBarrel,ffffff',
-        'TrackerTOBHalfBarrel,ffffff',
-        'TrackerTIDEndcap,ffffff',
-        'TrackerTECEndcap,ffffff'
+        'TrackerTIBHalfBarrel,000000',
+        'TrackerTOBHalfBarrel,000000',
+        'TrackerTIDEndcap,000000',
+        'TrackerTECEndcap,000000'
         )
     )
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -9,15 +9,12 @@
  */
 
 #include "MillePedeAlignmentAlgorithm.h"
-//#include "MillePedeAlignmentAlgorithm.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
-// in header, too
-// end in header, too
 
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeMonitor.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeVariables.h"
@@ -25,8 +22,8 @@
 #include "Alignment/MillePedeAlignmentAlgorithm/src/Mille.h"       // 'unpublished' interface located in src
 #include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h" // dito
 #include "Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.h" // dito
-#include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h" // dito
-#include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerPluginFactory.h" // dito
+#include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
+#include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerPluginFactory.h"
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
@@ -96,7 +93,8 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
   theMaximalCor2D(cfg.getParameter<double>("max2Dcorrelation")),
   theLastWrittenIov(0),
   theGblDoubleBinary(cfg.getParameter<bool>("doubleBinary")),
-  runAtPCL_(cfg.getParameter<bool>("runAtPCL"))
+  runAtPCL_(cfg.getParameter<bool>("runAtPCL")),
+  ignoreHitsWithoutGlobalDerivatives_(cfg.getParameter<bool>("ignoreHitsWithoutGlobalDerivatives"))
 {
   if (!theDir.empty() && theDir.find_last_of('/') != theDir.size()-1) theDir += '/';// may need '/'
   edm::LogInfo("Alignment") << "@SUB=MillePedeAlignmentAlgorithm" << "Start in mode '"
@@ -578,9 +576,11 @@ int MillePedeAlignmentAlgorithm::addMeasurementData(const edm::EventSetup &setup
 					tsos, alidet, alidet, theFloatBufferX, // 2x alidet, sic!
 					theFloatBufferY, theIntBuffer, params)) {
     return -1; // problem
-  } else if (theFloatBufferX.empty()) {
+  } else if (theFloatBufferX.empty() && ignoreHitsWithoutGlobalDerivatives_) {
      return 0; // empty for X: no alignable for hit, nor calibrations
-  } else { // now even if no alignable, but calibrations!
+  } else {
+    // store measurement even if no alignable or calibrations
+    // -> measurement used for pede-internal track-fit
     return this->callMille(refTrajPtr, iHit, theIntBuffer, theFloatBufferX, theFloatBufferY);
   }
 }
@@ -1086,7 +1086,10 @@ void MillePedeAlignmentAlgorithm::diagonalize
   
   //edm::LogInfo("Alignment") << "NEW HIT loca in matrix after diag:"<<aLocalDerivativesM(0,0);
   aHitResidualsM      = aTranfoToDiagonalSystemInvF * aHitResidualsM;
-  aGlobalDerivativesM = aTranfoToDiagonalSystemInvF * aGlobalDerivativesM;
+  if (aGlobalDerivativesM.GetNoElements() > 0) {
+    // diagnoalize only if measurement depends on alignables or calibrations
+    aGlobalDerivativesM = aTranfoToDiagonalSystemInvF * aGlobalDerivativesM;
+  }
 }
 
 //__________________________________________________________________________________________________

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -263,6 +263,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   bool                      theGblDoubleBinary;
 
   const bool                runAtPCL_;
+  const bool                ignoreHitsWithoutGlobalDerivatives_;
 };
 
 DEFINE_EDM_PLUGIN(AlignmentAlgorithmPluginFactory,

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h
@@ -46,6 +46,8 @@ class MillePedeFileExtractor :
     return (nBinaries_ >= maxNumberOfBinaries_) && hasBinaryNumberLimit(); }
   bool hasBinaryNumberLimit() { return maxNumberOfBinaries_ > -1; }
 
+  static void writeGzipped(const FileBlob&, const std::string&);
+
   const std::string outputDir_;
   const std::string outputFileName_;
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -22,6 +22,10 @@ MillePedeAlignmentAlgorithm = cms.PSet(
     monitorFile = cms.untracked.string('millePedeMonitor.root'), ## if empty: no monitoring...
 
     runAtPCL = cms.bool(False), # at the PCL the mille binaries are reset at lumi-section boundaries
+    ignoreHitsWithoutGlobalDerivatives = cms.bool(False), # - if all alignables and calibration for a
+                                                          #   hit are set to '0', the hit is ignored
+                                                          # - has only an effect with non-GBL
+                                                          #   material-effects description
 
     # PSet that allows to configure the pede labeler, i.e. select the actual
     # labeler plugin to use and parameters for the selected plugin


### PR DESCRIPTION
Reduces size of binaries written to disk in the harvesting step of the SiPixelAli to 30% of it's original size.
Addresses issue reported in [Tier-0 Operations HN](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1435/1/1.html).

Backport of  #14961 with #14876 merged.
