### PR TITLE
PR 81X Addendum to Fix sporadic crashes in HLT when Seeding with correlations.

### DIFF
--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -584,6 +584,16 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
             //
             for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
 
+                // in case of object-less triggers (e.g. L1_ZeroBias) condObjType vector is empty, so don't seed!
+                //
+                if(condObjType.size() == 0) {
+
+                  LogTrace("HLTL1TSeed")
+                  << "\talgoName = " << objMap->algoName() << " is object-less L1 algorithm, so do not attempt to store any objects to the list of seeds.\n"
+                  << std::endl;
+                  continue;
+
+                }
 
                 // the index of the object type is the same as the index of the object
                 size_t iType = std::distance((*itComb).begin(), itObject);


### PR DESCRIPTION
This is the addendum on PR #14992 & #14991

Missed the protection in case the vector of L1T object types is empty, while number of combinations in conditions is not zero.  This happens in case of object-less algorithms (eg. L1_ZeroBias, L1_BPTX, etc )

This fix prevents from an attempt to add objects into seeding list in case of object-less algos.
