### PR TITLE
check if updated TSOS is good in DYT to avoid a crash

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -378,12 +378,24 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
       getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
       if (bestDTEstimator >= initThr) continue;
       prelFitMeas.push_back(theMuonRecHitBuilder->build(&bestDTSeg));
-      prelFitState = updatorHandle->update(tsosDTlayer, *theMuonRecHitBuilder->build(&bestDTSeg));
+      auto aSegRH = prelFitMeas.back();
+      auto uRes = updatorHandle->update(tsosDTlayer, *aSegRH);
+      if (uRes.isValid()){
+	prelFitState = uRes;
+      } else {
+	prelFitMeas.pop_back();
+      }
     } else {
       getThresholdFromCFG(initThr, DetId(bestCSCSeg.cscDetId()));
       if (bestCSCEstimator >= initThr) continue;
       prelFitMeas.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
-      prelFitState = updatorHandle->update(tsosCSClayer, *theMuonRecHitBuilder->build(&bestCSCSeg));
+      auto aSegRH = prelFitMeas.back();
+      auto uRes = updatorHandle->update(tsosCSClayer, *aSegRH);
+      if (uRes.isValid()){
+	prelFitState = uRes;
+      } else {
+	prelFitMeas.pop_back();
+      }
     }
   }
   if (!prelFitMeas.empty()) prelFitMeas.pop_back();


### PR DESCRIPTION
to avoid seg fault reported in  https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1457.html

some longer investigation doesn't suggest a relatively simple and better solution.
In this case the DYT refit starts for a track that has only 3 (pixel) hits and very large uncertainty on momentum value, which gets worse with an internal refit. After propagation from pixel layer to DT the very large uncertainty spreads to all parameters (typical cov values of 1E14). This then fails numerically in the KF update.
Some truncation of uncertainties to improve numerical stability could be done.
The issue appears rather rarely and is expected to be more frequent for poorly measured tracks.
So, the physics benefits of better numerical behavior in similar cases is marginal.

the fix should affect only events that would otherwise crash in processing
