### PR TITLE
Customization of pp reco for heavy ions (backport from 81X)

### DIFF
--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -75,3 +75,73 @@ def addHIIsolationProducer(process):
     process.reconstruction *= process.photonIsolationHISequencePP
     
     return process
+
+
+    # modify cluster limits to run pp reconstruction on peripheral PbPb
+def modifyClusterLimits(process):
+
+    hiClusterCut = cms.string("strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
+
+    if hasattr(process,'initialStepSeedsPreSplitting'): process.initialStepSeedsPreSplitting.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'initialStepSeeds'): process.initialStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'lowPtTripletStepSeeds'): process.lowPtTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalSeedsFromTriplets'): process.globalSeedsFromTriplets.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'detachedTripletStepSeeds'): process.detachedTripletStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'mixedTripletStepSeedsA'): process.mixedTripletStepSeedsA.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'mixedTripletStepSeedsB'): process.mixedTripletStepSeedsB.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalMixedSeeds'): process.globalMixedSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelLessStepSeeds'): process.pixelLessStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalPixelLessSeeds'): process.globalPixelLessSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalPixelSeeds'): process.globalPixelSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelPairStepSeeds'): process.pixelPairStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'globalSeedsFromPairsWithVertices'): process.globalSeedsFromPairsWithVertices.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tobTecStepSeedsPair'): process.tobTecStepSeedsPair.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tobTecStepSeedsTripl'): process.tobTecStepSeedsTripl.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'pixelPairElectronSeeds'): process.pixelPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'regionalCosmicTrackerSeeds'): process.regionalCosmicTrackerSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'stripPairElectronSeeds'): process.stripPairElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'photonConvTrajSeedFromSingleLeg'): process.photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'photonConvTrajSeedFromQuadruplets'): process.photonConvTrajSeedFromQuadruplets.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'tripletElectronSeeds'): process.tripletElectronSeeds.ClusterCheckPSet.cut = hiClusterCut
+    if hasattr(process,'jetCoreRegionalStepSeeds'): process.jetCoreRegionalStepSeeds.ClusterCheckPSet.cut = hiClusterCut
+
+
+    maxElement = cms.uint32(1000000)
+    
+    if hasattr(process,'initialStepSeedsPreSplitting'): process.initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'initialStepSeeds'): process.initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'lowPtTripletStepSeeds'): process.lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'mixedTripletStepSeedsA'): process.mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'mixedTripletStepSeedsB'): process.mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'detachedTripletStepSeeds'): process.detachedTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'pixelLessStepSeeds'): process.pixelLessStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'tobTecStepSeedsTripl'): process.tobTecStepSeedsTripl.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = maxElement
+    if hasattr(process,'tobTecStepSeedsPair'): process.tobTecStepSeedsPair.OrderedHitsFactoryPSet.maxElement = maxElement
+    if hasattr(process,'pixelPairStepSeeds'): process.pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
+    if hasattr(process,'jetCoreRegionalStepSeeds'): process.jetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = maxElement
+
+    return process
+
+
+# Add caloTowers to AOD event content
+def storeCaloTowersAOD(process):
+
+    process.load('Configuration.EventContent.EventContent_cff')
+    
+    # extend AOD content
+    if hasattr(process,'AODoutput'):
+        process.AODoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+
+    if hasattr(process,'AODSIMoutput'):
+        process.AODSIMoutput.outputCommands.extend(['keep *_towerMaker_*_*'])
+
+    return process
+
+def customisePPwithHI(process):
+
+    process=addHIIsolationProducer(process)
+    process=modifyClusterLimits(process)
+    process=storeCaloTowersAOD(process)
+
+    return process
+

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -137,7 +137,14 @@ def storeCaloTowersAOD(process):
 
     return process
 
-def customisePPwithHI(process):
+def customisePPrecoforPPb(process):
+ 
+     process=addHIIsolationProducer(process)
+     process=storeCaloTowersAOD(process)
+ 
+     return process
+ 
+def customisePPrecoForPeripheralPbPb(process):
 
     process=addHIIsolationProducer(process)
     process=modifyClusterLimits(process)

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -137,14 +137,7 @@ def storeCaloTowersAOD(process):
 
     return process
 
-def customisePPrecoforPPb(process):
-
-    process=addHIIsolationProducer(process)
-    process=storeCaloTowersAOD(process)
-
-    return process
-
-def customisePPrecoForPeripheralPbPb(process):
+def customisePPwithHI(process):
 
     process=addHIIsolationProducer(process)
     process=modifyClusterLimits(process)

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -137,10 +137,17 @@ def storeCaloTowersAOD(process):
 
     return process
 
-def customisePPwithHI(process):
+def customisePPrecoforPPb(process):
 
     process=addHIIsolationProducer(process)
-    #process=modifyClusterLimits(process)
+    process=storeCaloTowersAOD(process)
+
+    return process
+
+def customisePPrecoForPeripheralPbPb(process):
+
+    process=addHIIsolationProducer(process)
+    process=modifyClusterLimits(process)
     process=storeCaloTowersAOD(process)
 
     return process

--- a/RecoHI/Configuration/python/customise_PPwithHI.py
+++ b/RecoHI/Configuration/python/customise_PPwithHI.py
@@ -140,7 +140,7 @@ def storeCaloTowersAOD(process):
 def customisePPwithHI(process):
 
     process=addHIIsolationProducer(process)
-    process=modifyClusterLimits(process)
+    #process=modifyClusterLimits(process)
     process=storeCaloTowersAOD(process)
 
     return process


### PR DESCRIPTION
Update of customizations that allows to store calo-towers in AOD.  This is needed for proton-lead data and MC in 80X.  This also includes a customization that modifies the tracking cluster limits 
This python script also contains a function that modifies the limits on the number of clusters for the pp tracking.  That was implemented in 75X for reprocessing of peripheral PbPb data.  I deactivated it by default, since the customization in 80X is intended for pPb, not PbPb.  
