### PR TITLE
Use up-to-date HLT GT for online DQM (81X)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.globaltag = "80X_dataRun2_HLT_v4"
+GlobalTag.globaltag = "80X_dataRun2_HLT_v12"


### PR DESCRIPTION
In `DQM/Integration/python/config/FrontierCondition_GT_cfi.py`, the Global Tag is updated to the value currently used online.
