### PR TITLE
suppress LogError for somewhat clearly bad input of TrajectoryStateCombiner

### DIFF
--- a/TrackingTools/TrackFitters/src/TrajectoryStateCombiner.cc
+++ b/TrackingTools/TrackFitters/src/TrajectoryStateCombiner.cc
@@ -17,10 +17,11 @@ TrajectoryStateCombiner::combine(const TSOS& Tsos1, const TSOS& Tsos2) const {
   AlgebraicMatrix55 && K = C1*Csum;
 
   if(!ok) {
-    edm::LogError("MatrixInversionFailure")
-      <<"the inversion of the combined error matrix failed. Impossible to get a combined state."
-      <<"\nmatrix 1:"<<C1
-      <<"\nmatrix 2:"<<C2;
+    if (! (C1(0,0) == 0.0 && C2(0,0) == 0.0) )//do not make noise about obviously bad input
+      edm::LogError("MatrixInversionFailure")
+	<<"the inversion of the combined error matrix failed. Impossible to get a combined state."
+	<<"\nmatrix 1:"<<C1
+	<<"\nmatrix 2:"<<C2;
     return TSOS();
   }
 

--- a/TrackingTools/TrackFitters/src/TrajectoryStateCombiner.cc
+++ b/TrackingTools/TrackFitters/src/TrajectoryStateCombiner.cc
@@ -18,7 +18,7 @@ TrajectoryStateCombiner::combine(const TSOS& Tsos1, const TSOS& Tsos2) const {
 
   if(!ok) {
     if (! (C1(0,0) == 0.0 && C2(0,0) == 0.0) )//do not make noise about obviously bad input
-      edm::LogError("MatrixInversionFailure")
+      edm::LogWarning("MatrixInversionFailure")
 	<<"the inversion of the combined error matrix failed. Impossible to get a combined state."
 	<<"\nmatrix 1:"<<C1
 	<<"\nmatrix 2:"<<C2;


### PR DESCRIPTION
demote TrajectoryStateCombiner::combiner MatrixInversionFailure issue to LogWarning for all and issue no message for somewhat clearly bad inputs.

Fairly frequent LogErrors from MatrixInversionFailure category in module StandAloneMuonProducer:standAloneSETMuons 

In my test I re-recoed about 5K events from Run2016B/MET/RAW-RECO/LogError-PromptReco-v2 runs (fractionally) 274241,274244,274250,274251,274282 for a total of 166 LS.

This error happened 641 times (some repeated multiple times in event)
and all of the cases were for a transformation of a seed with TSOS with 0 error values in in q/p row/column. This is clearly not invertible.

Maybe in the long run there should be a change in logic of the algorithm.

@VinInn  @rovere let me know if the change is OK
