### PR TITLE
Fix calling dtor on an abstract class with non-virtual dtor

### DIFF
--- a/TrackingTools/GeomPropagators/interface/HelixPlaneCrossing.h
+++ b/TrackingTools/GeomPropagators/interface/HelixPlaneCrossing.h
@@ -45,6 +45,7 @@ public:
    */
   virtual DirectionType direction( double s) const = 0;
 
+  virtual ~HelixPlaneCrossing() = default;
 };
 
 #endif


### PR DESCRIPTION
Clang pre-3.9 fails with an error:

```
In file included from src/TrackingTools/GeomPropagators/src/Aq:12:
TrackingTools/GeomPropagators/interface/OptimalHelixPlaneCrossing.h:42:34: error: destructor called on 'HelixPlaneCrossing' that is abstract but has non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
  ~OptimalHelixPlaneCrossing() { get()->~Base(); }
                                 ^
src/TrackingTools/GeomPropagators/interface/OptimalHelixPlaneCrossing.h:42:41: note: qualify call to silence this warning
  ~OptimalHelixPlaneCrossing() { get()->~Base(); }
                                        ^
                                        HelixPlaneCrossing::
1 error generated.
```

The changeset in Clang: http://reviews.llvm.org/D16206

Quote from C++ Standard used in this Clang changeset:

```
C++ [expr.delete]p3:
  In the first alternative (delete object), if the static type of the
  object to be deleted is different from its dynamic type, the static
  type shall be a base class of the dynamic type of the object to be
  deleted and the static type shall have a virtual destructor or the
  behavior is undefined.
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
