### PR TITLE
DataFormats/HcalRecHit: Add HFQIE10Info::N_RAW_MAX to HFQIE10Info.cc

### DIFF
--- a/DataFormats/HcalRecHit/src/HFQIE10Info.cc
+++ b/DataFormats/HcalRecHit/src/HFQIE10Info.cc
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
 
+const unsigned HFQIE10Info::N_RAW_MAX;
+
 HFQIE10Info::HFQIE10Info()
     : charge_(0.f),
       energy_(0.f),


### PR DESCRIPTION
The patch resolves issue with Clang compiler.
N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

```
src/DataFormats/HcalRecHit/src/HFQIE10Info.cc:(.text+0x7c): undefined
reference to FQIE10Info::N_RAW_MAX'
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
