### PR TITLE
SimG4CMS/Forward : gcc 6.0 misleading-indentation warning flags potential bug; with bug fix

### DIFF
--- a/SimG4CMS/Forward/src/CastorTestAnalysis.cc
+++ b/SimG4CMS/Forward/src/CastorTestAnalysis.cc
@@ -41,7 +41,7 @@ CastorTestAnalysis::CastorTestAnalysis(const edm::ParameterSet &p) {
   stepNtFileName           = m_Anal.getParameter<std::string>("StepNtupleFileName");
   eventNtFileName          = m_Anal.getParameter<std::string>("EventNtupleFileName");
 
-  if (verbosity > 0)
+  if (verbosity > 0) {
    std::cout<<std::endl;
    std::cout<<"============================================================================"<<std::endl;
    std::cout << "CastorTestAnalysis:: Initialized as observer"<< std::endl;
@@ -55,7 +55,7 @@ CastorTestAnalysis::CastorTestAnalysis(const edm::ParameterSet &p) {
    }
    std::cout<<"============================================================================"<<std::endl;
    std::cout<<std::endl;
-  
+  }
   if (doNTcastorstep  > 0)  
   castorstepntuple = new TNtuple("NTcastorstep","NTcastorstep","evt:trackid:charge:pdgcode:x:y:z:stepl:stepe:eta:phi:vpx:vpy:vpz");
   

--- a/SimG4CMS/Forward/src/CastorTestAnalysis.cc
+++ b/SimG4CMS/Forward/src/CastorTestAnalysis.cc
@@ -41,21 +41,20 @@ CastorTestAnalysis::CastorTestAnalysis(const edm::ParameterSet &p) {
   stepNtFileName           = m_Anal.getParameter<std::string>("StepNtupleFileName");
   eventNtFileName          = m_Anal.getParameter<std::string>("EventNtupleFileName");
 
-  if (verbosity > 0) {
-   std::cout<<std::endl;
-   std::cout<<"============================================================================"<<std::endl;
-   std::cout << "CastorTestAnalysis:: Initialized as observer"<< std::endl;
-   if (doNTcastorstep  > 0){
-     std::cout <<" Step Ntuple will be created"<< std::endl;
-     std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
-   }
-   if (doNTcastorevent > 0){
-     std::cout <<" Event Ntuple will be created"<< std::endl;
-     std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
-   }
-   std::cout<<"============================================================================"<<std::endl;
-   std::cout<<std::endl;
+  if (verbosity > 0) std::cout<<std::endl;
+  std::cout<<"============================================================================"<<std::endl;
+  std::cout << "CastorTestAnalysis:: Initialized as observer"<< std::endl;
+  if (doNTcastorstep  > 0){
+    std::cout <<" Step Ntuple will be created"<< std::endl;
+    std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
   }
+  if (doNTcastorevent > 0){
+    std::cout <<" Event Ntuple will be created"<< std::endl;
+    std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
+  }
+  std::cout<<"============================================================================"<<std::endl;
+  std::cout<<std::endl;
+  
   if (doNTcastorstep  > 0)  
   castorstepntuple = new TNtuple("NTcastorstep","NTcastorstep","evt:trackid:charge:pdgcode:x:y:z:stepl:stepe:eta:phi:vpx:vpy:vpz");
   

--- a/SimG4CMS/Forward/src/CastorTestAnalysis.cc
+++ b/SimG4CMS/Forward/src/CastorTestAnalysis.cc
@@ -41,20 +41,21 @@ CastorTestAnalysis::CastorTestAnalysis(const edm::ParameterSet &p) {
   stepNtFileName           = m_Anal.getParameter<std::string>("StepNtupleFileName");
   eventNtFileName          = m_Anal.getParameter<std::string>("EventNtupleFileName");
 
-  if (verbosity > 0) std::cout<<std::endl;
-  std::cout<<"============================================================================"<<std::endl;
-  std::cout << "CastorTestAnalysis:: Initialized as observer"<< std::endl;
-  if (doNTcastorstep  > 0){
-    std::cout <<" Step Ntuple will be created"<< std::endl;
-    std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
+  if (verbosity > 0) {
+      std::cout<<std::endl;
+      std::cout<<"============================================================================"<<std::endl;
+      std::cout << "CastorTestAnalysis:: Initialized as observer"<< std::endl;
+      if (doNTcastorstep  > 0){
+        std::cout <<" Step Ntuple will be created"<< std::endl;
+        std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
+      }
+      if (doNTcastorevent > 0){
+        std::cout <<" Event Ntuple will be created"<< std::endl;
+        std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
+      }
+      std::cout<<"============================================================================"<<std::endl;
+      std::cout<<std::endl;
   }
-  if (doNTcastorevent > 0){
-    std::cout <<" Event Ntuple will be created"<< std::endl;
-    std::cout <<" Step Ntuple file: "<<stepNtFileName<<std::endl;
-  }
-  std::cout<<"============================================================================"<<std::endl;
-  std::cout<<std::endl;
-  
   if (doNTcastorstep  > 0)  
   castorstepntuple = new TNtuple("NTcastorstep","NTcastorstep","evt:trackid:charge:pdgcode:x:y:z:stepl:stepe:eta:phi:vpx:vpy:vpz");
   


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Forward/src/CastorTestAnalysis.cc:44:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (verbosity > 0)
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/SimG4CMS/Forward/src/CastorTestAnalysis.cc:46:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    std::cout<<"============================================================================"<<std::endl;
    ^~~
