### PR TITLE
Fixes in HLT BTV release validation DQM [backport of #14986]

### DIFF
--- a/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
@@ -6,8 +6,8 @@ HltBTagPostValidation = cms.EDAnalyzer("HLTBTagHarvestingAnalyzer",
 	'HLT_PFMET120_',
 	'HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele32_eta2p1_',
-	'HLT_IsoMu24_eta2p1_'
+	'HLT_Ele27_eta2p1_',
+	'HLT_IsoMu22_'
 	),
 	histoName	= cms.vstring(
 	'hltCombinedSecondaryVertexBJetTagsCalo',

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -4,10 +4,10 @@ from HLTriggerOffline.Btag.hltBtagJetMCTools_cff import *
 #denominator trigger
 hltBtagTriggerSelection = cms.EDFilter( "TriggerResultsFilter",
     triggerConditions = cms.vstring(
-      "HLT_PFMET120_* OR HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_* OR HLT_QuadPFJet_VBF* OR HLT_Ele32_eta2p1_*"),
+      "HLT_PFMET120_* OR HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_* OR HLT_QuadPFJet_VBF* OR HLT_Ele27_eta2p1_* OR HLT_IsoMu22_*"),
     hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
 #    l1tResults = cms.InputTag( "simGtDigis" ),
-    l1tResults = cms.InputTag( "gtDigis" ),
+    l1tResults = cms.InputTag( "" ),
     throw = cms.bool( False )
 )
 
@@ -28,8 +28,8 @@ HltVertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
 	'HLT_QuadPFJet_VBF',
 	'HLT_QuadPFJet_VBF',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele32_eta2p1_',
-	'HLT_IsoMu24_eta2p1_'
+	'HLT_Ele27_eta2p1_',
+	'HLT_IsoMu22_'
 	),
 	Vertex = cms.VInputTag(
 		cms.InputTag("hltVerticesL3"), 
@@ -46,8 +46,8 @@ hltbTagValidation = cms.EDAnalyzer("HLTBTagPerformanceAnalyzer",
 	'HLT_PFMET120_',
 	'HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele32_eta2p1_',
-	'HLT_IsoMu24_eta2p1_'
+	'HLT_Ele27_eta2p1_',
+	'HLT_IsoMu22_'
 	),
 	JetTag = cms.VInputTag(
 		cms.InputTag("hltCombinedSecondaryVertexBJetTagsCalo"),

--- a/HLTriggerOffline/Btag/test/testSequences.py
+++ b/HLTriggerOffline/Btag/test/testSequences.py
@@ -5,14 +5,14 @@ process.load("L1TriggerConfig.L1GtConfigProducers.L1GtConfig_cff")
 process.load("DQMServices.Components.EDMtoMEConverter_cff")
 
 process.load("HLTriggerOffline.Btag.HltBtagValidation_cff")
-process.load("HLTriggerOffline.Btag.HltBtagValidationFastSim_cff")
+#process.load("HLTriggerOffline.Btag.HltBtagValidationFastSim_cff")
 process.load("HLTriggerOffline.Btag.HltBtagPostValidation_cff")
 
 process.DQM_BTag = cms.Path(    process.hltbtagValidationSequence + process.HltBTagPostVal + process.dqmSaver)
 
 
 process.source = cms.Source("PoolSource",
-	fileNames = cms.untracked.vstring("root://xrootd.ba.infn.it///store/relval/CMSSW_7_5_0_pre6/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PU25ns_75X_mcRun2_asymptotic_v1-v1/00000/00DE8AFD-1D1C-E511-988E-0025905A612C.root")
+	fileNames = cms.untracked.vstring("root://xrootd.ba.infn.it//store/relval/CMSSW_8_0_11/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/80X_mcRun2_asymptotic_v14_reHLT_HS-v1/10000/1AAA874F-0D33-E611-B99E-0CC47A4D75EE.root")
 #	fileNames = cms.untracked.vstring("file:RelVal750pre3.root")
 )
 


### PR DESCRIPTION
[backport of #14986]
This PR :
-fix the issue with the L1GT input tag: we don't use L1 trigger information at all and so it removes it;
-very small fix in testSequences.py;
-now it uses HLT Ele27_eta2p1 and IsoMu22 as trigger: this fixes the wrong name in the IsoMu trigger and improves a bit the statistics.
