### PR TITLE
Alignment/TrackerAlignment : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -302,17 +302,23 @@ void TrackerGeometryAnalyzer
     if (detId.det() == DetId::Tracker) {
       switch (detId.subdetId()) {
         case PixelSubdetector::PixelBarrel:
-          if (analyzePXB_) analyzePXBDetUnit(detId, ss); break;
+          if (analyzePXB_) analyzePXBDetUnit(detId, ss);
+          break;
         case PixelSubdetector::PixelEndcap:
-          if (analyzePXE_) analyzePXEDetUnit(detId, ss); break;
+          if (analyzePXE_) analyzePXEDetUnit(detId, ss);
+          break;
         case StripSubdetector::TIB:
-          if (analyzeTIB_) analyzeTIBDetUnit(detId, ss); break;
+          if (analyzeTIB_) analyzeTIBDetUnit(detId, ss);
+          break;
         case StripSubdetector::TID:
-          if (analyzeTID_) analyzeTIDDetUnit(detId, ss); break;
+          if (analyzeTID_) analyzeTIDDetUnit(detId, ss);
+          break;
         case StripSubdetector::TOB:
-          if (analyzeTOB_) analyzeTOBDetUnit(detId, ss); break;
+          if (analyzeTOB_) analyzeTOBDetUnit(detId, ss);
+          break;
         case StripSubdetector::TEC:
-          if (analyzeTEC_) analyzeTECDetUnit(detId, ss); break;
+          if (analyzeTEC_) analyzeTECDetUnit(detId, ss);
+          break;
       }
     }
   }


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc: In member function 'void TrackerGeometryAnalyzer::analyzeTrackerGeometry()':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:305:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzePXB_) analyzePXBDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:305:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzePXB_) analyzePXBDetUnit(detId, ss); break;
                                                          ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:307:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzePXE_) analyzePXEDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:307:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzePXE_) analyzePXEDetUnit(detId, ss); break;
                                                          ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:309:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzeTIB_) analyzeTIBDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:309:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzeTIB_) analyzeTIBDetUnit(detId, ss); break;
                                                          ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:311:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzeTID_) analyzeTIDDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:311:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzeTID_) analyzeTIDDetUnit(detId, ss); break;
                                                          ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:313:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzeTOB_) analyzeTOBDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:313:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzeTOB_) analyzeTOBDetUnit(detId, ss); break;
                                                          ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:315:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
            if (analyzeTEC_) analyzeTECDetUnit(detId, ss); break;
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc:315:58: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if (analyzeTEC_) analyzeTECDetUnit(detId, ss); break;
                                                          ^~~~~
