### PR TITLE
Phase-1 alignment updates

### DIFF
--- a/Alignment/CommonAlignment/interface/AlignableCompositeBuilder.h
+++ b/Alignment/CommonAlignment/interface/AlignableCompositeBuilder.h
@@ -9,6 +9,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableIndexer.h"
 #include "Alignment/CommonAlignment/interface/AlignmentLevel.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 
 
@@ -24,7 +25,7 @@ class AlignableCompositeBuilder {
     /// calling buildAll(), the order matters!
     /// Example for PixelBarrel-RunI geometry:
     /// -> PXBModule, PXBLadder, TPBLayer, TPBHalfBarrel, TPBBarrel
-    void addAlignmentLevel(AlignmentLevel* level);
+    void addAlignmentLevel(std::unique_ptr<AlignmentLevel> level);
 
     /// Resets the alignment-levels.
     void clearAlignmentLevels();
@@ -62,11 +63,11 @@ class AlignableCompositeBuilder {
     //       ever be used to build other kinds of alignables than tracker-
     //       alignables one has to add/implement something more general than
     //       the TrackerTopology
-    const TrackerTopology* trackerTopology;
+    const TrackerTopology* trackerTopology_;
 
-    AlignableIndexer alignableIndexer;
+    AlignableIndexer alignableIndexer_;
 
-    std::vector<AlignmentLevel*> alignmentLevels;
+    align::AlignmentLevels alignmentLevels_;
 
 };
 

--- a/Alignment/CommonAlignment/interface/AlignableObjectId.h
+++ b/Alignment/CommonAlignment/interface/AlignableObjectId.h
@@ -22,10 +22,10 @@ public:
   static void isPhaseIIGeometry();
 
   /// Convert name to type
-  align::StructureType nameToType( const std::string &name ) const;
+  static align::StructureType nameToType( const std::string &name );
 
   /// Convert type to name
-  std::string typeToName( align::StructureType type ) const;
+  static std::string typeToName( align::StructureType type );
   static const char *idToString(align::StructureType type);
   static align::StructureType stringToId(const char *);
   static align::StructureType stringToId(const std::string &s) { return stringToId(s.c_str()); };

--- a/Alignment/CommonAlignment/interface/AlignmentLevel.h
+++ b/Alignment/CommonAlignment/interface/AlignmentLevel.h
@@ -19,8 +19,15 @@ class AlignmentLevel {
       levelType(levelType),
       maxNumComponents(maxNumComponents),
       isFlat(isFlat) {};
+    // copy construction + assignment
+    AlignmentLevel(const AlignmentLevel&) = default;
+    AlignmentLevel& operator=(const AlignmentLevel&) = default;
 
-    virtual ~AlignmentLevel() {};
+    // move construction + assignment
+    AlignmentLevel(AlignmentLevel&&) = default;
+    AlignmentLevel& operator=(AlignmentLevel&&) = default;
+
+    virtual ~AlignmentLevel() = default;
 
   //=========================== PUBLIC DATA ===================================
   //===========================================================================

--- a/Alignment/CommonAlignment/interface/Utilities.h
+++ b/Alignment/CommonAlignment/interface/Utilities.h
@@ -11,6 +11,7 @@
  */
 
 #include <map>
+#include <memory>
 
 #include "CondFormats/Alignment/interface/Definitions.h"
 
@@ -25,10 +26,9 @@ namespace align
   typedef std::vector<GlobalVector> GlobalVectors;
   typedef std::vector<LocalPoint>   LocalPoints;
   typedef std::vector<LocalVector>  LocalVectors;
-  typedef std::vector<LocalVector>  LocalVectors;
   typedef std::vector<Alignable*>   Alignables;
   typedef std::vector<AlignmentParameters*> Parameters;
-  typedef std::vector<AlignmentLevel*> AlignmentLevels;
+  typedef std::vector<std::unique_ptr<AlignmentLevel> > AlignmentLevels;
 
   typedef std::map<std::pair<Alignable*, Alignable*>, AlgebraicMatrix> Correlations;
 

--- a/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
+++ b/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
@@ -19,35 +19,35 @@
 AlignableCompositeBuilder
 ::AlignableCompositeBuilder(const TrackerTopology* trackerTopology,
                             AlignableIndexer& alignableIndexer) :
-  trackerTopology(trackerTopology),
-  alignableIndexer(alignableIndexer)
+  trackerTopology_(trackerTopology),
+  alignableIndexer_(alignableIndexer)
 {
 }
 
 //_____________________________________________________________________________
 void AlignableCompositeBuilder
-::addAlignmentLevel(AlignmentLevel* level) {
-  alignmentLevels.push_back(level);
+::addAlignmentLevel(std::unique_ptr<AlignmentLevel> level) {
+  alignmentLevels_.push_back(std::move(level));
 }
 
 //_____________________________________________________________________________
 void AlignableCompositeBuilder
 ::clearAlignmentLevels() {
-  alignmentLevels.clear();
+  alignmentLevels_.clear();
 }
 
 //_____________________________________________________________________________
 unsigned int AlignableCompositeBuilder
 ::buildAll(AlignableMap& alignableMap)
 {
-  auto highestLevel = alignmentLevels.back()->levelType;
+  auto highestLevel = alignmentLevels_.back()->levelType;
 
   std::ostringstream ss;
   ss << "building CompositeAlignables for "
      << AlignableObjectId::idToString(highestLevel) << "\n";
 
   unsigned int numCompositeAlignables = 0;
-  for (unsigned int level = 1; level < alignmentLevels.size(); ++level) {
+  for (unsigned int level = 1; level < alignmentLevels_.size(); ++level) {
     numCompositeAlignables += buildLevel(level, alignableMap, ss);
   }
 
@@ -74,29 +74,29 @@ unsigned int AlignableCompositeBuilder
   unsigned int childLevel    = parentLevel - 1;
   unsigned int maxNumParents = maxNumComponents(parentLevel);
 
-  auto childType  = alignmentLevels[childLevel] ->levelType;
-  auto parentType = alignmentLevels[parentLevel]->levelType;
+  auto childType  = alignmentLevels_[childLevel] ->levelType;
+  auto parentType = alignmentLevels_[parentLevel]->levelType;
 
   auto& children = alignableMap.find(AlignableObjectId::idToString(childType));
   auto& parents  = alignableMap.get (AlignableObjectId::idToString(parentType));
   parents.reserve(maxNumParents);
 
   // This vector is used indicate if a parent already exists. It is initialized
-  // with 'naked' Alignables-pointers; if the pointer is not naked (!= 0) for
-  // one of the child-IDs, its parent was already built before.
-  Alignables tmpParents(maxNumParents, 0);
+  // with 'naked' Alignables-pointers; if the pointer is not naked (!= nullptr)
+  // for one of the child-IDs, its parent was already built before.
+  Alignables tmpParents(maxNumParents, nullptr);
 
-  for (auto* child : children) {
+  for (auto* child: children) {
     // get the number of the child-Alignable ...
-    unsigned int index = getIndexOfStructure(child->id(), parentLevel);
+    const auto index = getIndexOfStructure(child->id(), parentLevel);
     // ... and use it as index to get the parent of this child
-    Alignable*& parent = tmpParents[index];
+    auto& parent = tmpParents[index];
 
     // if parent was not built yet ...
-    if (parent == 0) {
-      // ... built new composite Alignable with ID of child (obviously its the
+    if (!parent) {
+      // ... build new composite Alignable with ID of child (obviously its the
       // first child of the Alignable)
-      if (alignmentLevels[parentLevel]->isFlat) {
+      if (alignmentLevels_[parentLevel]->isFlat) {
         parent = new AlignableComposite(child->id(), parentType,
                                         child->globalRotation());
       } else {
@@ -111,10 +111,10 @@ unsigned int AlignableCompositeBuilder
   }
 
   ss << "   built " << parents.size() << " "
-     << AlignableObjectId::idToString(alignmentLevels[parentLevel]->levelType)
+     << AlignableObjectId::idToString(alignmentLevels_[parentLevel]->levelType)
      << "(s) (theoretical maximum: " << maxNumParents
      << ") consisting of " << children.size() << " "
-     << AlignableObjectId::idToString(alignmentLevels[childLevel]->levelType)
+     << AlignableObjectId::idToString(alignmentLevels_[childLevel]->levelType)
      << "(s)\n";
 
   return parents.size();
@@ -127,9 +127,9 @@ unsigned int AlignableCompositeBuilder
   unsigned int components = 1;
 
   for (unsigned int level = startLevel;
-       level < alignmentLevels.size();
+       level < alignmentLevels_.size();
        ++level) {
-    components *= alignmentLevels[level]->maxNumComponents;
+    components *= alignmentLevels_[level]->maxNumComponents;
   }
 
   return components;
@@ -140,13 +140,13 @@ unsigned int AlignableCompositeBuilder
 ::getIndexOfStructure(align::ID id, unsigned int level) const
 {
   // indexer returns a function pointer for the structure-type
-  auto indexOf = alignableIndexer.get(alignmentLevels[level]->levelType);
+  auto indexOf = alignableIndexer_.get(alignmentLevels_[level]->levelType);
 
-  if (alignmentLevels.size() - 1 > level) {
+  if (alignmentLevels_.size() - 1 > level) {
     return getIndexOfStructure(id, level + 1)
-             * alignmentLevels[level]->maxNumComponents
-             + indexOf(id, trackerTopology) - 1;
+             * alignmentLevels_[level]->maxNumComponents
+             + indexOf(id, trackerTopology_) - 1;
   }
 
-  return indexOf(id, trackerTopology) - 1;
+  return indexOf(id, trackerTopology_) - 1;
 }

--- a/Alignment/CommonAlignment/src/AlignableObjectId.cc
+++ b/Alignment/CommonAlignment/src/AlignableObjectId.cc
@@ -257,13 +257,13 @@ void AlignableObjectId
 
 //_____________________________________________________________________________
 StructureType
-AlignableObjectId::nameToType( const std::string &name) const
+AlignableObjectId::nameToType( const std::string &name)
 {
   return stringToId(name.c_str());
 }
 
 //_____________________________________________________________________________
-std::string AlignableObjectId::typeToName( StructureType type ) const
+std::string AlignableObjectId::typeToName( StructureType type )
 {
   return idToString(type);
 }

--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
@@ -194,6 +194,7 @@ private:
   const PropagationDirection propDir_;
   const bool useBeamSpot_;
   const bool includeAPEs_;
+  const bool allowZeroMaterial_;
 };
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
@@ -130,6 +130,7 @@ public:
     bool useRefittedState{false};
     bool constructTsosWithErrors{false};
     bool includeAPEs{false};
+    bool allowZeroMaterial{false};
   };
 
   virtual ~ReferenceTrajectoryBase() {}

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -71,6 +71,7 @@ protected:
 
   const bool useBeamSpot_;
   const bool includeAPEs_;
+  const bool allowZeroMaterial_;
 };
 
 

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -57,6 +57,7 @@ BzeroReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
                                              theMass, theMomentumEstimate);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
+      config.allowZeroMaterial = allowZeroMaterial_;
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
       trajectories.push_back(ReferenceTrajectoryPtr(new BzeroReferenceTrajectory(input.first, input.second,
@@ -107,6 +108,7 @@ BzeroReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
                                                theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         ReferenceTrajectoryPtr refTraj (new BzeroReferenceTrajectory(*itExternal, input.second,
@@ -124,6 +126,7 @@ BzeroReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
                                                theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         trajectories.push_back(ReferenceTrajectoryPtr(new BzeroReferenceTrajectory(input.first, input.second,

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -89,6 +89,7 @@ DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup  &setup,
                                              theMass, theMomentumEstimate);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
+      config.allowZeroMaterial = allowZeroMaterial_;
       ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(input.refTsos,
                                                                   input.fwdRecHits,
                                                                   input.bwdRecHits,
@@ -144,6 +145,7 @@ DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup &setup,
                                                theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(propExternal,
                                                                     input.fwdRecHits,
                                                                     input.bwdRecHits,
@@ -161,6 +163,7 @@ DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup &setup,
                                                theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(input.refTsos,
                                                                     input.fwdRecHits,
                                                                     input.bwdRecHits,

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -93,6 +93,7 @@ DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
       ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
+      config.allowZeroMaterial = allowZeroMaterial_;
       ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(input.refTsos,
                                                              input.fwdRecHits,
                                                              input.bwdRecHits,
@@ -153,6 +154,7 @@ DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(propExternal,
                                                                input.fwdRecHits,
                                                                input.bwdRecHits,
@@ -169,6 +171,7 @@ DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(input.refTsos,
                                                                input.fwdRecHits,
                                                                input.bwdRecHits,

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -99,6 +99,7 @@ ReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
       ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
+      config.allowZeroMaterial = allowZeroMaterial_;
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
       trajectories.push_back(ReferenceTrajectoryPtr(new ReferenceTrajectory(input.first, input.second,
@@ -150,6 +151,7 @@ ReferenceTrajectoryFactory::trajectories( const edm::EventSetup & setup,
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         ReferenceTrajectoryPtr refTraj(new ReferenceTrajectory(*itExternal, input.second,
@@ -165,6 +167,7 @@ ReferenceTrajectoryFactory::trajectories( const edm::EventSetup & setup,
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
+        config.allowZeroMaterial = allowZeroMaterial_;
         config.hitsAreReverse = false;
         trajectories.push_back(ReferenceTrajectoryPtr(new ReferenceTrajectory(input.first, input.second,
                                                                               magneticField.product(),

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -244,6 +244,7 @@ TwoBodyDecayTrajectoryFactory::constructTrajectories( const ConstTrajTrackPairCo
   ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection());
   config.useBeamSpot = useBeamSpot_;
   config.includeAPEs = includeAPEs_;
+  config.allowZeroMaterial = allowZeroMaterial_;
   config.useRefittedState = theUseRefittedStateFlag;
   config.constructTsosWithErrors = theConstructTsosWithErrorsFlag;
   // set the flag for reversing the RecHits to false, since they are already in the correct order.

--- a/Alignment/ReferenceTrajectories/python/TrajectoryFactories_cff.py
+++ b/Alignment/ReferenceTrajectories/python/TrajectoryFactories_cff.py
@@ -24,7 +24,8 @@ TrajectoryFactoryBase = cms.PSet(
     UseInvalidHits = cms.bool(False), ## if false, invalid hits are skipped
     UseHitWithoutDet = cms.bool(True), ## if false, RecHits that are not attached to GeomDets are skipped
     UseBeamSpot = cms.bool(False), ## if true, the beam spot is used as a constraint via a virtual TTRecHit
-    IncludeAPEs = cms.bool(False) ## if true, the APEs are included in the hit error
+    IncludeAPEs = cms.bool(False), ## if true, the APEs are included in the hit error
+    AllowZeroMaterial = cms.bool(False) # if true, exceptions due to singular scatter matrices are suppressed
 )
 
 ###############################################################

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
@@ -15,7 +15,8 @@ TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config) :
   useInvalidHits_(config.getParameter<bool>("UseInvalidHits")),
   useProjectedHits_(config.getParameter<bool>("UseProjectedHits")),
   useBeamSpot_(config.getParameter<bool>("UseBeamSpot")),
-  includeAPEs_(config.getParameter<bool>("IncludeAPEs"))
+  includeAPEs_(config.getParameter<bool>("IncludeAPEs")),
+  allowZeroMaterial_(config.getParameter<bool>("AllowZeroMaterial"))
 {
   edm::LogInfo("Alignment")
     << "@SUB=TrajectoryFactoryBase"
@@ -27,7 +28,8 @@ TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config) :
     << "\nuse invalid hits: " << (useInvalidHits_ ? "yes" : "no")
     << "\nuse projected hits: " << (useProjectedHits_ ? "yes" : "no")
     << "\nuse beamspot: " << (useBeamSpot_ ? "yes" : "no")
-    << "\ninclude APEs: " << (includeAPEs_ ? "yes" : "no");
+    << "\ninclude APEs: " << (includeAPEs_ ? "yes" : "no")
+    << "\nallow zero material: " << (allowZeroMaterial_ ? "yes" : "no");
 }
 
 

--- a/Alignment/TrackerAlignment/interface/AlignableTracker.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTracker.h
@@ -8,6 +8,7 @@
 // alignment
 #include "Alignment/CommonAlignment/interface/AlignableMap.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+#include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 
 class TrackerGeometry;
 class TrackerTopology;
@@ -30,22 +31,30 @@ public:
     return alignableMap.find(subStructName);
   }
 
-  // TODO: Are these methods still used? It seems that only the above method
-  //       is used; anyways, these methods will not work after the geometry-
-  //       upgrade, because the names of some structures will change.
-
   /// Return TOB half barrels
-  Alignables& outerHalfBarrels() { return this->subStructures("TOBHalfBarrel");}
+  Alignables& outerHalfBarrels() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TOBHalfBarrel));
+  }
   /// Return TIB half barrels
-  Alignables& innerHalfBarrels() { return this->subStructures("TIBHalfBarrel");}
+  Alignables& innerHalfBarrels() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIBHalfBarrel));
+  }
   /// Return Pixel half barrels
-  Alignables& pixelHalfBarrels() { return this->subStructures("TPBHalfBarrel");}
+  Alignables& pixelHalfBarrels() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPBHalfBarrel));
+  }
   /// Return TECs
-  Alignables& endCaps() { return this->subStructures("TECEndcap");}
+  Alignables& endCaps() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TECEndcap));
+  }
   /// Return TPEs
-  Alignables& pixelEndCaps() { return this->subStructures("TPEEndcap");}
+  Alignables& pixelEndCaps() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPEEndcap));
+  }
   /// Return TIDs
-  Alignables& TIDs() { return this->subStructures("TIDEndcap");}
+  Alignables& TIDs() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIDEndcap));
+  }
 
   /// Return inner and outer barrel GeomDets together 
   Alignables barrelGeomDets() { return this->merge(this->innerBarrelGeomDets(),
@@ -55,49 +64,85 @@ public:
 						   this->TIDGeomDets());
   }
   /// Return inner barrel GeomDets 
-  Alignables& innerBarrelGeomDets() { return this->subStructures("TIBModule");}
+  Alignables& innerBarrelGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIBModule));
+  }
   /// Return outer barrel GeomDets
-  Alignables& outerBarrelGeomDets() { return this->subStructures("TOBModule");}
+  Alignables& outerBarrelGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TOBModule));
+  }
   /// Return pixel barrel GeomDets
-  Alignables& pixelHalfBarrelGeomDets() { return this->subStructures("TPBModule");}
+  Alignables& pixelHalfBarrelGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPBModule));
+  }
   /// Return endcap  GeomDets
-  Alignables& endcapGeomDets() { return this->subStructures("TECModule");}
+  Alignables& endcapGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TECModule));
+  }
   /// Return TID  GeomDets  
-  Alignables& TIDGeomDets() { return this->subStructures("TIDModule");}
+  Alignables& TIDGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIDModule));
+  }
   /// Return pixel endcap GeomDets
-  Alignables& pixelEndcapGeomDets() { return this->subStructures("TPEModule");}
+  Alignables& pixelEndcapGeomDets() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPEModule));
+  }
   
   /// Return inner and outer barrel rods
   Alignables barrelRods() { return this->merge(this->innerBarrelRods(), this->outerBarrelRods());}
   /// Return inner barrel rods
-  Alignables& innerBarrelRods() { return this->subStructures("TIBString");}
+  Alignables& innerBarrelRods() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIBString));
+  }
   /// Return outer barrel rods
-  Alignables& outerBarrelRods() { return this->subStructures("TOBRod");}
+  Alignables& outerBarrelRods() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TOBRod));
+  }
   /// Return pixel half barrel ladders (implemented as AlignableRods)
-  Alignables& pixelHalfBarrelLadders() { return this->subStructures("TPBLadder");}
+  Alignables& pixelHalfBarrelLadders() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPBLadder));
+  }
   /// Return encap petals
-  Alignables& endcapPetals() { return this->subStructures("TECPetal");}
+  Alignables& endcapPetals() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TECPetal));
+  }
   /// Return TID rings
-  Alignables& TIDRings() { return this->subStructures("TIDRing");}
+  Alignables& TIDRings() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIDRing));
+  }
   /// Return pixel endcap petals
-  Alignables& pixelEndcapPetals() { return this->subStructures("TPEPanel");}
+  Alignables& pixelEndcapPetals() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPEPanel));
+  }
 		     
   /// Return inner and outer barrel layers
   Alignables barrelLayers() { return this->merge(this->innerBarrelLayers(),
 						 this->outerBarrelLayers() );
   }
   /// Return inner barrel layers
-  Alignables& innerBarrelLayers() { return this->subStructures("TIBLayer");}
+  Alignables& innerBarrelLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIBLayer));
+  }
   /// Return outer barrel layers
-  Alignables& outerBarrelLayers() { return this->subStructures("TOBLayer");}
+  Alignables& outerBarrelLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TOBLayer));
+  }
   /// Return pixel half barrel layers
-  Alignables& pixelHalfBarrelLayers() { return this->subStructures("TPBLayer");}
+  Alignables& pixelHalfBarrelLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPBLayer));
+  }
   /// Return endcap layers
-  Alignables& endcapLayers() { return this->subStructures("TECDisk");}
+  Alignables& endcapLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TECDisk));
+  }
   /// Return TID layers
-  Alignables& TIDLayers() { return this->subStructures("TIDDisk");}
+  Alignables& TIDLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TIDDisk));
+  }
   /// Return pixel endcap layers
-  Alignables& pixelEndcapLayers() { return this->subStructures("TPEHalfDisk");}
+  Alignables& pixelEndcapLayers() {
+    return this->subStructures(AlignableObjectId::typeToName(align::TPEHalfDisk));
+  }
 
 
 

--- a/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
@@ -29,7 +29,7 @@ class TrackerAlignmentLevelBuilder {
     virtual ~TrackerAlignmentLevelBuilder();
 
     void addDetUnitInfo(const DetId& detId);
-    std::vector<align::AlignmentLevels*> build();
+    std::vector<align::AlignmentLevels> build();
 
   //========================= PRIVATE METHODS =================================
   private: //==================================================================
@@ -41,69 +41,58 @@ class TrackerAlignmentLevelBuilder {
     void addTOBDetUnitInfo(const DetId& detId);
     void addTECDetUnitInfo(const DetId& detId);
 
-    void buildPXBAlignmentLevels();
-    void buildPXEAlignmentLevels();
-    void buildTIBAlignmentLevels();
-    void buildTIDAlignmentLevels();
-    void buildTOBAlignmentLevels();
-    void buildTECAlignmentLevels();
+    align::AlignmentLevels buildPXBAlignmentLevels();
+    align::AlignmentLevels buildPXEAlignmentLevels();
+    align::AlignmentLevels buildTIBAlignmentLevels();
+    align::AlignmentLevels buildTIDAlignmentLevels();
+    align::AlignmentLevels buildTOBAlignmentLevels();
+    align::AlignmentLevels buildTECAlignmentLevels();
 
   //========================== PRIVATE DATA ===================================
   //===========================================================================
 
-    const TrackerTopology* trackerTopology;
-
-    // sub-detector alignment levels
-    align::AlignmentLevels pxb;
-    align::AlignmentLevels pxe;
-    align::AlignmentLevels tib;
-    align::AlignmentLevels tid;
-    align::AlignmentLevels tob;
-    align::AlignmentLevels tec;
-
-    // all alignment levels of tracker
-    std::vector<align::AlignmentLevels*> levels;
+    const TrackerTopology* trackerTopology_;
 
     // PixelBarrel
-    std::set<unsigned int> pxbLayerIDs;
-    std::set<unsigned int> pxbLadderIDs;
-    std::set<unsigned int> pxbModuleIDs;
-    std::map<unsigned int, unsigned int> pxbLaddersPerLayer;
+    std::set<unsigned int> pxbLayerIDs_;
+    std::set<unsigned int> pxbLadderIDs_;
+    std::set<unsigned int> pxbModuleIDs_;
+    std::map<unsigned int, unsigned int> pxbLaddersPerLayer_;
 
     // PixelEndcap
-    std::set<unsigned int> pxeSideIDs;
-    std::set<unsigned int> pxeDiskIDs;
-    std::set<unsigned int> pxeBladeIDs;
-    std::set<unsigned int> pxePanelIDs;
-    std::set<unsigned int> pxeModuleIDs;
+    std::set<unsigned int> pxeSideIDs_;
+    std::set<unsigned int> pxeDiskIDs_;
+    std::set<unsigned int> pxeBladeIDs_;
+    std::set<unsigned int> pxePanelIDs_;
+    std::set<unsigned int> pxeModuleIDs_;
 
     // TIB
-    std::set<unsigned int> tibSideIDs;
-    std::set<unsigned int> tibLayerIDs;
-    std::set<unsigned int> tibStringIDs;
-    std::set<unsigned int> tibModuleIDs;
-    std::map<unsigned int, unsigned int> pxbStringsPerHalfShell;
+    std::set<unsigned int> tibSideIDs_;
+    std::set<unsigned int> tibLayerIDs_;
+    std::set<unsigned int> tibStringIDs_;
+    std::set<unsigned int> tibModuleIDs_;
+    std::map<unsigned int, unsigned int> pxbStringsPerHalfShell_;
 
     // TID
-    std::set<unsigned int> tidSideIDs;
-    std::set<unsigned int> tidWheelIDs;
-    std::set<unsigned int> tidRingIDs;
-    std::set<unsigned int> tidModuleIDs;
-    std::map<unsigned int, unsigned int> tidStringsInnerLayer;
-    std::map<unsigned int, unsigned int> tidStringsOuterLayer;
+    std::set<unsigned int> tidSideIDs_;
+    std::set<unsigned int> tidWheelIDs_;
+    std::set<unsigned int> tidRingIDs_;
+    std::set<unsigned int> tidModuleIDs_;
+    std::map<unsigned int, unsigned int> tidStringsInnerLayer_;
+    std::map<unsigned int, unsigned int> tidStringsOuterLayer_;
 
     // TOB
-    std::set<unsigned int> tobLayerIDs;
-    std::set<unsigned int> tobSideIDs;
-    std::set<unsigned int> tobRodIDs;
-    std::set<unsigned int> tobModuleIDs;
+    std::set<unsigned int> tobLayerIDs_;
+    std::set<unsigned int> tobSideIDs_;
+    std::set<unsigned int> tobRodIDs_;
+    std::set<unsigned int> tobModuleIDs_;
 
     // TEC
-    std::set<unsigned int> tecSideIDs;
-    std::set<unsigned int> tecWheelIDs;
-    std::set<unsigned int> tecPetalIDs;
-    std::set<unsigned int> tecRingIDs;
-    std::set<unsigned int> tecModuleIDs;
+    std::set<unsigned int> tecSideIDs_;
+    std::set<unsigned int> tecWheelIDs_;
+    std::set<unsigned int> tecPetalIDs_;
+    std::set<unsigned int> tecRingIDs_;
+    std::set<unsigned int> tecModuleIDs_;
 
 };
 

--- a/Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h
+++ b/Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <string>
 
+#include "Alignment/CommonAlignment/interface/StructureType.h"
 #include "Alignment/CommonAlignment/interface/MisalignmentScenarioBuilder.h"
 
 class AlignableTracker;
@@ -38,7 +39,10 @@ public:
   /// True if hierarchy level 'sub' could be part of hierarchy level 'large'.
   virtual bool possiblyPartOf(const std::string &sub, const std::string &large) const;
 
-private: // Members
+private:
+  std::string stripOffModule(const align::StructureType& type) const;
+
+ // Members
 
   AlignableTracker* theAlignableTracker;   ///< Pointer to mother alignable object
   /// following things are needed in possiblyPartOf:

--- a/Alignment/TrackerAlignment/plugins/BuildFile.xml
+++ b/Alignment/TrackerAlignment/plugins/BuildFile.xml
@@ -35,3 +35,20 @@
   <use   name="root"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library name="AlignmentTrackerAlignmentRecordGeneratorPlugins"
+	 file="CreateTrackerAlignmentRcds.cc">
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="Alignment/CommonAlignment"/>
+  <use name="CondFormats/AlignmentRecord"/>
+  <use name="CondCore/DBOutputService"/>
+  <use name="CondFormats/GeometryObjects"/>
+  <use name="CondFormats/Alignment"/>
+  <use name="DataFormats/TrackerCommon" />
+  <use name="Geometry/Records"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
+  <use name="CLHEP"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
+++ b/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
@@ -1,0 +1,410 @@
+// -*- C++ -*-
+//
+// Package:    Alignment/TrackerAlignment
+// Class:      CreateIdealTkAlRecords
+//
+/**\class CreateIdealTkAlRecords CreateIdealTkAlRecords.cc Alignment/TrackerAlignment/plugins/CreateIdealTkAlRecords.cc
+
+ Description: Plugin to create ideal tracker alignment records.
+
+ Implementation:
+     The plugin takes the geometry stored in the global tag and transfers this
+     information to the format needed in the TrackerAlignmentRcd. The APEs are
+     set to zero for all det IDs of the tracker geometry and put into an
+     TrackerAlignmentErrorExtendedRcd. In addition an empty
+     TrackerSurfaceDeformationRcd is created corresponding to ideal surfaces.
+
+     An option exists to align to the content of the used global tag. This is
+     useful, if the geometry record and the tracker alignment records do not
+     match.
+
+*/
+//
+// Original Author:  Gregor Mittag
+//         Created:  Tue, 26 Apr 2016 09:45:13 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "CondFormats/Alignment/interface/AlignTransform.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "CondFormats/Alignment/interface/AlignTransformError.h"
+#include "CondFormats/Alignment/interface/AlignTransformErrorExtended.h"
+#include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/PTrackerParametersRcd.h"
+
+#include "CLHEP/Vector/RotationInterfaces.h"
+
+//
+// class declaration
+//
+
+class CreateIdealTkAlRecords : public edm::one::EDAnalyzer<>  {
+public:
+  explicit CreateIdealTkAlRecords(const edm::ParameterSet&);
+  ~CreateIdealTkAlRecords();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static std::string toString(const GeomDetEnumerators::SubDetector&);
+  static GeomDetEnumerators::SubDetector toSubDetector(const std::string& sub);
+  static std::vector<GeomDetEnumerators::SubDetector>
+  toSubDetectors(const std::vector<std::string>& subs);
+
+private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void clearAlignmentInfos();
+  std::unique_ptr<TrackerGeometry> retrieveGeometry(const edm::EventSetup&);
+  void addAlignmentInfo(const GeomDet&);
+  void alignToGT(const edm::EventSetup&);
+  void writeToDB();
+
+  // ----------member data ---------------------------
+  const std::vector<GeomDetEnumerators::SubDetector> skipSubDetectors_;
+  const bool alignToGlobalTag_;
+  const bool createReferenceRcd_;
+  bool firstEvent_;
+  Alignments alignments_;
+  AlignmentErrorsExtended alignmentErrors_;
+  AlignmentSurfaceDeformations alignmentSurfaceDeformations_;
+  std::vector<uint32_t> rawIDs_;
+  std::vector<GeomDetEnumerators::SubDetector> subDets_;
+};
+
+
+//
+// constructors and destructor
+//
+CreateIdealTkAlRecords::CreateIdealTkAlRecords(const edm::ParameterSet& iConfig) :
+  skipSubDetectors_(toSubDetectors(iConfig.getUntrackedParameter<std::vector<std::string> >("skipSubDetectors"))),
+  alignToGlobalTag_(iConfig.getUntrackedParameter<bool>("alignToGlobalTag")),
+  createReferenceRcd_(iConfig.getUntrackedParameter<bool>("createReferenceRcd")),
+  firstEvent_(true)
+{
+}
+
+
+CreateIdealTkAlRecords::~CreateIdealTkAlRecords()
+{
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+CreateIdealTkAlRecords::analyze(const edm::Event&, const edm::EventSetup& iSetup)
+{
+  if (firstEvent_) {
+    clearAlignmentInfos();
+    const auto tracker = retrieveGeometry(iSetup);
+
+    auto dets = tracker->dets();
+    std::sort(dets.begin(), dets.end(),
+              [](const auto& a, const auto& b) {
+                return a->geographicalId().rawId() < b->geographicalId().rawId();});
+
+    for (const auto& det: dets) addAlignmentInfo(*det);
+    if (alignToGlobalTag_ && !createReferenceRcd_) alignToGT(iSetup);
+    writeToDB();
+    firstEvent_ = false;
+  }
+}
+
+
+std::string
+CreateIdealTkAlRecords::toString(const GeomDetEnumerators::SubDetector& sub)
+{
+  switch (sub) {
+  case GeomDetEnumerators::PixelBarrel: return "PixelBarrel";
+  case GeomDetEnumerators::PixelEndcap: return "PixelEndcap";
+  case GeomDetEnumerators::TIB:         return "TIB";
+  case GeomDetEnumerators::TOB:         return "TOB";
+  case GeomDetEnumerators::TID:         return "TID";
+  case GeomDetEnumerators::TEC:         return "TEC";
+  case GeomDetEnumerators::CSC:         return "CSC";
+  case GeomDetEnumerators::DT:          return "DT";
+  case GeomDetEnumerators::RPCBarrel:   return "RPCBarrel";
+  case GeomDetEnumerators::RPCEndcap:   return "RPCEndcap";
+  case GeomDetEnumerators::GEM:         return "GEM";
+  case GeomDetEnumerators::ME0:         return "ME0";
+  case GeomDetEnumerators::P2OTB:       return "P2OTB";
+  case GeomDetEnumerators::P2OTEC:      return "P2OTEC";
+  case GeomDetEnumerators::P1PXB:       return "P1PXB";
+  case GeomDetEnumerators::P1PXEC:      return "P1PXEC";
+  case GeomDetEnumerators::P2PXEC:      return "P2PXEC";
+  case GeomDetEnumerators::invalidDet:  return "invalidDet";
+  default:
+    throw cms::Exception("UnknownSubdetector");
+  }
+}
+
+
+GeomDetEnumerators::SubDetector
+CreateIdealTkAlRecords::toSubDetector(const std::string& sub)
+{
+  if (sub == "PixelBarrel")      return GeomDetEnumerators::PixelBarrel;
+  else if (sub == "PixelEndcap") return GeomDetEnumerators::PixelEndcap;
+  else if (sub == "TIB")         return GeomDetEnumerators::TIB;
+  else if (sub == "TOB")         return GeomDetEnumerators::TOB;
+  else if (sub == "TID")         return GeomDetEnumerators::TID;
+  else if (sub == "TEC")         return GeomDetEnumerators::TEC;
+  else if (sub == "CSC")         return GeomDetEnumerators::CSC;
+  else if (sub == "DT")          return GeomDetEnumerators::DT;
+  else if (sub == "RPCBarrel")   return GeomDetEnumerators::RPCBarrel;
+  else if (sub == "RPCEndcap")   return GeomDetEnumerators::RPCEndcap;
+  else if (sub == "GEM")         return GeomDetEnumerators::GEM;
+  else if (sub == "ME0")         return GeomDetEnumerators::ME0;
+  else if (sub == "P2OTB")       return GeomDetEnumerators::P2OTB;
+  else if (sub == "P2OTEC")      return GeomDetEnumerators::P2OTEC;
+  else if (sub == "P1PXB")       return GeomDetEnumerators::P1PXB;
+  else if (sub == "P1PXEC")      return GeomDetEnumerators::P1PXEC;
+  else if (sub == "P2PXEC")      return GeomDetEnumerators::P2PXEC;
+  else if (sub == "invalidDet")  return GeomDetEnumerators::invalidDet;
+  else throw cms::Exception("UnknownSubdetector") << sub;
+}
+
+
+std::vector<GeomDetEnumerators::SubDetector>
+CreateIdealTkAlRecords::toSubDetectors(const std::vector<std::string>& subs)
+{
+  std::vector<GeomDetEnumerators::SubDetector> result;
+  for (const auto& sub: subs) result.emplace_back(toSubDetector(sub));
+  return result;
+}
+
+
+void
+CreateIdealTkAlRecords::clearAlignmentInfos()
+{
+  alignments_.clear();
+  alignmentErrors_.clear();
+  alignmentSurfaceDeformations_ = AlignmentSurfaceDeformations{};
+  rawIDs_.clear();
+}
+
+
+std::unique_ptr<TrackerGeometry>
+CreateIdealTkAlRecords::retrieveGeometry(const edm::EventSetup& iSetup)
+{
+  edm::ESHandle<GeometricDet> geometricDet;
+  iSetup.get<IdealGeometryRecord>().get(geometricDet);
+
+  edm::ESHandle<PTrackerParameters> ptp;
+  iSetup.get<PTrackerParametersRcd>().get(ptp);
+
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const auto* const tTopo = tTopoHandle.product();
+
+  TrackerGeomBuilderFromGeometricDet trackerBuilder;
+
+  return std::unique_ptr<TrackerGeometry> {
+    trackerBuilder.build(&(*geometricDet), *ptp, tTopo )};
+}
+
+
+void
+CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det)
+{
+  const auto subDetector = toString(det.subDetector());
+  const auto& detId = det.geographicalId().rawId();
+  const auto& pos = det.position();
+  const auto& rot = det.rotation();
+  rawIDs_.push_back(detId);
+  subDets_.push_back(det.subDetector());
+
+  // TrackerAlignmentRcd entry
+  if (createReferenceRcd_) {
+    alignments_.m_align.emplace_back(AlignTransform(AlignTransform::Translation(),
+                                                    AlignTransform::Rotation(),
+                                                    detId));
+  } else {
+    const AlignTransform::Translation translation(pos.x(), pos.y(), pos.z());
+    const AlignTransform::Rotation rotation(
+        CLHEP::HepRep3x3(rot.xx(),rot.xy(),rot.xz(),
+                         rot.yx(),rot.yy(),rot.yz(),
+                         rot.zx(),rot.zy(),rot.zz()));
+    const auto& eulerAngles = rotation.eulerAngles();
+    LogDebug("Alignment")
+      << "============================================================\n"
+      << "subdetector: " << subDetector << "\n"
+      << "detId:       " << detId << "\n"
+      << "------------------------------------------------------------\n"
+      << "     x: " << pos.x() << "\n"
+      << "     y: " << pos.y() << "\n"
+      << "     z: " << pos.z() << "\n"
+      << "   phi: " << eulerAngles.phi() << "\n"
+      << " theta: " << eulerAngles.theta() << "\n"
+      << "   psi: " << eulerAngles.psi() << "\n"
+      << "============================================================\n";
+    alignments_.m_align.emplace_back(AlignTransform(translation, rotation, detId));
+  }
+
+  // TrackerAlignmentErrorExtendedRcd entry
+  const AlignTransformError::SymMatrix zeroAPEs(6, 0);
+  alignmentErrors_.m_alignError.emplace_back(AlignTransformErrorExtended(zeroAPEs, detId));
+}
+
+
+void
+CreateIdealTkAlRecords::alignToGT(const edm::EventSetup& iSetup)
+{
+  LogDebug("Alignment") << "Aligning to global tag\n";
+
+  edm::ESHandle<Alignments> alignments;
+  iSetup.get<TrackerAlignmentRcd>().get(alignments);
+  edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+  edm::ESHandle<AlignmentSurfaceDeformations> surfaceDeformations;
+  iSetup.get<TrackerSurfaceDeformationRcd>().get(surfaceDeformations);
+
+  if (alignments->m_align.size() != alignmentErrors->m_alignError.size())
+    throw cms::Exception("GeometryMismatch")
+      << "Size mismatch between alignments (size=" << alignments->m_align.size()
+      << ") and alignment errors (size=" << alignmentErrors->m_alignError.size()
+      << ")";
+
+  std::vector<uint32_t> commonIDs;
+  auto itAlignErr = alignmentErrors->m_alignError.cbegin();
+  for (auto itAlign = alignments->m_align.cbegin();
+       itAlign != alignments->m_align.cend();
+       ++itAlign, ++itAlignErr) {
+    const auto id = itAlign->rawId();
+    auto found = std::find(rawIDs_.cbegin(), rawIDs_.cend(), id);
+    if (found != rawIDs_.cend()) {
+      if (id != itAlignErr->rawId())
+        throw cms::Exception("GeometryMismatch")
+          << "DetId mismatch between alignments (rawId=" << id
+          << ") and alignment errors (rawId=" << itAlignErr->rawId() << ")";
+
+      const auto index = std::distance(rawIDs_.cbegin(), found);
+      if (std::find(skipSubDetectors_.begin(),
+                    skipSubDetectors_.end(),
+                    subDets_[index]) != skipSubDetectors_.end()) continue;
+
+      if (alignments_.m_align[index].rawId()
+          != alignmentErrors_.m_alignError[index].rawId())
+        throw cms::Exception("GeometryMismatch")
+          << "DetId mismatch between alignments (rawId="
+          << alignments_.m_align[index].rawId()
+          << ") and alignment errors (rawId="
+          << alignmentErrors_.m_alignError[index].rawId() << ")";
+
+      LogDebug("Alignment")
+	<< "============================================================\n"
+	<< "\nGeometry content (" << toString(subDets_[index]) << ", "
+	<< alignments_.m_align[index].rawId() << "):\n"
+	<< "\tx: " << alignments_.m_align[index].translation().x()
+	<< "\ty: " << alignments_.m_align[index].translation().y()
+	<< "\tz: " << alignments_.m_align[index].translation().z()
+	<< "\tphi: " << alignments_.m_align[index].rotation().phi()
+	<< "\ttheta: " << alignments_.m_align[index].rotation().theta()
+	<< "\tpsi: " << alignments_.m_align[index].rotation().psi()
+	<< "============================================================\n";
+      alignments_.m_align[index] = *itAlign;
+      alignmentErrors_.m_alignError[index] = *itAlignErr;
+      commonIDs.push_back(id);
+      LogDebug("Alignment")
+	<< "============================================================\n"
+	<< "Global tag content (" << toString(subDets_[index]) << ", "
+	<< alignments_.m_align[index].rawId() << "):\n"
+	<< "\tx: " << alignments_.m_align[index].translation().x()
+	<< "\ty: " << alignments_.m_align[index].translation().y()
+	<< "\tz: " << alignments_.m_align[index].translation().z()
+	<< "\tphi: " << alignments_.m_align[index].rotation().phi()
+	<< "\ttheta: " << alignments_.m_align[index].rotation().theta()
+	<< "\tpsi: " << alignments_.m_align[index].rotation().psi()
+	<< "============================================================\n";
+    }
+  }
+
+  // - surface deformations are stored differently
+  //   -> different treatment
+  // - the above payloads contain also entries for ideal modules
+  // - no entry is created for ideal surfaces
+  //   -> size of surface deformation payload does not necessarily match the
+  //      size of the other tracker alignment payload
+  for (const auto& id: commonIDs) {
+    // search for common raw ID in surface deformation items
+    auto item = std::find_if(surfaceDeformations->items().cbegin(),
+                             surfaceDeformations->items().cend(),
+                             [&id](const auto& i) { return i.m_rawId == id; });
+    if (item == surfaceDeformations->items().cend()) continue; // not found
+
+    // copy surface deformation item
+    const auto index = std::distance(surfaceDeformations->items().cbegin(), item);
+    const auto beginEndPair = surfaceDeformations->parameters(index);
+    std::vector<align::Scalar> params(beginEndPair.first, beginEndPair.second);
+    alignmentSurfaceDeformations_.add(item->m_rawId,
+                                      item->m_parametrizationType,
+                                      params);
+  }
+}
+
+
+void
+CreateIdealTkAlRecords::writeToDB()
+{
+  const auto& since = cond::timeTypeSpecs[cond::runnumber].beginValue;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDb;
+  if (!poolDb.isAvailable()) {
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+  }
+
+  edm::LogInfo("Alignment")
+    << "Writing ideal tracker-alignment records.";
+  poolDb->writeOne(&alignments_, since, "TrackerAlignmentRcd");
+  poolDb->writeOne(&alignmentErrors_, since, "TrackerAlignmentErrorExtendedRcd");
+  poolDb->writeOne(&alignmentSurfaceDeformations_, since, "TrackerSurfaceDeformationRcd");
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+CreateIdealTkAlRecords::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.setComment("Creates ideal TrackerAlignmentRcd and TrackerAlignmentErrorExtendedRcd "
+                  "from the loaded tracker geometry. "
+                  "PoolDBOutputService must be set up for these records.");
+  desc.addUntracked<bool>("alignToGlobalTag", false);
+  desc.addUntracked<std::vector<std::string> >("skipSubDetectors",
+                                               std::vector<std::string>{});
+  desc.addUntracked<bool>("createReferenceRcd", false);
+  descriptions.add("createIdealTkAlRecords", desc);
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(CreateIdealTkAlRecords);

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -239,10 +239,10 @@ void AlignableTrackerBuilder
   AlignableCompositeBuilder compositeBuilder(trackerTopology, trackerIndexer);
   auto trackerLevels = trackerAlignmentLevelBuilder.build();
 
-  for (auto* trackerSubLevels : trackerLevels) {
+  for (auto& trackerSubLevels: trackerLevels) {
     // first add all levels of the current subdetector to the builder
-    for (auto* level : *trackerSubLevels) {
-      compositeBuilder.addAlignmentLevel(level);
+    for (auto& level: trackerSubLevels) {
+      compositeBuilder.addAlignmentLevel(std::move(level));
     }
     // now build this tracker-level
     numCompositeAlignables += compositeBuilder.buildAll(*alignableMap);

--- a/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
@@ -24,7 +24,7 @@ namespace align
 //_____________________________________________________________________________
 TrackerAlignmentLevelBuilder
 ::TrackerAlignmentLevelBuilder(const TrackerTopology* trackerTopology) :
-  trackerTopology(trackerTopology)
+  trackerTopology_(trackerTopology)
 {
 }
 
@@ -32,13 +32,6 @@ TrackerAlignmentLevelBuilder
 TrackerAlignmentLevelBuilder::
 ~TrackerAlignmentLevelBuilder()
 {
-  // cleanup; AlignmentLevels were created here, so this level-builder is
-  // also responsible for deleting them
-  for (auto* subLevels : levels) {
-    for (auto* level : *subLevels) {
-      delete level;
-    }
-  }
 }
 
 //_____________________________________________________________________________
@@ -58,23 +51,16 @@ void TrackerAlignmentLevelBuilder
 }
 
 //_____________________________________________________________________________
-std::vector<align::AlignmentLevels*> TrackerAlignmentLevelBuilder
+std::vector<align::AlignmentLevels> TrackerAlignmentLevelBuilder
 ::build()
 {
-  buildPXBAlignmentLevels();
-  buildPXEAlignmentLevels();
-  buildTIBAlignmentLevels();
-  buildTIDAlignmentLevels();
-  buildTOBAlignmentLevels();
-  buildTECAlignmentLevels();
-
-  levels.push_back(&pxb);
-  levels.push_back(&pxe);
-  levels.push_back(&tib);
-  levels.push_back(&tid);
-  levels.push_back(&tob);
-  levels.push_back(&tec);
-
+  std::vector<align::AlignmentLevels> levels;
+  levels.push_back(buildPXBAlignmentLevels());
+  levels.push_back(buildPXEAlignmentLevels());
+  levels.push_back(buildTIBAlignmentLevels());
+  levels.push_back(buildTIDAlignmentLevels());
+  levels.push_back(buildTOBAlignmentLevels());
+  levels.push_back(buildTECAlignmentLevels());
   return levels;
 }
 
@@ -88,120 +74,120 @@ std::vector<align::AlignmentLevels*> TrackerAlignmentLevelBuilder
 void TrackerAlignmentLevelBuilder
 ::addPXBDetUnitInfo(const DetId& detId)
 {
-  auto layerID  = trackerTopology->pxbLayer(detId);
-  auto ladderID = trackerTopology->pxbLadder(detId);
-  auto moduleID = trackerTopology->module(detId);
+  auto layerID  = trackerTopology_->pxbLayer(detId);
+  auto ladderID = trackerTopology_->pxbLadder(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
-  if (pxbLaddersPerLayer[layerID-1] < ladderID) {
-    pxbLaddersPerLayer[layerID-1] = ladderID;
+  if (pxbLaddersPerLayer_[layerID-1] < ladderID) {
+    pxbLaddersPerLayer_[layerID-1] = ladderID;
   }
 
-  pxbLayerIDs. insert(layerID);
-  pxbLadderIDs.insert(ladderID);
-  pxbModuleIDs.insert(moduleID);
+  pxbLayerIDs_. insert(layerID);
+  pxbLadderIDs_.insert(ladderID);
+  pxbModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
 void TrackerAlignmentLevelBuilder
 ::addPXEDetUnitInfo(const DetId& detId)
 {
-  auto sideID   = trackerTopology->pxfSide(detId);
-  auto diskID   = trackerTopology->pxfDisk(detId);
-  auto bladeID  = trackerTopology->pxfBlade(detId);
-  auto panelID  = trackerTopology->pxfPanel(detId);
-  auto moduleID = trackerTopology->module(detId);
+  auto sideID   = trackerTopology_->pxfSide(detId);
+  auto diskID   = trackerTopology_->pxfDisk(detId);
+  auto bladeID  = trackerTopology_->pxfBlade(detId);
+  auto panelID  = trackerTopology_->pxfPanel(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
-  pxeSideIDs.  insert(sideID);
-  pxeDiskIDs.  insert(diskID);
-  pxeBladeIDs. insert(bladeID);
-  pxePanelIDs. insert(panelID);
-  pxeModuleIDs.insert(moduleID);
+  pxeSideIDs_.  insert(sideID);
+  pxeDiskIDs_.  insert(diskID);
+  pxeBladeIDs_. insert(bladeID);
+  pxePanelIDs_. insert(panelID);
+  pxeModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
 void TrackerAlignmentLevelBuilder
 ::addTIBDetUnitInfo(const DetId& detId)
 {
-  auto sideID    = trackerTopology->tibSide(detId);
-  auto layerID   = trackerTopology->tibLayer(detId);
-  auto layerSide = trackerTopology->tibOrder(detId);
-  auto stringID  = trackerTopology->tibString(detId);
-  auto moduleID  = trackerTopology->module(detId);
+  auto sideID    = trackerTopology_->tibSide(detId);
+  auto layerID   = trackerTopology_->tibLayer(detId);
+  auto layerSide = trackerTopology_->tibOrder(detId);
+  auto stringID  = trackerTopology_->tibString(detId);
+  auto moduleID  = trackerTopology_->module(detId);
 
   if (layerSide == 1) {
-    if (tidStringsInnerLayer[layerID-1] < stringID) {
-      tidStringsInnerLayer[layerID-1] = stringID;
+    if (tidStringsInnerLayer_[layerID-1] < stringID) {
+      tidStringsInnerLayer_[layerID-1] = stringID;
     }
   } else {
-    if (tidStringsOuterLayer[layerID-1] < stringID) {
-      tidStringsOuterLayer[layerID-1] = stringID;
+    if (tidStringsOuterLayer_[layerID-1] < stringID) {
+      tidStringsOuterLayer_[layerID-1] = stringID;
     }
   }
 
-  tibSideIDs.  insert(sideID);
-  tibLayerIDs. insert(layerID);
-  tibStringIDs.insert(stringID);
-  tibModuleIDs.insert(moduleID);
+  tibSideIDs_.  insert(sideID);
+  tibLayerIDs_. insert(layerID);
+  tibStringIDs_.insert(stringID);
+  tibModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
 void TrackerAlignmentLevelBuilder
 ::addTIDDetUnitInfo(const DetId& detId)
 {
-  auto sideID   = trackerTopology->tidSide(detId);
-  auto wheelID  = trackerTopology->tidWheel(detId);
-  auto ringID   = trackerTopology->tidRing(detId);
-  auto moduleID = trackerTopology->module(detId);
+  auto sideID   = trackerTopology_->tidSide(detId);
+  auto wheelID  = trackerTopology_->tidWheel(detId);
+  auto ringID   = trackerTopology_->tidRing(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
   // tidOrder
-  tidSideIDs.  insert(sideID);
-  tidWheelIDs. insert(wheelID);
-  tidRingIDs.  insert(ringID);
-  tidModuleIDs.insert(moduleID);
+  tidSideIDs_.  insert(sideID);
+  tidWheelIDs_. insert(wheelID);
+  tidRingIDs_.  insert(ringID);
+  tidModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
 void TrackerAlignmentLevelBuilder
 ::addTOBDetUnitInfo(const DetId& detId)
 {
-  auto layerID  = trackerTopology->tobLayer(detId);
-  auto sideID   = trackerTopology->tobSide(detId);
-  auto rodID    = trackerTopology->tobRod(detId);
-  auto moduleID = trackerTopology->module(detId);
+  auto layerID  = trackerTopology_->tobLayer(detId);
+  auto sideID   = trackerTopology_->tobSide(detId);
+  auto rodID    = trackerTopology_->tobRod(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
-  tobLayerIDs. insert(layerID);
-  tobSideIDs.  insert(sideID);
-  tobRodIDs.   insert(rodID);
-  tobModuleIDs.insert(moduleID);
+  tobLayerIDs_. insert(layerID);
+  tobSideIDs_.  insert(sideID);
+  tobRodIDs_.   insert(rodID);
+  tobModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
 void TrackerAlignmentLevelBuilder
 ::addTECDetUnitInfo(const DetId& detId)
 {
-  auto sideID   = trackerTopology->tecSide(detId);
-  auto wheelID  = trackerTopology->tecWheel(detId);
-  auto petalID  = trackerTopology->tecPetalNumber(detId);
-  auto ringID   = trackerTopology->tecRing(detId);
-  auto moduleID = trackerTopology->module(detId);
+  auto sideID   = trackerTopology_->tecSide(detId);
+  auto wheelID  = trackerTopology_->tecWheel(detId);
+  auto petalID  = trackerTopology_->tecPetalNumber(detId);
+  auto ringID   = trackerTopology_->tecRing(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
-  tecSideIDs.  insert(sideID);
-  tecWheelIDs. insert(wheelID);
-  tecPetalIDs. insert(petalID);
-  tecRingIDs.  insert(ringID);
-  tecModuleIDs.insert(moduleID);
+  tecSideIDs_.  insert(sideID);
+  tecWheelIDs_. insert(wheelID);
+  tecPetalIDs_. insert(petalID);
+  tecRingIDs_.  insert(ringID);
+  tecModuleIDs_.insert(moduleID);
 }
 
 
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildPXBAlignmentLevels()
 {
-  int maxNumModules = pxbModuleIDs.size();
-  int maxNumLadders = pxbLadderIDs.size() / 2; // divide by 2 since we have
+  int maxNumModules = pxbModuleIDs_.size();
+  int maxNumLadders = pxbLadderIDs_.size() / 2; // divide by 2 since we have
                                                // HalfBarrels
-  int maxNumLayers  = pxbLayerIDs.size();
+  int maxNumLayers  = pxbLayerIDs_.size();
 
   std::ostringstream ss;
   ss << "determined following numbers for "
@@ -209,11 +195,11 @@ void TrackerAlignmentLevelBuilder
      << "   max. number of modules: " << maxNumModules                  << "\n"
      << "   max. number of ladders: " << maxNumLadders                  << "\n";
 
-  for (size_t layer = 0; layer < pxbLaddersPerLayer.size(); ++layer) {
+  for (size_t layer = 0; layer < pxbLaddersPerLayer_.size(); ++layer) {
     // divide by 4, because we need the ladders per quarter cylinder
-    align::tpb::lpqc.push_back(pxbLaddersPerLayer[layer] / 4);
+    align::tpb::lpqc.push_back(pxbLaddersPerLayer_[layer] / 4);
     ss << "      ladders in layer-" << layer << ": "
-       << pxbLaddersPerLayer[layer] << "\n";
+       << pxbLaddersPerLayer_[layer] << "\n";
   }
 
   ss << "   max. number of layers:  " << maxNumLayers;
@@ -221,22 +207,24 @@ void TrackerAlignmentLevelBuilder
      << "@SUB=TrackerAlignmentLevelBuilder::buildPXBAlignmentLevels"
      << ss.str();
 
-  pxb.push_back(new AlignmentLevel(align::TPBModule,     maxNumModules, false));
-  pxb.push_back(new AlignmentLevel(align::TPBLadder,     maxNumLadders, true));
-  pxb.push_back(new AlignmentLevel(align::TPBLayer,      maxNumLayers,  false));
-  pxb.push_back(new AlignmentLevel(align::TPBHalfBarrel, 2,             false));
-  pxb.push_back(new AlignmentLevel(align::TPBBarrel,     1,             false));
+  align::AlignmentLevels pxb;
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBModule,     maxNumModules, false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLadder,     maxNumLadders, true));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLayer,      maxNumLayers,  false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBHalfBarrel, 2,             false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBBarrel,     1,             false));
+  return pxb;
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildPXEAlignmentLevels()
 {
-  int maxNumModules = pxeModuleIDs.size();
-  int maxNumPanels  = pxePanelIDs.size();
-  int maxNumBlades  = pxeBladeIDs.size() / 2;
-  int maxNumDisks   = pxeDiskIDs.size();
-  int maxNumSides   = pxeSideIDs.size();
+  int maxNumModules = pxeModuleIDs_.size();
+  int maxNumPanels  = pxePanelIDs_.size();
+  int maxNumBlades  = pxeBladeIDs_.size() / 2;
+  int maxNumDisks   = pxeDiskIDs_.size();
+  int maxNumSides   = pxeSideIDs_.size();
 
   std::ostringstream ss;
   ss << "determined following numbers for "
@@ -254,22 +242,24 @@ void TrackerAlignmentLevelBuilder
      << "@SUB=TrackerAlignmentLevelBuilder::buildPXEAlignmentLevels"
      << ss.str();
 
-  pxe.push_back(new AlignmentLevel(align::TPEModule,       maxNumModules, false));
-  pxe.push_back(new AlignmentLevel(align::TPEPanel,        maxNumPanels,  true));
-  pxe.push_back(new AlignmentLevel(align::TPEBlade,        maxNumBlades,  true));
-  pxe.push_back(new AlignmentLevel(align::TPEHalfDisk,     maxNumDisks,   false));
-  pxe.push_back(new AlignmentLevel(align::TPEHalfCylinder, 2,             false));
-  pxe.push_back(new AlignmentLevel(align::TPEEndcap,       maxNumSides,   false));
+  align::AlignmentLevels pxe;
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEModule,       maxNumModules, false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEPanel,        maxNumPanels,  true));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEBlade,        maxNumBlades,  true));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfDisk,     maxNumDisks,   false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfCylinder, 2,             false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEEndcap,       maxNumSides,   false));
+  return pxe;
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildTIBAlignmentLevels()
 {
-  int maxNumModules = tibModuleIDs.size();
-  int maxNumStrings = tibStringIDs.size();
-  int maxNumLayers  = tibLayerIDs.size();
-  int maxNumSides   = tibSideIDs.size();
+  int maxNumModules = tibModuleIDs_.size();
+  int maxNumStrings = tibStringIDs_.size();
+  int maxNumLayers  = tibLayerIDs_.size();
+  int maxNumSides   = tibSideIDs_.size();
 
   std::ostringstream ss;
   ss << "determined following numbers for "
@@ -277,15 +267,15 @@ void TrackerAlignmentLevelBuilder
      << "   max. number of modules: " << maxNumModules                  << "\n"
      << "   max. number of strings: " << maxNumStrings                  << "\n";
 
-  for (size_t layer = 0; layer < tidStringsInnerLayer.size(); ++layer) {
+  for (size_t layer = 0; layer < tidStringsInnerLayer_.size(); ++layer) {
     // divide by 2, because we have HalfShells
-    align::tib::sphs.push_back(tidStringsInnerLayer[layer] / 2);
-    align::tib::sphs.push_back(tidStringsOuterLayer[layer] / 2);
+    align::tib::sphs.push_back(tidStringsInnerLayer_[layer] / 2);
+    align::tib::sphs.push_back(tidStringsOuterLayer_[layer] / 2);
 
     ss << "      strings in layer-" << layer << " (inside):  "
-       << tidStringsInnerLayer[layer] << "\n"
+       << tidStringsInnerLayer_[layer] << "\n"
        << "      strings in layer-" << layer << " (outside): "
-       << tidStringsOuterLayer[layer] << "\n";
+       << tidStringsOuterLayer_[layer] << "\n";
   }
 
   ss << "   max. number of layers:  " << maxNumLayers                   << "\n"
@@ -294,25 +284,27 @@ void TrackerAlignmentLevelBuilder
        << "@SUB=TrackerAlignmentLevelBuilder::buildTIBAlignmentLevels"
        << ss.str();
 
-  tib.push_back(new AlignmentLevel(align::TIBModule,     maxNumModules, false));
-  tib.push_back(new AlignmentLevel(align::TIBString,     maxNumStrings, true));
-  tib.push_back(new AlignmentLevel(align::TIBSurface,    2, false)); // 2 surfaces per half shell
-  tib.push_back(new AlignmentLevel(align::TIBHalfShell,  2, false)); // 2 half shells per layer
-  tib.push_back(new AlignmentLevel(align::TIBLayer,      maxNumLayers, false));
-  tib.push_back(new AlignmentLevel(align::TIBHalfBarrel, 2, false));
-  tib.push_back(new AlignmentLevel(align::TIBBarrel,     1, false));
+  align::AlignmentLevels tib;
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBModule,     maxNumModules, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBString,     maxNumStrings, true));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBSurface,    2, false)); // 2 surfaces per half shell
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBHalfShell,  2, false)); // 2 half shells per layer
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBLayer,      maxNumLayers, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBHalfBarrel, 2, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBBarrel,     1, false));
+  return tib;
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildTIDAlignmentLevels()
 {
-  int maxNumModules = tidModuleIDs.size();
-  int maxNumRings   = tidRingIDs.size();
+  int maxNumModules = tidModuleIDs_.size();
+  int maxNumRings   = tidRingIDs_.size();
   // TODO: for PhaseII geometry the method name for tidWheel changes:
   //       -> trackerTopology->tidDisk(detId);
-  int maxNumWheels  = tidWheelIDs.size();
-  int maxNumSides   = tidSideIDs.size();
+  int maxNumWheels  = tidWheelIDs_.size();
+  int maxNumSides   = tidSideIDs_.size();
 
   edm::LogInfo("AlignableBuildProcess")
      << "@SUB=TrackerAlignmentLevelBuilder::buildTIDAlignmentLevels"
@@ -323,21 +315,23 @@ void TrackerAlignmentLevelBuilder
      << "   max. number of wheels:  " << maxNumWheels                   << "\n"
      << "   max. number of sides:   " << maxNumSides;
 
-  tid.push_back(new AlignmentLevel(align::TIDModule, maxNumModules, false));
-  tid.push_back(new AlignmentLevel(align::TIDSide,   2,             false)); // 2 sides per ring
-  tid.push_back(new AlignmentLevel(align::TIDRing,   maxNumRings,   false));
-  tid.push_back(new AlignmentLevel(align::TIDDisk,   maxNumWheels,  false));
-  tid.push_back(new AlignmentLevel(align::TIDEndcap, 2,             false)); // 2 endcaps in TID
+  align::AlignmentLevels tid;
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDModule, maxNumModules, false));
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDSide,   2,             false)); // 2 sides per ring
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDRing,   maxNumRings,   false));
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDDisk,   maxNumWheels,  false));
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDEndcap, 2,             false)); // 2 endcaps in TID
+  return tid;
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildTOBAlignmentLevels()
 {
-  int maxNumModules = tobModuleIDs.size();
-  int maxNumRods    = tobRodIDs.size();
-  int maxNumSides   = tobSideIDs.size();
-  int maxNumLayers  = tobLayerIDs.size();
+  int maxNumModules = tobModuleIDs_.size();
+  int maxNumRods    = tobRodIDs_.size();
+  int maxNumSides   = tobSideIDs_.size();
+  int maxNumLayers  = tobLayerIDs_.size();
 
   edm::LogInfo("AlignableBuildProcess")
      << "@SUB=TrackerAlignmentLevelBuilder::buildTOBAlignmentLevels"
@@ -348,22 +342,24 @@ void TrackerAlignmentLevelBuilder
      << "   max. number of sides:   " << maxNumSides                    << "\n"
      << "   max. number of layers:  " << maxNumLayers;
 
-  tob.push_back(new AlignmentLevel(align::TOBModule,     maxNumModules, false));
-  tob.push_back(new AlignmentLevel(align::TOBRod,        maxNumRods,    true));
-  tob.push_back(new AlignmentLevel(align::TOBLayer,      maxNumLayers,  false));
-  tob.push_back(new AlignmentLevel(align::TOBHalfBarrel, maxNumSides,   false));
-  tob.push_back(new AlignmentLevel(align::TOBBarrel,     1,             false));
+  align::AlignmentLevels tob;
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBModule,     maxNumModules, false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBRod,        maxNumRods,    true));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBLayer,      maxNumLayers,  false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBHalfBarrel, maxNumSides,   false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBBarrel,     1,             false));
+  return tob;
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
+align::AlignmentLevels TrackerAlignmentLevelBuilder
 ::buildTECAlignmentLevels()
 {
-  int maxNumModules = tecModuleIDs.size();
-  int maxNumRings   = tecRingIDs.size();
-  int maxNumPetals  = tecPetalIDs.size();
-  int maxNumDisks   = tecWheelIDs.size();
-  int maxNumSides   = tecSideIDs.size();
+  int maxNumModules = tecModuleIDs_.size();
+  int maxNumRings   = tecRingIDs_.size();
+  int maxNumPetals  = tecPetalIDs_.size();
+  int maxNumDisks   = tecWheelIDs_.size();
+  int maxNumSides   = tecSideIDs_.size();
 
   edm::LogInfo("AlignableBuildProcess")
      << "@SUB=TrackerAlignmentLevelBuilder::buildTECAlignmentLevels"
@@ -375,10 +371,12 @@ void TrackerAlignmentLevelBuilder
      << "   max. number of wheels:  " << maxNumDisks                    << "\n"
      << "   max. number of sides:   " << maxNumSides;
 
-  tec.push_back(new AlignmentLevel(align::TECModule, maxNumModules, false));
-  tec.push_back(new AlignmentLevel(align::TECRing,   maxNumRings,   true));
-  tec.push_back(new AlignmentLevel(align::TECPetal,  maxNumPetals,  true));
-  tec.push_back(new AlignmentLevel(align::TECSide,   2,             false)); // 2 sides per disk
-  tec.push_back(new AlignmentLevel(align::TECDisk,   maxNumDisks,   false));
-  tec.push_back(new AlignmentLevel(align::TECEndcap, 2,             false));
+  align::AlignmentLevels tec;
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECModule, maxNumModules, false));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECRing,   maxNumRings,   true));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECPetal,  maxNumPetals,  true));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECSide,   2,             false)); // 2 sides per disk
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECDisk,   maxNumDisks,   false));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECEndcap, 2,             false));
+  return tec;
 }

--- a/Alignment/TrackerAlignment/src/TrackerScenarioBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerScenarioBuilder.cc
@@ -15,7 +15,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // Alignment
-
+#include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 #include "Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
@@ -30,13 +30,13 @@ TrackerScenarioBuilder::TrackerScenarioBuilder(AlignableTracker* alignable)
   }
 
   // Fill what is needed for possiblyPartOf(..):
-  theSubdets.push_back("TPB"); // Take care, order matters: 1st pixel, 2nd strip.
-  theSubdets.push_back("TPE");
+  theSubdets.push_back(stripOffModule(align::TPBModule)); // Take care, order matters: 1st pixel, 2nd strip.
+  theSubdets.push_back(stripOffModule(align::TPEModule));
   theFirstStripIndex = theSubdets.size();
-  theSubdets.push_back("TIB");
-  theSubdets.push_back("TID");
-  theSubdets.push_back("TOB");
-  theSubdets.push_back("TEC");
+  theSubdets.push_back(stripOffModule(align::TIBModule));
+  theSubdets.push_back(stripOffModule(align::TIDModule));
+  theSubdets.push_back(stripOffModule(align::TOBModule));
+  theSubdets.push_back(stripOffModule(align::TECModule));
 }
 
 
@@ -109,3 +109,15 @@ bool TrackerScenarioBuilder::possiblyPartOf(const std::string &subStruct, const 
   return true; 
 }
 
+//__________________________________________________________________________________________________
+std::string TrackerScenarioBuilder::stripOffModule(const align::StructureType& type) const {
+  const std::string module{"Module"};
+  std::string name{AlignableObjectId::typeToName(type)};
+  auto start = name.find(module);
+  if (start == std::string::npos) {
+    throw cms::Exception("LogicError")
+      << "[TrackerScenarioBuilder] '" << name << "' is not a module type";
+  }
+  name.replace(start, module.length(), "");
+  return name;
+}

--- a/Alignment/TrackerAlignment/test/createTrackerAlignmentRcds_cfg.py
+++ b/Alignment/TrackerAlignment/test/createTrackerAlignmentRcds_cfg.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("Alignment")
+
+process.load("Configuration.StandardSequences.MagneticField_cff") # B-field map
+process.load("Configuration.Geometry.GeometryRecoDB_cff") # Ideal geometry and interface
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff") # Global tag
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.load("Alignment.TrackerAlignment.createIdealTkAlRecords_cfi")
+
+################################################################################
+# parameters to configure:                                                     #
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase1_2017_design")    #
+                                                                               #
+process.createIdealTkAlRecords.alignToGlobalTag   = True                       #
+################################################################################
+
+
+usedGlobalTag = process.GlobalTag.globaltag._value
+print "Using Global Tag:", usedGlobalTag
+
+from CondCore.CondDB.CondDB_cfi import *
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    CondDB,
+    timetype = cms.untracked.string("runnumber"),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string("TrackerAlignmentRcd"),
+            tag = cms.string("Alignments")
+        ),
+        cms.PSet(
+            record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+            tag = cms.string("AlignmentErrorsExtended")
+        ),
+        cms.PSet(
+            record = cms.string("TrackerSurfaceDeformationRcd"),
+            tag = cms.string("AlignmentSurfaceDeformations")
+        ),
+    )
+)
+process.PoolDBOutputService.connect = \
+    ("sqlite_file:ideal_tracker_alignment_"+
+     usedGlobalTag+("_reference.db"
+                    if process.createIdealTkAlRecords.createReferenceRcd
+                    else ".db"))
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.source = cms.Source("EmptySource")
+process.p = cms.Path(process.createIdealTkAlRecords)


### PR DESCRIPTION
Summary of changes:
- added a tool to create tracker alignment payloads for a given tracker geometry
- added a switch for MillePede to handle modules w/o material
- made the misalignment tool geometry-independent
- address https://github.com/cms-sw/cmssw/pull/13976#discussion_r60824907 by @davidlange6 in the last update
