### PR TITLE
DQM/CastorMonitor : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
@@ -211,11 +211,12 @@ void CastorRecHitMonitor::processEvent(const CastorRecHitCollection& castorHits)
     etot += es;
   } // end for(int phi=0;
 
-  if(ievt_ %100 == 0) 
+  if(ievt_ %100 == 0){ 
    for(int mod=1; mod<=14; mod++) for(int sec=1; sec<=16;sec++) {
      double a= h2RHmap->getTH2F()->GetBinContent(mod,sec);
      h2RHoccmap->getTH2F()->SetBinContent(mod,sec,a/double(ievt_));
    }
+  }
 
   if(fVerbosity>0) std::cout << "CastorRecHitMonitor::processEvent (end)"<< std::endl;
   return;

--- a/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
@@ -211,11 +211,11 @@ void CastorRecHitMonitor::processEvent(const CastorRecHitCollection& castorHits)
     etot += es;
   } // end for(int phi=0;
 
- if(ievt_ %100 == 0) 
-  for(int mod=1; mod<=14; mod++) for(int sec=1; sec<=16;sec++) {
-    double a= h2RHmap->getTH2F()->GetBinContent(mod,sec);
-    h2RHoccmap->getTH2F()->SetBinContent(mod,sec,a/double(ievt_));
-  }
+  if(ievt_ %100 == 0) 
+   for(int mod=1; mod<=14; mod++) for(int sec=1; sec<=16;sec++) {
+     double a= h2RHmap->getTH2F()->GetBinContent(mod,sec);
+     h2RHoccmap->getTH2F()->SetBinContent(mod,sec,a/double(ievt_));
+   }
 
   if(fVerbosity>0) std::cout << "CastorRecHitMonitor::processEvent (end)"<< std::endl;
   return;


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/CastorMonitor/src/CastorRecHitMonitor.cc: In member function 'void CastorRecHitMonitor::processEvent(const CastorRecHitCollection&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/CastorMonitor/src/CastorRecHitMonitor.cc:214:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if(ievt_ %100 == 0)
  ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/CastorMonitor/src/CastorRecHitMonitor.cc:220:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(fVerbosity>0) std::cout << "CastorRecHitMonitor::processEvent (end)"<< std::endl;
   ^~
