### PR TITLE
Extended hltDiff with CVS/JSON/ROOT output formats [8_1_X]

### DIFF
--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -507,7 +507,7 @@ private:
     return str;
   }
 
-  static std::string key(std::string _key, std::string _delim="") {
+  static std::string key(const std::string& _key, const std::string& _delim="") {
     std::string str = "\"\":";
     str.insert(1, _key);
     str.append(_delim);
@@ -515,7 +515,7 @@ private:
     return str;
   }
 
-  static std::string key_string(std::string _key, std::string _string, std::string _delim="") {
+  static std::string key_string(const std::string& _key, const std::string& _string, const std::string& _delim="") {
     std::string str = key(_key, _delim);
     str.push_back('"');
     str.append(_string);
@@ -523,14 +523,14 @@ private:
     return str;
   }
 
-  static std::string key_int(std::string _key, int _int, std::string _delim="") {
+  static std::string key_int(const std::string& _key, int _int, const std::string& _delim="") {
     std::string str = key(_key, _delim);
     str.append(std::to_string(_int));
 
     return str;
   }
 
-  static std::string string(std::string _string, std::string _delim="") {
+  static std::string string(const std::string& _string, const std::string& _delim="") {
     std::string str = "\"\"";
     str.insert(1, _string);
     str.append(_delim);
@@ -538,9 +538,9 @@ private:
     return str;
   }
 
-  static std::string list_string(std::vector<std::string> _values, std::string _delim="") {
+  static std::string list_string(const std::vector<std::string>& _values, const std::string& _delim="") {
     std::string str = "[";
-    for (std::vector<std::string>::iterator it = _values.begin(); it != _values.end(); ++it) {
+    for (std::vector<std::string>::const_iterator it = _values.begin(); it != _values.end(); ++it) {
       str.append(_delim);
       str.push_back('"');
       str.append(*it);

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -829,10 +829,10 @@ int main(int argc, char ** argv) {
       case 'j':
         if (optarg) {
           json_out = optarg;
-	} else if (!optarg && NULL != argv[optind] && '-' != argv[optind][0]) {
-	  // workaround for a bug in getopt which doesn't allow space before optional arguments
-	  const char *tmp_optarg = argv[optind++];
-	  json_out = tmp_optarg;
+      	} else if (!optarg && NULL != argv[optind] && '-' != argv[optind][0]) {
+      	  // workaround for a bug in getopt which doesn't allow space before optional arguments
+      	  const char *tmp_optarg = argv[optind++];
+      	  json_out = tmp_optarg;
         } else {
           json_out = "hltDiff_output.json";
         }
@@ -844,11 +844,11 @@ int main(int argc, char ** argv) {
 
       case 'v':
         verbose = 1;
-	if (optarg) {
+      	if (optarg) {
           verbose = std::max(1, atoi(optarg));
-	} else if (!optarg && NULL != argv[optind] && '-' != argv[optind][0]) {
-	  // workaround for a bug in getopt which doesn't allow space before optional arguments
-	  const char *tmp_optarg = argv[optind++];
+      	} else if (!optarg && NULL != argv[optind] && '-' != argv[optind][0]) {
+      	  // workaround for a bug in getopt which doesn't allow space before optional arguments
+      	  const char *tmp_optarg = argv[optind++];
           verbose = std::max(1, atoi(tmp_optarg));
         }
         break;

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -695,7 +695,7 @@ public:
 
     std::string serialise(size_t _indent=0) {
       std::ostringstream json;
-      json << indent(_indent) << key_int("tr", tr) << ',';   // line
+      json << indent(_indent) << key_int("t ", tr) << ',';   // line
       json << indent(_indent) << key("o") << '{' << o.serialise() << "},";   // line
       json << indent(_indent) << key("n") << '{' << n.serialise() << "}";   // line
 
@@ -714,14 +714,14 @@ public:
 
     std::string serialise(size_t _indent=0) {
       std::ostringstream json;
-      json << indent(_indent) << '"' << run << ':' << lumi << ':' << event << "\":[";   // line open
+      json << indent(_indent) << '{' << "\"r\"" << ':' << run << ",\"l\":" << lumi << ",\"e\":" << event << ",\"t\":[";   // line open
       for (std::vector<JsonTriggerEventState>::iterator it = triggerStates.begin(); it != triggerStates.end(); ++it) {
         json << '{';   // line open
         json << (*it).serialise(_indent+2);   // block
         json << indent(_indent+1) << '}';   // line close
         if (it != --triggerStates.end()) json << ',';
       }
-      json << indent(_indent) << ']';   // line close
+      json << indent(_indent) << ']' << '}';   // line close
 
       return json.str();
     }
@@ -772,12 +772,12 @@ public:
     out_file << configuration.serialise(1) << ',';
     out_file << vars.serialise(1) << ',';
     // writing block for each event
-    out_file << indent(1) << key("events") << '{'; // line open
+    out_file << indent(1) << key("events") << '['; // line open
     for (std::vector<JsonEvent>::iterator it = events.begin(); it != events.end(); ++it) {
       out_file << (*it).serialise(2);
       if (it != --events.end()) out_file << ',';
     }
-    out_file << indent(1) << '}'; // line close
+    out_file << indent(1) << ']'; // line close
     out_file << indent(0) << "}"; // line close
     out_file.close();
   }

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -690,7 +690,10 @@ public:
 
     std::string serialise(size_t _indent=0) {
       std::ostringstream json;
-      json << key_int("s", int(s)) << ',';   // line
+      json << key_int("s", int(s));   // line
+      // No more information needed if the state is 'accepted'
+      if (s == State::Pass) return json.str();
+      json << ',';
       json << key_int("m", m) << ',';
       json << key_int("l", l) << ',';
       json << key_int("t", t);

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -670,7 +670,7 @@ private:
       if (id < vars.label.size()) 
         return id;
       vars.label.push_back(labelName);
-      return vars.label.size();
+      return vars.label.size()-1;
     }
     
     unsigned int typeId(std::string typeName) {
@@ -678,7 +678,7 @@ private:
       if (id < vars.type.size()) 
         return id;
       vars.type.push_back(typeName);
-      return vars.type.size();
+      return vars.type.size()-1;
     }
 
 public:
@@ -778,7 +778,7 @@ public:
 
   JsonEventState eventState(State _s, int _m, const std::string& _l, const std::string& _t) {
     return JsonEventState(_s, _m, this->labelId(_l), this->typeId(_t));
-    }
+  }
 
   void write() {
     out_file.open(out_file_name, std::ofstream::out);
@@ -1103,7 +1103,7 @@ int main(int argc, char ** argv) {
   std::string               old_process("");
   std::vector<std::string>  new_files;
   std::string               new_process("");
-  unsigned int              max_events = 0;
+  unsigned int              max_events = 1e9;
   bool                      ignore_prescales = true;
   std::string               json_out("");
   bool                      file_check = false;

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -782,8 +782,7 @@ public:
     out_file.close();
   }
 };
-size_t JsonOutputProducer::tab_spaces = 1;
-
+size_t JsonOutputProducer::tab_spaces = 0;
 
 
 bool check_file(std::string const & file) {

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -911,10 +911,7 @@ void compare(std::vector<std::string> const & old_files, std::string const & old
         common_config = std::unique_ptr<HLTCommonConfig>(new HLTCommonConfig(*old_config_data, *new_config_data));
         old_config = & common_config->getView(HLTCommonConfig::Index::First);
         new_config = & common_config->getView(HLTCommonConfig::Index::Second);
-        std::cerr << "Warning: old and new TriggerResults come from different HLT menus. Only the common triggers will be compared:" << std::endl;
-        for (unsigned int i = 0; i < old_config->size(); ++i)
-          std::cerr << "    " << old_config->triggerName(i) << std::endl;
-        std::cerr << std::endl;
+        std::cout << "Warning: old and new TriggerResults come from different HLT menus. Only the common " << old_config->size() << " triggers are compared.\n" << std::endl;
       }
 
       differences.clear();
@@ -1040,7 +1037,7 @@ void compare(std::vector<std::string> const & old_files, std::string const & old
       std::cout << ", " << skipped << " events were skipped";
     std::cout <<  "." << std::endl;
   } else {
-    std::cout << "Found " << affected << " events out of " << counter << " with differences";
+    std::cout << "Found " << counter << " matching events, out of which " << affected << " have different HLT results";
     if (skipped)
       std::cout << ", " << skipped << " events were skipped";
     std::cout << ":\n" << std::endl;

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -850,7 +850,12 @@ void compare(std::vector<std::string> const & old_files, std::string const & old
   std::vector<TriggerDiff> differences;
 
   // loop over the reference events
+  const unsigned int nEvents = std::min((int)old_events->size(), (int)max_events);
   for (old_events->toBegin(); not old_events->atEnd(); ++(*old_events)) {
+    // printing progress on every 10%
+    if (counter%(nEvents/10) == 0) {
+      printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, 100*counter/nEvents);
+    }
 
     // seek the same event in the "new" files
     edm::EventID const& id = old_events->id();
@@ -1026,7 +1031,7 @@ void compare(std::vector<std::string> const & old_files, std::string const & old
     }
 
     ++counter;
-    if (max_events and counter >= max_events)
+    if (nEvents and counter >= nEvents)
       break;
   }
 

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -699,7 +699,7 @@ public:
 
     std::string serialise(size_t _indent=0) {
       std::ostringstream json;
-      json << indent(_indent) << key_int("t ", tr) << ',';   // line
+      json << indent(_indent) << key_int("t", tr) << ',';   // line
       json << indent(_indent) << key("o") << '{' << o.serialise() << "},";   // line
       json << indent(_indent) << key("n") << '{' << n.serialise() << "}";   // line
 
@@ -858,7 +858,7 @@ void compare(std::vector<std::string> const & old_files, std::string const & old
   for (old_events->toBegin(); not old_events->atEnd(); ++(*old_events)) {
     // printing progress on every 10%
     if (counter%(nEvents/10) == 0) {
-      printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, counter/(nEvents/10));
+      printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, 10*counter/(nEvents/10));
     }
 
     // seek the same event in the "new" files

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -1042,17 +1042,32 @@ private:
       }
     }
 
+    // Styling the histograms
+    for (const auto& nameHisto : m_histo) {
+      const std::string name = nameHisto.first;
+      TH1* histo = nameHisto.second;
+      if (name.find("gained") != std::string::npos || name.find("changed") != std::string::npos) {
+        if (name.find("frac") != std::string::npos) 
+          histo->GetYaxis()->SetRangeUser(0.0, 1.0);
+      }
+      if (name.find("lost") != std::string::npos) {
+        if (name.find("frac") != std::string::npos) 
+          histo->GetYaxis()->SetRangeUser(-1.0, 0.0);
+      }
+    }
+
     // Storing histograms to a ROOT file
     std::string file_name = json.output_filename_base(this->run)+=".root";
-    TFile out_file(file_name.c_str(), "RECREATE");
+    TFile* out_file = new TFile(file_name.c_str(), "RECREATE");
     // Storing the histograms is a proper folder according to the DQM convention
     char savePath[1000];
-    sprintf(savePath, "/DQMData/Run %d/HLT/Run summary/EventByEvent/", this->run);
-    out_file.mkdir(savePath);
-    out_file.cd(savePath);
+    sprintf(savePath, "DQMData/Run %d/HLT/Run summary/EventByEvent/", this->run);
+    out_file->mkdir(savePath);
+    gDirectory->cd(savePath);
+    gDirectory->Write();
     for (const auto& nameHisto : m_histo)
       nameHisto.second->Write(nameHisto.first.c_str());
-    out_file.Close();
+    out_file->Close();
 
     return file_name;
   }

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -981,13 +981,14 @@ private:
     // Filling the per-trigger bins in the summary histograms
     size_t bin(0), bin_c(0), bin_gl(0);
     for (const auto& idSummary : m_triggerSummary) {
-      if (idSummary.second.accepted_o == 0) continue;
-      ++bin;
       const TriggerSummary& summary = idSummary.second;
-      // Setting bin contents
-      m_histo.at("trigger_accepted")->SetBinContent(bin, summary.accepted_o);
-      // Setting bin labels
-      m_histo.at("trigger_accepted")->GetXaxis()->SetBinLabel(bin, summary.name.c_str());
+      if (summary.accepted_o > 0) {
+        ++bin;
+        // Setting bin contents
+        m_histo.at("trigger_accepted")->SetBinContent(bin, summary.accepted_o);
+        // Setting bin labels
+        m_histo.at("trigger_accepted")->GetXaxis()->SetBinLabel(bin, summary.name.c_str());
+      }
       if (summary.keepForGL()) {
         ++bin_gl;
         // Setting bin contents
@@ -1424,7 +1425,7 @@ public:
       std::cout << "Found " << counter << " matching events, out of which " << affected << " have different HLT results";
       if (skipped)
         std::cout << ", " << skipped << " events were skipped";
-      std::cout << "\nSee more in the files listed below..." << std::endl;
+      std::cout << "\nSee more in the files listed below...\n" << std::endl;
     }
 
     // writing all the required output

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -1413,25 +1413,25 @@ public:
         if (verbose > 0)
           std::cout << std::endl;
       }
-    }
-    if (affected_event)
-      ++affected;
+      if (event_affected)
+        ++affected;
 
-    // compare the TriggerEvent
-    if (affected_event and verbose > 2 and old_summary and new_summary) {
-      std::map<std::string, std::pair<std::string, std::string>> collections;
-      for (auto const & old_collection: old_summary->collectionTags())
-        collections[strip_process_name(old_collection)].first  = old_collection;
-      for (auto const & new_collection: new_summary->collectionTags())
-        collections[strip_process_name(new_collection)].second = new_collection;
+      // compare the TriggerEvent
+      if (event_affected and verbose > 2 and old_summary and new_summary) {
+        std::map<std::string, std::pair<std::string, std::string>> collections;
+        for (auto const & old_collection: old_summary->collectionTags())
+          collections[strip_process_name(old_collection)].first  = old_collection;
+        for (auto const & new_collection: new_summary->collectionTags())
+          collections[strip_process_name(new_collection)].second = new_collection;
 
-      for (auto const & collection: collections) {
-        std::cout << "    Collection " << collection.first << ":\n";
-        std::cout << "        old trigger candidates:\n";
-        print_trigger_collection(std::cout, * old_summary, collection.second.first);
-        std::cout << "        new trigger candidates:\n";
-        print_trigger_collection(std::cout, * new_summary, collection.second.second);
-        std::cout << std::endl;
+        for (auto const & collection: collections) {
+          std::cout << "    Collection " << collection.first << ":\n";
+          std::cout << "        old trigger candidates:\n";
+          print_trigger_collection(std::cout, * old_summary, collection.second.first);
+          std::cout << "        new trigger candidates:\n";
+          print_trigger_collection(std::cout, * new_summary, collection.second.second);
+          std::cout << std::endl;
+        }
       }
 
       ++counter;

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -1424,14 +1424,10 @@ public:
       std::cout << "Found " << counter << " matching events, out of which " << affected << " have different HLT results";
       if (skipped)
         std::cout << ", " << skipped << " events were skipped";
-      std::cout << ":\n" << std::endl;
-      std::cout << std::setw(12) << "Events" << std::setw(12) << "Accepted" << std::setw(12) << "Gained" << std::setw(12) << "Lost" << std::setw(12) << "Other" << "  " << "Trigger" << std::endl;
-      for (unsigned int p = 0; p < old_config->size(); ++p)
-        std::cout << std::setw(12) << counter << differences[p] << "  " << old_config->triggerName(p) << std::endl;
+      std::cout << "\nSee more in the files listed below..." << std::endl;
     }
 
     // writing all the required output
-    std::cout << std::endl;
     json.write();   // to JSON file for interactive visualisation
     SummaryOutputProducer summary(json, this->root_out, true);
     summary.write();   // to ROOT file for fast validation with static plots


### PR DESCRIPTION
Extended the event-by-event validation code with output in different formats:
- **CSV**: can be directly inserted in GoogleDoc Sheets for custom statistical calculations
- **JSON**: can be used in the interactive [Web-interface](https://cms-hltdiff-visual.web.cern.ch/cms-hltDiff-visual/) for a deeper view on the affected triggers/modules
- **ROOT**: can be uploaded to the DQM GUI for a fast visual validation

No large summary printed by default any more. This info can be found in CSV files or with increased verbosity level.
