### PR TITLE
siPhase2Clusters in RECOSIM event content in 81X

### DIFF
--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
@@ -23,3 +23,10 @@ RecoLocalTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep ClusterSummary_clusterSummaryProducer_*_*')
 )
 
+from Configuration.StandardSequences.Eras import eras
+def _updateOutput( era, outputPSets, commands):
+   for o in outputPSets:
+      era.toModify( o, outputCommands = o.outputCommands + commands )
+
+_outputs = [RecoLocalTrackerFEVT, RecoLocalTrackerRECO]
+_updateOutput(eras.phase2_tracker, _outputs, ['keep *_siPhase2Clusters_*_*'])


### PR DESCRIPTION
This PR is done in order to allow the Validation tools used only for the tracking part to run on RECO events. The tracking MC association is not possible when the clusters information is not stored.

@makortel please check
@kpedro88 this is the second PR that will fix Validation for tracking. Good to have in pre8 if possible, as I mentioned in #14951 
@VinInn @rovere
