### PR TITLE
SimG4CMS/FP420 : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/SimG4CMS/FP420/plugins/FP420Test.cc
+++ b/SimG4CMS/FP420/plugins/FP420Test.cc
@@ -953,37 +953,37 @@ void FP420Test::update(const EndOfEvent * evt) {
 
   // prim.vertex:
   G4int nvertex = (*evt)()->GetNumberOfPrimaryVertex();
-  if (nvertex !=1)
+  if (nvertex !=1) 
     std::cout << "FP420Test: My warning: NumberOfPrimaryVertex != 1  -->  = " << nvertex <<  std::endl;
 
-    for (int i = 0 ; i<nvertex; i++) {
-      G4PrimaryVertex* avertex = (*evt)()->GetPrimaryVertex(i);
-      if (avertex == 0)
-	std::cout << "FP420Test  End Of Event ERR: pointer to vertex = 0"
-	     << std::endl;
+  for (int i = 0 ; i<nvertex; i++) {
+    G4PrimaryVertex* avertex = (*evt)()->GetPrimaryVertex(i);
+    if (avertex == 0)
+      std::cout << "FP420Test  End Of Event ERR: pointer to vertex = 0"
+      << std::endl;
     G4int npart = avertex->GetNumberOfParticle();
     if (npart !=1)
       std::cout << "FP420Test: My warning: NumberOfPrimaryPart != 1  -->  = " << npart <<  std::endl;
     if (npart ==0)
       std::cout << "FP420Test End Of Event ERR: no NumberOfParticle" << std::endl;
 
-    // find just primary track:                                                             track pointer: thePrim
+  // find just primary track:                                                             track pointer: thePrim
     if (thePrim==0) thePrim=avertex->GetPrimary(trackID);
 
-       if (thePrim!=0) {
-	 // primary vertex:
-	 G4double vx=0.,vy=0.,vz=0.;
-	 vx = avertex->GetX0();
-	 vy = avertex->GetY0();
-	 vz = avertex->GetZ0();
-	 //UserNtuples->fillh01(vx);
-	 //UserNtuples->fillh02(vy);
-	 //UserNtuples->fillh03(vz);
-	 TheHistManager->GetHisto("VtxX")->Fill(vx);
-	 TheHistManager->GetHisto("VtxY")->Fill(vy);
-	 TheHistManager->GetHisto("VtxZ")->Fill(vz);
-       }
+    if (thePrim!=0) {
+      // primary vertex:
+      G4double vx=0.,vy=0.,vz=0.;
+      vx = avertex->GetX0();
+      vy = avertex->GetY0();
+      vz = avertex->GetZ0();
+      //UserNtuples->fillh01(vx);
+      //UserNtuples->fillh02(vy);
+      //UserNtuples->fillh03(vz);
+      TheHistManager->GetHisto("VtxX")->Fill(vx);
+      TheHistManager->GetHisto("VtxY")->Fill(vy);
+      TheHistManager->GetHisto("VtxZ")->Fill(vz);
     }
+  }
   // prim.vertex loop end
 
 //=========================== thePrim != 0 ================================================================================


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/FP420/plugins/FP420Test.cc:956:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (nvertex !=1)
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/FP420/plugins/FP420Test.cc:959:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     for (int i = 0 ; i<nvertex; i++) {
     ^~~
