### PR TITLE
add Phase2 workflows to PR tests

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -17,6 +17,7 @@ numWFSkip=200
 #2023 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias, TTbar PU, ZEE PU)
 numWFIB = [10821.0,10824.0,10825.0,10826.0] #2023sim scenario
 numWFIB.extend([10621.0,10624.0,10625.0,10626.0]) #2023 with tilted tracker
+numWFIB.extend([11021.0,11024.0,11025.0,11026.0]) #2023Lreco
 numWFIB.extend([11221.0,11224.0,11225.0,11226.0]) #2023Greco
 for i,key in enumerate(upgradeKeys):
     numWF=numWFStart+i*numWFSkip

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -57,8 +57,10 @@ if __name__ == '__main__':
                      140.53, #2011 HI data
                      1330, #Run2 MC Zmm
                      135.4, #Run 2 Zee ttbar
+                     10021.0, #2017 tenmu
+                     10024.0, #2017 ttbar
                      11024.0, #2023LReco ttbar (w/ HGCal)
-                     11224.0  #2023GReco ttbar (flat tracker, Run2 calo)
+                     10624.0  #2023tilted ttbar (tilted tracker, Run2 calo, full reco)
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -56,7 +56,9 @@ if __name__ == '__main__':
                      136.731, #2016B Photon data
                      140.53, #2011 HI data
                      1330, #Run2 MC Zmm
-                     135.4 #Run 2 Zee ttbar
+                     135.4, #Run 2 Zee ttbar
+                     11024.0, #2023LReco ttbar (w/ HGCal)
+                     11224.0  #2023GReco ttbar (flat tracker, Run2 calo)
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC


### PR DESCRIPTION
Choice of workflows/processes to add:
- 2023LReco has HGCal
- 2023GReco has full reco workflow (currently with Run2 calorimeters)
- ttbar tends to exercise the most algorithms

attn: @boudoul, @calabria, @slava77
