### PR TITLE
RecoLocalMuon/RPCRecHit : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -123,7 +123,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
 
                 DTChamberId dtid(geomDet->geographicalId().rawId());
                 int dtW=dtid.wheel(), dtS=dtid.sector(), dtT=dtid.station();
-                if(dtS==13) dtS=4; if(dtS==14) dtS=10;
+                if(dtS==13) dtS=4; 
+                if(dtS==14) dtS=10;
                 DTStationIndex theindex(0,dtW,dtS,dtT);
                 std::set<RPCDetId> rollsForThisDT = dtMap->getRolls(theindex);
                 for(std::set<RPCDetId>::iterator iteraRoll = rollsForThisDT.begin();iteraRoll != rollsForThisDT.end(); iteraRoll++)
@@ -172,7 +173,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
 
 	        int En = cscid.endcap(), St = cscid.station(), Ri = cscid.ring();
 	        int rpcSegment = cscid.chamber();
-                if(En==2) En= -1; if(Ri==4) Ri =1; 
+                if(En==2) En= -1; 
+                if(Ri==4) Ri =1; 
 
                 CSCStationIndex theindex(En,St,Ri,rpcSegment);
                 std::set<RPCDetId> rollsForThisCSC = cscMap->getRolls(theindex);
@@ -232,7 +234,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
 
                DTChamberId dtid(geomDet->geographicalId().rawId());
                int Se = dtid.sector(), Wh = dtid.wheel(), St = dtid.station();
-               if(Se == 13) Se=4; if(Se ==14) Se=10;  
+               if(Se == 13) Se=4;
+               if(Se ==14) Se=10;  
 
                if( rEn==0&& (rSe-Se)==0 && (rWr-Wh) ==0 && (rSt-St)==0 && distanceN < distance)
                {
@@ -251,7 +254,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
 
                CSCDetId cscid(geomDet->geographicalId().rawId());
                int En =cscid.endcap(), Ri=cscid.ring(), St=cscid.station(), Ch=cscid.chamber();
-               if(En==2) En=-1; if(Ri==4) Ri=1;
+               if(En==2) En=-1;
+               if(Ri==4) Ri=1;
 
                if((rEn-En)==0 && (rSt-St)==0 && (Ch-rCh) ==0 && rWr!=1 && rSt!=4 && distanceN < distance)
                {


### PR DESCRIPTION
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc: In constructor 'TracktoRPC::TracktoRPC(const TrackCollection*, const edm::EventSetup&, bool, const edm::ParameterSet&, const edm::InputTag&)':
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:126:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                  if(dtS==13) dtS=4; if(dtS==14) dtS=10;
                 ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:126:36: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                 if(dtS==13) dtS=4; if(dtS==14) dtS=10;
                                    ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:175:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                  if(En==2) En= -1; if(Ri==4) Ri =1;
                 ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:175:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                 if(En==2) En= -1; if(Ri==4) Ri =1;
                                   ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:235:16: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                 if(Se == 13) Se=4; if(Se ==14) Se=10;
                ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:235:35: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                if(Se == 13) Se=4; if(Se ==14) Se=10;
                                   ^~
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:254:16: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                 if(En==2) En=-1; if(Ri==4) Ri=1;
                ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc:254:33: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                if(En==2) En=-1; if(Ri==4) Ri=1;
                                 ^~
