### PR TITLE
DQMServices/Core : gcc 6.0 misleading-indentation warning flags potential bug; with formatting fix ???

### DIFF
--- a/DQMServices/Core/src/DQMNet.cc
+++ b/DQMServices/Core/src/DQMNet.cc
@@ -205,11 +205,16 @@ DQMNet::unpackQualityData(QReports &qr, uint32_t &flags, const char *from)
   while (*qdata)
   {
     ++nqv;
-    while (*qdata) ++qdata; ++qdata;
-    while (*qdata) ++qdata; ++qdata;
-    while (*qdata) ++qdata; ++qdata;
-    while (*qdata) ++qdata; ++qdata;
-    while (*qdata) ++qdata; ++qdata;
+    while (*qdata) ++qdata; 
+    ++qdata;
+    while (*qdata) ++qdata; 
+    ++qdata;
+    while (*qdata) ++qdata; 
+    ++qdata;
+    while (*qdata) ++qdata; 
+    ++qdata;
+    while (*qdata) ++qdata; 
+    ++qdata;
   }
 
   // Now extract the qreports.

--- a/DQMServices/Core/src/QTest.cc
+++ b/DQMServices/Core/src/QTest.cc
@@ -857,7 +857,7 @@ double NoisyChannel::getAverage(int bin, const TH1 *h) const
       bin_low = ncx + bin_low;
     while (bin_hi > ncx) // shift bin by -ncx
       bin_hi = bin_hi - ncx;
-      sum += h->GetBinContent(bin_low) + h->GetBinContent(bin_hi);
+    sum += h->GetBinContent(bin_low) + h->GetBinContent(bin_hi);
   }
   /// average is sum over the # of bins used
   return sum/(numNeighbors_ * 2);
@@ -1216,11 +1216,11 @@ float MeanWithinExpected::runTest(const MonitorElement *me )
       return 0;
     }
   }
-  else 
+  else {
     if (verbose_>0) 
       std::cout << "QTest:MeanWithinExpected"
                 << " Error, neither Range, nor Sigma, nor RMS, exiting\n";
-    return -1; 
+    return -1; }
 }
 
 void MeanWithinExpected::useRange(double xmin, double xmax)


### PR DESCRIPTION
I don't know what lines 208-212 of DWMNet.cc are supposed to be doing so I just added line breaks.
