### PR TITLE
CondTools/SiPixel : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/CondTools/SiPixel/test/SiPixelLorentzAngleReader.cc
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleReader.cc
@@ -30,11 +30,11 @@ SiPixelLorentzAngleReader::SiPixelLorentzAngleReader( const edm::ParameterSet& i
 SiPixelLorentzAngleReader::~SiPixelLorentzAngleReader(){}
 
 void SiPixelLorentzAngleReader::analyze( const edm::Event& e, const edm::EventSetup& iSetup){
- edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_; 
- if(useSimRcd_ == true)
-  iSetup.get<SiPixelLorentzAngleSimRcd>().get(SiPixelLorentzAngle_);
- else
-  iSetup.get<SiPixelLorentzAngleRcd>().get(SiPixelLorentzAngle_);
+  edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_; 
+  if(useSimRcd_ == true)
+   iSetup.get<SiPixelLorentzAngleSimRcd>().get(SiPixelLorentzAngle_);
+  else
+   iSetup.get<SiPixelLorentzAngleRcd>().get(SiPixelLorentzAngle_);
   edm::LogInfo("SiPixelLorentzAngleReader") << "[SiPixelLorentzAngleReader::analyze] End Reading SiPixelLorentzAngle" << std::endl;
   edm::Service<TFileService> fs;
   LorentzAngleBarrel_ = fs->make<TH1F>("LorentzAngleBarrelPixel","LorentzAngleBarrelPixel",150,0,0.15);


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondTools/SiPixel/test/SiPixelLorentzAngleReader.cc: In member function 'virtual void SiPixelLorentzAngleReader::analyze(const edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondTools/SiPixel/test/SiPixelLorentzAngleReader.cc:36:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
   else
  ^~~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/CondTools/SiPixel/test/SiPixelLorentzAngleReader.cc:38:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
   edm::LogInfo("SiPixelLorentzAngleReader") << "[SiPixelLorentzAngleReader::analyze] End Reading SiPixelLorentzAngle" << std::endl;
   ^~~
