### PR TITLE
PR 81X Fix sporadic crashes in HLT when Seeding with correlations.

### DIFF
--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -577,13 +577,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
         for (std::vector<SingleCombInCond>::const_iterator itComb = (*condComb).begin(); itComb != (*condComb).end(); itComb++) {
 
+            LogTrace("HLTL1TSeed")
+            << setw(15) << "\tnew combination" << endl;
+
+            size_t iType = 0; 
+
             // loop over objects in a combination for a given condition
             //
             for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
-
-              // loop over types for the object in a combination.  This object might have more then one type (i.e. mu-eg)
-              //
-              for (size_t iType =0; iType < condObjType.size(); iType++) {
 
                 // get object type and push indices on the list
                 //
@@ -659,7 +660,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
                 } // end switch objTypeVal
 
-            } // end for iType 
+               iType++;
 
           } // end for itObj
 

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -580,11 +580,12 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
             LogTrace("HLTL1TSeed")
             << setw(15) << "\tnew combination" << endl;
 
-            size_t iType = 0; 
-
             // loop over objects in a combination for a given condition
             //
             for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
+
+
+                size_t iType = std::distance((*itComb).begin(), itObject);
 
                 // get object type and push indices on the list
                 //
@@ -659,8 +660,6 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
                     break;
 
                 } // end switch objTypeVal
-
-               iType++;
 
           } // end for itObj
 

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -585,6 +585,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
             for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
 
 
+                // the index of the object type is the same as the index of the object
                 size_t iType = std::distance((*itComb).begin(), itObject);
 
                 // get object type and push indices on the list


### PR DESCRIPTION
This is a fix for the sporadic crashes in the HLT in case of L1T correlation triggers are used.

The problem was in the HLTL1TSeed module which was making ghost combinations in case of cross-object triggers. What effectively was a double loop (once over the vector SingleCombinationInCondition and once over the object types) was causing seeding combinations to be n^2, where n is the larger number of seeds of the two object types.  Some of the objects of the type with smaller number of passing objects were not necessarily passing the L1T conditions but were still being promoted as seeds, creating ghosts.

The code was previously looping both over object types and over vector SingleCombinationInCondition.
This is fixed by now only looping over SingleCombinationInCondition while tracking the object
type to seed properly. 
