### PR TITLE
DataFormats/TrackerRecHit2D : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/DataFormats/TrackerRecHit2D/test/mayown_t.cpp
+++ b/DataFormats/TrackerRecHit2D/test/mayown_t.cpp
@@ -21,7 +21,8 @@ int main() {
   }
 
   VD vd2; std::swap(vd,vd2);  assert(10==vd2.size());
-  for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; std::cout << std::endl;
+  for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; 
+  std::cout << std::endl;
   for (auto i=0U; i<vd2.size(); ++i) if (i%2==0) assert(!vd2[i].isOwn()); else assert(vd2[i].isOwn());
 
   std::cout << "reset" << std::endl;
@@ -30,10 +31,12 @@ int main() {
 
   std::cout << "remove" << std::endl;
   auto last = std::remove_if(vd2.begin(),vd2.end(),[](PD const & p) {return p.empty();});
-  for (auto i=vd2.begin(); i!=last; ++i)  std::cout << **i<< ' '; std::cout << std::endl;
+  for (auto i=vd2.begin(); i!=last; ++i)  std::cout << **i<< ' '; 
+  std::cout << std::endl;
   vd2.resize(last-vd2.begin());
   assert(8==vd2.size());
-  for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; std::cout << std::endl;
+  for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; 
+  std::cout << std::endl;
 
 
   return 0;


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp: In function 'int main()':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:24:3: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
    for (auto i=0U; i<vd2.size(); ++i) std::cout << _vd2[i] << ' '; std::cout << std::endl;
   ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:24:67: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
   for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; std::cout << std::endl;
                                                                   ^~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:33:3: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
    for (auto i=vd2.begin(); i!=last; ++i)  std::cout << *_i<< ' '; std::cout << std::endl;
   ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:33:67: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
   for (auto i=vd2.begin(); i!=last; ++i)  std::cout << **i<< ' '; std::cout << std::endl;
                                                                   ^~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:36:3: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
    for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; std::cout << std::endl;
   ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/DataFormats/TrackerRecHit2D/test/mayown_t.cpp:36:67: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
   for (auto i=0U; i<vd2.size(); ++i) std::cout << *vd2[i] << ' '; std::cout << std::endl;
