### PR TITLE
Initial implementation of the HB/HE Phase 1 reconstruction

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
+++ b/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
@@ -1,0 +1,213 @@
+#ifndef DataFormats_HcalRecHit_HBHEChannelInfo_h_
+#define DataFormats_HcalRecHit_HBHEChannelInfo_h_
+
+#include <cfloat>
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalRecHit/interface/HcalSpecialTimes.h"
+
+/** \class HBHEChannelInfo
+ *
+ * Unpacked charge and TDC information in a format which works
+ * for both QIE8 and QIE11
+ */
+class HBHEChannelInfo
+{
+public:
+    typedef HcalDetId key_type;
+
+    static const unsigned MAXSAMPLES = 10;
+
+    inline HBHEChannelInfo()
+        : rawCharge_{0.}, pedestal_{0.}, gain_{0.}, riseTime_{0.f}, adc_{0},
+          hasTimeInfo_(false) {clear();}
+
+    inline explicit HBHEChannelInfo(const bool hasTimeFromTDC)
+        : rawCharge_{0.}, pedestal_{0.}, gain_{0.}, riseTime_{0.f}, adc_{0},
+          hasTimeInfo_(hasTimeFromTDC) {clear();}
+
+    inline void clear()
+    {
+        id_ = HcalDetId(0U);
+        nSamples_ = 0;
+        soi_ = 0;
+        capid_ = 0;
+        dropped_ = true;
+        hasLinkError_ = false;
+        hasCapidError_ = false;
+    }
+
+    inline void setChannelInfo(const HcalDetId& detId, const unsigned nSamp,
+                               const unsigned iSoi, const int iCapid,
+                               const bool linkError, const bool capidError,
+                               const bool dropThisChannel)
+    {
+        id_ = detId;
+        nSamples_ = nSamp < MAXSAMPLES ? nSamp : MAXSAMPLES;
+        soi_ = iSoi;
+        capid_ = iCapid;
+        dropped_ = dropThisChannel;
+        hasLinkError_ = linkError;
+        hasCapidError_ = capidError;
+    }
+
+    inline void tagAsDropped()
+        {dropped_ = true;}
+
+    // For speed, the "setSample" function does not perform bounds checking
+    inline void setSample(const unsigned ts, const uint8_t rawADC,
+                          const double q, const double ped,
+                          const double g, const float t)
+    {
+        rawCharge_[ts] = q;
+        pedestal_[ts] = ped;
+        gain_[ts] = g;
+        riseTime_[ts] = t;
+        adc_[ts] = rawADC;
+    }
+
+    // Inspectors
+    inline HcalDetId id() const {return id_;}
+
+    inline unsigned nSamples() const {return nSamples_;}
+    inline unsigned soi() const {return soi_;}
+    inline int capid() const {return capid_;}
+    inline bool hasTimeInfo() const {return hasTimeInfo_;}
+    inline bool isDropped() const {return dropped_;}
+    inline bool hasLinkError() const {return hasLinkError_;}
+    inline bool hasCapidError() const {return hasCapidError_;}
+
+    // Direct read-only access to time slice arrays
+    inline const double* rawCharge() const {return rawCharge_;}
+    inline const double* pedestal() const {return pedestal_;}
+    inline const double* gain() const {return gain_;}
+    inline const uint8_t* adc() const {return adc_;}
+    inline const float* riseTime() const
+        {if (hasTimeInfo_) return riseTime_; else return nullptr;}
+
+    // Indexed access to time slice quantities. No bounds checking.
+    inline double tsRawCharge(const unsigned ts) const {return rawCharge_[ts];}
+    inline double tsPedestal(const unsigned ts) const {return pedestal_[ts];}
+    inline double tsCharge(const unsigned ts) const
+        {return rawCharge_[ts] - pedestal_[ts];}
+    inline double tsEnergy(const unsigned ts) const
+        {return (rawCharge_[ts] - pedestal_[ts])*gain_[ts];}
+    inline double tsGain(const unsigned ts) const {return gain_[ts];}
+    inline uint8_t tsAdc(const unsigned ts) const {return adc_[ts];}
+    inline float tsRiseTime(const unsigned ts) const
+        {return hasTimeInfo_ ? riseTime_[ts] : HcalSpecialTimes::UNKNOWN_T_NOTDC;}
+
+    // Signal rise time measurement for the SOI, if available
+    inline float soiRiseTime() const
+    {
+        return (hasTimeInfo_ && soi_ < nSamples_) ?
+                riseTime_[soi_] : HcalSpecialTimes::UNKNOWN_T_NOTDC;
+    }
+
+    // The TS with the "end" index is not included in the window
+    inline double chargeInWindow(const unsigned begin, const unsigned end) const
+    {
+        double sum = 0.0;
+        const unsigned imax = end < nSamples_ ? end : nSamples_;
+        for (unsigned i=begin; i<imax; ++i)
+            sum += (rawCharge_[i] - pedestal_[i]);
+        return sum;
+    }
+
+    inline double energyInWindow(const unsigned begin, const unsigned end) const
+    {
+        double sum = 0.0;
+        const unsigned imax = end < nSamples_ ? end : nSamples_;
+        for (unsigned i=begin; i<imax; ++i)
+            sum += (rawCharge_[i] - pedestal_[i])*gain_[i];
+        return sum;
+    }
+
+    // The two following methods return MAXSAMPLES if the specified
+    // window does not overlap with the samples stored
+    inline unsigned peakChargeTS(const unsigned begin, const unsigned end) const
+    {
+        unsigned iPeak = MAXSAMPLES;
+        double dmax = -DBL_MAX;
+        const unsigned imax = end < nSamples_ ? end : nSamples_;
+        for (unsigned i=begin; i<imax; ++i)
+        {
+            const double q = rawCharge_[i] - pedestal_[i];
+            if (q > dmax)
+            {
+                dmax = q;
+                iPeak = i;
+            }
+        }
+        return iPeak;
+    }
+
+    inline unsigned peakEnergyTS(const unsigned begin, const unsigned end) const
+    {
+        unsigned iPeak = MAXSAMPLES;
+        double dmax = -DBL_MAX;
+        const unsigned imax = end < nSamples_ ? end : nSamples_;
+        for (unsigned i=begin; i<imax; ++i)
+        {
+            const double e = (rawCharge_[i] - pedestal_[i])*gain_[i];
+            if (e > dmax)
+            {
+                dmax = e;
+                iPeak = i;
+            }
+        }
+        return iPeak;
+    }
+
+    // The following function can be used, for example,
+    // in a check for presence of saturated ADC values
+    inline uint8_t peakAdcValue(const unsigned begin, const unsigned end) const
+    {
+        uint8_t peak = 0;
+        const unsigned imax = end < nSamples_ ? end : nSamples_;
+        for (unsigned i=begin; i<imax; ++i)
+            if (adc_[i] > peak)
+                peak = adc_[i];
+        return peak;
+    }
+
+private:
+    HcalDetId id_;
+
+    // Charge in fC for all time slices
+    double rawCharge_[MAXSAMPLES];
+
+    // Pedestal in fC
+    double pedestal_[MAXSAMPLES];
+
+    // fC to GeV conversion factor (can depend on CAPID)
+    double gain_[MAXSAMPLES];
+
+    // Signal rise time from TDC in ns (if provided)
+    float riseTime_[MAXSAMPLES];
+
+    // Raw QIE ADC values
+    uint8_t adc_[MAXSAMPLES];
+
+    // Number of time slices actually filled
+    uint32_t nSamples_;
+
+    // "Sample of interest" in the array of time slices
+    uint32_t soi_;
+
+    // QIE8 or QIE11 CAPID for the sample of interest
+    int32_t capid_;
+
+    // Flag indicating presence of the time info from TDC (QIE11)
+    bool hasTimeInfo_;
+
+    // Flag indicating that this channel should be dropped
+    // (typically, tagged bad from DB or zero-suppressed)
+    bool dropped_;
+
+    // Flags indicating presence of hardware errors
+    bool hasLinkError_;
+    bool hasCapidError_;
+};
+
+#endif // DataFormats_HcalRecHit_HBHEChannelInfo_h_

--- a/DataFormats/HcalRecHit/interface/HBHERecHit.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHit.h
@@ -18,9 +18,9 @@ public:
   HBHERecHit(const HcalDetId& id, float amplitude, float timeRising, float timeFalling=0);
 
   /// get the hit falling time
-  float timeFalling() const { return timeFalling_; }
+  inline float timeFalling() const { return timeFalling_; }
   /// get the id
-  HcalDetId id() const { return HcalDetId(detid()); }
+  inline HcalDetId id() const { return HcalDetId(detid()); }
 
   inline void setRawEnergy(const float en) {rawEnergy_ = en;}
   inline float eraw() const {return rawEnergy_;}
@@ -31,11 +31,15 @@ public:
   inline void setAuxHBHE(const uint32_t aux) { auxHBHE_ = aux;}
   inline uint32_t auxHBHE() const {return auxHBHE_;}
 
+  inline void setAuxPhase1(const uint32_t aux) { auxPhase1_ = aux;}
+  inline uint32_t auxPhase1() const {return auxPhase1_;}
+
 private:
   float timeFalling_;
   float rawEnergy_;
   float auxEnergy_;
   uint32_t auxHBHE_;
+  uint32_t auxPhase1_;
 };
 
 std::ostream& operator<<(std::ostream& s, const HBHERecHit& hit);

--- a/DataFormats/HcalRecHit/interface/HFQIE10Info.h
+++ b/DataFormats/HcalRecHit/interface/HFQIE10Info.h
@@ -21,14 +21,6 @@ public:
     static const unsigned N_RAW_MAX = 5;
     static const raw_type INVALID_RAW = std::numeric_limits<raw_type>::max();
 
-    // Special value for the rise time used in case the QIE10 pulse
-    // is always below the discriminator
-    static constexpr float UNKNOWN_T_UNDERSHOOT = -100.f;
-
-    // Special value for the rise time used in case the QIE10 pulse
-    // is always above the discriminator
-    static constexpr float UNKNOWN_T_OVERSHOOT = -110.f;
-
     HFQIE10Info();
 
     // Argument "soi" provides the index of the sample of interest

--- a/DataFormats/HcalRecHit/interface/HcalRecHitCollections.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitCollections.h
@@ -10,6 +10,7 @@
 #include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
 #include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HcalCalibRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
 
 
 typedef edm::SortedCollection<HBHERecHit> HBHERecHitCollection;
@@ -19,5 +20,6 @@ typedef edm::SortedCollection<HFRecHit> HFRecHitCollection;
 typedef edm::SortedCollection<ZDCRecHit> ZDCRecHitCollection;
 typedef edm::SortedCollection<CastorRecHit> CastorRecHitCollection;
 typedef edm::SortedCollection<HcalCalibRecHit> HcalCalibRecHitCollection;
+typedef edm::SortedCollection<HBHEChannelInfo> HBHEChannelInfoCollection;
 
 #endif

--- a/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
+++ b/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
@@ -1,0 +1,27 @@
+#ifndef DataFormats_HcalRecHit_HcalSpecialTimes_h_
+#define DataFormats_HcalRecHit_HcalSpecialTimes_h_
+
+namespace HcalSpecialTimes
+{
+    // Special value for the rise time used in case the QIE10/11 pulse
+    // is always below the discriminator
+    constexpr float UNKNOWN_T_UNDERSHOOT = -100.f;
+
+    // Special value for the rise time used in case the QIE10/11 pulse
+    // is always above the discriminator
+    constexpr float UNKNOWN_T_OVERSHOOT = -110.f;
+
+    // Special value for the time to use in case the TDC info is
+    // not available or not meaningful (e.g., for QIE8)
+    constexpr float UNKNOWN_T_NOTDC = -120.f;
+
+    // Check if the given time represents one of the special values
+    inline bool isSpecial(const float t)
+    {
+        return t == UNKNOWN_T_UNDERSHOOT ||
+               t == UNKNOWN_T_OVERSHOOT ||
+               t == UNKNOWN_T_NOTDC;
+    }
+}
+
+#endif // DataFormats_HcalRecHit_HcalSpecialTimes_h_

--- a/DataFormats/HcalRecHit/src/HBHERecHit.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHit.cc
@@ -1,14 +1,22 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 
 
-HBHERecHit::HBHERecHit() : CaloRecHit(), rawEnergy_(-1.0e21), auxEnergy_(-1.0e21) {
+HBHERecHit::HBHERecHit()
+    : CaloRecHit(),
+      rawEnergy_(-1.0e21),
+      auxEnergy_(-1.0e21),
+      auxHBHE_(0),
+      auxPhase1_(0)
+{
 }
 
-HBHERecHit::HBHERecHit(const HcalDetId& id, float energy, float timeRising, float timeFalling) :
-  CaloRecHit(id,energy,timeRising),
-  timeFalling_(timeFalling),
-  rawEnergy_(-1.0e21),
-  auxEnergy_(-1.0e21)
+HBHERecHit::HBHERecHit(const HcalDetId& id, float energy, float timeRising, float timeFalling)
+    : CaloRecHit(id,energy,timeRising),
+      timeFalling_(timeFalling),
+      rawEnergy_(-1.0e21),
+      auxEnergy_(-1.0e21),
+      auxHBHE_(0),
+      auxPhase1_(0)
 {
 }
 

--- a/DataFormats/HcalRecHit/src/classes.h
+++ b/DataFormats/HcalRecHit/src/classes.h
@@ -4,6 +4,7 @@
 #include "DataFormats/HcalRecHit/interface/HFRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"
 #include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h" 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h" 
@@ -27,6 +28,7 @@ namespace DataFormats_HcalRecHit {
     std::vector<ZDCRecHit> vZDC_;
     std::vector<CastorRecHit> vCastor_;
     std::vector<HcalCalibRecHit> vcal_;
+    std::vector<HBHEChannelInfo> vChanInfo_;
 
     HBHERecHitCollection theHBHE_;
     HORecHitCollection theHO_;
@@ -36,6 +38,7 @@ namespace DataFormats_HcalRecHit {
     CastorRecHitCollection theCastor_;
     HcalCalibRecHitCollection thecalib_;
     HcalSourcePositionData theSPD_;
+    HBHEChannelInfoCollection theChanInfo_;
 
     edm::Wrapper<HBHERecHitCollection> theHBHEw_;
     edm::Wrapper<HORecHitCollection> theHOw_;
@@ -45,6 +48,7 @@ namespace DataFormats_HcalRecHit {
     edm::Wrapper<CastorRecHitCollection> theCastorw_;
     edm::Wrapper<HcalCalibRecHitCollection> theCalibw_;
     edm::Wrapper<HcalSourcePositionData> theSPDw_;
+    edm::Wrapper<HBHEChannelInfoCollection> theChanInfow_;
 
     edm::Ref<HBHERecHitCollection> theHBHEr_;
     edm::Ref<HORecHitCollection> theHOr_;
@@ -53,6 +57,7 @@ namespace DataFormats_HcalRecHit {
     edm::Ref<ZDCRecHitCollection> theZDCr_;
     edm::Ref<CastorRecHitCollection> theCastorr_;
     edm::Ref<HcalCalibRecHitCollection> theCalibr_;
+    edm::Ref<HBHEChannelInfoCollection> theChanInfor_;
 
     edm::RefProd<HBHERecHitCollection> theHBHErp_;
     edm::RefProd<HORecHitCollection> theHOrp_;
@@ -61,6 +66,7 @@ namespace DataFormats_HcalRecHit {
     edm::RefProd<ZDCRecHitCollection> theZDCrp_;
     edm::RefProd<CastorRecHitCollection> theCastorrp_;
     edm::RefProd<HcalCalibRecHitCollection> theCalibrp_;
+    edm::RefProd<HBHEChannelInfoCollection> theChanInfop_;
 
     edm::RefVector<HBHERecHitCollection> theHBHErv_;
     edm::RefVector<HORecHitCollection> theHOrv_;
@@ -69,6 +75,7 @@ namespace DataFormats_HcalRecHit {
     edm::RefVector<ZDCRecHitCollection> theZDCrv_;
     edm::RefVector<CastorRecHitCollection> theCastorrv_;
     edm::RefVector<HcalCalibRecHitCollection> theCalibrv_;
+    edm::RefVector<HBHEChannelInfoCollection> theChanInfov_;
 
     edm::reftobase::Holder<CaloRecHit, HBHERecHitRef> rb4;
     edm::reftobase::Holder<CaloRecHit, HORecHitRef > rb5;

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-   <class name="HBHERecHit" ClassVersion="16">
+   <class name="HBHERecHit" ClassVersion="17">
+    <version ClassVersion="17" checksum="4076697378"/>
     <version ClassVersion="16" checksum="2359330573"/>
     <version ClassVersion="15" checksum="3086172316"/>
     <version ClassVersion="14" checksum="525320376"/>
@@ -17,6 +18,9 @@
    </class>
    <class name="HFPreRecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="224636588"/>
+   </class>
+   <class name="HBHEChannelInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="184305963"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3957655113"/>
@@ -46,6 +50,7 @@
    <class name="std::vector<ZDCRecHit>"/>
    <class name="std::vector<CastorRecHit>"/>
    <class name="std::vector<HcalCalibRecHit>"/>
+   <class name="std::vector<HBHEChannelInfo>"/>
 
    <class name="edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >"/>
    <class name="edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >"/>
@@ -54,6 +59,7 @@
    <class name="edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >"/>
    <class name="edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> >"/>
    <class name="edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> >" splitLevel="0"/>
+   <class name="edm::SortedCollection<HBHEChannelInfo,edm::StrictWeakOrdering<HBHEChannelInfo> >"/>
 
    <class name="edm::StrictWeakOrdering<HBHERecHit>"/>
    <class name="edm::StrictWeakOrdering<HORecHit>"/>
@@ -62,6 +68,7 @@
    <class name="edm::StrictWeakOrdering<ZDCRecHit>"/>
    <class name="edm::StrictWeakOrdering<CastorRecHit>"/>
    <class name="edm::StrictWeakOrdering<HcalCalibRecHit>" splitLevel="0"/>
+   <class name="edm::StrictWeakOrdering<HBHEChannelInfo>"/>
 
    <class name="edm::Wrapper<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> > >" />
    <class name="edm::Wrapper<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> > >" />
@@ -70,6 +77,7 @@
    <class name="edm::Wrapper<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> > >" splitLevel="0"/>
    <class name="edm::Wrapper<edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> > >" />
    <class name="edm::Wrapper<edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> > >" splitLevel="0"/>
+   <class name="edm::Wrapper<edm::SortedCollection<HBHEChannelInfo,edm::StrictWeakOrdering<HBHEChannelInfo> > >" />
 
    <class name="edm::Wrapper<HcalSourcePositionData>"/>
 
@@ -88,6 +96,7 @@
    <class name="edm::RefProd<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> > >"/>
    <class name="edm::RefProd<edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> > >"/>
    <class name="edm::RefProd<edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> > >"/>
+   <class name="edm::RefProd<edm::SortedCollection<HBHEChannelInfo,edm::StrictWeakOrdering<HBHEChannelInfo> > >"/>
 
    <class name="edm::RefVector<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >, HBHERecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >, HBHERecHit> >"/>
    <class name="edm::RefVector<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >, HORecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >, HORecHit> >"/>
@@ -96,6 +105,7 @@
    <class name="edm::RefVector<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >, ZDCRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >, ZDCRecHit> >"/>
    <class name="edm::RefVector<edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> >, CastorRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> >, CastorRecHit> >"/>
    <class name="edm::RefVector<edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> >, HcalCalibRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> >, HcalCalibRecHit> >"/>
+   <class name="edm::RefVector<edm::SortedCollection<HBHEChannelInfo,edm::StrictWeakOrdering<HBHEChannelInfo> >, HBHEChannelInfo, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHEChannelInfo,edm::StrictWeakOrdering<HBHEChannelInfo> >, HBHEChannelInfo> >"/>
 
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >,ZDCRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >,ZDCRecHit> > >" />
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit> >,HFRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit> >,HFRecHit> > >" />

--- a/RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h
@@ -1,0 +1,56 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_AbsHBHEPhase1Algo_h_
+#define RecoLocalCalo_HcalRecAlgos_AbsHBHEPhase1Algo_h_
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "CondFormats/HcalObjects/interface/HcalRecoParam.h"
+
+class AbsHFPhase1AlgoData;
+
+//
+// It is assumed that the HBHE Phase 1 algorithms will be developed
+// utilizing pairs of classes: a DB class with relevant calibration
+// constants and configuration parameters, derived from AbsHFPhase1AlgoData,
+// and the algo class, derived from AbsHBHEPhase1Algo, utilizing that DB class.
+//
+// We can expect that the same calibration constants might be utilized
+// by different reco algorithms.
+//
+// In principle, of course, the configuration objects do not have to be
+// actually stored in the database. It is expected that, at the early
+// stages of our understanding of energy reconstruction with QIE11
+// ASICs, these objects will be created from the module configuration
+// parameters.
+//
+class AbsHBHEPhase1Algo
+{
+public:
+    inline virtual ~AbsHBHEPhase1Algo() {}
+
+    inline virtual void beginRun(const edm::Run&, const edm::EventSetup&) {}
+    inline virtual void endRun() {}
+
+    // Does this class expect to receive its configuration from the database?
+    virtual bool isConfigurable() const = 0;
+
+    // If using DB, expect that the configuration will be updated
+    // once per run. We will not manage the pointer here. "true"
+    // should be returned on success (typically, automatic cast
+    // from the pointer checked by the appropriate dynamic cast).
+    inline virtual bool configure(const AbsHFPhase1AlgoData*) {return false;}
+
+    // Convention: if we do not want to use the given channel at
+    // all (i.e., it is to be discarded), the returned HBHERecHit
+    // should have its id (of type HcalDetId) set to 0.
+    //
+    // Note that "params" pointer is allowed to be null.
+    //
+    virtual HBHERecHit reconstruct(const HBHEChannelInfo& info,
+                                   const HcalRecoParam* params,
+                                   const HcalCalibrations& calibs,
+                                   bool isRealData) = 0;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_AbsHBHEPhase1Algo_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h
@@ -1,0 +1,24 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_
+#define RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_
+
+#include <cstdint>
+
+// Useful helpers for uint32_t fields
+namespace CaloRecHitAuxSetter
+{
+    inline void setField(uint32_t* u, const unsigned mask,
+                         const unsigned offset, const unsigned value)
+        {*u &= ~(mask << offset); *u |= ((value & mask) << offset);}
+
+    inline unsigned getField(const uint32_t u, const unsigned mask,
+                             const unsigned offset)
+        {return (u >> offset) & mask;}
+
+    inline void setBit(uint32_t* u, const unsigned bitnum, const bool b)
+        {if (b) {*u |= (1U << bitnum);} else {*u &= ~(1U << bitnum);}}
+
+    inline bool getBit(const uint32_t u, const unsigned bitnum)
+        {return u & (1U << bitnum);}
+}
+
+#endif // RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h
@@ -1,0 +1,45 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_
+#define RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_
+
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
+
+//
+// Set rechit "auxiliary words" for the Phase 1 HBHE reco.
+//
+// The standars CaloRecHit "aux" word contains ADC values 0-3.
+//
+// The "auxHBHE" word of HBHERecHit contains ADC values 4-7.
+//
+// The "auxPhase1" word of HBHERecHit contains ADC values 8-9
+// and other info, as specified by the masks and offsets below.
+//
+struct HBHERecHitAuxSetter
+{
+    static const unsigned MASK_ADC = 0xffff;
+    static const unsigned OFF_ADC = 0;
+
+    // How many ADC values are actually stored
+    static const unsigned MASK_NSAMPLES = 0xf;
+    static const unsigned OFF_NSAMPLES = 16;
+
+    // Which ADC corresponds to the sample of interest.
+    static const unsigned MASK_SOI = 0xf;
+    static const unsigned OFF_SOI = 20;
+
+    // CAPID for the sample of interest.
+    static const unsigned MASK_CAPID = 0x3;
+    static const unsigned OFF_CAPID = 24;
+
+    // Various status bits (pack bools from HBHEChannelInfo)
+    static const unsigned OFF_TDC_TIME = 26;
+    static const unsigned OFF_DROPPED = 27;
+    static const unsigned OFF_LINK_ERR = 28;
+    static const unsigned OFF_CAPID_ERR = 29;
+
+    // Main function for setting the aux words.
+    static void setAux(const HBHEChannelInfo& info,
+                       HBHERecHit* rechit);
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFRecHitAuxSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFRecHitAuxSetter.h
@@ -45,21 +45,6 @@ struct HFRecHitAuxSetter
                        const unsigned anodeStates[2],
                        unsigned soiPhase,
                        HFRecHit* rechit);
-
-    // Useful helpers for unsigned fields
-    inline static void setField(unsigned* u, const unsigned mask,
-                                const unsigned offset, const unsigned value)
-        {*u &= ~(mask << offset); *u |= ((value & mask) << offset);}
-
-    inline static unsigned getField(const unsigned u, const unsigned mask,
-                                    const unsigned offset)
-        {return (u >> offset) & mask;}
-
-    inline static void setBit(unsigned* u, const unsigned bitnum, const bool b)
-        {if (b) {*u |= (1U << bitnum);} else {*u &= ~(1U << bitnum);}}
-
-    inline static bool getBit(const unsigned u, const unsigned bitnum)
-        {return u & (1U << bitnum);}
 };
 
 #endif // RecoLocalCalo_HcalRecAlgos_HFRecHitAuxSetter_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
@@ -8,6 +8,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/PedestalSub.h"
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
@@ -19,6 +20,11 @@ class HcalDeterministicFit {
   ~HcalDeterministicFit();
 
   void init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, NegStrategy nStrat, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr);
+
+  void phase1Apply(const HBHEChannelInfo& channelData,
+                   const HcalCalibrations& calibs,
+                   float* reconstructedEnergy,
+                   float* reconstructedTime) const;
 
   // This is the CMSSW Implementation of the apply function
   template<class Digi>

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -4,6 +4,7 @@
 #include <typeinfo>
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
@@ -88,6 +89,12 @@ class PulseShapeFitOOTPileupCorrection
 public:
     PulseShapeFitOOTPileupCorrection();
     ~PulseShapeFitOOTPileupCorrection();
+
+    void phase1Apply(const HBHEChannelInfo& channelData,
+                     const HcalCalibrations& calibs,
+                     float* reconstructedEnergy,
+                     float* reconstructedTime,
+                     bool* usedTripleTemplate) const;
 
     void apply(const CaloSamples & cs, const std::vector<int> & capidvec, const HcalCalibrations & calibs, std::vector<double> & correctedOutput) const;
     void setPUParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,bool iUnConstrainedFit,bool iApplyTimeSlew,

--- a/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
@@ -1,0 +1,97 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_SimpleHBHEPhase1Algo_h_
+#define RecoLocalCalo_HcalRecAlgos_SimpleHBHEPhase1Algo_h_
+
+#include <memory>
+#include <vector>
+
+// Base class header
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h"
+
+// Other headers
+#include "CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h"
+
+
+class SimpleHBHEPhase1Algo : public AbsHBHEPhase1Algo
+{
+public:
+    // Constructor arguments:
+    //
+    //   firstSampleShift -- first TS w.r.t. SOI to use for "Method 0"
+    //                       reconstruction.
+    //
+    //   samplesToAdd     -- number of samples to add for "Method 0"
+    //                       reconstruction. If, let say, SOI = 4,
+    //                       firstSampleShift = -1, and samplesToAdd = 3
+    //                       then the code will add time slices 3, 4, and 5.
+    //
+    //   phaseNS          -- default "phase" parameter for the pulse
+    //                       containment correction
+    //
+    //   timeShift        -- time shift for QIE11 TDC times
+    //
+    //   m2               -- "Method 2" object
+    //
+    //   detFit           -- "Method 3" (a.k.a. "deterministic fit") object
+    //
+    SimpleHBHEPhase1Algo(int firstSampleShift,
+                         int samplesToAdd,
+                         float phaseNS,
+                         float timeShift,
+                         std::unique_ptr<PulseShapeFitOOTPileupCorrection> m2,
+                         std::unique_ptr<HcalDeterministicFit> detFit);
+
+    inline virtual ~SimpleHBHEPhase1Algo() {}
+
+    // Methods to override from the base class
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void endRun() override;
+
+    inline virtual bool isConfigurable() const override {return false;}
+
+    virtual HBHERecHit reconstruct(const HBHEChannelInfo& info,
+                                   const HcalRecoParam* params,
+                                   const HcalCalibrations& calibs,
+                                   bool isRealData) override;
+    // Basic accessors
+    inline int getFirstSampleShift() const {return firstSampleShift_;}
+    inline int getSamplesToAdd() const {return samplesToAdd_;}
+    inline float getPhaseNS() const {return phaseNS_;}
+    inline int getRunNumber() const {return runnum_;}
+
+protected:
+    // Special HB- correction
+    float hbminusCorrectionFactor(const HcalDetId& cell,
+                                  float energy, bool isRealData) const;
+
+    // "Method 0" rechit energy. Calls a non-const member of
+    // HcalPulseContainmentManager, so no const qualifier here.
+    // HB- correction is not applied inside this function.
+    float m0Energy(const HBHEChannelInfo& info,
+                   double reconstructedCharge,
+                   bool applyContainmentCorrection,
+                   double phaseNS);
+
+    // "Method 0" rechit timing (original low-pileup QIE8 algorithm)
+    float m0Time(const HBHEChannelInfo& info,
+                 double reconstructedCharge,
+                 const HcalCalibrations& calibs) const;
+private:
+    HcalPulseContainmentManager pulseCorr_;
+
+    int firstSampleShift_;
+    int samplesToAdd_;
+    float phaseNS_;
+    float timeShift_;
+    int runnum_;
+
+    // "Metod 2" algorithm
+    std::unique_ptr<PulseShapeFitOOTPileupCorrection> psFitOOTpuCorr_;
+
+    // "Metod 3" algorithm
+    std::unique_ptr<HcalDeterministicFit> hltOOTpuCorr_;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_SimpleHBHEPhase1Algo_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
@@ -1,0 +1,21 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_parseHBHEPhase1AlgoDescription_h
+#define RecoLocalCalo_HcalRecAlgos_parseHBHEPhase1AlgoDescription_h
+
+#include <memory>
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h"
+
+namespace edm {
+    class ParameterSet;
+}
+
+//
+// Factory function for creating objects of types
+// inheriting from AbsHBHEPhase1Algo out of parameter sets.
+//
+// Update the implementation of this function if you need
+// to add a new algorithm to HBHEPhase1Reconstructor.
+//
+std::unique_ptr<AbsHBHEPhase1Algo>
+parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps);
+
+#endif // RecoLocalCalo_HcalRecAlgos_parseHBHEPhase1AlgoDescription_h

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHERecHitAuxSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHERecHitAuxSetter.cc
@@ -1,0 +1,40 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
+
+void HBHERecHitAuxSetter::setAux(const HBHEChannelInfo& info,
+                                 HBHERecHit* rechit)
+{
+    using namespace CaloRecHitAuxSetter;
+
+    uint32_t aux = 0, auxHBHE = 0, auxPhase1 = 0;
+
+    // Pack ADC values
+    unsigned nSamples = info.nSamples();
+    if (nSamples > 10)
+        nSamples = 10;
+    for (unsigned i=0; i<4 && i<nSamples; ++i)
+        setField(&aux, 0xff, i*8, info.tsAdc(i));
+    for (unsigned i=4; i<8 && i<nSamples; ++i)
+        setField(&auxHBHE, 0xff, (i-4)*8, info.tsAdc(i));
+    for (unsigned i=8; i<nSamples; ++i)
+        setField(&auxPhase1, 0xff, (i-8)*8, info.tsAdc(i));
+
+    // Pack other fields
+    setField(&auxPhase1, MASK_NSAMPLES, OFF_NSAMPLES, nSamples);
+    unsigned soi = info.soi();
+    if (soi > 10)
+        soi = 10;
+    setField(&auxPhase1, MASK_SOI, OFF_SOI, soi);
+    setField(&auxPhase1, MASK_CAPID, OFF_CAPID, info.capid());
+
+    // Pack status bits
+    setBit(&auxPhase1, OFF_TDC_TIME, info.hasTimeInfo());
+    setBit(&auxPhase1, OFF_DROPPED, info.isDropped());
+    setBit(&auxPhase1, OFF_LINK_ERR, info.hasLinkError());
+    setBit(&auxPhase1, OFF_CAPID_ERR, info.hasCapidError());
+
+    // Copy the aux words into the rechit
+    rechit->setAux(aux);
+    rechit->setAuxHBHE(auxHBHE);
+    rechit->setAuxPhase1(auxPhase1);
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/HFPreRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFPreRecAlgo.cc
@@ -1,6 +1,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h"
 
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalRecHit/interface/HcalSpecialTimes.h"
 
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
@@ -19,6 +20,11 @@ HFQIE10Info HFPreRecAlgo::reconstruct(const QIE10DataFrame& digi,
     static const int qie10_tdc_code_overshoot = 62;
     static const int qie10_tdc_code_undershoot = 63;
 
+    // Scrap the trailing edge time for now -- until the front-end
+    // FPGA firmware is finalized and the description of the FPGA
+    // output becomes available
+    static const float timeFalling = HcalSpecialTimes::UNKNOWN_T_NOTDC;
+
     HFQIE10Info result;
 
     CaloSamples cs;
@@ -35,13 +41,9 @@ HFQIE10Info HFPreRecAlgo::reconstruct(const QIE10DataFrame& digi,
         const int tdc = s.le_tdc();
         float timeRising = qie10_tdc_to_ns*tdc;
         if (tdc == qie10_tdc_code_overshoot)
-            timeRising = HFQIE10Info::UNKNOWN_T_OVERSHOOT;
+            timeRising = HcalSpecialTimes::UNKNOWN_T_OVERSHOOT;
         else if (tdc == qie10_tdc_code_undershoot)
-            timeRising = HFQIE10Info::UNKNOWN_T_UNDERSHOOT;
-
-        // We will assume for now that the trailing edge time
-        // is ok as long as the leading edge is ok
-        const float timeFalling = qie10_tdc_to_ns*s.te_tdc();
+            timeRising = HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT;
 
         // Figure out the window in the raw data
         // that we want to store. This window will

--- a/RecoLocalCalo/HcalRecAlgos/src/HFRecHitAuxSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFRecHitAuxSetter.cc
@@ -3,17 +3,21 @@
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFAnodeStatus.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFRecHitAuxSetter.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
+
 
 void HFRecHitAuxSetter::setAux(const HFPreRecHit& prehit,
                                const unsigned anodeStates[2],
                                const unsigned u_soiPhase,
                                HFRecHit* rechit)
 {
+    using namespace CaloRecHitAuxSetter;
+
     const int wantedPhase = u_soiPhase < 2U ? u_soiPhase : 2U;
 
     for (unsigned ianode=0; ianode<2; ++ianode)
     {
-        unsigned aux = 0;
+        uint32_t aux = 0;
         const HFQIE10Info* anodeInfo = prehit.getHFQIE10Info(ianode);
         if (anodeInfo)
         {

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -42,3 +42,12 @@ void HcalDeterministicFit::getLandauFrac(float tStart, float tEnd, float &sum) c
   sum= landauFrac[int(ceil(tStart+tsWidth))];
   return;
 }
+
+void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
+                                       const HcalCalibrations& calibs,
+                                       float* reconstructedEnergy,
+                                       float* reconstructedTime) const
+{
+    // IMPLEMENT THIS!!!
+}
+

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -473,3 +473,13 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
      chargevalfit=-999.;
    }
 }
+
+void PulseShapeFitOOTPileupCorrection::phase1Apply(
+    const HBHEChannelInfo& channelData,
+    const HcalCalibrations& calibs,
+    float* reconstructedEnergy,
+    float* reconstructedTime,
+    bool* usedTripleTemplate) const
+{
+    // IMPLEMENT THIS!!!
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -1,0 +1,202 @@
+#include <algorithm>
+
+#include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalCorrectionFunctions.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
+
+#include "FWCore/Framework/interface/Run.h"
+
+#include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+
+// Maximum fractional error for calculating Method 0
+// pulse containment correction
+constexpr float PulseContainmentFractionalError = 0.002f;
+
+
+SimpleHBHEPhase1Algo::SimpleHBHEPhase1Algo(
+    const int firstSampleShift,
+    const int samplesToAdd,
+    const float phaseNS,
+    const float timeShift,
+    std::unique_ptr<PulseShapeFitOOTPileupCorrection> m2,
+    std::unique_ptr<HcalDeterministicFit> detFit)
+    : pulseCorr_(PulseContainmentFractionalError),
+      firstSampleShift_(firstSampleShift),
+      samplesToAdd_(samplesToAdd),
+      phaseNS_(phaseNS),
+      timeShift_(timeShift),
+      runnum_(0),
+      psFitOOTpuCorr_(std::move(m2)),
+      hltOOTpuCorr_(std::move(detFit))
+{
+}
+
+void SimpleHBHEPhase1Algo::beginRun(const edm::Run& r,
+                                    const edm::EventSetup& es)
+{
+    runnum_ = r.run();
+    pulseCorr_.beginRun(es);
+}
+
+void SimpleHBHEPhase1Algo::endRun()
+{
+    runnum_ = 0;
+    pulseCorr_.endRun();
+}
+
+HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
+                                             const HcalRecoParam* params,
+                                             const HcalCalibrations& calibs,
+                                             const bool isData)
+{
+    HBHERecHit rh;
+
+    const HcalDetId channelId(info.id());
+
+    // Calculate "Method 0" quantities
+    float m0t = 0.f, m0E = 0.f;
+    {
+        int ibeg = static_cast<int>(info.soi()) + firstSampleShift_;
+        if (ibeg < 0)
+            ibeg = 0;
+        const double fc_ampl = info.chargeInWindow(ibeg, ibeg + samplesToAdd_);
+        const bool applyContainment = params ? params->correctForPhaseContainment() : true;
+        const float phasens = params ? params->correctionPhaseNS() : phaseNS_;
+        m0E = m0Energy(info, fc_ampl, applyContainment, phasens);
+        m0E *= hbminusCorrectionFactor(channelId, m0E, isData);
+        m0t = m0Time(info, fc_ampl, calibs);
+    }
+
+    // Run "Method 2"
+    float m2t = 0.f, m2E = 0.f;
+    bool useTriple = false;
+    const PulseShapeFitOOTPileupCorrection* method2 = psFitOOTpuCorr_.get();
+    if (method2)
+    {
+        method2->phase1Apply(info, calibs, &m2E, &m2t, &useTriple);
+        m2E *= hbminusCorrectionFactor(channelId, m2E, isData);
+    }
+
+    // Run "Method 3"
+    float m3t = 0.f, m3E = 0.f;
+    const HcalDeterministicFit* method3 = hltOOTpuCorr_.get();
+    if (method3)
+    {
+        method3->phase1Apply(info, calibs, &m3E, &m3t);
+        m3E *= hbminusCorrectionFactor(channelId, m3E, isData);
+    }
+
+    // Finally, construct the rechit
+    float rhE = m0E;
+    float rht = m0t;
+    if (method2)
+    {
+        rhE = m2E;
+        rht = m2t;
+    }
+    else if (method3)
+    {
+        rhE = m3E;
+        rht = m3t;
+    }
+    float tdcTime = info.soiRiseTime();
+    if (!HcalSpecialTimes::isSpecial(tdcTime))
+        tdcTime += timeShift_;
+    rh = HBHERecHit(channelId, rhE, rht, tdcTime);
+    rh.setRawEnergy(m0E);
+    rh.setAuxEnergy(m3E);
+
+    // Set rechit aux words
+    HBHERecHitAuxSetter::setAux(info, &rh);
+
+    // Set some rechit flags
+    if (useTriple)
+        rh.setFlagField(1, HcalCaloFlagLabels::HBHEPulseFitBit);
+
+    return rh;
+}
+
+float SimpleHBHEPhase1Algo::hbminusCorrectionFactor(const HcalDetId& cell,
+                                                    const float energy,
+                                                    const bool isRealData) const
+{
+    float corr = 1.f;
+    if (isRealData && runnum_ > 0)
+        if (cell.subdet() == HcalBarrel)
+        {
+            const int ieta = cell.ieta();
+            const int iphi = cell.iphi();
+            corr = hbminus_special_ecorr(ieta, iphi, energy, runnum_);
+        }
+    return corr;
+}
+
+float SimpleHBHEPhase1Algo::m0Energy(const HBHEChannelInfo& info,
+                                     const double fc_ampl,
+                                     const bool applyContainmentCorrection,
+                                     const double phaseNs)
+{
+    int ibeg = static_cast<int>(info.soi()) + firstSampleShift_;
+    if (ibeg < 0)
+        ibeg = 0;
+    double e = info.energyInWindow(ibeg, ibeg + samplesToAdd_);
+
+    // Pulse containment correction
+    {    
+        double corrFactor = 1.0;
+        if (applyContainmentCorrection)
+            corrFactor = pulseCorr_.get(info.id(), samplesToAdd_, phaseNs)->getCorrection(fc_ampl);
+        e *= corrFactor;
+    }
+
+    return e;
+}
+
+float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
+                                   const double fc_ampl,
+                                   const HcalCalibrations& calibs) const
+{
+    float time = -9999.f; // historic value
+
+    const unsigned nSamples = info.nSamples();
+    if (nSamples > 2U)
+    {
+        const int soi = info.soi();
+        int ibeg = soi + firstSampleShift_;
+        if (ibeg < 0)
+            ibeg = 0;
+        const int iend = ibeg + samplesToAdd_;
+        unsigned maxI = info.peakEnergyTS(ibeg, iend);
+        if (maxI < HBHEChannelInfo::MAXSAMPLES)
+        {
+            if (!maxI)
+                maxI = 1U;
+            else if (maxI >= nSamples - 1U)
+                maxI = nSamples - 2U;
+
+            // The remaining code in this scope emulates
+            // the historic algorithm
+            float t0 = info.tsEnergy(maxI - 1U);
+            float maxA = info.tsEnergy(maxI);
+            float t2 = info.tsEnergy(maxI + 1U);
+
+            // Handle negative excursions by moving "zero"
+            float minA = t0;
+            if (maxA < minA) minA = maxA;
+            if (t2 < minA)   minA=t2;
+            if (minA < 0.f) { maxA-=minA; t0-=minA; t2-=minA; }
+            float wpksamp = (t0 + maxA + t2);
+            if (wpksamp) wpksamp = (maxA + 2.f*t2) / wpksamp;
+            time = (maxI - soi)*25.f + timeshift_ns_hbheho(wpksamp);
+
+            // Legacy QIE8 timing correction
+            time -= HcalTimeSlew::delay(std::max(1.0, fc_ampl),
+                                        HcalTimeSlew::Medium);
+            // Time calibration
+            time -= calibs.timecorr();
+        }
+    }
+    return time;
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -8,7 +8,10 @@
 
 #include "FWCore/Framework/interface/Run.h"
 
-#include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+// We will likely have to remap the rechit status bits, so the relevant
+// header is commented out for now
+//
+// #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 
 // Maximum fractional error for calculating Method 0
 // pulse containment correction
@@ -112,8 +115,8 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
     HBHERecHitAuxSetter::setAux(info, &rh);
 
     // Set some rechit flags
-    if (useTriple)
-        rh.setFlagField(1, HcalCaloFlagLabels::HBHEPulseFitBit);
+    // if (useTriple)
+    //    rh.setFlagField(1, HcalCaloFlagLabels::HBHEPulseFitBit);
 
     return rh;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -1,0 +1,99 @@
+#include <cassert>
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h"
+
+// Phase 1 HBHE reco algorithm headers
+#include "RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h"
+
+
+static std::unique_ptr<PulseShapeFitOOTPileupCorrection>
+parseHBHEMethod2Description(const edm::ParameterSet& conf)
+{
+    const bool iPedestalConstraint = conf.getParameter<bool>  ("applyPedConstraint");
+    const bool iTimeConstraint =     conf.getParameter<bool>  ("applyTimeConstraint");
+    const bool iAddPulseJitter =     conf.getParameter<bool>  ("applyPulseJitter");
+    const bool iUnConstrainedFit =   conf.getParameter<bool>  ("applyUnconstrainedFit");
+    const bool iApplyTimeSlew =      conf.getParameter<bool>  ("applyTimeSlew");
+    const double iTS4Min =           conf.getParameter<double>("ts4Min");
+    const double iTS4Max =           conf.getParameter<double>("ts4Max");
+    const double iPulseJitter =      conf.getParameter<double>("pulseJitter");
+    const double iTimeMean =         conf.getParameter<double>("meanTime");
+    const double iTimeSig =          conf.getParameter<double>("timeSigma");
+    const double iPedMean =          conf.getParameter<double>("meanPed");
+    const double iPedSig =           conf.getParameter<double>("pedSigma");
+    const double iNoise =            conf.getParameter<double>("noise");
+    const double iTMin =             conf.getParameter<double>("timeMin");
+    const double iTMax =             conf.getParameter<double>("timeMax");
+    const double its3Chi2 =          conf.getParameter<double>("ts3chi2");
+    const double its4Chi2 =          conf.getParameter<double>("ts4chi2");
+    const double its345Chi2 =        conf.getParameter<double>("ts345chi2");
+    const double iChargeThreshold =  conf.getParameter<double>("chargeMax"); //For the unconstrained Fit
+    const int iFitTimes =            conf.getParameter<int>   ("fitTimes");
+
+    if (iPedestalConstraint) assert(iPedSig);
+    if (iTimeConstraint) assert(iTimeSig);
+
+    std::unique_ptr<PulseShapeFitOOTPileupCorrection> corr =
+        std::make_unique<PulseShapeFitOOTPileupCorrection>();
+    corr->setPUParams(iPedestalConstraint, iTimeConstraint, iAddPulseJitter,
+                      iUnConstrainedFit, iApplyTimeSlew, iTS4Min, iTS4Max,
+                      iPulseJitter, iTimeMean, iTimeSig, iPedMean, iPedSig,
+                      iNoise, iTMin, iTMax, its3Chi2, its4Chi2, its345Chi2,
+                      iChargeThreshold, HcalTimeSlew::Medium, iFitTimes);
+    return corr;
+}
+
+
+static std::unique_ptr<HcalDeterministicFit>
+parseHBHEMethod3Description(const edm::ParameterSet& conf)
+{
+    const int iPedSubMethod =      conf.getParameter<int>   ("pedestalSubtractionType");
+    const float iPedSubThreshold = conf.getParameter<double>("pedestalUpperLimit");
+    const int iTimeSlewParsType =  conf.getParameter<int>   ("timeSlewParsType");
+    const double irespCorrM3 =     conf.getParameter<double>("respCorrM3");
+    const std::vector<double>& iTimeSlewPars =
+                     conf.getParameter<std::vector<double> >("timeSlewPars");
+
+    PedestalSub pedSubFxn;
+    pedSubFxn.init(((PedestalSub::Method)iPedSubMethod), 0, iPedSubThreshold, 0.0);
+
+    std::unique_ptr<HcalDeterministicFit> fit = std::make_unique<HcalDeterministicFit>();
+    fit->init((HcalTimeSlew::ParaSource)iTimeSlewParsType,
+              HcalTimeSlew::Medium, (HcalDeterministicFit::NegStrategy)2,
+              pedSubFxn, iTimeSlewPars, irespCorrM3);
+    return fit;
+}
+
+
+std::unique_ptr<AbsHBHEPhase1Algo>
+parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps)
+{
+    std::unique_ptr<AbsHBHEPhase1Algo> algo;
+
+    const std::string& className = ps.getParameter<std::string>("Class");
+
+    if (className == "SimpleHBHEPhase1Algo")
+    {
+        std::unique_ptr<PulseShapeFitOOTPileupCorrection> m2;
+        if (ps.getParameter<bool>("useM2"))
+            m2 = parseHBHEMethod2Description(ps);
+
+        std::unique_ptr<HcalDeterministicFit> detFit;
+        if (ps.getParameter<bool>("useM3"))
+            detFit = parseHBHEMethod3Description(ps);
+
+        algo = std::unique_ptr<AbsHBHEPhase1Algo>(
+            new SimpleHBHEPhase1Algo(ps.getParameter<int>   ("firstSampleShift"),
+                                     ps.getParameter<int>   ("samplesToAdd"),
+                                     ps.getParameter<double>("correctionPhaseNS"),
+                                     ps.getParameter<double>("tdcTimeShift"),
+                                     std::move(m2), std::move(detFit))
+            );
+    }
+
+    return algo;
+}

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -6,13 +6,13 @@ hbheprereco = cms.EDProducer(
 
     # Label for the input HBHEDigiCollection, and flag indicating
     # whether we should process this collection
-    digiLabelHB = cms.InputTag("hcalDigis"),
-    processHB = cms.bool(True),
+    digiLabelQIE8 = cms.InputTag("hcalDigis"),
+    processQIE8 = cms.bool(True),
 
     # Label for the input QIE11DigiCollection, and flag indicating
     # whether we should process this collection
-    digiLabelHE = cms.InputTag("hcalDigis"),
-    processHE = cms.bool(True),
+    digiLabelQIE11 = cms.InputTag("hcalDigis"),
+    processQIE11 = cms.bool(True),
 
     # Get the "sample of interest" index from DB?
     # If not, it is taken from the dataframe.

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -1,0 +1,86 @@
+import FWCore.ParameterSet.Config as cms
+import RecoLocalCalo.HcalRecProducers.HBHEMethod3Parameters_cfi as method3
+
+hbheprereco = cms.EDProducer(
+    "HBHEPhase1Reconstructor",
+
+    # Label for the input HBHEDigiCollection, and flag indicating
+    # whether we should process this collection
+    digiLabelHB = cms.InputTag("hcalDigis"),
+    processHB = cms.bool(True),
+
+    # Label for the input QIE11DigiCollection, and flag indicating
+    # whether we should process this collection
+    digiLabelHE = cms.InputTag("hcalDigis"),
+    processHE = cms.bool(True),
+
+    # Get the "sample of interest" index from DB?
+    # If not, it is taken from the dataframe.
+    tsFromDB = cms.bool(False),
+
+    # Use the HcalRecoParam structure from DB inside
+    # the reconstruction algorithm?
+    recoParamsFromDB = cms.bool(True),
+
+    # Drop zero-suppressed channels?
+    dropZSmarkedPassed = cms.bool(True),
+
+    # Flag indicating whether we should produce HBHERecHitCollection
+    makeRecHits = cms.bool(True),
+
+    # Flag indicating whether we should produce HBHEChannelInfoCollection
+    saveInfos = cms.bool(False),
+
+    # Flag indicating whether we should include HBHEChannelInfo objects
+    # into HBHEChannelInfoCollection despite the fact that the channels
+    # are either tagged bad in DB of zero-suppressed. Note that the rechit
+    # collection will not include such channels even if this flag is set.
+    saveDroppedInfos = cms.bool(False),
+
+    # Configure the reconstruction algorithm
+    algorithm = cms.PSet(
+        # Parameters for "Method 3" (non-keyword arguments have to go first)
+        method3.m3Parameters,
+
+        Class = cms.string("SimpleHBHEPhase1Algo"),
+
+        # Time shift (in ns) to add to TDC timing (for QIE11)
+        tdcTimeShift = cms.double(0.0),
+
+        # Parameters for "Method 0"
+        firstSampleShift  = cms.int32(0),
+        samplesToAdd      = cms.int32(2),
+        correctionPhaseNS = cms.double(6.0),
+
+        # Use "Method 2"? Change this to True when implemented.
+        useM2 = cms.bool(False),
+
+        # Parameters for "Method 2"
+        applyPedConstraint    = cms.bool(True),
+        applyTimeConstraint   = cms.bool(True),
+        applyPulseJitter      = cms.bool(False),  
+        applyUnconstrainedFit = cms.bool(False),  #Turn on original Method 2
+        applyTimeSlew         = cms.bool(True),   #units
+        ts4Min                = cms.double(0.),   #fC
+        ts4Max                = cms.double(100.), #fC
+        pulseJitter           = cms.double(1.),   #GeV/bin
+        meanTime              = cms.double(0.),   #ns
+        timeSigma             = cms.double(5.),   #ns
+        meanPed               = cms.double(0.),   #GeV
+        pedSigma              = cms.double(0.5),  #GeV
+        noise                 = cms.double(1),    #fC
+        timeMin               = cms.double(-12.5),#ns
+        timeMax               = cms.double(12.5), #ns
+        ts3chi2               = cms.double(5.),   #chi2 (not used)
+        ts4chi2               = cms.double(15.),  #chi2 for triple pulse 
+        ts345chi2             = cms.double(100.), #chi2 (not used)
+        chargeMax             = cms.double(6.),   #Charge cut (fC) for uncstrianed Fit 
+        fitTimes              = cms.int32(1),     # -1 means no constraint on number of fits per channel
+
+        # Use "Method 3"? Change this to True when implemented.
+        useM3 = cms.bool(False)
+    ),
+
+    # Reconstruction algorithm configuration data to fetch from DB, if any
+    algoConfigClass = cms.string("")
+)

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -168,8 +168,8 @@ private:
 
     // Configuration parameters
     std::string algoConfigClass_;
-    bool processHB_;
-    bool processHE_;
+    bool processQIE8_;
+    bool processQIE11_;
     bool saveInfos_;
     bool saveDroppedInfos_;
     bool makeRecHits_;
@@ -178,8 +178,8 @@ private:
     bool recoParamsFromDB_;
 
     // Other members
-    edm::EDGetTokenT<HBHEDigiCollection> tok_hb_;
-    edm::EDGetTokenT<QIE11DigiCollection> tok_he_;
+    edm::EDGetTokenT<HBHEDigiCollection> tok_qie8_;
+    edm::EDGetTokenT<QIE11DigiCollection> tok_qie11_;
     std::unique_ptr<AbsHBHEPhase1Algo> reco_;
     std::unique_ptr<AbsHFPhase1AlgoData> recoConfig_;
     std::unique_ptr<HcalRecoParams> paramTS_;
@@ -212,8 +212,8 @@ private:
 //
 HBHEPhase1Reconstructor::HBHEPhase1Reconstructor(const edm::ParameterSet& conf)
     : algoConfigClass_(conf.getParameter<std::string>("algoConfigClass")),
-      processHB_(conf.getParameter<bool>("processHB")),
-      processHE_(conf.getParameter<bool>("processHE")),
+      processQIE8_(conf.getParameter<bool>("processQIE8")),
+      processQIE11_(conf.getParameter<bool>("processQIE11")),
       saveInfos_(conf.getParameter<bool>("saveInfos")),
       saveDroppedInfos_(conf.getParameter<bool>("saveDroppedInfos")),
       makeRecHits_(conf.getParameter<bool>("makeRecHits")),
@@ -228,13 +228,13 @@ HBHEPhase1Reconstructor::HBHEPhase1Reconstructor(const edm::ParameterSet& conf)
             << "Invalid HBHEPhase1Algo algorithm configuration"
             << std::endl;
 
-    if (processHB_)
-        tok_hb_ = consumes<HBHEDigiCollection>(
-            conf.getParameter<edm::InputTag>("digiLabelHB"));
+    if (processQIE8_)
+        tok_qie8_ = consumes<HBHEDigiCollection>(
+            conf.getParameter<edm::InputTag>("digiLabelQIE8"));
 
-    if (processHE_)
-        tok_he_ = consumes<QIE11DigiCollection>(
-            conf.getParameter<edm::InputTag>("digiLabelHE"));
+    if (processQIE11_)
+        tok_qie11_ = consumes<QIE11DigiCollection>(
+            conf.getParameter<edm::InputTag>("digiLabelQIE11"));
 
     if (saveInfos_)
         produces<HBHEChannelInfoCollection>();
@@ -397,16 +397,16 @@ HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetu
     // Find the input data
     unsigned maxOutputSize = 0;
     Handle<HBHEDigiCollection> hbDigis;
-    if (processHB_)
+    if (processQIE8_)
     {
-        e.getByToken(tok_hb_, hbDigis);
+        e.getByToken(tok_qie8_, hbDigis);
         maxOutputSize += hbDigis->size();
     }
 
     Handle<QIE11DigiCollection> heDigis;
-    if (processHE_)
+    if (processQIE11_)
     {
-        e.getByToken(tok_he_, heDigis);
+        e.getByToken(tok_qie11_, heDigis);
         maxOutputSize += heDigis->size();
     }
 
@@ -427,14 +427,14 @@ HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
     // Process the input collections, filling the output ones
     const bool isData = e.isRealData();
-    if (processHB_)
+    if (processQIE8_)
     {
         HBHEChannelInfo channelInfo(false);
         processData<HBHEDataFrame>(*hbDigis, *conditions, *p, *mycomputer,
                                    isData, &channelInfo, infos.get(), out.get());
     }
 
-    if (processHE_)
+    if (processQIE11_)
     {
         HBHEChannelInfo channelInfo(true);
         processData<QIE11DataFrame>(*heDigis, *conditions, *p, *mycomputer,
@@ -492,11 +492,11 @@ HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descri
 {
     edm::ParameterSetDescription desc;
 
-    desc.add<edm::InputTag>("digiLabelHB");
-    desc.add<edm::InputTag>("digiLabelHE");
+    desc.add<edm::InputTag>("digiLabelQIE8");
+    desc.add<edm::InputTag>("digiLabelQIE11");
     desc.add<std::string>("algoConfigClass");
-    desc.add<bool>("processHB");
-    desc.add<bool>("processHE");
+    desc.add<bool>("processQIE8");
+    desc.add<bool>("processQIE11");
     desc.add<bool>("saveInfos");
     desc.add<bool>("saveDroppedInfos");
     desc.add<bool>("makeRecHits");

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -1,0 +1,513 @@
+// -*- C++ -*-
+//
+// Package:    RecoLocalCalo/HcalRecProducers
+// Class:      HBHEPhase1Reconstructor
+// 
+/**\class HBHEPhase1Reconstructor HBHEPhase1Reconstructor.cc RecoLocalCalo/HcalRecProducers/plugins/HBHEPhase1Reconstructor.cc
+
+ Description: Phase 1 reconstruction module for HB/HE
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Tue, 21 Jun 2016 00:56:40 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <utility>
+#include <algorithm>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+
+// Base class for Phase 1 HB/HE reco algorithms configuration objects
+#include "CondFormats/HcalObjects/interface/AbsHFPhase1AlgoData.h"
+
+// Parser for Phase 1 HB/HE reco algorithms
+#include "RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h"
+
+// Some helper functions
+namespace {
+    // Class Data must inherit from AbsHFPhase1AlgoData
+    // and must have a copy constructor. This function
+    // returns an object allocated on the heap.
+    template <class Data, class Record>
+    Data* fetchHBHEPhase1AlgoDataHelper(const edm::EventSetup& es)
+    {
+        edm::ESHandle<Data> p;
+        es.get<Record>().get(p);
+        return new Data(*p.product());
+    }
+
+    // Factory function for fetching (from EventSetup) objects
+    // of the types inheriting from AbsHFPhase1AlgoData
+    std::unique_ptr<AbsHFPhase1AlgoData>
+    fetchHBHEPhase1AlgoData(const std::string& className, const edm::EventSetup& es)
+    {
+        AbsHFPhase1AlgoData* data = 0;
+        // Compare with possibe class names
+        // if (className == "MyHFPhase1AlgoData")
+        //     data = fetchHBHEPhase1AlgoDataHelper<MyHFPhase1AlgoData, MyHFPhase1AlgoDataRcd>(es);
+        // else if (className == "OtherHFPhase1AlgoData")
+        //     ...;
+        return std::unique_ptr<AbsHFPhase1AlgoData>(data);
+    }
+
+    // The following function should apply the SiPM nonlinearity
+    // correction. It may need extra arguments for that. It should
+    // return the best estimate of the charge before pedestal subtraction.
+    double getRawChargeFromSample(const QIE11DataFrame::Sample& s,
+                                  const double decodedCharge,
+                                  const HcalCalibrations& calib)
+    {
+        // FIX THIS!!!
+        return decodedCharge;
+    }
+
+    double getRawChargeFromSample(const HcalQIESample& s,
+                                  const double decodedCharge,
+                                  const HcalCalibrations& calib)
+    {
+        return decodedCharge;
+    }
+
+    float getTDCTimeFromSample(const QIE11DataFrame::Sample& s)
+    {
+        // Conversion from TDC to ns for the QIE11 chip
+        static const float qie11_tdc_to_ns = 0.5f;
+
+        // TDC values produced in case the pulse is always above/below
+        // the discriminator
+        static const int qie11_tdc_code_overshoot = 62;
+        static const int qie11_tdc_code_undershoot = 63;
+
+        const int tdc = s.tdc();
+        float t = qie11_tdc_to_ns*tdc;
+        if (tdc == qie11_tdc_code_overshoot)
+            t = HcalSpecialTimes::UNKNOWN_T_OVERSHOOT;
+        else if (tdc == qie11_tdc_code_undershoot)
+            t = HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT;
+        return t;
+    }
+
+    float getTDCTimeFromSample(const HcalQIESample&)
+    {
+        return HcalSpecialTimes::UNKNOWN_T_NOTDC;
+    }
+
+    // The first element of the pair indicates presence of optical
+    // link errors. The second indicated presence of capid errors.
+    std::pair<bool,bool> findHWErrors(const HBHEDataFrame& df,
+                                      const unsigned len)
+    {
+        bool linkErr = false;
+        bool capidErr = false;
+        if (len)
+        {
+            int expectedCapid = df[0].capid();
+            for (unsigned i=0; i<len; ++i)
+            {
+                if (df[i].er())
+                    linkErr = true;
+                if (df[i].capid() != expectedCapid)
+                    capidErr = true;
+                expectedCapid = (expectedCapid + 1) % 4;
+            }
+        }
+        return std::pair<bool,bool>(linkErr, capidErr);
+    }
+
+    std::pair<bool,bool> findHWErrors(const QIE11DataFrame& df,
+                                      const unsigned /* len */)
+    {
+        return std::pair<bool,bool>(df.linkError(), df.capidError());
+    }
+}
+
+
+//
+// class declaration
+//
+class HBHEPhase1Reconstructor : public edm::stream::EDProducer<>
+{
+public:
+    explicit HBHEPhase1Reconstructor(const edm::ParameterSet&);
+    ~HBHEPhase1Reconstructor();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+    virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+
+    // Configuration parameters
+    std::string algoConfigClass_;
+    bool processHB_;
+    bool processHE_;
+    bool saveInfos_;
+    bool saveDroppedInfos_;
+    bool makeRecHits_;
+    bool dropZSmarkedPassed_;
+    bool tsFromDB_;
+    bool recoParamsFromDB_;
+
+    // Other members
+    edm::EDGetTokenT<HBHEDigiCollection> tok_hb_;
+    edm::EDGetTokenT<QIE11DigiCollection> tok_he_;
+    std::unique_ptr<AbsHBHEPhase1Algo> reco_;
+    std::unique_ptr<AbsHFPhase1AlgoData> recoConfig_;
+    std::unique_ptr<HcalRecoParams> paramTS_;
+
+    // Status bit setters
+    // ... Not available yet ...
+
+    // For the function below, arguments "infoColl" and/or "rechits"
+    // are allowed to be null.
+    template<class DataFrame, class Collection>
+    void processData(const Collection& coll,
+                     const HcalDbService& cond,
+                     const HcalChannelQuality& qual,
+                     const HcalSeverityLevelComputer& severity,
+                     const bool isRealData,
+                     HBHEChannelInfo* info,
+                     HBHEChannelInfoCollection* infoColl,
+                     HBHERecHitCollection* rechits);
+
+    // Methods for setting rechit status bits
+    void setAsicSpecificBits(const HBHEDataFrame& frame,
+                             const HBHEChannelInfo& info, HBHERecHit* rh);
+    void setAsicSpecificBits(const QIE11DataFrame& frame,
+                             const HBHEChannelInfo& info, HBHERecHit* rh);
+    void setCommonStatusBits(const HBHEChannelInfo& info, HBHERecHit* rh);
+};
+
+//
+// constructors and destructor
+//
+HBHEPhase1Reconstructor::HBHEPhase1Reconstructor(const edm::ParameterSet& conf)
+    : algoConfigClass_(conf.getParameter<std::string>("algoConfigClass")),
+      processHB_(conf.getParameter<bool>("processHB")),
+      processHE_(conf.getParameter<bool>("processHE")),
+      saveInfos_(conf.getParameter<bool>("saveInfos")),
+      saveDroppedInfos_(conf.getParameter<bool>("saveDroppedInfos")),
+      makeRecHits_(conf.getParameter<bool>("makeRecHits")),
+      dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed")),
+      tsFromDB_(conf.getParameter<bool>("tsFromDB")),
+      recoParamsFromDB_(conf.getParameter<bool>("recoParamsFromDB")),
+      reco_(parseHBHEPhase1AlgoDescription(conf.getParameter<edm::ParameterSet>("algorithm")))
+{
+    // Check that the reco algorithm has been successfully configured
+    if (!reco_.get())
+        throw cms::Exception("HBHEPhase1BadConfig")
+            << "Invalid HBHEPhase1Algo algorithm configuration"
+            << std::endl;
+
+    if (processHB_)
+        tok_hb_ = consumes<HBHEDigiCollection>(
+            conf.getParameter<edm::InputTag>("digiLabelHB"));
+
+    if (processHE_)
+        tok_he_ = consumes<QIE11DigiCollection>(
+            conf.getParameter<edm::InputTag>("digiLabelHE"));
+
+    if (saveInfos_)
+        produces<HBHEChannelInfoCollection>();
+
+    if (makeRecHits_)
+        produces<HBHERecHitCollection>();
+}
+
+
+HBHEPhase1Reconstructor::~HBHEPhase1Reconstructor()
+{
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+template<class DFrame, class Collection>
+void HBHEPhase1Reconstructor::processData(const Collection& coll,
+                                          const HcalDbService& cond,
+                                          const HcalChannelQuality& qual,
+                                          const HcalSeverityLevelComputer& severity,
+                                          const bool isRealData,
+                                          HBHEChannelInfo* channelInfo,
+                                          HBHEChannelInfoCollection* infos,
+                                          HBHERecHitCollection* rechits)
+{
+    // If "saveDroppedInfos_" flag is set, fill the info with something
+    // meaningful even if the database tells us to drop this channel.
+    // Note that this flag affects only "infos", the rechits are still
+    // not going to be constructed from such channels.
+    const bool skipDroppedChannels = !(infos && saveDroppedInfos_);
+
+    // Iterate over the input collection
+    for (typename Collection::const_iterator it = coll.begin();
+         it != coll.end(); ++it)
+    {
+        const DFrame& frame(*it);
+        const HcalDetId cell(frame.id());
+        const HcalRecoParam* param_ts = nullptr;
+        if (tsFromDB_ || recoParamsFromDB_)
+            param_ts = paramTS_->getValues(cell.rawId());
+
+        // Check if the database tells us to drop this channel
+        const HcalChannelStatus* mydigistatus = qual.getValues(cell.rawId());
+        const bool taggedBadByDb = severity.dropChannel(mydigistatus->getValue());
+        if (taggedBadByDb && skipDroppedChannels)
+            continue;
+
+        // Check if the channel is zero suppressed
+        bool dropByZS = false;
+        if (dropZSmarkedPassed_)
+            if (frame.zsMarkAndPass())
+                dropByZS = true;
+        if (dropByZS && skipDroppedChannels)
+            continue;
+
+        // Basic ADC decoding tools
+        const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
+        const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
+        const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
+        HcalCoderDb coder(*channelCoder, *shape);
+
+        // ADC to fC conversion
+        CaloSamples cs;
+        coder.adc2fC(frame, cs);
+
+        // Prepare to iterate over time slices
+        const int nRead = cs.size();
+        const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
+        const int soi = tsFromDB_ ? param_ts->firstSample() : frame.presamples();
+        int soiCapid = 4;
+
+        // Go over time slices and fill the samples
+        for (int ts = 0; ts < maxTS; ++ts)
+        {
+            auto s(frame[ts]);
+            const int capid = s.capid();
+            const double pedestal = calib.pedestal(capid);
+            const double gain = calib.respcorrgain(capid);
+            const double rawCharge = getRawChargeFromSample(s, cs[ts], calib);
+            const float t = getTDCTimeFromSample(s);
+            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, gain, t);
+            if (ts == soi)
+                soiCapid = capid;
+        }
+
+        // Fill the overall channel info items
+        const std::pair<bool,bool> hwerr = findHWErrors(frame, maxTS);
+        channelInfo->setChannelInfo(cell, maxTS, soi, soiCapid,
+                                    hwerr.first, hwerr.second,
+                                    taggedBadByDb || dropByZS);
+
+        // If needed, add the channel info to the output collection
+        const bool makeThisRechit = !channelInfo->isDropped();
+        if (infos && (saveDroppedInfos_ || makeThisRechit))
+            infos->push_back(*channelInfo);
+
+        // Reconstruct the rechit
+        if (rechits && makeThisRechit)
+        {
+            const HcalRecoParam* pptr = nullptr;
+            if (recoParamsFromDB_)
+                pptr = param_ts;
+            HBHERecHit rh = reco_->reconstruct(*channelInfo, pptr, calib, isRealData);
+            if (rh.id().rawId())
+            {
+                setAsicSpecificBits(frame, *channelInfo, &rh);
+                setCommonStatusBits(*channelInfo, &rh);
+                rechits->push_back(rh);
+            }
+        }
+    }
+}
+
+void HBHEPhase1Reconstructor::setCommonStatusBits(
+    const HBHEChannelInfo& info, HBHERecHit* rh)
+{
+    // FIX THIS!!! after status bit inventory
+}
+
+void HBHEPhase1Reconstructor::setAsicSpecificBits(
+    const HBHEDataFrame& frame, const HBHEChannelInfo& info, HBHERecHit* rh)
+{
+    // FIX THIS!!! after status bit inventory
+}
+
+void HBHEPhase1Reconstructor::setAsicSpecificBits(
+    const QIE11DataFrame& frame, const HBHEChannelInfo& info, HBHERecHit* rh)
+{
+    // FIX THIS!!! after status bit inventory
+}
+
+// ------------ method called to produce the data  ------------
+void
+HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
+{
+    using namespace edm;
+
+    // Get the Hcal topology if needed
+    ESHandle<HcalTopology> htopo;
+    if (tsFromDB_ || recoParamsFromDB_)
+    {
+        eventSetup.get<HcalRecNumberingRecord>().get(htopo);
+        paramTS_->setTopo(htopo.product());
+    }
+
+    // Fetch the calibrations
+    ESHandle<HcalDbService> conditions;
+    eventSetup.get<HcalDbRecord>().get(conditions);
+
+    ESHandle<HcalChannelQuality> p;
+    eventSetup.get<HcalChannelQualityRcd>().get("withTopo", p);
+ 
+    ESHandle<HcalSeverityLevelComputer> mycomputer;
+    eventSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
+
+    // Find the input data
+    unsigned maxOutputSize = 0;
+    Handle<HBHEDigiCollection> hbDigis;
+    if (processHB_)
+    {
+        e.getByToken(tok_hb_, hbDigis);
+        maxOutputSize += hbDigis->size();
+    }
+
+    Handle<QIE11DigiCollection> heDigis;
+    if (processHE_)
+    {
+        e.getByToken(tok_he_, heDigis);
+        maxOutputSize += heDigis->size();
+    }
+
+    // Create new output collections
+    std::unique_ptr<HBHEChannelInfoCollection> infos;
+    if (saveInfos_)
+    {
+        infos = std::make_unique<HBHEChannelInfoCollection>();
+        infos->reserve(maxOutputSize);
+    }
+
+    std::unique_ptr<HBHERecHitCollection> out;
+    if (makeRecHits_)
+    {
+        out = std::make_unique<HBHERecHitCollection>();
+        out->reserve(maxOutputSize);
+    }
+
+    // Process the input collections, filling the output ones
+    const bool isData = e.isRealData();
+    if (processHB_)
+    {
+        HBHEChannelInfo channelInfo(false);
+        processData<HBHEDataFrame>(*hbDigis, *conditions, *p, *mycomputer,
+                                   isData, &channelInfo, infos.get(), out.get());
+    }
+
+    if (processHE_)
+    {
+        HBHEChannelInfo channelInfo(true);
+        processData<QIE11DataFrame>(*heDigis, *conditions, *p, *mycomputer,
+                                    isData, &channelInfo, infos.get(), out.get());
+    }
+
+    // Add the output collections to the event record
+    if (saveInfos_)
+        e.put(std::move(infos));
+    if (makeRecHits_)
+        e.put(std::move(out));
+}
+
+// ------------ method called when starting to processes a run  ------------
+void
+HBHEPhase1Reconstructor::beginRun(edm::Run const& r, edm::EventSetup const& es)
+{
+    if (tsFromDB_ || recoParamsFromDB_)
+    {
+        edm::ESHandle<HcalRecoParams> p;
+        es.get<HcalRecoParamsRcd>().get(p);
+        paramTS_ = std::make_unique<HcalRecoParams>(*p.product());
+    }
+
+    if (reco_->isConfigurable())
+    {
+        recoConfig_ = fetchHBHEPhase1AlgoData(algoConfigClass_, es);
+        if (!recoConfig_.get())
+            throw cms::Exception("HBHEPhase1BadConfig")
+                << "Invalid HFPhase1Reconstructor \"algoConfigClass\" parameter value \""
+                << algoConfigClass_ << '"' << std::endl;
+        if (!reco_->configure(recoConfig_.get()))
+            throw cms::Exception("HBHEPhase1BadConfig")
+                << "Failed to configure HBHEPhase1Algo algorithm from EventSetup"
+                << std::endl;
+    }
+
+    reco_->beginRun(r, es);
+}
+
+void
+HBHEPhase1Reconstructor::endRun(edm::Run const&, edm::EventSetup const&)
+{
+    reco_->endRun();
+}
+
+#define add_param_set(name) /**/       \
+    edm::ParameterSetDescription name; \
+    name.setAllowAnything();           \
+    desc.add<edm::ParameterSetDescription>(#name, name)
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+    edm::ParameterSetDescription desc;
+
+    desc.add<edm::InputTag>("digiLabelHB");
+    desc.add<edm::InputTag>("digiLabelHE");
+    desc.add<std::string>("algoConfigClass");
+    desc.add<bool>("processHB");
+    desc.add<bool>("processHE");
+    desc.add<bool>("saveInfos");
+    desc.add<bool>("saveDroppedInfos");
+    desc.add<bool>("makeRecHits");
+    desc.add<bool>("dropZSmarkedPassed");
+    desc.add<bool>("tsFromDB");
+    desc.add<bool>("recoParamsFromDB");
+
+    add_param_set(algorithm);
+    
+    descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HBHEPhase1Reconstructor);

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -107,8 +107,8 @@ def customise_Hcal2017Full(process):
         from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco
         process.globalReplace("hbheprereco", hbheprereco)
         process.hbheprereco.saveInfos = cms.bool(True)
-        process.hbheprereco.digiLabelHB = cms.InputTag("simHcalDigis")
-        process.hbheprereco.digiLabelHE = cms.InputTag("simHcalDigis", "HBHEQIE11DigiCollection")
+        process.hbheprereco.digiLabelQIE8 = cms.InputTag("simHcalDigis")
+        process.hbheprereco.digiLabelQIE11 = cms.InputTag("simHcalDigis", "HBHEQIE11DigiCollection")
 
     return process
     

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -80,6 +80,7 @@ def customise_Hcal2017(process):
     if hasattr(process,'reconstruction_step'):
         process.hbheprereco.digiLabel = cms.InputTag("simHcalDigis")
         process.hbheprereco.setNoiseFlags = cms.bool(False)
+        # process.hbheprereco.puCorrMethod = cms.int32(0)
         process.horeco.digiLabel = cms.InputTag("simHcalDigis")
         process.zdcreco.digiLabel = cms.InputTag("simHcalUnsuppressedDigis")
         process.zdcreco.digiLabelhcal = cms.InputTag("simHcalUnsuppressedDigis")
@@ -100,7 +101,14 @@ def customise_Hcal2017Full(process):
     
     #use HE phase1 conditions - test SiPM/QIE11
     process.es_hardcode.useHEUpgrade = cms.bool(True)
-    
+
+    if hasattr(process,'reconstruction_step'):
+        # Customise HB/HE reco
+        from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco
+        process.globalReplace("hbheprereco", hbheprereco)
+        process.hbheprereco.saveInfos = cms.bool(True)
+        process.hbheprereco.digiLabelHB = cms.InputTag("simHcalDigis")
+
     return process
     
 def customise_HcalPhase1(process):

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -108,6 +108,7 @@ def customise_Hcal2017Full(process):
         process.globalReplace("hbheprereco", hbheprereco)
         process.hbheprereco.saveInfos = cms.bool(True)
         process.hbheprereco.digiLabelHB = cms.InputTag("simHcalDigis")
+        process.hbheprereco.digiLabelHE = cms.InputTag("simHcalDigis", "HBHEQIE11DigiCollection")
 
     return process
     


### PR DESCRIPTION
Includes the framework (CMSSW module, algorithms) for the HB/HE Phase 1 reconstruction
as well as a minor refactoring of a few HF-related functions. This code was discussed at

https://indico.cern.ch/event/546917/contributions/2218561/attachments/1301181/1943877/notes.pdf
