### PR TITLE
CaloOnlineTools/HcalOnlineDb : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc
@@ -169,41 +169,64 @@ namespace hcal {
 
 
   bool ConfigurationDatabase::FPGAId::operator<(const FPGAId& a) const {
-    if (crate<a.crate) return true; if (crate>a.crate) return false;
-    if (slot<a.slot) return true; if (slot>a.slot) return false;
-    if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;
+    if (crate<a.crate) return true; 
+    if (crate>a.crate) return false;
+    if (slot<a.slot) return true; 
+    if (slot>a.slot) return false;
+    if (fpga<a.fpga) return true; 
+    if (fpga>a.fpga) return false;
     return false; // equal is not less
   }
   bool ConfigurationDatabase::LUTId::operator<(const LUTId& a) const {
-    if (crate<a.crate) return true; if (crate>a.crate) return false;
-    if (slot<a.slot) return true; if (slot>a.slot) return false;
-    if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;
-    if (fiber_slb<a.fiber_slb) return true; if (fiber_slb>a.fiber_slb) return false;
-    if (channel<a.channel) return true; if (channel>a.channel) return false;
-    if (lut_type<a.lut_type) return true; if (lut_type>a.lut_type) return false;
+    if (crate<a.crate) return true; 
+    if (crate>a.crate) return false;
+    if (slot<a.slot) return true; 
+    if (slot>a.slot) return false;
+    if (fpga<a.fpga) return true; 
+    if (fpga>a.fpga) return false;
+    if (fiber_slb<a.fiber_slb) return true; 
+    if (fiber_slb>a.fiber_slb) return false;
+    if (channel<a.channel) return true; 
+    if (channel>a.channel) return false;
+    if (lut_type<a.lut_type) return true; 
+    if (lut_type>a.lut_type) return false;
     return false; // equal is not less
   }
   bool ConfigurationDatabase::PatternId::operator<(const PatternId& a) const {
-    if (crate<a.crate) return true; if (crate>a.crate) return false;
-    if (slot<a.slot) return true; if (slot>a.slot) return false;
-    if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;
-    if (fiber<a.fiber) return true; if (fiber>a.fiber) return false;
+    if (crate<a.crate) return true; 
+    if (crate>a.crate) return false;
+    if (slot<a.slot) return true;
+    if (slot>a.slot) return false;
+    if (fpga<a.fpga) return true;
+    if (fpga>a.fpga) return false;
+    if (fiber<a.fiber) return true;
+    if (fiber>a.fiber) return false;
     return false; // equal is not less
   }
   bool ConfigurationDatabase::ZSChannelId::operator<(const ZSChannelId& a) const {
-    if (crate<a.crate) return true; if (crate>a.crate) return false;
-    if (slot<a.slot) return true; if (slot>a.slot) return false;
-    if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;
-    if (fiber<a.fiber) return true; if (fiber>a.fiber) return false;
-    if (channel<a.channel) return true; if (channel>a.channel) return false;
+    if (crate<a.crate) return true;
+    if (crate>a.crate) return false;
+    if (slot<a.slot) return true;
+    if (slot>a.slot) return false;
+    if (fpga<a.fpga) return true;
+    if (fpga>a.fpga) return false;
+    if (fiber<a.fiber) return true; 
+    if (fiber>a.fiber) return false;
+    if (channel<a.channel) return true; 
+    if (channel>a.channel) return false;
     return false; // equal is not less
   }
   bool ConfigurationDatabase::RBXdatumId::operator<(const RBXdatumId& a) const {
-    if (rm<a.rm) return true; if (rm>a.rm) return false;
-    if (card<a.card) return true; if (card>a.card) return false;
-    if (qie_or_gol<a.qie_or_gol) return true; if (qie_or_gol>a.qie_or_gol) return false;
-    if (dtype<a.dtype) return true; if (dtype>a.dtype) return false;
-    if (ltype<a.ltype) return true; if (ltype>a.ltype) return false;
+    if (rm<a.rm) return true; 
+    if (rm>a.rm) return false;
+    if (card<a.card) return true; 
+    if (card>a.card) return false;
+    if (qie_or_gol<a.qie_or_gol) return true; 
+    if (qie_or_gol>a.qie_or_gol) return false;
+    if (dtype<a.dtype) return true; 
+    if (dtype>a.dtype) return false;
+    if (ltype<a.ltype) return true; 
+    if (ltype>a.ltype) return false;
     return false; // equal is not less
   }
 


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:172:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (crate<a.crate) return true; if (crate>a.crate) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:172:37: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (crate<a.crate) return true; if (crate>a.crate) return false;
                                     ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:173:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (slot<a.slot) return true; if (slot>a.slot) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:173:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (slot<a.slot) return true; if (slot>a.slot) return false;
                                   ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:174:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:174:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (fpga<a.fpga) return true; if (fpga>a.fpga) return false;

  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:181:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (fiber_slb<a.fiber_slb) return true; if (fiber_slb>a.fiber_slb) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:181:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (fiber_slb<a.fiber_slb) return true; if (fiber_slb>a.fiber_slb) return false;
                                             ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:182:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (channel<a.channel) return true; if (channel>a.channel) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:182:41: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (channel<a.channel) return true; if (channel>a.channel) return false;
                                         ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:183:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (lut_type<a.lut_type) return true; if (lut_type>a.lut_type) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:183:43: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (lut_type<a.lut_type) return true; if (lut_type>a.lut_type) return false;
                                           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc: In member function 'bool hcal::ConfigurationDatabase::RBXdatumId::operator<(const hcal::ConfigurationDatabase::RBXdatumId&) const':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:202:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (rm<a.rm) return true; if (rm>a.rm) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:202:31: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (rm<a.rm) return true; if (rm>a.rm) return false;
                               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:203:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (card<a.card) return true; if (card>a.card) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:203:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (card<a.card) return true; if (card>a.card) return false;
                                   ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:204:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (qie_or_gol<a.qie_or_gol) return true; if (qie_or_gol>a.qie_or_gol) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:204:47: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (qie_or_gol<a.qie_or_gol) return true; if (qie_or_gol>a.qie_or_gol) return false;
                                               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:205:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (dtype<a.dtype) return true; if (dtype>a.dtype) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:205:37: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (dtype<a.dtype) return true; if (dtype>a.dtype) return false;
                                     ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:206:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (ltype<a.ltype) return true; if (ltype>a.ltype) return false;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc:206:37: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (ltype<a.ltype) return true; if (ltype>a.ltype) return false;
                                     ^~
