### PR TITLE
RecoMuon/MuonSeedGenerator : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedPtExtractor.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedPtExtractor.cc
@@ -211,7 +211,8 @@ std::vector<double> MuonSeedPtExtractor::pT_extract(MuonTransientTrackingRecHit:
     //eta = innerPoint.eta();
     GlobalVector gv = innerHit->globalDirection();
     double gvPerpPos = gv.x()*gv.x() + gv.y()*gv.y();
-    if (gvPerpPos < 1e-32) gvPerpPos = 1e-32; gvPerpPos=sqrt(gvPerpPos);
+    if (gvPerpPos < 1e-32) gvPerpPos = 1e-32; 
+    gvPerpPos=sqrt(gvPerpPos);
     // Psi is angle between the segment origin and segment direction
     // Use dot product between two vectors to get Psi in global x-y plane
     double cosDpsi  = (gv.x()*innerPoint.x() + gv.y()*innerPoint.y());


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoMuon/MuonSeedGenerator/src/MuonSeedPtExtractor.cc: In member function 'virtual std::vector<double> MuonSeedPtExtractor::pT_extract(MuonTransientTrackingRecHit::ConstMuonRecHitPointer, MuonTransientTrackingRecHit::ConstMuonRecHitPointer) const':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoMuon/MuonSeedGenerator/src/MuonSeedPtExtractor.cc:214:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
      if (gvPerpPos < 1e-32) gvPerpPos = 1e-32; gvPerpPos=sqrt(gvPerpPos);
     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoMuon/MuonSeedGenerator/src/MuonSeedPtExtractor.cc:214:47: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     if (gvPerpPos < 1e-32) gvPerpPos = 1e-32; gvPerpPos=sqrt(gvPerpPos);
                                               ^~~~~~~~~
