### PR TITLE
add PS column monitoring

### DIFF
--- a/DQM/HLTEvF/plugins/DQMCorrelationClient.cc
+++ b/DQM/HLTEvF/plugins/DQMCorrelationClient.cc
@@ -1,0 +1,213 @@
+#include "DQM/HLTEvF/plugins/DQMCorrelationClient.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// -------------------------------------- Constructor --------------------------------------------
+//
+DQMCorrelationClient::DQMCorrelationClient(const edm::ParameterSet& iConfig) :
+  me1onX_ ( iConfig.getParameter<bool>("me1onX") )
+  , meXpset_ ( me1onX_ ? getHistoPSet(iConfig.getParameter<edm::ParameterSet>("me1") ) : getHistoPSet(iConfig.getParameter<edm::ParameterSet>("me2") ) )
+  , meYpset_ ( me1onX_ ? getHistoPSet(iConfig.getParameter<edm::ParameterSet>("me2") ) : getHistoPSet(iConfig.getParameter<edm::ParameterSet>("me1") ) )
+  , mepset_  ( getOutputHistoPSet (iConfig.getParameter<edm::ParameterSet>("me")  ) )
+{
+  edm::LogInfo("DQMCorrelationClient") <<  "Constructor  DQMCorrelationClient::DQMCorrelationClient " << std::endl;
+
+  correlation_ = nullptr;
+
+}
+
+MEPSet DQMCorrelationClient::getHistoPSet(edm::ParameterSet pset)
+{
+  return MEPSet{
+    pset.getParameter<std::string>("name"),
+      pset.getParameter<std::string>("folder"),
+      pset.getParameter<bool>("profileX"),
+  };
+}
+
+OutputMEPSet DQMCorrelationClient::getOutputHistoPSet(edm::ParameterSet pset)
+{
+  return OutputMEPSet{
+    pset.getParameter<std::string>("name"),
+      pset.getParameter<std::string>("folder"),
+      pset.getParameter<bool>("doXaxis"),
+      pset.getParameter<int>("nbinsX"),
+      pset.getParameter<double>("xminX"),
+      pset.getParameter<double>("xmaxX"),
+      pset.getParameter<bool>("doYaxis"),
+      pset.getParameter<int>("nbinsY"),
+      pset.getParameter<double>("xminY"),
+      pset.getParameter<double>("xmaxY"),
+      };
+}
+
+//
+// -------------------------------------- beginJob --------------------------------------------
+//
+void DQMCorrelationClient::beginJob()
+{
+  edm::LogInfo("DQMCorrelationClient") <<  "DQMCorrelationClient::beginJob " << std::endl;
+}
+
+TH1* DQMCorrelationClient::getTH1(MonitorElement* me, bool profileX=true) {
+  
+  TH1* th1 = nullptr;
+
+  MonitorElement::Kind kind = me->kind();
+  switch(kind) {
+  case(MonitorElement::DQM_KIND_TH2D):
+    th1 = ( profileX ? me->getTH2D()->ProfileX() : me->getTH2D()->ProfileY() );
+    break;
+  case(MonitorElement::DQM_KIND_TH2F):
+    th1 = ( profileX ? me->getTH2F()->ProfileX() : me->getTH2F()->ProfileY() );
+    break;
+  case(MonitorElement::DQM_KIND_TH2S):
+    th1 = ( profileX ? me->getTH2S()->ProfileX() : me->getTH2S()->ProfileY() );
+    break;
+  case(MonitorElement::DQM_KIND_TPROFILE):
+    th1 = me->getTH1();
+    break;
+  default:
+    break;
+  }
+
+  return th1;
+}
+void DQMCorrelationClient::setAxisTitle(MonitorElement* meX, MonitorElement* meY)
+{
+  if (correlation_ == nullptr) return;
+  correlation_->setAxisTitle(meX->getTH1()->GetYaxis()->GetTitle(),1);
+  correlation_->setAxisTitle(meY->getTH1()->GetYaxis()->GetTitle(),2);
+
+  if ( !mepset_.doXaxis ) {
+    TAxis* axis = (meX->getTH1()->GetYaxis());
+    for ( int i=1; i<=axis->GetNbins(); ++i )
+      correlation_->getTH1()->GetXaxis()->SetBinLabel(i,axis->GetBinLabel(i));
+  }
+
+  if ( !mepset_.doYaxis ) {
+    TAxis* axis = (meY->getTH1()->GetYaxis());
+    for ( int i=1; i<=axis->GetNbins(); ++i )
+      correlation_->getTH1()->GetYaxis()->SetBinLabel(i,axis->GetBinLabel(i));
+  }  
+}
+
+//
+// -------------------------------------- get and book in the endJob --------------------------------------------
+//
+void DQMCorrelationClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_)
+{
+  std::string hname = "";
+
+  // create and cd into new folder
+  std::string currentFolder = mepset_.folder;
+  ibooker_.setCurrentFolder(currentFolder.c_str());
+
+  //get available histograms
+  hname = meXpset_.folder + "/" + meXpset_.name;
+  MonitorElement* meX = igetter_.get( hname.c_str() );
+  hname = meYpset_.folder + "/" + meYpset_.name;
+  MonitorElement* meY = igetter_.get( hname.c_str() );
+
+  if (!meX || !meY) {
+    edm::LogError("DQMCorrelationClient") <<  "MEs not found! " 
+					  << ( !meX ? meXpset_.folder + "/" + meXpset_.name + " not found " : "" ) 
+					  << ( !meY ? meYpset_.folder + "/" + meYpset_.name + " not found " : "" ) 
+					  << std::endl;
+    return;
+  }
+
+  // get range and binning for new MEs
+  int    nbinsX = ( mepset_.doXaxis ? mepset_.nbinsX : meX->getNbinsY() );
+  double xminX  = ( mepset_.doXaxis ? mepset_.xminX  : meX->getTH1()->GetYaxis()->GetXmin() );
+  double xmaxX  = ( mepset_.doXaxis ? mepset_.xmaxX  : meX->getTH1()->GetYaxis()->GetXmax() );
+  int    nbinsY = ( mepset_.doYaxis ? mepset_.nbinsY : meY->getNbinsY() );
+  double xminY  = ( mepset_.doYaxis ? mepset_.xminY  : meY->getTH1()->GetYaxis()->GetXmin() );
+  double xmaxY  = ( mepset_.doYaxis ? mepset_.xmaxY  : meY->getTH1()->GetYaxis()->GetXmax() );
+
+  //book new histogram
+  hname = mepset_.name;
+  correlation_ = ibooker_.book2D(hname,hname,nbinsX,xminX,xmaxX,nbinsY,xminY,xmaxY);
+  setAxisTitle(meX, meY);
+
+  // handle mes
+  TH1* x = nullptr;
+  TH1* y = nullptr;
+  x = getTH1(meX,meXpset_.profileX);
+  y = getTH1(meY,meYpset_.profileX);
+
+  size_t size = x->GetXaxis()->GetNbins();
+
+  std::vector<double> xvalue;
+  std::vector<int> xbinvalue;
+  for ( size_t ibin=1; ibin <= size; ++ibin ) {
+    // avoid to store points w/ no info
+    if ( x->GetBinContent(ibin) == 0. ) continue;
+    xvalue.push_back    ( x->GetBinContent(ibin)            );
+    xbinvalue.push_back ( x->GetXaxis()->GetBinCenter(ibin) );
+  }
+
+  for ( size_t i=0; i < xbinvalue.size(); ++i ) {
+    int ybin = y->GetXaxis()->FindBin(xbinvalue[i]);
+    double yvalue = y->GetBinContent(ybin);
+    correlation_->Fill(xvalue[i],yvalue);
+  }
+
+}
+
+//
+// -------------------------------------- get in the endLumi if needed --------------------------------------------
+//
+void DQMCorrelationClient::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker_, DQMStore::IGetter & igetter_, edm::LuminosityBlock const & iLumi, edm::EventSetup const& iSetup) 
+{
+  edm::LogInfo("DQMCorrelationClient") <<  "DQMCorrelationClient::endLumi " << std::endl;
+}
+
+void DQMCorrelationClient::fillMePSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<std::string>("folder","");
+  pset.add<std::string>("name","");
+  pset.add<bool>("profileX",true);
+}
+
+void DQMCorrelationClient::fillOutputMePSetDescription(edm::ParameterSetDescription & pset)
+{
+  //  fillMePSetDescription(pset);
+  pset.add<std::string>("folder");
+  pset.add<std::string>("name");
+  pset.add<bool>("doXaxis", true);
+  pset.add<int>("nbinsX",  2500);
+  pset.add<double>("xminX",   0.);
+  pset.add<double>("xmaxX",2500.);
+  pset.add<bool>("doYaxis", true);
+  pset.add<int>("nbinsY", 2500);
+  pset.add<double>("xminY",   0.);
+  pset.add<double>("xmaxY",2500.);
+}
+
+void DQMCorrelationClient::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("me1onX",true);
+
+  edm::ParameterSetDescription mePSet;
+  fillOutputMePSetDescription(mePSet);
+  desc.add<edm::ParameterSetDescription>("me", mePSet);
+
+  edm::ParameterSetDescription me1PSet;
+  fillMePSetDescription(me1PSet);
+  desc.add<edm::ParameterSetDescription>("me1", me1PSet);
+
+  edm::ParameterSetDescription me2PSet;
+  fillMePSetDescription(me2PSet);
+  desc.add<edm::ParameterSetDescription>("me2", me2PSet);
+
+  descriptions.add("dqmCorrelationClient", desc);
+
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DQMCorrelationClient);

--- a/DQM/HLTEvF/plugins/DQMCorrelationClient.h
+++ b/DQM/HLTEvF/plugins/DQMCorrelationClient.h
@@ -1,0 +1,76 @@
+#ifndef DQMCORRELATIONCLIENT_H
+#define DQMCORRELATIONCLIENT_H
+
+//Framework
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+ 
+struct MEPSet {
+  std::string name;
+  std::string folder;
+  bool        profileX;
+};
+
+struct OutputMEPSet {
+  std::string name;
+  std::string folder;
+  bool doXaxis;
+  int nbinsX;
+  double xminX;
+  double xmaxX;
+  bool doYaxis;
+  int nbinsY;
+  double xminY;
+  double xmaxY;
+};
+
+class DQMCorrelationClient: public DQMEDHarvester{
+
+ public:
+
+  DQMCorrelationClient(const edm::ParameterSet& ps);
+  virtual ~DQMCorrelationClient() = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillMePSetDescription(edm::ParameterSetDescription & pset);
+  static void fillOutputMePSetDescription(edm::ParameterSetDescription & pset);
+      
+ protected:
+
+  void beginJob();
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
+  
+ private:
+
+  static MEPSet       getHistoPSet      (edm::ParameterSet pset);
+  static OutputMEPSet getOutputHistoPSet(edm::ParameterSet pset);
+
+  TH1* getTH1(MonitorElement* me, bool profileX);
+  void setAxisTitle(MonitorElement* meX, MonitorElement* meY);
+
+//private variables
+
+  //variables from config file
+  bool me1onX_;
+
+  // Histograms
+  MonitorElement* correlation_;
+
+  MEPSet meXpset_;
+  MEPSet meYpset_;
+  OutputMEPSet mepset_;
+
+};
+
+
+#endif // DQMCORRELATIONCLIENT_H

--- a/DQM/HLTEvF/plugins/PSMonitor.cc
+++ b/DQM/HLTEvF/plugins/PSMonitor.cc
@@ -1,0 +1,113 @@
+#include "DQM/HLTEvF/plugins/PSMonitor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQM/TrackingMonitor/interface/GetLumi.h"
+
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+PSMonitor::PSMonitor( const edm::ParameterSet& iConfig ) : 
+  folderName_   ( iConfig.getParameter<std::string>("FolderName") )
+  , ugtBXToken_ ( consumes<GlobalAlgBlkBxCollection>(iConfig.getParameter<edm::InputTag>("ugtBXInputTag") ) )
+{
+
+  /// Prescale service
+  if ( edm::Service<edm::service::PrescaleService>().isAvailable() )
+      psService_ = edm::Service<edm::service::PrescaleService>().operator->();
+
+  psColumnIndexVsLS_ = nullptr;
+
+  edm::ParameterSet histoPSet    = iConfig.getParameter<edm::ParameterSet>("histoPSet");
+  edm::ParameterSet psColumnPSet = histoPSet.getParameter<edm::ParameterSet>("psColumnPSet");
+  edm::ParameterSet lsPSet       = histoPSet.getParameter<edm::ParameterSet>("lsPSet");
+
+  getHistoPSet(psColumnPSet, ps_binning_);
+  getHistoPSet(lsPSet,       ls_binning_);
+
+}
+
+void PSMonitor::getHistoPSet(edm::ParameterSet& pset, MEbinning& mebinning)
+{
+  mebinning.nbins = pset.getParameter<int32_t>("nbins");
+  mebinning.xmin  = 0.;
+  mebinning.xmax  = double(pset.getParameter<int32_t>("nbins"));
+}
+
+
+void PSMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+			       edm::Run const        & iRun,
+			       edm::EventSetup const & iSetup) 
+{  
+  
+  std::string histname, histtitle;
+
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder.c_str());
+
+  std::vector<std::string> psLabels = psService_->getLvl1Labels();
+  int nbins   = ( psLabels.size() ? psLabels.size()         : ps_binning_.nbins );
+  double xmin = ( psLabels.size() ? 0.                      : ps_binning_.xmin  );
+  double xmax = ( psLabels.size() ? double(psLabels.size()) : ps_binning_.xmax  );
+
+  histname = "psColumnIndexVsLS"; histtitle = "PS column index vs LS";
+  psColumnIndexVsLS_ = ibooker.book2D(histname, histtitle, 
+				      ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,
+				      nbins, xmin, xmax);
+  psColumnIndexVsLS_->setAxisTitle("LS",1);
+  psColumnIndexVsLS_->setAxisTitle("PS column index",2);
+  
+  int ibin = 1;
+  for ( auto l : psLabels ) {
+    psColumnIndexVsLS_->setBinLabel(ibin,l.c_str(),2);
+    ibin++;
+  }
+
+}
+
+void PSMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+
+  int ls = iEvent.id().luminosityBlock();
+
+  int psColumn = -1;
+  
+  edm::Handle<GlobalAlgBlkBxCollection> ugtBXhandle;
+  iEvent.getByToken(ugtBXToken_, ugtBXhandle);
+  if (ugtBXhandle.isValid() and not ugtBXhandle->isEmpty(0))
+    psColumn = ugtBXhandle->at(0, 0).getPreScColumn();
+
+  psColumnIndexVsLS_->Fill(ls, psColumn);
+
+}
+
+void PSMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset, int value)
+{
+  pset.add<int>( "nbins", value);
+}
+
+void PSMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>( "ugtBXInputTag", edm::InputTag("hltGtStage2Digis") );
+  desc.add<std::string>  ( "FolderName",    "HLT/PSMonitoring" );
+
+  edm::ParameterSetDescription histoPSet;
+
+  edm::ParameterSetDescription psColumnPSet;
+  fillHistoPSetDescription(psColumnPSet,8);
+  histoPSet.add<edm::ParameterSetDescription>("psColumnPSet", psColumnPSet);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoPSetDescription(lsPSet,2500);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("psMonitoring", desc);
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PSMonitor);

--- a/DQM/HLTEvF/plugins/PSMonitor.h
+++ b/DQM/HLTEvF/plugins/PSMonitor.h
@@ -1,0 +1,76 @@
+#ifndef LUMIMONITOR_H
+#define LUMIMONITOR_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+//DataFormats
+
+// legacy/stage-1 L1T:
+//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+
+// stage-2 L1T:
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+
+// PS service
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/PrescaleService/interface/PrescaleService.h"
+
+struct MEbinning {
+  int nbins;
+  double xmin;
+  double xmax;
+  //  MEbinning() {};
+  //  explicit MEbinning(int n, double min, double max) { nbins= n; xmin = min; xmax = max;}
+};
+
+//
+// class declaration
+//
+
+class PSMonitor : public DQMEDAnalyzer 
+{
+public:
+  PSMonitor( const edm::ParameterSet& );
+  ~PSMonitor() = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset, int value);
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
+
+private:
+
+  void getHistoPSet(edm::ParameterSet& pset, MEbinning& mebinning);
+
+  std::string folderName_;
+
+  edm::EDGetTokenT<GlobalAlgBlkBxCollection> ugtBXToken_;
+  
+  /// Prescale service
+  edm::service::PrescaleService* psService_;
+
+  MonitorElement* psColumnIndexVsLS_;
+
+  MEbinning ps_binning_;
+  MEbinning ls_binning_;
+
+};
+
+#endif // LUMIMONITOR_H

--- a/DQM/HLTEvF/plugins/PSMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/PSMonitorClient.cc
@@ -1,0 +1,131 @@
+// C++ headers
+#include <string>
+#include <cstring>
+
+// boost headers
+#include <boost/regex.hpp>
+
+// Root headers
+#include <TH1F.h>
+
+// CMSSW headers
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+struct MEPSet {
+  std::string name;
+  std::string folder;
+};
+
+class PSMonitorClient : public DQMEDHarvester {
+public:
+  explicit PSMonitorClient(edm::ParameterSet const &);
+  ~PSMonitorClient() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillMePSetDescription(edm::ParameterSetDescription & pset);
+
+private:
+
+  static MEPSet getHistoPSet(edm::ParameterSet pset);
+
+  std::string m_dqm_path;
+
+  void dqmEndLuminosityBlock(DQMStore::IBooker & booker, DQMStore::IGetter & getter, edm::LuminosityBlock const &, edm::EventSetup const&) override;
+  void dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter) override;
+
+  void check(DQMStore::IBooker & booker, DQMStore::IGetter & getter);
+
+  MEPSet psColumnVSlumiPSet;
+};
+
+
+PSMonitorClient::PSMonitorClient(edm::ParameterSet const & config) :
+  m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
+  , psColumnVSlumiPSet ( getHistoPSet(config.getParameter<edm::ParameterSet>("me")) )
+{
+}
+
+MEPSet PSMonitorClient::getHistoPSet(edm::ParameterSet pset)
+{
+  return MEPSet{
+    pset.getParameter<std::string>("name"),
+      pset.getParameter<std::string>("folder"),
+  };
+}
+
+void PSMonitorClient::fillMePSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<std::string>("folder","HLT/PSMonitoring");
+  pset.add<std::string>("name","psColumnVSlumi");
+}
+
+
+void
+PSMonitorClient::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
+{
+  check(booker, getter);
+}
+
+void
+PSMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker & booker, DQMStore::IGetter & getter, edm::LuminosityBlock const & lumi, edm::EventSetup const & setup)
+{
+  check(booker, getter);
+}
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+void
+PSMonitorClient::check(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
+{
+
+  std::string folder = psColumnVSlumiPSet.folder;
+  std::string name   = psColumnVSlumiPSet.name;
+
+  getter.setCurrentFolder(folder);
+  MonitorElement* psColumnVSlumi = getter.get(psColumnVSlumiPSet.folder+"/"+psColumnVSlumiPSet.name);
+  // if no ME available, return
+  if ( !psColumnVSlumi ) {
+    edm::LogWarning("PSMonitorClient") << "no " << psColumnVSlumiPSet.name << " ME is available in " << psColumnVSlumiPSet.folder << std::endl;
+    return;
+  }
+  
+  /*
+  TH2F* h = psColumnVSlumi->getTH2F();
+  size_t nbinsX = psColumnVSlumi->getNbinsX();
+  size_t nbinsY = psColumnVSlumi->getNbinsY();
+
+  for ( size_t ibinY=1; ibinY < nbinsY; ++ibinY )
+    std::cout << h->GetXaxis()->GetBinLabel(ibinY) << std::endl;
+    for ( size_t ibinX=1; ibinX< nbinsX; ++ibinX )
+      if ( psColumnVSlumi->getBinContent(ibinX) )
+	std::cout << "ibinX: " << psColumnVSlumi->getBinContent(ibinX) << std::endl;
+  */
+
+}
+
+void
+PSMonitorClient::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+  // The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>( "dqmPath", "HLT/PSMonitoring");
+
+  edm::ParameterSetDescription mePSet;
+  fillMePSetDescription(mePSet);
+  desc.add<edm::ParameterSetDescription>("me", mePSet);
+
+  descriptions.add("psMonitorClient", desc);
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PSMonitorClient);

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -27,4 +27,35 @@ if process.dqmRunConfig.type.value() is "playback":
 process.load('HLTrigger.Timer.fastTimerServiceClient_cfi')
 process.fastTimerServiceClient.dqmPath = "HLT/TimerService"
 
-process.p = cms.EndPath( process.fastTimerServiceClient + process.dqmEnv + process.dqmSaver )
+# PS column VS lumi
+process.load('DQM.HLTEvF.dqmCorrelationClient_cfi')
+process.psColumnVsLumi = process.dqmCorrelationClient.clone(
+   me = cms.PSet(
+      folder = cms.string("HLT/PSMonitoring"),
+      name   = cms.string("psColumnVSlumi"),
+      doXaxis = cms.bool( True ),
+      nbinsX = cms.int32( 6500),
+      xminX  = cms.double(    0.),
+      xmaxX  = cms.double(13000.),
+      doYaxis = cms.bool( False ),
+      nbinsY = cms.int32 (   8),
+      xminY  = cms.double(   0.),
+      xmaxY  = cms.double(   8.),
+   ),
+   me1 = cms.PSet(
+      folder   = cms.string("HLT/LumiMonitoring"),
+      name     = cms.string("lumiVsLS"),
+      profileX = cms.bool(True)
+   ),
+   me2 = cms.PSet(
+      folder   = cms.string("HLT/PSMonitoring"),
+      name     = cms.string("psColumnIndexVsLS"),
+      profileX = cms.bool(True)
+   ),
+)
+
+process.load('DQM.HLTEvF.psMonitorClient_cfi')
+process.psChecker = process.psMonitorClient.clone()
+
+
+process.p = cms.EndPath( process.fastTimerServiceClient + process.psColumnVsLumi + process.psChecker + process.dqmEnv + process.dqmSaver )


### PR DESCRIPTION
this new code allows the monitoring of the PS column vs LS and then vs inst lumi
it should be used by the HLT online DQM application

as https://github.com/cms-sw/cmssw/pull/14938
the HLT menu needs to be updated in order to run the new DQM source[1](a dedicated jira ticket will be opened as soon the PR will be merged and the new confDB template will be available)

[1]
process.psMonitoring = cms.EDAnalyzer('PSMonitor',
  ugtBXInputTag = cms.InputTag('hltGtStage2Digis'),
  FolderName = cms.string('HLT/PSMonitoring'),
  histoPSet = cms.PSet(
    psColumnPSet = cms.PSet(
      nbins = cms.int32(8)
    ),
    lsPSet = cms.PSet(
      nbins = cms.int32(2500)
    )
  )
)
process.hltPSColumnMonitoring = cms.EndPath( process.hltGtStage2Digis + process.psMonitoring )
