### PR TITLE
RecoParticleFlow/PFTracking formatting fix for  gcc 6.0 misleading-indentation warning.

### DIFF
--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -332,12 +332,13 @@ int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
 
 bool PFDisplacedVertexHelper::isKaonMass(const PFDisplacedVertex& v) const {
 
-  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(), 
-    trkFinal = v.refittedTracks()[0].momentum();
+  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(); 
+  math::XYZVector trkFinal = v.refittedTracks()[0].momentum();
 
-  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
-    trkInit = v.refittedTracks()[0].momentum(),
-      trkFinal =  v.refittedTracks()[1].momentum();
+  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX) {
+    trkInit = v.refittedTracks()[0].momentum();
+    trkFinal =  v.refittedTracks()[1].momentum();
+  }
 
 
     math::XYZVector trkNeutre(trkInit.x()-trkFinal.x(),  trkInit.y()-trkFinal.y(),

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -332,12 +332,13 @@ int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
 
 bool PFDisplacedVertexHelper::isKaonMass(const PFDisplacedVertex& v) const {
 
-    math::XYZVector  trkInit = v.refittedTracks()[1].momentum(), 
-    trkFinal = v.refittedTracks()[0].momentum();
+  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(); 
+  math::XYZVector trkFinal = v.refittedTracks()[0].momentum();
 
-    if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
-      trkInit = v.refittedTracks()[0].momentum(),
-      trkFinal =  v.refittedTracks()[1].momentum();
+  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX) {
+    trkInit = v.refittedTracks()[0].momentum();
+    trkFinal =  v.refittedTracks()[1].momentum();
+  }
 
 
     math::XYZVector trkNeutre(trkInit.x()-trkFinal.x(),  trkInit.y()-trkFinal.y(),

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -332,13 +332,12 @@ int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
 
 bool PFDisplacedVertexHelper::isKaonMass(const PFDisplacedVertex& v) const {
 
-  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(); 
-  math::XYZVector trkFinal = v.refittedTracks()[0].momentum();
+  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(), 
+    trkFinal = v.refittedTracks()[0].momentum();
 
-  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX) {
-    trkInit = v.refittedTracks()[0].momentum();
-    trkFinal =  v.refittedTracks()[1].momentum();
-  }
+  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
+    trkInit = v.refittedTracks()[0].momentum(),
+      trkFinal =  v.refittedTracks()[1].momentum();
 
 
     math::XYZVector trkNeutre(trkInit.x()-trkFinal.x(),  trkInit.y()-trkFinal.y(),

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -332,11 +332,11 @@ int PFDisplacedVertexHelper::lambdaCP(const PFDisplacedVertex& v) const {
 
 bool PFDisplacedVertexHelper::isKaonMass(const PFDisplacedVertex& v) const {
 
-  math::XYZVector  trkInit = v.refittedTracks()[1].momentum(), 
+    math::XYZVector  trkInit = v.refittedTracks()[1].momentum(), 
     trkFinal = v.refittedTracks()[0].momentum();
 
-  if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
-    trkInit = v.refittedTracks()[0].momentum(),
+    if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
+      trkInit = v.refittedTracks()[0].momentum(),
       trkFinal =  v.refittedTracks()[1].momentum();
 
 


### PR DESCRIPTION
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc: In member function 'bool PFDisplacedVertexHelper::isKaonMass(const reco::PFDisplacedVertex&) const':
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc:338:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if (v.trackTypes()[0] == PFDisplacedVertex::T_TO_VERTEX)
   ^~
/home/cms_admin/CMSSW_8_1_X_2016-06-28-1400/src/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc:343:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     math::XYZVector trkNeutre(trkInit.x()-trkFinal.x(),  trkInit.y()-trkFinal.y(),
     ^~~~
