### PR TITLE
DQM/HcalMonitorTasks : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -658,7 +658,7 @@ void HcalDetDiagLEDMonitor::fillHistos(){
   for(int i=0;i<18;i++) for(int j=0;j<4;j++)
    ho0[i][j]=nho0[i][j]=ho1p[i][j]=nho1p[i][j]=ho2p[i][j]=nho2p[i][j]=ho1m[i][j]=nho1m[i][j]=ho2m[i][j]=nho2m[i][j]=0;
 
-   std::vector <HcalElectronicsId> AllElIds = emap->allElectronicsIdPrecision();
+  std::vector <HcalElectronicsId> AllElIds = emap->allElectronicsIdPrecision();
    for(std::vector <HcalElectronicsId>::iterator eid = AllElIds.begin(); eid != AllElIds.end(); eid++){
       DetId detid=emap->lookup(*eid);
       if(detid.det()!=DetId::Hcal) continue;

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
@@ -633,7 +633,8 @@ void HcalDetDiagNoiseMonitor::done(){}
  
 HcalDetDiagNoiseMonitor::~HcalDetDiagNoiseMonitor()
 {
-  if(LocalRun) UpdateHistos(); SaveRates(); 
+  if(LocalRun) UpdateHistos();
+  SaveRates(); 
 
   if ( RMSummary ) delete RMSummary;
 }

--- a/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
@@ -90,8 +90,8 @@ void HcalNoiseMonitor::setup(DQMStore::IBooker &ib)
    setupDone_ = true;
    HcalBaseDQMonitor::setup(ib);
 
-   if(debug_ > 1)
-      std::cout << "<HcalNoiseMonitor::setup> Creating histograms" << std::endl;
+      if(debug_ > 1)
+         std::cout << "<HcalNoiseMonitor::setup> Creating histograms" << std::endl;
 
       ib.setCurrentFolder(subdir_);
 


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc: In member function 'void HcalDetDiagLEDMonitor::fillHistos()':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc:658:25: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
    for(int i=0;i<18;i++) for(int j=0;j<4;j++)
                         ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc:661:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
    std::vector <HcalElectronicsId> AllElIds = emap->allElectronicsIdPrecision();
    ^~~

> > Compiling  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalCaloTowerMonitor.cc 
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gcc/6.0.0-cms2/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_X_2016-06-26-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_X_2016-06-26-2300" -DEIGEN_DONT_PARALLELIZE -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/coral/CORAL_2_3_21-giojec4/include/LCG -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/classlib/3.1.3-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/lcg/root/6.06.04-giojec2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/boost/1.57.0-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/pcre/8.37-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/bz2lib/1.0.6-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/clhep/2.2.0.4-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gsl/1.16-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/hepmc/2.06.07-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/libuuid/2.22.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/openssl/1.0.2d-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/protobuf/2.6.1-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/python/2.7.11-cms3/include/python2.7 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/sigcpp/2.6.2-cms2/include/sigc++-2.0 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/tbb/44_20160316oss/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/vdt/v0.3.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xerces-c/3.1.3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xz/5.2.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/zlib/1.2.8-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/eigen/3.2.2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalCaloTowerMonitor.d /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalCaloTowerMonitor.cc -o tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalCaloTowerMonitor.o
> > Compiling  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc 
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gcc/6.0.0-cms2/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_X_2016-06-26-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_X_2016-06-26-2300" -DEIGEN_DONT_PARALLELIZE -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/coral/CORAL_2_3_21-giojec4/include/LCG -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/classlib/3.1.3-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/lcg/root/6.06.04-giojec2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/boost/1.57.0-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/pcre/8.37-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/bz2lib/1.0.6-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/clhep/2.2.0.4-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gsl/1.16-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/hepmc/2.06.07-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/libuuid/2.22.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/openssl/1.0.2d-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/protobuf/2.6.1-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/python/2.7.11-cms3/include/python2.7 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/sigcpp/2.6.2-cms2/include/sigc++-2.0 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/tbb/44_20160316oss/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/vdt/v0.3.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xerces-c/3.1.3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xz/5.2.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/zlib/1.2.8-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/eigen/3.2.2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalNoiseMonitor.d /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc -o tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalNoiseMonitor.o
> > Compiling  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc 
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gcc/6.0.0-cms2/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_X_2016-06-26-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_X_2016-06-26-2300" -DEIGEN_DONT_PARALLELIZE -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/coral/CORAL_2_3_21-giojec4/include/LCG -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/classlib/3.1.3-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/lcg/root/6.06.04-giojec2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/boost/1.57.0-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/pcre/8.37-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/bz2lib/1.0.6-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/clhep/2.2.0.4-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gsl/1.16-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/hepmc/2.06.07-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/libuuid/2.22.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/openssl/1.0.2d-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/protobuf/2.6.1-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/python/2.7.11-cms3/include/python2.7 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/sigcpp/2.6.2-cms2/include/sigc++-2.0 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/tbb/44_20160316oss/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/vdt/v0.3.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xerces-c/3.1.3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xz/5.2.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/zlib/1.2.8-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/eigen/3.2.2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalRawDataMonitor.d /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc -o tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalRawDataMonitor.o
> > Compiling  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc 
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gcc/6.0.0-cms2/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_X_2016-06-26-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_X_2016-06-26-2300" -DEIGEN_DONT_PARALLELIZE -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/coral/CORAL_2_3_21-giojec4/include/LCG -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/classlib/3.1.3-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/lcg/root/6.06.04-giojec2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/boost/1.57.0-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/pcre/8.37-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/bz2lib/1.0.6-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/clhep/2.2.0.4-cms3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/gsl/1.16-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/hepmc/2.06.07-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/libuuid/2.22.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/openssl/1.0.2d-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/protobuf/2.6.1-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/python/2.7.11-cms3/include/python2.7 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/sigcpp/2.6.2-cms2/include/sigc++-2.0 -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/tbb/44_20160316oss/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/cms/vdt/v0.3.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xerces-c/3.1.3/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/xz/5.2.2-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/zlib/1.2.8-cms2/include -I/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc600/external/eigen/3.2.2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalDetDiagNoiseMonitor.d /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc -o tmp/slc6_amd64_gcc600/src/DQM/HcalMonitorTasks/src/DQMHcalMonitorTasks/HcalDetDiagNoiseMonitor.o
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc: In member function 'virtual void HcalNoiseMonitor::setup(DQMStore::IBooker&)':
> >   /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc:93:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
> >      if(debug_ > 1)
> >     ^~
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc:96:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
> >        ib.setCurrentFolder(subdir_);
> >        ^~
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc: In destructor 'virtual HcalDetDiagNoiseMonitor::~HcalDetDiagNoiseMonitor()':
> >   /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc:636:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
> >     if(LocalRun) UpdateHistos(); SaveRates();
> >    ^~
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc:636:32: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
> >    if(LocalRun) UpdateHistos(); SaveRates();
> >                                 ^~~~~~~~~
