### PR TITLE
RecoLocalTracker/SubCollectionProducers : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -141,10 +141,10 @@ HLTTrackClusterRemoverNew::HLTTrackClusterRemoverNew(const ParameterSet& iConfig
       if (not (iConfig.getParameter<InputTag>("oldClusterRemovalInfo")== edm::InputTag())) mergeOld_=true;
     }
 
-  if ((doPixelChargeCheck_ && !doPixel_) || (doStripChargeCheck_ && !doStrip_))
-    throw cms::Exception("Configuration Error") << "HLTTrackClusterRemoverNew: Charge check asked without cluster collection ";
-  if (doPixelChargeCheck_)
-    throw cms::Exception("Configuration Error") << "HLTTrackClusterRemoverNew: Pixel cluster charge check not yet implemented";
+    if ((doPixelChargeCheck_ && !doPixel_) || (doStripChargeCheck_ && !doStrip_))
+      throw cms::Exception("Configuration Error") << "HLTTrackClusterRemoverNew: Charge check asked without cluster collection ";
+    if (doPixelChargeCheck_)
+      throw cms::Exception("Configuration Error") << "HLTTrackClusterRemoverNew: Pixel cluster charge check not yet implemented";
 
     fill(pblocks_, pblocks_+NumberOfParamBlocks, ParamBlock());
     readPSet(iConfig, "Common",-1);


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc: In constructor 'HLTTrackClusterRemoverNew::HLTTrackClusterRemoverNew(const edm::ParameterSet&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc:146:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (doPixelChargeCheck_)
   ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc:149:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     fill(pblocks_, pblocks_+NumberOfParamBlocks, ParamBlock());
     ^~~~
