### PR TITLE
Calibration/IsolatedParticles : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/Calibration/IsolatedParticles/plugins/StudyHLT.cc
+++ b/Calibration/IsolatedParticles/plugins/StudyHLT.cc
@@ -102,8 +102,8 @@ StudyHLT::StudyHLT(const edm::ParameterSet& iConfig) : nRun(0) {
 StudyHLT::~StudyHLT() {}
 
 void StudyHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-if (verbosity > 0) 
-  edm::LogInfo("IsoTrack") << "Event starts===================================="; 
+  if (verbosity > 0) 
+    edm::LogInfo("IsoTrack") << "Event starts===================================="; 
   int RunNo = iEvent.id().run();
   int EvtNo = iEvent.id().event();
   int Lumi  = iEvent.luminosityBlock();


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/IsolatedParticles/plugins/StudyHLT.cc: In member function 'virtual void StudyHLT::analyze(const edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/IsolatedParticles/plugins/StudyHLT.cc:105:1: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  if (verbosity > 0)
 ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/IsolatedParticles/plugins/StudyHLT.cc:107:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   int RunNo = iEvent.id().run();
   ^~~
