### PR TITLE
L1TriggerConfig/L1ScalesProducers : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -282,8 +282,8 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(tp_version)) ? analyticalLUT[k] : identityLUT[k];
 	 
 
-	   // tpg - compressed value
-	   unsigned int tpg = outputLut[0];
+	 // tpg - compressed value
+	 unsigned int tpg = outputLut[0];
           
 	   int low = 0;
 


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc: In member function 'virtual std::shared_ptr<L1CaloHcalScale> L1CaloHcalScaleConfigOnlineProd::newObject(const string&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc:281:10: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
           for (unsigned int k = threshold; k < 1024; ++k)
          ^~~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8258e37281729e179b5af9c3b033d930/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-06-26-2300/src/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc:286:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
     unsigned int tpg = outputLut[0];
     ^~~~~~~~
