### PR TITLE
Improve efficiency of trigTools::setFiltersObjPasses

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTTrigTools.h
+++ b/DQMOffline/Trigger/interface/EgHLTTrigTools.h
@@ -53,7 +53,7 @@ namespace egHLT {
     std::vector<TrigCodes::TrigBitSet> partTrigBits(particles.size());
     const double maxDeltaR=0.1;
     for(size_t filterNrInVec=0;filterNrInVec<filters.size();filterNrInVec++){
-      size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec],"",hltTag).encode());
+      size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec],"",hltTag));
       const TrigCodes::TrigBitSet filterCode = trigCodes.getCode(filters[filterNrInVec].c_str());
       
       if(filterNrInEvt<trigEvt->sizeFilters()){ //filter found in event, something passes it
@@ -76,7 +76,7 @@ namespace egHLT {
       const TrigCodes::TrigBitSet filterCode = trigCodes.getCode(l1PreAndSeedFilters[l1FilterNrInVec].first.c_str());
       if((filterCode&evtTrigBits)==filterCode){ //check that filter has fired in the event
    
-	size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(l1PreAndSeedFilters[l1FilterNrInVec].second,"",hltTag).encode());
+	size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(l1PreAndSeedFilters[l1FilterNrInVec].second,"",hltTag));
 	
 	if(filterNrInEvt<trigEvt->sizeFilters()){ //filter found in event, something passes it
 	  const trigger::Keys& trigKeys = trigEvt->filterKeys(filterNrInEvt);  //trigger::Keys is actually a vector<uint16_t> holding the position of trigger objects in the trigger collection passing the filter


### PR DESCRIPTION
The function was creating a edm::InputTag, converting that to a string
then passing the string to a function which needs an edm::InputTag so
the compiler created yet another edm::InputTag. Now the code just
directly passes the edm::InputTag to the function.

This code was brought to my attention because running this code
using multiple threads has periodically crashed at this line of code.
The problem is not understood and it is unlikely that this change
fixes the underlying problem.
