### PR TITLE
updating JECs and Tracker Alignment tag for HLT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,29 +10,29 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v15',
+    'run2_design'       :   '80X_mcRun2_design_v16',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '80X_mcRun2_startup_v15',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v15',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v16',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v14',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v9',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v16',
+    'run1_data'         :   '80X_dataRun2_v17',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v16',
+    'run2_data'         :   '80X_dataRun2_v17',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v14',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v15',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v12',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v11',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v12',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v9',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '80X_upgrade2017_design_v15',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v16) as [80X_mcRun2_design_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v16/80X_mcRun2_design_v15): 
  - updated JEC to `Spring16_25ns_v3` [HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2417.html)
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v16) as [80X_mcRun2_asymptotic_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v16/80X_mcRun2_asymptotic_v15): 
  - updated JEC to `Spring16_25ns_v3` [HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2417.html)
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v17) as [80X_dataRun2_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v16) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v17/80X_dataRun2_v16): 
  - updated JEC to `Spring16_25ns_v3` [HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2417.html) as in ICHEP2016B re-reco
- **RunII HLTHI processing** : [80X_dataRun2_HLTHI_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v10) as [80X_dataRun2_HLTHI_frozen_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v10/80X_dataRun2_HLTHI_frozen_v9): 
  - technical change of Tracker Alignment tag to allow enabling of `SiPixelAli` PCL worfklow
- **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v13) as [80X_dataRun2_HLT_frozen_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v13/80X_dataRun2_HLT_frozen_v12): 
  - technical change of Tracker Alignment tag to allow enabling of `SiPixelAli` PCL worfklow
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v12) as [80X_dataRun2_HLT_relval_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v12/80X_dataRun2_HLT_relval_v11): 
  - technical change of Tracker Alignment tag to allow enabling of `SiPixelAli` PCL worfklow
- **RunII Offline relval processing** : [80X_dataRun2_relval_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v15) as [80X_dataRun2_relval_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v14) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v15/80X_dataRun2_relval_v14): 
  - updated JEC to `Spring16_25ns_v3` [HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2417.html) ) as in ICHEP2016B re-reco
# 

Side note: the change of snapshot will allow to "see" in the data (HLT and RECO) Global Tags the new IOV for 2016B as in the ICHEP Re-Reco @fabozzi 
