### PR TITLE
Fix an obvious bug in DQM Online input source.

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -255,7 +255,7 @@ void DQMFileIterator::collect(bool ignoreTimers) {
         unsigned int lumi = std::stoi(result[2]);
         std::string label = result[3];
 
-        filesSeen_.insert(fn);
+        filesSeen_.insert(filename);
 
         if (run != runNumber_) continue;
 


### PR DESCRIPTION
It caused the log file to explode for a single specific application.
