### PR TITLE
Input monitoring for DAQ (80X)

### DIFF
--- a/EventFilter/Utilities/interface/DataPoint.h
+++ b/EventFilter/Utilities/interface/DataPoint.h
@@ -99,13 +99,13 @@ public:
 	}
 
 	//fastpath (not implemented now)
-	std::string fastOutCSV();
+	std::string fastOutCSV(int sid=-1);
 
 	//pointed object should be available until discard
 	JsonMonitorable * mergeAndRetrieveValue(unsigned int forLumi);
 
 	//get everything collected prepared for output
-	void mergeAndSerialize(Json::Value& jsonRoot, unsigned int lumi, bool initJsonValue);
+	void mergeAndSerialize(Json::Value& jsonRoot, unsigned int lumi, bool initJsonValue, int sid);
 
 	//cleanup lumi
 	void discardCollected(unsigned int forLumi);

--- a/EventFilter/Utilities/interface/FastMonitor.h
+++ b/EventFilter/Utilities/interface/FastMonitor.h
@@ -62,7 +62,7 @@ public:
   void snapStreamAtomic(unsigned int ls, unsigned int streamID);
 
   //fastpath CSV string
-  std::string getCSVString();
+  std::string getCSVString(int sid=-1);
 
   //fastpath file output
   void outputCSV(std::string const& path, std::string const& csvString);
@@ -71,7 +71,8 @@ public:
   JsonMonitorable* getMergedIntJForLumi(std::string const& name,unsigned int forLumi);
 
   // merges and outputs everything collected for the given stream to JSON file
-  bool outputFullJSON(std::string const& path, unsigned int lumi, bool log=true);
+  bool outputFullJSONs(std::string const& pathstem, std::string const& ext, unsigned int lumi);
+  bool outputFullJSON(std::string const& path, unsigned int lumi);
 
   //discard what was collected for a lumisection
   void discardCollected(unsigned int forLumi);

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -112,6 +112,7 @@ namespace evf{
 
       // the names of the states - some of them are never reached in an online app
       static const std::string macroStateNames[FastMonitoringThread::MCOUNT];
+      static const std::string inputStateNames[FastMonitoringThread::inCOUNT]; 
       // Reserved names for microstates
       // moved into base class in EventFilter/Utilities for compatibility with MicroStateServiceClassic
       static const std::string nopath_;
@@ -121,6 +122,7 @@ namespace evf{
      
       std::string makePathLegendaJson();
       std::string makeModuleLegendaJson();
+      std::string makeInputLegendaJson();
 
       void preallocate(edm::service::SystemBounds const&);
       void jobFailure();
@@ -169,6 +171,8 @@ namespace evf{
       }
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
       void setInputSource(FedRawDataInputSource *inputSource) {inputSource_=inputSource;}
+      void setInState(FastMonitoringThread::InputState inputState) {inputState_=inputState;}
+      void setInStateSup(FastMonitoringThread::InputState inputState) {inputSupervisorState_=inputState;}
 
     private:
 
@@ -184,7 +188,10 @@ namespace evf{
 	while (!fmt_.m_stoprequest) {
 	  edm::LogInfo("FastMonitoringService") << "Current states: Ms=" << fmt_.m_data.fastMacrostateJ_.value()
 	            << " ms=" << encPath_[0].encode(ministate_[0])
-	            << " us=" << encModule_.encode(microstate_[0]) << std::endl;
+	            << " us=" << encModule_.encode(microstate_[0])
+	            << " is=" << inputStateNames[inputState_]
+	            << " iss="<< inputStateNames[inputSupervisorState_]
+                    << std::endl;
 
 	  {
             std::lock_guard<std::mutex> lock(fmt_.monlock_);
@@ -202,7 +209,7 @@ namespace evf{
             snapCounter_++;
             
           }
-	  ::sleep(sleepTime_);
+	  ::usleep(sleepTime_);
 	}
       }
 
@@ -211,6 +218,8 @@ namespace evf{
       Encoding encModule_;
       std::vector<Encoding> encPath_;
       FedRawDataInputSource * inputSource_ = nullptr;
+      FastMonitoringThread::InputState inputState_;
+      FastMonitoringThread::InputState inputSupervisorState_;
 
       unsigned int nStreams_;
       unsigned int nThreads_;
@@ -269,6 +278,7 @@ namespace evf{
       std::string moduleLegendFileJson_;
       std::string pathLegendFile_;
       std::string pathLegendFileJson_;
+      std::string inputLegendFileJson_;
       bool pathLegendWritten_ = false;
       unsigned int nOutputModules_ =0;
 

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -20,16 +20,20 @@ namespace evf{
 		      sShuttingDown, sDone, sJobEnded, sError, sErrorEnded, sEnd, sInvalid,MCOUNT}; 
 
     enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived, 
-                      inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest,inNoRequestWithIdleThreads, 
+                      inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest, inNoRequestWithIdleThreads,
+                      inNoRequestWithIdleAndEoLThreads, inNoRequestWithGlobalEoL, inNoRequestWithAllEoLThreads, inNoRequestWithEoLThreads,
                       //supervisor thread and worker threads state
-                      inSupFileLimit, inSupWaitFreeChunk, inSupWaitFreeThread, inSupBusy, inSupLockPolling,
-                      inSupNoFile,inSupNewFile,inSupNewFileWaitThreadCopying,inSupNewFileWaitThread,
+                      inSupFileLimit, inSupWaitFreeChunk, inSupWaitFreeChunkCopying, inSupWaitFreeThread, inSupWaitFreeThreadCopying, inSupBusy, inSupLockPolling,
+                      inSupLockPollingCopying,inSupNoFile,inSupNewFile,inSupNewFileWaitThreadCopying,inSupNewFileWaitThread,
                       inSupNewFileWaitChunkCopying,inSupNewFileWaitChunk,
-                      //combined with inWaitInput and inWaitChunk
-                      inWaitInput_fileLimit,inWaitInput_waitFreeChunk,inWaitInput_waitFreeThread,inWaitInput_busy,inWaitInput_lockPolling,inWaitInput_runEnd,
+                      //combined with inWaitInput
+                      inWaitInput_fileLimit,inWaitInput_waitFreeChunk,inWaitInput_waitFreeChunkCopying,inWaitInput_waitFreeThread,inWaitInput_waitFreeThreadCopying,
+                      inWaitInput_busy,inWaitInput_lockPolling,inWaitInput_lockPollingCopying,inWaitInput_runEnd,
                       inWaitInput_noFile,inWaitInput_newFile,inWaitInput_newFileWaitThreadCopying,inWaitInput_newFileWaitThread,
                       inWaitInput_newFileWaitChunkCopying,inWaitInput_newFileWaitChunk,
-                      inWaitChunk_fileLimit,inWaitChunk_waitFreeChunk,inWaitChunk_waitFreeThread,inWaitChunk_busy,inWaitChunk_lockPolling,inWaitChunk_runEnd,
+                      //combined with inWaitChunk
+                      inWaitChunk_fileLimit,inWaitChunk_waitFreeChunk,inWaitChunk_waitFreeChunkCopying,inWaitChunk_waitFreeThread,inWaitChunk_waitFreeThreadCopying,
+                      inWaitChunk_busy,inWaitChunk_lockPolling,inWaitChunk_lockPollingCopying,inWaitChunk_runEnd,
                       inWaitChunk_noFile,inWaitChunk_newFile,inWaitChunk_newFileWaitThreadCopying,inWaitChunk_newFileWaitThread,
                       inWaitChunk_newFileWaitChunkCopying,inWaitChunk_newFileWaitChunk,
                       inCOUNT}; 
@@ -126,7 +130,6 @@ namespace evf{
 
 	//provide vector with updated per stream lumis and let it finish initialization
 	fm->commit(&streamLumi_);
-        //1,215,194,2407,0,0.0276364,0,0,14
       }
     };
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -151,9 +151,10 @@ private:
 
   std::mutex mReader_;
   std::vector<std::condition_variable*> cvReader_;
+  std::vector<unsigned int> tid_active_;
 
   std::atomic<bool> quit_threads_;
-  std::vector<bool> thread_quit_signal;
+  std::vector<unsigned int> thread_quit_signal;
   bool setExceptionState_ = false;
   std::mutex startupLock_;
   std::condition_variable startupCv_;

--- a/EventFilter/Utilities/interface/MicroStateService.h
+++ b/EventFilter/Utilities/interface/MicroStateService.h
@@ -22,7 +22,7 @@ namespace evf{
     class MicroStateService
     {
     public:
-      enum Microstate { mInvalid = 0, mIdle, mFwkOvhSrc, mFwkOvhMod, mFwkEoL ,mInput, mDqm, mBoL, mEoL, mCOUNT}; 
+      enum Microstate { mInvalid = 0, mIdle, mFwkOvhSrc, mFwkOvhMod, mFwkEoL ,mInput, mDqm, mBoL, mEoL, mGlobEoL, mCOUNT}; 
       // the names of the states - some of them are never reached in an online app
       static const edm::ModuleDescription reservedMicroStateNames[mCOUNT];
       MicroStateService(const edm::ParameterSet&,edm::ActivityRegistry&);

--- a/EventFilter/Utilities/interface/MicroStateService.h
+++ b/EventFilter/Utilities/interface/MicroStateService.h
@@ -22,7 +22,7 @@ namespace evf{
     class MicroStateService
     {
     public:
-      enum Microstate { mInvalid = 0, mFwkOvh, mIdle, mInput, mInputDone, mDqm, mEoL, mCOUNT}; 
+      enum Microstate { mInvalid = 0, mIdle, mFwkOvhSrc, mFwkOvhMod, mFwkEoL ,mInput, mDqm, mBoL, mEoL, mCOUNT}; 
       // the names of the states - some of them are never reached in an online app
       static const edm::ModuleDescription reservedMicroStateNames[mCOUNT];
       MicroStateService(const edm::ParameterSet&,edm::ActivityRegistry&);

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -145,7 +145,7 @@ namespace evf{
     gettimeofday(&tv_start_,0);
   }
 
-  void ExceptionGenerator::analyze(const edm::Event & e, const edm::EventSetup& c)
+  void __attribute__((optimize("O0"))) ExceptionGenerator::analyze(const edm::Event & e, const edm::EventSetup& c)
     {
       float dummy = 0.;
       unsigned int iterations = 0;

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -245,7 +245,7 @@ void RawEventFileWriterForBU::finishFileWrite(int ls)
     std::string path = source.replace_extension(".jsn").string();
 
     fileMon_->snap(ls);
-    fileMon_->outputFullJSON(path, ls, false);
+    fileMon_->outputFullJSON(path, ls);
     fileMon_->discardCollected(ls);
 
     //move the json file from open

--- a/EventFilter/Utilities/plugins/microstatedef.jsd
+++ b/EventFilter/Utilities/plugins/microstatedef.jsd
@@ -35,7 +35,10 @@
       {
          "name" : "LockCount",
          "operation" : "sum"
+      },
+      {
+         "name" : "Inputstate",
+         "operation" : "histo"
       }
-
    ]
 }

--- a/EventFilter/Utilities/plugins/microstatedeffast.jsd
+++ b/EventFilter/Utilities/plugins/microstatedeffast.jsd
@@ -35,6 +35,10 @@
       {
          "name" : "LockCount",
          "operation" : "sum"
+      },
+      {
+         "name" : "Inputstate",
+         "operation" : "histo"
       }
 
    ]

--- a/EventFilter/Utilities/src/DataPoint.cc
+++ b/EventFilter/Utilities/src/DataPoint.cc
@@ -248,24 +248,31 @@ void DataPoint::snapStreamAtomic(unsigned int lumi, unsigned int streamID)
   else assert(monType_!=TYPEINT);//not yet implemented
 }
 
-std::string DataPoint::fastOutCSV()
+std::string DataPoint::fastOutCSV(int sid)
 {
   if (tracked_) {
     if (isStream_) {
       std::stringstream ss;
-      if (isAtomic_) { 
-#if ATOMIC_LEVEL>0
-        ss << (unsigned int) (static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->at(fastIndex_)->load(std::memory_order_relaxed); 
-#else
-        ss << (unsigned int) *((static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->at(fastIndex_));
-#endif 
-        fastIndex_ = (fastIndex_+1) % (static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->size();
+      if (sid<0) {
+        if (isAtomic_) { 
+//        if ATOMIC_LEVEL>0
+//        ss << (unsigned int) (static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->at(fastIndex_)->load(std::memory_order_relaxed); 
+
+          ss << (unsigned int) *((static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->at(fastIndex_));
+          fastIndex_ = (fastIndex_+1) % (static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->size();
+        }
+        else {
+          ss << (static_cast<std::vector<unsigned int>*>(tracked_))->at(fastIndex_);
+          fastIndex_ = (fastIndex_+1) % (static_cast<std::vector<unsigned int>*>(tracked_))->size();
+        }
+
       }
       else {
-        ss << (static_cast<std::vector<unsigned int>*>(tracked_))->at(fastIndex_);
-        fastIndex_ = (fastIndex_+1) % (static_cast<std::vector<unsigned int>*>(tracked_))->size();
+        if (isAtomic_)
+          ss << (unsigned int) *((static_cast<std::vector<AtomicMonUInt*>*>(tracked_))->at(unsigned(sid)));
+        else
+          ss << (static_cast<std::vector<unsigned int>*>(tracked_))->at(unsigned(sid));
       }
-
       return ss.str();
     }
     return (static_cast<JsonMonitorable*>(tracked_))->toString();
@@ -288,7 +295,7 @@ JsonMonitorable* DataPoint::mergeAndRetrieveValue(unsigned int lumi)
   return newJ;//assume the caller takes care of deleting the object
 }
 
-void DataPoint::mergeAndSerialize(Json::Value & root,unsigned int lumi,bool initJsonValue)
+void DataPoint::mergeAndSerialize(Json::Value & root,unsigned int lumi,bool initJsonValue, int sid)
 {
   if (initJsonValue) {
     root[SOURCE] = source_;
@@ -323,9 +330,17 @@ void DataPoint::mergeAndSerialize(Json::Value & root,unsigned int lumi,bool init
       std::stringstream ss;
       unsigned int updates=0;
       unsigned int sum=0;
-      for (unsigned int i=0;i<streamDataMaps_.size();i++) {
-        auto itr = streamDataMaps_[i].find(lumi);
-        if (itr!=streamDataMaps_[i].end()) {
+      if (sid<1)
+        for (unsigned int i=0;i<streamDataMaps_.size();i++) {
+          auto itr = streamDataMaps_[i].find(lumi);
+          if (itr!=streamDataMaps_[i].end()) {
+            sum+=static_cast<IntJ*>(itr->second.get())->value();
+            updates++;
+          }
+        }
+      else {
+        auto itr = streamDataMaps_[unsigned(sid)].find(lumi);
+        if (itr!=streamDataMaps_[unsigned(sid)].end()) {
           sum+=static_cast<IntJ*>(itr->second.get())->value();
           updates++;
         }
@@ -347,14 +362,29 @@ void DataPoint::mergeAndSerialize(Json::Value & root,unsigned int lumi,bool init
       }
       memset(buf_,0,bufLen_*sizeof(uint32_t));
       unsigned int updates=0;
+      if (sid<1)
       for (unsigned int i=0;i<streamDataMaps_.size();i++) {
-        auto itr = streamDataMaps_[i].find(lumi);
-        if (itr!=streamDataMaps_[i].end()) {
+          auto itr = streamDataMaps_[i].find(lumi);
+          if (itr!=streamDataMaps_[i].end()) {
+            HistoJ <unsigned int>* monObj = static_cast<HistoJ<unsigned int>*>(itr->second.get());
+            updates+=monObj->getUpdates();
+            auto &hvec = monObj->value();
+            for (unsigned int j=0;j<hvec.size();j++) {
+              unsigned int thisbin=(unsigned int) hvec[j];
+              if (thisbin<*nBinsPtr_) {
+                buf_[thisbin]++;
+              }
+            }
+          }
+        }
+      else {
+        auto itr = streamDataMaps_[unsigned(sid)].find(lumi);
+        if (itr!=streamDataMaps_[unsigned(sid)].end()) {
           HistoJ <unsigned int>* monObj = static_cast<HistoJ<unsigned int>*>(itr->second.get());
           updates+=monObj->getUpdates();
           auto &hvec = monObj->value();
-          for (unsigned int i=0;i<hvec.size();i++) {
-            unsigned int thisbin=(unsigned int) hvec[i];
+          for (unsigned int j=0;j<hvec.size();j++) {
+            unsigned int thisbin=(unsigned int) hvec[j];
             if (thisbin<*nBinsPtr_) {
               buf_[thisbin]++;
             }

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -26,7 +26,7 @@ using namespace jsoncollector;
 constexpr double throughputFactor() {return (1000000)/double(1024*1024);}
 
 static const int nReservedModules = 64;
-static const int nSpecialModules = 9;
+static const int nSpecialModules = 10;
 static const int nReservedPaths = 1;
 
 namespace evf{
@@ -39,13 +39,17 @@ namespace evf{
   const std::string FastMonitoringService::inputStateNames[FastMonitoringThread::inCOUNT] = 
     {"Ignore","Init","WaitInput","NewLumi","RunEnd","ProcessingFile","WaitChunk","ChunkReceived",
      "ChecksumEvent","CachedEvent","ReadEvent","ReadCleanup","NoRequest","NoRequestWithIdleThreads",
-     "SupFileLimit", "SupWaitFreeChunk", "SupWaitFreeThread", "SupBusy", "SupLockPolling",
+     "NoRequestWithIdleAndEoLThreads","NoRequestWithGlobalEoL","NoRequestWithAllEoLThreads","NoRequestWithEoLThreads",
+     "SupFileLimit", "SupWaitFreeChunk","SupWaitFreeChunkCopying", "SupWaitFreeThread","SupWaitFreeThreadCopying",
+     "SupBusy", "SupLockPolling","SupLockPollingCopying",
      "SupNoFile", "SupNewFile", "SupNewFileWaitThreadCopying", "SupNewFileWaitThread",
      "SupNewFileWaitChunkCopying", "SupNewFileWaitChunk",
-     "WaitInput_fileLimit","WaitInput_waitFreeChunk","WaitInput_waitFreeThread","WaitInput_busy","WaitInput_lockPolling","WaitInput_runEnd",
+     "WaitInput_fileLimit","WaitInput_waitFreeChunk","WaitInput_waitFreeChunkCopying","WaitInput_waitFreeThread","WaitInput_waitFreeThreadCopying",
+     "WaitInput_busy","WaitInput_lockPolling","WaitInput_lockPollingCopying","WaitInput_runEnd",
      "WaitInput_noFile","WaitInput_newFile","WaitInput_newFileWaitThreadCopying","WaitInput_newFileWaitThread",
      "WaitInput_newFileWaitChunkCopying","WaitInput_newFileWaitChunk",
-     "WaitChunk_fileLimit","WaitChunk_waitFreeChunk","WaitChunk_waitFreeThread","WaitChunk_busy","WaitChunk_lockPolling","WaitChunk_runEnd",
+     "WaitChunk_fileLimit","WaitChunk_waitFreeChunk","WaitChunk_waitFreeChunkCopying","WaitChunk_waitFreeThread","WaitChunk_waitFreeThreadCopying",
+     "WaitChunk_busy","WaitChunk_lockPolling","WaitChunk_lockPollingCopying","WaitChunk_runEnd",
      "WaitChunk_noFile","WaitChunk_newFile","WaitChunk_newFileWaitThreadCopying","WaitChunk_newFileWaitThread",
      "WaitChunk_newFileWaitChunkCopying","WaitChunk_newFileWaitChunk"
     };
@@ -62,6 +66,7 @@ namespace evf{
     ,fastMonIntervals_(iPS.getUntrackedParameter<unsigned int>("fastMonIntervals", 2))
     ,fastName_("fastmoni")
     ,slowName_("slowmoni")
+    ,filePerFwkStream_(iPS.getUntrackedParameter<bool>("filePerFwkStream", false))
     ,totalEventsProcessed_(0)
   {
     reg.watchPreallocate(this, &FastMonitoringService::preallocate);//receiving information on number of threads
@@ -122,6 +127,7 @@ namespace evf{
     desc.setComment("Service for File-based DAQ monitoring and event accounting");
     desc.addUntracked<int> ("sleepTime",1)->setComment("Sleep time of the monitoring thread");
     desc.addUntracked<unsigned int> ("fastMonIntervals",2)->setComment("Modulo of sleepTime intervals on which fastmon file is written out");
+    desc.addUntracked<bool> ("filePerFwkStream", false)->setComment("Switches on monitoring output per framework stream");
     desc.setAllowAnything();
     descriptions.add("FastMonitoringService", desc);
   }
@@ -205,6 +211,14 @@ namespace evf{
     boost::filesystem::path fast = workingDirectory_;
     fast /= fastFileName.str();
     fastPath_ = fast.string();
+    if (filePerFwkStream_)
+      for (unsigned int i=0;i<nStreams_;i++) {
+        std::ostringstream fastFileNameTid;
+        fastFileNameTid << fastName_ << "_pid" << std::setfill('0') << std::setw(5) << getpid() << "_tid" << i << ".fast";
+        boost::filesystem::path fastTid = workingDirectory_;
+        fastTid /= fastFileNameTid.str();
+        fastPathList_.push_back(fastTid.string());
+      }
 
     std::ostringstream moduleLegFile;
     std::ostringstream moduleLegFileJson;
@@ -423,14 +437,6 @@ namespace evf{
 	  //update
 	  doSnapshot(lumi,true);
 
-	  // create file name for slow monitoring file
-	  std::stringstream slowFileName;
-	  slowFileName << slowName_ << "_ls" << std::setfill('0') << std::setw(4)
-			<< lumi << "_pid" << std::setfill('0')
-			<< std::setw(5) << getpid() << ".jsn";
-	  boost::filesystem::path slow = workingDirectory_;
-	  slow /= slowFileName.str();
-
 	  //retrieve one result we need (todo: sanity check if it's found)
 	  IntJ *lumiProcessedJptr = dynamic_cast<IntJ*>(fmt_.jsonMonitor_->getMergedIntJForLumi("Processed",lumi));
           if (!lumiProcessedJptr)
@@ -471,7 +477,26 @@ namespace evf{
 	  delete lumiProcessedJptr;
 
 	  //full global and stream merge&output for this lumi
-	  fmt_.jsonMonitor_->outputFullJSON(slow.string(),lumi);//full global and stream merge and JSON write for this lumi
+          
+	  // create file name for slow monitoring file
+          if (filePerFwkStream_) {
+	    std::stringstream slowFileNameStem;
+	    slowFileNameStem << slowName_ << "_ls" << std::setfill('0') << std::setw(4)
+			<< lumi << "_pid" << std::setfill('0')
+			<< std::setw(5) << getpid();
+	    boost::filesystem::path slow = workingDirectory_;
+	    slow /= slowFileNameStem.str();
+	    fmt_.jsonMonitor_->outputFullJSONs(slow.string(),".jsn",lumi);
+          }
+          else {
+	    std::stringstream slowFileName;
+	    slowFileName << slowName_ << "_ls" << std::setfill('0') << std::setw(4)
+			<< lumi << "_pid" << std::setfill('0')
+			<< std::setw(5) << getpid() << ".jsn";
+	    boost::filesystem::path slow = workingDirectory_;
+	    slow /= slowFileName.str();
+	    fmt_.jsonMonitor_->outputFullJSON(slow.string(),lumi);//full global and stream merge and JSON write for this lumi
+          }
 	  fmt_.jsonMonitor_->discardCollected(lumi);//we don't do further updates for this lumi
 
 	  isGlobalLumiTransition_=true;
@@ -735,44 +760,72 @@ namespace evf{
        fmt_.m_data.fastLockWaitJ_=0.;
        fmt_.m_data.fastLockCountJ_=0.;
       }
- 
     }
-    else return;
-
+    else {
+      for (unsigned int i=0;i<nStreams_;i++) {
+        microstate_[i]=&reservedMicroStateNames[mGlobEoL];
+      }
+    }
+    //else return;
     //capture latest mini/microstate of streams
     bool anyThreadsIdle=false;
+    bool anyThreadsEoL=false;
+    bool allThreadsEoL=true;
     for (unsigned int i=0;i<nStreams_;i++) {
       fmt_.m_data.ministateEncoded_[i] = encPath_[i].encode(ministate_[i]);
       fmt_.m_data.microstateEncoded_[i] = encModule_.encode(microstate_[i]);
       if (microstate_[i]==&reservedMicroStateNames[mIdle]) anyThreadsIdle=true;
+      if (microstate_[i]==&reservedMicroStateNames[mEoL]) anyThreadsEoL=true;
+      else allThreadsEoL=false;
     }
 
     if (inputState_==FastMonitoringThread::inWaitInput) {
       switch (inputSupervisorState_) {
         case FastMonitoringThread::inSupFileLimit:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_fileLimit;
+          break;
         case FastMonitoringThread::inSupWaitFreeChunk:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_waitFreeChunk;
+          break;
+        case FastMonitoringThread::inSupWaitFreeChunkCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_waitFreeChunkCopying;
+          break;
         case FastMonitoringThread::inSupWaitFreeThread:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_waitFreeThread;
+          break;
+        case FastMonitoringThread::inSupWaitFreeThreadCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_waitFreeThreadCopying;
+          break;
         case FastMonitoringThread::inSupBusy:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_busy;
+          break;
         case FastMonitoringThread::inSupLockPolling:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_lockPolling;
+          break;
+        case FastMonitoringThread::inSupLockPollingCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_lockPollingCopying;
+          break;
         case FastMonitoringThread::inRunEnd:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_runEnd;
+          break;
         case FastMonitoringThread::inSupNoFile:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_noFile;
+          break;
         case FastMonitoringThread::inSupNewFile:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_newFile;
+          break;
         case FastMonitoringThread::inSupNewFileWaitThreadCopying:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_newFileWaitThreadCopying;
+          break;
         case FastMonitoringThread::inSupNewFileWaitThread:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_newFileWaitThread;
+          break;
         case FastMonitoringThread::inSupNewFileWaitChunkCopying:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_newFileWaitChunkCopying;
+          break;
         case FastMonitoringThread::inSupNewFileWaitChunk:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput_newFileWaitChunk;
+          break;
         default: 
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitInput;
       }
@@ -782,34 +835,67 @@ namespace evf{
       switch (inputSupervisorState_) {
         case FastMonitoringThread::inSupFileLimit:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_fileLimit;
+          break;
         case FastMonitoringThread::inSupWaitFreeChunk:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_waitFreeChunk;
+          break;
+        case FastMonitoringThread::inSupWaitFreeChunkCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_waitFreeChunkCopying;
+          break;
         case FastMonitoringThread::inSupWaitFreeThread:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_waitFreeThread;
+          break;
+        case FastMonitoringThread::inSupWaitFreeThreadCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_waitFreeThreadCopying;
+          break;
         case FastMonitoringThread::inSupBusy:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_busy;
+          break;
         case FastMonitoringThread::inSupLockPolling:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_lockPolling;
+          break;
+        case FastMonitoringThread::inSupLockPollingCopying:
+          fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_lockPollingCopying;
+          break;
         case FastMonitoringThread::inRunEnd:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_runEnd;
+          break;
         case FastMonitoringThread::inSupNoFile:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_noFile;
+          break;
         case FastMonitoringThread::inSupNewFile:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_newFile;
+          break;
         case FastMonitoringThread::inSupNewFileWaitThreadCopying:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_newFileWaitThreadCopying;
+          break;
         case FastMonitoringThread::inSupNewFileWaitThread:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_newFileWaitThread;
+          break;
         case FastMonitoringThread::inSupNewFileWaitChunkCopying:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_newFileWaitChunkCopying;
+          break;
         case FastMonitoringThread::inSupNewFileWaitChunk:
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk_newFileWaitChunk;
+          break;
         default: 
           fmt_.m_data.inputState_[0]=FastMonitoringThread::inWaitChunk;
       }
     }
-    else if (inputState_==FastMonitoringThread::inNoRequest && anyThreadsIdle)
-      fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithIdleThreads;
+    else if (inputState_==FastMonitoringThread::inNoRequest) {
+      if (isGlobalLumiTransition_)
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithGlobalEoL;
+      else if (anyThreadsEoL && anyThreadsIdle)
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithIdleAndEoLThreads;
+      else if (anyThreadsIdle)
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithIdleThreads;
+      else if (anyThreadsEoL)
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithEoLThreads;
+      else if (allThreadsEoL)
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequestWithAllEoLThreads;
+      else
+        fmt_.m_data.inputState_[0]=FastMonitoringThread::inNoRequest;
+    }
     else
       fmt_.m_data.inputState_[0]=inputState_;
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -150,6 +150,8 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   if (fms_) {
    daqDirector_->setFMS(fms_);
    fms_->setInputSource(this);
+   fms_->setInState(evf::FastMonitoringThread::inInit);
+   fms_->setInStateSup(evf::FastMonitoringThread::inInit);
   }
   //should delete chunks when run stops
   for (unsigned int i=0;i<numBuffers_;i++) {
@@ -165,6 +167,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
     thread_quit_signal.push_back(false);
     workerJob_.push_back(ReaderInfo(nullptr,nullptr));
     cvReader_.push_back(new std::condition_variable);
+    tid_active_.push_back(0);
     threadInit_.store(false,std::memory_order_release);
     workerThreads_.push_back(new std::thread(&FedRawDataInputSource::readWorker,this,i));
     startupCv_.wait(lk);
@@ -240,10 +243,9 @@ bool FedRawDataInputSource::checkNextEvent()
   //signal hltd to start event accounting
   if (!currentLumiSection_ && daqDirector_->emptyLumisectionMode())
     daqDirector_->createProcessingNotificationMaybe();
-
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inWaitInput);
   switch (nextEvent() ) {
     case evf::EvFDaqDirector::runEnded: {
-
       //maybe create EoL file in working directory before ending run
       struct stat buf;
       if ( currentLumiSection_ > 0) {
@@ -373,6 +375,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     }
 
     evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
+    if (fms_) fms_->setInState(evf::FastMonitoringThread::inWaitInput);
     if (!fileQueue_.try_pop(currentFile_))
     {
       //sleep until wakeup (only in single-buffer mode) or timeout
@@ -383,6 +386,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     status = currentFile_->status_;
     if ( status == evf::EvFDaqDirector::runEnded)
     {
+      if (fms_) fms_->setInState(evf::FastMonitoringThread::inRunEnd);
       delete currentFile_;
       currentFile_=nullptr;
       return status;
@@ -393,6 +397,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     }
     else if (status == evf::EvFDaqDirector::newLumi)
     {
+      if (fms_) fms_->setInState(evf::FastMonitoringThread::inNewLumi);
       if (getLSFromFilename_) {
 	if (currentFile_->lumi_ > currentLumiSection_) {
           reportEventsThisLumiInSource(currentLumiSection_,eventsThisLumi_);
@@ -415,6 +420,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     else
       assert(0);
   }
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inProcessingFile);
 
   //file is empty
   if (!currentFile_->fileSize_) {
@@ -453,7 +459,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
       cvWakeup_.notify_one();
     }
     bufferInputRead_=0;
-    if (!daqDirector_->isSingleStreamThread()) {
+    if (!daqDirector_->isSingleStreamThread() && !fileListMode_) {
       //put the file in pending delete list;
       std::unique_lock<std::mutex> lkw(fileDeleteLock_);
       filesToDelete_.push_back(std::pair<int,InputFile*>(currentFileIndex_,currentFile_));
@@ -477,10 +483,12 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
   if (singleBufferMode_) {
 
     //should already be there
+    if (fms_) fms_->setInState(evf::FastMonitoringThread::inWaitChunk);
     while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
       usleep(10000);
       if (currentFile_->parent_->exceptionState()) currentFile_->parent_->threadError();
     }
+    if (fms_) fms_->setInState(evf::FastMonitoringThread::inChunkReceived);
 
     unsigned char *dataPosition = currentFile_->chunks_[0]->buf_+ currentFile_->chunkPosition_;
 
@@ -537,10 +545,12 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
   else
   {
     //wait for the current chunk to become added to the vector
+    if (fms_) fms_->setInState(evf::FastMonitoringThread::inWaitChunk);
     while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
       usleep(10000);
       if (setExceptionState_) threadError();
     }
+    if (fms_) fms_->setInState(evf::FastMonitoringThread::inChunkReceived);
 
     //check if header is at the boundary of two chunks
     chunkIsFree_ = false;
@@ -590,6 +600,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
       }
     }
   }//end multibuffer mode
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inChecksumEvent);
 
   if (verifyChecksum_ && event_->version() >= 5)
   {
@@ -614,7 +625,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
         " but calculated 0x" << adler;
     }
   }
-
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inCachedEvent);
 
   currentFile_->nProcessed_++;
 
@@ -656,6 +667,7 @@ void FedRawDataInputSource::deleteFile(std::string const& fileName)
 
 void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
 {
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inReadEvent);
   std::unique_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
   edm::Timestamp tstamp = fillFEDRawDataCollection(*rawData);
 
@@ -695,6 +707,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
                      daqProvenanceHelper_.dummyProvenance());
 
   eventsThisLumi_++;
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inReadCleanup);
 
   //this old file check runs no more often than every 10 events
   if (!((currentFile_->nProcessed_-1)%(checkEvery_))) {
@@ -720,6 +733,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   }
   if (chunkIsFree_) freeChunks_.push(currentFile_->chunks_[currentFile_->currentChunk_-1]);
   chunkIsFree_=false;
+  if (fms_) fms_->setInState(evf::FastMonitoringThread::inNoRequest);
   return;
 }
 
@@ -914,6 +928,12 @@ void FedRawDataInputSource::readSupervisor()
     int counter=0;
     while ((workerPool_.empty() && !singleBufferMode_) || freeChunks_.empty() || readingFilesCount_>=maxBufferedFiles_)
     {
+      //report state to monitoring
+      if (fms_) {
+        if (readingFilesCount_>=maxBufferedFiles_) fms_->setInStateSup(evf::FastMonitoringThread::inSupFileLimit);
+        else if (freeChunks_.empty()) fms_->setInStateSup(evf::FastMonitoringThread::inSupWaitFreeChunk);
+        else fms_->setInStateSup(evf::FastMonitoringThread::inSupWaitFreeThread);
+      }
       std::unique_lock<std::mutex> lkw(mWakeup_);
       //sleep until woken up by condition or a timeout
       if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout) {
@@ -933,7 +953,11 @@ void FedRawDataInputSource::readSupervisor()
     std::string nextFile;
     uint32_t fileSize;
 
-    if (fms_) fms_->startedLookingForFile();
+    if (fms_) {
+      fms_->setInStateSup(evf::FastMonitoringThread::inSupBusy);
+      fms_->startedLookingForFile();
+      fms_->setInStateSup(evf::FastMonitoringThread::inSupLockPolling);
+    }
 
     evf::EvFDaqDirector::FileStatus status =  evf::EvFDaqDirector::noFile;
 
@@ -950,6 +974,8 @@ void FedRawDataInputSource::readSupervisor()
       }
       else
         status = daqDirector_->updateFuLock(ls,nextFile,fileSize,thisLockWaitTimeUs);
+        
+      if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inSupBusy);
 
       if (currentLumiSection!=ls && status==evf::EvFDaqDirector::runEnded) status=evf::EvFDaqDirector::noFile;
 
@@ -967,6 +993,7 @@ void FedRawDataInputSource::readSupervisor()
 
       //check again for any remaining index/EoLS files after EoR file is seen
       if ( status == evf::EvFDaqDirector::runEnded && !fileListMode_) {
+        if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inRunEnd);
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
         status = daqDirector_->updateFuLock(ls,nextFile,fileSize,thisLockWaitTimeUs);
@@ -981,6 +1008,7 @@ void FedRawDataInputSource::readSupervisor()
 
       //queue new lumisection
       if( getLSFromFilename_ && ls > currentLumiSection) {
+        //fms_->setInStateSup(evf::FastMonitoringThread::inSupNewLumi);
 	currentLumiSection = ls;
 	fileQueue_.push(new InputFile(evf::EvFDaqDirector::newLumi, currentLumiSection));
       }
@@ -994,12 +1022,14 @@ void FedRawDataInputSource::readSupervisor()
 
       int dbgcount=0;
       if (status == evf::EvFDaqDirector::noFile) {
+        if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inSupNoFile);
 	dbgcount++;
 	if (!(dbgcount%20)) LogDebug("FedRawDataInputSource") << "No file for me... sleep and try again...";
 	usleep(100000);
       }
     }
     if ( status == evf::EvFDaqDirector::newFile ) {
+      if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFile);
       LogDebug("FedRawDataInputSource") << "The director says to grab -: " << nextFile;
 
 
@@ -1016,7 +1046,11 @@ void FedRawDataInputSource::readSupervisor()
       }
       fileSize=st.st_size;
 
-      if (fms_) fms_->stoppedLookingForFile(ls);
+      if (fms_) {
+        fms_->setInStateSup(evf::FastMonitoringThread::inSupBusy);
+        fms_->stoppedLookingForFile(ls);
+        fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFile);
+      }
       int eventsInNewFile;
       if (fileListMode_) {
         if (fileSize==0) eventsInNewFile=0;
@@ -1045,12 +1079,28 @@ void FedRawDataInputSource::readSupervisor()
 
 	for (unsigned int i=0;i<neededChunks;i++) {
 
+          if (fms_) {
+            bool copy_active=false;
+            for (auto j : tid_active_) if (j) copy_active=true;
+            if (copy_active)
+              fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFileWaitThreadCopying);
+            else
+              fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFileWaitThread);
+          }
 	  //get thread
 	  unsigned int newTid = 0xffffffff;
 	  while (!workerPool_.try_pop(newTid)) {
 	    usleep(100000);
 	  }
 
+          if (fms_) {
+            bool copy_active=false;
+            for (auto j : tid_active_) if (j) copy_active=true;
+            if (copy_active)
+              fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFileWaitChunkCopying);
+            else
+              fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFileWaitChunk);
+          }
 	  InputChunk * newChunk = nullptr;
 	  while (!freeChunks_.try_pop(newChunk)) {
             usleep(100000);
@@ -1063,6 +1113,7 @@ void FedRawDataInputSource::readSupervisor()
             stop = true;
             break;
           }
+          if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inSupNewFile);
 
 	  std::unique_lock<std::mutex> lk(mReader_);
 
@@ -1108,6 +1159,7 @@ void FedRawDataInputSource::readSupervisor()
       }
     }
   }
+  if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inRunEnd);
   //make sure threads finish reading
   unsigned numFinishedThreads = 0;
   while (numFinishedThreads < workerThreads_.size()) {
@@ -1131,6 +1183,7 @@ void FedRawDataInputSource::readWorker(unsigned int tid)
 
   while (1) {
 
+    tid_active_[tid]=false;
     std::unique_lock<std::mutex> lk(mReader_);
     workerJob_[tid].first=nullptr;
     workerJob_[tid].first=nullptr;
@@ -1146,6 +1199,7 @@ void FedRawDataInputSource::readWorker(unsigned int tid)
     cvReader_[tid]->wait(lk);
 
     if (thread_quit_signal[tid])  return;
+    tid_active_[tid]=true;
 
     InputFile * file;
     InputChunk * chunk;

--- a/EventFilter/Utilities/src/MicroStateService.cc
+++ b/EventFilter/Utilities/src/MicroStateService.cc
@@ -13,7 +13,8 @@ namespace evf{
       edm::ModuleDescription("Dummy","Input"), 
       edm::ModuleDescription("Dummy","DQM"),
       edm::ModuleDescription("Dummy","BoL"), 
-      edm::ModuleDescription("Dummy","EoL")};
+      edm::ModuleDescription("Dummy","EoL"),
+      edm::ModuleDescription("Dummy","GlobalEoL")};
 
   const std::string MicroStateService::default_return_="NotImplemented";
 

--- a/EventFilter/Utilities/src/MicroStateService.cc
+++ b/EventFilter/Utilities/src/MicroStateService.cc
@@ -4,9 +4,15 @@
 namespace evf{
   
   const edm::ModuleDescription MicroStateService::reservedMicroStateNames[mCOUNT] = 
-    { edm::ModuleDescription("Dummy","Invalid"), edm::ModuleDescription("Dummy","FwkOvh"), 
-      edm::ModuleDescription("Dummy","Idle"), edm::ModuleDescription("Dummy","Input"), 
-      edm::ModuleDescription("Dummy","InputDone"), edm::ModuleDescription("Dummy","DQM"),
+    { 
+      edm::ModuleDescription("Dummy","Invalid"),
+      edm::ModuleDescription("Dummy","Idle"),
+      edm::ModuleDescription("Dummy","FwkOvhSrc"), 
+      edm::ModuleDescription("Dummy","FwkOvhMod"), 
+      edm::ModuleDescription("Dummy","FwkEoL"), 
+      edm::ModuleDescription("Dummy","Input"), 
+      edm::ModuleDescription("Dummy","DQM"),
+      edm::ModuleDescription("Dummy","BoL"), 
       edm::ModuleDescription("Dummy","EoL")};
 
   const std::string MicroStateService::default_return_="NotImplemented";


### PR DESCRIPTION
Adding more monitoring information to EventFIlter to try to better understand bottlenecks:
- input source monitoring (similar as microstate, but samples current state of the input source)
- more micro states to understand state distribution in HLT during collision runs
- accounting global EoL state
  switch for CMSSW stream/thread microstate output (off by default).
- excluding optimizations in Exception generator analyze, as they optimize
  out loop used for CPU burn. this was included in 7X but never carried over to 80X, 81X.
- switch for per-thread microstate output. false by default
- avoid using vector<bool> where thread safe access to vector elements is needed as bool values can be packed in the same byte
