### PR TITLE
RecoJet/JetAlgorithms : formatting fix for gcc 6.0 misleading-indentation warning

### DIFF
--- a/RecoJets/JetAlgorithms/src/SubjetFilterAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/SubjetFilterAlgorithm.cc
@@ -181,7 +181,8 @@ void SubjetFilterAlgorithm::run(const std::vector<fastjet::PseudoJet>& fjInputs,
 	  cout<<"Rbb="<<Rbb<<", Rfilt="<<Rfilt<<endl;
 	  cout<<"FILTER JETS: "<<flush;
 	  for (size_t i=0;i<fjFilterJets.size();i++) {
-	    if (i>0) cout<<"             "<<flush; cout<<fjFilterJets[i]<<endl;
+	    if (i>0) cout<<"             "<<flush; 
+	    cout<<fjFilterJets[i]<<endl;
 	  }
 	}
 	


### PR DESCRIPTION
  /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoJets/JetAlgorithms/src/SubjetFilterAlgorithm.cc:184:6: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if (i>0) cout<<"             "<<flush; cout<<fjFilterJets[i]<<endl;
      ^~
/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/af38ea181bab81af50738f2f40bb931e/opt/cmssw/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-07-05-2300/src/RecoJets/JetAlgorithms/src/SubjetFilterAlgorithm.cc:184:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
      if (i>0) cout<<"             "<<flush; cout<<fjFilterJets[i]<<endl;
                                             ^~~~
