### PR TITLE
new ParticleGun-RandomtXiGunProducer for CTPPS

### DIFF
--- a/Configuration/Generator/python/SingleProton_RandomtXiGunProducer_cfi.py
+++ b/Configuration/Generator/python/SingleProton_RandomtXiGunProducer_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("RandomtXiGunProducer",
+           PGunParameters = cms.PSet(
+                            PartID = cms.vint32(2212),
+                            MinPhi = cms.double(-3.14159265359),
+                            MaxPhi = cms.double(-3.14159265359),
+                            ECMS   = cms.double(13000),
+                            Mint   = cms.double(0.),
+                            Maxt   = cms.double(2.0),
+                            MinXi  = cms.double(0.01),
+                            MaxXi  = cms.double(0.2)
+           ),
+           Verbosity = cms.untracked.int32(0),
+           psethack = cms.string('single protons'),
+           FireBackward = cms.bool(True),
+           FireForward  = cms.bool(True),
+           firstRun = cms.untracked.uint32(1)
+)

--- a/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
@@ -1,0 +1,68 @@
+#ifndef BaseRandomtXiGunProducer_H
+#define BaseRandomtXiGunProducer_H
+
+/** \class FlatRandomEGunProducer
+ *
+ * Generates single particle gun in HepMC format
+ * Julia Yarba 10/2005 
+ ***************************************/
+#include <string>
+
+#include "HepPDT/defs.h"
+#include "HepPDT/TableBuilder.hh"
+#include "HepPDT/ParticleDataTable.hh"
+
+#include "HepMC/GenEvent.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
+namespace edm
+{
+  
+  class BaseRandomtXiGunProducer : public one::EDProducer<one::WatchRuns,
+                                                          EndRunProducer>
+  {
+  
+  public:
+    BaseRandomtXiGunProducer(const ParameterSet &);
+    virtual ~BaseRandomtXiGunProducer();
+    void beginRun(const edm::Run & r, const edm::EventSetup& ) override ;
+    void endRun(const edm::Run& r, const edm::EventSetup& ) override;
+    void endRunProduce(edm::Run& r, const edm::EventSetup&) override;
+
+  private:
+   
+  protected:
+  
+    // non-virtuals ! this and only way !
+    //
+    // data members
+    
+    // gun particle(s) characteristics
+    std::vector<int> fPartIDs ;
+    double           fMinPhi ;
+    double           fMaxPhi ;
+    double           fpEnergy;
+    double           fECMS;
+
+    // the event format itself
+    HepMC::GenEvent* fEvt;
+
+    ESHandle<HepPDT::ParticleDataTable> fPDGTable ;
+            	    	
+    int              fVerbosity ;
+
+    const HepPDT::ParticleData*   PData;
+
+    bool             fFireForward;
+    bool             fFireBackward;
+    
+  };
+} 
+#endif

--- a/IOMC/ParticleGuns/interface/RandomtXiGunProducer.h
+++ b/IOMC/ParticleGuns/interface/RandomtXiGunProducer.h
@@ -1,0 +1,38 @@
+#ifndef RandomtXiGunProducer_H
+#define RandomtXiGunProducer_H
+
+#include "IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+
+namespace edm {
+  
+  class RandomtXiGunProducer : public BaseRandomtXiGunProducer {
+  
+  public:
+    RandomtXiGunProducer(const ParameterSet &);
+    virtual ~RandomtXiGunProducer();
+
+  private:
+   
+    virtual void produce(Event & e, const EventSetup& es) override;
+
+    HepMC::FourVector make_particle(double t,double Xi,double phi,int PartID, int direction);
+    double Minimum_t(double xi) {double partE = fpEnergy*(1.-xi);
+                                 double massSQ= pow(PData->mass().value(),2);
+                                 double partP = sqrt(partE*partE-massSQ);
+                                 return -2.*(sqrt(fpEnergy*fpEnergy-massSQ)*partP-fpEnergy*partE+massSQ);
+                                };
+    
+  protected :
+  
+    // data members
+    
+    double            fMint   ;
+    double            fMaxt   ;
+    double            fMinXi  ;
+    double            fMaxXi  ;
+
+  };
+} 
+#endif

--- a/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
@@ -1,0 +1,88 @@
+/*
+ *  $Date: 2010/01/19 16:17:26 $
+ *  $Revision: 1.7 $
+ *  \author Julia Yarba
+ */
+
+#include <ostream>
+#include <memory>
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
+#include "IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h"
+
+
+#include <iostream>
+
+using namespace edm;
+using namespace std;
+using namespace CLHEP;
+
+
+BaseRandomtXiGunProducer::BaseRandomtXiGunProducer( const edm::ParameterSet& pset ) :
+   fEvt(0)
+{
+   Service<RandomNumberGenerator> rng;
+   if(!rng.isAvailable()) {
+    throw cms::Exception("Configuration")
+       << "The RandomNumberProducer module requires the RandomNumberGeneratorService\n"
+          "which appears to be absent.  Please add that service to your configuration\n"
+          "or remove the modules that require it.";
+   }
+
+   ParameterSet pgun_params = pset.getParameter<ParameterSet>("PGunParameters") ;
+  
+   // although there's the method ParameterSet::empty(),  
+   // it looks like it's NOT even necessary to check if it is,
+   // before trying to extract parameters - if it is empty,
+   // the default values seem to be taken
+   fPartIDs    = pgun_params.getParameter< vector<int> >("PartID");  
+   fMinPhi     = pgun_params.getParameter<double>("MinPhi");
+   fMaxPhi     = pgun_params.getParameter<double>("MaxPhi");
+   fECMS       = pgun_params.getParameter<double>("ECMS");
+   fpEnergy    = fECMS/2.0;
+
+
+
+  fVerbosity = pset.getUntrackedParameter<int>( "Verbosity",0 ) ;
+
+   fFireBackward = pset.getParameter<bool>("FireBackward") ;
+   fFireForward  = pset.getParameter<bool>("FireForward") ;
+
+   produces<GenRunInfoProduct, InRun>();
+}
+
+BaseRandomtXiGunProducer::~BaseRandomtXiGunProducer()
+{
+  
+}
+
+
+void BaseRandomtXiGunProducer::beginRun(const edm::Run & r, const EventSetup& es )
+{
+   es.getData( fPDGTable ) ;
+   return ;
+
+}
+
+void BaseRandomtXiGunProducer::endRun(const Run &run, const EventSetup& es )
+{}
+void BaseRandomtXiGunProducer::endRunProduce(Run &run, const EventSetup& es)
+{
+   // just create an empty product
+   // to keep the EventContent definitions happy
+   // later on we might put the info into the run info that this is a PGun
+   auto_ptr<GenRunInfoProduct> genRunInfo( new GenRunInfoProduct() );
+   run.put( genRunInfo );
+}

--- a/IOMC/ParticleGuns/src/RandomtXiGunProducer.cc
+++ b/IOMC/ParticleGuns/src/RandomtXiGunProducer.cc
@@ -1,0 +1,175 @@
+/*
+ *  $Date: 2011/12/19 23:10:40 $
+ *  $Revision: 1.4 $
+ *  \author Luiz Mundim
+ */
+
+#include <ostream>
+
+#include "IOMC/ParticleGuns/interface/RandomtXiGunProducer.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "CLHEP/Random/RandFlat.h"
+
+using namespace edm;
+using namespace std;
+
+RandomtXiGunProducer::RandomtXiGunProducer(const edm::ParameterSet& pset) : 
+   BaseRandomtXiGunProducer(pset)
+{
+
+   ParameterSet defpset ;
+   edm::ParameterSet pgun_params = 
+      pset.getParameter<edm::ParameterSet>("PGunParameters") ;
+  
+   fMint = pgun_params.getParameter<double>("Mint");
+   fMaxt = pgun_params.getParameter<double>("Maxt");
+   fMinXi= pgun_params.getParameter<double>("MinXi");
+   fMaxXi= pgun_params.getParameter<double>("MaxXi");
+  
+  produces<HepMCProduct>("unsmeared");
+  produces<GenEventInfoProduct>();
+}
+
+RandomtXiGunProducer::~RandomtXiGunProducer()
+{
+   // no need to cleanup GenEvent memory - done in HepMCProduct
+}
+
+void RandomtXiGunProducer::produce(edm::Event &e, const edm::EventSetup& es) 
+{
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
+   if ( fVerbosity > 0 )
+   {
+      cout << " RandomtXiGunProducer : Begin New Event Generation" << endl ; 
+   }
+   // event loop (well, another step in it...)
+          
+   // no need to clean up GenEvent memory - done in HepMCProduct
+   // 
+   
+   // here re-create fEvt (memory)
+   //
+   fEvt = new HepMC::GenEvent() ;
+   
+   // now actualy, cook up the event from PDGTable and gun parameters
+   //
+   // 1st, primary vertex
+   //
+   HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(0.,0.,0.));
+
+   // loop over particles
+   //
+   int barcode = 1 ;
+   for (unsigned int ip=0; ip<fPartIDs.size(); ++ip)
+   {
+       int PartID = fPartIDs[ip];
+//  t = -2*P*P'*(1-cos(theta)) -> t/(2*P*P')+1=cos(theta)
+// xi = 1 - P'/P  --> P'= (1-xi)*P
+// 
+       PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID)));
+       if (!PData) exit(1);
+       double t  = 0;
+       double Xi = 0;
+       double phi=0;
+       if (fFireForward) {
+          while(1) {
+               Xi     = CLHEP::RandFlat::shoot(engine,fMinXi,fMaxXi);
+               double min_t = std::max(fMint,Minimum_t(Xi));
+               double max_t = fMaxt;
+               if (min_t>max_t) {
+                  std::cout << "WARNING: t limits redefined (unphysical values for given xi)." << endl;
+                  max_t = min_t;
+               }
+               t      = CLHEP::RandFlat::shoot(engine,min_t,max_t);
+               break;
+          }
+          phi    = CLHEP::RandFlat::shoot(engine,fMinPhi, fMaxPhi) ;
+          HepMC::GenParticle* Part = 
+              new HepMC::GenParticle(make_particle(t,Xi,phi,PartID,1),PartID,1);
+          Part->suggest_barcode( barcode ) ;
+          barcode++ ;
+          Vtx->add_particle_out(Part);
+       }
+       if ( fFireBackward) {
+          while(1) {
+               Xi     = CLHEP::RandFlat::shoot(engine,fMinXi,fMaxXi);
+               double min_t = std::max(fMint,Minimum_t(Xi));
+               double max_t = fMaxt;
+               if (min_t>max_t) {
+                  std::cout << "WARNING: t limits redefined (unphysical values for given xi)." << endl;
+                  max_t = min_t;
+               }
+               t      = CLHEP::RandFlat::shoot(engine,min_t,max_t);
+               break;
+          }
+          phi    = CLHEP::RandFlat::shoot(engine,fMinPhi, fMaxPhi) ;
+	  HepMC::GenParticle* Part2 =
+	     new HepMC::GenParticle(make_particle(t,Xi,phi,PartID,-1),PartID,1);
+	  Part2->suggest_barcode( barcode ) ;
+	  barcode++ ;
+	  Vtx->add_particle_out(Part2) ;
+       }
+   }
+
+   fEvt->add_vertex(Vtx) ;
+   fEvt->set_event_number(e.id().event()) ;
+   fEvt->set_signal_process_id(20) ; 
+        
+   if ( fVerbosity > 0 )
+   {
+      fEvt->print() ;  
+   }
+
+   std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   BProduct->addHepMCData( fEvt );
+   e.put(std::move(BProduct),"unsmeared");
+
+   std::unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
+    
+   if ( fVerbosity > 0 )
+   {
+      // for testing purpose only
+      // fEvt->print() ; // prints empty info after it's made into edm::Event
+      cout << " RandomtXiGunProducer : Event Generation Done " << endl;
+   }
+}
+HepMC::FourVector RandomtXiGunProducer::make_particle(double t,double Xi,double phi,int PartID, int direction)
+{
+       double mass   = PData->mass().value() ;
+       double fpMom  = sqrt(fpEnergy*fpEnergy-mass*mass); // momentum of beam proton
+       double sEnergy = (1.0-Xi)*fpEnergy; // energy of scattered particle
+       double sMom    = sqrt(sEnergy*sEnergy-mass*mass); // momentum of scattered particle
+       double min_t = -2.*(fpMom*sMom-fpEnergy*sEnergy+mass*mass);
+       if (t<min_t) t=min_t; // protect against kinemactically forbiden region
+       long double theta  = acos((-t/2.- mass*mass + fpEnergy*sEnergy)/(sMom*fpMom)); // use t = -t
+
+       if (direction<1) theta = acos(-1.) - theta;
+
+       double px     = sMom*cos(phi)*sin(theta)*direction;
+       double py     = sMom*sin(phi)*sin(theta);
+       double pz     = sMom*cos(theta) ;  // the direction is already set by the theta angle
+       if (fVerbosity > 0) 
+          edm::LogInfo("RandomXiGunProducer") << "-----------------------------------------------------------------------------------------------------\n"
+                                              << "Produced a proton with  phi : " << phi << " theta: " << theta << " t: " << t << " Xi: " << Xi << "\n"
+                                              << "                         Px : " << px  << " Py : " << py << " Pz : " << pz << "\n"
+                                              << "                   direction: " << direction  << "\n"
+                                              << "-----------------------------------------------------------------------------------------------------"
+                                              << std::endl;
+
+       return HepMC::FourVector(px,py,pz,sEnergy) ;
+}
+//#include "FWCore/Framework/interface/MakerMacros.h"
+//DEFINE_FWK_MODULE(RandomtXiGunProducer);

--- a/IOMC/ParticleGuns/src/SealModule.cc
+++ b/IOMC/ParticleGuns/src/SealModule.cc
@@ -14,6 +14,8 @@
 #include "IOMC/ParticleGuns/interface/ExpoRandomPtGunProducer.h"
 #include "IOMC/ParticleGuns/interface/ExpoRandomPGunProducer.h"
 #include "IOMC/ParticleGuns/interface/MultiParticleInConeGunProducer.h"
+#include "IOMC/ParticleGuns/interface/RandomtXiGunProducer.h"
+
 
 // particle gun prototypes
 //
@@ -42,3 +44,5 @@ using edm::ExpoRandomPGunProducer;
 DEFINE_FWK_MODULE(ExpoRandomPGunProducer);
 using edm::MultiParticleInConeGunProducer;
 DEFINE_FWK_MODULE(MultiParticleInConeGunProducer);
+using edm::RandomtXiGunProducer;
+DEFINE_FWK_MODULE(RandomtXiGunProducer);


### PR DESCRIPTION
@covarell @govoni 

Hi Roberto and Pietro
We are opening a PR for RandomtXiProducer which was used in the publication of the CTPPS TDR.

Below, you can find some cmsDriver commands as one example to use it.

 cmsDriver.py SingleProton_RandomtXiGunProducer_cfi.py --mc --eventcontent FEVTDEBUG --datatier GEN-SIM --conditions 80X_mcRun2_asymptotic_2016_v2 --step GEN,SIM --era Run2_25ns --processName=CTPPS -n 2 --no_exec

Let us know your opnion about this PR

Thanks in advance,
Sandro
