### PR TITLE
CondCore/Utilities : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -176,7 +176,7 @@ namespace cond {
 	editor = session.editIov( destTag );
 	if( editor.timeType() != p.timeType() )
 	  throwException( "TimeType of the destination tag does not match with the source tag timeType.", "importIovs"); 
-	  if( editor.payloadType() != p.payloadObjectType() )
+	if( editor.payloadType() != p.payloadObjectType() )
 	  throwException( "PayloadType of the destination tag does not match with the source tag payloadType.", "importIovs");
       } else {
 	editor = session.createIov( p.payloadObjectType(), destTag, p.timeType(), p.synchronizationType() );


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondCore/Utilities/src/CondDBTools.cc: In function 'bool cond::persistency::copyIov(cond::persistency::Session&, const string&, const string&, cond::Time_t, cond::Time_t, const string&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondCore/Utilities/src/CondDBTools.cc:177:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if( editor.timeType() != p.timeType() )
  ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondCore/Utilities/src/CondDBTools.cc:179:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    if( editor.payloadType() != p.payloadObjectType() )
    ^~
