### PR TITLE
fixed static analiser warnings3

### DIFF
--- a/SimG4CMS/Calo/interface/CaloG4Hit.h
+++ b/SimG4CMS/Calo/interface/CaloG4Hit.h
@@ -35,7 +35,7 @@ class CaloG4Hit : public G4VHit {
 public:
   
   CaloG4Hit();
-  ~CaloG4Hit();
+  virtual ~CaloG4Hit();
   CaloG4Hit(const CaloG4Hit &right);
   const CaloG4Hit& operator=(const CaloG4Hit &right);
   bool operator==(const CaloG4Hit &){return false;}

--- a/SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h
+++ b/SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h
@@ -27,10 +27,8 @@ class EnergyResolutionVsLumi {
     calcmuTot();
   };
 
-
   virtual ~EnergyResolutionVsLumi();
-  
-	  
+  	  
   struct DegradationAtEta{
     double eta;
     double muEM;
@@ -42,12 +40,9 @@ class EnergyResolutionVsLumi {
     double resolutitonConstantTerm;
   };
   
-
-  
-
   DegradationAtEta CalculateDegradation(double eta);
   double  Resolution(double eta, double ene);
-  void Decomposition();
+  //void Decomposition();
 
   void setLumi(double x){m_lumi=x;};
   void setInstLumi(double x){m_instlumi=x;};

--- a/SimG4CMS/Calo/interface/HcalTestAnalysis.h
+++ b/SimG4CMS/Calo/interface/HcalTestAnalysis.h
@@ -69,7 +69,7 @@ private:
   int                       addTower;
 
   // Private Tuples
-  std::auto_ptr<HcalTestHistoManager>    tuplesManager;
+  std::unique_ptr<HcalTestHistoManager>    tuplesManager;
   HcalTestHistoClass        *tuples;
 
   // Numbering scheme

--- a/SimG4CMS/Calo/src/CaloG4Hit.cc
+++ b/SimG4CMS/Calo/src/CaloG4Hit.cc
@@ -7,7 +7,7 @@
 
 #include "G4SystemOfUnits.hh"
 
-G4ThreadLocal G4Allocator<CaloG4Hit> *fpCaloG4HitAllocator = 0;
+G4ThreadLocal G4Allocator<CaloG4Hit> *fpCaloG4HitAllocator = nullptr;
 
 CaloG4Hit::CaloG4Hit(){
 
@@ -54,7 +54,6 @@ void CaloG4Hit::addEnergyDeposit(const CaloG4Hit& aHit) {
 
   addEnergyDeposit(aHit.getEM(),aHit.getHadr());
 }
-
 
 void CaloG4Hit::Print() {
   LogDebug("CaloSim") << (*this);

--- a/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
+++ b/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
@@ -6,18 +6,15 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-
 EnergyResolutionVsLumi::EnergyResolutionVsLumi()
 {
   m_lumi=0;
-  m_instlumi=0;
-  
+  m_instlumi=0;  
 }
 
 EnergyResolutionVsLumi::~EnergyResolutionVsLumi()
 {
 }
-
 
 EnergyResolutionVsLumi::DegradationAtEta EnergyResolutionVsLumi::CalculateDegradation(double eta)
 {
@@ -52,7 +49,6 @@ EnergyResolutionVsLumi::DegradationAtEta EnergyResolutionVsLumi::CalculateDegrad
   return result;
 }
 
-
 double EnergyResolutionVsLumi::calcmuEM(double eta)
 {
   double instLumi = m_instlumi;
@@ -68,7 +64,6 @@ double EnergyResolutionVsLumi::calcmuHD(double eta)
   double result = model.InducedAbsorptionHadronic(totLumi, eta);
   return result;
 }
-
 
 void  EnergyResolutionVsLumi::calcmuTot(){
 
@@ -100,9 +95,7 @@ void  EnergyResolutionVsLumi::calcmuTot(){
 	}
     }
   }
-
 }
-
 
 double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted(DetId id, double z)
 {
@@ -126,18 +119,13 @@ double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted(DetId id, d
   }
   double zcor=z;
   EvolutionECAL model;
-  if(z<0.02 ) zcor=0.02;
-  if(z>0.98) zcor=0.98;
+  if(z<0.02 )     { zcor=0.02; }
+  else if(z>0.98) { zcor=0.98; }
 
   double result=model.LightCollectionEfficiencyWeighted( zcor , muTot)*v;
   
-  
-  
   return result; 
-
 }
-
-
 
 double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted2(double eta, double z, double mu_ind)
 {
@@ -147,7 +135,6 @@ double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted2(double eta
   double result=model.LightCollectionEfficiencyWeighted( z , mu_ind)*v;
   return result; 
 }
-
 
 double EnergyResolutionVsLumi::calcmuTot(double eta)
 {
@@ -222,11 +209,8 @@ double EnergyResolutionVsLumi::calcresolutitonConstantTerm(double eta)
   return result;
 }
 
-
 double  EnergyResolutionVsLumi::Resolution(double eta, double ene)
 {  
-
-
   // Initial parameters for ECAL resolution
   double S;
   double Nadc;
@@ -244,7 +228,6 @@ double  EnergyResolutionVsLumi::Resolution(double eta, double ene)
     C = 0.004;
   }
 
-
   DegradationAtEta d = CalculateDegradation(eta);
 
   // adjust resolution parameters
@@ -257,22 +240,14 @@ double  EnergyResolutionVsLumi::Resolution(double eta, double ene)
   return sqrt(S*S/ene + N*N/ene/ene + C*C);
 
 }
-
-
-
-
-
-
-
- void EnergyResolutionVsLumi::Decomposition()
+/*
+void EnergyResolutionVsLumi::Decomposition()
 {
-
   double eta = 2.2;
   m_instlumi = 5.0e+34;
   m_lumi = 3000.0;
 
   DegradationAtEta d = this->CalculateDegradation(eta);
-
 
   // Initial parameters for ECAL resolution
   double S;
@@ -291,7 +266,6 @@ double  EnergyResolutionVsLumi::Resolution(double eta, double ene)
     C = 0.0038;
   }
 
-
   // adjust resolution parameters
   S /= sqrt(d.ampDropTotal);
   Nadc *= d.noiseIncreaseADC;
@@ -299,27 +273,14 @@ double  EnergyResolutionVsLumi::Resolution(double eta, double ene)
   //  double N = Nadc*adc2GeV*3.0;   // 3x3 noise in GeV 
   C = sqrt(C*C + d.resolutitonConstantTerm*d.resolutitonConstantTerm);
 
-
-
-  /*  for(double ene=1.0; ene<1e+3; ene*=1.1){
-
-
+  for(double ene=1.0; ene<1e+3; ene*=1.1){
     // this is the resolution
-
     double res =  sqrt(S*S/ene + N*N/ene/ene + C*C);
-
     double factor = 1.0;
     factor = sin(2.0*atan(exp(-1.0*eta)));
-  
-
   }
-
-  */
-
-
 }
-
-
+*/
 
 
 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -49,12 +49,11 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   hfshower(0), showerParam(0), showerPMT(0), showerBundle(0), m_HEDarkening(0),
   m_HFDarkening(0) {
 
-  //static SimpleConfigurable<bool>   on1(false, "HCalSD:UseBirkLaw");
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
   //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
   //static SimpleConfigurable<double> bk3(1.75,  "HCalSD:BirkC3");
   // Values from NIM 80 (1970) 239-244: as implemented in Geant3
-  //static SimpleConfigurable<bool> on2(true,"HCalSD:UseShowerLibrary");
+
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HCalSD");
   useBirk          = m_HC.getParameter<bool>("UseBirkLaw");
   birk1            = m_HC.getParameter<double>("BirkC1")*(g/(MeV*cm2));
@@ -539,26 +538,6 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
   }
   double wt1 = getResponseWt(theTrack);
   double wt2 = theTrack->GetWeight();
-  /*
-  if (wt2 != 1.0) { 
-    edm::LogInfo("HcalSim") << "HCalSD: Detector " << det+3 << " Depth " 
-			    << depth << " weight= " << weight << " wt1= " 
-			    << wt1 << " wt2= " << wt2;
-    const G4VProcess* pr = theTrack->GetCreatorProcess();
-    if (pr) {
-      edm::LogInfo("HcalSim") << theTrack->GetDefinition()->GetParticleName()
-			      << " " << theTrack->GetKineticEnergy()
-			      << " Id=" << theTrack->GetTrackID()
-			      << " IdP=" << theTrack->GetParentID()
-			      << " from  " << pr->GetProcessName();
-    } else {
-      edm::LogInfo("HcalSim") << theTrack->GetDefinition()->GetParticleName()
-			      << " " << theTrack->GetKineticEnergy()
-			      << " Id=" << theTrack->GetTrackID()
-			      << " IdP=" << theTrack->GetParentID();
-    }
-  }
-  */
 #ifdef DebugLog
   edm::LogInfo("HcalSim") << "HCalSD: Detector " << det+3 << " Depth " << depth
                           << " weight " << weight0 << " " << weight << " " << wt1 
@@ -654,7 +633,6 @@ bool HCalSD::filterHit(CaloG4Hit* aHit, double time) {
   }
   return ((time <= tmaxHit) && (aHit->getEnergyDeposit() > threshold));
 }
-
 
 uint32_t HCalSD::setDetUnitId (int det, const G4ThreeVector& pos, int depth, int lay=1) { 
   uint32_t id = 0;
@@ -1142,8 +1120,8 @@ void HCalSD::plotProfile(G4Step* aStep,const G4ThreeVector& global, double edep,
                          double time, int id) { 
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  static G4String modName[8] = {"HEModule", "HVQF" , "HBModule", "MBAT",
-                                "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
+  static const G4String modName[8] = {"HEModule", "HVQF" , "HBModule", "MBAT",
+				      "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
   G4ThreeVector local;
   bool found=false;
   double depth=-2000;

--- a/SimG4CMS/Calo/src/HFCherenkov.cc
+++ b/SimG4CMS/Calo/src/HFCherenkov.cc
@@ -285,7 +285,6 @@ int HFCherenkov::computeNPEinPMT(G4ParticleDefinition* pDef, double pBeta,
 #endif
 	if (rand < 1.0) { // survived all the times and sent to photo-cathode
 	  wlatten.push_back(lambda);
-	  rand = G4UniformRand();
 	  double qEffic = computeQEff(lambda);//Quantum efficiency of the PMT
 	  rand = G4UniformRand();
 #ifdef DebugLog

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -118,10 +118,9 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
 }
 
 HFShowerLibrary::~HFShowerLibrary() {
-  if (hf)     hf->Close();
-  if (fibre)  delete   fibre;
-  fibre  = 0;
-  if (photo)  delete photo;
+  if (hf) { hf->Close(); }
+  delete fibre;
+  delete photo;
 }
 
 void HFShowerLibrary::initRun(G4ParticleTable * theParticleTable,
@@ -373,14 +372,11 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(G4ThreeVector & hitP
   if (nHit > npe && !onlyLong)
     edm::LogWarning("HFShower") << "HFShowerLibrary: Hit buffer " << npe 
 				<< " smaller than " << nHit << " Hits";
- return hit;
-
+  return hit;
 }
 
 bool HFShowerLibrary::rInside(double r) {
-
-  if (r >= rMin && r <= rMax) return true;
-  else                        return false;
+  return (r >= rMin && r <= rMax);
 }
 
 void HFShowerLibrary::getRecord(int type, int record) {
@@ -440,8 +436,9 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     listVersion = 3.6;
     pmom        = {2,3,5,7,10,15,20,30,50,75,100,150,250,350,500,1000};
   }
-  for (int i=0; i<nMomBin; i++) 
+  for (int i=0; i<nMomBin; i++) {
     pmom[i] *= GeV;
+  }
 }
 
 void HFShowerLibrary::interpolate(int type, double pin) {
@@ -451,7 +448,7 @@ void HFShowerLibrary::interpolate(int type, double pin) {
 		       << " GeV with " << nMomBin << " momentum bins and " 
 		       << evtPerBin << " entries/bin -- total " << totEvents;
 #endif
-  int irc[2];
+  int irc[2] = {0, 0};
   double w = 0.;
   double r = G4UniformRand();
 

--- a/SimG4CMS/Calo/src/HcalTestAnalysis.cc
+++ b/SimG4CMS/Calo/src/HcalTestAnalysis.cc
@@ -30,7 +30,7 @@
 #include <iomanip>
 
 HcalTestAnalysis::HcalTestAnalysis(const edm::ParameterSet &p): 
-  myqie(0), addTower(3), tuplesManager(0), tuples(0), numberingFromDDD(0), org(0) {
+  addTower(3),tuples(nullptr),numberingFromDDD(nullptr),hcons(nullptr),org(nullptr) {
 
   edm::ParameterSet m_Anal = p.getParameter<edm::ParameterSet>("HcalTestAnalysis");
   eta0         = m_Anal.getParameter<double>("Eta0");
@@ -40,6 +40,7 @@ HcalTestAnalysis::HcalTestAnalysis(const edm::ParameterSet &p):
   names        = m_Anal.getParameter<std::vector<std::string> >("Names");
   fileName     = m_Anal.getParameter<std::string>("FileName");
 
+  tuplesManager.reset(nullptr); 
   edm::LogInfo("HcalSim") << "HcalTestAnalysis:: Initialised as observer of "
 			  << "begin/end events and of G4step";
 
@@ -148,12 +149,14 @@ std::vector<int> HcalTestAnalysis::towersToAdd(int centre, int nadd) {
 }
 
 //==================================================================== per JOB
+
 void HcalTestAnalysis::update(const BeginOfJob * job) {
 
   // Numbering From DDD
   edm::ESHandle<HcalDDDSimConstants>    hdc;
   (*job)()->get<HcalSimNumberingRecord>().get(hdc);
-  hcons = (HcalDDDSimConstants*)(&(*hdc));
+  if(!hcons) { hcons = (HcalDDDSimConstants*)(&(*hdc)); }
+  //if(!hcons) { hcons = &(*hdc); }
   edm::LogInfo("HcalSim") << "HcalTestAnalysis:: Initialise "
 			  << "HcalNumberingFromDDD for " << names[0];
   numberingFromDDD = new HcalNumberingFromDDD(hcons);
@@ -331,8 +334,8 @@ void HcalTestAnalysis::update(const EndOfEvent * evt) {
   LogDebug("HcalSim") << "HcalTestAnalysis:: ---  after LayerAnalysis";
 
   // Writing the data to the Tree
-  tuplesManager->fillTree(tuples); // (no need to delete it...)
-  tuples = 0; // but avoid to reuse it...
+  tuplesManager.get()->fillTree(tuples); // (no need to delete it...)
+  tuples = nullptr; // but avoid to reuse it...
   LogDebug("HcalSim") << "HcalTestAnalysis:: --- after fillTree";
 
 }

--- a/SimG4CMS/FP420/plugins/FP420Test.cc
+++ b/SimG4CMS/FP420/plugins/FP420Test.cc
@@ -17,14 +17,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 // to retreive hits
 #include "SimG4CMS/FP420/interface//FP420NumberingScheme.h"
-//#include "SimG4CMS/Calo/interface/CaloG4Hit.h"
-//#include "SimG4CMS/Calo/interface/CaloG4HitCollection.h"
 #include "SimG4CMS/FP420/interface//FP420G4HitCollection.h"
-//#include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "SimG4CMS/FP420/interface/FP420Test.h"
-
-//#include "Utilities/GenUtil/interface/CMSexception.h"
-//#include "Utilities/UI/interface/SimpleConfigurable.h"
 
 // G4 stuff
 #include "G4SDManager.hh"
@@ -35,13 +29,9 @@
 #include "G4UserEventAction.hh"
 #include "G4TransportationManager.hh"
 #include "G4ProcessManager.hh"
-//#include "G4EventManager.hh"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
-#include <stdio.h>
-//#include <gsl/gsl_fit.h>
-
 
 
 //================================================================
@@ -129,8 +119,6 @@ FP420Test::FP420Test(const edm::ParameterSet &p){
   }
 }
 
-
-
 FP420Test::~FP420Test() {
   //  delete UserNtuples;
 
@@ -150,11 +138,6 @@ FP420Test::~FP420Test() {
   if (verbosity > 0) {
     std::cout << std::endl << "FP420Test Destructor  -------->  End of FP420Test : " << std::endl;
   }
-
-  std::cout<<"FP420Test: End of process"<<std::endl;
-
-
-
 }
 
 //================================================================
@@ -336,66 +319,6 @@ void Fp420AnalysisHistManager::StoreWeights()
 
 //================================================================
 
-/*
-ObserveBeginOfRun::ObserveBeginOfRun() {  }
-
-void ObserveBeginOfRun::update(const BeginOfRun *) {
-    std::cout <<" BeginOfRun " << std::endl;
-  // const G4Run * r = (*run)(); 
-  // recover G4 pointer if wanted
-  // user monitoring code... 
-}
-
-ObserveEndOfRun::ObserveEndOfRun() {  }
-
-void ObserveEndOfRun::update(const EndOfRun *) {
-  // const G4Run * r = (*run)();
-  // recover G4 pointer if wanted
-  // user monitoring code...
-}
-
-ObserveBeginOfEvent::ObserveBeginOfEvent() {  }
-
-void ObserveBeginOfEvent::update(const BeginOfEvent * evt) {
-    std::cout <<" BeginOfEvent " << std::endl;
- // const G4Event * e = (*evt)();
- // recover G4 pointer if wanted
-  // user monitoring code...
-}
-
-ObserveEndOfEvent::ObserveEndOfEvent() {  }
-
-void ObserveEndOfEvent::update(const EndOfEvent *) {
-  // const G4Event * e = (*evt)(); 
-  // recover G4 pointer if wanted
-  // user monitoring code... 
-
-//    std::cout << "ObserveEndOfEvent:  start   " << std::endl;
-
-}
-
-ObserveBeginOfTrack::ObserveBeginOfTrack() {  }
-
-void ObserveBeginOfTrack::update(const BeginOfTrack * trk) {
-  // const G4Track * t = (*trk)(); 
-  // recover G4 pointer if wanted
-  // user monitoring code...
-}
-
-ObserveEndOfTrack::ObserveEndOfTrack() {  }
-
-void ObserveEndOfTrack::update(const EndOfTrack *) {
-  // const G4Track * t = (*trk)(); 
-  // recover G4 pointer if wanted
-  // user monitoring code... 
-}
-
-ObserveStep::ObserveStep() {  }
-
-void ObserveStep::update(const G4Step *) {
-  // user monitoring code... 
-}
-*/
 // using several observers
 
 //==================================================================== per JOB
@@ -412,10 +335,7 @@ void FP420Test::update(const BeginOfRun * run) {
  std::cout << std::endl << "FP420Test:: Begining of Run"<< std::endl; 
 }
 
-
 void FP420Test::update(const EndOfRun * run) {;}
-
-
 
 //=================================================================== per EVENT
 void FP420Test::update(const BeginOfEvent * evt) {
@@ -440,8 +360,6 @@ void FP420Test::update(const BeginOfTrack * trk) {
      tracklength0 = 0.;
   }
 }
-
-
 
 //=================================================================== per EndOfTrack
 void FP420Test::update(const EndOfTrack * trk) {
@@ -538,17 +456,7 @@ void FP420Test::update(const EndOfTrack * trk) {
          //UserNtuples->fillg532(lastpo.y(),1.);
          //UserNtuples->fillg533(lastpo.z(),1.);
          }
-
-	 /*
-      float th_tr     = lastpo.theta();
-      float eta_tr    = -log(tan(th_tr/2));
-      float phi_tr    = lastpo.phi();
-      if (phi_tr < 0.) phi_tr += twopi;
-*/
-
-
   }
-
 }
 
 // ====================================================
@@ -566,7 +474,6 @@ void FP420Test::update(const G4Step * aStep) {
   TrackInformation* trkInfo = dynamic_cast<TrackInformation*> (theTrack->GetUserInformation());
    if (trkInfo == 0) {
      std::cout << "FP420Test on aStep: No trk info !!!! abort " << std::endl;
-     //     throw Genexception("FP420Test:FP420Test on aStep: cannot get trkInfo");
    } 
   G4int         id             = theTrack->GetTrackID();
   G4String       particleType   = theTrack->GetDefinition()->GetParticleName();   //   !!!
@@ -609,16 +516,17 @@ void FP420Test::update(const G4Step * aStep) {
   G4VPhysicalVolume* currentPV     = preStepPoint->GetPhysicalVolume();
   G4String         prename       = currentPV->GetName();
 
-const G4VTouchable*  pre_touch    = preStepPoint->GetTouchable();
-     int          pre_levels   = detLevels(pre_touch);
+  const G4VTouchable*  pre_touch    = preStepPoint->GetTouchable();
+  int          pre_levels   = detLevels(pre_touch);
 
-//     G4String      pre_name1    = detName(pre_touch, pre_levels, 1);
-//     G4String      pre_name2    = detName(pre_touch, pre_levels, 2);
-//     G4String      pre_name3    = detName(pre_touch, pre_levels, 3);
-        G4String name1[20]; int copyno1[20];
-      if (pre_levels > 0) {
-        detectorLevel(pre_touch, pre_levels, copyno1, name1);
-      }
+  G4String name1[20]; int copyno1[20];
+  for(int i=0; i<20; ++i) {
+    name1[i]   = "";
+    copyno1[i] = 0;
+  }
+  if (pre_levels > 0) {
+    detectorLevel(pre_touch, pre_levels, copyno1, name1);
+  }
 
 //  G4LogicalVolume*   lv            = currentPV->GetLogicalVolume();
 //  G4Material*       mat           = lv->GetMaterial();
@@ -1527,20 +1435,12 @@ void FP420Test::update(const EndOfEvent * evt) {
 // .............
     }   // MI or no MI or all  - end
 
-
-
     }                                                // primary end
-//=========================== thePrim != 0  end   ================================================================================
-  //==================================================================================================================
-
-
-
-
+//=========================== thePrim != 0  end   ===
   // ==========================================================================
   if (verbosity > 0) {
    std::cout << "FP420Test:  END OF Event " << (*evt)()->GetEventID() << std::endl;
   }
-
 }
 
 // ==========================================================================

--- a/SimG4CMS/Forward/interface/ZdcTestAnalysis.h
+++ b/SimG4CMS/Forward/interface/ZdcTestAnalysis.h
@@ -52,15 +52,13 @@
 #include "TMath.h"
 #include "TF1.h"
 
-
-
-
 class G4Step;
 class BeginOfJob;
 class BeginOfRun;
 class EndOfRun;
 class BeginOfEvent;
 class EndOfEvent;
+class ZdcNumberingScheme;
 
 class ZdcTestAnalysis : public SimWatcher,
 			public Observer<const BeginOfJob *>, 
@@ -104,6 +102,8 @@ private:
 
   Float_t zdcsteparray[18];
   Float_t zdceventarray[16];
+
+  ZdcNumberingScheme* theZdcNumScheme;
 
 };
 

--- a/SimG4CMS/Forward/src/BscTest.cc
+++ b/SimG4CMS/Forward/src/BscTest.cc
@@ -20,9 +20,6 @@
 #include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
 #include "SimG4CMS/Forward/interface/BscTest.h"
 
-//#include "Utilities/GenUtil/interface/CMSexception.h"
-//#include "Utilities/UI/interface/SimpleConfigurable.h"
-
 // G4 stuff
 #include "G4SDManager.hh"
 #include "G4Step.hh"
@@ -32,13 +29,9 @@
 #include "G4UserEventAction.hh"
 #include "G4TransportationManager.hh"
 #include "G4ProcessManager.hh"
-//#include "G4EventManager.hh"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
-#include <stdio.h>
-//#include <gsl/gsl_fit.h>
-
 
 //================================================================
 // Root stuff
@@ -81,8 +74,6 @@ BscTest::BscTest(const edm::ParameterSet &p){
   }
 }
 
-
-
 BscTest::~BscTest() {
   //  delete UserNtuples;
   delete theBscNumberingScheme;
@@ -105,9 +96,6 @@ BscTest::~BscTest() {
   }
 
   std::cout<<"BscTest: End of process"<<std::endl;
-
-
-
 }
 
 //================================================================
@@ -126,9 +114,6 @@ BscAnalysisHistManager::BscAnalysisHistManager(const TString& managername)
 
   fHistArray->Compress();            // Removes empty space
   fHistNamesArray->Compress();
-
-  //      StoreWeights();                    // Store the weights
-
 }
 //-----------------------------------------------------------------------------
 
@@ -278,7 +263,6 @@ void BscTest::update(const BeginOfJob * job) {
   std::cout<<"BscTest:beggining of job"<<std::endl;;
 }
 
-
 //==================================================================== per RUN
 void BscTest::update(const BeginOfRun * run) {
   //run
@@ -286,10 +270,7 @@ void BscTest::update(const BeginOfRun * run) {
   std::cout << std::endl << "BscTest:: Begining of Run"<< std::endl; 
 }
 
-
 void BscTest::update(const EndOfRun * run) {;}
-
-
 
 //=================================================================== per EVENT
 void BscTest::update(const BeginOfEvent * evt) {
@@ -315,8 +296,6 @@ void BscTest::update(const BeginOfTrack * trk) {
   }
 }
 
-
-
 //=================================================================== per EndOfTrack
 void BscTest::update(const EndOfTrack * trk) {
   itrk = (*trk)()->GetTrackID();
@@ -333,23 +312,11 @@ void BscTest::update(const EndOfTrack * trk) {
     G4ThreeVector   vert_mom  = (*trk)()->GetVertexMomentumDirection();
     G4ThreeVector   vert_pos  = (*trk)()->GetVertexPosition(); // vertex ,where this track was created
   
-    //    float eta = 0.5 * log( (1.+vert_mom.z()) / (1.-vert_mom.z()) );
-    /*
-    float phi = atan2(vert_mom.y(),vert_mom.x());
-    if (phi < 0.) phi += twopi;
-    if(tracklength < z4) {
-
-    }
-    */
     // last step information
     const G4Step* aStep = (*trk)()->GetStep();
     G4StepPoint*      preStepPoint = aStep->GetPreStepPoint(); 
     lastpo   = preStepPoint->GetPosition();	
-
-    // Analysis:
-
   }
-
 }
 
 // ====================================================
@@ -367,7 +334,6 @@ void BscTest::update(const G4Step * aStep) {
   TrackInformation* trkInfo = dynamic_cast<TrackInformation*> (theTrack->GetUserInformation());
   if (trkInfo == 0) {
     std::cout << "BscTest on aStep: No trk info !!!! abort " << std::endl;
-    //     throw Genexception("BscTest:BscTest on aStep: cannot get trkInfo");
   } 
   G4int         id             = theTrack->GetTrackID();
   G4String       particleType   = theTrack->GetDefinition()->GetParticleName();   //   !!!
@@ -391,6 +357,10 @@ void BscTest::update(const G4Step * aStep) {
   const G4VTouchable*  pre_touch    = preStepPoint->GetTouchable();
   int          pre_levels   = detLevels(pre_touch);
   G4String name1[20]; int copyno1[20];
+  for(int i=0; i<20; ++i) {
+    name1[i]   = "";
+    copyno1[i] = 0;
+  }
   if (pre_levels > 0) {
     detectorLevel(pre_touch, pre_levels, copyno1, name1);
   }
@@ -647,18 +617,6 @@ void BscTest::update(const EndOfEvent * evt) {
 
   //=========================== thePrim != 0 ================================================================================
   if (thePrim != 0) {
-    //      inline G4ParticleDefinition * GetG4code() const
-    //      inline G4PrimaryParticle * GetNext() const
-    //      inline G4PrimaryParticle * GetDaughter() const
-    /*
-    // prim.vertex
-    int ivert = 0 ;
-    G4PrimaryVertex* avertex = (*evt)()->GetPrimaryVertex(ivert);
-    G4double vx=0.,vy=0.,vz=0.;
-    vx = avertex->GetX0();
-    vy = avertex->GetY0();
-    vz = avertex->GetZ0();
-    */
     //
     // number of secondary particles deposited their energy along primary track
     //UserNtuples->fillg518(numofpart,1.);
@@ -729,11 +687,8 @@ void BscTest::update(const EndOfEvent * evt) {
       TheHistManager->GetHisto("zHits")->Fill(zz);
       if(tracklength0>8300.) TheHistManager->GetHisto("zHitsTrLoLe")->Fill(zz);
     }
-    // varia = 0;
-    //     if( varia == 0) {
+
     if( varia == 2) {
-
-
       int nhit11 = 0, nhit12 = 0, nhit13 = 0 ;
       double  totallosenergy= 0.;
       for (int j=0; j<theCAFI->entries(); j++) {
@@ -745,8 +700,6 @@ void BscTest::update(const EndOfEvent * evt) {
 	int trackIDhit  = aHit->getTrackID();
 	unsigned int unitID = aHit->getUnitID();
 	double  losenergy = aHit->getEnergyLoss();
-	//double phi_hit   = hitPoint.phi();
-	//if (phi_hit < 0.) phi_hit += twopi;
 
 	double   zz    = hitPoint.z();
 

--- a/SimG4CMS/Forward/src/ZdcNumberingScheme.cc
+++ b/SimG4CMS/Forward/src/ZdcNumberingScheme.cc
@@ -48,7 +48,9 @@ unsigned int ZdcNumberingScheme::getUnitID(const G4Step* aStep) const {
       } 
       else if (name[ich] == "ZDC_EMLayer") {
         section = HcalZDCDetId::EM;
+#ifdef debug
         layer = copyno[ich];
+#endif
       }
       else if (name[ich] == "ZDC_EMFiber") {
         fiber = copyno[ich];
@@ -68,9 +70,6 @@ unsigned int ZdcNumberingScheme::getUnitID(const G4Step* aStep) const {
         layer = copyno[ich];
         channel = layer;
       }
-      else if (name[ich] == "ZDC_LumGas") {
-        fiber = 1;
-      }
       else if (name[ich] == "ZDC_HadLayer") {
         section = HcalZDCDetId::HAD;
         layer = copyno[ich];
@@ -83,19 +82,22 @@ unsigned int ZdcNumberingScheme::getUnitID(const G4Step* aStep) const {
       	else
           channel = 4;
       }
+#ifdef debug
+      else if (name[ich] == "ZDC_LumGas") {
+        fiber = 1;
+      }
       else if (name[ich] == "ZDC_HadFiber") {
         fiber = copyno[ich];
       }
+#endif
     }
  
 #ifdef debug
     unsigned intindex=0;
-    // intindex = myPacker.packZdcIndex (section, layer, fiber, channel, zside);
     intindex = packZdcIndex (section, layer, fiber, channel, zside);
 #endif
 
     bool true_for_positive_eta = true;
-    //if(zside == 1)true_for_positive_eta = true;
     if(zside == -1)true_for_positive_eta = false;
 
     HcalZDCDetId zdcId(section, true_for_positive_eta, channel);

--- a/SimG4CMS/Forward/src/ZdcTestAnalysis.cc
+++ b/SimG4CMS/Forward/src/ZdcTestAnalysis.cc
@@ -56,29 +56,20 @@ ZdcTestAnalysis::ZdcTestAnalysis(const edm::ParameterSet &p){
        new TNtuple("NTzdcevent","NTzdcevent",
 		   "evt:ihit:fiberid:zside:subdet:layer:fiber:channel:enem:enhad:hitenergy:x:y:z:time:etot");
 
+   theZdcNumScheme = nullptr;
    //theZdcSD = new ZdcSD("ZDCHITSB", new ZdcNumberingScheme());
 }
    
 ZdcTestAnalysis::~ZdcTestAnalysis() {
   // destructor
   finish();
-  if (verbosity > 0) {
-    std::cout << std::endl << "ZdcTestAnalysis Dextructor  -------->  End of ZdcTestAnalysis : "
-      << std::endl << std::endl; 
-  }
-
-  //if (doNTzdcstep  > 0)delete zdcstepntuple;
-  //if (doNTzdcevent > 0)delete zdceventntuple;
-
-  std::cout<<"ZdcTestAnalysis: End of process"<<std::endl;
+  delete theZdcNumScheme;
 }
-
 
 void ZdcTestAnalysis::update(const BeginOfJob * job) {
   //job
   std::cout<<"beggining of job"<<std::endl;;
 }
-
 
 //==================================================================== per RUN
 void ZdcTestAnalysis::update(const BeginOfRun * run) {
@@ -101,16 +92,12 @@ void ZdcTestAnalysis::update(const BeginOfRun * run) {
   eventIndex = 0;
 }
 
-
-
-
 void ZdcTestAnalysis::update(const BeginOfEvent * evt) {
   //event
   std::cout << "ZdcTest: Processing Event Number: "<<eventIndex<< std::endl;
   eventIndex++;
   stepIndex = 0;
 }
-
 
 void ZdcTestAnalysis::update(const G4Step * aStep) {
   //step;
@@ -257,7 +244,7 @@ void ZdcTestAnalysis::update(const EndOfEvent * evt) {
   CaloG4HitCollection* theZDCHC = (CaloG4HitCollection*) allHC->GetHC(theZDCHCid);
   std::cout << " - theZDCHC = " << theZDCHC << std::endl;
   
-  ZdcNumberingScheme * theZdcNumScheme = new ZdcNumberingScheme(1);
+  if(!theZdcNumScheme) { theZdcNumScheme = new ZdcNumberingScheme(1); }
   
   float ETot=0., SEnergy=0.;
   int maxTime=0;
@@ -404,6 +391,5 @@ void ZdcTestAnalysis::finish(){
    std::cout << "ZdcTestAnalysis: Ntuple event written for event: "<<eventIndex<<std::endl;   
    zdcOutputEventFile->Close();
    std::cout << "ZdcTestAnalysis: Event file closed" << std::endl;
- }
- 
+ } 
 }

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberG4Hit.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberG4Hit.h
@@ -9,7 +9,6 @@
 #include "G4Allocator.hh"
 #include "G4LogicalVolume.hh"
 
-#include <boost/cstdint.hpp>
 #include <vector>
 
 class FiberG4Hit : public G4VHit {

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h
@@ -10,7 +10,6 @@
 #include "G4ThreeVector.hh"
 #include "G4LogicalVolume.hh"
 
-#include <boost/cstdint.hpp>
 #include <vector>
 
 class HFShowerG4Hit : public G4VHit {

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
@@ -25,7 +25,7 @@
 #include "TTree.h"
 
 
-class HcalForwardLibWriter : public edm::EDAnalyzer {
+class HcalForwardLibWriter : public edm::one::EDAnalyzer<> {
 public:
   struct FileHandle{
     std::string name;

--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -36,11 +36,11 @@
 
 CastorShowerLibraryMaker::CastorShowerLibraryMaker(const edm::ParameterSet &p) : 
                              NPGParticle(0),DoHadSL(false),DoEmSL(false),DeActivatePhysicsProcess(false),
-                             emShower(NULL) , hadShower(NULL) {
+                             emShower(nullptr) , hadShower(nullptr) {
 
   MapOfSecondaries.clear();
-  hadInfo = NULL;
-  emInfo  = NULL;
+  hadInfo = nullptr;
+  emInfo  = nullptr;
   edm::ParameterSet p_SLM   = p.getParameter<edm::ParameterSet>("CastorShowerLibraryMaker");
   verbosity                 = p_SLM.getParameter<int>("Verbosity");
   eventNtFileName           = p_SLM.getParameter<std::string>("EventNtupleFileName");
@@ -233,13 +233,13 @@ void CastorShowerLibraryMaker::update(const BeginOfEvent * evt) {
   PrimaryPosition.clear();
   int NAccepted =0;
 // reset the pointers to the shower objects
-  SLShowerptr = NULL;
+  SLShowerptr = nullptr;
   MapOfSecondaries.clear();
   thePrims.clear();
   G4EventManager *e_mgr = G4EventManager::GetEventManager();
   if (IsSLReady()) {
       printSLstatus(-1,-1,-1);
-      update((EndOfRun*)NULL);
+      update((EndOfRun*)nullptr);
       return;
   }
 
@@ -305,7 +305,7 @@ void CastorShowerLibraryMaker::update(const BeginOfEvent * evt) {
      const_cast<G4Event*>((*evt)())->KeepTheEvent((G4bool)false);
      e_mgr->AbortCurrentEvent();
   }
-  SLShowerptr=NULL;
+  SLShowerptr=nullptr;
 //
   std::cout << "CastorShowerLibraryMaker: Processing Event Number: " << eventIndex << std::endl;
 }
@@ -455,7 +455,7 @@ void CastorShowerLibraryMaker::update(const EndOfEvent * evt) {
   for(unsigned int i=0;i<thePrims.size();i++) {
      G4PrimaryParticle* thePrim = thePrims.at(i);
      if (!thePrim) {
-        edm::LogInfo("CastorShowerLibraryMaker") << "NULL Pointer to the primary" << std::endl;
+        edm::LogInfo("CastorShowerLibraryMaker") << "nullptr Pointer to the primary" << std::endl;
         continue;
      }
 // Check primary particle type
@@ -507,7 +507,7 @@ void CastorShowerLibraryMaker::update(const EndOfEvent * evt) {
         std::cout << "Name of collection " << ii << " : " << allHC->GetHC(ii)->GetName() << std::endl;
 */
 
-     CastorShowerEvent* shower=NULL;
+     CastorShowerEvent* shower=nullptr;
      int cur_evt_idx = SLShowerptr->nEvtInBinPhi.at(ebin).at(etabin).at(phibin);
      shower = &(SLShowerptr->SLCollection.at(ebin).at(etabin).at(phibin).at(cur_evt_idx));
 
@@ -613,8 +613,8 @@ void CastorShowerLibraryMaker::update(const EndOfRun * run)
        theTree->SetBranchStatus("hadShowerLibInfo.",0);
     }
   }
-// check if run is NULL and exit
-  if (run==NULL) throw SimG4Exception("\n\nNumber of needed trigger events reached in CastorShowerLibraryMaker\n\n");
+// check if run is nullptr and exit
+  if (run==nullptr) throw SimG4Exception("\n\nNumber of needed trigger events reached in CastorShowerLibraryMaker\n\n");
 }
 
 //============================================================
@@ -641,7 +641,7 @@ int CastorShowerLibraryMaker::FindEnergyBin(double energy) {
   //
   if (!SLShowerptr) {
      edm::LogInfo("CastorShowerLibraryMaker") << "\n\nFindEnergyBin can be called only after BeginOfEvent\n\n";
-     throw SimG4Exception("\n\nNULL Pointer to the shower library.\n\n");
+     throw SimG4Exception("\n\nnullptr Pointer to the shower library.\n\n");
   }
   const std::vector<double>& SLenergies = SLShowerptr->SLEnergyBins;
   if (energy >= SLenergies.back()) return SLenergies.size()-1;
@@ -662,7 +662,7 @@ int CastorShowerLibraryMaker::FindEtaBin(double eta) {
   //
   if (!SLShowerptr) {
      edm::LogInfo("CastorShowerLibraryMaker") << "\n\nFindEtaBin can be called only after BeginOfEvent\n\n";
-     throw SimG4Exception("\n\nNULL Pointer to the shower library.\n\n");
+     throw SimG4Exception("\n\nnullptr Pointer to the shower library.\n\n");
   }
   const std::vector<double>& SLetas = SLShowerptr->SLEtaBins;
   if (eta>=SLetas.back()) return SLetas.size()-1;
@@ -683,7 +683,7 @@ int CastorShowerLibraryMaker::FindPhiBin(double phi) {
   //
   if (!SLShowerptr) {
      edm::LogInfo("CastorShowerLibraryMaker") << "\n\nFindPhiBin can be called only after BeginOfEvent\n\n";
-     throw SimG4Exception("\n\nNULL Pointer to the shower library.\n\n");
+     throw SimG4Exception("\n\nnullptr Pointer to the shower library.\n\n");
   }
   const std::vector<double>& SLphis = SLShowerptr->SLPhiBins;
   if (phi>=SLphis.back()) return SLphis.size()-1;
@@ -697,17 +697,17 @@ int CastorShowerLibraryMaker::FindPhiBin(double phi) {
 }
 bool CastorShowerLibraryMaker::IsSLReady()
 {
-// at this point, the pointer to the shower library should be NULL
+// at this point, the pointer to the shower library should be nullptr
   if (SLShowerptr) {
      edm::LogInfo("CastorShowerLibraryMaker") << "\n\nIsSLReady must be called when a new event starts.\n\n";
-     throw SimG4Exception("\n\nNOT NULL Pointer to the shower library.\n\n");
+     throw SimG4Exception("\n\nNOT nullptr Pointer to the shower library.\n\n");
   }
 // it is enough to check if all the energy bin is filled
   if (DoEmSL) {
      SLShowerptr = &emSLHolder;
      for(unsigned int i=0;i<SLShowerptr->SLEnergyBins.size();i++) {
         if (!SLisEBinFilled(i)) {
-           SLShowerptr=NULL;
+           SLShowerptr=nullptr;
            return false;
         }
      }
@@ -716,12 +716,12 @@ bool CastorShowerLibraryMaker::IsSLReady()
      SLShowerptr = &hadSLHolder;
      for(unsigned int i=0;i<SLShowerptr->SLEnergyBins.size();i++) {
         if (!SLisEBinFilled(i)) {
-           SLShowerptr=NULL;
+           SLShowerptr=nullptr;
            return false;
         }
      }
   }
-  SLShowerptr=NULL;
+  SLShowerptr=nullptr;
   return true;
 }
 void CastorShowerLibraryMaker::GetKinematics(int thePrim,double& px, double& py, double& pz, double& pInit, double& eta, double& phi)
@@ -793,14 +793,14 @@ std::vector<G4PrimaryParticle*> CastorShowerLibraryMaker::GetPrimary(const G4Eve
 void CastorShowerLibraryMaker::printSLstatus(int ebin,int etabin,int phibin)
 {
   if (!SLShowerptr) {
-     edm::LogInfo("CastorShowerLibraryInfo") << "NULL shower pointer. Printing both";
+     edm::LogInfo("CastorShowerLibraryInfo") << "nullptr shower pointer. Printing both";
      std::cout << "Electromagnetic" << std::endl;
      SLShowerptr = &emSLHolder;
      this->printSLstatus(ebin,etabin,phibin);
      std::cout << "Hadronic" << std::endl;
      SLShowerptr = &hadSLHolder;
      this->printSLstatus(ebin,etabin,phibin);
-     SLShowerptr = NULL;
+     SLShowerptr = nullptr;
      return;
   }
   int nBinsE  =SLShowerptr->SLEnergyBins.size();
@@ -834,8 +834,8 @@ void CastorShowerLibraryMaker::printSLstatus(int ebin,int etabin,int phibin)
 }
 bool CastorShowerLibraryMaker::SLacceptEvent(int ebin, int etabin, int phibin)
 {
-     if (SLShowerptr==NULL) {
-        edm::LogInfo("CastorShowerLibraryMaker::SLacceptEvent:") << "Error. NULL pointer to CastorShowerEvent";
+     if (SLShowerptr==nullptr) {
+        edm::LogInfo("CastorShowerLibraryMaker::SLacceptEvent:") << "Error. nullptr pointer to CastorShowerEvent";
         return false;
      }
      if (ebin<0||ebin>=int(SLShowerptr->SLEnergyBins.size())) return false;
@@ -864,7 +864,7 @@ bool CastorShowerLibraryMaker::FillShowerEvent(CaloG4HitCollection* theCAFI, Cas
      }
 */
      if (!shower) {
-        edm::LogInfo("CastorShowerLibraryMaker") << "Error. NULL pointer to CastorShowerEvent";
+        edm::LogInfo("CastorShowerLibraryMaker") << "Error. nullptr pointer to CastorShowerEvent";
         return false;
      }
 
@@ -936,7 +936,7 @@ int& CastorShowerLibraryMaker::SLnEvtInBinE(int ebin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLnEvtInBinE can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    return SLShowerptr->nEvtInBinE.at(ebin);
 }
@@ -945,7 +945,7 @@ int& CastorShowerLibraryMaker::SLnEvtInBinEta(int ebin, int etabin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLnEvtInBinEta can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    return SLShowerptr->nEvtInBinEta.at(ebin).at(etabin);
 }
@@ -954,7 +954,7 @@ int& CastorShowerLibraryMaker::SLnEvtInBinPhi(int ebin, int etabin, int phibin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLnEvtInBinPhi can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    return SLShowerptr->nEvtInBinPhi.at(ebin).at(etabin).at(phibin);
 }
@@ -962,7 +962,7 @@ bool CastorShowerLibraryMaker::SLisEBinFilled(int ebin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLisEBinFilled can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    if (SLShowerptr->nEvtInBinE.at(ebin)<(int)SLShowerptr->nEvtPerBinE) return false;
    return true;
@@ -971,7 +971,7 @@ bool CastorShowerLibraryMaker::SLisEtaBinFilled(int ebin,int etabin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLisEtaBinFilled can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    if (SLShowerptr->nEvtInBinEta.at(ebin).at(etabin)<(int)SLShowerptr->nEvtPerBinEta) return false;
    return true;
@@ -980,13 +980,13 @@ bool CastorShowerLibraryMaker::SLisPhiBinFilled(int ebin,int etabin,int phibin)
 {
    if (!SLShowerptr) {
       edm::LogInfo("CastorShowerLibraryMaker") << "\n\nSLisPhiBinFilled can be called only after BeginOfEvent\n\n";
-      throw SimG4Exception("\n\nNULL Pointer to the shower library.");
+      throw SimG4Exception("\n\nnullptr Pointer to the shower library.");
    }
    if (SLShowerptr->nEvtInBinPhi.at(ebin).at(etabin).at(phibin)<(int)SLShowerptr->nEvtPerBinPhi) return false;
    return true;
 }
 void CastorShowerLibraryMaker::KillSecondaries(const G4Step * aStep) {
-   G4TrackVector *p_sec = const_cast<G4TrackVector*>(aStep->GetSecondary());
+   const G4TrackVector *p_sec = aStep->GetSecondary();
    for(int i=0;i<int(p_sec->size());i++) {
       /*if (verbosity)*/ std::cout << "Killing track ID " << p_sec->at(i)->GetTrackID() << " and its secondaries"
           << " Produced by Process " << p_sec->at(i)->GetCreatorProcess()->GetProcessName()

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberG4Hit.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberG4Hit.cc
@@ -1,8 +1,7 @@
 #include "SimG4CMS/ShowerLibraryProducer/interface/FiberG4Hit.h"
 #include <iostream>
 
-
-G4ThreadLocal G4Allocator<FiberG4Hit> *fFiberG4HitAllocator = 0;
+G4ThreadLocal G4Allocator<FiberG4Hit> *fFiberG4HitAllocator = nullptr;
 
 FiberG4Hit::FiberG4Hit() : theTowerId(0), theDepth(0), theTrackId(0),
 			   theNpe(0), theTime(0), theLogV(0) {

--- a/SimG4CMS/ShowerLibraryProducer/src/HFShowerG4Hit.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFShowerG4Hit.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 
 
-G4ThreadLocal G4Allocator<HFShowerG4Hit> *fHFShowerG4HitAllocator = 0;
+G4ThreadLocal G4Allocator<HFShowerG4Hit> *fHFShowerG4HitAllocator = nullptr;
 
 HFShowerG4Hit::HFShowerG4Hit() : theHitId(0), theTrackId(0), theEdep(0),
 				 theTime(0) {}

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -95,7 +95,7 @@ void createWatchers(const edm::ParameterSet& iP,
   for(vector<ParameterSet>::iterator itWatcher = watchers.begin();
       itWatcher != watchers.end();
       ++itWatcher) {
-    std::auto_ptr<SimWatcherMakerBase> maker( 
+    std::shared_ptr<SimWatcherMakerBase> maker( 
       SimWatcherFactory::get()->create
       (itWatcher->getParameter<std::string> ("type")) );
     if(maker.get()==0) {
@@ -221,7 +221,7 @@ void RunManager::initG4(const edm::EventSetup & es)
     }
 
   // we need the track manager now
-  m_trackManager = std::auto_ptr<SimTrackManager>(new SimTrackManager);
+  m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
 
   // attach sensitive detector
   m_attach = new AttachSD;
@@ -248,7 +248,7 @@ void RunManager::initG4(const edm::EventSetup & es)
 
   m_primaryTransformer = new PrimaryTransformer();
 
-  std::auto_ptr<PhysicsListMakerBase> 
+  std::unique_ptr<PhysicsListMakerBase> 
     physicsMaker(PhysicsListFactory::get()->create(
       m_pPhysics.getParameter<std::string> ("type")));
   if (physicsMaker.get()==nullptr) {

--- a/SimG4Core/Notification/src/CMSSteppingVerbose.cc
+++ b/SimG4Core/Notification/src/CMSSteppingVerbose.cc
@@ -322,5 +322,6 @@ void CMSSteppingVerbose::NextStep(const G4Step* step,
 	   << std::setw(18)
 	   << (*tv)[i]->GetDefinition()->GetParticleName() << G4endl;
   }
+  G4cout.precision(prec);
 }
 


### PR DESCRIPTION
Fixed static analyser warnings in SimG4Core and SimG4CMS. Removed unnecessary comments and empty lines. Substitute auto_ptr. Should not affect production.
