### PR TITLE
Use up-to-date HLT GT for online DQM (80X)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
 GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
-GlobalTag.globaltag = "80X_dataRun2_HLT_v2"
+GlobalTag.globaltag = "80X_dataRun2_HLT_v12"
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')


### PR DESCRIPTION
In `DQM/Integration/python/config/FrontierCondition_GT_cfi.py`, the Global Tag is updated to the value currently used online.

Backport of #14980 
