### PR TITLE
Set the input tag for the PileupSummaryInfo collection retrieval

### DIFF
--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <boost/shared_ptr.hpp>
 #include <vector>
+#include "FWCore/Utilities/interface/InputTag.h"
 
 namespace reweight{
 
@@ -227,6 +228,8 @@ namespace edm {
 
     LumiReWeighting ( ) { } ;
 
+    inline void setPileupSummaryInfoInputTag( const edm::InputTag& pusi ) { pileupSumInfoTag_=pusi; }
+
     double weight( int npv ) ;
 
     double weight( float npv ) ;
@@ -241,6 +244,7 @@ namespace edm {
     std::string dataFileName_;
     std::string GenHistName_;
     std::string DataHistName_;
+    edm::InputTag pileupSumInfoTag_;
     boost::shared_ptr<TFile>     generatedFile_;
     boost::shared_ptr<TFile>     dataFile_;
     boost::shared_ptr<TH1>      weights_;

--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -221,11 +221,11 @@ namespace edm {
   public:
     LumiReWeighting( std::string generatedFile,
 		     std::string dataFile,
-		     std::string GenHistName,
-		     std::string DataHistName,
-		     const edm::InputTag& PileupSumInfoInputTag);
+		     std::string GenHistName = "pileup",
+		     std::string DataHistName = "pileup",
+		     const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) );
     
-    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag);
+    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) );
 
     LumiReWeighting ( ) { } ;
 

--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -223,7 +223,7 @@ namespace edm {
 		     std::string dataFile,
 		     std::string GenHistName,
 		     std::string DataHistName,
-                     const edm::InputTag& PileupSumInfoInputTag);
+		     const edm::InputTag& PileupSumInfoInputTag);
     
     LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag);
 

--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -222,13 +222,12 @@ namespace edm {
     LumiReWeighting( std::string generatedFile,
 		     std::string dataFile,
 		     std::string GenHistName,
-		     std::string DataHistName);
+		     std::string DataHistName,
+                     const edm::InputTag& PileupSumInfoInputTag);
     
-    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr);
+    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag);
 
     LumiReWeighting ( ) { } ;
-
-    inline void setPileupSummaryInfoInputTag( const edm::InputTag& pusi ) { pileupSumInfoTag_=pusi; }
 
     double weight( int npv ) ;
 

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -38,9 +38,9 @@ using namespace edm;
 
 LumiReWeighting::LumiReWeighting( std::string generatedFile,
 		   std::string dataFile,
-		   std::string GenHistName = "pileup",
-		   std::string DataHistName = "pileup",
-		   const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) ) :
+		   std::string GenHistName,
+		   std::string DataHistName,
+		   const edm::InputTag& PileupSumInfoInputTag ) :
       generatedFileName_( generatedFile), 
       dataFileName_     ( dataFile ), 
       GenHistName_      ( GenHistName ), 
@@ -83,7 +83,7 @@ LumiReWeighting::LumiReWeighting( std::string generatedFile,
 	OldLumiSection_ = -1;
 }
 
-LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) ) :
+LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag ) :
       pileupSumInfoTag_ ( PileupSumInfoInputTag )
   {
   // no histograms for input: use vectors

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -42,8 +42,9 @@ LumiReWeighting::LumiReWeighting( std::string generatedFile,
 		   std::string DataHistName = "pileup" ) :
       generatedFileName_( generatedFile), 
       dataFileName_     ( dataFile ), 
-      GenHistName_        ( GenHistName ), 
-      DataHistName_        ( DataHistName )
+      GenHistName_      ( GenHistName ), 
+      DataHistName_     ( DataHistName ),
+      pileupSumInfoTag_ ( edm::InputTag("addPileupInfo") )
       {
 	generatedFile_ = boost::shared_ptr<TFile>( new TFile(generatedFileName_.c_str()) ); //MC distribution
 	dataFile_      = boost::shared_ptr<TFile>( new TFile(dataFileName_.c_str()) );      //Data distribution
@@ -81,7 +82,9 @@ LumiReWeighting::LumiReWeighting( std::string generatedFile,
 	OldLumiSection_ = -1;
 }
 
-LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr) {
+LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr) :
+  pileupSumInfoTag_ ( edm::InputTag("addPileupInfo") )
+  {
   // no histograms for input: use vectors
   
   // now, make histograms out of them:
@@ -173,7 +176,7 @@ double LumiReWeighting::weight( const edm::EventBase &e ) {
   // get pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
-  e.getByLabel(edm::InputTag("addPileupInfo"), PupInfo);
+  e.getByLabel(pileupSumInfoTag_, PupInfo);
 
   std::vector<PileupSummaryInfo>::const_iterator PVI;
 
@@ -224,7 +227,7 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
   // find the pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
-  e.getByLabel(edm::InputTag("addPileupInfo"), PupInfo);
+  e.getByLabel(pileupSumInfoTag_, PupInfo);
 
   std::vector<PileupSummaryInfo>::const_iterator PVI;
 

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -39,12 +39,13 @@ using namespace edm;
 LumiReWeighting::LumiReWeighting( std::string generatedFile,
 		   std::string dataFile,
 		   std::string GenHistName = "pileup",
-		   std::string DataHistName = "pileup" ) :
+		   std::string DataHistName = "pileup",
+		   const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) ) :
       generatedFileName_( generatedFile), 
       dataFileName_     ( dataFile ), 
       GenHistName_      ( GenHistName ), 
       DataHistName_     ( DataHistName ),
-      pileupSumInfoTag_ ( edm::InputTag("addPileupInfo") )
+      pileupSumInfoTag_ ( PileupSumInfoInputTag )
       {
 	generatedFile_ = boost::shared_ptr<TFile>( new TFile(generatedFileName_.c_str()) ); //MC distribution
 	dataFile_      = boost::shared_ptr<TFile>( new TFile(dataFileName_.c_str()) );      //Data distribution
@@ -82,8 +83,8 @@ LumiReWeighting::LumiReWeighting( std::string generatedFile,
 	OldLumiSection_ = -1;
 }
 
-LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr) :
-  pileupSumInfoTag_ ( edm::InputTag("addPileupInfo") )
+LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) ) :
+      pileupSumInfoTag_ ( PileupSumInfoInputTag )
   {
   // no histograms for input: use vectors
   


### PR DESCRIPTION
Added the capability to set the input tag for the PileupSummaryInfo collection retrieval. This new method can be used for the interaction with MiniAOD files (using slimmedAddPileupInfo instead of addPileupInfo as a label for the vector&lt;PileupSummaryInfo&gt; collection)
