### PR TITLE
SimG4CMS/Calo : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -119,7 +119,7 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
 
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
-  if (fibre)  delete   fibre;  fibre  = 0;
+  if (fibre)  {delete   fibre;  fibre  = 0;}
   if (photo)  delete photo;
 }
 

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -119,7 +119,8 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
 
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
-  if (fibre)  {delete   fibre;  fibre  = 0;}
+  if (fibre)  delete   fibre;
+  fibre  = 0;
   if (photo)  delete photo;
 }
 

--- a/SimG4CMS/Calo/test/HOSimHitStudy.cc
+++ b/SimG4CMS/Calo/test/HOSimHitStudy.cc
@@ -502,8 +502,10 @@ void HOSimHitStudy::analyzeHits () {
   eHO17T_->Fill(etaInc,eHO17T);
   eHO18T_->Fill(etaInc,eHO18T);
   int nHO=0, nHOT=0;
-  if (eHO17 > 0) nHO++; if (eHO17T > 0) nHOT++;
-  if (eHO18 > 0) nHO++; if (eHO18T > 0) nHOT++;
+  if (eHO17 > 0) nHO++; 
+  if (eHO17T > 0) nHOT++;
+  if (eHO18 > 0) nHO++; 
+  if (eHO18T > 0) nHOT++;
   nHO1_->Fill(etaInc,(double)(nHO));
   nHO2_->Fill(etaInc,phiInc,(double)(nHO));
   nHO1T_->Fill(etaInc,(double)(nHOT));
@@ -529,8 +531,10 @@ void HOSimHitStudy::analyzeHits () {
     nHOE1T_[ieta]->Fill((double)(nHOT));
     nHOE2T_[ieta]->Fill(phiInc,(double)(nHOT));
     int nHOE=0, nHOET=0;
-    if (eHOE17[ieta] > 0) nHOE++; if (eHOE17T[ieta] > 0) nHOET++;
-    if (eHOE18[ieta] > 0) nHOE++; if (eHOE18T[ieta] > 0) nHOET++;
+    if (eHOE17[ieta] > 0) nHOE++;
+    if (eHOE17T[ieta] > 0) nHOET++;
+    if (eHOE18[ieta] > 0) nHOE++; 
+    if (eHOE18T[ieta] > 0) nHOET++;
     nHOEta1_[ieta]->Fill((double)(nHOE));
     nHOEta2_[ieta]->Fill(phiInc,(double)(nHOE));
     nHOEta1T_[ieta]->Fill((double)(nHOET));


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/src/HFShowerLibrary.cc:122:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (fibre)  delete   fibre;  fibre  = 0;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/src/HFShowerLibrary.cc:122:32: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if (fibre)  delete   fibre;  fibre  = 0;
                                ^~~~~

  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:505:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (eHO17 > 0) nHO++; if (eHO17T > 0) nHOT++;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:505:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if (eHO17 > 0) nHO++; if (eHO17T > 0) nHOT++;
                         ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:506:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (eHO18 > 0) nHO++; if (eHO18T > 0) nHOT++;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:506:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if (eHO18 > 0) nHO++; if (eHO18T > 0) nHOT++;
                         ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:532:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (eHOE17[ieta] > 0) nHOE++; if (eHOE17T[ieta] > 0) nHOET++;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:532:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (eHOE17[ieta] > 0) nHOE++; if (eHOE17T[ieta] > 0) nHOET++;
                                   ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:533:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (eHOE18[ieta] > 0) nHOE++; if (eHOE18T[ieta] > 0) nHOET++;
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Calo/test/HOSimHitStudy.cc:533:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (eHOE18[ieta] > 0) nHOE++; if (eHOE18T[ieta] > 0) nHOET++;
                                   ^~
