### PR TITLE
RecoLocalTracker/SiStripRecHitConverter : formating fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/src/CrosstalkInversion.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/CrosstalkInversion.cc
@@ -29,10 +29,13 @@ unfold(const SiStripCluster& clus, const float x) {
     for(unsigned i=0; i<(N+1)/2; i++) {
       for(unsigned j=i; j<N-i; j++) {
 	const float Cij = inverse(i+1,j+1);
-	Q[i+1] += Cij * STATS(q[  j  ]) ;  if( i!=j)   
-	Q[j+1] += Cij * STATS(q[  i  ]) ;  if( N!=i+j+1) {
-	Q[N-i] += Cij * STATS(q[N-j-1]) ;  if( i!=j)
-	Q[N-j] += Cij * STATS(q[N-i-1]) ;
+	Q[i+1] += Cij * STATS(q[  j  ]) ;
+	if( i!=j)
+	Q[j+1] += Cij * STATS(q[  i  ]) ;  
+	if( N!=i+j+1) {
+		Q[N-i] += Cij * STATS(q[N-j-1]) ;  
+		if( i!=j)
+		Q[N-j] += Cij * STATS(q[N-i-1]) ;
 	}
       }
     }


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalTracker/SiStripRecHitConverter/src/CrosstalkInversion.cc:32:37: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   Q[i+1] += Cij \* STATS(q[  j  ]) ;  if( i!=j)
                                     ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalTracker/SiStripRecHitConverter/src/CrosstalkInversion.cc:33:37: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  Q[j+1] += Cij \* STATS(q[  i  ]) ;  if( N!=i+j+1) {
                                     ^~
