### PR TITLE
Fix HLTL1TSeed accounting for prescale handling (80X)

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -165,7 +165,7 @@ void HLTConfigData::extract()
        if (label.front()!='-' && moduleType(label) == "HLTL1TSeed") {
 	 const ParameterSet& pset(modulePSet(label));
 	 if (pset!=ParameterSet()) {
-	   const string l1Gtag(pset.getParameter<string>("L1GlobalInputTag"));
+	   const string l1Gtag(pset.getParameter<edm::InputTag>("L1GlobalInputTag").label());
 	   // Emulator output is used to ignore L1T prescales
 	   if (l1Gtag!="hltGtStage2ObjectMap") {
 	     const string l1Seed(pset.getParameter<string>("L1SeedsLogicalExpression"));

--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -165,8 +165,12 @@ void HLTConfigData::extract()
        if (label.front()!='-' && moduleType(label) == "HLTL1TSeed") {
 	 const ParameterSet& pset(modulePSet(label));
 	 if (pset!=ParameterSet()) {
-	   const string l1Seed(pset.getParameter<string>("L1SeedsLogicalExpression"));
-	   hltL1TSeeds_[i].push_back(l1Seed);
+	   const string l1Gtag(pset.getParameter<string>("L1GlobalInputTag"));
+	   // Emulator output is used to ignore L1T prescales
+	   if (l1Gtag!="hltGtStage2ObjectMap") {
+	     const string l1Seed(pset.getParameter<string>("L1SeedsLogicalExpression"));
+	     hltL1TSeeds_[i].push_back(l1Seed);
+	   }
 	 }
        }
      }


### PR DESCRIPTION
Do not consider HLTL1TSeed modules using the emulator (which ignores prescales) for L1T prescales determination.
