### PR TITLE
Update Global Tags: new JEC, introducing HcalFrontEndMapRcd, updated Phase-I Pixel Geometry

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,35 +12,31 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '81X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v1',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v1',
+    'run1_data'         :   '81X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v1',
-    # GlobalTag for Run2 data (as Prompt) WILL DISAPPEAR ONCE RERECO UPDATED
-    'run2_prompt_WillDisappearInJul16' :   '81X_dataRun2_Run2016B_Prompt_frozen_v2',
+    'run2_data'         :   '81X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
-    # GlobalTag for Run2 data (as HLT) WILL DISAPPEAR ONCE RERECO UPDATED
-    'run2_hlt_WillDisappearInJul16'    :   '81X_dataRun2_Run2016B_HLT_frozen_v1',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v11',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v0',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v3',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v4',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v3',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1020,7 +1020,7 @@ steps['HLTDR2_25ns']=merge( [ {'-s':'L1REPACK:GT2,HLT:@%s'%hltKey25ns,},{'--cond
 
 hltKey2016='relval2016'
 menuR2_2016 = autoHLT[hltKey2016]
-steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_WillDisappearInJul16'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
+steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
 # use --era 
 steps['RECODR2_50ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_50ns',},dataReco])
@@ -1161,7 +1161,7 @@ steps['RECODreHLTAlCaCalo']=merge([{'--hltProcess':'reHLT','--conditions':'auto:
 
 steps['RECODR2_25nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_25ns']])
 steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']])
-steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_prompt_WillDisappearInJul16'},steps['RECODR2_2016']])
+steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2_2016']])
 steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
 
 


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v2) as [81X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v2/81X_mcRun2_design_v1): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration 
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v2) as [81X_mcRun2cosmics_startup_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v2/81X_mcRun2cosmics_startup_peak_v1): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration 
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v2) as [81X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v2/81X_mcRun2_asymptotic_v1): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration 
- **RunII Startup scenario** : [81X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v2) as [81X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v2/81X_mcRun2_startup_v1): 
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration 
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v2) as [81X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v2/81X_mcRun2_HeavyIon_v1): 
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration 
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v2) as [81X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v2/81X_dataRun2_v1): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: four IOVs that have the description of the front end map during different periods of data taking (Run1, Long Shutdown 1 and Run 2)
- **RunII HLTHI processing** : [81X_dataRun2_HLTHI_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v0) as [80X_dataRun2_HLTHI_frozen_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v0/80X_dataRun2_HLTHI_frozen_v9): 
  - new tag for `HcalFrontEndMapRcd`: four IOVs that have the description of the front end map during different periods of data taking (Run1, Long Shutdown 1 and Run 2)
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v0) as [80X_dataRun2_HLT_relval_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v0/80X_dataRun2_HLT_relval_v11): 
  - new tag for `HcalFrontEndMapRcd`: four IOVs that have the description of the front end map during different periods of data taking (Run1, Long Shutdown 1 and Run 2)
- **RunII HLT processing** : [81X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v0) as [80X_dataRun2_HLT_frozen_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v0/80X_dataRun2_HLT_frozen_v12): 
  - new tag for `HcalFrontEndMapRcd`: four IOVs that have the description of the front end map during different periods of data taking (Run1, Long Shutdown 1 and Run 2)
- **RunII Offline relval processing** : [81X_dataRun2_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v2) as [81X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v2/81X_dataRun2_relval_v1): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: four IOVs that have the description of the front end map during different periods of data taking (Run1, Long Shutdown 1 and Run 2)
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v4) as [81X_upgrade2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v4/81X_upgrade2017_realistic_v3): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration
  - updated phase-I tracker geometry to `81YV5` (Updated Phase 1 BPIX Geometry #14726)
- **PhaseI design scenario** : [81X_upgrade2017_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v4) as [81X_upgrade2017_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v4/81X_upgrade2017_design_v3): 
  - updated Jet Energy corrections and resolutions from `Spring16_v6` package
  - new tag for `HcalFrontEndMapRcd`: Run2 + QIE10 channels configuration
  - updated phase-I tracker geometry to `81YV5` (Updated Phase 1 BPIX Geometry #14726)

---

Since conditions in the `offline` tags for re-reco have been updated with IOVs for 2016, we can remove now the temporary keys `auto:run2_*_WillDisappearInJul16` from the 2016B relval matrix
