### PR TITLE
DQM/DTMonitorModule : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
@@ -454,9 +454,9 @@ void DTEfficiencyTask::fillHistos(DTLayerId lId,
 				  bool unassHit) {
 
  vector<MonitorElement *> histos =  histosPerL[lId];
- if(unassHit) {
+ if(unassHit)
    histos[1]->Fill(missingWire);
-   histos[2]->Fill(missingWire); }
+ histos[2]->Fill(missingWire);
 }
 
 // Local Variables:

--- a/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
@@ -454,9 +454,9 @@ void DTEfficiencyTask::fillHistos(DTLayerId lId,
 				  bool unassHit) {
 
  vector<MonitorElement *> histos =  histosPerL[lId];
- if(unassHit)
+ if(unassHit) {
    histos[1]->Fill(missingWire);
-   histos[2]->Fill(missingWire);
+   histos[2]->Fill(missingWire); }
 }
 
 // Local Variables:


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/DTMonitorModule/src/DTEfficiencyTask.cc: In member function 'void DTEfficiencyTask::fillHistos(DTLayerId, int, int, int, bool)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/DTMonitorModule/src/DTEfficiencyTask.cc:457:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if(unassHit)
  ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/DTMonitorModule/src/DTEfficiencyTask.cc:459:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    histos[2]->Fill(missingWire);
    ^~~~~~
