### PR TITLE
CalibCalorimetry/EcalLaserAnalyzer : gcc 6.0 misleading-indentation warning flags potential bug; with bug fix

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc
@@ -224,7 +224,7 @@ MEChannel::oneLine( int ig )
   if( ig<ME::iLMRegion )
     {
       out += ME::region[reg_];
-      if( ig==ME::iSector ) out+="/S="; out+=_id[ME::iSector];
+      if( ig==ME::iSector ) {out+="/S="; out+=_id[ME::iSector];}
       return out;
     }
   int lmr_ = _id[ME::iLMRegion];
@@ -301,7 +301,7 @@ MEChannel::oneWord( int ig )
     {
       out = "ECAL_"; 
       out += ME::region[reg_];
-      if( ig==ME::iSector ) out+="_S"; out+=_id[ME::iSector];
+      if( ig==ME::iSector ) {out+="_S"; out+=_id[ME::iSector];}
       return out;
     }
   int lmr_ = _id[ME::iLMRegion];


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc: In member function 'TString MEChannel::oneLine(int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc:227:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if( ig==ME::iSector ) out+="/S="; out+=_id[ME::iSector];
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc:227:41: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       if( ig==ME::iSector ) out+="/S="; out+=_id[ME::iSector];
                                         ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc: In member function 'TString MEChannel::oneWord(int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc:304:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if( ig==ME::iSector ) out+="_S"; out+=_id[ME::iSector];
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/EcalLaserAnalyzer/src/MEChannel.cc:304:40: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       if( ig==ME::iSector ) out+="_S"; out+=_id[ME::iSector];
                                        ^~~
