### PR TITLE
Reducing duplicates in Phase2 tracking reconstruction (with some minor effects on phase0/1 tracking)

### DIFF
--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -848,11 +848,11 @@ GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed&seed,
     // (e.g. because no Tracker layers outside seeding region) 
     //
 
-    if ( it->measurements().size()<=startingTraj.measurements().size() ) {
-      rebuiltTrajectories.push_back(std::move(*it));
-      LogDebug("CkfPattern")<< "RebuildSeedingRegion skipped as in-out trajectory does not exceed seed size.";
-      continue;
-    }
+    //if ( it->measurements().size()<=startingTraj.measurements().size() ) {
+    //  rebuiltTrajectories.push_back(std::move(*it));
+    //  LogDebug("CkfPattern")<< "RebuildSeedingRegion skipped as in-out trajectory does not exceed seed size.";
+    //  continue;
+    //}
     //
     // Refit - keep existing trajectory in case fit is not possible
     // or fails
@@ -1018,7 +1018,7 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
   // skip candidates which are not exceeding the seed size
   // (e.g. Because no Tracker layers exist outside seeding region)
   //
-  if unlikely( candidate.measurements().size()<=nSeed ) return TempTrajectory();
+  //if unlikely( candidate.measurements().size()<=nSeed ) return TempTrajectory();
 
   LogDebug("CkfPattern")<<"nSeed " << nSeed << endl
 			<< "Old traj direction = " << candidate.direction() << endl

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -843,17 +843,7 @@ GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed&seed,
 
   for ( TempTrajectoryContainer::iterator it=result.begin();
 	it!=result.end(); it++ ) {
-    //
-    // skip candidates which are not exceeding the seed size 
-    // (e.g. because no Tracker layers outside seeding region) 
-    //
 
-    //if ( it->measurements().size()<=startingTraj.measurements().size() ) {
-    //  rebuiltTrajectories.push_back(std::move(*it));
-    //  LogDebug("CkfPattern")<< "RebuildSeedingRegion skipped as in-out trajectory does not exceed seed size.";
-    //  continue;
-    //}
-    //
     // Refit - keep existing trajectory in case fit is not possible
     // or fails
     //
@@ -1014,11 +1004,6 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
   // clear array of non-fitted hits
   //
   remainingHits.clear();
-  //
-  // skip candidates which are not exceeding the seed size
-  // (e.g. Because no Tracker layers exist outside seeding region)
-  //
-  //if unlikely( candidate.measurements().size()<=nSeed ) return TempTrajectory();
 
   LogDebug("CkfPattern")<<"nSeed " << nSeed << endl
 			<< "Old traj direction = " << candidate.direction() << endl


### PR DESCRIPTION
With this PR, I am importing the PR#3051 done in SLHC by @cerati .
A first comparison can be seen [here](http://ebrondol.web.cern.ch/ebrondol/Migration81X/MTV_TTbar_81xvsSLHCDEV_fix/plots_ootb/effandfake1.pdf). 
Since this part is touching the run2 reconstruction, I have already run the most important WFs and check that everything produce the same results. Still, a more detail test analysis is for sure needed.

@VinInn @rovere 
