### PR TITLE
CommonTools/TrackerMap : fix for bug flagged by gcc 6.0 misleading-indentation warning

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -1481,9 +1481,9 @@ void TrackerMap::save_as_fectrackermap(bool print_total,float minval, float maxv
         col =gROOT->GetColor(ncolor+100);
         if(col)
           col->SetRGB((Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
-        else
+        else {
           c = new TColor(ncolor+100,(Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
-          vc.push_back(c);
+          vc.push_back(c);}
 	ncolor++;
       }
       for (int i=0;i<npoints;i++){
@@ -1762,9 +1762,9 @@ void TrackerMap::save_as_HVtrackermap(bool print_total,float minval, float maxva
 	col =gROOT->GetColor(ncolor+100);
 	if(col) 
 	  col->SetRGB((Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.)); 
-	else 
+	else {
 	  c = new TColor(ncolor+100,(Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
-	  vc.push_back(c);
+	  vc.push_back(c);}
 	ncolor++;
       }
       for (int i=0;i<npoints;i++){

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -1483,7 +1483,8 @@ void TrackerMap::save_as_fectrackermap(bool print_total,float minval, float maxv
           col->SetRGB((Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
         else {
           c = new TColor(ncolor+100,(Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
-          vc.push_back(c);}
+          vc.push_back(c);
+          }
 	ncolor++;
       }
       for (int i=0;i<npoints;i++){
@@ -1764,7 +1765,8 @@ void TrackerMap::save_as_HVtrackermap(bool print_total,float minval, float maxva
 	  col->SetRGB((Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.)); 
 	else {
 	  c = new TColor(ncolor+100,(Double_t)(red/255.),(Double_t)(green/255.),(Double_t)(blue/255.));
-	  vc.push_back(c);}
+	  vc.push_back(c);
+          }
 	ncolor++;
       }
       for (int i=0;i<npoints;i++){


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc: In member function 'void TrackerMap::save_as_fectrackermap(bool, float, float, std::string, int, int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:1484:9: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
          else
         ^~~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:1486:11: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
           vc.push_back(c);
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc: In member function 'void TrackerMap::save_as_HVtrackermap(bool, float, float, std::string, int, int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:1765:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
   else
  ^~~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:1767:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
    vc.push_back(c);
    ^~
