### PR TITLE
DQM/HcalMonitorClient : Formatting fix for gcc 6.0 misleading-indentation warning.

### DIFF
--- a/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
@@ -908,8 +908,12 @@ void HcalDetDiagLaserClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter
   htmlFile << state[ind2] << HEP[1] <<"</td>" << endl;
   htmlFile << "</tr><tr>" << endl;
   htmlFile << "<td class=\"s1\" align=\"center\">HE-</td>" << endl;
-  if(HEM[0]==0) ind1=2; if(HEM[0]>0 && HEM[0]<=12) ind1=1; if(HEM[0]>12) ind1=0; 
-  if(HEM[1]==0) ind2=2; if(HEM[1]>0 && HEM[1]<=12) ind2=1; if(HEM[1]>12) ind2=0; 
+  if(HEM[0]==0) ind1=2;
+  if(HEM[0]>0 && HEM[0]<=12) ind1=1;
+  if(HEM[0]>12) ind1=0; 
+  if(HEM[1]==0) ind2=2;
+  if(HEM[1]>0 && HEM[1]<=12) ind2=1;
+  if(HEM[1]>12) ind2=0; 
   if(!HEpresent_) ind1=ind2=3;  
   if(ind1==0 || ind2==0) status|=2; else if(ind1==1 || ind2==1) status|=1;
   htmlFile << state[ind1] << HEM[0] <<"</td>" << endl;


### PR DESCRIPTION
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc: In member function 'virtual void HcalDetDiagLaserClient::htmlOutput(DQMStore::IBooker&, DQMStore::IGetter&, std::string)':
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc:924:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if(HEM[0]==0) ind1=2; if(HEM[0]>0 && HEM[0]<=12) ind1=1;
   ^~
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc:924:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(HEM[0]==0) ind1=2; if(HEM[0]>0 && HEM[0]<=12) ind1=1;
                         ^~
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc:926:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if(HEM[1]==0) ind2=2; if(HEM[1]>0 && HEM[1]<=12) ind2=1;
   ^~
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc:926:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   if(HEM[1]==0) ind2=2; if(HEM[1]>0 && HEM[1]<=12) ind2=1;
                         ^~
