### PR TITLE
TrackingTools/Products fix for bug flagged by gcc 6.0 misleading-indentation warning

### DIFF
--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -33,7 +33,7 @@ StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iReco
 
   PropagationDirection dir = alongMomentum;
 
-  if (pdir == "oppositeToMomentum, alongMomentum, anyDirection")
+//  if (pdir == "oppositeToMomentum, alongMomentum, anyDirection")
     if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
     if (pdir == "alongMomentum") dir = alongMomentum;
     if (pdir == "anyDirection") dir = anyDirection;

--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -33,10 +33,8 @@ StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iReco
 
   PropagationDirection dir = alongMomentum;
 
-//  if (pdir == "oppositeToMomentum, alongMomentum, anyDirection")
-    if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
-    if (pdir == "alongMomentum") dir = alongMomentum;
-    if (pdir == "anyDirection") dir = anyDirection;
+  if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
+  else if (pdir == "anyDirection") dir = anyDirection;
   _propagator = std::make_shared<StraightLinePropagator>(&(*magfield),dir);
   return _propagator;
 }


### PR DESCRIPTION
The text cannot be equal to the full string and the partial string.
