### PR TITLE
Protection against empty globalDirs

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
@@ -165,6 +165,7 @@ bool ClusterShapeTrackFilter::operator()
 
   // Get global directions
   vector<GlobalVector> globalDirs = getGlobalDirs(globalPoss);
+  if ( globalDirs.empty() ) return false;
 
   bool ok = true;
 


### PR DESCRIPTION
(cherry picked from commit eecbc979b4b833fe4b4fedbc51c6a6202c9594e8)
Protection against empty vector.
Same as #15053
