### PR TITLE
CalibCalorimetry/CaloTPG :formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -58,9 +58,9 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	if (not HcalGenericDetId(*i).isHcalTrigTowerDetId()) {
 	  if ((not HcalGenericDetId(*i).isHcalDetId()) and
 	      (not HcalGenericDetId(*i).isHcalZDCDetId()) and
-	      (not HcalGenericDetId(*i).isHcalCastorDetId()))
+	      (not HcalGenericDetId(*i).isHcalCastorDetId())) {
 	    edm::LogWarning("CaloTPGTranscoderULUT") << "Encountered invalid HcalDetId " << HcalGenericDetId(*i);
-	    continue;
+	    continue; }
 	}
 	
 	HcalTrigTowerDetId id(*i); 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -58,9 +58,9 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	if (not HcalGenericDetId(*i).isHcalTrigTowerDetId()) {
 	  if ((not HcalGenericDetId(*i).isHcalDetId()) and
 	      (not HcalGenericDetId(*i).isHcalZDCDetId()) and
-	      (not HcalGenericDetId(*i).isHcalCastorDetId())) {
+	      (not HcalGenericDetId(*i).isHcalCastorDetId()))
 	    edm::LogWarning("CaloTPGTranscoderULUT") << "Encountered invalid HcalDetId " << HcalGenericDetId(*i);
-	    continue; }
+	  continue; 
 	}
 	
 	HcalTrigTowerDetId id(*i); 


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc:59:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if ((not HcalGenericDetId(*i).isHcalDetId()) and
    ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc:63:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
      continue;
      ^~~~~~~~
