### PR TITLE
CalibCalorimetry/HcalAlgos :  gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc
@@ -17,9 +17,13 @@ void getLinearizedADC(const HcalQIEShape& shape,
 
 float maxDiff(float one, float two, float three, float four){
   float max=-1000; float min = 1000;
-  if(one>max) max = one;      if(one<min) min = one;
-  if(two>max) max = two;      if(two<min) min = two;
-  if(three>max) max = three;  if(three<min) min = three;
-  if(four>max) max = four;    if(four<min) min = four;
+  if(one>max) max = one;
+  if(one<min) min = one;
+  if(two>max) max = two;
+  if(two<min) min = two;
+  if(three>max) max = three;
+  if(three<min) min = three;
+  if(four>max) max = four;
+  if(four<min) min = four;
   return fabs(max-min);
 }


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc: In function 'float maxDiff(float, float, float, float)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:20:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if(one>max) max = one;      if(one<min) min = one;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:20:31: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(one>max) max = one;      if(one<min) min = one;
                               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:21:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if(two>max) max = two;      if(two<min) min = two;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:21:31: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(two>max) max = two;      if(two<min) min = two;
                               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:22:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if(three>max) max = three;  if(three<min) min = three;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:22:31: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(three>max) max = three;  if(three<min) min = three;
                               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:23:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if(four>max) max = four;    if(four<min) min = four;
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc:23:31: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(four>max) max = four;    if(four<min) min = four;
                               ^~
