### PR TITLE
ElectroWeakAnalysis/WMuNu : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc
+++ b/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc
@@ -549,7 +549,7 @@ bool WMuNuValidator::filter (Event & ev, const EventSetup &) {
                         fill_histogram("DXY_LASTCUT",dxy);
                   if (!muon_sel[3] || flags_passed==NFLAGS)
                         fill_histogram("CHI2_LASTCUT",normalizedChi2);
-                        fill_histogram("ValidMuonHits_LASTCUT",validmuonhits);
+                  fill_histogram("ValidMuonHits_LASTCUT",validmuonhits);
                   if (!muon_sel[4] || flags_passed==NFLAGS)
                         fill_histogram("NHITS_LASTCUT",trackerHits);
                   if (!muon_sel[5] || flags_passed==NFLAGS)
@@ -558,23 +558,23 @@ bool WMuNuValidator::filter (Event & ev, const EventSetup &) {
                         fill_histogram("ISO_LASTCUT",isovar);
                   if (!muon_sel[7] || flags_passed==NFLAGS)
                         if (!hlt_hist_done) fill_histogram("TRIG_LASTCUT",trigger_fired);
-                        hlt_hist_done = true;
+                  hlt_hist_done = true;
                   if (!muon_sel[8] || flags_passed==NFLAGS)
                         fill_histogram("MT_LASTCUT",massT);
                   if (!muon_sel[9] || flags_passed==NFLAGS)
                         if (!met_hist_done) fill_histogram("MET_LASTCUT",met_et);
-                        met_hist_done = true;
+                  met_hist_done = true;
                   if (!muon_sel[10] || flags_passed==NFLAGS)
                         fill_histogram("ACOP_LASTCUT",acop);
                   if (!muon_sel[11] || flags_passed==NFLAGS)
                         if (!nz1_hist_done) fill_histogram("NZ1_LASTCUT",nmuonsForZ1);
-                        nz1_hist_done = true;
+                  nz1_hist_done = true;
                   if (!muon_sel[11] || flags_passed==NFLAGS)
                         if (!nz2_hist_done) fill_histogram("NZ2_LASTCUT",nmuonsForZ2);
-                        nz2_hist_done = true;
+                  nz2_hist_done = true;
                   if (!muon_sel[12] || flags_passed==NFLAGS)
                         if (!njets_hist_done) fill_histogram("NJETS_LASTCUT",njets);
-                        njets_hist_done = true;
+                  njets_hist_done = true;
               }
             }
 

--- a/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc
+++ b/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc
@@ -547,34 +547,39 @@ bool WMuNuValidator::filter (Event & ev, const EventSetup &) {
                         fill_histogram("ETA_LASTCUT",eta);
                   if (!muon_sel[2] || flags_passed==NFLAGS)
                         fill_histogram("DXY_LASTCUT",dxy);
-                  if (!muon_sel[3] || flags_passed==NFLAGS)
+                  if (!muon_sel[3] || flags_passed==NFLAGS) {
                         fill_histogram("CHI2_LASTCUT",normalizedChi2);
-                  fill_histogram("ValidMuonHits_LASTCUT",validmuonhits);
+                        fill_histogram("ValidMuonHits_LASTCUT",validmuonhits); }
                   if (!muon_sel[4] || flags_passed==NFLAGS)
                         fill_histogram("NHITS_LASTCUT",trackerHits);
                   if (!muon_sel[5] || flags_passed==NFLAGS)
                         fill_histogram("TKMU_LASTCUT",mu.isTrackerMuon());
                   if (!muon_sel[6] || flags_passed==NFLAGS)
                         fill_histogram("ISO_LASTCUT",isovar);
-                  if (!muon_sel[7] || flags_passed==NFLAGS)
-                        if (!hlt_hist_done) fill_histogram("TRIG_LASTCUT",trigger_fired);
-                  hlt_hist_done = true;
+                  if (!muon_sel[7] || flags_passed==NFLAGS) {
+                        if (!hlt_hist_done) { fill_histogram("TRIG_LASTCUT",trigger_fired);
+                                              hlt_hist_done = true;}
+                  }
                   if (!muon_sel[8] || flags_passed==NFLAGS)
                         fill_histogram("MT_LASTCUT",massT);
-                  if (!muon_sel[9] || flags_passed==NFLAGS)
-                        if (!met_hist_done) fill_histogram("MET_LASTCUT",met_et);
-                  met_hist_done = true;
+                  if (!muon_sel[9] || flags_passed==NFLAGS) {
+                        if (!met_hist_done) { fill_histogram("MET_LASTCUT",met_et);
+                                              met_hist_done = true;}
+                  } 
                   if (!muon_sel[10] || flags_passed==NFLAGS)
                         fill_histogram("ACOP_LASTCUT",acop);
-                  if (!muon_sel[11] || flags_passed==NFLAGS)
-                        if (!nz1_hist_done) fill_histogram("NZ1_LASTCUT",nmuonsForZ1);
-                  nz1_hist_done = true;
-                  if (!muon_sel[11] || flags_passed==NFLAGS)
-                        if (!nz2_hist_done) fill_histogram("NZ2_LASTCUT",nmuonsForZ2);
-                  nz2_hist_done = true;
-                  if (!muon_sel[12] || flags_passed==NFLAGS)
-                        if (!njets_hist_done) fill_histogram("NJETS_LASTCUT",njets);
-                  njets_hist_done = true;
+                  if (!muon_sel[11] || flags_passed==NFLAGS) {
+                        if (!nz1_hist_done) { fill_histogram("NZ1_LASTCUT",nmuonsForZ1);
+                                              nz1_hist_done = true;}
+                  }
+                  if (!muon_sel[11] || flags_passed==NFLAGS) {
+                        if (!nz2_hist_done) { fill_histogram("NZ2_LASTCUT",nmuonsForZ2);
+                                              nz2_hist_done = true; }
+                  }
+                  if (!muon_sel[12] || flags_passed==NFLAGS) {
+                        if (!njets_hist_done) { fill_histogram("NJETS_LASTCUT",njets);
+                                                njets_hist_done = true;}
+                  }
               }
             }
 


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc: In member function 'virtual bool WMuNuValidator::filter(edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:550:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[3] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:552:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         fill_histogram("ValidMuonHits_LASTCUT",validmuonhits);
                         ^~~~~~~~~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:559:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[7] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:561:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         hlt_hist_done = true;
                         ^~~~~~~~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:564:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[9] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:566:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         met_hist_done = true;
                         ^~~~~~~~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:569:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[11] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:571:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         nz1_hist_done = true;
                         ^~~~~~~~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:572:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[11] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:574:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         nz2_hist_done = true;
                         ^~~~~~~~~~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:575:19: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                    if (!muon_sel[12] || flags_passed==NFLAGS)
                   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/ElectroWeakAnalysis/WMuNu/src/WMuNuValidator.cc:577:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                         njets_hist_done = true;
                         ^~~~~~~~~~~~~~~
