### PR TITLE
CTPPS: exceptions fix

### DIFF
--- a/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
@@ -97,24 +97,24 @@ void TotemDAQTriggerDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::R
   
   ibooker.setCurrentFolder("CTPPS/DAQ/");
 
-  daq_bx_diff = ibooker.book1D("bx_diff", ";OptoRx_{i}.BX - OptoRx_{j}.BX", 100, 0., 0.);
-  daq_event_bx_diff = ibooker.book1D("daq_event_bx_diff", ";OptoRx_{i}.BX - Event.BX", 100, 0., 0.);
-  daq_event_bx_diff_vs_fed = ibooker.book2D("daq_event_bx_diff_vs_fed", ";OptoRx.ID;OptoRx.BX - Event.BX", 10, 0., 0., 10., 0., 0.);
+  daq_bx_diff = ibooker.book1D("bx_diff", ";OptoRx_{i}.BX - OptoRx_{j}.BX", 21, -10.5, +10.5);
+  daq_event_bx_diff = ibooker.book1D("daq_event_bx_diff", ";OptoRx_{i}.BX - Event.BX", 21, -10.5, +10.5);
+  daq_event_bx_diff_vs_fed = ibooker.book2D("daq_event_bx_diff_vs_fed", ";OptoRx.ID;OptoRx.BX - Event.BX", 10, 575.5, 585.5, 21, -10.5, +10.5);
 
-  daq_trigger_bx_diff = ibooker.book1D("trigger_bx_diff", ";OptoRx_{i}.BX - LoneG.BX", 100, 0., 0.);
+  daq_trigger_bx_diff = ibooker.book1D("trigger_bx_diff", ";OptoRx_{i}.BX - LoneG.BX", 100, 0., 4000.);
 
   ibooker.setCurrentFolder("CTPPS/Trigger/");
 
-  trigger_type = ibooker.book1D("type", ";type", 100, 0., 0.);
-  trigger_event_num = ibooker.book1D("event_num", ";event_num", 100, 0., 0.);
-  trigger_bunch_num = ibooker.book1D("bunch_num", ";bunch_num", 100, 0., 0.);
-  trigger_src_id = ibooker.book1D("src_id", ";src_id", 100, 0., 0.);
-  trigger_orbit_num = ibooker.book1D("orbit_num", ";orbit_num", 100, 0., 0.);
-  trigger_revision_num = ibooker.book1D("revision_num", ";revision_num", 100, 0., 0.);
-  trigger_run_num = ibooker.book1D("run_num", ";run_num", 100, 0., 0.);
-  trigger_trigger_num = ibooker.book1D("trigger_num", ";trigger_num", 100, 0., 0.);
-  trigger_inhibited_triggers_num = ibooker.book1D("inhibited_triggers_num", ";inhibited_triggers_num", 100, 0., 0.);
-  trigger_input_status_bits = ibooker.book1D("input_status_bits", ";input_status_bits", 100, 0., 0.);
+  trigger_type = ibooker.book1D("type", ";type", 100, 0., 1000.);
+  trigger_event_num = ibooker.book1D("event_num", ";event_num", 100, 0., 1000.);
+  trigger_bunch_num = ibooker.book1D("bunch_num", ";bunch_num", 100, 0., 1000.);
+  trigger_src_id = ibooker.book1D("src_id", ";src_id", 100, 0., 1000.);
+  trigger_orbit_num = ibooker.book1D("orbit_num", ";orbit_num", 100, 0., 1000.);
+  trigger_revision_num = ibooker.book1D("revision_num", ";revision_num", 100, 0., 1000.);
+  trigger_run_num = ibooker.book1D("run_num", ";run_num", 100, 0., 1000.);
+  trigger_trigger_num = ibooker.book1D("trigger_num", ";trigger_num", 100, 0., 1000.);
+  trigger_inhibited_triggers_num = ibooker.book1D("inhibited_triggers_num", ";inhibited_triggers_num", 100, 0., 1000.);
+  trigger_input_status_bits = ibooker.book1D("input_status_bits", ";input_status_bits", 100, 0., 1000.);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -186,6 +186,7 @@ TotemRPDQMSource::DiagonalPlots::DiagonalPlots(DQMStore::IBooker &ibooker, int _
 
   ibooker.setCurrentFolder(string("CTPPS/TrackingStrip/") + name);
 
+  // TODO: define ranges! If defined automatically, can lead to problems when histograms are merged from several instances of the module.
   h_lrc_x_d = ibooker.book2D("dx left vs right", string(name) + " : dx left vs. right, histogram;#Delta x_{45};#Delta x_{56}", 50, 0., 0., 50, 0., 0.);
   h_lrc_x_n = ibooker.book2D("xn left vs right", string(name) + " : xn left vs. right, histogram;x^{N}_{45};x^{N}_{56}", 50, 0., 0., 50, 0., 0.);
   h_lrc_x_f = ibooker.book2D("xf left vs right", string(name) + " : xf left vs. right, histogram;x^{F}_{45};x^{F}_{56}", 50, 0., 0., 50, 0., 0.);

--- a/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPGeometryESModule.cc
@@ -416,33 +416,34 @@ void TotemRPGeometryESModule::ApplyAlignments(const edm::ESHandle<DDCompactView>
 
 auto_ptr<DDCompactView> TotemRPGeometryESModule::produceMeasuredDDCV(const VeryForwardMeasuredGeometryRecord &iRecord)
 {
-    // get the ideal DDCompactView from EventSetup
-    edm::ESHandle<DDCompactView> idealCV;
-    iRecord.getRecord<IdealGeometryRecord>().get("XMLIdealGeometryESSource_CTPPS", idealCV);
+  // get the ideal DDCompactView from EventSetup
+  edm::ESHandle<DDCompactView> idealCV;
+  iRecord.getRecord<IdealGeometryRecord>().get("XMLIdealGeometryESSource_CTPPS", idealCV);
 
-    // load alignments
-    edm::ESHandle<RPAlignmentCorrectionsData> alignments;
-    try {
-        iRecord.getRecord<RPMeasuredAlignmentRecord>().get(alignments);
-    } catch (...) {
-        cout<< "Exception in TotemRPGeometryESModule::produceMeasuredDDCV"
-            << " during iRecord.getRecord<RPMeasuredAlignmentRecord>().get(alignments)"<<endl;
+  // load alignments
+  edm::ESHandle<RPAlignmentCorrectionsData> alignments;
+  try {
+    iRecord.getRecord<RPMeasuredAlignmentRecord>().get(alignments);
+  } catch (...) {}
+
+  if (alignments.isValid())
+  {
+    if (verbosity)
+    {
+      LogVerbatim("TotemRPGeometryESModule::produceMeasuredDDCV")
+        << ">> TotemRPGeometryESModule::produceMeasuredDDCV > Measured geometry: "
+        << alignments->GetRPMap().size() << " RP and "
+        << alignments->GetSensorMap().size() << " sensor alignments applied.";
     }
+  } else {
+    if (verbosity)
+      LogVerbatim("TotemRPGeometryESModule::produceMeasuredDDCV")
+        << ">> TotemRPGeometryESModule::produceMeasuredDDCV > Measured geometry: No alignments applied.";
+  }
 
-    if (alignments.isValid()) {
-        if (verbosity){
-            cout << ">> TotemRPGeometryESModule::produceMeasuredDDCV > Measured geometry: "
-                << alignments->GetRPMap().size() << " RP and "
-                << alignments->GetSensorMap().size() << " sensor alignments applied.\n";
-        }
-    } else {
-        if (verbosity)
-            cout << ">> TotemRPGeometryESModule::produceMeasuredDDCV > Measured geometry: No alignments applied.\n";
-    }
-
-    DDCompactView *measuredCV = NULL;
-    ApplyAlignments(idealCV, alignments, measuredCV);
-    return auto_ptr<DDCompactView>(measuredCV);
+  DDCompactView *measuredCV = NULL;
+  ApplyAlignments(idealCV, alignments, measuredCV);
+  return auto_ptr<DDCompactView>(measuredCV);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -470,13 +471,18 @@ auto_ptr<DetGeomDesc> TotemRPGeometryESModule::produceRealGD(const VeryForwardRe
   edm::ESHandle<RPAlignmentCorrectionsData> alignments;
   try { iRecord.getRecord<RPRealAlignmentRecord>().get(alignments); }
   catch (...) {}
-  if (alignments.isValid()) {
+
+  if (alignments.isValid())
+  {
     if (verbosity)
-      printf(">> TotemRPGeometryESModule::produceRealGD > Real geometry: %lu RP and %lu sensor alignments applied.\n",
-        alignments->GetRPMap().size(), alignments->GetSensorMap().size());
+      LogVerbatim("TotemRPGeometryESModule::produceRealGD")
+        << ">> TotemRPGeometryESModule::produceRealGD > Measured geometry: "
+        << alignments->GetRPMap().size() << " RP and "
+        << alignments->GetSensorMap().size() << " sensor alignments applied.";
   } else {
     if (verbosity)
-      printf(">> TotemRPGeometryESModule::produceRealGD > Real geometry: No alignments applied.\n");
+      LogVerbatim("TotemRPGeometryESModule::produceRealGD")
+        << ">> TotemRPGeometryESModule::produceRealGD > Real geometry: No alignments applied.";
   }
 
   DetGeomDesc* newGD = NULL;
@@ -496,12 +502,18 @@ auto_ptr<DetGeomDesc> TotemRPGeometryESModule::produceMisalignedGD(const VeryFor
   edm::ESHandle<RPAlignmentCorrectionsData> alignments;
   try { iRecord.getRecord<RPMisalignedAlignmentRecord>().get(alignments); }
   catch (...) {}
-  if (alignments.isValid()) {
-      printf(">> TotemRPGeometryESModule::produceMisalignedGD > Misaligned geometry: %lu RP and %lu sensor alignments applied.\n",
-        alignments->GetRPMap().size(), alignments->GetSensorMap().size());
+
+  if (alignments.isValid())
+  {
+    if (verbosity)
+      LogVerbatim("TotemRPGeometryESModule::produceMisalignedGD")
+        << ">> TotemRPGeometryESModule::produceMisalignedGD > Measured geometry: "
+        << alignments->GetRPMap().size() << " RP and "
+        << alignments->GetSensorMap().size() << " sensor alignments applied.";
   } else {
     if (verbosity)
-      printf(">> TotemRPGeometryESModule::produceMisalignedGD > Misaligned geometry: No alignments applied.\n");
+      LogVerbatim("TotemRPGeometryESModule::produceMisalignedGD")
+        << ">> TotemRPGeometryESModule::produceMisalignedGD > Misaligned geometry: No alignments applied.";
   }
 
   DetGeomDesc* newGD = NULL;

--- a/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPIncludeAlignments.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPIncludeAlignments.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/VeryForwardGeometryBuilder/interface/RPAlignmentCorrectionsDataSequence.h"
 #include "CondFormats/AlignmentRecord/interface/RPMeasuredAlignmentRecord.h"
@@ -53,6 +54,8 @@ class  TotemRPIncludeAlignments : public edm::ESProducer, public edm::EventSetup
     /// builds a sequence of corrections from provided sources and runs a few checks
     void PrepareSequence(const std::string &label, RPAlignmentCorrectionsDataSequence &seq, const std::vector<std::string> &files) const;
 };
+
+//----------------------------------------------------------------------------------------------------
 
 using namespace std;
 using namespace edm;
@@ -189,11 +192,15 @@ void TotemRPIncludeAlignments::setIntervalFor(const edm::eventsetup::EventSetupR
 {
   if (verbosity)
   {
-    printf(">> TotemRPIncludeAlignments::setIntervalFor(%s)\n", key.name());
+    LogVerbatim("TotemRPIncludeAlignments")
+      << ">> TotemRPIncludeAlignments::setIntervalFor(" << key.name() << ")";
+
     time_t unixTime = iosv.time().unixTime();
     char timeStr[50];
     strftime(timeStr, 50, "%F %T", localtime(&unixTime));
-    printf("\trun=%u, event=%llu, UNIX timestamp=%lu (%s)\n", iosv.eventID().run(), iosv.eventID().event(), unixTime, timeStr);
+
+    LogVerbatim("TotemRPIncludeAlignments")
+      << "    run=" << iosv.eventID().run() << ", event=" << iosv.eventID().event() << ", UNIX timestamp=" << unixTime << " (" << timeStr << ")";
   }
 
   // determine what sequence and corrections should be used
@@ -234,10 +241,9 @@ void TotemRPIncludeAlignments::setIntervalFor(const edm::eventsetup::EventSetupR
 
       if (verbosity)
       {
-        printf("\tsetting validity interval [%s, %s]\n",
-          TimeValidityInterval::ValueToUNIXString(valInt.first().time().value()).c_str(),
-          TimeValidityInterval::ValueToUNIXString(valInt.last().time().value()).c_str()
-        );
+        LogVerbatim("TotemRPIncludeAlignments")
+          << "    setting validity interval [" << TimeValidityInterval::ValueToUNIXString(valInt.first().time().value())
+          << ", " << TimeValidityInterval::ValueToUNIXString(valInt.last().time().value()) << "]";
       }
 
       return;
@@ -260,10 +266,9 @@ void TotemRPIncludeAlignments::setIntervalFor(const edm::eventsetup::EventSetupR
   
   if (verbosity)
   {
-    printf("\tsetting validity interval [%s, %s]\n",
-      TimeValidityInterval::ValueToUNIXString(valInt.first().time().value()).c_str(),
-      TimeValidityInterval::ValueToUNIXString(valInt.last().time().value()).c_str()
-    );
+    LogVerbatim("TotemRPIncludeAlignments")
+      << "    setting validity interval [" << TimeValidityInterval::ValueToUNIXString(valInt.first().time().value())
+      << ", " << TimeValidityInterval::ValueToUNIXString(valInt.last().time().value()) << "]";
   }
 }
 


### PR DESCRIPTION
- geometry: no (misleading) error is printed when no alignment corrections are loaded, LogVerbatim is used instead of printf and cout
- DQM: histograms created with fixed ranges to avoid problems when merging histograms from several module instances
