### PR TITLE
Geometry/EcalCommonData : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc
+++ b/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc
@@ -496,7 +496,9 @@ void DDEcalPreshowerAlgo::doLadders(DDCompactView& cpv) {
 	    boxay =  ladder_length-LdrFrnt_Length-LdrBck_Length; boxax = ladder_width; boxaz = ladder_thick;
 
 	    DDSolid solid_a = DDSolidFactory::box(dd_tmp_name_a,boxax/2,boxay/2,boxaz/2.);
-	    if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
+	    if(ladd_side==0) sdxe[enb] = ladder_width/4; 
+	    sdye[enb]= -boxay/2 - LdrFrnt_Length/2; 
+	    sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
 	    if(ladd_side==1) sdxe[enb] = -ladder_width/4;
 	    
 	    DDSolid solid_b = DDSolidFactory::unionSolid(dd_tmp_name_b,solid_a,solid_lfhalf,DDTranslation(sdxe[enb],sdye[enb],sdze[enb]),DDRotation("esalgo:RM1299"));
@@ -522,7 +524,7 @@ void DDEcalPreshowerAlgo::doLadders(DDCompactView& cpv) {
 	    boxay =  ladder_length-LdrFrnt_Length-LdrBck_Length; boxax = ladder_width; boxaz = ladder_thick;
 	    DDSolid solid_a = DDSolidFactory::box(dd_tmp_name_a,boxax/2,boxay/2,boxaz/2.);
 	    if(ladd_side==0) sdxe[enb] = ladder_width/4; 
-	    sdye[enb]= -boxay/2 - LdrFrnt_Length/2; i
+	    sdye[enb]= -boxay/2 - LdrFrnt_Length/2;
 	    sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
 	    if(ladd_side==1) sdxe[enb] = -ladder_width/4;
 	    

--- a/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc
+++ b/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc
@@ -384,12 +384,15 @@ void DDEcalPreshowerAlgo::doLadders(DDCompactView& cpv) {
 	  boxay =  ladder_length-LdrFrnt_Length-LdrBck_Length; boxax = ladder_width; boxaz = ladder_thick;
 	  
 	  DDSolid solid_5a = DDSolidFactory::box(dd_tmp_name_5a,boxax/2,boxay/2,boxaz/2.);
-	  if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
+	  if(ladd_side==0) sdxe[enb] = ladder_width/4; 
+	  sdye[enb]= -boxay/2 - LdrFrnt_Length/2; 
+	  sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
 	  if(ladd_side==1) sdxe[enb] = -ladder_width/4;
 	  
 	  DDSolid solid_5b = DDSolidFactory::unionSolid(dd_tmp_name_5b,solid_5a,solid_lfhalf,DDTranslation(sdxe[enb],sdye[enb],sdze[enb]),DDRotation("esalgo:RM1299"));
 	  
-	  if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
+	  if(ladd_side==0) sdxe2[enb] = -ladder_width/4; 
+     sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
 	  sdze2[enb] = -ladder_thick/2. + LdrFrnt_Offset + (waf_active*sin(wedge_angle*2))/4;
 	  if(ladd_side==1) sdxe2[enb] = ladder_width/4;
 	  
@@ -466,7 +469,9 @@ void DDEcalPreshowerAlgo::doLadders(DDCompactView& cpv) {
 	  sdxe[enb] = 0; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
 	  DDSolid solid_b = DDSolidFactory::unionSolid(dd_tmp_name_b,solid_a,solid_lfront,DDTranslation(sdxe[enb],sdye[enb],sdze[enb]),DDRotation("esalgo:RM1299"));
 	  
-	  if(ladd_side==0) sdxe2[enb] = ladder_width/4; sdye2[enb] = boxay/2 + LdrBck_Length/2; sdze2[enb] = -ladder_thick/2. + LdrBck_Offset;
+	  if(ladd_side==0) sdxe2[enb] = ladder_width/4; 
+	  sdye2[enb] = boxay/2 + LdrBck_Length/2; 
+	  sdze2[enb] = -ladder_thick/2. + LdrBck_Offset;
 	  if(ladd_side==1) sdxe2[enb] = -ladder_width/4; 
           DDSolid solid = DDSolidFactory::unionSolid(ddname,solid_b,solid_lbhalf,DDTranslation(sdxe2[enb],sdye2[enb],sdze2[enb]),DDRotation("esalgo:RM1299"));      
 	  
@@ -516,12 +521,15 @@ void DDEcalPreshowerAlgo::doLadders(DDCompactView& cpv) {
 	    
 	    boxay =  ladder_length-LdrFrnt_Length-LdrBck_Length; boxax = ladder_width; boxaz = ladder_thick;
 	    DDSolid solid_a = DDSolidFactory::box(dd_tmp_name_a,boxax/2,boxay/2,boxaz/2.);
-	    if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
+	    if(ladd_side==0) sdxe[enb] = ladder_width/4; 
+	    sdye[enb]= -boxay/2 - LdrFrnt_Length/2; i
+	    sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
 	    if(ladd_side==1) sdxe[enb] = -ladder_width/4;
 	    
 	    DDSolid solid_b = DDSolidFactory::unionSolid(dd_tmp_name_b,solid_a,solid_lfhalf,DDTranslation(sdxe[enb],sdye[enb],sdze[enb]),DDRotation("esalgo:RM1299"));
 	    
-	    if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
+	    if(ladd_side==0) sdxe2[enb] = -ladder_width/4; 
+	    sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
 	    sdze2[enb] = -ladder_thick/2. + LdrFrnt_Offset + (waf_active*sin(wedge_angle*2))/4;
 	    if(ladd_side==1) sdxe2[enb] = ladder_width/4;
 	    


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc: In member function 'void DDEcalPreshowerAlgo::doLadders(DDCompactView&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:387:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
    ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:387:49: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
                                                 ^~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:392:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
    ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:392:51: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
                                                   ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:469:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if(ladd_side==0) sdxe2[enb] = ladder_width/4; sdye2[enb] = boxay/2 + LdrBck_Length/2; sdze2[enb] = -ladder_thick/2. + LdrBck_Offset;
    ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:469:50: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    if(ladd_side==0) sdxe2[enb] = ladder_width/4; sdye2[enb] = boxay/2 + LdrBck_Length/2; sdze2[enb] = -ladder_thick/2. + LdrBck_Offset;
                                                  ^~~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:494:6: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
      ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:494:51: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
      if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
                                                   ^~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:519:6: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
      ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:519:51: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
      if(ladd_side==0) sdxe[enb] = ladder_width/4; sdye[enb]= -boxay/2 - LdrFrnt_Length/2; sdze[enb] = -ladder_thick/2. + LdrFrnt_Offset;
                                                   ^~~~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:524:6: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
      ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/Geometry/EcalCommonData/src/DDEcalPreshowerAlgo.cc:524:53: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
      if(ladd_side==0) sdxe2[enb] = -ladder_width/4; sdye2[enb]= -boxay/2 - LdrFrnt_Length/2 + waf_active/2;
                                                     ^~~~~
