### PR TITLE
Multi run harvesting for 8 0 x

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -766,6 +766,10 @@ SiStripGainFromCalibTree::algoEndJob() {
 
 	// Now that we have the full statistics we can extract the information of the 2D histograms
 	algoComputeMPVandGain();
+
+        // Force the DB object writing,
+        // thus setting the IOV as the first processed run (if timeFromEndRun is set to false)
+        storeOnDbNow();
    
 	if(AlgoMode != "PCL" or saveSummary){
             edm::LogInfo("SiStripGainFromCalibTree") << "Saving summary into root file" << std::endl;

--- a/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
@@ -34,7 +34,7 @@ SiStripCalib = cms.EDAnalyzer(
 
     SinceAppendMode     = cms.bool(True),
     TimeFromEndRun      = cms.untracked.bool(True),
-    IOVMode             = cms.string('Job'),
+    IOVMode             = cms.string('AlgoDriven'),
     Record              = cms.string('SiStripApvGainRcd'),
     doStoreOnDB         = cms.bool(True),
 

--- a/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
@@ -32,11 +32,12 @@ SiStripCalib = cms.EDAnalyzer(
     NClustersForTagProd = cms.untracked.double(1E8),
     
 
-    SinceAppendMode     = cms.bool(True),
-    TimeFromEndRun      = cms.untracked.bool(True),
-    IOVMode             = cms.string('AlgoDriven'),
-    Record              = cms.string('SiStripApvGainRcd'),
-    doStoreOnDB         = cms.bool(True),
+    SinceAppendMode         = cms.bool(True),
+    TimeFromEndRun          = cms.untracked.bool(False),
+    TimeFromStartOfRunRange = cms.untracked.bool(True),
+    IOVMode                 = cms.string('AlgoDriven'),
+    Record                  = cms.string('SiStripApvGainRcd'),
+    doStoreOnDB             = cms.bool(True),
 
     treePath            = cms.untracked.string('gainCalibrationTree/tree'),
     gain                = cms.untracked.PSet(label = cms.untracked.string('shallowGainCalibration'), prefix = cms.untracked.string("GainCalibration"), suffix = cms.untracked.string('')),

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsAfterAbortGapHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsAfterAbortGapHarvester_cfi.py
@@ -9,3 +9,4 @@ alcaSiStripGainsAfterAbortGapHarvester.calibrationMode     = cms.untracked.strin
 alcaSiStripGainsAfterAbortGapHarvester.DQMdir              = cms.untracked.string('AlCaReco/SiStripGainsAfterAbortGap')
 alcaSiStripGainsAfterAbortGapHarvester.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 alcaSiStripGainsAfterAbortGapHarvester.harvestingMode      = cms.untracked.bool(True)
+alcaSiStripGainsAfterAbortGapHarvester.Record              = cms.string('SiStripApvGainRcdAfterAbortGap')

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -69,9 +69,9 @@ ALCAHARVESTSiStripGains_dbOutput = cms.PSet(record = cms.string('SiStripApvGainR
                                             )
 
 # SiStrip Gains (AfterAbortGap)
-ALCAHARVESTSiStripGainsAfterAbortGap_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcd'))
+ALCAHARVESTSiStripGainsAfterAbortGap_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcdAfterAbortGap'))
 
-ALCAHARVESTSiStripGainsAfterAbortGap_dbOutput = cms.PSet(record = cms.string('SiStripApvGainRcd'),
+ALCAHARVESTSiStripGainsAfterAbortGap_dbOutput = cms.PSet(record = cms.string('SiStripApvGainRcdAfterAbortGap'),
                                                          tag = cms.string('SiStripApvGainAfterAbortGap_pcl'),
                                                          timetype   = cms.untracked.string('runnumber')
                                                          )

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -69,9 +69,9 @@ ALCAHARVESTSiStripGains_dbOutput = cms.PSet(record = cms.string('SiStripApvGainR
                                             )
 
 # SiStrip Gains (AfterAbortGap)
-ALCAHARVESTSiStripGainsAfterAbortGap_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcdAfterAbortGap'))
+ALCAHARVESTSiStripGainsAfterAbortGap_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcd'))
 
-ALCAHARVESTSiStripGainsAfterAbortGap_dbOutput = cms.PSet(record = cms.string('SiStripApvGainRcdAfterAbortGap'),
+ALCAHARVESTSiStripGainsAfterAbortGap_dbOutput = cms.PSet(record = cms.string('SiStripApvGainRcd'),
                                                          tag = cms.string('SiStripApvGainAfterAbortGap_pcl'),
                                                          timetype   = cms.untracked.string('runnumber')
                                                          )


### PR DESCRIPTION
Greetings,

this PR implements the correct setting of the IOV of the gain calibration payload produced with the multi run harvesting procedure in PCL. Currently the IOV is set to the "oldest" run analyzed in the harvesting step.

It also include a fix delivered by Marco Musich in #14949
