### PR TITLE
New feature in GEM simulation: GEMPadDigiCluster

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -1,0 +1,41 @@
+#ifndef DataFormats_GEMDigi_GEMPadDigiCluster_h
+#define DataFormats_GEMDigi_GEMPadDigiCluster_h
+
+/** \class GEMPadDigiCluster
+ *
+ * Cluster of maximal 8 adjacent GEM pad digis
+ * with the same BX
+ *  
+ * \author Sven Dildick
+ *
+ */
+
+#include <boost/cstdint.hpp>
+#include <iosfwd>
+
+class GEMPadDigiCluster{
+
+public:
+  explicit GEMPadDigiCluster (int firstPad, int lastPad, int bx);
+  GEMPadDigiCluster ();
+
+  bool operator==(const GEMPadDigiCluster& digi) const;
+  bool operator!=(const GEMPadDigiCluster& digi) const;
+  bool operator<(const GEMPadDigiCluster& digi) const;
+
+  int firstPad() const { return firstPad_; }
+  int lastPad() const { return lastPad_; }
+  int bx() const { return bx_; }
+
+  void print() const;
+
+private:
+  uint16_t firstPad_;
+  uint16_t lastPad_;
+  int32_t  bx_; 
+};
+
+std::ostream & operator<<(std::ostream & o, const GEMPadDigiCluster& digi);
+
+#endif
+

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -12,27 +12,26 @@
 
 #include <boost/cstdint.hpp>
 #include <iosfwd>
+#include <vector>
 
 class GEMPadDigiCluster{
 
 public:
-  explicit GEMPadDigiCluster (int firstPad, int lastPad, int bx);
+  explicit GEMPadDigiCluster (std::vector<uint16_t> pads, int bx);
   GEMPadDigiCluster ();
 
   bool operator==(const GEMPadDigiCluster& digi) const;
   bool operator!=(const GEMPadDigiCluster& digi) const;
   bool operator<(const GEMPadDigiCluster& digi) const;
 
-  int firstPad() const { return firstPad_; }
-  int lastPad() const { return lastPad_; }
+  const std::vector<uint16_t>& pads() const { return v_; }
   int bx() const { return bx_; }
 
   void print() const;
 
 private:
-  uint16_t firstPad_;
-  uint16_t lastPad_;
-  int32_t  bx_; 
+  std::vector<uint16_t> v_;
+  int32_t  bx_;
 };
 
 std::ostream & operator<<(std::ostream & o, const GEMPadDigiCluster& digi);

--- a/DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h
@@ -1,0 +1,16 @@
+#ifndef DataFormats_GEMDigi_GEMPadDigiClusterCollection_h
+#define DataFormats_GEMDigi_GEMPadDigiClusterCollection_h
+
+/** \class GEMPadDigiClusterCollection
+ *  
+ *  \author SVen Dildick
+ */
+
+#include <DataFormats/MuonDetId/interface/GEMDetId.h>
+#include <DataFormats/GEMDigi/interface/GEMPadDigiCluster.h>
+#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+
+typedef MuonDigiCollection<GEMDetId, GEMPadDigiCluster> GEMPadDigiClusterCollection;
+
+#endif
+

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,30 +1,28 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include <iostream>
 
-GEMPadDigiCluster::GEMPadDigiCluster (int firstPad, int lastPad, int bx) :
-  firstPad_(firstPad),
-  lastPad_(lastPad),
+GEMPadDigiCluster::GEMPadDigiCluster (std::vector<uint16_t> pads, int bx) :
+  v_(pads),
   bx_(bx)
 {}
 
 GEMPadDigiCluster::GEMPadDigiCluster ():
-  firstPad_(0),
-  lastPad_(0),
-  bx_(0) 
+  v_(std::vector<uint16_t>()),
+  bx_(0)
 {}
 
 
 // Comparison
 bool GEMPadDigiCluster::operator == (const GEMPadDigiCluster& digi) const
 {
-  return firstPad_ == digi.firstPad() and lastPad_ == digi.lastPad() and bx_ == digi.bx();
+  return v_ == digi.pads() and bx_ == digi.bx();
 }
 
 
 // Comparison
 bool GEMPadDigiCluster::operator != (const GEMPadDigiCluster& digi) const
 {
-  return firstPad_ != digi.firstPad() or lastPad_ != digi.lastPad() or bx_ != digi.bx();
+  return v_ != digi.pads() or bx_ != digi.bx();
 }
 
 
@@ -32,7 +30,7 @@ bool GEMPadDigiCluster::operator != (const GEMPadDigiCluster& digi) const
 bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const
 {
   if(digi.bx() == bx_)
-    return digi.firstPad() < firstPad_;
+    return digi.pads().front() < v_.front();
   else 
     return digi.bx() < bx_;
 }
@@ -40,12 +38,16 @@ bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const
 
 std::ostream & operator<<(std::ostream & o, const GEMPadDigiCluster& digi)
 {
-  return o << " " << digi.firstPad() << " " << digi.lastPad() <<" " << digi.bx();
+  o << " bx: " << digi.bx() << " pads: ";
+  for (auto p: digi.pads()) o << " " << p;
+  o << std::endl;
+  return o;
 }
 
 
 void GEMPadDigiCluster::print() const
 {
-  std::cout << "First pad " << firstPad() << "Last pad " << lastPad() <<" bx " << bx() <<std::endl;
+  std::cout << " bx: " << bx() << " pads: ";
+  for (auto p: pads()) std::cout << " " << p;
+  std::cout << std::endl;
 }
-

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,0 +1,51 @@
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+#include <iostream>
+
+GEMPadDigiCluster::GEMPadDigiCluster (int firstPad, int lastPad, int bx) :
+  firstPad_(firstPad),
+  lastPad_(lastPad),
+  bx_(bx)
+{}
+
+GEMPadDigiCluster::GEMPadDigiCluster ():
+  firstPad_(0),
+  lastPad_(0),
+  bx_(0) 
+{}
+
+
+// Comparison
+bool GEMPadDigiCluster::operator == (const GEMPadDigiCluster& digi) const
+{
+  return firstPad_ == digi.firstPad() and lastPad_ == digi.lastPad() and bx_ == digi.bx();
+}
+
+
+// Comparison
+bool GEMPadDigiCluster::operator != (const GEMPadDigiCluster& digi) const
+{
+  return firstPad_ != digi.firstPad() or lastPad_ != digi.lastPad() or bx_ != digi.bx();
+}
+
+
+///Precedence operator
+bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const
+{
+  if(digi.bx() == bx_)
+    return digi.firstPad() < firstPad_;
+  else 
+    return digi.bx() < bx_;
+}
+
+
+std::ostream & operator<<(std::ostream & o, const GEMPadDigiCluster& digi)
+{
+  return o << " " << digi.firstPad() << " " << digi.lastPad() <<" " << digi.bx();
+}
+
+
+void GEMPadDigiCluster::print() const
+{
+  std::cout << "First pad " << firstPad() << "Last pad " << lastPad() <<" bx " << bx() <<std::endl;
+}
+

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -4,6 +4,9 @@
 #include <DataFormats/GEMDigi/interface/GEMPadDigi.h>
 #include <DataFormats/GEMDigi/interface/GEMPadDigiCollection.h>
 
+#include <DataFormats/GEMDigi/interface/GEMPadDigiCluster.h>
+#include <DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h>
+
 #include <DataFormats/GEMDigi/interface/GEMCoPadDigi.h>
 #include <DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h>
 
@@ -27,6 +30,12 @@ namespace DataFormats_GEMDigi {
     std::vector<std::vector<GEMPadDigi> >  vvgc;
     GEMPadDigiCollection gccol;
     edm::Wrapper<GEMPadDigiCollection> wgc;
+
+    GEMPadDigiCluster gcc;
+    std::vector<GEMPadDigiCluster>  vgcc;
+    std::vector<std::vector<GEMPadDigiCluster> >  vvgcc;
+    GEMPadDigiClusterCollection gcccol;
+    edm::Wrapper<GEMPadDigiClusterCollection> wgcc;
 
     GEMCoPadDigi gcp;
     std::vector<GEMCoPadDigi>  vgcp;

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -17,7 +17,7 @@
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/> 
 
 <class name="GEMPadDigiCluster" ClassVersion="10">
- <version ClassVersion="10" checksum="3524654055"/>
+ <version ClassVersion="10" checksum="2569340006"/>
 </class>
 <class name="std::vector<GEMPadDigiCluster>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -16,6 +16,14 @@
 <class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/> 
 
+<class name="GEMPadDigiCluster" ClassVersion="10">
+ <version ClassVersion="10" checksum="3524654055"/>
+</class>
+<class name="std::vector<GEMPadDigiCluster>"/>
+<class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
+<class name="MuonDigiCollection<GEMDetId,GEMPadDigiCluster>"/> 
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigiCluster> >" splitLevel="0"/> 
+
 <class name="GEMCoPadDigi" ClassVersion="12">
  <version ClassVersion="12" checksum="2678638706"/>
 </class>

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -40,7 +40,9 @@ SimMuonAOD = cms.PSet(
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*', 'keep *_simMuonGEMPadDigis_*_*'] )
+eras.run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*',
+                                                                                              'keep *_simMuonGEMPadDigis_*_*',
+                                                                                              'keep *_simMuonGEMPadDigiClusters_*_*'] )
 eras.run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 eras.run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 eras.phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0Digis_*_*'] )

--- a/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
@@ -1,0 +1,43 @@
+#ifndef SimMuon_GEMDigitizer_GEMPadDigiClusterProducer_h
+#define SimMuon_GEMDigitizer_GEMPadDigiClusterProducer_h
+
+#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
+
+class GEMGeometry;
+
+class GEMPadDigiClusterProducer : public edm::stream::EDProducer<>
+{
+public:
+
+  explicit GEMPadDigiClusterProducer(const edm::ParameterSet& ps);
+
+  virtual ~GEMPadDigiClusterProducer();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  
+  void buildClusters(const GEMPadDigiCollection &pads, GEMPadDigiClusterCollection &out_clusters);
+
+  /// Name of input digi Collection
+  edm::EDGetTokenT<GEMPadDigiCollection> pad_token_;
+  edm::InputTag pads_;
+
+  unsigned int maxClusters_;
+  unsigned int maxClusterSize_;
+
+  const GEMGeometry * geometry_;
+};
+
+#endif
+

--- a/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
+++ b/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
@@ -238,7 +238,8 @@ def customize_digi_addGEM_muon_only(process):
         process.simMuonDTDigis + 
         process.simMuonRPCDigis + 
         process.simMuonGEMDigis + 
-        process.simMuonGEMPadDigis
+        process.simMuonGEMPadDigis +
+        process.simMuonGEMPadDigiClusters
     )
     process.pdigi = cms.Sequence(
         cms.SequencePlaceholder("randomEngineStateProducer")*

--- a/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from SimMuon.GEMDigitizer.muonGEMDigis_cfi import *
 from SimMuon.GEMDigitizer.muonGEMPadDigis_cfi import *
+from SimMuon.GEMDigitizer.muonGEMPadDigiClusters_cfi import *
 
-muonGEMDigi = cms.Sequence(simMuonGEMDigis*simMuonGEMPadDigis)
+muonGEMDigi = cms.Sequence(simMuonGEMDigis*simMuonGEMPadDigis*simMuonGEMPadDigiClusters)

--- a/SimMuon/GEMDigitizer/python/muonGEMPadDigiClusters_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMPadDigiClusters_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Module to create GEM pad digi clusters
+simMuonGEMPadDigiClusters = cms.EDProducer("GEMPadDigiClusterProducer",
+    InputCollection = cms.InputTag('simMuonGEMPadDigis'),
+    maxClusters = cms.uint32(8),
+    maxClusterSize = cms.uint32(8)
+)

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
@@ -1,0 +1,143 @@
+#include "SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <string>
+#include <map>
+#include <vector>
+
+
+GEMPadDigiClusterProducer::GEMPadDigiClusterProducer(const edm::ParameterSet& ps)
+: geometry_(nullptr)
+{
+  pads_ = ps.getParameter<edm::InputTag>("InputCollection");
+  maxClusters_ = ps.getParameter<unsigned int>("maxClusters");
+  maxClusterSize_ = ps.getParameter<unsigned int>("maxClusterSize");
+
+  pad_token_ = consumes<GEMPadDigiCollection>(pads_);
+
+  produces<GEMPadDigiClusterCollection>();
+  consumes<GEMPadDigiCollection>(pads_);
+}
+
+
+GEMPadDigiClusterProducer::~GEMPadDigiClusterProducer()
+{}
+
+
+void GEMPadDigiClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup)
+{
+  edm::ESHandle<GEMGeometry> hGeom;
+  eventSetup.get<MuonGeometryRecord>().get(hGeom);
+  geometry_ = &*hGeom;
+}
+
+
+void GEMPadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
+{
+  edm::Handle<GEMPadDigiCollection> hpads;
+  e.getByToken(pad_token_, hpads);
+
+  // Create empty output
+  std::unique_ptr<GEMPadDigiClusterCollection> pClusters(new GEMPadDigiClusterCollection());
+
+  // build the clusters
+  buildClusters(*(hpads.product()), *pClusters);
+
+  for (auto pad_range_it = pClusters->begin(); pad_range_it != pClusters->end(); ++pad_range_it)
+  {
+    auto id = (*pad_range_it).first;
+    //    auto roll = geometry_->etaPartition(id);
+    
+    auto pads_range = (*pad_range_it).second;
+    for (auto p = pads_range.first; p != pads_range.second; ++p)
+    {  
+      std::cout<<id <<" paddigi(pad,bx) "<<*p << std::endl;
+    }
+  }
+  // store them in the event
+  e.put(std::move(pClusters));
+}
+
+
+void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection &det_pads, GEMPadDigiClusterCollection &out_clusters)
+{
+  auto etaPartitions = geometry_->etaPartitions();
+  std::cout << "Build pad digi clusters"  << std::endl;
+  for(auto p: etaPartitions)
+  {
+    auto pads = det_pads.get(p->id());
+    //unsigned int clusters = 0;
+    std::vector<GEMPadDigi> cl;//(maxClusterSize_);
+    for (auto d = pads.first; d != pads.second; ++d)
+    {
+      std::cout << "Check status of " << *d << " " << GEMDetId(p->id()) << std::endl;
+      if (cl.size() == 0) {
+	cl.push_back(*d);
+	std::cout << "\tadd first pad to cluster " << *d << std::endl;
+      }
+      else {
+	std::cout << "\tCheck " << (*d).bx() << " " << cl.back().bx() << " " << (*d).pad() << " " << cl.back().pad() + 1 << std::endl; 
+	if ((*d).bx() == cl.back().bx() and (*d).pad() == cl.back().pad() + 1) {
+	  std::cout << "\t\tsuccess" << std::endl;
+	  cl.push_back(*d);
+	  std::cout << "\tadd pad to cluster " << *d << std::endl;
+	}
+	else {
+	  std::cout << "\t\tfailed" << std::endl;
+	  GEMPadDigiCluster pad_cluster(cl.front().pad(), cl.back().pad(), cl.front().bx());
+	  out_clusters.insertDigi(p->id(), pad_cluster);
+	  std::cout << "\tdefine new cluster " << pad_cluster << std::endl;
+	  cl.clear();
+	  cl.push_back(*d);
+	  std::cout << "\tadd pad to cluster " << *d << std::endl;
+	}
+      }
+      std::cout << std::endl;
+    }
+    if (pads.first != pads.second){
+      GEMPadDigiCluster pad_cluster(cl.front().pad(), cl.back().pad(), cl.front().bx());
+      out_clusters.insertDigi(p->id(), pad_cluster);
+      std::cout << "\tdefine new cluster " << pad_cluster << std::endl;
+    } 
+  }
+}
+
+      // auto pad = *d;     
+      // if (cl.size() != 0 and (clusterBX != pad.bx() or cl.back()+1 != pad.pad())){
+      // 	GEMPadDigiCluster pad_cluster(cl.front(), cl.back(), clusterBX);
+      // 	out_clusters.insertDigi(p->id(), pad_cluster);
+      // 	std::cout << "\tdefine new cluster " << pad_cluster << std::endl;  	
+      // 	cl.clear();
+      // 	clusters++;
+      // 	clusterBX = pad.bx();
+      // 	if (clusters == 8) break;
+      // }
+      // cl.push_back(pad.pad());
+      // std::cout << GEMDetId(p->id()) << " " << pad << " current cluster size "<< cl.size()<< " " << clusterBX << " " << cl.back() << std::endl;
+    //   std::cout << "current cluster size "<< cl.size() << std::endl;
+    //   std::cout << "current cluster BX "<< clusterBX << std::endl;
+
+    //   auto pad = *d;
+    //   std::cout << GEMDetId(p->id()) << " " << pad << " " << pad.bx() << " " << cl.back() << " " << pad.pad() << std::endl;
+    //   if (cl.size()==0 or (clusterBX == pad.bx() and cl.back()+1 == pad.pad())) {
+    // 	std::cout << "\tadd pad to cluster" << std::endl;
+    // 	cl.push_back(pad.pad());
+    //     clusterBX = pad.bx();
+    // 	//if (cl.size() == maxClusterSize_) break;
+    //   }
+    //   else {
+    // 	std::cout << "\tdefine new cluster " << std::endl;
+    // 	std::cout << "\tfirst " << cl.front() << " back " << cl.back() << " BX " << clusterBX << std::endl;
+    // 	GEMPadDigiCluster pad_cluster(cl.front(), cl.back(), clusterBX);
+    // 	out_clusters.insertDigi(p->id(), pad_cluster);
+    // 	cl.clear();
+    // 	clusters++;
+    //   }
+    //   std::cout << std::endl;
+    // }
+    // if (clusters == maxClusters_) break;

--- a/SimMuon/GEMDigitizer/src/SealModule.cc
+++ b/SimMuon/GEMDigitizer/src/SealModule.cc
@@ -16,6 +16,9 @@ DEFINE_EDM_PLUGIN(GEMDigiModelFactory, GEMSimpleModel, "GEMSimpleModel");
 #include "SimMuon/GEMDigitizer/interface/GEMPadDigiProducer.h"
 DEFINE_FWK_MODULE(GEMPadDigiProducer);
 
+#include "SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h"
+DEFINE_FWK_MODULE(GEMPadDigiClusterProducer);
+
 #include "SimMuon/GEMDigitizer/interface/ME0DigiPreRecoProducer.h"
 DEFINE_FWK_MODULE(ME0DigiPreRecoProducer);
 

--- a/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
@@ -6,10 +6,8 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-#process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
-#process.load('Configuration.Geometry.GeometryExtended2023Muon_cff')
-process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023_cff')
+process.load('Configuration.Geometry.GeometryExtended2023simReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023sim_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
@@ -21,7 +19,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
 process.maxEvents = cms.untracked.PSet( 
-    input = cms.untracked.int32(-1) 
+    input = cms.untracked.int32(1) 
 )
 
 #process.Timing = cms.Service("Timing")
@@ -30,25 +28,8 @@ process.options = cms.untracked.PSet(
 )
 
 # customization of the process.pdigi sequence to add the GEM digitizer 
-# choose between different options below:
-
-### GEM Only ############
-# from SimMuon.GEMDigitizer.customizeGEMDigi import customize_digi_addGEM_gem_only
-# process = customize_digi_addGEM_gem_only(process)  # only GEM digi
-#########################
-
-### All Muon Only #######
 from SimMuon.GEMDigitizer.customizeGEMDigi import customize_digi_addGEM_muon_only
 process = customize_digi_addGEM_muon_only(process) 
-# from SimMuon.GEMDigitizer.customizeGEMDigi import customize_d2r_addGEM_muon_only
-# process = customize_d2r_addGEM_muon_only(process) 
-# from SimMuon.GEMDigitizer.customizeGEMDigi import customize_r2d_addGEM_muon_only
-# process = customize_r2d_addGEM_muon_only(process) 
-#########################
-
-### All Detectors #######
-# process = customize_digi_addGEM(process)  # run all detectors digi
-#########################
 
 ### Fix RPC Digitization ###
 ############################
@@ -58,7 +39,7 @@ process = fixRPCConditions(process)
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    'file:/afs/cern.ch/work/a/archie/public/SingleMuPt100_GEN-SIM__CMSSW_75X.root'
+    'file:out_sim.root'
     )
 )
 
@@ -93,7 +74,6 @@ process.output = cms.OutputModule("PoolOutputModule",
 #process.contentAna = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.digi_step     = cms.Path(process.pdigi)
-process.digi2raw_step = cms.Path(process.DigiToRaw)
 process.endjob_step   = cms.Path(process.endOfProcess)
 process.out_step      = cms.EndPath(process.output)
 
@@ -103,8 +83,3 @@ process.schedule = cms.Schedule(
     process.endjob_step,
     process.out_step
 )
-
-#file = open('runGEMDigiProducer.py','w')
-#file.write(str(process.dumpPython()))
-#file.close()
-


### PR DESCRIPTION
A GEMPadDigiCluster is a set of adjacent GEMPadDigis in a single GEM chamber. Currently we send all trigger pads from the GEM chamber to the CSC chamber. In the hardware each GEM chamber optohybrid will send at most 8 clusters of at most 8 adjacent trigger pads to the nearby CSC optical trigger mother board. The effects are expected to be very small (<1%) on the local GEM-CSC trigger performance. 

Still needs to be done: use GEMPadDigiClusters instead of GEMPadDigis in CSC trigger emulator.
