### PR TITLE
HLTrigger/Tools : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix

### DIFF
--- a/HLTrigger/Tools/bin/hltTimingSummary.cpp
+++ b/HLTrigger/Tools/bin/hltTimingSummary.cpp
@@ -64,7 +64,7 @@ bool usePathByName(HLTPerformanceInfo::Path path,
                      std::vector<std::string> skip) {
   for (unsigned int i=0; i<skip.size(); i++)
     if (path.name() == skip.at(i)) return false; 
-    return true; 
+  return true; 
 }
 
 //initialize the following parameters


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/HLTrigger/Tools/bin/hltTimingSummary.cpp: In function 'bool usePathByName(HLTPerformanceInfo::Path, std::vectorstd::basic_string<char >)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/HLTrigger/Tools/bin/hltTimingSummary.cpp:65:3: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
    for (unsigned int i=0; i<skip.size(); i++)
   ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/HLTrigger/Tools/bin/hltTimingSummary.cpp:67:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
     return true;
     ^~~~~~
