### PR TITLE
CondFormats/TotemReadoutObjects : fix for bug flagged by gcc 6.0 misleading-indentation warning

### DIFF
--- a/CondFormats/TotemReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/TotemReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -872,9 +872,9 @@ void TotemDAQMappingESSourceXML::ParseTreeT1(ParseType pType, xercesc::DOMNode *
             }
         }
 
-        if (!strcmp(XMLString::transcode(a->getNodeName()), "hw_id"))
+        if (!strcmp(XMLString::transcode(a->getNodeName()), "hw_id")) {
           sscanf(XMLString::transcode(a->getNodeValue()), "%x", &hw_id);
-          hw_id_set = true;
+          hw_id_set = true; }
       }
     }
 


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondFormats/TotemReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc: In member function 'void TotemDAQMappingESSourceXML::ParseTreeT1(TotemDAQMappingESSourceXML::ParseType, xercesc_3_1::DOMNode*, TotemDAQMappingESSourceXML::NodeType, unsigned int, const boost::shared_ptr<TotemDAQMapping>&, const boost::shared_ptr<TotemAnalysisMask>&, unsigned int, unsigned int, unsigned int)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondFormats/TotemReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc:875:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
          if (!strcmp(XMLString::transcode(a->getNodeName()), "hw_id"))
         ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondFormats/TotemReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc:877:11: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           hw_id_set = true;
           ^~~~~~~~~
