### PR TITLE
DQM/L1TMonitor : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTF.cc
@@ -304,7 +304,7 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
   {
     if (nDataMuons>=8)
       break;
-      if ( (trk->first.BX() <2) && (trk->first.BX() > -1) )
+    if ( (trk->first.BX() <2) && (trk->first.BX() > -1) )
         {
 	  //int mOdE = (trk->first.ptLUTAddress()>>16)&0xf; 
 	  //cout << "D->Mode: " << mOdE << ", Rank " << trk->first.rank() << endl;
@@ -341,7 +341,7 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
   {
      if(nEmulMuons>=8)
        break;
-       if((trk->first.BX() <2) && (trk->first.BX() >-1))
+     if((trk->first.BX() <2) && (trk->first.BX() >-1))
          {
 	    //int mOdE = (trk->first.ptLUTAddress()>>16)&0xf; 
 	    //cout << "E->Mode: " << mOdE << ", Rank " << trk->first.rank() << endl;
@@ -504,7 +504,7 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
     {
       if(dDtCounter>=15)
         break;
-        if((stu->BX()>4) && (stu->BX()<9))
+      if((stu->BX()>4) && (stu->BX()<9))
         {
           dDtStub[0][dDtCounter] = stu->phiPacked();
 	  dDtStub[1][dDtCounter] = stu->getQuality();
@@ -537,7 +537,7 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
     {		
       if (eDtCounter>=15)
         break;
-	if((eStu->BX()>4) && (eStu->BX()<9) )
+      if((eStu->BX()>4) && (eStu->BX()<9) )
 	{
 	  eDtStub[0][eDtCounter] = eStu->phiPacked();
 	  eDtStub[1][eDtCounter] = eStu->getQuality();


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc: In member function 'virtual void L1TdeCSCTF::analyze(const edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:305:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (nDataMuons>=8)
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:307:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       if ( (trk->first.BX() <2) && (trk->first.BX() > -1) )
       ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:342:6: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if(nEmulMuons>=8)
      ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:344:8: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
        if((trk->first.BX() <2) && (trk->first.BX() >-1))
        ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:505:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if(dDtCounter>=15)
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:507:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
         if((stu->BX()>4) && (stu->BX()<9))
         ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:538:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
        if (eDtCounter>=15)
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/L1TMonitor/src/L1TdeCSCTF.cc:540:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  if((eStu->BX()>4) && (eStu->BX()<9) )
  ^~
