### PR TITLE
Protect against negative occupancy thresholds

### DIFF
--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -211,7 +211,8 @@ namespace ecaldqm
         meanFED = meanFEDEE;
         rmsFED  = rmsFEDEE;
       }
-      if ( meanFED > 1000. && Nrhentries[iDCC] < meanFED - nRMS*rmsFED )
+      float threshold( meanFED < nRMS*rmsFED ? 10. : meanFED - nRMS*rmsFED );
+      if ( meanFED > 1000. && Nrhentries[iDCC] < threshold )
         meQualitySummary.setBinContent( id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad );
     }
 

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -157,7 +157,8 @@ namespace ecaldqm
         meanFED = meanFEDEE;
         rmsFED  = rmsFEDEE;
       }
-      if ( meanFED > 100. && Nentries[iDCC] < meanFED - nRMS*rmsFED )
+      float threshold( meanFED < nRMS*rmsFED ? 10. : meanFED - nRMS*rmsFED );
+      if ( meanFED > 100. && Nentries[iDCC] < threshold )
         meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
     }
 


### PR DESCRIPTION
Modify quality threshold for cases where we see vanishing occupancy:
- Originally: if Entries in a FED < overall FED mean - 5*overall FED rms => set Occupancy Quality to RED
- However, if occupancy is exactly zero, the rms tends to be quite large and the overall FED mean <  5*overall FED rms, so the threshold occupancy < 0. This was seen, for instance, in collisions run 275766, where the Emulation Quality continued to show YELLOW
- To protect against these cases (without tightening the 5 sigma constraint), if threshold occupancy < 0, set threshold occupancy to 10.

In conjunction with 80X PR https://github.com/cms-sw/cmssw/pull/14978.
