### PR TITLE
CalibTracker/SiStripChannelGain : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -620,10 +620,10 @@ SiStripGainFromData::algoEndJob() {
 
          if(SRun==0)SRun = tmp_SRun;
 
-              if(tmp_SRun< SRun){SRun=tmp_SRun; SEvent=tmp_SEvent;}
+         if     (tmp_SRun< SRun){SRun=tmp_SRun; SEvent=tmp_SEvent;}
          else if(tmp_SRun==SRun && tmp_SEvent<SEvent){SEvent=tmp_SEvent;}
 
-              if(tmp_ERun> ERun){ERun=tmp_ERun; EEvent=tmp_EEvent;}
+         if     (tmp_ERun> ERun){ERun=tmp_ERun; EEvent=tmp_EEvent;}
          else if(tmp_ERun==ERun && tmp_EEvent>EEvent){EEvent=tmp_EEvent;}
 
 	 printf("Deleting Current Input File\n");
@@ -644,7 +644,8 @@ SiStripGainFromData::algoEndJob() {
       double* FitResults = new double[5];
       I=0;
       for(__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator it = APVsColl.begin();it!=APVsColl.end();it++){
-      if( I%3650==0 ) printf("Fitting Histograms \t %6.2f%%\n",(100.0*I)/APVsColl.size());I++;
+         if( I%3650==0 ) printf("Fitting Histograms \t %6.2f%%\n",(100.0*I)/APVsColl.size());
+         I++;
          stAPVGain* APV = it->second;
 
          int bin = APV_Charge->GetXaxis()->FindBin(APV->Index);
@@ -1038,7 +1039,7 @@ SiStripGainFromData::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup
   
       for(Trajectory::RecHitContainer::const_iterator rechit = transRecHits.begin(); rechit != transRecHits.end(); ++rechit)
          if ((*rechit)->isValid()) ndof += (*rechit)->dimension();  
-         ndof -= 5;
+      ndof -= 5;
       //END TO COMPUTE NDOF FOR TRACKS NO IMPLEMENTED BEFORE 200pre3
 
       HTrackChi2OverNDF->Fill(traj.chiSquared()/ndof);


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc: In member function 'virtual void SiStripGainFromData::algoEndJob()':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:624:10: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
           else if(tmp_SRun==SRun && tmp_SEvent<SEvent){SEvent=tmp_SEvent;}
          ^~~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:626:15: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
               if(tmp_ERun> ERun){ERun=tmp_ERun; EEvent=tmp_EEvent;}
               ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:647:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if( I%3650==0 ) printf("Fitting Histograms \t %6.2f%%\n",(100.0_I)/APVsColl.size());I++;
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:647:91: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       if( I%3650==0 ) printf("Fitting Histograms \t %6.2f%%\n",(100.0_I)/APVsColl.size());I++;
                                                                                           ^
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc: In member function 'virtual void SiStripGainFromData::algoAnalyze(const edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:1039:7: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
        for(Trajectory::RecHitContainer::const_iterator rechit = transRecHits.begin(); rechit != transRecHits.end(); ++rechit)
       ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc:1041:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
          ndof -= 5;
          ^~~~
