### PR TITLE
FixAxisLimits

### DIFF
--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -205,12 +205,12 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         ),
 
     TH2CStripVsCpixel = cms.PSet(
-        Nbinsx = cms.int32(150),
+        Nbinsx = cms.int32(300),
         xmin   = cms.double(-0.5),
-        xmax   = cms.double(74999.5),
-        Nbinsy = cms.int32(50),
+        xmax   = cms.double(149999.5),
+        Nbinsy = cms.int32(60),
         ymin   = cms.double(-0.5),
-        ymax   = cms.double(14999.5),
+        ymax   = cms.double(17999.5),
         globalswitchon = cms.bool(True)
         ),
                                        
@@ -244,8 +244,8 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
                                        
 # Number of Cluster in Strip
     TH1NClusStrip = cms.PSet(
-        Nbinsx = cms.int32(500),
-        xmax = cms.double(99999.5),                      
+        Nbinsx = cms.int32(600),
+        xmax = cms.double(119999.5),                      
         xmin = cms.double(-0.5)
         ),
 

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -32,14 +32,14 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                                   maxWidth = cms.double(200.0)
                                   ),
     
-    TH1nClustersOn = cms.PSet( Nbinx = cms.int32(100),
+    TH1nClustersOn = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
-                             xmax  = cms.double(1999.5)
+                             xmax  = cms.double(2999.5)
                              ),   
 
-    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(100),
+    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
-                             xmax  = cms.double(14999.5)
+                             xmax  = cms.double(19999.5)
                              ),
     
     TH1ClusterCharge = cms.PSet(


### PR DESCRIPTION
Fix the range of axis limits for Strip and Pixel cluster number plots to fit the higher luminosity of the machine
