### PR TITLE
EventFilter/SiPixelRawToDigi : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -97,7 +97,8 @@ void SiPixelDigiToRaw::produce( edm::Event& ev,
     es.get<SiPixelFedCablingMapRcd>().get( cablingMap );
     fedIds = cablingMap->fedIds();
     cablingTree_= cablingMap->cablingTree();
-    if (frameReverter_) delete frameReverter_; frameReverter_ = new SiPixelFrameReverter( es, cablingMap.product() );
+    if (frameReverter_) delete frameReverter_; 
+    frameReverter_ = new SiPixelFrameReverter( es, cablingMap.product() );
   }
 
   debug = edm::MessageDrop::instance()->debugEnabled;


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc: In member function 'virtual void SiPixelDigiToRaw::produce(edm::Event&, const edm::EventSetup&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc:100:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (frameReverter_) delete frameReverter_; frameReverter_ = new SiPixelFrameReverter( es, cablingMap.product() );
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc:100:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (frameReverter_) delete frameReverter_; frameReverter_ = new SiPixelFrameReverter( es, cablingMap.product() );
                                                ^~~~~~~~~~~~~~
