### PR TITLE
Site Local Config Memory Leak Fix

### DIFF
--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Concurrency"/>
 <use   name="FWCore/Framework"/>
+<use   name="Utilities/Xerces"/>
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="roothistmatrix"/>

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -27,7 +27,9 @@ using namespace xercesc;
 
 namespace {
   inline std::string _toString(XMLCh const* toTranscode) {
-      std::string tmp(XMLString::transcode(toTranscode));
+      char* localForm = XMLString::transcode(toTranscode);
+      std::string tmp(localForm);
+      XMLString::release(&localForm);
       return tmp;
   }
 
@@ -50,11 +52,6 @@ namespace {
      double returnValue;
      iss >> returnValue;
      return returnValue;
-  }
-
-  inline XMLCh*  _toDOMS(std::string temp) {
-      XMLCh* buff = XMLString::transcode(temp.c_str());
-      return  buff;
   }
 
   // concatenate all the XML node attribute/value pairs into a
@@ -134,8 +131,31 @@ namespace edm {
           m_statisticsDestination(),
           m_statisticsAddrInfo(nullptr),
           m_statisticsInfoAvail(false),
-          m_siteName() {
-
+          m_siteName()
+    {  
+        m_str_site = XMLString::transcode("site");
+	m_str_name = XMLString::transcode("name");
+	m_str_event_data = XMLString::transcode("event-data");
+	m_str_catalog = XMLString::transcode("catalog");
+	m_str_url = XMLString::transcode("url");
+	m_str_rfiotype = XMLString::transcode("rfiotype");
+	m_str_value = XMLString::transcode("value");
+	m_str_calib_data = XMLString::transcode("calib-data");
+	m_str_frontier_connect = XMLString::transcode("frontier-connect");
+	m_str_source_config = XMLString::transcode("source-config");
+	m_str_cache_temp_dir = XMLString::transcode("cache-temp-dir");
+	m_str_cache_min_free = XMLString::transcode("cache-min-free");
+	m_str_cache_hint = XMLString::transcode("cache-hint");
+	m_str_clone_cache_hint = XMLString::transcode("clone-cache-hint");
+	m_str_read_hint = XMLString::transcode("read-hint");
+	m_str_ttree_cache_size = XMLString::transcode("ttree-cache-size");
+	m_str_timeout_in_seconds = XMLString::transcode("timeout-in-seconds");
+	m_str_statistics_destination = XMLString::transcode("statistics-destination");
+	m_str_endpoint = XMLString::transcode("endpoint");
+	m_str_info = XMLString::transcode("info");
+	m_str_prefetching = XMLString::transcode("prefetching");
+	m_str_native_protocols = XMLString::transcode("native-protocols");
+    
         char* tmp = getenv("CMS_PATH");
 
         if (tmp) {
@@ -176,6 +196,28 @@ namespace edm {
         freeaddrinfo(m_statisticsAddrInfo);
         m_statisticsAddrInfo = nullptr;
       }
+      XMLString::release(&m_str_site);
+      XMLString::release(&m_str_name);
+      XMLString::release(&m_str_event_data);
+      XMLString::release(&m_str_catalog);
+      XMLString::release(&m_str_url);
+      XMLString::release(&m_str_rfiotype);
+      XMLString::release(&m_str_value);
+      XMLString::release(&m_str_calib_data);
+      XMLString::release(&m_str_frontier_connect);
+      XMLString::release(&m_str_source_config);
+      XMLString::release(&m_str_cache_temp_dir);
+      XMLString::release(&m_str_cache_min_free);
+      XMLString::release(&m_str_cache_hint);
+      XMLString::release(&m_str_clone_cache_hint);
+      XMLString::release(&m_str_read_hint);
+      XMLString::release(&m_str_ttree_cache_size);
+      XMLString::release(&m_str_timeout_in_seconds);
+      XMLString::release(&m_str_statistics_destination);
+      XMLString::release(&m_str_endpoint);
+      XMLString::release(&m_str_info);
+      XMLString::release(&m_str_prefetching);
+      XMLString::release(&m_str_native_protocols);
     }
 
     std::string const
@@ -390,48 +432,48 @@ namespace edm {
 
         // FIXME: should probably use the parser for validating the XML.
 
-        DOMNodeList *sites = doc->getElementsByTagName(_toDOMS("site"));
+        DOMNodeList *sites = doc->getElementsByTagName(m_str_site);
         XMLSize_t numSites = sites->getLength();
         for (XMLSize_t i = 0; i < numSites; ++i) {
           DOMElement *site = static_cast<DOMElement *>(sites->item(i));
 
           // Parse the site name
-          m_siteName = _toString(site->getAttribute(_toDOMS("name")));
+          m_siteName = _toString(site->getAttribute(m_str_name));
 
           // Parsing of the event data section
           {
-            DOMNodeList *eventDataList = site->getElementsByTagName(_toDOMS("event-data"));
+            DOMNodeList *eventDataList = site->getElementsByTagName(m_str_event_data);
             if (eventDataList->getLength() > 0) {
               DOMElement *eventData = static_cast<DOMElement *>(eventDataList->item(0));
 
-              DOMNodeList *catalogs = eventData->getElementsByTagName(_toDOMS("catalog"));
+              DOMNodeList *catalogs = eventData->getElementsByTagName(m_str_catalog);
 
               if (catalogs->getLength() > 0) {
                 DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(0));
-                m_dataCatalog = _toString(catalog->getAttribute(_toDOMS("url")));
+                m_dataCatalog = _toString(catalog->getAttribute(m_str_url));
               }
 
               if (catalogs->getLength() > 1) {
                 DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(1));
-                m_fallbackDataCatalog = _toString(catalog->getAttribute(_toDOMS("url")));
+                m_fallbackDataCatalog = _toString(catalog->getAttribute(m_str_url));
               }
 
-              DOMNodeList* rfiotypes = eventData->getElementsByTagName(_toDOMS("rfiotype"));
+              DOMNodeList* rfiotypes = eventData->getElementsByTagName(m_str_rfiotype);
 
               if (rfiotypes->getLength() > 0) {
                 DOMElement* rfiotype = static_cast<DOMElement *>(rfiotypes->item(0));
-                m_rfioType = _toString(rfiotype->getAttribute(_toDOMS("value")));
+                m_rfioType = _toString(rfiotype->getAttribute(m_str_value));
               }
             }
           }
 
           // Parsing of the calib-data section
           {
-            DOMNodeList *calibDataList = site->getElementsByTagName(_toDOMS("calib-data"));
+            DOMNodeList *calibDataList = site->getElementsByTagName(m_str_calib_data);
 
             if (calibDataList->getLength() > 0) {
               DOMElement *calibData = static_cast<DOMElement *>(calibDataList->item(0));
-              DOMNodeList *frontierConnectList = calibData->getElementsByTagName(_toDOMS("frontier-connect"));
+              DOMNodeList *frontierConnectList = calibData->getElementsByTagName(m_str_frontier_connect);
 
               if (frontierConnectList->getLength() > 0) {
                 DOMElement *frontierConnect = static_cast<DOMElement *>(frontierConnectList->item(0));
@@ -441,94 +483,94 @@ namespace edm {
           }
           // Parsing of the source config section
           {
-            DOMNodeList *sourceConfigList = site->getElementsByTagName(_toDOMS("source-config"));
+            DOMNodeList *sourceConfigList = site->getElementsByTagName(m_str_source_config);
 
             if (sourceConfigList->getLength() > 0) {
               DOMElement *sourceConfig = static_cast<DOMElement *>(sourceConfigList->item(0));
-              DOMNodeList *cacheTempDirList = sourceConfig->getElementsByTagName(_toDOMS("cache-temp-dir"));
+              DOMNodeList *cacheTempDirList = sourceConfig->getElementsByTagName(m_str_cache_temp_dir);
 
               if (cacheTempDirList->getLength() > 0) {
                 DOMElement *cacheTempDir = static_cast<DOMElement *>(cacheTempDirList->item(0));
-                m_cacheTempDir = _toString(cacheTempDir->getAttribute(_toDOMS("name")));
+                m_cacheTempDir = _toString(cacheTempDir->getAttribute(m_str_name));
                 m_cacheTempDirPtr = &m_cacheTempDir;
               }
 
-              DOMNodeList *cacheMinFreeList = sourceConfig->getElementsByTagName(_toDOMS("cache-min-free"));
+              DOMNodeList *cacheMinFreeList = sourceConfig->getElementsByTagName(m_str_cache_min_free);
 
               if (cacheMinFreeList->getLength() > 0) {
                 DOMElement *cacheMinFree = static_cast<DOMElement *>(cacheMinFreeList->item(0));
-                m_cacheMinFree = _toDouble(cacheMinFree->getAttribute(_toDOMS("value")));
+                m_cacheMinFree = _toDouble(cacheMinFree->getAttribute(m_str_value));
                 m_cacheMinFreePtr = &m_cacheMinFree;
               }
 
-              DOMNodeList *cacheHintList = sourceConfig->getElementsByTagName(_toDOMS("cache-hint"));
+              DOMNodeList *cacheHintList = sourceConfig->getElementsByTagName(m_str_cache_hint);
 
               if (cacheHintList->getLength() > 0) {
                 DOMElement *cacheHint = static_cast<DOMElement *>(cacheHintList->item(0));
-                m_cacheHint = _toString(cacheHint->getAttribute(_toDOMS("value")));
+                m_cacheHint = _toString(cacheHint->getAttribute(m_str_value));
                 m_cacheHintPtr = &m_cacheHint;
               }
 
-              DOMNodeList *cloneCacheHintList = sourceConfig->getElementsByTagName(_toDOMS("clone-cache-hint"));
+              DOMNodeList *cloneCacheHintList = sourceConfig->getElementsByTagName(m_str_clone_cache_hint);
 
               if (cloneCacheHintList->getLength() > 0) {
                 DOMElement *cloneCacheHint = static_cast<DOMElement *>(cloneCacheHintList->item(0));
-                m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(_toDOMS("value")));
+                m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(m_str_value));
                 m_cloneCacheHintPtr = &m_cloneCacheHint;
               }
 
-              DOMNodeList *readHintList = sourceConfig->getElementsByTagName(_toDOMS("read-hint"));
+              DOMNodeList *readHintList = sourceConfig->getElementsByTagName(m_str_read_hint);
 
               if (readHintList->getLength() > 0) {
                 DOMElement *readHint = static_cast<DOMElement *>(readHintList->item(0));
-                m_readHint = _toString(readHint->getAttribute(_toDOMS("value")));
+                m_readHint = _toString(readHint->getAttribute(m_str_value));
                 m_readHintPtr = &m_readHint;
               }
 
-              DOMNodeList *ttreeCacheSizeList = sourceConfig->getElementsByTagName(_toDOMS("ttree-cache-size"));
+              DOMNodeList *ttreeCacheSizeList = sourceConfig->getElementsByTagName(m_str_ttree_cache_size);
 
               if (ttreeCacheSizeList->getLength() > 0) {
                 DOMElement *ttreeCacheSize = static_cast<DOMElement *>(ttreeCacheSizeList->item(0));
-                m_ttreeCacheSize = _toUInt(ttreeCacheSize->getAttribute(_toDOMS("value")));
+                m_ttreeCacheSize = _toUInt(ttreeCacheSize->getAttribute(m_str_value));
                 m_ttreeCacheSizePtr = &m_ttreeCacheSize;
               }
 
-              DOMNodeList *timeoutList = sourceConfig->getElementsByTagName(_toDOMS("timeout-in-seconds"));
+              DOMNodeList *timeoutList = sourceConfig->getElementsByTagName(m_str_timeout_in_seconds);
 
               if (timeoutList->getLength() > 0) {
                 DOMElement *timeout = static_cast<DOMElement *>(timeoutList->item(0));
-                m_timeout = _toUInt(timeout->getAttribute(_toDOMS("value")));
+                m_timeout = _toUInt(timeout->getAttribute(m_str_value));
                 m_timeoutPtr = &m_timeout;
               }
 
-              DOMNodeList *statsDestList = sourceConfig->getElementsByTagName(_toDOMS("statistics-destination"));
+              DOMNodeList *statsDestList = sourceConfig->getElementsByTagName(m_str_statistics_destination);
 
               if (statsDestList->getLength() > 0) {
                 DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
-                m_statisticsDestination = _toString(statsDest->getAttribute(_toDOMS("endpoint")));
+                m_statisticsDestination = _toString(statsDest->getAttribute(m_str_endpoint));
                 if (!m_statisticsDestination.size()) {
-                  m_statisticsDestination = _toString(statsDest->getAttribute(_toDOMS("name")));
+                  m_statisticsDestination = _toString(statsDest->getAttribute(m_str_name));
                 }
-                std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(_toDOMS("info")));
+                std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(m_str_info));
                 boost::split(m_statisticsInfo, tmpStatisticsInfo, boost::is_any_of("\t ,"));
                 m_statisticsInfoAvail = !tmpStatisticsInfo.empty();
               }
 
-              DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(_toDOMS("prefetching"));
+              DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(m_str_prefetching);
 
               if (prefetchingList->getLength() > 0) {
                 DOMElement *prefetching = static_cast<DOMElement *>(prefetchingList->item(0));
-                m_enablePrefetching = _toBool(prefetching->getAttribute(_toDOMS("value")));
+                m_enablePrefetching = _toBool(prefetching->getAttribute(m_str_value));
                 m_enablePrefetchingPtr = &m_enablePrefetching;
               }
 
-              DOMNodeList *nativeProtocolsList = sourceConfig->getElementsByTagName(_toDOMS("native-protocols"));
+              DOMNodeList *nativeProtocolsList = sourceConfig->getElementsByTagName(m_str_native_protocols);
 
               if (nativeProtocolsList->getLength() > 0) {
                 DOMElement *nativeProtocol = static_cast<DOMElement *>(nativeProtocolsList->item(0));
                 DOMNodeList *childList = nativeProtocol->getChildNodes();
 
-                XMLCh* prefixXMLCh = _toDOMS("prefix");
+                XMLCh* prefixXMLCh = XMLString::transcode("prefix");
                 XMLSize_t numNodes = childList->getLength();
                 for (XMLSize_t i = 0; i < numNodes; ++i) {
                   DOMNode *childNode = childList->item(i);
@@ -538,6 +580,7 @@ namespace edm {
                   DOMElement *child = static_cast<DOMElement *>(childNode);
                   m_nativeProtocols.push_back(_toString(child->getAttribute(prefixXMLCh)));
                 }
+		XMLString::release(&prefixXMLCh);
                 m_nativeProtocolsPtr = &m_nativeProtocols;
               }
             }

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -26,14 +26,17 @@ using namespace xercesc;
 //<<<<<< MEMBER FUNCTION DEFINITIONS                                    >>>>>>
 
 namespace {
+  
+  inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
+  inline void dispose(char* ptr)  { XMLString::release(&ptr); }
 
   template< class CharType >
   class ZStr      // Zero-terminated string.
   {
   public:
-    ZStr(CharType const* str, void (*deleter)(CharType*))
-      : m_array(const_cast<CharType*>(str), deleter)
-    { assert(deleter != 0); }
+    ZStr(CharType const* str)
+      : m_array(const_cast<CharType*>(str), &dispose)
+    {}
     
     CharType const* ptr() const { return m_array.get(); }
 
@@ -41,17 +44,14 @@ namespace {
     std::unique_ptr< CharType, void (*)(CharType*) > m_array;
   };
   
-  inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
-  inline void dispose(char* ptr)  { XMLString::release(&ptr); }
-
   inline ZStr<XMLCh> uStr(char const* str)
   {
-    return ZStr<XMLCh>(XMLString::transcode(str), &dispose);
+    return ZStr<XMLCh>(XMLString::transcode(str));
   }
  
   inline ZStr<char> cStr(XMLCh const* str)
   {
-    return ZStr<char>(XMLString::transcode(str), &dispose);
+    return ZStr<char>(XMLString::transcode(str));
   }
   
   inline std::string _toString(XMLCh const* toTranscode) {

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -8,12 +8,13 @@
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include "FWCore/Concurrency/interface/Xerces.h"
-#include <xercesc/util/XMLString.hpp>
+#include "Utilities/Xerces/interface/XercesStrUtils.h"
 #include <sstream>
 #include <memory>
 #include <boost/algorithm/string.hpp>
 
 using namespace xercesc;
+using namespace cms::utils;
 
 //<<<<<< PRIVATE DEFINES                                                >>>>>>
 //<<<<<< PRIVATE CONSTANTS                                              >>>>>>
@@ -27,58 +28,6 @@ using namespace xercesc;
 
 namespace {
   
-  inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
-  inline void dispose(char* ptr)  { XMLString::release(&ptr); }
-
-  template< class CharType >
-  class ZStr      // Zero-terminated string.
-  {
-  public:
-    ZStr(CharType const* str)
-      : m_array(const_cast<CharType*>(str), &dispose)
-    {}
-    
-    CharType const* ptr() const { return m_array.get(); }
-
-  private:
-    std::unique_ptr< CharType, void (*)(CharType*) > m_array;
-  };
-  
-  inline ZStr<XMLCh> uStr(char const* str)
-  {
-    return ZStr<XMLCh>(XMLString::transcode(str));
-  }
- 
-  inline ZStr<char> cStr(XMLCh const* str)
-  {
-    return ZStr<char>(XMLString::transcode(str));
-  }
-  
-  inline std::string _toString(XMLCh const* toTranscode) {
-    return std::string(cStr(toTranscode).ptr());
-  }
-
-  inline unsigned int _toUInt(XMLCh const* toTranscode) {
-     std::istringstream iss(_toString(toTranscode));
-     unsigned int returnValue;
-     iss >> returnValue;
-     return returnValue;
-  }
-
-  inline bool _toBool(XMLCh const* toTranscode) {
-    std::string value = _toString(toTranscode);
-    if ((value == "true") || (value == "1"))
-      return true;
-    return false;
-  }
-
-  inline double _toDouble(XMLCh const* toTranscode) {
-     std::istringstream iss(_toString(toTranscode));
-     double returnValue;
-     iss >> returnValue;
-     return returnValue;
-  }
-
   // concatenate all the XML node attribute/value pairs into a
   // paren-separated string (for use by CORAL and frontier_client)
   inline std::string _toParenString(DOMNode const& nodeToConvert) {
@@ -103,9 +52,9 @@ namespace {
             }
             DOMAttr *attribute = static_cast<DOMAttr *>(attributeNode);
 
-            oss << "(" << _toString(child->getTagName()) <<
-                          _toString(attribute->getName()) << "=" <<
-                          _toString(attribute->getValue()) << ")";
+            oss << "(" << toString(child->getTagName()) <<
+                          toString(attribute->getName()) << "=" <<
+                          toString(attribute->getValue()) << ")";
         }
       }
       return oss.str();
@@ -419,7 +368,7 @@ namespace edm {
 	    DOMElement *site = static_cast<DOMElement *>(sites->item(i));
 	    
 	    // Parse the site name
-	    m_siteName = _toString(site->getAttribute(uStr("name").ptr()));
+	    m_siteName = toString(site->getAttribute(uStr("name").ptr()));
 	    
 	    // Parsing of the event data section
 	    {
@@ -431,19 +380,19 @@ namespace edm {
 		
 		if (catalogs->getLength() > 0) {
 		  DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(0));
-		  m_dataCatalog = _toString(catalog->getAttribute(uStr("url").ptr()));
+		  m_dataCatalog = toString(catalog->getAttribute(uStr("url").ptr()));
 		}
 		
 		if (catalogs->getLength() > 1) {
 		  DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(1));
-		  m_fallbackDataCatalog = _toString(catalog->getAttribute(uStr("url").ptr()));
+		  m_fallbackDataCatalog = toString(catalog->getAttribute(uStr("url").ptr()));
 		}
 		
 		DOMNodeList* rfiotypes = eventData->getElementsByTagName(uStr("rfiotype").ptr());
 		
 		if (rfiotypes->getLength() > 0) {
 		  DOMElement* rfiotype = static_cast<DOMElement *>(rfiotypes->item(0));
-		  m_rfioType = _toString(rfiotype->getAttribute(uStr("value").ptr()));
+		  m_rfioType = toString(rfiotype->getAttribute(uStr("value").ptr()));
 		}
 	      }
 	    }
@@ -472,7 +421,7 @@ namespace edm {
 		
 		if (cacheTempDirList->getLength() > 0) {
 		  DOMElement *cacheTempDir = static_cast<DOMElement *>(cacheTempDirList->item(0));
-		  m_cacheTempDir = _toString(cacheTempDir->getAttribute(uStr("name").ptr()));
+		  m_cacheTempDir = toString(cacheTempDir->getAttribute(uStr("name").ptr()));
 		  m_cacheTempDirPtr = &m_cacheTempDir;
 		}
 		
@@ -480,7 +429,7 @@ namespace edm {
 		
 		if (cacheMinFreeList->getLength() > 0) {
 		  DOMElement *cacheMinFree = static_cast<DOMElement *>(cacheMinFreeList->item(0));
-		  m_cacheMinFree = _toDouble(cacheMinFree->getAttribute(uStr("value").ptr()));
+		  m_cacheMinFree = toDouble(cacheMinFree->getAttribute(uStr("value").ptr()));
 		  m_cacheMinFreePtr = &m_cacheMinFree;
 		}
 		
@@ -488,7 +437,7 @@ namespace edm {
 		
 		if (cacheHintList->getLength() > 0) {
 		  DOMElement *cacheHint = static_cast<DOMElement *>(cacheHintList->item(0));
-		  m_cacheHint = _toString(cacheHint->getAttribute(uStr("value").ptr()));
+		  m_cacheHint = toString(cacheHint->getAttribute(uStr("value").ptr()));
 		  m_cacheHintPtr = &m_cacheHint;
 		}
 		
@@ -496,7 +445,7 @@ namespace edm {
 		
 		if (cloneCacheHintList->getLength() > 0) {
 		  DOMElement *cloneCacheHint = static_cast<DOMElement *>(cloneCacheHintList->item(0));
-		  m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(uStr("value").ptr()));
+		  m_cloneCacheHint = toString(cloneCacheHint->getAttribute(uStr("value").ptr()));
 		  m_cloneCacheHintPtr = &m_cloneCacheHint;
 		}
 		
@@ -504,7 +453,7 @@ namespace edm {
 		
 		if (readHintList->getLength() > 0) {
 		  DOMElement *readHint = static_cast<DOMElement *>(readHintList->item(0));
-		  m_readHint = _toString(readHint->getAttribute(uStr("value").ptr()));
+		  m_readHint = toString(readHint->getAttribute(uStr("value").ptr()));
 		  m_readHintPtr = &m_readHint;
 		}
 		
@@ -512,7 +461,7 @@ namespace edm {
 		
 		if (ttreeCacheSizeList->getLength() > 0) {
 		  DOMElement *ttreeCacheSize = static_cast<DOMElement *>(ttreeCacheSizeList->item(0));
-		  m_ttreeCacheSize = _toUInt(ttreeCacheSize->getAttribute(uStr("value").ptr()));
+		  m_ttreeCacheSize = toUInt(ttreeCacheSize->getAttribute(uStr("value").ptr()));
 		  m_ttreeCacheSizePtr = &m_ttreeCacheSize;
 		}
 		
@@ -520,7 +469,7 @@ namespace edm {
 		
 		if (timeoutList->getLength() > 0) {
 		  DOMElement *timeout = static_cast<DOMElement *>(timeoutList->item(0));
-		  m_timeout = _toUInt(timeout->getAttribute(uStr("value").ptr()));
+		  m_timeout = toUInt(timeout->getAttribute(uStr("value").ptr()));
 		  m_timeoutPtr = &m_timeout;
 		}
 		
@@ -528,11 +477,11 @@ namespace edm {
 		
 		if (statsDestList->getLength() > 0) {
 		  DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
-		  m_statisticsDestination = _toString(statsDest->getAttribute(uStr("endpoint").ptr()));
+		  m_statisticsDestination = toString(statsDest->getAttribute(uStr("endpoint").ptr()));
 		  if (!m_statisticsDestination.size()) {
-		    m_statisticsDestination = _toString(statsDest->getAttribute(uStr("name").ptr()));
+		    m_statisticsDestination = toString(statsDest->getAttribute(uStr("name").ptr()));
 		  }
-		  std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(uStr("info").ptr()));
+		  std::string tmpStatisticsInfo = toString(statsDest->getAttribute(uStr("info").ptr()));
 		  boost::split(m_statisticsInfo, tmpStatisticsInfo, boost::is_any_of("\t ,"));
 		  m_statisticsInfoAvail = !tmpStatisticsInfo.empty();
 		}
@@ -541,7 +490,7 @@ namespace edm {
 		
 		if (prefetchingList->getLength() > 0) {
 		  DOMElement *prefetching = static_cast<DOMElement *>(prefetchingList->item(0));
-		  m_enablePrefetching = _toBool(prefetching->getAttribute(uStr("value").ptr()));
+		  m_enablePrefetching = toBool(prefetching->getAttribute(uStr("value").ptr()));
 		  m_enablePrefetchingPtr = &m_enablePrefetching;
 		}
 		
@@ -558,7 +507,7 @@ namespace edm {
 		      continue;
 		    }
 		    DOMElement *child = static_cast<DOMElement *>(childNode);
-		    m_nativeProtocols.push_back(_toString(child->getAttribute(uStr("prefix").ptr())));
+		    m_nativeProtocols.push_back(toString(child->getAttribute(uStr("prefix").ptr())));
 		  }
 		  m_nativeProtocolsPtr = &m_nativeProtocols;
 		}

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -132,30 +132,7 @@ namespace edm {
           m_statisticsAddrInfo(nullptr),
           m_statisticsInfoAvail(false),
           m_siteName()
-    {  
-        m_str_site = XMLString::transcode("site");
-	m_str_name = XMLString::transcode("name");
-	m_str_event_data = XMLString::transcode("event-data");
-	m_str_catalog = XMLString::transcode("catalog");
-	m_str_url = XMLString::transcode("url");
-	m_str_rfiotype = XMLString::transcode("rfiotype");
-	m_str_value = XMLString::transcode("value");
-	m_str_calib_data = XMLString::transcode("calib-data");
-	m_str_frontier_connect = XMLString::transcode("frontier-connect");
-	m_str_source_config = XMLString::transcode("source-config");
-	m_str_cache_temp_dir = XMLString::transcode("cache-temp-dir");
-	m_str_cache_min_free = XMLString::transcode("cache-min-free");
-	m_str_cache_hint = XMLString::transcode("cache-hint");
-	m_str_clone_cache_hint = XMLString::transcode("clone-cache-hint");
-	m_str_read_hint = XMLString::transcode("read-hint");
-	m_str_ttree_cache_size = XMLString::transcode("ttree-cache-size");
-	m_str_timeout_in_seconds = XMLString::transcode("timeout-in-seconds");
-	m_str_statistics_destination = XMLString::transcode("statistics-destination");
-	m_str_endpoint = XMLString::transcode("endpoint");
-	m_str_info = XMLString::transcode("info");
-	m_str_prefetching = XMLString::transcode("prefetching");
-	m_str_native_protocols = XMLString::transcode("native-protocols");
-    
+    {
         char* tmp = getenv("CMS_PATH");
 
         if (tmp) {
@@ -196,28 +173,6 @@ namespace edm {
         freeaddrinfo(m_statisticsAddrInfo);
         m_statisticsAddrInfo = nullptr;
       }
-      XMLString::release(&m_str_site);
-      XMLString::release(&m_str_name);
-      XMLString::release(&m_str_event_data);
-      XMLString::release(&m_str_catalog);
-      XMLString::release(&m_str_url);
-      XMLString::release(&m_str_rfiotype);
-      XMLString::release(&m_str_value);
-      XMLString::release(&m_str_calib_data);
-      XMLString::release(&m_str_frontier_connect);
-      XMLString::release(&m_str_source_config);
-      XMLString::release(&m_str_cache_temp_dir);
-      XMLString::release(&m_str_cache_min_free);
-      XMLString::release(&m_str_cache_hint);
-      XMLString::release(&m_str_clone_cache_hint);
-      XMLString::release(&m_str_read_hint);
-      XMLString::release(&m_str_ttree_cache_size);
-      XMLString::release(&m_str_timeout_in_seconds);
-      XMLString::release(&m_str_statistics_destination);
-      XMLString::release(&m_str_endpoint);
-      XMLString::release(&m_str_info);
-      XMLString::release(&m_str_prefetching);
-      XMLString::release(&m_str_native_protocols);
     }
 
     std::string const
@@ -393,6 +348,30 @@ namespace edm {
     void
     SiteLocalConfigService::parse(std::string const& url) {
       cms::concurrency::xercesInitialize();
+      {
+	XMLCh *str_site = XMLString::transcode("site");
+	XMLCh *str_name = XMLString::transcode("name");
+	XMLCh *str_event_data = XMLString::transcode("event-data");
+	XMLCh *str_catalog = XMLString::transcode("catalog");
+	XMLCh *str_url = XMLString::transcode("url");
+	XMLCh *str_rfiotype = XMLString::transcode("rfiotype");
+	XMLCh *str_value = XMLString::transcode("value");
+	XMLCh *str_calib_data = XMLString::transcode("calib-data");
+	XMLCh *str_frontier_connect = XMLString::transcode("frontier-connect");
+	XMLCh *str_source_config = XMLString::transcode("source-config");
+	XMLCh *str_cache_temp_dir = XMLString::transcode("cache-temp-dir");
+	XMLCh *str_cache_min_free = XMLString::transcode("cache-min-free");
+	XMLCh *str_cache_hint = XMLString::transcode("cache-hint");
+	XMLCh *str_clone_cache_hint = XMLString::transcode("clone-cache-hint");
+	XMLCh *str_read_hint = XMLString::transcode("read-hint");
+	XMLCh *str_ttree_cache_size = XMLString::transcode("ttree-cache-size");
+	XMLCh *str_timeout_in_seconds = XMLString::transcode("timeout-in-seconds");
+	XMLCh *str_statistics_destination = XMLString::transcode("statistics-destination");
+	XMLCh *str_endpoint = XMLString::transcode("endpoint");
+	XMLCh *str_info = XMLString::transcode("info");
+	XMLCh *str_prefetching = XMLString::transcode("prefetching");
+	XMLCh *str_native_protocols = XMLString::transcode("native-protocols");
+    
       auto parser = std::make_unique<XercesDOMParser>();
       try {
         parser->setValidationScheme(XercesDOMParser::Val_Auto);
@@ -432,48 +411,48 @@ namespace edm {
 
         // FIXME: should probably use the parser for validating the XML.
 
-        DOMNodeList *sites = doc->getElementsByTagName(m_str_site);
+        DOMNodeList *sites = doc->getElementsByTagName(str_site);
         XMLSize_t numSites = sites->getLength();
         for (XMLSize_t i = 0; i < numSites; ++i) {
           DOMElement *site = static_cast<DOMElement *>(sites->item(i));
 
           // Parse the site name
-          m_siteName = _toString(site->getAttribute(m_str_name));
+          m_siteName = _toString(site->getAttribute(str_name));
 
           // Parsing of the event data section
           {
-            DOMNodeList *eventDataList = site->getElementsByTagName(m_str_event_data);
+            DOMNodeList *eventDataList = site->getElementsByTagName(str_event_data);
             if (eventDataList->getLength() > 0) {
               DOMElement *eventData = static_cast<DOMElement *>(eventDataList->item(0));
 
-              DOMNodeList *catalogs = eventData->getElementsByTagName(m_str_catalog);
+              DOMNodeList *catalogs = eventData->getElementsByTagName(str_catalog);
 
               if (catalogs->getLength() > 0) {
                 DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(0));
-                m_dataCatalog = _toString(catalog->getAttribute(m_str_url));
+                m_dataCatalog = _toString(catalog->getAttribute(str_url));
               }
 
               if (catalogs->getLength() > 1) {
                 DOMElement * catalog = static_cast<DOMElement *>(catalogs->item(1));
-                m_fallbackDataCatalog = _toString(catalog->getAttribute(m_str_url));
+                m_fallbackDataCatalog = _toString(catalog->getAttribute(str_url));
               }
 
-              DOMNodeList* rfiotypes = eventData->getElementsByTagName(m_str_rfiotype);
+              DOMNodeList* rfiotypes = eventData->getElementsByTagName(str_rfiotype);
 
               if (rfiotypes->getLength() > 0) {
                 DOMElement* rfiotype = static_cast<DOMElement *>(rfiotypes->item(0));
-                m_rfioType = _toString(rfiotype->getAttribute(m_str_value));
+                m_rfioType = _toString(rfiotype->getAttribute(str_value));
               }
             }
           }
 
           // Parsing of the calib-data section
           {
-            DOMNodeList *calibDataList = site->getElementsByTagName(m_str_calib_data);
+            DOMNodeList *calibDataList = site->getElementsByTagName(str_calib_data);
 
             if (calibDataList->getLength() > 0) {
               DOMElement *calibData = static_cast<DOMElement *>(calibDataList->item(0));
-              DOMNodeList *frontierConnectList = calibData->getElementsByTagName(m_str_frontier_connect);
+              DOMNodeList *frontierConnectList = calibData->getElementsByTagName(str_frontier_connect);
 
               if (frontierConnectList->getLength() > 0) {
                 DOMElement *frontierConnect = static_cast<DOMElement *>(frontierConnectList->item(0));
@@ -483,88 +462,88 @@ namespace edm {
           }
           // Parsing of the source config section
           {
-            DOMNodeList *sourceConfigList = site->getElementsByTagName(m_str_source_config);
+            DOMNodeList *sourceConfigList = site->getElementsByTagName(str_source_config);
 
             if (sourceConfigList->getLength() > 0) {
               DOMElement *sourceConfig = static_cast<DOMElement *>(sourceConfigList->item(0));
-              DOMNodeList *cacheTempDirList = sourceConfig->getElementsByTagName(m_str_cache_temp_dir);
+              DOMNodeList *cacheTempDirList = sourceConfig->getElementsByTagName(str_cache_temp_dir);
 
               if (cacheTempDirList->getLength() > 0) {
                 DOMElement *cacheTempDir = static_cast<DOMElement *>(cacheTempDirList->item(0));
-                m_cacheTempDir = _toString(cacheTempDir->getAttribute(m_str_name));
+                m_cacheTempDir = _toString(cacheTempDir->getAttribute(str_name));
                 m_cacheTempDirPtr = &m_cacheTempDir;
               }
 
-              DOMNodeList *cacheMinFreeList = sourceConfig->getElementsByTagName(m_str_cache_min_free);
+              DOMNodeList *cacheMinFreeList = sourceConfig->getElementsByTagName(str_cache_min_free);
 
               if (cacheMinFreeList->getLength() > 0) {
                 DOMElement *cacheMinFree = static_cast<DOMElement *>(cacheMinFreeList->item(0));
-                m_cacheMinFree = _toDouble(cacheMinFree->getAttribute(m_str_value));
+                m_cacheMinFree = _toDouble(cacheMinFree->getAttribute(str_value));
                 m_cacheMinFreePtr = &m_cacheMinFree;
               }
 
-              DOMNodeList *cacheHintList = sourceConfig->getElementsByTagName(m_str_cache_hint);
+              DOMNodeList *cacheHintList = sourceConfig->getElementsByTagName(str_cache_hint);
 
               if (cacheHintList->getLength() > 0) {
                 DOMElement *cacheHint = static_cast<DOMElement *>(cacheHintList->item(0));
-                m_cacheHint = _toString(cacheHint->getAttribute(m_str_value));
+                m_cacheHint = _toString(cacheHint->getAttribute(str_value));
                 m_cacheHintPtr = &m_cacheHint;
               }
 
-              DOMNodeList *cloneCacheHintList = sourceConfig->getElementsByTagName(m_str_clone_cache_hint);
+              DOMNodeList *cloneCacheHintList = sourceConfig->getElementsByTagName(str_clone_cache_hint);
 
               if (cloneCacheHintList->getLength() > 0) {
                 DOMElement *cloneCacheHint = static_cast<DOMElement *>(cloneCacheHintList->item(0));
-                m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(m_str_value));
+                m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(str_value));
                 m_cloneCacheHintPtr = &m_cloneCacheHint;
               }
 
-              DOMNodeList *readHintList = sourceConfig->getElementsByTagName(m_str_read_hint);
+              DOMNodeList *readHintList = sourceConfig->getElementsByTagName(str_read_hint);
 
               if (readHintList->getLength() > 0) {
                 DOMElement *readHint = static_cast<DOMElement *>(readHintList->item(0));
-                m_readHint = _toString(readHint->getAttribute(m_str_value));
+                m_readHint = _toString(readHint->getAttribute(str_value));
                 m_readHintPtr = &m_readHint;
               }
 
-              DOMNodeList *ttreeCacheSizeList = sourceConfig->getElementsByTagName(m_str_ttree_cache_size);
+              DOMNodeList *ttreeCacheSizeList = sourceConfig->getElementsByTagName(str_ttree_cache_size);
 
               if (ttreeCacheSizeList->getLength() > 0) {
                 DOMElement *ttreeCacheSize = static_cast<DOMElement *>(ttreeCacheSizeList->item(0));
-                m_ttreeCacheSize = _toUInt(ttreeCacheSize->getAttribute(m_str_value));
+                m_ttreeCacheSize = _toUInt(ttreeCacheSize->getAttribute(str_value));
                 m_ttreeCacheSizePtr = &m_ttreeCacheSize;
               }
 
-              DOMNodeList *timeoutList = sourceConfig->getElementsByTagName(m_str_timeout_in_seconds);
+              DOMNodeList *timeoutList = sourceConfig->getElementsByTagName(str_timeout_in_seconds);
 
               if (timeoutList->getLength() > 0) {
                 DOMElement *timeout = static_cast<DOMElement *>(timeoutList->item(0));
-                m_timeout = _toUInt(timeout->getAttribute(m_str_value));
+                m_timeout = _toUInt(timeout->getAttribute(str_value));
                 m_timeoutPtr = &m_timeout;
               }
 
-              DOMNodeList *statsDestList = sourceConfig->getElementsByTagName(m_str_statistics_destination);
+              DOMNodeList *statsDestList = sourceConfig->getElementsByTagName(str_statistics_destination);
 
               if (statsDestList->getLength() > 0) {
                 DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
-                m_statisticsDestination = _toString(statsDest->getAttribute(m_str_endpoint));
+                m_statisticsDestination = _toString(statsDest->getAttribute(str_endpoint));
                 if (!m_statisticsDestination.size()) {
-                  m_statisticsDestination = _toString(statsDest->getAttribute(m_str_name));
+                  m_statisticsDestination = _toString(statsDest->getAttribute(str_name));
                 }
-                std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(m_str_info));
+                std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(str_info));
                 boost::split(m_statisticsInfo, tmpStatisticsInfo, boost::is_any_of("\t ,"));
                 m_statisticsInfoAvail = !tmpStatisticsInfo.empty();
               }
 
-              DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(m_str_prefetching);
+              DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(str_prefetching);
 
               if (prefetchingList->getLength() > 0) {
                 DOMElement *prefetching = static_cast<DOMElement *>(prefetchingList->item(0));
-                m_enablePrefetching = _toBool(prefetching->getAttribute(m_str_value));
+                m_enablePrefetching = _toBool(prefetching->getAttribute(str_value));
                 m_enablePrefetchingPtr = &m_enablePrefetching;
               }
 
-              DOMNodeList *nativeProtocolsList = sourceConfig->getElementsByTagName(m_str_native_protocols);
+              DOMNodeList *nativeProtocolsList = sourceConfig->getElementsByTagName(str_native_protocols);
 
               if (nativeProtocolsList->getLength() > 0) {
                 DOMElement *nativeProtocol = static_cast<DOMElement *>(nativeProtocolsList->item(0));
@@ -590,6 +569,32 @@ namespace edm {
       }
       catch (xercesc::DOMException const& e) {
       }
+        XMLString::release(&str_site);
+	XMLString::release(&str_name);
+	XMLString::release(&str_event_data);
+	XMLString::release(&str_catalog);
+	XMLString::release(&str_url);
+	XMLString::release(&str_rfiotype);
+	XMLString::release(&str_value);
+	XMLString::release(&str_calib_data);
+	XMLString::release(&str_frontier_connect);
+	XMLString::release(&str_source_config);
+	XMLString::release(&str_cache_temp_dir);
+	XMLString::release(&str_cache_min_free);
+	XMLString::release(&str_cache_hint);
+	XMLString::release(&str_clone_cache_hint);
+	XMLString::release(&str_read_hint);
+	XMLString::release(&str_ttree_cache_size);
+	XMLString::release(&str_timeout_in_seconds);
+	XMLString::release(&str_statistics_destination);
+	XMLString::release(&str_endpoint);
+	XMLString::release(&str_info);
+	XMLString::release(&str_prefetching);
+	XMLString::release(&str_native_protocols);
+      } // The extra pair of braces ensures that
+        // all implicit destructors are called
+        // *before* terminating Xerces-C++.
+      cms::concurrency::xercesTerminate();
     }
 
     void

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -14,7 +14,7 @@
 #include <boost/algorithm/string.hpp>
 
 using namespace xercesc;
-using namespace cms::utils;
+using namespace cms::xerces;
 
 //<<<<<< PRIVATE DEFINES                                                >>>>>>
 //<<<<<< PRIVATE CONSTANTS                                              >>>>>>

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -38,7 +38,7 @@ namespace {
     CharType const* ptr() const { return m_array.get(); }
 
   private:
-    std::shared_ptr< CharType >   m_array;
+    std::unique_ptr< CharType, void (*)(CharType*) > m_array;
   };
   
   inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include <xercesc/util/XercesDefs.hpp>
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
 //<<<<<< PUBLIC CONSTANTS                                               >>>>>>
 //<<<<<< PUBLIC TYPES                                                   >>>>>>
@@ -85,6 +86,28 @@ namespace edm {
             std::set<std::string> m_statisticsInfo;
             bool m_statisticsInfoAvail;
             std::string         m_siteName;
+	    XMLCh *m_str_site;
+	    XMLCh *m_str_name;
+	    XMLCh *m_str_event_data;
+	    XMLCh *m_str_catalog;
+	    XMLCh *m_str_url;
+	    XMLCh *m_str_rfiotype;
+	    XMLCh *m_str_value;
+	    XMLCh *m_str_calib_data;
+	    XMLCh *m_str_frontier_connect;
+	    XMLCh *m_str_source_config;
+	    XMLCh *m_str_cache_temp_dir;
+	    XMLCh *m_str_cache_min_free;
+	    XMLCh *m_str_cache_hint;
+	    XMLCh *m_str_clone_cache_hint;
+	    XMLCh *m_str_read_hint;
+	    XMLCh *m_str_ttree_cache_size;
+	    XMLCh *m_str_timeout_in_seconds;
+	    XMLCh *m_str_statistics_destination;
+	    XMLCh *m_str_endpoint;
+	    XMLCh *m_str_info;
+	    XMLCh *m_str_prefetching;
+	    XMLCh *m_str_native_protocols;
          };
 
          inline

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -7,7 +7,6 @@
 #include <vector>
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include <xercesc/util/XercesDefs.hpp>
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
 //<<<<<< PUBLIC CONSTANTS                                               >>>>>>
 //<<<<<< PUBLIC TYPES                                                   >>>>>>
@@ -86,28 +85,6 @@ namespace edm {
             std::set<std::string> m_statisticsInfo;
             bool m_statisticsInfoAvail;
             std::string         m_siteName;
-	    XMLCh *m_str_site;
-	    XMLCh *m_str_name;
-	    XMLCh *m_str_event_data;
-	    XMLCh *m_str_catalog;
-	    XMLCh *m_str_url;
-	    XMLCh *m_str_rfiotype;
-	    XMLCh *m_str_value;
-	    XMLCh *m_str_calib_data;
-	    XMLCh *m_str_frontier_connect;
-	    XMLCh *m_str_source_config;
-	    XMLCh *m_str_cache_temp_dir;
-	    XMLCh *m_str_cache_min_free;
-	    XMLCh *m_str_cache_hint;
-	    XMLCh *m_str_clone_cache_hint;
-	    XMLCh *m_str_read_hint;
-	    XMLCh *m_str_ttree_cache_size;
-	    XMLCh *m_str_timeout_in_seconds;
-	    XMLCh *m_str_statistics_destination;
-	    XMLCh *m_str_endpoint;
-	    XMLCh *m_str_info;
-	    XMLCh *m_str_prefetching;
-	    XMLCh *m_str_native_protocols;
          };
 
          inline

--- a/Utilities/Xerces/BuildFile.xml
+++ b/Utilities/Xerces/BuildFile.xml
@@ -1,0 +1,1 @@
+<use   name="xerces-c"/>

--- a/Utilities/Xerces/interface/XercesStrUtils.h
+++ b/Utilities/Xerces/interface/XercesStrUtils.h
@@ -1,0 +1,65 @@
+#ifndef UTILITIES_XERCES_STRING_UTILS_H
+#define UTILITIES_XERCES_STRING_UTILS_H
+
+#include <xercesc/util/XercesDefs.hpp>
+#include <xercesc/util/XMLString.hpp>
+
+#ifdef XERCES_CPP_NAMESPACE_USE
+XERCES_CPP_NAMESPACE_USE
+#endif
+
+namespace cms {
+  namespace utils {
+    inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
+    inline void dispose(char* ptr)  { XMLString::release(&ptr); }
+
+    template< class CharType >
+    class ZStr      // Zero-terminated string.
+    {
+    public:
+    ZStr(CharType const* str)
+      : m_array(const_cast<CharType*>(str), &dispose)
+	{}
+    
+      CharType const* ptr() const { return m_array.get(); }
+
+    private:
+      std::unique_ptr< CharType, void (*)(CharType*) > m_array;
+    };
+  
+    inline ZStr<XMLCh> uStr(char const* str) {
+      return ZStr<XMLCh>(XMLString::transcode(str));
+    }
+ 
+    inline ZStr<char> cStr(XMLCh const* str) {
+      return ZStr<char>(XMLString::transcode(str));
+    }
+  
+    inline std::string toString(XMLCh const* toTranscode) {
+      return std::string(cStr(toTranscode).ptr());
+    }
+
+    inline unsigned int toUInt(XMLCh const* toTranscode) {
+      std::istringstream iss(toString(toTranscode));
+      unsigned int returnValue;
+      iss >> returnValue;
+      return returnValue;
+    }
+
+    inline bool toBool(XMLCh const* toTranscode) {
+      std::string value = toString(toTranscode);
+      if ((value == "true") || (value == "1"))
+	return true;
+      return false;
+    }
+    
+    inline double toDouble(XMLCh const* toTranscode) {
+      std::istringstream iss(toString(toTranscode));
+      double returnValue;
+      iss >> returnValue;
+      return returnValue;
+    }
+  }
+}
+
+#endif

--- a/Utilities/Xerces/interface/XercesStrUtils.h
+++ b/Utilities/Xerces/interface/XercesStrUtils.h
@@ -9,7 +9,7 @@ XERCES_CPP_NAMESPACE_USE
 #endif
 
 namespace cms {
-  namespace utils {
+  namespace xerces {
     inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
     inline void dispose(char* ptr)  { XMLString::release(&ptr); }
 


### PR DESCRIPTION
- Make sure Xerces releases memory

```
...
==17013== 499 bytes in 13 blocks are definitely lost in loss record 20,978 of 25,216
==17013==    at 0x4028108: operator new(unsigned long) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/external/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17013==    by 0xB0C7A10: xercesc_3_1::MemoryManagerImpl::allocate(unsigned long) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/external/xerces-c/3.1.3/lib/libxerces-c-3.1.so)
==17013==    by 0xB1B28B8: xercesc_3_1::IconvGNULCPTranscoder::transcode(unsigned short const*, xercesc_3_1::MemoryManager*) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/external/xerces-c/3.1.3/lib/libxerces-c-3.1.so)
==17013==    by 0xB032A8C: xercesc_3_1::XMLString::transcode(unsigned short const*, xercesc_3_1::MemoryManager*) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/external/xerces-c/3.1.3/lib/libxerces-c-3.1.so)
==17013==    by 0x868CD25: edm::service::SiteLocalConfigService::parse(std::string const&) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServices.so)
==17013==    by 0x868F25B: edm::service::SiteLocalConfigService::SiteLocalConfigService(edm::ParameterSet const&) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServices.so)
==17013==    by 0xA916C2B: edm::serviceregistry::ServiceMaker<edm::SiteLocalConfig, edm::serviceregistry::ParameterSetMaker<edm::SiteLocalConfig, edm::service::SiteLocalConfigService> >::make(edm::ParameterSet const&, edm::ActivityRegistry&, edm::serviceregistry::ServicesManager&) const (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/pluginFWCoreServicesPlugins.so)
==17013==    by 0x4053670: edm::serviceregistry::ServicesManager::MakerHolder::add(edm::serviceregistry::ServicesManager&) const (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServiceRegistry.so)
==17013==    by 0x4053926: edm::serviceregistry::ServicesManager::createServices() (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServiceRegistry.so)
==17013==    by 0x4056707: edm::serviceregistry::ServicesManager::ServicesManager(edm::ServiceToken, edm::serviceregistry::ServiceLegacy, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&, bool) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServiceRegistry.so)
==17013==    by 0x4052B4E: edm::ServiceRegistry::createSet(std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&, edm::ServiceToken, edm::serviceregistry::ServiceLegacy, bool) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreServiceRegistry.so)
==17013==    by 0x4AF637A: edm::ScheduleItems::initServices(std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&, edm::ParameterSet&, edm::ServiceToken const&, edm::serviceregistry::ServiceLegacy, bool) (in /cvmfs/cms-ib.cern.ch/2016-26/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_X_2016-06-22-2300/lib/slc6_amd64_gcc530/libFWCoreFramework.so)
...
```
