### PR TITLE
DQM/SiPixelMonitorClient : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -392,7 +392,7 @@ void SiPixelActionExecutor::fillSummary(DQMStore::IBooker& iBooker, DQMStore::IG
 		(*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
 		(*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
 	  prefix="SUMCLU";
-          if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
 	else if((*iv)=="residualX"||(*iv)=="residualY")
 	  prefix="SUMTRK";
 	else if((*iv)=="ClustX"||(*iv)=="ClustY"||(*iv)=="nRecHits"||(*iv)=="ErrorX"||(*iv)=="ErrorY")
@@ -967,7 +967,7 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore::IBooker & iBo
 		    (*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
 		    (*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
 	      prefix="SUMCLU";
-	      if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	    if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
 	    else if((*iv)=="residualX_mean"||(*iv)=="residualY_mean"||
 		    (*iv)=="residualX_RMS"||(*iv)=="residualY_RMS")
 	      prefix="SUMTRK";
@@ -1215,7 +1215,7 @@ void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore::IBooker& iBoo
 		    (*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
 		    (*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
 	      prefix="SUMCLU";
-	      if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	    if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
 	    else if((*iv)=="residualX_mean"||(*iv)=="residualY_mean"||
 		    (*iv)=="residualX_RMS"||(*iv)=="residualY_RMS")
 	      prefix="SUMTRK";


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc: In member function 'void SiPixelActionExecutor::fillSummary(DQMStore::IBooker&, DQMStore::IGetter&, std::string, std::vectorstd::basic_string<char >&, bool, bool)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:391:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   else if((_iv)=="nclusters"||(_iv)=="x"||(_iv)=="y"||(_iv)=="charge"||
       ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:395:11: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
           if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc: In member function 'void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore::IBooker&, DQMStore::IGetter&, std::vectorstd::basic_string<char >&, bool)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:966:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       else if((_iv)=="nclusters"||(_iv)=="x"||(_iv)=="y"||(_iv)=="charge"||(_iv)=="chargeCOMB"||
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:970:8: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
        if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
        ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc: In member function 'void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore::IBooker&, DQMStore::IGetter&, std::vectorstd::basic_string<char >&, bool)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:1214:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       else if((_iv)=="nclusters"||(_iv)=="x"||(_iv)=="y"||(_iv)=="charge"||(_iv)=="chargeCOMB"||
           ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc:1218:8: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
        if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
        ^~
