### PR TITLE
Cellular Automaton for quadruplet pixel seeding

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -155,7 +155,7 @@ public:
         auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
         auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
 
-        auto minimumOfInteserctionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
+        auto minimumOfIntersectionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
 
         if (centers_distance_squared >= minimumOfIntersectionRange) {
             auto minimumOfIntersectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -1,5 +1,5 @@
-#ifndef CACELL_H_
-#define CACELL_H_
+#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
+#define RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
 
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
@@ -21,63 +21,63 @@ public:
     theInnerZ(doublets->z(doubletId, HitDoublets::inner)), theOuterZ(doublets->z(doubletId, HitDoublets::outer)) {
     }
 
-    unsigned int get_cell_id() const {
+    unsigned int getCellId() const {
         return theCellId;
     }
 
-    Hit const & get_inner_hit() const {
+    Hit const & getInnerHit() const {
         return theDoublets->hit(theDoubletId, HitDoublets::inner);
     }
 
-    Hit const & get_outer_hit() const {
+    Hit const & getOuterHit() const {
         return theDoublets->hit(theDoubletId, HitDoublets::outer);
     }
 
-    float get_inner_x() const {
+    float getInnerX() const {
         return theDoublets->x(theDoubletId, HitDoublets::inner);
     }
 
-    float get_outer_x() const {
+    float getOuterX() const {
         return theDoublets->x(theDoubletId, HitDoublets::outer);
     }
 
-    float get_inner_y() const {
+    float getInnerY() const {
         return theDoublets->y(theDoubletId, HitDoublets::inner);
     }
 
-    float get_outer_y() const {
+    float getOuterY() const {
         return theDoublets->y(theDoubletId, HitDoublets::outer);
     }
 
-    float get_inner_z() const {
+    float getInnerZ() const {
         return theInnerZ;
     }
 
-    float get_outer_z() const {
+    float getOuterZ() const {
         return theOuterZ;
     }
 
-    float get_inner_r() const {
+    float getInnerR() const {
         return theInnerR;
     }
 
-    float get_outer_r() const {
+    float getOuterR() const {
         return theOuterR;
     }
 
-    float get_inner_phi() const {
+    float getInnerPhi() const {
         return theDoublets->phi(theDoubletId, HitDoublets::inner);
     }
 
-    float get_outer_phi() const {
+    float getOuterPhi() const {
         return theDoublets->phi(theDoubletId, HitDoublets::outer);
     }
 
-    unsigned int get_inner_hit_id() const {
+    unsigned int getInnerHitId() const {
         return theInnerHitId;
     }
 
-    unsigned int get_outer_hit_id() const {
+    unsigned int getOuterHitId() const {
         return theOuterHitId;
     }
 
@@ -88,7 +88,7 @@ public:
 
         for (unsigned int i = 0; i < numberOfNeighbors; ++i) {
 
-            if (theOuterNeighbors[i]->get_CA_state() == theCAState) {
+            if (theOuterNeighbors[i]->getCAState() == theCAState) {
 
                 hasSameStateNeighbors = 1;
 
@@ -98,41 +98,41 @@ public:
 
     }
 
-    void check_alignment_and_tag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut) {
+    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut) {
 
-        if (are_aligned_RZ(innerCell, ptmin, thetaCut) && have_similar_curvature(innerCell, region_origin_x, region_origin_y, region_origin_radius, phiCut)) {
-            tag_as_inner_neighbor(innerCell);
-            innerCell->tag_as_outer_neighbor(this);
+        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell, region_origin_x, region_origin_y, region_origin_radius, phiCut)) {
+            tagAsInnerNeighbor(innerCell);
+            innerCell->tagAsOuterNeighbor(this);
         }
     }
 
-    bool are_aligned_RZ(const CACell* otherCell, const float ptmin, const float thetaCut) const {
+    bool areAlignedRZ(const CACell* otherCell, const float ptmin, const float thetaCut) const {
 
-        float r1 = otherCell->get_inner_r();
-        float z1 = otherCell->get_inner_z();
+        float r1 = otherCell->getInnerR();
+        float z1 = otherCell->getInnerZ();
         float distance_13_squared = (r1 - theOuterR)*(r1 - theOuterR) + (z1 - theOuterZ)*(z1 - theOuterZ);
         float tan_12_13_half = fabs(z1 * (theInnerR - theOuterR) + theInnerZ * (theOuterR - r1) + theOuterZ * (r1 - theInnerR)) / distance_13_squared;
         return tan_12_13_half * ptmin <= thetaCut;
     }
 
-    void tag_as_outer_neighbor(CACell* otherCell) {
+    void tagAsOuterNeighbor(CACell* otherCell) {
         theOuterNeighbors.push_back(otherCell);
     }
 
-    void tag_as_inner_neighbor(CACell* otherCell) {
+    void tagAsInnerNeighbor(CACell* otherCell) {
         theInnerNeighbors.push_back(otherCell);
     }
 
-    bool have_similar_curvature(const CACell* otherCell,
+    bool haveSimilarCurvature(const CACell* otherCell,
             const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut) const {
-        auto x1 = otherCell->get_inner_x();
-        auto y1 = otherCell->get_inner_y();
+        auto x1 = otherCell->getInnerX();
+        auto y1 = otherCell->getInnerY();
 
-        auto x2 = get_inner_x();
-        auto y2 = get_inner_y();
+        auto x2 = getInnerX();
+        auto y2 = getInnerY();
 
-        auto x3 = get_outer_x();
-        auto y3 = get_outer_y();
+        auto x3 = getOuterX();
+        auto y3 = getOuterY();
 
         auto precision = 0.5f;
         auto offset = x2 * x2 + y2*y2;
@@ -169,23 +169,23 @@ public:
 
     }
 
-    unsigned int get_CA_state() const {
+    unsigned int getCAState() const {
         return theCAState;
     }
     // if there is at least one left neighbor with the same state (friend), the state has to be increased by 1.
 
-    void update_state() {
+    void updateState() {
         theCAState += hasSameStateNeighbors;
     }
 
-    bool is_root_cell(const unsigned int minimumCAState) const {
+    bool isRootCell(const unsigned int minimumCAState) const {
         return (theCAState >= minimumCAState);
     }
 
     // trying to free the track building process from hardcoded layers, leaving the visit of the graph
     // based on the neighborhood connections between cells.
 
-    void find_ntuplets(std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
+    void findNtuplets(std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
 
         // the building process for a track ends if:
         // it has no right neighbor
@@ -201,7 +201,7 @@ public:
             unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
             for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
                 tmpNtuplet.push_back((theOuterNeighbors[i]));
-                theOuterNeighbors[i]->find_ntuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+                theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
                 tmpNtuplet.pop_back();
             }
         }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -155,11 +155,11 @@ public:
         auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
         auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
 
-        auto minimumOfIntesectionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
+        auto minimumOfInteserctionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
 
-        if (centers_distance_squared >= minimumOfIntesectionRange) {
-            auto maximumOfIntesectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
-            return centers_distance_squared <= maximumOfIntesectionRange;
+        if (centers_distance_squared >= minimumOfintersectionRange) {
+            auto maximumOfintersectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
+            return centers_distance_squared <= maximumOfintersectionRange;
         } else {
 
             return false;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -1,0 +1,233 @@
+#ifndef CACELL_H_
+#define CACELL_H_
+
+#include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#include <cmath>
+#include <array>
+
+class CACell {
+public:
+    using Hit = RecHitsSortedInPhi::Hit;
+    using CAntuplet = std::vector<CACell*>;
+
+    CACell(const HitDoublets* doublets, int doubletId, const unsigned int cellId, const int innerHitId, const int outerHitId) :
+    theCAState(0), theInnerHitId(innerHitId), theOuterHitId(outerHitId), theCellId(cellId), hasSameStateNeighbors(0), theDoublets(doublets), theDoubletId(doubletId),
+    theInnerR(doublets->r(doubletId, HitDoublets::inner)), theOuterR(doublets->r(doubletId, HitDoublets::outer)),
+    theInnerZ(doublets->z(doubletId, HitDoublets::inner)), theOuterZ(doublets->z(doubletId, HitDoublets::outer)) {
+    }
+
+    unsigned int get_cell_id() const {
+        return theCellId;
+    }
+
+    Hit const & get_inner_hit() const {
+        return theDoublets->hit(theDoubletId, HitDoublets::inner);
+    }
+
+    Hit const & get_outer_hit() const {
+        return theDoublets->hit(theDoubletId, HitDoublets::outer);
+    }
+
+    float get_inner_x() const {
+        return theDoublets->x(theDoubletId, HitDoublets::inner);
+    }
+
+    float get_outer_x() const {
+        return theDoublets->x(theDoubletId, HitDoublets::outer);
+    }
+
+    float get_inner_y() const {
+        return theDoublets->y(theDoubletId, HitDoublets::inner);
+    }
+
+    float get_outer_y() const {
+        return theDoublets->y(theDoubletId, HitDoublets::outer);
+    }
+
+    float get_inner_z() const {
+        return theInnerZ;
+    }
+
+    float get_outer_z() const {
+        return theOuterZ;
+    }
+
+    float get_inner_r() const {
+        return theInnerR;
+    }
+
+    float get_outer_r() const {
+        return theOuterR;
+    }
+
+    float get_inner_phi() const {
+        return theDoublets->phi(theDoubletId, HitDoublets::inner);
+    }
+
+    float get_outer_phi() const {
+        return theDoublets->phi(theDoubletId, HitDoublets::outer);
+    }
+
+    unsigned int get_inner_hit_id() const {
+        return theInnerHitId;
+    }
+
+    unsigned int get_outer_hit_id() const {
+        return theOuterHitId;
+    }
+
+    void evolve() {
+
+        hasSameStateNeighbors = 0;
+        unsigned int numberOfNeighbors = theOuterNeighbors.size();
+
+        for (unsigned int i = 0; i < numberOfNeighbors; ++i) {
+
+            if (theOuterNeighbors[i]->get_CA_state() == theCAState) {
+
+                hasSameStateNeighbors = 1;
+
+                break;
+            }
+        }
+
+    }
+
+    void check_alignment_and_tag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut) {
+
+        if (are_aligned_RZ(innerCell, ptmin, thetaCut) && have_similar_curvature(innerCell, region_origin_x, region_origin_y, region_origin_radius, phiCut)) {
+            tag_as_inner_neighbor(innerCell);
+            innerCell->tag_as_outer_neighbor(this);
+        }
+    }
+
+    bool are_aligned_RZ(const CACell* otherCell, const float ptmin, const float thetaCut) const {
+
+        float r1 = otherCell->get_inner_r();
+        float z1 = otherCell->get_inner_z();
+        float distance_13_squared = (r1 - theOuterR)*(r1 - theOuterR) + (z1 - theOuterZ)*(z1 - theOuterZ);
+        float tan_12_13_half = fabs(z1 * (theInnerR - theOuterR) + theInnerZ * (theOuterR - r1) + theOuterZ * (r1 - theInnerR)) / distance_13_squared;
+        return tan_12_13_half * ptmin <= thetaCut;
+    }
+
+    void tag_as_outer_neighbor(CACell* otherCell) {
+        theOuterNeighbors.push_back(otherCell);
+    }
+
+    void tag_as_inner_neighbor(CACell* otherCell) {
+        theInnerNeighbors.push_back(otherCell);
+    }
+
+    bool have_similar_curvature(const CACell* otherCell,
+            const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut) const {
+        auto x1 = otherCell->get_inner_x();
+        auto y1 = otherCell->get_inner_y();
+
+        auto x2 = get_inner_x();
+        auto y2 = get_inner_y();
+
+        auto x3 = get_outer_x();
+        auto y3 = get_outer_y();
+
+        auto precision = 0.5f;
+        auto offset = x2 * x2 + y2*y2;
+
+        auto bc = (x1 * x1 + y1 * y1 - offset) / 2.f;
+
+        auto cd = (offset - x3 * x3 - y3 * y3) / 2.f;
+
+        auto det = (x1 - x2) * (y2 - y3) - (x2 - x3)* (y1 - y2);
+
+        //points are aligned
+        if (fabs(det) < precision)
+            return true;
+
+        auto idet = 1.f / det;
+
+        auto x_center = (bc * (y2 - y3) - cd * (y1 - y2)) * idet;
+        auto y_center = (cd * (x1 - x2) - bc * (x2 - x3)) * idet;
+
+        auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
+        auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
+
+        auto minimumOfIntesectionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
+
+        if (centers_distance_squared >= minimumOfIntesectionRange) {
+            auto maximumOfIntesectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
+            return centers_distance_squared <= maximumOfIntesectionRange;
+        } else {
+
+            return false;
+        }
+        return true;
+
+
+    }
+
+    unsigned int get_CA_state() const {
+        return theCAState;
+    }
+    // if there is at least one left neighbor with the same state (friend), the state has to be increased by 1.
+
+    void update_state() {
+        theCAState += hasSameStateNeighbors;
+    }
+
+    bool is_root_cell(const unsigned int minimumCAState) const {
+        return (theCAState >= minimumCAState);
+    }
+
+    // trying to free the track building process from hardcoded layers, leaving the visit of the graph
+    // based on the neighborhood connections between cells.
+
+    void find_ntuplets(std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
+
+        // the building process for a track ends if:
+        // it has no right neighbor
+        // it has no compatible neighbor
+        // the ntuplets is then saved if the number of hits it contains is greater than a threshold
+
+        if (theOuterNeighbors.size() == 0) {
+            if (tmpNtuplet.size() >= minHitsPerNtuplet - 1)
+                foundNtuplets.push_back(tmpNtuplet);
+            else
+                return;
+        } else {
+            unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
+            for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
+                tmpNtuplet.push_back((theOuterNeighbors[i]));
+                theOuterNeighbors[i]->find_ntuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+                tmpNtuplet.pop_back();
+            }
+        }
+    }
+    
+    
+private:
+    std::vector<CACell*> theInnerNeighbors;
+    std::vector<CACell*> theOuterNeighbors;
+
+    unsigned int theCAState;
+
+    const unsigned int theInnerHitId;
+    const unsigned int theOuterHitId;
+    const unsigned int theCellId;
+    unsigned int hasSameStateNeighbors;
+
+    const HitDoublets* theDoublets;
+    const int theDoubletId;
+
+    const float theInnerR;
+    const float theOuterR;
+    const float theInnerZ;
+    const float theOuterZ;
+
+};
+
+
+#endif /*CACELL_H_ */

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -111,8 +111,8 @@ public:
         float r1 = otherCell->getInnerR();
         float z1 = otherCell->getInnerZ();
         float distance_13_squared = (r1 - theOuterR)*(r1 - theOuterR) + (z1 - theOuterZ)*(z1 - theOuterZ);
-        float tan_12_13_half = fabs(z1 * (theInnerR - theOuterR) + theInnerZ * (theOuterR - r1) + theOuterZ * (r1 - theInnerR)) / distance_13_squared;
-        return tan_12_13_half * ptmin <= thetaCut;
+        float tan_12_13_half_mul_distance_13_squared = fabs(z1 * (theInnerR - theOuterR) + theInnerZ * (theOuterR - r1) + theOuterZ * (r1 - theInnerR)) ;
+        return tan_12_13_half_mul_distance_13_squared * ptmin <= thetaCut * distance_13_squared;
     }
 
     void tagAsOuterNeighbor(CACell* otherCell) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -137,9 +137,9 @@ public:
         auto precision = 0.5f;
         auto offset = x2 * x2 + y2*y2;
 
-        auto bc = (x1 * x1 + y1 * y1 - offset) / 2.f;
+        auto bc = (x1 * x1 + y1 * y1 - offset)*0.5f;
 
-        auto cd = (offset - x3 * x3 - y3 * y3) / 2.f;
+        auto cd = (offset - x3 * x3 - y3 * y3)*0.5f;
 
         auto det = (x1 - x2) * (y2 - y3) - (x2 - x3)* (y1 - y2);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -157,9 +157,9 @@ public:
 
         auto minimumOfInteserctionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
 
-        if (centers_distance_squared >= minimumOfintersectionRange) {
-            auto maximumOfintersectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
-            return centers_distance_squared <= maximumOfintersectionRange;
+        if (centers_distance_squared >= minimumOfIntersectionRange) {
+            auto minimumOfIntersectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
+            return centers_distance_squared <= minimumOfIntersectionRange;
         } else {
 
             return false;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -67,6 +67,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(
   edm::Handle<SeedingLayerSetsHits> hlayers;
   ev.getByToken(theSeedingLayerToken, hlayers);
   const SeedingLayerSetsHits& layers = *hlayers;
+  std::cout << "yuhuuu" << std::endl;
   if (layers.numberOfLayersInSet() != 4)
     throw cms::Exception("Configuration") << "CAHitQuadrupletsGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 4, got " << layers.numberOfLayersInSet();
   for (unsigned int j=0; j < layers.size(); j++)
@@ -118,12 +119,10 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
 
   unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
 
-  //  std::cout << "entering the found quadruplets loop" << std::endl;
   // Loop over quadruplets
   for (unsigned int quadId = 0; quadId < numberOfFoundQuadruplets; ++quadId)
   {
 
-    //    std::cout << "checking quadruplet " << quadId << " with outer hit id " << foundQuadruplets[quadId][2]->get_outer_hit_id() << std::endl;
     auto isBarrel = [](const unsigned id) -> bool
     {
       return id == PixelSubdetector::PixelBarrel;
@@ -204,8 +203,6 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
       if (fitFastCircleChi2Cut && chi2 > thisMaxChi2)
         continue;
     }
-
-    //    std::cout << "it has chi2: " << chi2 << std::endl;
 
     result.emplace_back(foundQuadruplets[quadId][0]->get_inner_hit(), foundQuadruplets[quadId][1]->get_inner_hit(), foundQuadruplets[quadId][2]->get_inner_hit(), foundQuadruplets[quadId][2]->get_outer_hit());
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -162,7 +162,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     {
       // Following PixelFitterByConformalMappingAndLine
       const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
-      const float pt = 1 / PixelRecoUtilities::inversePt(abscurv, es);
+      const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
       for (int i=0; i < 4; ++i)
       {
         const GlobalPoint & point = gps[i];

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -126,22 +126,18 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     {
       return id == PixelSubdetector::PixelBarrel;
     };
+    for(unsigned int i = 0; i< 2; ++i)
+    {
+        auto const& ahit = foundQuadruplets[quadId][i]->getInnerHit();
+        gps[i] = ahit->globalPosition();
+        ges[i] = ahit->globalPositionError();
+        barrels[i] = isBarrel(ahit->geographicalId().subdetId());
+    }
 
-    gps[0] = foundQuadruplets[quadId][0]->getInnerHit()->globalPosition();
-    ges[0] = foundQuadruplets[quadId][0]->getInnerHit()->globalPositionError();
-    barrels[0] = isBarrel(foundQuadruplets[quadId][0]->getInnerHit()->geographicalId().subdetId());
-
-    gps[1] = foundQuadruplets[quadId][1]->getInnerHit()->globalPosition();
-    ges[1] = foundQuadruplets[quadId][1]->getInnerHit()->globalPositionError();
-    barrels[1] = isBarrel(foundQuadruplets[quadId][1]->getInnerHit()->geographicalId().subdetId());
-
-    gps[2] = foundQuadruplets[quadId][2]->getInnerHit()->globalPosition();
-    ges[2] = foundQuadruplets[quadId][2]->getInnerHit()->globalPositionError();
-    barrels[2] = isBarrel(foundQuadruplets[quadId][2]->getInnerHit()->geographicalId().subdetId());
-
-    gps[3] = foundQuadruplets[quadId][2]->getOuterHit()->globalPosition();
-    ges[3] = foundQuadruplets[quadId][2]->getOuterHit()->globalPositionError();
-    barrels[3] = isBarrel(foundQuadruplets[quadId][2]->getOuterHit()->geographicalId().subdetId());
+    auto const& ahit = foundQuadruplets[quadId][2]->getOuterHit();
+    gps[3] = ahit->globalPosition();
+    ges[3] = ahit->globalPositionError();
+    barrels[3] = isBarrel(ahit->geographicalId().subdetId());
 
     PixelRecoLineRZ line(gps[0], gps[2]);
     ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2], extraHitRPhitolerance);
@@ -205,7 +201,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     }
 
     result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
-
+    std::cout << " result size: " << result.size() << std::endl;
   }
 
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -100,11 +100,11 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
 
   CellularAutomaton<4> ca;
 
-  ca.create_and_connect_cells (layersDoublets, fourLayers, region, CAThetaCut, CAPhiCut);
+  ca.createAndConnectCells (layersDoublets, fourLayers, region, CAThetaCut, CAPhiCut);
 
   ca.evolve();
 
-  ca.find_ntuplets(foundQuadruplets, 4);
+  ca.findNtuplets(foundQuadruplets, 4);
 
   const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
@@ -127,21 +127,21 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
       return id == PixelSubdetector::PixelBarrel;
     };
 
-    gps[0] = foundQuadruplets[quadId][0]->get_inner_hit()->globalPosition();
-    ges[0] = foundQuadruplets[quadId][0]->get_inner_hit()->globalPositionError();
-    barrels[0] = isBarrel(foundQuadruplets[quadId][0]->get_inner_hit()->geographicalId().subdetId());
+    gps[0] = foundQuadruplets[quadId][0]->getInnerHit()->globalPosition();
+    ges[0] = foundQuadruplets[quadId][0]->getInnerHit()->globalPositionError();
+    barrels[0] = isBarrel(foundQuadruplets[quadId][0]->getInnerHit()->geographicalId().subdetId());
 
-    gps[1] = foundQuadruplets[quadId][1]->get_inner_hit()->globalPosition();
-    ges[1] = foundQuadruplets[quadId][1]->get_inner_hit()->globalPositionError();
-    barrels[1] = isBarrel(foundQuadruplets[quadId][1]->get_inner_hit()->geographicalId().subdetId());
+    gps[1] = foundQuadruplets[quadId][1]->getInnerHit()->globalPosition();
+    ges[1] = foundQuadruplets[quadId][1]->getInnerHit()->globalPositionError();
+    barrels[1] = isBarrel(foundQuadruplets[quadId][1]->getInnerHit()->geographicalId().subdetId());
 
-    gps[2] = foundQuadruplets[quadId][2]->get_inner_hit()->globalPosition();
-    ges[2] = foundQuadruplets[quadId][2]->get_inner_hit()->globalPositionError();
-    barrels[2] = isBarrel(foundQuadruplets[quadId][2]->get_inner_hit()->geographicalId().subdetId());
+    gps[2] = foundQuadruplets[quadId][2]->getInnerHit()->globalPosition();
+    ges[2] = foundQuadruplets[quadId][2]->getInnerHit()->globalPositionError();
+    barrels[2] = isBarrel(foundQuadruplets[quadId][2]->getInnerHit()->geographicalId().subdetId());
 
-    gps[3] = foundQuadruplets[quadId][2]->get_outer_hit()->globalPosition();
-    ges[3] = foundQuadruplets[quadId][2]->get_outer_hit()->globalPositionError();
-    barrels[3] = isBarrel(foundQuadruplets[quadId][2]->get_outer_hit()->geographicalId().subdetId());
+    gps[3] = foundQuadruplets[quadId][2]->getOuterHit()->globalPosition();
+    ges[3] = foundQuadruplets[quadId][2]->getOuterHit()->globalPositionError();
+    barrels[3] = isBarrel(foundQuadruplets[quadId][2]->getOuterHit()->geographicalId().subdetId());
 
     PixelRecoLineRZ line(gps[0], gps[2]);
     ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2], extraHitRPhitolerance);
@@ -151,7 +151,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
 
     if (theComparitor)
     {
-      SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->get_inner_hit(), foundQuadruplets[quadId][2]->get_inner_hit(), foundQuadruplets[quadId][2]->get_outer_hit());
+      SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
 
 
       if (!theComparitor->compatible(tmpTriplet, region) )
@@ -204,7 +204,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
         continue;
     }
 
-    result.emplace_back(foundQuadruplets[quadId][0]->get_inner_hit(), foundQuadruplets[quadId][1]->get_inner_hit(), foundQuadruplets[quadId][2]->get_inner_hit(), foundQuadruplets[quadId][2]->get_outer_hit());
+    result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
 
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -1,0 +1,214 @@
+#include "CAHitQuadrupletGenerator.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
+#include "LayerQuadruplets.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
+
+
+#include "CellularAutomaton.h"
+
+#include "CommonTools/Utils/interface/DynArray.h"
+
+#include "FWCore/Utilities/interface/isFinite.h"
+
+namespace
+{
+
+  template <typename T>
+  T sqr(T x)
+  {
+    return x*x;
+  }
+}
+
+
+
+using namespace std;
+using namespace ctfseeding;
+
+CAHitQuadrupletGenerator::CAHitQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) :
+theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))),
+extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
+maxChi2(cfg.getParameter<edm::ParameterSet>("maxChi2")),
+fitFastCircle(cfg.getParameter<bool>("fitFastCircle")),
+fitFastCircleChi2Cut(cfg.getParameter<bool>("fitFastCircleChi2Cut")),
+useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
+CAThetaCut(cfg.getParameter<double>("CAThetaCut")),
+CAPhiCut(cfg.getParameter<double>("CAPhiCut"))
+{
+  if (cfg.exists("SeedComparitorPSet"))
+  {
+    edm::ParameterSet comparitorPSet =
+            cfg.getParameter<edm::ParameterSet>("SeedComparitorPSet");
+    std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
+    if (comparitorName != "none")
+    {
+      theComparitor.reset(SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC));
+    }
+  }
+}
+
+CAHitQuadrupletGenerator::~CAHitQuadrupletGenerator()
+{
+}
+
+void CAHitQuadrupletGenerator::hitQuadruplets(
+                                              const TrackingRegion& region, OrderedHitSeeds & result,
+                                              const edm::Event& ev, const edm::EventSetup& es)
+{
+  edm::Handle<SeedingLayerSetsHits> hlayers;
+  ev.getByToken(theSeedingLayerToken, hlayers);
+  const SeedingLayerSetsHits& layers = *hlayers;
+  if (layers.numberOfLayersInSet() != 4)
+    throw cms::Exception("Configuration") << "CAHitQuadrupletsGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 4, got " << layers.numberOfLayersInSet();
+  for (unsigned int j=0; j < layers.size(); j++)
+  {
+    findQuadruplets(region, result, ev, es, layers[j]);
+  }
+
+  theLayerCache.clear();
+}
+
+void
+CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, OrderedHitSeeds& result,
+                                           const edm::Event& ev, const edm::EventSetup& es,
+                                           const SeedingLayerSetsHits::SeedingLayerSet& fourLayers)
+{
+  if (theComparitor) theComparitor->init (ev, es);
+  HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+
+  std::vector<CACell::CAntuplet> foundQuadruplets;
+
+  std::vector<const HitDoublets*> layersDoublets(3);
+
+  HitDoublets doublets0 =  thePairGenerator.doublets(region, ev, es, fourLayers[0], fourLayers[1] );
+  HitDoublets doublets1 =  thePairGenerator.doublets(region, ev, es, fourLayers[1], fourLayers[2] );
+  HitDoublets doublets2 =  thePairGenerator.doublets(region, ev, es, fourLayers[2], fourLayers[3] );
+
+  layersDoublets[0] = &(doublets0);
+  layersDoublets[1] = &(doublets1);
+  layersDoublets[2] = &(doublets2);
+
+
+  CellularAutomaton<4> ca;
+
+  ca.create_and_connect_cells (layersDoublets, fourLayers, region, CAThetaCut, CAPhiCut);
+
+  ca.evolve();
+
+  ca.find_ntuplets(foundQuadruplets, 4);
+
+  const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
+
+
+  // re-used thoughout, need to be vectors because of RZLine interface
+  std::vector<float> bc_r(4), bc_z(4), bc_errZ(4);
+
+  declareDynArray(GlobalPoint, 4, gps);
+  declareDynArray(GlobalError, 4, ges);
+  declareDynArray(bool, 4, barrels);
+
+  unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
+
+  //  std::cout << "entering the found quadruplets loop" << std::endl;
+  // Loop over quadruplets
+  for (unsigned int quadId = 0; quadId < numberOfFoundQuadruplets; ++quadId)
+  {
+
+    //    std::cout << "checking quadruplet " << quadId << " with outer hit id " << foundQuadruplets[quadId][2]->get_outer_hit_id() << std::endl;
+    auto isBarrel = [](const unsigned id) -> bool
+    {
+      return id == PixelSubdetector::PixelBarrel;
+    };
+
+    gps[0] = foundQuadruplets[quadId][0]->get_inner_hit()->globalPosition();
+    ges[0] = foundQuadruplets[quadId][0]->get_inner_hit()->globalPositionError();
+    barrels[0] = isBarrel(foundQuadruplets[quadId][0]->get_inner_hit()->geographicalId().subdetId());
+
+    gps[1] = foundQuadruplets[quadId][1]->get_inner_hit()->globalPosition();
+    ges[1] = foundQuadruplets[quadId][1]->get_inner_hit()->globalPositionError();
+    barrels[1] = isBarrel(foundQuadruplets[quadId][1]->get_inner_hit()->geographicalId().subdetId());
+
+    gps[2] = foundQuadruplets[quadId][2]->get_inner_hit()->globalPosition();
+    ges[2] = foundQuadruplets[quadId][2]->get_inner_hit()->globalPositionError();
+    barrels[2] = isBarrel(foundQuadruplets[quadId][2]->get_inner_hit()->geographicalId().subdetId());
+
+    gps[3] = foundQuadruplets[quadId][2]->get_outer_hit()->globalPosition();
+    ges[3] = foundQuadruplets[quadId][2]->get_outer_hit()->globalPositionError();
+    barrels[3] = isBarrel(foundQuadruplets[quadId][2]->get_outer_hit()->geographicalId().subdetId());
+
+    PixelRecoLineRZ line(gps[0], gps[2]);
+    ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2], extraHitRPhitolerance);
+    const float curvature = predictionRPhi.curvature(ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
+    const float abscurv = std::abs(curvature);
+    const float thisMaxChi2 = maxChi2Eval.value(abscurv);
+
+    if (theComparitor)
+    {
+      SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->get_inner_hit(), foundQuadruplets[quadId][2]->get_inner_hit(), foundQuadruplets[quadId][2]->get_outer_hit());
+
+
+      if (!theComparitor->compatible(tmpTriplet, region) )
+      {
+        continue;
+      }
+    }
+
+    float chi2 = std::numeric_limits<float>::quiet_NaN();
+    // TODO: Do we have any use case to not use bending correction?
+    if (useBendingCorrection)
+    {
+      // Following PixelFitterByConformalMappingAndLine
+      const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
+      const float pt = 1 / PixelRecoUtilities::inversePt(abscurv, es);
+      for (int i=0; i < 4; ++i)
+      {
+        const GlobalPoint & point = gps[i];
+        const GlobalError & error = ges[i];
+        bc_r[i] = sqrt( sqr(point.x() - region.origin().x()) + sqr(point.y() - region.origin().y()) );
+        bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt, es)(bc_r[i]);
+        bc_z[i] = point.z() - region.origin().z();
+        bc_errZ[i] =  (barrels[i]) ? sqrt(error.czz()) : sqrt( error.rerr(point) ) * simpleCot;
+      }
+      RZLine rzLine(bc_r, bc_z, bc_errZ);
+      float      cottheta, intercept, covss, covii, covsi;
+      rzLine.fit(cottheta, intercept, covss, covii, covsi);
+      chi2 = rzLine.chi2(cottheta, intercept);
+    } else
+    {
+      RZLine rzLine(gps, ges, barrels);
+      float  cottheta, intercept, covss, covii, covsi;
+      rzLine.fit(cottheta, intercept, covss, covii, covsi);
+      chi2 = rzLine.chi2(cottheta, intercept);
+    }
+    if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
+    {
+      continue;
+    }
+    // TODO: Do we have any use case to not use circle fit? Maybe
+    // HLT where low-pT inefficiency is not a problem?
+    if (fitFastCircle)
+    {
+      FastCircleFit c(gps, ges);
+      chi2 += c.chi2();
+      if (edm::isNotFinite(chi2))
+        continue;
+      if (fitFastCircleChi2Cut && chi2 > thisMaxChi2)
+        continue;
+    }
+
+    //    std::cout << "it has chi2: " << chi2 << std::endl;
+
+    result.emplace_back(foundQuadruplets[quadId][0]->get_inner_hit(), foundQuadruplets[quadId][1]->get_inner_hit(), foundQuadruplets[quadId][2]->get_inner_hit(), foundQuadruplets[quadId][2]->get_outer_hit());
+
+  }
+
+}

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -108,7 +108,6 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
 
   const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
-
   // re-used thoughout, need to be vectors because of RZLine interface
   std::vector<float> bc_r(4), bc_z(4), bc_errZ(4);
 
@@ -126,7 +125,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     {
       return id == PixelSubdetector::PixelBarrel;
     };
-    for(unsigned int i = 0; i< 2; ++i)
+    for(unsigned int i = 0; i< 3; ++i)
     {
         auto const& ahit = foundQuadruplets[quadId][i]->getInnerHit();
         gps[i] = ahit->globalPosition();
@@ -201,7 +200,8 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     }
 
     result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
-    std::cout << " result size: " << result.size() << std::endl;
   }
 
 }
+
+

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -67,7 +67,6 @@ void CAHitQuadrupletGenerator::hitQuadruplets(
   edm::Handle<SeedingLayerSetsHits> hlayers;
   ev.getByToken(theSeedingLayerToken, hlayers);
   const SeedingLayerSetsHits& layers = *hlayers;
-  std::cout << "yuhuuu" << std::endl;
   if (layers.numberOfLayersInSet() != 4)
     throw cms::Exception("Configuration") << "CAHitQuadrupletsGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 4, got " << layers.numberOfLayersInSet();
   for (unsigned int j=0; j < layers.size(); j++)
@@ -191,6 +190,7 @@ CAHitQuadrupletGenerator::findQuadruplets (const TrackingRegion& region, Ordered
     if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
     {
       continue;
+              
     }
     // TODO: Do we have any use case to not use circle fit? Maybe
     // HLT where low-pT inefficiency is not a problem?

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef CAHitQuadrupletGenerator_H
-#define CAHitQuadrupletGenerator_H
+#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
+#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
 
 #include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -1,0 +1,131 @@
+#ifndef CAHitQuadrupletGenerator_H
+#define CAHitQuadrupletGenerator_H
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+#include "RecoPixelVertexing/PixelTrackFitting/src/RZLine.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastCircleFit.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+#include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+class TrackingRegion;
+class HitQuadrupletGeneratorFromTripletAndLayers;
+class SeedingLayerSetsHits;
+
+namespace edm {
+    class Event;
+}
+namespace edm {
+    class EventSetup;
+}
+
+class CAHitQuadrupletGenerator : public HitQuadrupletGenerator {
+public:
+    typedef LayerHitMapCache LayerCacheType;
+
+public:
+
+    CAHitQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
+
+    virtual ~CAHitQuadrupletGenerator();
+
+    /// from base class
+    virtual void hitQuadruplets(const TrackingRegion& reg, OrderedHitSeeds & triplets,
+            const edm::Event & ev, const edm::EventSetup& es);
+
+    void findQuadruplets(const TrackingRegion& region, OrderedHitSeeds& result,
+            const edm::Event& ev, const edm::EventSetup& es,
+            const SeedingLayerSetsHits::SeedingLayerSet& fourLayers);
+    
+    
+private:
+    edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
+
+    LayerCacheType theLayerCache;
+
+    std::unique_ptr<SeedComparitor> theComparitor;
+
+    class QuantityDependsPtEval {
+    public:
+
+        QuantityDependsPtEval(float v1, float v2, float c1, float c2) :
+        value1_(v1), value2_(v2), curvature1_(c1), curvature2_(c2) {
+        }
+
+        float value(float curvature) const {
+            if (value1_ == value2_) // not enabled
+                return value1_;
+
+            if (curvature1_ < curvature)
+                return value1_;
+            if (curvature2_ < curvature && curvature <= curvature1_)
+                return value2_ + (curvature - curvature2_) / (curvature1_ - curvature2_) * (value1_ - value2_);
+            return value2_;
+        }
+
+    private:
+        const float value1_;
+        const float value2_;
+        const float curvature1_;
+        const float curvature2_;
+    };
+
+    // Linear interpolation (in curvature) between value1 at pt1 and
+    // value2 at pt2. If disabled, value2 is given (the point is to
+    // allow larger/smaller values of the quantity at low pt, so it
+    // makes more sense to have the high-pt value as the default).
+
+    class QuantityDependsPt {
+    public:
+
+        explicit QuantityDependsPt(const edm::ParameterSet& pset) :
+        value1_(pset.getParameter<double>("value1")),
+        value2_(pset.getParameter<double>("value2")),
+        pt1_(pset.getParameter<double>("pt1")),
+        pt2_(pset.getParameter<double>("pt2")),
+        enabled_(pset.getParameter<bool>("enabled")) {
+            if (enabled_ && pt1_ >= pt2_)
+                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
+            if (pt1_ <= 0)
+                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 needs to be > 0; is " << pt1_;
+            if (pt2_ <= 0)
+                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt2 needs to be > 0; is " << pt2_;
+        }
+
+        QuantityDependsPtEval evaluator(const edm::EventSetup& es) const {
+            if (enabled_) {
+                return QuantityDependsPtEval(value1_, value2_,
+                        PixelRecoUtilities::curvature(1.f / pt1_, es),
+                        PixelRecoUtilities::curvature(1.f / pt2_, es));
+            }
+            return QuantityDependsPtEval(value2_, value2_, 0.f, 0.f);
+        }
+
+    private:
+        const float value1_;
+        const float value2_;
+        const float pt1_;
+        const float pt2_;
+        const bool enabled_;
+    };
+
+    const float extraHitRPhitolerance;
+
+    const QuantityDependsPt maxChi2;
+    const bool fitFastCircle;
+    const bool fitFastCircleChi2Cut;
+    const bool useBendingCorrection;
+
+    const float CAThetaCut = 0.00125f;
+    const float CAPhiCut = 10.f;
+
+};
+#endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -13,34 +13,36 @@ void CellularAutomaton<numberOfLayers>::createAndConnectCells (std::vector<const
   unsigned int layerPairId = 0;
   auto innerLayerId = layerPairId;
   auto outerLayerId = innerLayerId + 1;
-  auto numberOfDoublets = doublets[layerPairId]->size ();
+  auto & doubletLayerPairId = doublets[layerPairId];
+  auto numberOfDoublets = doubletLayerPairId->size ();
 
   isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
+
   theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
   for (unsigned int i = 0; i < numberOfDoublets; ++i)
   {
-    theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i,  cellId,  doublets[layerPairId]->innerHitId(i), doublets[layerPairId]->outerHitId(i));
+    theFoundCellsPerLayer[layerPairId].emplace_back (doubletLayerPairId, i,  cellId,  doubletLayerPairId->innerHitId(i), doubletLayerPairId->outerHitId(i));
 
-    isOuterHitOfCell[outerLayerId][doublets[layerPairId]->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
+    isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
     cellId++;
 
   }
 
   for (layerPairId = 1; layerPairId < numberOfLayerPairs; ++layerPairId)
   {
-
+	doubletLayerPairId = doublets[layerPairId];
     innerLayerId = layerPairId;
     outerLayerId = innerLayerId + 1;
-    numberOfDoublets = doublets[layerPairId]->size ();
+    numberOfDoublets =doubletLayerPairId->size ();
     isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
 
     theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
     for (unsigned int i = 0; i < numberOfDoublets; ++i)
     {
-      theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i, cellId, doublets[layerPairId]->innerHitId(i), doublets[layerPairId]->outerHitId(i));
-      isOuterHitOfCell[outerLayerId][doublets[layerPairId]->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
+      theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i, cellId, doubletLayerPairId->innerHitId(i), doubletLayerPairId->outerHitId(i));
+      isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
       cellId++;
-      for (auto neigCell : isOuterHitOfCell[innerLayerId][doublets[layerPairId]->innerHitId(i)])
+      for (auto neigCell : isOuterHitOfCell[innerLayerId][doubletLayerPairId->innerHitId(i)])
       {
         theFoundCellsPerLayer[layerPairId][i].checkAlignmentAndTag (neigCell, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut, phiCut);
       }
@@ -110,3 +112,5 @@ CellularAutomaton<numberOfLayers>::findNtuplets(std::vector<CACell::CAntuplet>& 
 }
 
 template class CellularAutomaton<4>;
+
+

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -2,7 +2,7 @@
 #include "CellularAutomaton.h"
 
 template <unsigned int numberOfLayers>
-void CellularAutomaton<numberOfLayers>::create_and_connect_cells (std::vector<const HitDoublets*> doublets, const SeedingLayerSetsHits::SeedingLayerSet& fourLayers, const TrackingRegion& region, const float thetaCut, const float phiCut)
+void CellularAutomaton<numberOfLayers>::createAndConnectCells (std::vector<const HitDoublets*> doublets, const SeedingLayerSetsHits::SeedingLayerSet& fourLayers, const TrackingRegion& region, const float thetaCut, const float phiCut)
 {
   unsigned int cellId = 0;
   constexpr unsigned int numberOfLayerPairs =   numberOfLayers - 1;
@@ -42,7 +42,7 @@ void CellularAutomaton<numberOfLayers>::create_and_connect_cells (std::vector<co
       cellId++;
       for (auto neigCell : isOuterHitOfCell[innerLayerId][doublets[layerPairId]->innerHitId(i)])
       {
-        theFoundCellsPerLayer[layerPairId][i].check_alignment_and_tag (neigCell, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut, phiCut);
+        theFoundCellsPerLayer[layerPairId][i].checkAlignmentAndTag (neigCell, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut, phiCut);
       }
     }
   }
@@ -70,7 +70,7 @@ CellularAutomaton<numberOfLayers>::evolve ()
 
       for (auto& cell : theFoundCellsPerLayer[innerLayerId])
       {
-        cell.update_state();
+        cell.updateState();
       }
     }
   }
@@ -85,8 +85,8 @@ CellularAutomaton<numberOfLayers>::evolve ()
 
   for (auto& cell : theFoundCellsPerLayer[0])
   {
-    cell.update_state();
-    if (cell.is_root_cell (numberOfLayers - 2 ))
+    cell.updateState();
+    if (cell.isRootCell (numberOfLayers - 2 ))
     {
       theRootCells.push_back (&cell);
     }
@@ -95,7 +95,7 @@ CellularAutomaton<numberOfLayers>::evolve ()
 
 template <unsigned int numberOfLayers>
 void
-CellularAutomaton<numberOfLayers>::find_ntuplets(std::vector<CACell::CAntuplet>& foundNtuplets,  const unsigned int minHitsPerNtuplet)
+CellularAutomaton<numberOfLayers>::findNtuplets(std::vector<CACell::CAntuplet>& foundNtuplets,  const unsigned int minHitsPerNtuplet)
 {
   std::vector<CACell*> tmpNtuplet;
   tmpNtuplet.reserve(numberOfLayers);
@@ -104,7 +104,7 @@ CellularAutomaton<numberOfLayers>::find_ntuplets(std::vector<CACell::CAntuplet>&
   {
     tmpNtuplet.clear();
     tmpNtuplet.push_back(root_cell);
-    root_cell->find_ntuplets (foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+    root_cell->findNtuplets (foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
   }
 
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -1,0 +1,112 @@
+
+#include "CellularAutomaton.h"
+
+template <unsigned int numberOfLayers>
+void CellularAutomaton<numberOfLayers>::create_and_connect_cells (std::vector<const HitDoublets*> doublets, const SeedingLayerSetsHits::SeedingLayerSet& fourLayers, const TrackingRegion& region, const float thetaCut, const float phiCut)
+{
+  unsigned int cellId = 0;
+  constexpr unsigned int numberOfLayerPairs =   numberOfLayers - 1;
+  float ptmin = region.ptMin();
+  float region_origin_x = region.origin().x();
+  float region_origin_y = region.origin().y();
+  float region_origin_radius = region.originRBound();
+  unsigned int layerPairId = 0;
+  auto innerLayerId = layerPairId;
+  auto outerLayerId = innerLayerId + 1;
+  auto numberOfDoublets = doublets[layerPairId]->size ();
+
+  isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
+  theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
+  for (unsigned int i = 0; i < numberOfDoublets; ++i)
+  {
+    theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i,  cellId,  doublets[layerPairId]->innerHitId(i), doublets[layerPairId]->outerHitId(i));
+
+    isOuterHitOfCell[outerLayerId][doublets[layerPairId]->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
+    cellId++;
+
+  }
+
+  for (layerPairId = 1; layerPairId < numberOfLayerPairs; ++layerPairId)
+  {
+
+    innerLayerId = layerPairId;
+    outerLayerId = innerLayerId + 1;
+    numberOfDoublets = doublets[layerPairId]->size ();
+    isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
+
+    theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
+    for (unsigned int i = 0; i < numberOfDoublets; ++i)
+    {
+      theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i, cellId, doublets[layerPairId]->innerHitId(i), doublets[layerPairId]->outerHitId(i));
+      isOuterHitOfCell[outerLayerId][doublets[layerPairId]->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
+      cellId++;
+      for (auto neigCell : isOuterHitOfCell[innerLayerId][doublets[layerPairId]->innerHitId(i)])
+      {
+        theFoundCellsPerLayer[layerPairId][i].check_alignment_and_tag (neigCell, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut, phiCut);
+      }
+    }
+  }
+}
+
+template <unsigned int numberOfLayers>
+void
+CellularAutomaton<numberOfLayers>::evolve ()
+{
+  constexpr unsigned int numberOfIterations = numberOfLayers - 2;
+  unsigned int numberOfCellsFound ;
+  for (unsigned int iteration = 0; iteration < numberOfIterations - 1; ++iteration)
+  {
+    for (unsigned int innerLayerId = 0; innerLayerId < numberOfIterations - iteration ; ++innerLayerId)
+    {
+
+      for (auto& cell : theFoundCellsPerLayer[innerLayerId])
+      {
+        cell.evolve();
+      }
+    }
+
+    for (unsigned int innerLayerId = 0; innerLayerId < numberOfLayers - iteration - 2; ++innerLayerId)
+    {
+
+      for (auto& cell : theFoundCellsPerLayer[innerLayerId])
+      {
+        cell.update_state();
+      }
+    }
+  }
+
+  //last iteration 
+  numberOfCellsFound = theFoundCellsPerLayer[0].size();
+
+  for (unsigned int cellId = 0; cellId < numberOfCellsFound; ++cellId)
+  {
+    theFoundCellsPerLayer[0][cellId].evolve();
+  }
+
+  for (auto& cell : theFoundCellsPerLayer[0])
+  {
+    cell.update_state();
+    if (cell.is_root_cell (numberOfLayers - 2 ))
+    {
+      theRootCells.push_back (&cell);
+    }
+  }
+}
+
+template <unsigned int numberOfLayers>
+void
+CellularAutomaton<numberOfLayers>::find_ntuplets(std::vector<CACell::CAntuplet>& foundNtuplets,  const unsigned int minHitsPerNtuplet)
+{
+  std::vector<CACell*> tmpNtuplet;
+  tmpNtuplet.reserve(numberOfLayers);
+
+  for (CACell* root_cell : theRootCells)
+  {
+    tmpNtuplet.clear();
+    tmpNtuplet.push_back(root_cell);
+    root_cell->find_ntuplets (foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+  }
+
+}
+
+template class CellularAutomaton<4>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -1,0 +1,36 @@
+#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
+#define RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
+#include <array>
+#include "CACell.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
+template<unsigned int theNumberOfLayers>
+class CellularAutomaton {
+public:
+
+    CellularAutomaton() {
+
+    }
+
+    void create_and_connect_cells(std::vector<const HitDoublets*>, const SeedingLayerSetsHits::SeedingLayerSet&, const TrackingRegion&, const float, const float);
+    void evolve();
+    void find_ntuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
+
+
+
+private:
+
+
+
+    //for each hit in each layer, store the pointers of the Cells of which it is outerHit
+    std::array<std::vector<std::vector<CACell*> >, theNumberOfLayers> isOuterHitOfCell;
+    std::array<std::vector<CACell>, theNumberOfLayers> theFoundCellsPerLayer;
+
+    std::vector<CACell*> theRootCells;
+    std::vector<std::vector<CACell*> > theNtuplets;
+
+};
+
+
+#endif 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -13,9 +13,9 @@ public:
 
     }
 
-    void create_and_connect_cells(std::vector<const HitDoublets*>, const SeedingLayerSetsHits::SeedingLayerSet&, const TrackingRegion&, const float, const float);
+    void createAndConnectCells(std::vector<const HitDoublets*>, const SeedingLayerSetsHits::SeedingLayerSet&, const TrackingRegion&, const float, const float);
     void evolve();
-    void find_ntuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
+    void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
 
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
@@ -25,3 +25,6 @@ DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitQuadrupletGenerator, "
 #include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGeneratorFromTripletAndLayersFactory.h"
 #include "PixelQuadrupletGenerator.h"
 DEFINE_EDM_PLUGIN(HitQuadrupletGeneratorFromTripletAndLayersFactory, PixelQuadrupletGenerator, "PixelQuadrupletGenerator");
+
+#include "CAHitQuadrupletGenerator.h"
+DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CAHitQuadrupletGenerator, "CAHitQuadrupletGenerator");

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
@@ -11,6 +11,6 @@ CAHitQuadrupletGenerator = cms.PSet(
     fitFastCircle = cms.bool(False),
     fitFastCircleChi2Cut = cms.bool(False),
     useBendingCorrection = cms.bool(False),
-    CAThetaCut = 0.00125,
-    CAPhiCut = 10.0,
+    CAThetaCut = cms.double(0.00125),
+    CAPhiCut = cms.double(10),
 )

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+CAHitQuadrupletGenerator = cms.PSet(
+    ComponentName = cms.string("CAHitQuadrupletGenerator"),
+    extraHitRPhitolerance = cms.double(0.1),
+    maxChi2 = cms.PSet(
+        pt1    = cms.double(0.2), pt2    = cms.double(1.5),
+        value1 = cms.double(500), value2 = cms.double(50),
+        enabled = cms.bool(True),
+    ),
+    fitFastCircle = cms.bool(False),
+    fitFastCircleChi2Cut = cms.bool(False),
+    useBendingCorrection = cms.bool(False),
+    CAThetaCut = 0.00125,
+    CAPhiCut = 10.0,
+)

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseForQuadrupletsByCellularAutomaton(process):
+    for module in process._Process__producers.values():
+        if not hasattr(module, "OrderedHitsFactoryPSet"):
+            continue
+	pset = getattr(module, "OrderedHitsFactoryPSet")
+        if not hasattr(pset, "ComponentName"):
+	    continue
+	if not (pset.ComponentName == "CombinedHitQuadrupletGenerator"):
+	    continue    
+        # Adjust seeding layers
+        seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+        seedingLayersModule = getattr(process, seedingLayersName)
+        seedingLayersModule.layerList = process.PixelSeedMergerQuadruplets.layerList.value()
+
+        # Configure seed generator / pixel track producer
+        quadruplets = module.OrderedHitsFactoryPSet.clone()
+        from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
+
+        module.OrderedHitsFactoryPSet  = _CAHitQuadrupletGenerator.clone(
+            ComponentName = cms.string("CAHitQuadrupletGenerator"),
+            extraHitRPhitolerance = quadruplets.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = dict(
+                pt1    = 0.8, pt2    = 2,
+                value1 = 200, value2 = 100,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            fitFastCircle = True,
+            fitFastCircleChi2Cut = True,
+            SeedingLayers = cms.InputTag(seedingLayersName),
+            CAThetaCut = cms.double(0.00125),
+            CAPhiCut = cms.double(10),
+        )
+
+        if hasattr(quadruplets.GeneratorPSet, "SeedComparitorPSet"):
+            pset.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
+    return process

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
@@ -11,8 +11,8 @@ def customiseForQuadrupletsByCellularAutomaton(process):
 	    continue    
         # Adjust seeding layers
         seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
-        seedingLayersModule = getattr(process, seedingLayersName)
-        seedingLayersModule.layerList = process.PixelSeedMergerQuadruplets.layerList.value()
+   
+
 
         # Configure seed generator / pixel track producer
         quadruplets = module.OrderedHitsFactoryPSet.clone()

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -25,7 +25,9 @@ public:
 
   HitDoublets doublets( const TrackingRegion& reg,
                         const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
-
+  HitDoublets doublets( const TrackingRegion& reg,
+                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer);
+  
   void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
                  const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
   static void doublets(
@@ -38,6 +40,8 @@ public:
 						      const unsigned int theMaxElement,
 						      HitDoublets & result);
 
+  
+  
   Layer innerLayer(const Layers& layers) const { return layers[theInnerLayer]; }
   Layer outerLayer(const Layers& layers) const { return layers[theOuterLayer]; }
 

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -146,10 +146,12 @@ public:
   void add (int il, int ol) { indeces.push_back(il);indeces.push_back(ol);}
 
   DetLayer const * detLayer(layer l) const { return layers[l]->layer; }
-
+  int innerHitId(int i) const {return indeces[2*i];}
+  int outerHitId(int i) const {return indeces[2*i+1];}
   Hit const & hit(int i, layer l) const { return layers[l]->theHits[indeces[2*i+l]].hit();}
   float       phi(int i, layer l) const { return layers[l]->phi(indeces[2*i+l]);}
   float       rv(int i, layer l) const { return layers[l]->rv(indeces[2*i+l]);}
+  float       r(int i, layer l) const { float xp = x(i,l); float yp = y(i,l);  return sqrt (xp*xp + yp*yp);}
   float        z(int i, layer l) const { return layers[l]->z[indeces[2*i+l]];}
   float        x(int i, layer l) const { return layers[l]->x[indeces[2*i+l]];}
   float        y(int i, layer l) const { return layers[l]->y[indeces[2*i+l]];}

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -109,6 +109,29 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& regio
 
 }
 
+
+HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& region,
+						    const edm::Event & iEvent, const edm::EventSetup& iSetup, const Layer& innerLayer, const Layer& outerLayer) {
+
+  typedef OrderedHitPair::InnerRecHit InnerHit;
+  typedef OrderedHitPair::OuterRecHit OuterHit;
+  typedef RecHitsSortedInPhi::Hit Hit;
+
+
+  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayer, region, iEvent, iSetup);
+  if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
+
+  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayer, region, iEvent, iSetup);
+  if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
+  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
+  doublets(region,
+	   *innerLayer.detLayer(),*outerLayer.detLayer(),
+	   innerHitsMap,outerHitsMap,iSetup,theMaxElement,result);
+  
+  return result;
+
+}
+
 void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
 						    const DetLayer & innerHitDetLayer,
 						    const DetLayer & outerHitDetLayer,


### PR DESCRIPTION
Phase 1 quadruplet seeding using Cellular automaton, disabled by default.
You can find the talk here:
https://indico.cern.ch/event/542270/
you can customise the process by adding:

`# customisation of the process.

from RecoTracker.Configuration.customiseForQuadrupletsByCellularAutomaton import customiseForQuadrupletsByCellularAutomaton

process = customiseForQuadrupletsByCellularAutomaton(process)
`
