### PR TITLE
GeneratorInterface/LHEInterface : formatting fix for statements flagged by gcc 6.0 indentation warning

### DIFF
--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -288,7 +288,7 @@ std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 		double cTau = hepeup.VTIMUP.at(i);	// decay time
 	
 		// current particle has a mother? --- Sorry, parent! We're PC.
-		if (mother1) {
+		if (mother1)
 			mother1--;      // FORTRAN notation!
 		if (mother2)
 			mother2--;
@@ -306,7 +306,7 @@ std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 			genVertices.push_back(current_vtx);
 		}
 
-		for(unsigned int j = mother1; j <= mother2; j++)	// set mother-daughter relations
+		for(unsigned int j = mother1; j <= mother2; j++) {	// set mother-daughter relations
 			if (!genParticles.at(j)->end_vertex())
 				current_vtx->add_particle_in(genParticles.at(j));
 

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -288,27 +288,27 @@ std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 		double cTau = hepeup.VTIMUP.at(i);	// decay time
 	
 		// current particle has a mother? --- Sorry, parent! We're PC.
-		if (mother1)
+		if (mother1) {
 			mother1--;      // FORTRAN notation!
-		if (mother2)
-			mother2--;
-		else
-			mother2 = mother1;
+			if (mother2)
+				mother2--;
+			else
+				mother2 = mother1;
 
-		HepMC::GenParticle *in_par = genParticles.at(mother1);
-		HepMC::GenVertex *current_vtx = in_par->end_vertex();  // vertex of first mother
+			HepMC::GenParticle *in_par = genParticles.at(mother1);
+			HepMC::GenVertex *current_vtx = in_par->end_vertex();  // vertex of first mother
 
-		if (!current_vtx) {
-			current_vtx = new HepMC::GenVertex(
-					HepMC::FourVector(0, 0, 0, cTau));
+			if (!current_vtx) {
+				current_vtx = new HepMC::GenVertex(
+						HepMC::FourVector(0, 0, 0, cTau));
 
-			// add vertex to event
-			genVertices.push_back(current_vtx);
-		}
+				// add vertex to event
+				genVertices.push_back(current_vtx);
+			}
 
-		for(unsigned int j = mother1; j <= mother2; j++) {	// set mother-daughter relations
-			if (!genParticles.at(j)->end_vertex())
-				current_vtx->add_particle_in(genParticles.at(j));
+			for(unsigned int j = mother1; j <= mother2; j++) // set mother-daughter relations
+				if (!genParticles.at(j)->end_vertex())
+					current_vtx->add_particle_in(genParticles.at(j));
 
 			// connect THIS outgoing particle to current vertex
 			current_vtx->add_particle_out(genParticles.at(i));


### PR DESCRIPTION
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/GeneratorInterface/LHEInterface/src/LHEEvent.cc: In member function 'std::auto_ptr<HepMC::Ge
nEvent> lhef::LHEEvent::asHepMCEvent() const':
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/GeneratorInterface/LHEInterface/src/LHEEvent.cc:309:3: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
   for(unsigned int j = mother1; j <= mother2; j++) // set mother-daughter relations
   ^~~
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/GeneratorInterface/LHEInterface/src/LHEEvent.cc:314:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
    current_vtx->add_particle_out(genParticles.at(i));
    ^~~~~~~~~~~
