### PR TITLE
New L1REPACK workflow for DATA with simulation of TPs 

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1499,7 +1499,7 @@ class ConfigBuilder(object):
 
     def prepare_L1REPACK(self, sequence = None):
             """ Enrich the schedule with the L1 simulation step, running the L1 emulator on data unpacked from the RAW collection, and repacking the result in a new RAW collection"""
-	    supported = ['GT','GT1','GT2','GCTGT','Full','FullMC','Full2015Data','uGT']
+	    supported = ['GT','GT1','GT2','GCTGT','Full','FullSimTP','FullMC','Full2015Data','uGT']
             if sequence in supported:
                 self.loadAndRemember('Configuration/StandardSequences/SimL1EmulatorRepack_%s_cff'%sequence)
 		if self._options.scenario == 'HeavyIons':

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -162,6 +162,7 @@ workflows[136.731] = ['',['RunSinglePh2016B','HLTDR2_2016','RECODR2_2016reHLT','
 workflows[136.732] = ['',['RunZeroBias2016B','HLTDR2_2016','RECODR2_2016reHLT','HARVESTDR2']]
 workflows[136.733] = ['',['RunCosmics2016B','RECOCOSDRUN2','ALCACOSDRUN2','HARVESTDCRUN2']]
 workflows[136.734] = ['',['RunMuOnia2016B','HLTDR2_2016','RECODR2_2016reHLT_skimMuOnia','HARVESTDR2']]
+workflows[136.7321] = ['',['RunZeroBias2016BnewL1repack','HLTDR2newL1repack_2016','RECODR2newL1repack_2016reHLT','HARVESTDR2']]
 
 ### fastsim ###
 workflows[5.1] = ['TTbar', ['TTbarFS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -199,6 +199,7 @@ steps['RunSingleMu2016B']={'INPUT':InputInfo(dataSet='/SingleMuon/Run2016B-v2/RA
 steps['RunSinglePh2016B']={'INPUT':InputInfo(dataSet='/SinglePhoton/Run2016B-v2/RAW',label='sigPh2016B',events=100000,location='STD', ls=Run2016B)}
 steps['RunZeroBias2016B']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016B-v2/RAW',label='zb2016B',events=100000,location='STD', ls=Run2016B)}
 steps['RunMuOnia2016B']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016B-v2/RAW',label='muOnia2016B',events=100000,location='STD', ls=Run2016B)}
+steps['RunZeroBias2016BnewL1repack']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016B-v2/RAW',label='zb2016BnewL1rep',events=100000,location='STD', ls=Run2016B)}
 
 # Highstat HLTPhysics 
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
@@ -1011,6 +1012,7 @@ steps['HLTDR2_25ns']=merge( [ {'-s':'L1REPACK:GT2,HLT:@%s'%hltKey25ns,},{'--cond
 hltKey2016='relval2016'
 menuR2_2016 = autoHLT[hltKey2016]
 steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
+steps['HLTDR2newL1repack_2016']=merge( [ {'-s':'L1REPACK:FullSimTP,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
 
 # custom function to be put back once the CSC tracked/untracked will have been fixed.. :-)
@@ -1137,6 +1139,7 @@ steps['RECODreHLTAlCaCalo']=merge([{'--hltProcess':'reHLT','--conditions':'auto:
 steps['RECODR2_25nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_25ns']])
 steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']])
 steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_2016']])
+steps['RECODR2newL1repack_2016reHLT']=merge([{'-s':'L1REPACK:FullSimTP,RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@miniAODDQM','--hltProcess':'reHLT'},steps['RECODR2_2016']])
 steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
 
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -45,9 +45,12 @@ else:
 
     # Second, Re-Emulate the entire L1T
 
-    #from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
-    from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
+    from SimCalorimetry.EcalTrigPrimProducers.ecalTriggerPrimitiveDigis_cfi import *
+    #from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
+    simEcalTriggerPrimitiveDigis.InstanceEB = cms.string('ebDigis')
+    simEcalTriggerPrimitiveDigis.InstanceEE = cms.string('eeDigis')
     simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
+    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
     simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
         cms.InputTag('unpackHcal'),
         cms.InputTag('unpackHcal')

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -71,9 +71,11 @@ else:
     simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
     # simOmtfDigis.srcDTPh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
     # simOmtfDigis.srcDTTh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
+    simOmtfDigis.srcCSC              = cms.InputTag("unpackCsctf")   
     # simOmtfDigis.srcCSC              = cms.InputTag("simCscTriggerPrimitiveDigis")   # DEFAULT
 
     # EMTF
+    simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf")
     # simEmtfDigis.CSCInput            = cms.InputTag("simCscTriggerPrimitiveDigis")     # DEFAULT
 
     # simCaloStage2Layer1Digis.ecalToken = cms.InputTag('simEcalTriggerPrimitiveDigis')  # DEFAULT

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -1,0 +1,106 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
+
+
+if not (eras.stage2L1Trigger.isChosen()):
+    print "L1T WARN:  L1REPACK:FullSimTP (intended for 2016 data) only supports Stage 2 eras for now."
+    print "L1T WARN:  Use a legacy version of L1REPACK for now."
+else:
+    print "L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."
+
+    # First, Unpack all inputs to L1:
+    import EventFilter.L1TRawToDigi.bmtfDigis_cfi
+    unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
+    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
+    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+
+    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.DTRawToDigi.dtunpacker_cfi
+    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
+    # Second, Re-Emulate the entire L1T
+
+    #from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+    from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
+    simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
+    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),
+        cms.InputTag('unpackHcal')
+    )
+
+    from L1Trigger.Configuration.SimL1Emulator_cff import *
+    
+    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
+    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
+
+    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
+    # simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")  # DEFAULT
+    # simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")  # DEFAULT
+
+    # BMTF
+    # simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")               # DEFAULT
+    # simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
+
+    # OMTF
+    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
+    # simOmtfDigis.srcDTPh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
+    # simOmtfDigis.srcDTTh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
+    # simOmtfDigis.srcCSC              = cms.InputTag("simCscTriggerPrimitiveDigis")   # DEFAULT
+
+    # EMTF
+    # simEmtfDigis.CSCInput            = cms.InputTag("simCscTriggerPrimitiveDigis")     # DEFAULT
+
+    # simCaloStage2Layer1Digis.ecalToken = cms.InputTag('simEcalTriggerPrimitiveDigis')  # DEFAULT
+    # simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')  # DEFAULT
+
+    # Finally, pack the new L1T output back into RAW
+    
+    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+    # combine the new L1 RAW with existing RAW for other FEDs
+    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+        verbose = cms.untracked.int32(0),
+        RawCollectionList = cms.VInputTag(
+            cms.InputTag('packCaloStage2'),
+            cms.InputTag('packGmtStage2'),
+            cms.InputTag('packGtStage2'),
+            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+            )
+        )
+
+
+    
+    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackCsctf+unpackBmtf
+                                 +simEcalTriggerPrimitiveDigis
+                                 +simHcalTriggerPrimitiveDigis
+                                 +SimL1EmulatorCore+packCaloStage2
+                                 +packGmtStage2+packGtStage2+rawDataCollector)


### PR DESCRIPTION
This is a test.

A new L1T workflow defined as step `L1REPACK:FullSimTP` for running on DATA is introduced.
It is designed for the needs of AlCa group for tests at RelVal where most of Trigger Primitives are re-simulated and used as inputs to L1T.  

In this workflow L1T emulation uses the following TPs:
-- sim DT TPs
-- unpacked CSC TPs 
-- sim Ecal TPs
-- sim Hcal TPs  

Note: Unpacked CSC TPs are used because the simCSC TPs have offset of BX=2.  Till this is fixed, 
prefer to use unpacked CSC TPs than to individually configure muon track finders (EMTF, OMTF) emulators to do internal BX shifting of its input TPs.

An example command using the step `L1REPACK:FullSimTP` on a RAW 2016 data file:

<pre>
cmsDriver.py L1TEST --python_filename=l1t_test.py -s L1REPACK:FullSimTP  --era=Run2_2016 --conditions=80X_dataRun2_HLT_v12 -n 10 --data --filein=/store/data/Run2016B/ZeroBias/RAW/v2/000/274/442/00000/F08D3D87-762C-E611-BBB8-02163E014160.root --eventcontent  FEVTDEBUGHLT  
</pre>

