### PR TITLE
protect RawTask::_process from processing bad HcalHTRData

### DIFF
--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -263,7 +263,7 @@ RawTask::RawTask(edm::ParameterSet const& ps):
 			for (int is=0; is<HcalDCCHeader::SPIGOT_COUNT; is++)
 			{
 				int r = hdcc->getSpigotData(is, htr, raw.size());
-				if (r!=0)
+				if (r!=0 || !htr.check())
 					continue;
 				HcalElectronicsId eid = HcalElectronicsId(
 					constants::FIBERCH_MIN, constants::FIBER_VME_MIN,


### PR DESCRIPTION
RawTask::_process() doesn't check the validity of the HcalHTRData from getSpigotData(), which can result in invalid memory accesses if the data are corrupt or missing.  This is seen in valgrind for some IB workflows, e.g. 134.703, and is suspected of causing intermittent crashes in the threaded IBs.  Details are in issue #14898.  This PR proposes a minimal point fix, copying a pattern used elsewhere in the HCAL DQM.

From the IB log files, it looks like the input file (from step2) for this workflow is missing most of the collections needed by step3; perhaps there ought to be some higher level check that would skip processing missing data altogether, but that's out of scope for this PR.
