### PR TITLE
RecoLocalMuon/CSCSegment : gcc 6.0 misleading-indentation warning flags potential bug ; with formating fix

### DIFF
--- a/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.cc
@@ -240,7 +240,7 @@ void CSCCondSegFit::correctTheCovX(void){
     double chi2uCorrection = chiUZ/chi2Norm_;
     for(unsigned i=0; i<uu.size(); ++i)
       lex_[i]=lex_[i]*chi2uCorrection;
-      setScaleXError(chi2uCorrection);
+    setScaleXError(chi2uCorrection);
   }
     
   // Find most deviant hit 


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.cc:241:5: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
      for(unsigned i=0; i<uu.size(); ++i)
     ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.cc:243:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
       setScaleXError(chi2uCorrection);
       ^~~~~~~~~~~~~~
