### PR TITLE
rho analyzer and empty area correction added to customize

### DIFF
--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -136,12 +136,49 @@ def storeCaloTowersAOD(process):
         process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
 
     return process
+	
+# Add rhoProducer to AOD event content
+def addRhoProducer(process):
+    process.load('RecoJets.JetProducers.kt4PFJets_cfi')
+    process.load('RecoHI.HiJetAlgos.hiFJRhoProducer')
+    process.load('RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff')
+
+	# process.kt4PFJets.src = cms.InputTag('particleFlowTmp')
+    process.kt4PFJets.doAreaFastjet = True
+    process.kt4PFJets.jetPtMin      = cms.double(0.0)
+    process.kt4PFJets.GhostArea     = cms.double(0.005)
+    process.hiFJGridEmptyAreaCalculator.doCentrality = False
+    
+	# extend AOD content
+    process.reconstruction *= process.kt4PFJets
+    process.reconstruction *= process.hiFJRhoProducer
+    process.reconstruction *= process.hiFJGridEmptyAreaCalculator
+
+    # extend AOD content
+    if hasattr(process,'AODoutput'):
+        process.AODoutput.outputCommands.extend(['keep *_hiFJGridEmptyAreaCalculator_*_*'])
+        process.AODoutput.outputCommands.extend(['keep *_hiFJRhoProducer_*_*'])
+
+    if hasattr(process,'AODSIMoutput'):
+        process.AODSIMoutput.outputCommands.extend(['keep *_hiFJGridEmptyAreaCalculator_*_*'])
+        process.AODSIMoutput.outputCommands.extend(['keep *_hiFJRhoProducer_*_*'])
+		
+    if hasattr(process,'RECOSIMoutput'):
+        process.RECOSIMoutput.outputCommands.extend(['keep *_hiFJGridEmptyAreaCalculator_*_*'])
+        process.RECOSIMoutput.outputCommands.extend(['keep *_hiFJRhoProducer_*_*'])
+
+    if hasattr(process,'RECOoutput'):
+        process.RECOoutput.outputCommands.extend(['keep *_hiFJGridEmptyAreaCalculator_*_*'])
+        process.RECOoutput.outputCommands.extend(['keep *_hiFJRhoProducer_*_*'])
+
+    return process
 
 def customisePPwithHI(process):
 
     process=addHIIsolationProducer(process)
     process=modifyClusterLimits(process)
     process=storeCaloTowersAOD(process)
+    process=addRhoProducer(process)
 
     return process
 

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -136,14 +136,13 @@ def storeCaloTowersAOD(process):
         process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
 
     return process
-	
+
 # Add rhoProducer to AOD event content
 def addRhoProducer(process):
     process.load('RecoJets.JetProducers.kt4PFJets_cfi')
     process.load('RecoHI.HiJetAlgos.hiFJRhoProducer')
     process.load('RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff')
 
-	# process.kt4PFJets.src = cms.InputTag('particleFlowTmp')
     process.kt4PFJets.doAreaFastjet = True
     process.kt4PFJets.jetPtMin      = cms.double(0.0)
     process.kt4PFJets.GhostArea     = cms.double(0.005)
@@ -172,13 +171,19 @@ def addRhoProducer(process):
         process.RECOoutput.outputCommands.extend(['keep *_hiFJRhoProducer_*_*'])
 
     return process
-
-def customisePPwithHI(process):
+	
+def customisePPrecoforPPb(process):
+ 
+     process=addHIIsolationProducer(process)
+     process=storeCaloTowersAOD(process)
+     process=addRhoProducer(process)
+	 
+     return process
+ 
+def customisePPrecoForPeripheralPbPb(process):
 
     process=addHIIsolationProducer(process)
     process=modifyClusterLimits(process)
     process=storeCaloTowersAOD(process)
-    process=addRhoProducer(process)
 
     return process
-

--- a/RecoHI/HiJetAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/plugins/BuildFile.xml
@@ -12,7 +12,7 @@
 <use   name="cgal"/>
 <use   name="f77compiler"/>
 
-<flags CXXFLAGS="-frounding-math -Wno-unknown-pragmas"/>
+<flags CXXFLAGS="-DCGAL_DISABLE_ROUNDING_MATH_CHECK -Wno-unknown-pragmas"/>
 <flags REM_CXXFLAGS="-Werror=unused-variable"/>
 <flags   EDM_PLUGIN="1"/>
 <library   file="*.cc,*.f" name="HiJetAlgosPlugins">

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -1,0 +1,462 @@
+// -*- C++ -*-
+//
+// Package:    HiJetBackground/HiFJGridEmptyAreaCalculator
+// Class:      HiFJGridEmptyAreaCalculator
+// Based on:   fastjet/tools/GridMedianBackgroundEstimator 
+//
+// Original Author:  Doga Gulhan
+//         Created:  Wed Mar 16 14:00:04 CET 2016
+//
+//
+
+#include "RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h"
+using namespace std;
+using namespace edm;
+
+
+HiFJGridEmptyAreaCalculator::HiFJGridEmptyAreaCalculator(const edm::ParameterSet& iConfig):
+  gridWidth_(iConfig.getUntrackedParameter<double>("gridWidth",0.005)),
+  band_(iConfig.getUntrackedParameter<double>("bandWidth",0.2)),
+  hiBinCut_(iConfig.getUntrackedParameter<int>("hiBinCut",60)),
+  doCentrality_(iConfig.getUntrackedParameter<bool>("doCentrality",true)),
+  keepGridInfo_(iConfig.getUntrackedParameter<bool>("keepGridInfo",true))
+{
+  pfCandsToken_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfCandSource" ));
+  mapEtaToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapEtaEdges" ));
+  mapRhoToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapToRho" ));
+  mapRhoMToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapToRhoM" ));
+  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
+  centralityBinToken_ = consumes<int>(iConfig.getParameter<edm::InputTag>("CentralityBinSrc"));
+
+  //register your products
+  produces<std::vector<double > >("mapEmptyCorrFac"); 
+  produces<std::vector<double > >("mapToRhoCorr");
+  produces<std::vector<double > >("mapToRhoMCorr");
+  produces<std::vector<double > >("mapToRhoCorr1Bin");
+  produces<std::vector<double > >("mapToRhoMCorr1Bin");
+  //rho calculation on a grid using median
+  if(keepGridInfo_){
+    produces<std::vector<double > >("mapRhoVsEtaGrid");
+    produces<std::vector<double > >("mapMeanRhoVsEtaGrid");
+    produces<std::vector<double > >("mapEtaMaxGrid");
+    produces<std::vector<double > >("mapEtaMinGrid");
+  }
+}
+
+
+HiFJGridEmptyAreaCalculator::~HiFJGridEmptyAreaCalculator()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+// ------------ method called to produce the data  ------------
+void
+HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  //Values from rho calculator  
+  edm::Handle<std::vector<double>> mapEtaRanges;
+  iEvent.getByToken(mapEtaToken_, mapEtaRanges);
+  
+  edm::Handle<std::vector<double>> mapRho;
+  iEvent.getByToken(mapRhoToken_, mapRho);
+
+  edm::Handle<std::vector<double>> mapRhoM;  
+  iEvent.getByToken(mapRhoMToken_, mapRhoM);
+
+  // if doCentrality is set to true calculate empty area correction
+  // for only events with hiBin > hiBinCut  
+  int hiBin = -1;
+  bool doEmptyArea = true; 
+  if(doCentrality_){
+    edm::Handle<int> cbin_;
+    iEvent.getByToken(centralityBinToken_,cbin_);
+    hiBin = *cbin_;
+   
+    if(hiBin < hiBinCut_) doEmptyArea = false;
+  }
+  
+  //Define output vectors
+  int neta = (int)mapEtaRanges->size();
+   
+  std::auto_ptr<std::vector<double>> mapToRhoCorrOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoMCorrOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoMCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+
+  setup_grid(mapEtaRanges->at(0), mapEtaRanges->at(neta-1));
+  
+  //calculate empty area correction over full acceptance leaving eta bands on the sides
+  double all_acceptance_corr = 1;
+  if(doEmptyArea){
+    _eta_min_jet = mapEtaRanges->at(0) - band_;
+    _eta_max_jet = mapEtaRanges->at(neta-1) + band_;
+  
+    calculate_area_fraction_of_jets(iEvent, iSetup);
+  
+    all_acceptance_corr =  _total_inbound_area;
+  }
+  
+  //calculate empty area correction in each eta range
+  for(int ieta = 0; ieta<(neta-1); ieta++) {
+   
+    double correction_kt = 1;   
+    double rho = mapRho->at(ieta);
+    double rhoM = mapRhoM->at(ieta);
+    
+    if(doEmptyArea){
+      double eta_min = mapEtaRanges->at(ieta);
+      double eta_max = mapEtaRanges->at(ieta+1);
+      
+      _eta_min_jet = eta_min + band_;  
+      _eta_max_jet = eta_max - band_;  
+   
+      calculate_area_fraction_of_jets(iEvent, iSetup);
+      correction_kt = _total_inbound_area;
+    }
+   
+    mapToRhoCorrOut->at(ieta) = correction_kt*rho;
+    mapToRhoMCorrOut->at(ieta) = correction_kt*rhoM;
+   
+    mapToRhoCorr1BinOut->at(ieta) = all_acceptance_corr*rho;
+    mapToRhoMCorr1BinOut->at(ieta) = all_acceptance_corr*rhoM;
+  }
+
+  iEvent.put(mapToRhoCorrOut,"mapToRhoCorr");
+  iEvent.put(mapToRhoMCorrOut,"mapToRhoMCorr");
+  iEvent.put(mapToRhoCorr1BinOut,"mapToRhoCorr1Bin");
+  iEvent.put(mapToRhoMCorr1BinOut,"mapToRhoMCorr1Bin");
+  
+  //calculate rho from grid as a function of eta over full range using PF candidates
+  
+  std::auto_ptr<std::vector<double>> mapRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapMeanRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapEtaMaxGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapEtaMinGridOut ( new std::vector<double>(_ny,0.));
+  calculate_grid_rho(iEvent, iSetup);
+  if(keepGridInfo_){
+    for(int ieta = 0; ieta < _ny; ieta++) {
+      mapRhoVsEtaGridOut->at(ieta) = _rho_vs_eta[ieta];
+      mapMeanRhoVsEtaGridOut->at(ieta) = _mean_rho_vs_eta[ieta];
+      mapEtaMaxGridOut->at(ieta) = _eta_max_grid[ieta];
+      mapEtaMinGridOut->at(ieta) = _eta_min_grid[ieta];
+    }
+
+    iEvent.put(mapRhoVsEtaGridOut,"mapRhoVsEtaGrid");
+    iEvent.put(mapMeanRhoVsEtaGridOut,"mapMeanRhoVsEtaGrid");
+    iEvent.put(mapEtaMaxGridOut,"mapEtaMaxGrid");
+    iEvent.put(mapEtaMinGridOut,"mapEtaMinGrid");
+  }
+}
+
+//----------------------------------------------------------------------
+// setting a new event
+//----------------------------------------------------------------------
+// tell the background estimator that it has a new event, composed
+// of the specified particles.
+void
+HiFJGridEmptyAreaCalculator::calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  vector<vector<double>> scalar_pt(_ny, vector<double>(_nphi, 0.0));
+  
+  edm::Handle<reco::PFCandidateCollection> pfCands;
+  iEvent.getByToken(pfCandsToken_, pfCands);
+  const reco::PFCandidateCollection *pfCandidateColl = pfCands.product();
+  for(unsigned icand = 0; icand < pfCandidateColl->size(); icand++) {
+   const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
+   //use ony the particles within the eta range
+   if (pfCandidate.eta() < _ymin || pfCandidate.eta() > _ymax ) continue;
+   int jeta = tile_index_eta(&pfCandidate);
+   int jphi = tile_index_phi(&pfCandidate);
+   scalar_pt[jeta][jphi] += pfCandidate.pt();
+  }
+  
+ _rho_vs_eta.resize(_ny);
+ _mean_rho_vs_eta.resize(_ny);
+  for(int jeta = 0; jeta < _ny; jeta++){
+  
+ 	 _rho_vs_eta[jeta] = 0;
+ 	 _mean_rho_vs_eta[jeta] = 0;
+	 vector<double> rho_vs_phi;
+	 int n_empty = 0;
+	
+	for(int jphi = 0; jphi < _nphi; jphi++){
+	  double binpt = scalar_pt[jeta][jphi];
+	  _mean_rho_vs_eta[jeta] += binpt;
+      //fill in the vector for median calculation
+	  if(binpt > 0) rho_vs_phi.push_back(binpt);
+	  else n_empty++;
+	 } 
+	 _mean_rho_vs_eta[jeta] /= ((double)_nphi);
+     _mean_rho_vs_eta[jeta] /= _tile_area;
+
+	 //median calculation
+	 sort(rho_vs_phi.begin(), rho_vs_phi.end());
+	 //use only the nonzero grid cells for median calculation;
+	 int n_full = _nphi - n_empty;
+	 if(n_full == 0){
+ 	  _rho_vs_eta[jeta] = 0;
+ 	  continue;
+	 }
+	 if (n_full  % 2 == 0)
+     {
+       _rho_vs_eta[jeta] = (rho_vs_phi[(int)(n_full / 2 - 1)] + rho_vs_phi[(int)(n_full / 2)]) / 2;
+     }
+     else 
+     {
+       _rho_vs_eta[jeta] = rho_vs_phi[(int)(n_full / 2)];
+     }
+     //correct for empty cells 
+	 _rho_vs_eta[jeta] *= (((double) n_full)/((double) _nphi));
+	 //normalize to area
+     _rho_vs_eta[jeta] /= _tile_area;
+  }
+}
+
+void
+HiFJGridEmptyAreaCalculator::calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+  edm::Handle<edm::View<reco::Jet> > jets;
+  iEvent.getByToken(jetsToken_, jets);
+  
+  //calculate jet kt area fraction inside boundary by grid
+  _total_inbound_area = 0;
+  
+  for(auto jet = jets->begin(); jet != jets->end(); ++jet) {
+    if (jet->eta() < _eta_min_jet || jet->eta() > _eta_max_jet) continue;
+   
+    double area_kt = jet->jetArea(); 
+    setup_grid_jet(&*jet);
+    std::vector<std::pair<int, int> > pf_indices_jet;
+    std::vector<std::pair<int, int> > pf_indices_jet_inbound;
+    int n_constit_jet = 0;
+    int n_constit_jet_inbound = 0;
+    for(auto daughter : jet->getJetConstituentsQuick()){
+      auto pfCandidate = static_cast<const reco::PFCandidate*>(daughter);
+
+	  int jeta = tile_index_eta_jet(&*pfCandidate);
+	  int jphi = tile_index_phi(&*pfCandidate);
+	  pf_indices_jet.push_back(std::make_pair(jphi, jeta));
+	  n_constit_jet++;
+	  if (pfCandidate->eta() < _eta_min_jet && pfCandidate->eta() > _eta_max_jet) continue;
+	  pf_indices_jet_inbound.push_back(std::make_pair(jphi, jeta));
+	  n_constit_jet_inbound++;
+   }   
+   
+   //if the jet is well within the eta range just add the area
+   if(n_constit_jet == n_constit_jet_inbound){
+	_total_inbound_area += area_kt;
+    continue;
+   }
+   
+   //for jets that fall outside of eta range calculate fraction of area
+   //inside the range with a grid
+   int nthis = 0;
+   if (n_constit_jet > 0) nthis = num_jet_grid_cells(pf_indices_jet);
+
+   int nthis_inbound = 0;
+   if (n_constit_jet_inbound > 0) nthis_inbound = num_jet_grid_cells(pf_indices_jet_inbound);
+   
+  
+   double fraction_area = ((double)nthis_inbound)/((double)nthis);
+   _total_inbound_area += area_kt*fraction_area;    
+  } 
+  
+  //divide by the total area in that range
+  _total_inbound_area /= ((_eta_max_jet - _eta_min_jet)*twopi);
+  
+  //the fraction can still be greater than 1 because kt area fraction inside 
+  //the range can differ from what we calculated with the grid
+  if (_total_inbound_area > 1) _total_inbound_area = 1;
+}
+
+
+// #ifndef FASTJET_GMBGE_USEFJGRID
+//----------------------------------------------------------------------
+// protected material
+//----------------------------------------------------------------------
+// configure the grid
+void
+HiFJGridEmptyAreaCalculator::setup_grid(double eta_min, double eta_max) {
+
+  // since we've exchanged the arguments of the grid constructor,
+  // there's a danger of calls with exchanged ymax,spacing arguments -- 
+  // the following check should catch most such situations.
+  _ymin = eta_min;
+  _ymax = eta_max;
+  
+  assert(_ymax - _ymin >= gridWidth_);
+
+  // this grid-definition code is becoming repetitive -- it should
+  // probably be moved somewhere central...
+  double ny_double = (_ymax-_ymin) / gridWidth_;
+  _ny = int(ny_double+0.5);
+  _dy = (_ymax-_ymin) / _ny;
+  
+  _nphi = int (twopi / gridWidth_ + 0.5);
+  _dphi = twopi / _nphi;
+
+  // some sanity checking (could throw a fastjet::Error)
+  assert(_ny >= 1 && _nphi >= 1);
+
+  _ntotal = _nphi * _ny;
+  //_scalar_pt.resize(_ntotal);
+  _tile_area = _dy * _dphi;
+  
+  
+  _eta_max_grid.resize(_ny);
+  _eta_min_grid.resize(_ny);
+  for(int jeta = 0; jeta < _ny; jeta++){
+   _eta_min_grid[jeta] = eta_min + _dy*((double)jeta);
+   _eta_max_grid[jeta] = eta_min + _dy*((double)jeta + 1.);
+  }
+}
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_phi(const reco::PFCandidate *pfCand)  {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+ 
+  int iphi = int( (pfCand->phi() + (twopi/2.))/_dphi );
+  assert(iphi >= 0 && iphi <= _nphi);
+  if (iphi == _nphi) iphi = 0; // just in case of rounding errors
+
+  return iphi;
+}
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_eta(const reco::PFCandidate *pfCand)  {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+  int iy = int(floor( (pfCand->eta() - _ymin) / _dy ));
+  if (iy < 0 || iy >= _ny) return -1;
+  
+  assert (iy < _ny && iy >= 0);
+
+  return iy;
+}
+
+// #ifndef FASTJET_GMBGE_USEFJGRID
+//----------------------------------------------------------------------
+// protected material
+//----------------------------------------------------------------------
+// configure the grid
+void
+HiFJGridEmptyAreaCalculator::setup_grid_jet(const reco::Jet *jet) {
+
+  // since we've exchanged the arguments of the grid constructor,
+  // there's a danger of calls with exchanged ymax,spacing arguments -- 
+  // the following check should catch most such situations.
+  _yminjet = jet->eta()-0.6;
+  _ymaxjet = jet->eta()+0.6;
+  
+  assert(_ymaxjet - _yminjet >= gridWidth_);
+
+  // this grid-definition code is becoming repetitive -- it should
+  // probably be moved somewhere central...
+  double ny_double = (_ymaxjet-_yminjet) / gridWidth_;
+  _nyjet = int(ny_double+0.5);
+  _dyjet = (_ymaxjet-_yminjet) / _nyjet;
+  
+  assert(_nyjet >= 1);
+
+  _ntotaljet = _nphi * _nyjet;
+  //_scalar_pt.resize(_ntotal);
+}
+
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_eta_jet(const reco::PFCandidate *pfCand) {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+  int iyjet = int(floor( (pfCand->eta() - _yminjet) / _dy ));
+  if (iyjet < 0 || iyjet >= _nyjet) return -1;
+  
+  assert (iyjet < _nyjet && iyjet >= 0);
+
+  return iyjet;
+}
+
+int 
+HiFJGridEmptyAreaCalculator::num_jet_grid_cells( std::vector<std::pair<int, int> >& indices )
+{
+  int ngrid = 0;
+  //sort phi eta grid indices in phi
+  std::sort(indices.begin(),indices.end());
+  int lowest_jphi = indices[0].first;
+  int lowest_jeta = indices[0].second;
+  int highest_jeta = lowest_jeta;
+    
+  //for each fixed phi value calculate the number of grids in eta
+  for(unsigned int iconst = 1; iconst < indices.size(); iconst++){
+     int jphi = indices[iconst].first;
+     int jeta = indices[iconst].second;
+     if (jphi == lowest_jphi){
+	  if (jeta < lowest_jeta) lowest_jeta = jeta;
+	  if (jeta > highest_jeta) highest_jeta = jeta;
+     }else{
+	  lowest_jphi = jphi;
+	  ngrid += highest_jeta - lowest_jeta + 1;
+      lowest_jeta = jeta;
+      highest_jeta = jeta;
+    }
+  }
+  ngrid += highest_jeta - lowest_jeta + 1;
+  return ngrid;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+HiFJGridEmptyAreaCalculator::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+HiFJGridEmptyAreaCalculator::endJob() {
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HiFJGridEmptyAreaCalculator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(HiFJGridEmptyAreaCalculator);
+

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -453,6 +453,12 @@ void HiFJGridEmptyAreaCalculator::fillDescriptions(edm::ConfigurationDescription
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("jetSource",edm::InputTag("kt4PFJets"));
+  desc.add<edm::InputTag>("CentralityBinSrc",edm::InputTag("centralityBin"));
+  desc.add<edm::InputTag>("mapEtaEdges",edm::InputTag("mapEtaEdges"));
+  desc.add<edm::InputTag>("mapToRho",edm::InputTag("mapToRho"));
+  desc.add<edm::InputTag>("mapToRhoM",edm::InputTag("mapToRhoM"));
+  desc.add<edm::InputTag>("pfCandSource",edm::InputTag("particleFlow"));
   desc.add<double>("gridWidth",0.05);
   desc.add<double>("bandWidth",0.2);
   desc.add<bool>("doCentrality", true);

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
@@ -1,0 +1,99 @@
+#ifndef HiJetBackground_HiFJGridEmptyAreaCalculator_h
+#define HiJetBackground_HiFJGridEmptyAreaCalculator_h
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "TMath.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
+   public:
+      explicit HiFJGridEmptyAreaCalculator(const edm::ParameterSet&);
+      ~HiFJGridEmptyAreaCalculator();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+      
+  /// @name setting a new event
+  //\{
+  //----------------------------------------------------------------
+
+  /// tell the background estimator that it has a new event, composed
+  /// of the specified particles.
+
+
+private:
+
+  /// configure the grid
+  void setup_grid(double eta_min, double eta_max);
+  void setup_grid_jet(const reco::Jet *jet);
+
+  /// retrieve the grid cell index for a given PseudoJet
+  int tile_index_jet(const reco::PFCandidate *pfCand);
+  int tile_index_eta(const reco::PFCandidate *pfCand);
+  int tile_index_eta_jet(const reco::PFCandidate *pfCand);
+  int tile_index_phi(const reco::PFCandidate *pfCand);
+  
+  ///number of grid cells that overlap with jet constituents filling in the in between area
+  int num_jet_grid_cells( std::vector<std::pair<int, int> >& indices );
+  
+  /// calculates the area of jets that fall within the eta 
+  /// range by scaling kt areas using grid areas
+  void calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  
+  /// information about the grid
+  const double twopi = 2*TMath::Pi(); 
+  
+  ///internal parameters for grid 
+  double _ymin, _ymax, _dy, _dphi, _tile_area, //parameters of grid covering the full acceptance
+  _dyjet, _yminjet, _ymaxjet, _total_inbound_area, //parameters of grid around jets
+  _eta_min_jet, _eta_max_jet; //leave bands at boundaries
+  int _ny, _nphi, _ntotal, //for the grid calculation covering the full acceptance
+  _ntotaljet, _nyjet; //for the grid calculation around each jet
+  
+  ///input parameters
+  double gridWidth_, band_;
+  int hiBinCut_;
+  bool doCentrality_;
+  bool keepGridInfo_;
+  
+  std::vector<double> _rho_vs_eta;
+  std::vector<double> _mean_rho_vs_eta;
+  std::vector<double> _eta_max_grid;
+  std::vector<double> _eta_min_grid;
+  
+  int n_tiles()  {return _ntotal;}
+  
+  /// input tokens
+  edm::EDGetTokenT<edm::View<reco::Jet>>                 jetsToken_;
+  edm::EDGetTokenT<reco::PFCandidateCollection>          pfCandsToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapEtaToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapRhoToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapRhoMToken_;
+
+  edm::EDGetTokenT<int> centralityBinToken_;
+  
+};
+
+#endif
+

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
@@ -9,11 +9,14 @@
 #include <vector>
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 #include "TMath.h"
 
@@ -21,7 +24,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
+class HiFJGridEmptyAreaCalculator : public edm::stream::EDProducer<> {
    public:
       explicit HiFJGridEmptyAreaCalculator(const edm::ParameterSet&);
       ~HiFJGridEmptyAreaCalculator();
@@ -29,9 +32,9 @@ class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
+      virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      virtual void endStream() override;
       
   /// @name setting a new event
   //\{
@@ -44,45 +47,67 @@ class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
 private:
 
   /// configure the grid
-  void setup_grid(double eta_min, double eta_max);
-  void setup_grid_jet(const reco::Jet *jet);
+  void setupGrid(double eta_min, double eta_max);
+  void setupGridJet(const reco::Jet *jet);
 
   /// retrieve the grid cell index for a given PseudoJet
-  int tile_index_jet(const reco::PFCandidate *pfCand);
-  int tile_index_eta(const reco::PFCandidate *pfCand);
-  int tile_index_eta_jet(const reco::PFCandidate *pfCand);
-  int tile_index_phi(const reco::PFCandidate *pfCand);
+  int tileIndexJet(const reco::PFCandidate *pfCand);
+  int tileIndexEta(const reco::PFCandidate *pfCand);
+  int tileIndexEtaJet(const reco::PFCandidate *pfCand);
+  int tileIndexPhi(const reco::PFCandidate *pfCand);
   
   ///number of grid cells that overlap with jet constituents filling in the in between area
-  int num_jet_grid_cells( std::vector<std::pair<int, int> >& indices );
+  int numJetGridCells( std::vector<std::pair<int, int> >& indices );
   
   /// calculates the area of jets that fall within the eta 
   /// range by scaling kt areas using grid areas
-  void calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  void calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculateAreaFractionOfJets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculateGridRho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   
   /// information about the grid
-  const double twopi = 2*TMath::Pi(); 
+  const double twopi_ = 2*M_PI;
   
-  ///internal parameters for grid 
-  double _ymin, _ymax, _dy, _dphi, _tile_area, //parameters of grid covering the full acceptance
-  _dyjet, _yminjet, _ymaxjet, _total_inbound_area, //parameters of grid around jets
-  _eta_min_jet, _eta_max_jet; //leave bands at boundaries
-  int _ny, _nphi, _ntotal, //for the grid calculation covering the full acceptance
-  _ntotaljet, _nyjet; //for the grid calculation around each jet
+  ///internal parameters for grid
+
+  //parameters of grid covering the full acceptance
+  double ymin_;
+  double ymax_;
+  double dy_;
+  double dphi_;
+  double tileArea_;
+
+  //parameters of grid around jets
+  double dyJet_;
+  double yminJet_;
+  double ymaxJet_;
+  double totalInboundArea_;
+
+  //leave bands at boundaries
+  double etaminJet_;
+  double etamaxJet_;
+
+  //for the grid calculation covering the full acceptance
+  int ny_;
+  int nphi_;
+  int ntotal_;
+
+  //for the grid calculation around each jet
+  int ntotalJet_;
+  int nyJet_;
   
   ///input parameters
-  double gridWidth_, band_;
+  double gridWidth_;
+  double band_;
   int hiBinCut_;
   bool doCentrality_;
   bool keepGridInfo_;
   
-  std::vector<double> _rho_vs_eta;
-  std::vector<double> _mean_rho_vs_eta;
-  std::vector<double> _eta_max_grid;
-  std::vector<double> _eta_min_grid;
+  std::vector<double> rhoVsEta_;
+  std::vector<double> meanRhoVsEta_;
+  std::vector<double> etaMaxGrid_;
+  std::vector<double> etaMinGrid_;
   
-  int n_tiles()  {return _ntotal;}
+  int n_tiles()  {return ntotal_;}
   
   /// input tokens
   edm::EDGetTokenT<edm::View<reco::Jet>>                 jetsToken_;

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
@@ -18,8 +18,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "TMath.h"
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -1,0 +1,240 @@
+// -*- C++ -*-
+//
+// Package:    HiJetBackground/HiFJRhoProducer
+// Class:      HiFJRhoProducer
+// 
+/**\class HiFJRhoProducer HiFJRhoProducer.cc HiJetBackground/HiFJRhoProducer/plugins/HiFJRhoProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marta Verweij
+//         Created:  Thu, 16 Jul 2015 10:57:12 GMT
+//
+//
+
+#include <memory>
+#include <string>
+
+#include "TMath.h"
+
+#include "RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+using namespace edm;
+using namespace pat;
+
+//using ival = boost::icl::interval<double>;
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+HiFJRhoProducer::HiFJRhoProducer(const edm::ParameterSet& iConfig) : 
+  nExcl_(iConfig.getUntrackedParameter<unsigned int>("nExcl",0)),
+  etaMaxExcl_(iConfig.getUntrackedParameter<double>("etaMaxExcl",2.)),
+  ptMinExcl_(iConfig.getUntrackedParameter<double>("ptMinExcl",20.)),
+  nExcl2_(iConfig.getUntrackedParameter<unsigned int>("nExcl2",0)),
+  etaMaxExcl2_(iConfig.getUntrackedParameter<double>("etaMaxExcl2",3.)),
+  ptMinExcl2_(iConfig.getUntrackedParameter<double>("ptMinExcl2",20.)),
+  checkJetCand(true),
+  usingPackedCand(false)
+{
+  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
+
+  //register your products
+  produces<std::vector<double > >("mapEtaEdges");
+  produces<std::vector<double > >("mapToRho");
+  produces<std::vector<double > >("mapToRhoM");
+  produces<std::vector<double > >("ptJets");
+  produces<std::vector<double > >("areaJets");
+  produces<std::vector<double > >("etaJets");
+  etaRanges = iConfig.getUntrackedParameter<std::vector<double> >("etaRanges");
+
+}
+
+
+HiFJRhoProducer::~HiFJRhoProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+// ------------ method called to produce the data  ------------
+void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  
+  // Get the vector of jets
+  edm::Handle<edm::View<reco::Jet> > jets;
+  iEvent.getByToken(jetsToken_, jets);
+
+  int neta = (int)etaRanges.size();
+  std::auto_ptr<std::vector<double>> mapEtaRangesOut ( new std::vector<double>(neta,-999.));
+
+  for(int ieta = 0; ieta < neta; ieta++){
+   mapEtaRangesOut->at(ieta) = etaRanges[ieta];
+  }
+  std::auto_ptr<std::vector<double>> mapToRhoOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoMOut ( new std::vector<double>(neta-1,1e-6));
+  
+  int njets = jets->size();
+  
+  std::auto_ptr<std::vector<double>> ptJetsOut ( new std::vector<double>(njets,1e-6));
+  std::auto_ptr<std::vector<double>> areaJetsOut ( new std::vector<double>(njets,1e-6));
+  std::auto_ptr<std::vector<double>> etaJetsOut ( new std::vector<double>(njets,1e-6));
+    
+  static double rhoVec[999];
+  static double rhomVec[999];
+  static double etaVec[999];
+
+  // int neta = (int)mapEtaRangesOut->size();
+  int nacc = 0;
+  unsigned int njetsEx = 0;
+  unsigned int njetsEx2 = 0;
+  for(auto jet = jets->begin(); jet != jets->end(); ++jet) {
+    if(njetsEx<nExcl_ && fabs(jet->eta())<etaMaxExcl_ && jet->pt()>ptMinExcl_) {
+      njetsEx++;
+      continue;
+    }
+    if(njetsEx2<nExcl2_ && fabs(jet->eta())<etaMaxExcl2_ && fabs(jet->eta())>etaMaxExcl_ && jet->pt()>ptMinExcl2_) {
+      njetsEx2++;
+      continue;
+    }
+    float pt = jet->pt();
+    float area = jet->jetArea();
+    float eta = jet->eta();
+	
+    if(eta<mapEtaRangesOut->at(0) || eta>mapEtaRangesOut->at(neta-1)) continue;
+    if(area>0.) {
+      rhoVec[nacc] = pt/area;
+      rhomVec[nacc] = calcMd(&*jet)/area;
+      etaVec[nacc] = eta;
+	  ptJetsOut->at(nacc) = pt;
+	  areaJetsOut->at(nacc) = area;
+	  etaJetsOut->at(nacc) = eta;
+      ++nacc;
+    }
+  }
+
+  ptJetsOut->resize(nacc);
+  areaJetsOut->resize(nacc);
+  etaJetsOut->resize(nacc);
+  //calculate rho and rhom in eta ranges
+  double radius = 0.2; //distance kt clusters needs to be from edge
+  for(int ieta = 0; ieta<(neta-1); ieta++) {
+    static double rhoVecCur[999] = {0.};
+    static double rhomVecCur[999]= {0.};
+
+    double etaMin = mapEtaRangesOut->at(ieta)+radius;
+    double etaMax = mapEtaRangesOut->at(ieta+1)-radius;
+     
+    int    naccCur    = 0 ;
+    double rhoCurSum  = 0.;
+    double rhomCurSum = 0.;
+    for(int i = 0; i<nacc; i++) {
+      if(etaVec[i]>=etaMin && etaVec[i]<etaMax) {
+        rhoVecCur[naccCur] = rhoVec[i];
+        rhomVecCur[naccCur] = rhomVec[i];
+        rhoCurSum += rhoVec[i];
+        rhomCurSum += rhomVec[i];
+        ++naccCur;
+      }//eta selection
+    }//accepted jet loop
+
+    if(naccCur>0) {
+      double rhoCur = TMath::Median(naccCur, rhoVecCur);
+      double rhomCur = TMath::Median(naccCur, rhomVecCur);
+      mapToRhoOut->at(ieta) = rhoCur;
+      mapToRhoMOut->at(ieta) = rhomCur;
+    }
+  }//eta ranges
+  
+  iEvent.put(mapEtaRangesOut,"mapEtaEdges");
+  iEvent.put(mapToRhoOut,"mapToRho");
+  iEvent.put(mapToRhoMOut,"mapToRhoM");
+  
+  iEvent.put(ptJetsOut,"ptJets");
+  iEvent.put(areaJetsOut,"areaJets");
+  iEvent.put(etaJetsOut,"etaJets");
+  
+}
+
+double HiFJRhoProducer::calcMd(const reco::Jet *jet) {
+  //
+  //get md as defined in http://arxiv.org/pdf/1211.2811.pdf
+  //
+
+  //Loop over the jet constituents
+  double sum = 0.;
+  for(auto daughter : jet->getJetConstituentsQuick()){
+    if(isPackedCandidate(daughter)){     //packed candidate situation
+      auto part = static_cast<const pat::PackedCandidate*>(daughter);
+      sum += sqrt(part->mass()*part->mass() + part->pt()*part->pt()) - part->pt();
+    } else {
+      auto part = static_cast<const reco::PFCandidate*>(daughter);
+      sum += sqrt(part->mass()*part->mass() + part->pt()*part->pt()) - part->pt();
+    }
+  }
+
+  return sum;
+}
+
+/// Function to tell us if we are using packedCandidates, only test for first candidate
+bool HiFJRhoProducer::isPackedCandidate(const reco::Candidate* candidate){
+  if(checkJetCand) {
+    if(typeid(pat::PackedCandidate)==typeid(*candidate)) usingPackedCand = true;
+    else if(typeid(reco::PFCandidate)==typeid(*candidate)) usingPackedCand = false;
+    else throw cms::Exception("WrongJetCollection", "Jet constituents are not particle flow candidates");
+    checkJetCand = false;
+  }
+  return usingPackedCand;
+}
+
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+HiFJRhoProducer::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+HiFJRhoProducer::endJob() {
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HiFJRhoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HiFJRhoProducer);

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -24,13 +24,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-using namespace edm;
+//using namespace edm;
 using namespace reco;
 //using namespace pat;
 
@@ -46,17 +48,18 @@ using namespace reco;
 //
 // constructors and destructor
 //
-HiFJRhoProducer::HiFJRhoProducer(const edm::ParameterSet& iConfig) : 
-  nExcl_(iConfig.getParameter<unsigned int>("nExcl")),
+HiFJRhoProducer::HiFJRhoProducer(const edm::ParameterSet& iConfig) :
+  src_(iConfig.getParameter<edm::InputTag>("jetSource")),
+  nExcl_(iConfig.getParameter<int>("nExcl")),
   etaMaxExcl_(iConfig.getParameter<double>("etaMaxExcl")),
   ptMinExcl_(iConfig.getParameter<double>("ptMinExcl")),
-  nExcl2_(iConfig.getParameter<unsigned int>("nExcl2")),
+  nExcl2_(iConfig.getParameter<int>("nExcl2")),
   etaMaxExcl2_(iConfig.getParameter<double>("etaMaxExcl2")),
   ptMinExcl2_(iConfig.getParameter<double>("ptMinExcl2")),
   checkJetCand(true),
   usingPackedCand(false)
 {
-  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
+  jetsToken_ = consumes<edm::View<reco::Jet> >(src_);
 
   //register your products
   produces<std::vector<double > >("mapEtaEdges");
@@ -232,6 +235,7 @@ void HiFJRhoProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("jetSource",edm::InputTag("kt4PFJets"));
   desc.add<int>("nExcl", 2);
   desc.add<double>("etaMaxExcl",2.);
   desc.add<double>("ptMinExcl",20.);

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -102,9 +102,9 @@ void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   std::auto_ptr<std::vector<double>> areaJetsOut ( new std::vector<double>(njets,1e-6));
   std::auto_ptr<std::vector<double>> etaJetsOut ( new std::vector<double>(njets,1e-6));
     
-  static double rhoVec[999];
-  static double rhomVec[999];
-  static double etaVec[999];
+  double rhoVec[999];
+  double rhomVec[999];
+  double etaVec[999];
 
   // int neta = (int)mapEtaRangesOut->size();
   int nacc = 0;
@@ -141,9 +141,9 @@ void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //calculate rho and rhom in eta ranges
   double radius = 0.2; //distance kt clusters needs to be from edge
   for(int ieta = 0; ieta<(neta-1); ieta++) {
-    static double rhoVecCur[999] = {0.};
-    static double rhomVecCur[999]= {0.};
-
+    double rhoVecCur[999] = {0.};
+    double rhomVecCur[999]= {0.};
+    
     double etaMin = mapEtaRangesOut->at(ieta)+radius;
     double etaMax = mapEtaRangesOut->at(ieta+1)-radius;
      

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -33,9 +33,8 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 using namespace edm;
-using namespace pat;
-
-//using ival = boost::icl::interval<double>;
+using namespace reco;
+//using namespace pat;
 
 //
 // constants, enums and typedefs
@@ -50,12 +49,12 @@ using namespace pat;
 // constructors and destructor
 //
 HiFJRhoProducer::HiFJRhoProducer(const edm::ParameterSet& iConfig) : 
-  nExcl_(iConfig.getUntrackedParameter<unsigned int>("nExcl",0)),
-  etaMaxExcl_(iConfig.getUntrackedParameter<double>("etaMaxExcl",2.)),
-  ptMinExcl_(iConfig.getUntrackedParameter<double>("ptMinExcl",20.)),
-  nExcl2_(iConfig.getUntrackedParameter<unsigned int>("nExcl2",0)),
-  etaMaxExcl2_(iConfig.getUntrackedParameter<double>("etaMaxExcl2",3.)),
-  ptMinExcl2_(iConfig.getUntrackedParameter<double>("ptMinExcl2",20.)),
+  nExcl_(iConfig.getParameter<unsigned int>("nExcl")),
+  etaMaxExcl_(iConfig.getParameter<double>("etaMaxExcl")),
+  ptMinExcl_(iConfig.getParameter<double>("ptMinExcl")),
+  nExcl2_(iConfig.getParameter<unsigned int>("nExcl2")),
+  etaMaxExcl2_(iConfig.getParameter<double>("etaMaxExcl2")),
+  ptMinExcl2_(iConfig.getParameter<double>("ptMinExcl2")),
   checkJetCand(true),
   usingPackedCand(false)
 {
@@ -68,7 +67,7 @@ HiFJRhoProducer::HiFJRhoProducer(const edm::ParameterSet& iConfig) :
   produces<std::vector<double > >("ptJets");
   produces<std::vector<double > >("areaJets");
   produces<std::vector<double > >("etaJets");
-  etaRanges = iConfig.getUntrackedParameter<std::vector<double> >("etaRanges");
+  etaRanges = iConfig.getParameter<std::vector<double> >("etaRanges");
 
 }
 
@@ -83,9 +82,7 @@ HiFJRhoProducer::~HiFJRhoProducer()
 
 // ------------ method called to produce the data  ------------
 void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  using namespace edm;
-  
+{  
   // Get the vector of jets
   edm::Handle<edm::View<reco::Jet> > jets;
   iEvent.getByToken(jetsToken_, jets);
@@ -178,7 +175,19 @@ void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put(ptJetsOut,"ptJets");
   iEvent.put(areaJetsOut,"areaJets");
   iEvent.put(etaJetsOut,"etaJets");
-  
+
+  return;
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+HiFJRhoProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+HiFJRhoProducer::endStream() {
 }
 
 double HiFJRhoProducer::calcMd(const reco::Jet *jet) {
@@ -213,26 +222,25 @@ bool HiFJRhoProducer::isPackedCandidate(const reco::Candidate* candidate){
 }
 
 
+// HiFJRhoProducer::beginJob() { //Stream(edm::StreamID) {
+// }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HiFJRhoProducer::beginJob()
-{
-
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HiFJRhoProducer::endJob() {
-}
+// void HiFJRhoProducer::endJob() {
+// }
  
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HiFJRhoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<int>("nExcl", 2);
+  desc.add<double>("etaMaxExcl",2.);
+  desc.add<double>("ptMinExcl",20.);
+  desc.add<int>("nExcl2", 2);
+  desc.add<double>("etaMaxExcl2",2.);
+  desc.add<double>("ptMinExcl2",20.);
+  desc.add<std::vector<double> >("etaRanges");
+  descriptions.add("hiFJRhoProducer",desc);
 }
 
 

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
@@ -1,0 +1,50 @@
+#ifndef HiJetBackground_HiFJRhoProducer_h
+#define HiJetBackground_HiFJRhoProducer_h
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+
+//
+// class declaration
+//
+
+class HiFJRhoProducer : public edm::EDProducer {
+   public:
+      explicit HiFJRhoProducer(const edm::ParameterSet&);
+      ~HiFJRhoProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+      
+      double calcMd(const reco::Jet *jet);
+      bool   isPackedCandidate(const reco::Candidate* candidate);
+      
+      // ----------member data ---------------------------
+      //input
+      edm::EDGetTokenT<edm::View<reco::Jet>>    jetsToken_;
+      
+      //members
+      unsigned int   nExcl_;              //Number of leading jets to exclude
+      double         etaMaxExcl_;         //max eta for jets to exclude
+      double         ptMinExcl_;          //min pt for excluded jets
+      unsigned int   nExcl2_;             //Number of leading jets to exclude in 2nd eta region
+      double         etaMaxExcl2_;        //max eta for jets to exclude in 2nd eta region
+      double         ptMinExcl2_;         //min pt for excluded jets in 2nd eta region
+      std::vector<double>         etaRanges;         //eta boundaries for rho calculation regions
+      bool           checkJetCand, usingPackedCand;
+};
+
+#endif

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
@@ -8,16 +8,22 @@
 #include <vector>
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
 #include "DataFormats/JetReco/interface/Jet.h"
 
 //
 // class declaration
 //
 
-class HiFJRhoProducer : public edm::EDProducer {
+class HiFJRhoProducer : public edm::stream::EDProducer<> {
    public:
       explicit HiFJRhoProducer(const edm::ParameterSet&);
       ~HiFJRhoProducer();
@@ -25,13 +31,13 @@ class HiFJRhoProducer : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
+      virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      virtual void endStream() override;
       
       double calcMd(const reco::Jet *jet);
       bool   isPackedCandidate(const reco::Candidate* candidate);
-      
+
       // ----------member data ---------------------------
       //input
       edm::EDGetTokenT<edm::View<reco::Jet>>    jetsToken_;

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
@@ -44,6 +44,7 @@ class HiFJRhoProducer : public edm::stream::EDProducer<> {
       edm::EDGetTokenT<edm::View<reco::Jet>>    jetsToken_;
       
       //members
+      edm::InputTag  src_;                // input kt jet source
       unsigned int   nExcl_;              //Number of leading jets to exclude
       double         etaMaxExcl_;         //max eta for jets to exclude
       double         ptMinExcl_;          //min pt for excluded jets

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
@@ -34,7 +34,8 @@ class HiFJRhoProducer : public edm::stream::EDProducer<> {
       virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
       virtual void endStream() override;
-      
+
+      double calcMedian(std::vector<double> &v);
       double calcMd(const reco::Jet *jet);
       bool   isPackedCandidate(const reco::Candidate* candidate);
 

--- a/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+hiFJGridEmptyAreaCalculator = cms.EDProducer('HiFJGridEmptyAreaCalculator',
+                                 gridWidth = cms.untracked.double(0.05),
+                                 bandWidth = cms.untracked.double(0.2),
+                                 mapEtaEdges = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+                                 mapToRho = cms.InputTag('hiFJRhoProducer','mapToRho'),
+                                 mapToRhoM = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+                                 pfCandSource = cms.InputTag('particleFlowTmp'),
+                                 jetSource = cms.InputTag('kt4PFJets'),
+								 doCentrality = cms.untracked.bool(True),
+								 hiBinCut = cms.untracked.int32(100),    
+								 CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
+								 keepGridInfo = cms.untracked.bool(False),
+)
+

--- a/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 hiFJGridEmptyAreaCalculator = cms.EDProducer('HiFJGridEmptyAreaCalculator',
-                                 gridWidth = cms.untracked.double(0.05),
-                                 bandWidth = cms.untracked.double(0.2),
-                                 mapEtaEdges = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
-                                 mapToRho = cms.InputTag('hiFJRhoProducer','mapToRho'),
-                                 mapToRhoM = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
-                                 pfCandSource = cms.InputTag('particleFlowTmp'),
-                                 jetSource = cms.InputTag('kt4PFJets'),
-								 doCentrality = cms.untracked.bool(True),
-								 hiBinCut = cms.untracked.int32(100),    
-								 CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
-								 keepGridInfo = cms.untracked.bool(False),
+                                             gridWidth = cms.double(0.05),
+                                             bandWidth = cms.double(0.2),
+                                             mapEtaEdges = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+                                             mapToRho = cms.InputTag('hiFJRhoProducer','mapToRho'),
+                                             mapToRhoM = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+                                             pfCandSource = cms.InputTag('particleFlowTmp'),
+                                             jetSource = cms.InputTag('kt4PFJets'),
+					     doCentrality = cms.bool(True),
+					     hiBinCut = cms.int32(100),    
+					     CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
+					     keepGridInfo = cms.bool(False),
 )
 

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
+                                 jetSource = cms.InputTag('kt4PFJets'),
+                                 nExcl = cms.untracked.uint32(2),
+                                 etaMaxExcl = cms.untracked.double(2.),
+                                 ptMinExcl = cms.untracked.double(20.),
+                                 nExcl2 = cms.untracked.uint32(1),
+                                 etaMaxExcl2 = cms.untracked.double(3.),
+                                 ptMinExcl2 = cms.untracked.double(20.),
+     					         etaRanges = cms.untracked.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)
+)

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
                                  jetSource = cms.InputTag('kt4PFJets'),
-                                 nExcl = cms.untracked.uint32(2),
-                                 etaMaxExcl = cms.untracked.double(2.),
-                                 ptMinExcl = cms.untracked.double(20.),
-                                 nExcl2 = cms.untracked.uint32(1),
-                                 etaMaxExcl2 = cms.untracked.double(3.),
-                                 ptMinExcl2 = cms.untracked.double(20.),
-     					         etaRanges = cms.untracked.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)
+                                 nExcl = cms.uint32(2),
+                                 etaMaxExcl = cms.double(2.),
+                                 ptMinExcl = cms.double(20.),
+                                 nExcl2 = cms.uint32(1),
+                                 etaMaxExcl2 = cms.double(3.),
+                                 ptMinExcl2 = cms.double(20.),
+     				 etaRanges = cms.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)
 )

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
                                  jetSource = cms.InputTag('kt4PFJets'),
-                                 nExcl = cms.uint32(2),
+                                 nExcl = cms.int32(2),
                                  etaMaxExcl = cms.double(2.),
                                  ptMinExcl = cms.double(20.),
-                                 nExcl2 = cms.uint32(1),
+                                 nExcl2 = cms.int32(1),
                                  etaMaxExcl2 = cms.double(3.),
                                  ptMinExcl2 = cms.double(20.),
      				 etaRanges = cms.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)


### PR DESCRIPTION
This PR includes rho and a correction for rho to take into account empty areas, both of these producers are based on fastjet algorithms. The reconstruction sequence is modified to run these producers and keep them in the output. There is a fix in the BuildFile for the issue discussed here:
https://github.com/cms-sw/cmssw/issues/14862#issuecomment-226190302
These producers were initially developed and tested for PbPb collisions and pp collisions with HI reconstruction in MB and dijet embedded samples in CMSSW_7_5_8_patch3, here are some links to validation plots:
https://twiki.cern.ch/twiki/pub/CMS/HiJetReco2015/160317_RCPeripheralCorr.pdf
https://twiki.cern.ch/twiki/pub/CMS/HiJetReco2015/160317_RCPeripheralCorr.pdf
In pp collisions a small dijet sample was produced with 112 option of the matrix with additional customizations for pPb to test the producers in CMSSW_8_1_X with pp reconstruction.
We would like to merge it to the IB in order to use it for 2016 pPb runs planned to be reconstructed with CMSSW_8_0, and future PbPb runs.

@mverwe @mandrenguyen @yetkinyilmaz
