### PR TITLE
Fireworks : Fixes for bugs flagged by gcc 6.0 misleading-indentation warning.

### DIFF
--- a/Fireworks/Core/src/FWGeoTopNode.cc
+++ b/Fireworks/Core/src/FWGeoTopNode.cc
@@ -186,11 +186,9 @@ bool FWGeoTopNode::selectPhysicalFromTable( int tableIndex)
       // printf("selectPhysicalFromTable found physical \n");
       return true;
    }
-   else if ( tableManager()->refEntries().at(tableIndex).testBit(FWGeometryTableManagerBase::kVisNodeSelf));
-   {
+   else if ( tableManager()->refEntries().at(tableIndex).testBit(FWGeometryTableManagerBase::kVisNodeSelf))
       fwLog(fwlog::kInfo) << "Selected entry not drawn in GL viewer. \n" ;
-      return false;
-   }
+   return false;
 }
 
 //______________________________________________________________________________

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -232,7 +232,7 @@ namespace {
 TString boxset_tooltip_callback(TEveDigitSet* ds, Int_t idx)
 {
    void* ud = ds->GetUserData(idx);
-   if (ud);
+   if (ud)
    {
       reco::PFRecHit* hit = (reco::PFRecHit*) ud;
       // printf("idx %d %p hit data %p\n", idx, (void*)hit, ud);
@@ -241,6 +241,7 @@ TString boxset_tooltip_callback(TEveDigitSet* ds, Int_t idx)
       else
          return "ERROR";
    }
+   return "NULL";
 }
 }
 //______________________________________________________________________________


### PR DESCRIPTION
Putting the semicolon after the if statement means the block in curly braces is always executed. I believe the author was trying to fix a return-type compilation error.
