### PR TITLE
MagneticField/Interpolation : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/MagneticField/Interpolation/src/MagneticFieldGrid.cc
+++ b/MagneticField/Interpolation/src/MagneticFieldGrid.cc
@@ -99,9 +99,9 @@ void MagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, floa
   int index1[3] = {0,0,0};
   for (int i=0; i<3; ++i){
     if (NumberOfPoints[i] > 1){
-                                           index0[i] = max(0,index[i]);
+      index0[i] = max(0,index[i]);
       if (index0[i] > NumberOfPoints[i]-2) index0[i] = NumberOfPoints[i]-2;
-                                           index1[i] = max(1,index[i]+1);
+      index1[i] = max(1,index[i]+1);
       if (index1[i] > NumberOfPoints[i]-1) index1[i] = NumberOfPoints[i]-1;
     }
   }


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/MagneticField/Interpolation/src/MagneticFieldGrid.cc:103:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if (index0[i] > NumberOfPoints[i]-2) index0[i] = NumberOfPoints[i]-2;
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/MagneticField/Interpolation/src/MagneticFieldGrid.cc:104:44: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                                            index1[i] = max(1,index[i]+1);
                                            ^~~~~~

http://cmslxr.fnal.gov/source/MagneticField/Interpolation/src/MagneticFieldGrid.cc?v=CMSSW_8_1_0_pre8#0103

Did the author intend to enclose the two statements in curly braces?
