### PR TITLE
Calibration/Tools : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/Calibration/Tools/src/EcalRingCalibrationTools.cc
+++ b/Calibration/Tools/src/EcalRingCalibrationTools.cc
@@ -79,10 +79,10 @@ std::vector<DetId> EcalRingCalibrationTools::getDetIdsInRing(short etaIndex)
     {
 
       int k =0;
-      if (etaIndex<85)
-	k=-85 + etaIndex;
-      else
-	k= etaIndex - 84;
+	if (etaIndex<85)
+		k=-85 + etaIndex;
+	else
+		k= etaIndex - 84;
 
 	for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) 
 	  


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/Tools/src/EcalRingCalibrationTools.cc: In static member function 'static std::vector<DetId> EcalRingCalibrationTools::getDetIdsInRing(short int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/Tools/src/EcalRingCalibrationTools.cc:84:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
        else
       ^~~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Calibration/Tools/src/EcalRingCalibrationTools.cc:87:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
  for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi)
  ^~~
