### PR TITLE
CommonTools/Utils : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CommonTools/Utils/interface/PointerComparator.h
+++ b/CommonTools/Utils/interface/PointerComparator.h
@@ -19,9 +19,9 @@ struct PointerComparator {
   typedef typename C::second_argument_type second_argument_type;
     bool operator()( const first_argument_type * t1, const second_argument_type * t2 ) const {
       if ( t1 == 0 || t2 == 0 )
-	throw edm::Exception( edm::errors::NullPointerError )
-	  << "PointerComparator: passed null pointer."; 
-	return cmp( *t1, *t2 );
+        throw edm::Exception( edm::errors::NullPointerError )
+           << "PointerComparator: passed null pointer."; 
+      return cmp( *t1, *t2 );
     }
   C cmp;
 };


### PR DESCRIPTION
In file included from /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/Utils/test/testComparators.cc:2:0:
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/Utils/interface/PointerComparator.h: In member function 'bool PointerComparator<C>::operator()(const first_argument_type_, const second_argument_type_) const':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/Utils/interface/PointerComparator.h:21:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if ( t1 == 0 || t2 == 0 )
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CommonTools/Utils/interface/PointerComparator.h:24:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  return cmp( *t1, *t2 );
  ^~~~~~
