### PR TITLE
SimCalorimetry/EcalTrigPrimProducers fix for bug flagged by gcc 6.0 misleading-indentation warning

### DIFF
--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -709,9 +709,10 @@ void EcalTrigPrimESProducer::parseTextFile()
 	}
       }
       
-      if(flagPrint_)
+      if(flagPrint_) {
         std::cout<<std::endl ;
         std::cout<<std::endl ;
+      }
 	
       mapLut_[id] = param ;
     }


### PR DESCRIPTION
Added curly braces as I think author intended.
