### PR TITLE
RecoTracker/MeasurementDet : bug fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -80,14 +80,16 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
       SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), leftCluster); 
       bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
       if(!isCompatible) break; // exit loop on first incompatible hit
-      for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();								
+      for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h)));
+      tmp.clear();								
     }
   }
   for ( ; rightCluster != detSet.end(); rightCluster++) {
     SiStripClusterRef clusterref = detSet.makeRefTo( data.stripData().handle(), rightCluster); 
     bool isCompatible = filteredRecHits(clusterref, cpepar, stateOnThisDet, est, data.stripClustersToSkip(), tmp);
     if(!isCompatible) break; // exit loop on first incompatible hit
-    for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
+    for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); 
+    tmp.clear();
   }
   
   return result.size()>oldSize;

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
@@ -20,14 +20,15 @@ void StMeasurementConditionSet::set128StripStatus(int i, bool good, int idx) {
     } else {
       bad128Strip_[offset+idx] = !good;
       if (good == false) {
-	hasAny128StripBad_[i] = false;
+	     hasAny128StripBad_[i] = false;
       } else { // this should not happen, as usually you turn on all fibers
-	// and then turn off the bad ones, and not vice-versa,
-	// so I don't care if it's not optimized
-	hasAny128StripBad_[i] = true;
-	for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
-	  if (bad128Strip_[j+offset] == false) hasAny128StripBad_[i] = false; break;
-	}
+	   // and then turn off the bad ones, and not vice-versa,
+	   // so I don't care if it's not optimized
+	     hasAny128StripBad_[i] = true;
+	     for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
+	       if (bad128Strip_[j+offset] == false) hasAny128StripBad_[i] = false;
+          break;
+	     }
       }    
     } 
   }

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
@@ -20,14 +20,14 @@ void StMeasurementConditionSet::set128StripStatus(int i, bool good, int idx) {
     } else {
       bad128Strip_[offset+idx] = !good;
       if (good == false) {
-	     hasAny128StripBad_[i] = false;
+         hasAny128StripBad_[i] = false;
       } else { // this should not happen, as usually you turn on all fibers
-	   // and then turn off the bad ones, and not vice-versa,
-	   // so I don't care if it's not optimized
-	     hasAny128StripBad_[i] = true;
-	     for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
-	       if (bad128Strip_[j+offset] == false) {hasAny128StripBad_[i] = false; break;}
-	     }
+       // and then turn off the bad ones, and not vice-versa,
+       // so I don't care if it's not optimized
+         hasAny128StripBad_[i] = true;
+         for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
+           if (bad128Strip_[j+offset] == false) {hasAny128StripBad_[i] = false; break;}
+         }
       }    
     } 
   }

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
@@ -26,8 +26,7 @@ void StMeasurementConditionSet::set128StripStatus(int i, bool good, int idx) {
 	   // so I don't care if it's not optimized
 	     hasAny128StripBad_[i] = true;
 	     for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
-	       if (bad128Strip_[j+offset] == false) hasAny128StripBad_[i] = false;
-          break;
+	       if (bad128Strip_[j+offset] == false) {hasAny128StripBad_[i] = false; break;}
 	     }
       }    
     } 


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc:83:7: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
        for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
       ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc:83:81: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
       for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
                                                                                 ^~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc:90:5: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
      for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
     ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc:90:79: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
     for (auto && h: tmp) result.push_back(new SiStripRecHit2D(std::move(h))); tmp.clear();
                                                                               ^~~

  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc:29:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (bad128Strip_[j+offset] == false) hasAny128StripBad_[i] = false; break;
    ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc:29:72: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    if (bad128Strip_[j+offset] == false) hasAny128StripBad_[i] = false; break;
                                                                        ^~~~~
