### PR TITLE
Fix LED RMS Quality threshold

### DIFF
--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -157,7 +157,8 @@ namespace ecaldqm
         float intensity(aMean / expectedAmplitude_[wlItr->second]);
         if(isForward(id)) intensity /= forwardFactor_;
 
-        if(intensity < toleranceAmplitude_ || aRms > aMean * toleranceAmpRMSRatio_ ||
+        float aRmsThr( sqrt(pow(aMean*toleranceAmpRMSRatio_,2) + pow(3.,2)) );
+        if(intensity < toleranceAmplitude_ || aRms > aRmsThr ||
            abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ || tRms > toleranceTimRMS_)
           qItr->setBinContent(doMask ? kMBad : kBad);
         else


### PR DESCRIPTION
Fix quality threshold in LED amplitude RMS so that we no longer show unwanted RED channels at high-eta region:
- Allow for spread in amplitude noise in threshold: 0.5*AmpMean -> sqrt[ (0.5xAmpMean)^2 + 3^2 ]

In conjunction with 81X PR https://github.com/cms-sw/cmssw/pull/15173
