### PR TITLE
DQM/SiStripCommissioningDbClients fix for bug flagged by gcc 6.0 misleading-indentation warning

### DIFF
--- a/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
@@ -137,14 +137,18 @@ bool LatencyHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devi
   for( CommissioningHistograms::Analysis it = data().begin(); it!=data().end();++it) {
     if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
        dynamic_cast<SamplingAnalysis*>( it->second )->granularity()==sistrip::PARTITION       )
+      {
       anal = dynamic_cast<SamplingAnalysis*>( it->second );
       latency = uint16_t(ceil(anal->maximum()/(-25.)))>latency ? uint16_t(ceil(anal->maximum()/(-25.))) : latency;
+      }
   }
   for( CommissioningHistograms::Analysis it = data().begin(); it!=data().end();++it) {
     if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
        dynamic_cast<SamplingAnalysis*>( it->second )->granularity()==sistrip::PARTITION       )
+      {
       anal = dynamic_cast<SamplingAnalysis*>( it->second );
       shift[SiStripFecKey(anal->fecKey()).fecCrate()] = anal->maximum()-(latency*(-25));
+      }
   }
   if(!perPartition_) {
     latency = globalLatency;


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc: In member function 'bool LatencyHistosUsingDb::update(SiStripConfigDb::DeviceDescriptionsRange, SiStripConfigDb::FedDescriptionsRange)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc:138:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc:141:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       latency = uint16_t(ceil(anal->maximum()/(-25.)))>latency ? uint16_t(ceil(anal->maximum()/(-25.))) : latency;
       ^~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc:144:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc:147:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       shift[SiStripFecKey(anal->fecKey()).fecCrate()] = anal->maximum()-(latency*(-25));
       ^~~~~
