### PR TITLE
PhysicsTools/MVATrainer : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
@@ -239,9 +239,9 @@ void ProcMLP::trainData(const std::vector<double> *values,
 		weight = limiter;
 	}
 
-	if (iteration == ITER_COUNT) {
+	if (iteration == ITER_COUNT)
 		count++;
-		weightSum += weight; }
+   weightSum += weight; 
 
 	if (iteration != ITER_TRAIN)
 		return;

--- a/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
@@ -239,9 +239,9 @@ void ProcMLP::trainData(const std::vector<double> *values,
 		weight = limiter;
 	}
 
-	if (iteration == ITER_COUNT)
+	if (iteration == ITER_COUNT) {
 		count++;
-		weightSum += weight;
+		weightSum += weight; }
 
 	if (iteration != ITER_TRAIN)
 		return;

--- a/PhysicsTools/MVATrainer/plugins/mlp_gen.cc
+++ b/PhysicsTools/MVATrainer/plugins/mlp_gen.cc
@@ -2917,10 +2917,10 @@ int MLP_PrCFun(char *filename)
 			{
 			fprintf(W,"      out%d[%d] = %e\n",il+1,in,
 					(double) NET.Weights[il][in][0]);
-			for(jn=1;jn<=NET.Nneur[il-1]; jn++) {
+			for(jn=1;jn<=NET.Nneur[il-1]; jn++) 
 				fprintf(W,"      +(%e) * out%d[%d]\n",
 					(double) NET.Weights[il][in][jn],il,jn-1);
-				fprintf(W,"      ;\n"); }
+		   fprintf(W,"      ;\n"); 
 			}
 		fprintf(W,"\n");
 		for(in=0; in<NET.Nneur[il]; in++)

--- a/PhysicsTools/MVATrainer/plugins/mlp_gen.cc
+++ b/PhysicsTools/MVATrainer/plugins/mlp_gen.cc
@@ -2917,10 +2917,10 @@ int MLP_PrCFun(char *filename)
 			{
 			fprintf(W,"      out%d[%d] = %e\n",il+1,in,
 					(double) NET.Weights[il][in][0]);
-			for(jn=1;jn<=NET.Nneur[il-1]; jn++)
+			for(jn=1;jn<=NET.Nneur[il-1]; jn++) {
 				fprintf(W,"      +(%e) * out%d[%d]\n",
 					(double) NET.Weights[il][in][jn],il,jn-1);
-				fprintf(W,"      ;\n");
+				fprintf(W,"      ;\n"); }
 			}
 		fprintf(W,"\n");
 		for(in=0; in<NET.Nneur[il]; in++)


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/mlp_gen.cc:2920:4: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
     for(jn=1;jn<=NET.Nneur[il-1]; jn++)
    ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/mlp_gen.cc:2923:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
     fprintf(W,"      ;\n");
     ^~~~~~~

> > Compiling edm plugin /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/mlp_sigmoide.cc 
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gcc/6.0.0-cms2/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_X_2016-06-26-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_X_2016-06-26-2300" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/coral/CORAL_2_3_21-giojec4/include/LCG -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/lcg/root/6.06.04-giojec2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/boost/1.57.0-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/pcre/8.37-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/bz2lib/1.0.6-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/clhep/2.2.0.4-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gsl/1.16-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/libuuid/2.22.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/openssl/1.0.2d-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/python/2.7.11-cms3/include/python2.7 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/sigcpp/2.6.2-cms2/include/sigc++-2.0 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/tbb/44_20160316oss/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xerces-c/3.1.3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/zlib/1.2.8-cms2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc600/src/PhysicsTools/MVATrainer/plugins/PhysicsToolsMVATrainerProcMLP/mlp_sigmoide.d /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/mlp_sigmoide.cc -o tmp/slc6_amd64_gcc600/src/PhysicsTools/MVATrainer/plugins/PhysicsToolsMVATrainerProcMLP/mlp_sigmoide.o
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/ProcMLP.cc: In member function 'virtual void {anonymous}::ProcMLP::trainData(const std::vector<double>*, bool, double)':
> >   /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/ProcMLP.cc:242:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
> >    if (iteration == ITER_COUNT)
> >   ^~
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/PhysicsTools/MVATrainer/plugins/ProcMLP.cc:244:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
> >    weightSum += weight;
> >    ^~~~~~~~~
