### PR TITLE
Added extra option switching SIM from Geant4 MT to Geant4 sequential

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -79,6 +79,7 @@ defaultOptions.runsScenarioForMC = None
 defaultOptions.runUnscheduled = False
 defaultOptions.timeoutOutput = False
 defaultOptions.nThreads = '1'
+defaultOptions.mcType = 'MT'
 
 # some helper routines
 def dumpPython(process,name):
@@ -2193,6 +2194,12 @@ class ConfigBuilder(object):
 
         # dump customise fragment
 	self.pythonCfgCode += self.addCustomise()
+
+	if self._options.mcType!='MT':
+		self.pythonCfgCode += '\nfor label, prod in process.producers_().iteritems():\n'
+		self.pythonCfgCode += '        if prod.type_() == ''"OscarMTProducer''"'':\n'
+                self.pythonCfgCode += '                prod.__dict__[''"_TypedParameterizable__type''"] = "OscarProducer"\n'
+
 
 	if self._options.runUnscheduled:	
 		# prune and delete paths

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -387,3 +387,9 @@ expertSettings.add_option("--nThreads",
                           default="1",
                           dest='nThreads'
                           )
+
+expertSettings.add_option("--mcType",
+                          help="Choice between sequential and MT SIM (default is MT)",
+                          default="MT",
+                          dest='mcType'
+                          )


### PR DESCRIPTION
By default Geant4 MT is used for the SIM step by OscarMTProducer. If mcType is not 'MT' a sequential Geant4  runs via OscarProducer. This choice independent on number of threads. 
