### PR TITLE
Fix Compilation Errors with EDM_ML_DEBUG Defined

### DIFF
--- a/DataFormats/EcalDetId/interface/ESDetId.h
+++ b/DataFormats/EcalDetId/interface/ESDetId.h
@@ -4,6 +4,7 @@
 #include <iosfwd>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 /** \class ESDetId
 

--- a/DetectorDescription/ExprAlgo/BuildFile.xml
+++ b/DetectorDescription/ExprAlgo/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="clhep"/>

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
@@ -24,7 +24,10 @@ DDHCalEndcapAlgo::DDHCalEndcapAlgo():
   layerN2(0),layerN3(0),layerN4(0),layerN5(0),thick(0),trimLeft(0),
   trimRight(0),zminBlock(0),zmaxBlock(0),rinBlock1(0),routBlock1(0),
   rinBlock2(0),routBlock2(0),layerType(0),layerT(0),scintT(0) {
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo info: Creating an instance";
+#endif
 }
 
 DDHCalEndcapAlgo::~DDHCalEndcapAlgo() {}
@@ -75,7 +78,6 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 				  const DDStringArguments & sArgs,
 				  const DDStringVectorArguments & vsArgs) {
 
-  int i,j;
   genMaterial   = sArgs["MaterialName"];
   rotation      = sArgs["Rotation"];
   nsectors      = int (nArgs["Sector"]);
@@ -105,6 +107,7 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   angBot        = nArgs["AngBot"];
   angGap        = nArgs["AngGap"];
 
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: General material " 
 			   << genMaterial << "\tSectors "  << nsectors << ",  " 
 			   << nsectortot << "\tEndcaps " << nEndcap  
@@ -120,7 +123,8 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 			   << " Bottom angle " << angBot << " Gap angle " 
 			   << angGap << " Z-Shift " << zShift << " " 
 			   << zShiftHac2;
-
+#endif
+  
   //Derived quantities
   angTop   = 2.0 * atan (exp(-etamin));
   slope    = tan(angGap);
@@ -130,20 +134,26 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   riDip    = ziDip*tan(angBot);
   roDip    = rout - heboxDepth;
   dzShift  = (z1Beam - z0Beam) - gap/sin(angGap);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: angTop " 
 			   << angTop/CLHEP::deg  <<"\tSlope " << slope 
 			   << "\tDzShift " << dzShift << "\n\tz1Beam " << z1Beam
 			   << "\tziKink" << ziKink << "\triKink " << riKink 
 			   << "\triDip " << riDip << "\n\troDip " << roDip 
 			   << "\tRotation " << rotation;
-
+#endif
+  
   ///////////////////////////////////////////////////////////////
   //Modules
   absMat        = sArgs["AbsMat"];
   modules       = int(nArgs["Modules"]);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: Number of modules " 
 			   << modules << " and absorber material " << absMat;
-
+#endif
+  
   modName       = vsArgs["ModuleName"];
   modMat        = vsArgs["ModuleMat"];
   modType       = dbl_to_int(vArgs["ModuleType"]);
@@ -159,7 +169,9 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   layerN3       = dbl_to_int(vArgs["LayerN3"]);
   layerN4       = dbl_to_int(vArgs["LayerN4"]);
   layerN5       = dbl_to_int(vArgs["LayerN5"]);
-  for (i = 0; i < modules; i++) {
+
+#ifdef EDM_ML_DEBUG
+  for (int i = 0; i < modules; i++) {
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: " << modName[i] 
 			     << " type " << modType[i] << " Sections " 
 			     << sectionModule[i] <<" thickness of absorber/air "
@@ -167,31 +179,32 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 			     << trimRight[i] << " equip module " << eModule[i]
 			     << " with " << layerN[i] << " layers";
     if (i == 0) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN0[j] << "/" << layerN0[j+1];
       }
     } else if (i == 1) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN1[j] << "/" << layerN1[j+1];
       }
     } else if (i == 2) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN2[j];
       }
     } else if (i == 3) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN3[j];
       }
     } else if (i == 4) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN4[j];
       }
     } else if (i == 5) {
-      for (j = 0; j < layerN[i]; j++) {
+      for (int j = 0; j < layerN[i]; j++) {
 	edm::LogInfo("HCalGeom") << "\t " << layerN5[j];
       }
     }
   }
+#endif
   
   ///////////////////////////////////////////////////////////////
   //Layers
@@ -205,19 +218,22 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   scintMat    = sArgs["ScintMat"];
   plastMat    = sArgs["PlastMat"];
   rotmat      = sArgs["RotMat"];
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: Phi Sections " 
 			   << phiSections;
-  for (i = 0; i < phiSections; i++) 
+  for (int i = 0; i < phiSections; i++) 
     edm::LogInfo("HCalGeom") << "\tName[" << i << "] : " << phiName[i];
   edm::LogInfo("HCalGeom") << "\tPlastic: " << plastMat << "\tScintillator: "
 			   << scintMat << "\tRotation matrix " << rotns << ":" 
 			   << rotmat << "\n\tNumber of layers " << layers;
-  for (i = 0; i < layers; i++) {
+  for (int i = 0; i < layers; i++) {
     edm::LogInfo("HCalGeom") << "\t" << layerName[i] << "\tType " 
 			     << layerType[i] << "\tThickness " << layerT[i] 
 			     << "\tScint.Thick " << scintT[i];
   }
-
+#endif
+  
   ///////////////////////////////////////////////////////////////
   // Derive bounding of the modules
   int module = 0;
@@ -287,25 +303,33 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
     module++;
   }
 
-  for (i = 0; i < module; i++)
+#ifdef EDM_ML_DEBUG
+  for (int i = 0; i < module; i++)
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: Module " << i 
 			     << "\tZ/Rin/Rout " << zminBlock[i] << ", " 
 			     << zmaxBlock[i] << "/ " << rinBlock1[i] << ", " 
 			     << rinBlock2[i] << "/ " << routBlock1[i] << ", " 
 			     << routBlock2[i];
+#endif
 
   idName      = sArgs["MotherName"];
   idNameSpace = DDCurrentNamespace::ns();
   idOffset = int (nArgs["IdOffset"]); 
+
+#ifdef EDM_ML_DEBUG
   DDName parentName = parent().name(); 
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo debug: Parent " << parentName 
 			   << " idName " << idName << " NameSpace " 
 			   << idNameSpace << " Offset " << idOffset;
+#endif
 
   tolPos      = nArgs["TolPos"];
   tolAbs      = nArgs["TolAbs"];
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") <<"DDHCalEndcapAlgo debug: Tolerances - Positioning "
 			   << tolPos << " Absorber " << tolAbs;
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -314,16 +338,25 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 
 void DDHCalEndcapAlgo::execute(DDCompactView& cpv) {
   
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "==>> Constructing DDHCalEndcapAlgo...";
+#endif
+
   constructGeneralVolume(cpv);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "<<== End of DDHCalEndcapAlgo construction ...";
+#endif
 }
 
 //----------------------start here for DDD work!!! ---------------
 
 void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: General volume...";
+#endif
+
   bool proto = true;
   for (int i=0; i<3; i++) 
     if (equipModule(i) > 0) proto = false;
@@ -331,9 +364,13 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   DDRotation    rot;
   if (DDSplit(getRotation()).first == "NULL") rot = DDRotation();
   else rot = DDRotation(DDName(DDSplit(getRotation()).first,DDSplit(getRotation()).second));
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << " First " << DDSplit(getRotation()).first
 			   << " Second " << DDSplit(getRotation()).second 
 			   << " Rotation " << rot;
+#endif
+  
   DDTranslation r0(0,0,getZShift());
   double alpha = CLHEP::pi/getNsectors();
   double dphi  = getNsectortot()*CLHEP::twopi/getNsectors();
@@ -376,11 +413,11 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   pgonRmax.push_back(getRoutDip()); 
 
   string name("Null");
-  unsigned int i=0;
   DDSolid solid;
   solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace),
 				    getNsectortot(), -alpha, dphi, pgonZ, 
 				    pgonRmin, pgonRmax);
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " 
 			   << DDName(idName, idNameSpace) 
 			   << " Polyhedra made of " << getGenMat() << " with " 
@@ -388,9 +425,10 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
 			   << -alpha/CLHEP::deg << " to " 
 			   << (-alpha+dphi)/CLHEP::deg << " and with " 
 			   << pgonZ.size() << " sections";
-  for (i = 0; i <pgonZ.size(); i++) 
+  for (unsigned int i = 0; i <pgonZ.size(); i++) 
     edm::LogInfo("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " 
 			     << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
+#endif
 
   DDName matname(DDSplit(getGenMat()).first, DDSplit(getGenMat()).second); 
   DDMaterial matter(matname);
@@ -398,23 +436,31 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
 
   DDName parentName = parent().name(); 
   cpv.position(DDName(idName, idNameSpace), parentName, 1, r0, rot);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " 
 			   << DDName(idName, idNameSpace)
 			   << " number 1 positioned in " << parentName 
 			   << " at " << r0 << " with " << rot;
+#endif
+  
   if (getEndcaps() != 1) {
     rot = DDRotation(DDName(rotHalf,rotns));
     cpv.position(DDName(idName, idNameSpace), parentName, 2, r0, rot);
+
+#ifdef EDM_ML_DEBUG
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " 
 			     << DDName(idName, idNameSpace) << " number 2 "
 			     << "positioned in " << parentName  << " at " << r0
 			     << " with " << rot;
+#endif
+
   }
 
   //Forward half
   name  = idName + "Front";
   vector<double> pgonZMod, pgonRminMod, pgonRmaxMod;
-  for (i=0; i < (pgonZ.size()-1); i++) {
+  for (unsigned int i=0; i < (pgonZ.size()-1); i++) {
     pgonZMod.push_back(pgonZ[i] + getDzShift()); 
     pgonRminMod.push_back(pgonRmin[i]); 
     pgonRmaxMod.push_back(pgonRmax[i]); 
@@ -422,38 +468,47 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace),
 				    getNsectortot(), -alpha, dphi, pgonZMod,
 				    pgonRminMod, pgonRmaxMod);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: "
 			   << DDName(name,idNameSpace) << " Polyhedra made of "
 			   << getGenMat() << " with " << getNsectortot() 
 			   << " sectors from " << -alpha/CLHEP::deg << " to " 
 			   << (-alpha+dphi)/CLHEP::deg << " and with "
 			   << pgonZMod.size() << " sections ";
-  for (i = 0; i < pgonZMod.size(); i++) 
+  for (unsigned int i = 0; i < pgonZMod.size(); i++) 
     edm::LogInfo("HCalGeom") << "\t\tZ = " << pgonZMod[i] << "\tRmin = " 
 			     << pgonRminMod[i] << "\tRmax = " << pgonRmaxMod[i];
+#endif
+  
   DDLogicalPart genlogich(DDName(name, idNameSpace), matter, solid);
 
   cpv.position(genlogich, genlogic, 1, DDTranslation(0.0, 0.0, -getDzShift()),
 	DDRotation());
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << genlogich.name() 
 			   << " number 1 positioned in " << genlogic.name() 
 			   << " at (0,0," << -getDzShift()
 			   << ") with no rotation";
+#endif
   
   //Construct sector (from -alpha to +alpha)
   name  = idName + "Module";
   solid =   DDSolidFactory::polyhedra(DDName(name, idNameSpace),
 				      1, -alpha, 2*alpha, pgonZMod,
 				      pgonRminMod, pgonRmaxMod);
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: "
 			   << DDName(name,idNameSpace)<< " Polyhedra made of "
 			   << getGenMat() <<" with 1 sector from " 
 			   << -alpha/CLHEP::deg << " to " << alpha/CLHEP::deg
 			   << " and with " << pgonZMod.size() << " sections";
-  for (i = 0; i < pgonZMod.size(); i++) 
+  for (unsigned int i = 0; i < pgonZMod.size(); i++) 
     edm::LogInfo("HCalGeom") << "\t\tZ = " << pgonZMod[i] << "\tRmin = " 
 			     << pgonRminMod[i] << "\tRmax = " << pgonRmaxMod[i];
-
+#endif
+  
   DDLogicalPart seclogic(DDName(name, idNameSpace), matter, solid);
   
   for (int ii=0; ii<getNsectortot(); ii++) {
@@ -468,10 +523,14 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
       rotstr = rotstr + dbl_to_string(phideg);
       rotation = DDRotation(DDName(rotstr, rotns)); 
       if (!rotation) {
+
+#ifdef EDM_ML_DEBUG
 	edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: Creating a new "
 				 << "rotation " << rotstr << "\t" << 90 << "," 
 				 << phideg << ","  << 90 << "," << (phideg+90)
 				 << ", 0, 0";
+#endif
+	
 	rotation = DDrot(DDName(rotstr, rotns), 90*CLHEP::deg, 
 			 phideg*CLHEP::deg, 90*CLHEP::deg, 
 			 (90+phideg)*CLHEP::deg, 0*CLHEP::deg,  0*CLHEP::deg);
@@ -479,10 +538,14 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
     } //if phideg!=0
   
    cpv.position(seclogic, genlogich, ii+1, DDTranslation(0.0, 0.0, 0.0), rotation);
+
+#ifdef EDM_ML_DEBUG
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << seclogic.name() 
 			     << " number " << ii+1 << " positioned in " 
 			     << genlogich.name() << " at (0,0,0) with " 
 			     << rotation;
+#endif
+    
   }
   
   //Construct the things inside the sector
@@ -500,31 +563,41 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace),
 				    getNsectortot(), -alpha, dphi, pgonZBack,
 				    pgonRminBack, pgonRmaxBack);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: "
 			   << DDName(name,idNameSpace) << " Polyhedra made of " 
 			   << getAbsMat() << " with " << getNsectortot() 
 			   << " sectors from " << -alpha/CLHEP::deg << " to " 
 			   << (-alpha+dphi)/CLHEP::deg << " and with " 
 			   << pgonZBack.size()	<< " sections";
-  for (i = 0; i < pgonZBack.size(); i++) 
+  for (unsigned int i = 0; i < pgonZBack.size(); i++) 
     edm::LogInfo("HCalGeom") << "\t\tZ = " << pgonZBack[i] << "\tRmin = " 
 			     << pgonRminBack[i] << "\tRmax = " 
 			     << pgonRmaxBack[i];
+#endif
+  
   DDName absMatname(DDSplit(getAbsMat()).first, DDSplit(getAbsMat()).second); 
   DDMaterial absMatter(absMatname);
   DDLogicalPart glog(DDName(name, idNameSpace), absMatter, solid);
 
   cpv.position(glog, genlogic, 1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			   << " number 1 positioned in "  << genlogic.name() 
 			   << " at (0,0,0) with no rotation";
+#endif
 }
 
 
 void DDHCalEndcapAlgo::constructInsideSector(DDLogicalPart sector, DDCompactView& cpv) {
   
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: Modules (" << getModules()
 			   << ") ...";
+#endif
+
   double alpha = CLHEP::pi/getNsectors();
 
   for (int i = 0; i < getModules(); i++) {
@@ -570,6 +643,8 @@ void DDHCalEndcapAlgo::constructInsideSector(DDLogicalPart sector, DDCompactView
       solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 
 					1, -alpha, 2*alpha,
 					pgonZ, pgonRmin, pgonRmax);
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " 
 			       << DDName(name,idNameSpace) 
 			       << " Polyhedra made of " << getModMat(i) 
@@ -579,21 +654,24 @@ void DDHCalEndcapAlgo::constructInsideSector(DDLogicalPart sector, DDCompactView
       for (unsigned int k=0; k<pgonZ.size(); k++)
 	edm::LogInfo("HCalGeom") << "\t\tZ = " << pgonZ[k] << "\tRmin = "
 				 << pgonRmin[k] << "\tRmax = " << pgonRmax[k];
-    
+#endif
+      
       DDLogicalPart glog(DDName(name, idNameSpace), matter, solid);
 
       cpv.position(glog, sector, i+1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			       << " number " << i+1 << " positioned in " 
 			       <<sector.name() <<" at (0,0,0) with no rotation";
+#endif
       
       if (getModType(i) == 0) 
 	constructInsideModule0 (glog, i, cpv);
       else
 	constructInsideModule  (glog, i, cpv);
     }
-  }
-  
+  } 
 }
 
 void DDHCalEndcapAlgo::parameterLayer0(int mod, int layer, int iphi, 
@@ -604,9 +682,12 @@ void DDHCalEndcapAlgo::parameterLayer0(int mod, int layer, int iphi,
   //Given module and layer number compute parameters of trapezoid
   //and positioning parameters
   double alpha = CLHEP::pi/getNsectors();
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "Input " << iphi << " " << layer << " " << iphi
 			   << " Alpha " << alpha/CLHEP::deg;
-
+#endif
+  
   double zi, zo;
   if (iphi == 0) {
     zi = getZminBlock(mod);
@@ -638,11 +719,13 @@ void DDHCalEndcapAlgo::parameterLayer0(int mod, int layer, int iphi,
   } else {
     alp  = -alp;
   }
+  
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "Output Dimensions " << yh << " " << bl << " "
 			   << tl << " " << alp/CLHEP::deg << " Position " 
 			   << xpos << " " << ypos << " " << zpos;
+#endif
 }
-
 
 void DDHCalEndcapAlgo::parameterLayer(int iphi, double rinF, double routF,
 				      double rinB, double routB, double zi,
@@ -655,11 +738,14 @@ void DDHCalEndcapAlgo::parameterLayer(int iphi, double rinF, double routF,
   //Given rin, rout compute parameters of the trapezoid and 
   //position of the trapezoid for a standrd layer
   double alpha = CLHEP::pi/getNsectors();
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "Input " << iphi << " Front " << rinF << " " 
 			   << routF << " " << zi << " Back " << rinB << " " 
 			   << routB << " " << zo << " Alpha " 
 			   << alpha/CLHEP::deg;
-
+#endif
+  
   yh1 = 0.5 * (routF - rinB);
   bl1 = 0.5 * rinB  * tan(alpha);
   tl1 = 0.5 * routF * tan(alpha);
@@ -682,19 +768,24 @@ void DDHCalEndcapAlgo::parameterLayer(int iphi, double rinF, double routF,
   double r   = sqrt (dx*dx + dy*dy);
   theta= atan (r/(zo-zi));
   phi  = atan2 (dy, dx);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "Output Dimensions " << yh1 << " " << bl1 << " "
 			   << tl1 << " " << yh2 << " " << bl2 << " " << tl2
 			   << " " << alp/CLHEP::deg << " " << theta/CLHEP::deg
 			   << " " << phi/CLHEP::deg << " Position " << xpos 
 			   << " " << ypos << " " << zpos;
+#endif
 }
 
 
 void DDHCalEndcapAlgo::constructInsideModule0(DDLogicalPart module, int mod, DDCompactView& cpv) {
   
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: \t\tInside module0 ..."
 			   << mod;
-
+#endif
+  
   ///////////////////////////////////////////////////////////////
   //Pointers to the Rotation Matrices and to the Materials
   string rotstr = getRotMat();
@@ -717,20 +808,28 @@ void DDHCalEndcapAlgo::constructInsideModule0(DDLogicalPart module, int mod, DDC
     solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
 				 0.5*getLayerT(layer), 0, 0, yh,
 				 bl, tl, alp, yh, bl, tl, alp);
+
+#ifdef EDM_ML_DEBUG
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << solid.name() 
 			     << " Trap made of " << getPlastMat() 
 			     << " of dimensions " << 0.5*getLayerT(layer) 
 			     << ", 0, 0, " << yh << ", " << bl << ", " << tl 
 			     << ", " << alp/CLHEP::deg << ", " << yh << ", " 
 			     << bl << ", " << tl << ", " << alp/CLHEP::deg;
+#endif
+
     glog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
     DDTranslation r1(xpos, ypos, zpos);
     cpv.position(glog, module, idOffset+layer+1, r1, rot);
+
+#ifdef EDM_ML_DEBUG
     edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			     << " number " << idOffset+layer+1 
 			     << " positioned in " << module.name() << " at "
 			     << r1 << " with " << rot;
+#endif
+
     //Now construct the layer of scintillator inside this
     int copyNo = layer0*10 + getLayerType(layer);
     name = getModName(mod)+getLayerName(layer)+getPhiName(iphi);
@@ -752,16 +851,24 @@ void DDHCalEndcapAlgo::constructInsideModule0(DDLogicalPart module, int mod, DDC
     rinB  = zo * tan(getAngBot());
     routB = zo * tan(getAngTop());
   }
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: Module " << mod 
 			   << " Front " << zi << ", " << rinF << ", " << routF
 			   << " Back " << zo << ", " << rinB << ", " << routB;
+#endif
+  
   double yh1, bl1, tl1, yh2, bl2, tl2, theta, phi, alp;
   parameterLayer(0, rinF, routF, rinB, routB, zi, zo, yh1, bl1, tl1, yh2, bl2, 
                  tl2, alp, theta, phi, xpos, ypos, zpos);
   double fact = getTolAbs();
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: Trim " << fact 
 			   << " Param " << yh1 << ", " << bl1 << ", " << tl1 
 			   << ", " << yh2 << ", " << bl2 << ", " << tl2;
+#endif
+  
   bl1 -= fact;
   tl1 -= fact;
   bl2 -= fact;
@@ -771,6 +878,7 @@ void DDHCalEndcapAlgo::constructInsideModule0(DDLogicalPart module, int mod, DDC
   solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
 			       0.5*getThick(mod), theta, phi, yh1,
 			       bl1, tl1, alp, yh2, bl2, tl2, alp);
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << solid.name() 
 			   << " Trap made of " << getAbsMat() 
 			   << " of dimensions " << 0.5*getThick(mod) << ", "
@@ -778,21 +886,28 @@ void DDHCalEndcapAlgo::constructInsideModule0(DDLogicalPart module, int mod, DDC
 			   << yh1 << ", " << bl1 << ", " << tl1 << ", " 
 			   << alp/CLHEP::deg << ", " << yh2 << ", "
 			   << bl2 << ", " << tl2 << ", " << alp/CLHEP::deg;
+#endif
+  
   glog = DDLogicalPart(solid.ddname(), matabsorbr, solid);
 
   DDTranslation r2(xpos, ypos, zpos);
   cpv.position(glog, module, 1, r2, rot);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			   << " number 1 positioned in " << module.name() 
 			   << " at " << r2 << " with " << rot;
+#endif
 }
 
 
 void DDHCalEndcapAlgo::constructInsideModule(DDLogicalPart module, int mod, DDCompactView& cpv) {
   
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: \t\tInside module ..." 
 			   << mod;
-
+#endif
+  
   ///////////////////////////////////////////////////////////////
   //Pointers to the Rotation Matrices and to the Materials
   string rotstr = getRotMat();
@@ -826,10 +941,14 @@ void DDHCalEndcapAlgo::constructInsideModule(DDLogicalPart module, int mod, DDCo
       double routB = (zo    - getZ1Beam()) * getSlope();
       if (routF > getRoutBlock2(mod)) routF =  getRoutBlock2(mod);
       if (routB > getRoutBlock2(mod)) routB =  getRoutBlock2(mod);
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: Layer " << i <<" Phi "
 			       << iphi << " Front " << ziAir << ", " << rinF
 			       << ", " << routF << " Back " << zo << ", "
 			       << rinB << ", " << routB;
+#endif
+
       double yh1, bl1, tl1, yh2, bl2, tl2, theta, phi, alp;
       double xpos, ypos, zpos;
       parameterLayer(iphi, rinF, routF, rinB, routB, ziAir, zo, yh1, bl1, tl1, 
@@ -839,6 +958,8 @@ void DDHCalEndcapAlgo::constructInsideModule(DDLogicalPart module, int mod, DDCo
       solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
 				   0.5*getThick(mod), theta, phi, yh1,
 				   bl1, tl1, alp, yh2, bl2, tl2, alp);
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << solid.name() 
 			       << " Trap made of " << getGenMat() 
 			       << " of dimensions " << 0.5*getThick(mod) << ", "
@@ -846,15 +967,20 @@ void DDHCalEndcapAlgo::constructInsideModule(DDLogicalPart module, int mod, DDCo
 			       << ", " << yh1 << ", " << bl1 << ", " << tl1 
 			       << ", " << alp/CLHEP::deg << ", " << yh2 << ", "
 			       << bl2 << ", " << tl2 << ", " << alp/CLHEP::deg;
+#endif
+
       glog = DDLogicalPart(solid.ddname(), matter, solid);
 
       DDTranslation r1(xpos, ypos, zpos);
       cpv.position(glog, module, layer+1, r1, rot);
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			       << " number " << layer+1 << " positioned in " 
 			       << module.name() << " at " << r1 << " with "
 			       << rot;
-
+#endif
+      
       //Now the plastic with scintillators
       double yh = 0.5 * (routF - rinB) - getTrim(mod,iphi);
       double bl = 0.5 * rinB  * tan(alpha) - getTrim(mod,iphi);
@@ -863,22 +989,29 @@ void DDHCalEndcapAlgo::constructInsideModule(DDLogicalPart module, int mod, DDCo
       solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
 				   0.5*getLayerT(layer), 0, 0, yh,
 				   bl, tl, alp, yh, bl, tl, alp);
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << solid.name() 
 			       << " Trap made of " << getPlastMat() 
 			       << " of dimensions " << 0.5*getLayerT(layer) 
 			       << ", 0, 0, " << yh << ", " << bl << ", " << tl
 			       << ", " << alp/CLHEP::deg << ", " << yh << ", " 
 			       << bl << ", " << tl << ", " << alp/CLHEP::deg;
+#endif
+
       plog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
       ypos = 0.5*(routF+rinB) - xpos;
       DDTranslation r2(0., ypos, 0.);
       cpv.position(plog, glog, idOffset+layer+1, r2, DDRotation());
+
+#ifdef EDM_ML_DEBUG
       edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << plog.name() 
 			       << " number " << idOffset+layer+1 
 			       << " positioned in " << glog.name() << " at " 
 			       << r2 << " with no rotation";
-
+#endif
+      
       //Constructin the scintillators inside
       int copyNo = layer*10 + getLayerType(layer);
       name = getModName(mod)+getLayerName(layer)+getPhiName(iphi);
@@ -900,18 +1033,23 @@ void DDHCalEndcapAlgo::constructScintLayer(DDLogicalPart detector, double dz,
 
   DDSolid solid = DDSolidFactory::trap(DDName(name, idNameSpace), 0.5*dz, 0, 0,
 				       yh, bl, tl, alp, yh, bl, tl, alp);
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " 
 			   << DDName(name,idNameSpace) << " Trap made of " 
 			   << getScintMat() <<" of dimensions " << 0.5*dz 
 			   << ", 0, 0, " << yh << ", "  << bl << ", "  << tl 
 			   << ", " << alp/CLHEP::deg << ", " << yh << ", " 
 			   << bl << ", " << tl << ", " << alp/CLHEP::deg;
-
+#endif
+  
   DDLogicalPart glog(solid.ddname(), matter, solid); 
 
   cpv.position(glog, detector, id, DDTranslation(0,0,0), DDRotation());
+
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "DDHCalEndcapAlgo test: " << glog.name() 
 			   << " number " << id << " positioned in " 
 			   << detector.name() << " at (0,0,0) with no rotation";
-
+#endif
 }

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -64,7 +64,7 @@ TrackerGeomBuilderFromGeometricDet::build( const GeometricDet* gd, const PTracke
     gdsubdetmap[subdetgd[i]->geographicalId().subdetId()-1]= subdetgd[i]->type();
     LogTrace("SubDetectorGeometricDetType") << "subdet " << i 
 					    << " type " << subdetgd[i]->type()
-					    << " detid " <<  subdetgd[i]->geographicalId()
+					    << " detid " <<  subdetgd[i]->geographicalId().rawId()
 					    << " subdetid " <<  subdetgd[i]->geographicalId().subdetId();
   }
   

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -1,6 +1,7 @@
 #include <typeinfo>
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -13,9 +14,6 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
-
-
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 
 namespace {
 GeomDetEnumerators::SubDetector
@@ -87,7 +85,9 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
   }
   LogDebug("DetTypeList") << " Content of DetTypetList : size " << theDetTypetList.size();
   for (auto iVal : theDetTypetList) {
-    LogDebug("DetTypeList") << " DetId " <<  std::get<0>(iVal) << " Type " << std::get<1>(iVal)<< " Thickness " << std::get<2>(iVal);
+    LogDebug("DetTypeList") << " DetId " << std::get<0>(iVal)
+			    << " Type " << static_cast<std::underlying_type<TrackerGeometry::ModuleType>::type>(std::get<1>(iVal))
+			    << " Thickness " << std::get<2>(iVal);
   }  
 }
 


### PR DESCRIPTION
- Allow compilation with EDM_ML_DEBUG
- Silence non-debug printout

@bsunanda - FYI, when you need debug output from DDHCalEndcapAlgo, just check it out and build it with:

```
scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
```
