### PR TITLE
Fixed static analyser warnings in sim-packages 4

### DIFF
--- a/Alignment/CocoaModel/interface/ALIUnitsTable.h
+++ b/Alignment/CocoaModel/interface/ALIUnitsTable.h
@@ -1,24 +1,5 @@
 //
-// ********************************************************************
-// * DISCLAIMER                                                       *
-// *                                                                  *
-// * The following disclaimer summarizes all the specific disclaimers *
-// * of contributors to this software. The specific disclaimers,which *
-// * govern, are listed with their locations in:                      *
-// *   http://cern.ch/geant4/license                                  *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.                                                             *
-// *                                                                  *
-// * This  code  implementation is the  intellectual property  of the *
-// * GEANT4 collaboration.                                            *
-// * By copying,  distributing  or modifying the Program (or any work *
-// * based  on  the Program)  you indicate  your  acceptance of  this *
-// * statement, and all its terms.                                    *
-// ********************************************************************
+// This class was derived from Geant4 by Pedro Arce
 //
 // -----------------------------------------------------------------
 //

--- a/Alignment/CocoaModel/interface/ALIUnitsTable.h
+++ b/Alignment/CocoaModel/interface/ALIUnitsTable.h
@@ -1,5 +1,24 @@
 //
-// This class was derived from Geant4 by Pedro Arce
+// ********************************************************************
+// * DISCLAIMER                                                       *
+// *                                                                  *
+// * The following disclaimer summarizes all the specific disclaimers *
+// * of contributors to this software. The specific disclaimers,which *
+// * govern, are listed with their locations in:                      *
+// *   http://cern.ch/geant4/license                                  *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.                                                             *
+// *                                                                  *
+// * This  code  implementation is the  intellectual property  of the *
+// * GEANT4 collaboration.                                            *
+// * By copying,  distributing  or modifying the Program (or any work *
+// * based  on  the Program)  you indicate  your  acceptance of  this *
+// * statement, and all its terms.                                    *
+// ********************************************************************
 //
 // -----------------------------------------------------------------
 //

--- a/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentProducer.h
+++ b/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentProducer.h
@@ -16,14 +16,14 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "HepMC/GenEvent.h"
 
 //
 // class decleration
 //
-class LaserAlignmentProducer : public edm::EDProducer {
+class LaserAlignmentProducer : public edm::one::EDProducer<> {
  public:
 	/// constructor
   explicit LaserAlignmentProducer(const edm::ParameterSet&);

--- a/SimRomanPot/SimFP420/interface/DigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/DigitizerFP420.h
@@ -4,7 +4,7 @@
 ///////////////////////////////////////////////////////////////////////
 #include "boost/shared_ptr.hpp"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -12,23 +12,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-
-//////////////////
-//#include "SimG4Core/Watcher/interface/SimWatcher.h"
-
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-//#include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-//#include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 #include "SimRomanPot/SimFP420/interface/FP420DigiMain.h"
 
 #include "DataFormats/FP420Digi/interface/DigiCollectionFP420.h"
 #include "DataFormats/FP420Digi/interface/HDigiFP420.h"
-//#include "SimRomanPot/SimFP420/interface/DigiCollectionFP420.h"
 
 #include <CLHEP/Vector/ThreeVector.h>
 #include <string>
@@ -38,26 +30,17 @@
 
 namespace cms
 {
-  class DigitizerFP420: public edm::EDProducer
+  class DigitizerFP420: public edm::one::EDProducer<>
   {
   public:
-    //     typedef DigiCollectionFP420<unsigned int, HDigiFP420> DigiColFP420;
     
     explicit DigitizerFP420(const edm::ParameterSet& conf);
     
     virtual ~DigitizerFP420();
     
-    //    virtual void produce(PSimHitCollection*, DigiCollectionFP420&);
     virtual void produce(edm::Event& e, const edm::EventSetup& c);
-    
-    //     virtual void prodfun(MixCollection<PSimHit>*, DigiCollectionFP420 &);
-    //  virtual void prodfun(std::unique_ptr<MixCollection<PSimHit> >*, DigiCollectionFP420 &);
-    
-    
-    //           virtual void prodfun(std::unique_ptr<MixCollection<PSimHit> >&, DigiCollectionFP420 &);
-    
+
   private:
-    //  std::vector<PSimHit> theStripHits;
     typedef std::vector<std::string> vstring;
     typedef std::map<unsigned int, std::vector<PSimHit>,std::less<unsigned int> > simhit_map;
     typedef simhit_map::iterator simhit_map_iterator;
@@ -66,38 +49,12 @@ namespace cms
     edm::ParameterSet conf_;
     vstring trackerContainers;
     
-    //  HitDigitizerFP420* theHitDigitizerFP420;
-    //    FP420DigiMain stripDigitizer_;
     FP420DigiMain* stripDigitizer_;
-    //  FP420DigiMain * theFP420DigiMain;
     int numStrips;    // number of strips in the module
     
     int dn0, sn0, pn0, rn0, verbosity;
-    
-    
+        
     std::vector<HDigiFP420> collector;
-    
-    //   DigiCollectionFP420 * output;
-    
-    
-    //   std::vector<edm::DetSet<HDigiFP420> > output;
-    
-    //      DigiCollectionFP420* poutput;
-    
-    //  std::map<GeomDetType* , boost::shared_ptr<FP420DigiMain> > theAlgoMap; 
-    // std::vector<edm::DetSet<HDigiFP420> > outputfinal;
-    //    std::vector<edm::DetSet<HDigiFP420SimLink> > theDigiLinkVector;
-    //      std::vector<edm::DetSet<PixelDigi> > theDigiVector;
-    
-    
-    
-    
-    //    G4ThreeVector bfield(G4ThreeVector);
-    //    G4ThreeVector bfield(double, double, double);
-    //    G4ThreeVector bfield(float, float, float);
-    //    G4ThreeVector bfield();
-    
-    
   };
 }
 

--- a/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
+++ b/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
@@ -9,9 +9,6 @@
 #include <memory>
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-//#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-//#include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
-//#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -28,14 +25,8 @@
 ///////////////////////////////////////////////////////////////////////////
 #include "SimRomanPot/SimFP420/interface/DigitizerFP420.h"
 
-//#include "SimRomanPot/SimFP420/interface/SimRPUtil.h"
-//#include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
-
 #include "DataFormats/FP420Digi/interface/DigiCollectionFP420.h"
 #include "DataFormats/FP420Digi/interface/HDigiFP420.h"
-//#include "SimRomanPot/SimFP420/interface/DigiCollectionFP420.h"
-//#include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
-//#include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 
 //needed for the geometry:
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -44,26 +35,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-//#include "Geometry/CommonTopologies/interface/StripTopology.h"
-//#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
-//#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-//needed for the magnetic field:
-//#include "MagneticField/Engine/interface/MagneticField.h"
-//#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-//#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-
-//Data Base infromations
-//#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
-//#include "CalibTracker/Records/interface/SiStripGainRcd.h"
-//#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
-//#include "CondFormats/DataRecord/interface/SiStripPedestalsRcd.h"
-//#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
-//#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
-//#include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
-//#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-//#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-//#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
 //Random Number
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -86,15 +58,9 @@
 
 using namespace std;
 
-//#include <iostream>
-
-
-
-
 namespace cms
 {
   DigitizerFP420::DigitizerFP420(const edm::ParameterSet& conf):conf_(conf),stripDigitizer_(new FP420DigiMain(conf)) {
-    
     
     std::string alias ( conf.getParameter<std::string>("@module_label") );
     
@@ -128,8 +94,7 @@ namespace cms
     if(verbosity>0) {
       std::cout << "Creating a DigitizerFP420" << std::endl;
       std::cout << "DigitizerFP420: dn0=" << dn0 << " sn0=" << sn0 << " pn0=" << pn0 <<  " rn0=" << rn0 << std::endl;
-      std::cout << "DigitizerFP420:trackerContainers.size()=" << trackerContainers.size() << std::endl;
-      
+      std::cout << "DigitizerFP420:trackerContainers.size()=" << trackerContainers.size() << std::endl;      
     }
   }
   
@@ -139,11 +104,7 @@ namespace cms
       std::cout << "Destroying a DigitizerFP420" << std::endl;
     }
     delete stripDigitizer_;
-    
   }  
-  
-  
-  
   //  void DigitizerFP420::produce(PSimHitCollection *   theCAFI, DigiCollectionFP420 & output) {
   void DigitizerFP420::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
     // be lazy and include the appropriate namespaces
@@ -162,7 +123,6 @@ namespace cms
     
     // Step A: Get Inputs for allTrackerHits
     
-    
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     std::vector<const CrossingFrame<PSimHit> *> cf_simhitvec;
     for(uint32_t i = 0; i< trackerContainers.size();i++){
@@ -180,27 +140,7 @@ namespace cms
 	  std::unique_ptr<MixCollection<PSimHit> > allTrackerHits( new MixCollection<PSimHit>(xFrame.product()) );
 	  std::cout <<" ============== DigitizerFP420: start loop           4   " << std::endl;
     */
-    
-    // use instead of the previous
-    /*           
-		 edm::Handle<CrossingFrame<PSimHit> > crossingFrame;
-		 const std::string FP420HitsName("FP420SI");
-		 bool isHit = true;
-		 iEvent.getByLabel("mix",FP420HitsName,crossingFrame);
-		 MixCollection<PSimHit> * FP420Hits = 0 ;
-		 std::cout <<" ============== DigitizerFP420: start loop           1   " << std::endl;
-		 //    std::unique_ptr<MixCollection<PSimHit> > allTrackerHits(new MixCollection<PSimHit>(crossingFrame.product()));
-		 FP420Hits = new MixCollection<PSimHit>(crossingFrame.product());
-		 std::cout <<" ============== DigitizerFP420: start loop           2   " << std::endl;
-		 //  if ( ! FP420Hits->inRegistry()  ) isHit = false;
-		 //  if ( isHit ) {
-		 std::unique_ptr<MixCollection<PSimHit> >  allTrackerHits( FP420Hits );
-		 std::cout <<" ============== DigitizerFP420: start loop           3   " << std::endl;
-		 //  }  
-		 */
-    
-    //    std::cout << "DigitizerFP420 Step A done" << std::endl;
-    
+        
     //Loop on PSimHit
     
     
@@ -314,17 +254,6 @@ namespace cms
 	  if(verbosity>0 || verbosity==-50) std::cout <<" ====== DigitizerFP420: unitID= " << unitID << "Hit number i=  " << i << std::endl;
 	  int det, zside, sector, zmodule; 
 	  FP420NumberingScheme::unpackFP420Index(unitID, det, zside, sector, zmodule);
-	  // <------
-	  // old: <------
-	  //     for (int det=1; det<dn0; det++) {
-	  //	for (int sector=1; sector<sn0; sector++) {
-	  // for (int zmodule=1; zmodule<pn0; zmodule++) {
-	  //  for (int zside=1; zside<rn0; zside++) {
-	  // <------
-	  
-	  
-	  
-	  
 	  
 	  unsigned int iu = FP420NumberingScheme::packMYIndex(rn0, pn0, sn0, det, zside, sector, zmodule);
 	  if(verbosity>0 || verbosity==-50) std::cout <<"for Hits iu = " << iu <<" sector = " << sector <<" zmodule = " << zmodule <<" zside = " << zside << "  det=" << det << std::endl;
@@ -481,35 +410,14 @@ namespace cms
 	//     end of check of access to the strip collection
 	
       }// if(verbosity	
-      //     
-      
       
       // Step D: write output to file
-      //    iEvent.put(std::move(output));
-      
       if(verbosity>0) {
 	std::cout << "DigitizerFP420 recoutput" << std::endl;
       }
       // Step D: write output to file
       iEvent.put(std::move(output));
-      // iEvent.put(std::move(outputlink));
-      //	  iEvent.put(std::move(pDigis));
-      
-      // Step D: write output to file 
-      //  iEvent.put(std::move(output));
-      //  iEvent.put(std::move(outputlink));
-      //-------------------------------------------------------------------
-      //    std::cout << "DigitizerFP420 recoutput" << std::endl;
-      //	  iEvent.put(std::move(pDigis));
-      
-      
-      
-      
   }//produce
   
 } // namespace cms
 
-//}
-//define this as a plug-in
-
-//DEFINE_FWK_MODULE(DigitizerFP420);

--- a/SimRomanPot/SimFP420/src/FP420DigiMain.cc
+++ b/SimRomanPot/SimFP420/src/FP420DigiMain.cc
@@ -6,23 +6,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-
-//#include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
-//#include "SimG4CMS/FP420/interface/FP420G4Hit.h"
-//#include "SimRomanPot/SimFP420/interface/SimRPUtil.h"
 #include "SimRomanPot/SimFP420/interface/FP420DigiMain.h"
 
 #include "SimRomanPot/SimFP420/interface/ChargeDrifterFP420.h"
 #include "SimRomanPot/SimFP420/interface/ChargeDividerFP420.h"
 
-//#include "SimRomanPot/SimFP420/interface/HDigiFP420.h"
 #include "DataFormats/FP420Digi/interface/HDigiFP420.h"
-//#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-//#include "DataFormats/Common/interface/DetSetVector.h"
-//#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-
-
-
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <gsl/gsl_sf_erf.h>
@@ -37,10 +26,8 @@ using namespace std;
 //#define CBOLTZ (1.38E-23)
 //#define e_SI (1.6E-19)
 
-
-
 FP420DigiMain::FP420DigiMain(const edm::ParameterSet& conf):conf_(conf){
-  std::cout << "Creating a FP420DigiMain" << std::endl;
+  edm::LogInfo("SimRomanPotSimFP420") << "Creating a FP420DigiMain";
   ndigis=0;
   verbosity        = conf_.getUntrackedParameter<int>("VerbosityLevel");
   theElectronPerADC= conf_.getParameter<double>("ElectronFP420PerAdc");
@@ -56,10 +43,11 @@ FP420DigiMain::FP420DigiMain(const edm::ParameterSet& conf):conf_(conf){
   // pn0              = 6;// number of superplanes
   // rn0              = 3; // number of sensors in superlayer
   xytype           = 2;
-  if(verbosity>0) {
-    std::cout << "theApplyTofCut=" << theApplyTofCut << " tofCut=" << tofCut << std::endl;
-    std::cout << "FP420DigiMain theElectronPerADC=" << theElectronPerADC << " theThreshold=" << theThreshold << " noNoise=" << noNoise << std::endl;
-  }
+
+  edm::LogInfo("SimRomanPotSimFP420") 
+    << "theApplyTofCut=" << theApplyTofCut << " tofCut=" << tofCut << "\n"
+    << "FP420DigiMain theElectronPerADC=" << theElectronPerADC << " theThreshold=" << theThreshold << " noNoise=" << noNoise;
+
   // X (or Y)define type of sensor (xytype=1 or 2 used to derive it: 1-Y, 2-X)
   // for every type there is normal pixel size=0.05 and Wide 0.400 mm
   Thick300 = 0.300;       // = 0.300 mm  normalized to 300micron Silicon
@@ -87,11 +75,9 @@ FP420DigiMain::FP420DigiMain(const edm::ParameterSet& conf):conf_(conf){
   //  tofCut = 1350.;           // Cut on the particle TOF range  = 1380 - 1500
   elossCut = 0.00003;           // Cut on the particle TOF   = 100 or 50
   
-  if(verbosity>0) std::cout << "FP420DigiMain moduleThickness=" << moduleThickness << std::endl;
+  edm::LogInfo("SimRomanPotSimFP420") << "FP420DigiMain moduleThickness=" << moduleThickness;
   
   float noiseRMS = ENC*moduleThickness/Thick300;
-  
-
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////  
   // Y:
@@ -111,45 +97,23 @@ FP420DigiMain::FP420DigiMain(const edm::ParameterSet& conf):conf_(conf){
     pitchW= pitchXW;
   }
   
-  //  float noiseRMS = ENC*moduleThickness/Thick300;
-  
-  
   theHitDigitizerFP420 = new HitDigitizerFP420(moduleThickness,ldrift,ldriftY,ldriftX,thez420,thezD2,thezD3,verbosity);
   int numPixels = numStrips*numStripsW;
   theGNoiseFP420 = new GaussNoiseFP420(numPixels,noiseRMS,theThreshold,addNoisyPixels,verbosity);
-  //  theGNoiseFP420 = new GaussNoiseFP420(numStrips,noiseRMS,theThreshold,addNoisyPixels);
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////  
-
-
-
-
   theZSuppressFP420 = new ZeroSuppressFP420(conf_,noiseRMS/theElectronPerADC); 
   thePileUpFP420 = new PileUpFP420();
   theDConverterFP420 = new DigiConverterFP420(theElectronPerADC,verbosity);
   
-  if(verbosity>0) std::cout << "FP420DigiMain end of constructor" << std::endl;
-
+  edm::LogInfo("SimRomanPotSimFP420") << "FP420DigiMain end of constructor";
 }
 
-
-
-
-
-
-
 FP420DigiMain::~FP420DigiMain(){
-  if(verbosity>0) {
-    std::cout << "Destroying a FP420DigiMain" << std::endl;
-  }
   delete theGNoiseFP420;
   delete theZSuppressFP420;
   delete theHitDigitizerFP420;
   delete thePileUpFP420;
-  delete theDConverterFP420;
-  
+  delete theDConverterFP420;  
 }
-
-
 
 //  Run the algorithm
 //  ------------------
@@ -158,8 +122,6 @@ vector <HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
 				       const G4ThreeVector& bfield, unsigned int iu )  {
 
   thePileUpFP420->reset();
-  //  unsigned int detID = det->globalId().rawId();
-  //  unsigned int detID = 1;
   bool first = true;
   
   // main loop 
@@ -198,26 +160,13 @@ vector <HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
       std::cout << " particleType= " << ihit.particleType() << std::endl;
   }
 
-  //
-
-  //  if ( ( !(theApplyTofCut)  ||  (theApplyTofCut &&   tofCut < abs(tof) < (tofCut+200.)) ) && losenergy > elossCut) {
     if ( ( !(theApplyTofCut)  ||  ( theApplyTofCut &&   abs(tof) > tofCut && abs(tof) < (tofCut+200.)) ) && losenergy > elossCut) {
-      //    if ( abs(tof) < tofCut && losenergy > elossCut) {
-      // if ( losenergy>0) {
       if(verbosity>0) std::cout << " inside tof: OK " << std::endl;
       
-      //   xytype = 1 - Y strips;   =2 - X strips;
-      //	  HitDigitizerFP420::hit_map_type _temp = theHitDigitizerFP420->processHit(ihit,bfield,xytype,numStrips,pitch);
       HitDigitizerFP420::hit_map_type _temp = theHitDigitizerFP420->processHit(ihit,bfield,xytype,numStrips,pitch,numStripsW,pitchW,moduleThickness,verbosity); 
-      
-      
       
       thePileUpFP420->add(_temp,ihit,verbosity);
       
-    }// if
-
-    else {
-      //    std::cout << " *******FP420DigiMain: ERROR???  losenergy =  " <<  losenergy  << std::endl;
     }
     // main part end (AZ) 
   } //for
@@ -235,28 +184,13 @@ vector <HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
     afterNoise = theGNoiseFP420->addNoise(theSignal);
     //    add_noise();
   }
-  
-  //  if((pixelInefficiency>0) && (_signal.size()>0)) 
-  //  pixel_inefficiency(); // Kill some pixels
-  
-  
-  
   digis.clear();
   
-  
-  
-  //                                                                                                                !!!!!
   push_digis(theZSuppressFP420->zeroSuppress(theDConverterFP420->convert(afterNoise),verbosity),
 	     theLink,afterNoise);
   
-  
-  
   return digis; // to HDigiFP420
 }
-
-
-
-
 
 void FP420DigiMain::push_digis(const DigitalMapType& dm,
 			       const HitToDigisMapType& htd,
@@ -266,7 +200,6 @@ void FP420DigiMain::push_digis(const DigitalMapType& dm,
   if(verbosity>0) {
     std::cout << " ****FP420DigiMain: push_digis start: do for loop dm.size()=" <<  dm.size() << std::endl;
   }
-  
   
   digis.reserve(50); 
   digis.clear();
@@ -284,41 +217,14 @@ void FP420DigiMain::push_digis(const DigitalMapType& dm,
     }    
     
   }
-  
-  ////////////////////////////det.specificReadout().addDigis( digis); // 
-  /*       
-  //
-  // reworked to access the fraction of amplitude per simhit PSimHit
-  //
-  for ( HitToDigisMapType::const_iterator mi=htd.begin(); mi!=htd.end(); mi++) {
-  #ifdef mydigidebug1
-  std::cout << " ****push_digis:first for:  (*mi).first = " << (*mi).first << std::endl;
-  std::cout << " if condition   = " << (*((const_cast<DigitalMapType * >(&dm))))[(*mi).first] << std::endl;
-  #endif
-  //    if ((*((const_cast<DigitalMapType * >(&dm))))[(*mi).first] != 0){
-  if ((*((const_cast<DigitalMapType * >(&dm)))).find((*mi).first) != (*((const_cast<DigitalMapType * >(&dm)))).end() ){
-  //
-  // For each channel, sum up the signals from a simtrack
-  //
-  std::map<const PSimHit *, Amplitude> totalAmplitudePerSimHit;
-  for (std::vector < std::pair < const PSimHit*, Amplitude > >::const_iterator simul = 
-  (*mi).second.begin() ; simul != (*mi).second.end(); simul ++){
-  #ifdef mydigidebug1
-  std::cout << " ****push_digis:inside last for: (*simul).second= " << (*simul).second << std::endl;
-  #endif
-  totalAmplitudePerSimHit[(*simul).first] += (*simul).second;
-  } // for
-  }  // if
-  } // for
-  */
-  
+    
   /////////////////////////////////////////////////////////////////////////////////////////////
     
     // reworked to access the fraction of amplitude per simhit
     
     for ( HitToDigisMapType::const_iterator mi=htd.begin(); mi!=htd.end(); mi++) {
       //      
-      if ((*((const_cast<DigitalMapType * >(&dm)))).find((*mi).first) != (*((const_cast<DigitalMapType * >(&dm)))).end() ){
+      if (dm.find((*mi).first) != dm.end() ){
 	// --- For each channel, sum up the signals from a simtrack
 	//
 	map<const PSimHit *, Amplitude> totalAmplitudePerSimHit;
@@ -352,10 +258,4 @@ void FP420DigiMain::push_digis(const DigitalMapType& dm,
 	//
       }//if
     }//for
-    //
-    //
-    /////////////////////////////////////////////////////////////////////////////////////////////
-      //      
-      //      
-      //      
-      }
+}

--- a/SimRomanPot/SimFP420/src/InduceChargeFP420.cc
+++ b/SimRomanPot/SimFP420/src/InduceChargeFP420.cc
@@ -10,8 +10,8 @@
 #include<iostream>
 using namespace std;
 
-static float capacitive_coupling[2] =  {.80,.10};
-static float FiducialXYZ[3] =  {3.6,4.,0.250};// dX/2, dY/2,dZ -- mm fiducial dimension of Si plate
+static const float capacitive_coupling[2] =  {.80,.10};
+static const float FiducialXYZ[3] =  {3.6,4.,0.250};// dX/2, dY/2,dZ -- mm fiducial dimension of Si plate
 
 IChargeFP420::hit_map_type InduceChargeFP420::induce(const CDrifterFP420::collection_type& _collection_points, int numStrips, double localPitch, int numStripsW, double localPitchW, int xytype, int verbosity){
   signalCoupling.clear();

--- a/SimTracker/Common/interface/SiG4UniversalFluctuation.h
+++ b/SimTracker/Common/interface/SiG4UniversalFluctuation.h
@@ -1,52 +1,16 @@
 //
-// ********************************************************************
-// * DISCLAIMER                                                       *
-// *                                                                  *
-// * The following disclaimer summarizes all the specific disclaimers *
-// * of contributors to this software. The specific disclaimers,which *
-// * govern, are listed with their locations in:                      *
-// *   http://cern.ch/geant4/license                                  *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.                                                             *
-// *                                                                  *
-// * This  code  implementation is the  intellectual property  of the *
-// * GEANT4 collaboration.                                            *
-// * By copying,  distributing  or modifying the Program (or any work *
-// * based  on  the Program)  you indicate  your  acceptance of  this *
-// * statement, and all its terms.                                    *
-// ********************************************************************
-//
-// GEANT4 tag $Name: CMSSW_4_2_3 $
-//
-// -------------------------------------------------------------------
-//
 // GEANT4 Class header file
 //
 //
-// File name:     G4UniversalFluctuation
+// File name:   SiG4UniversalFluctuation 
 //
-// Author:        Vladimir Ivanchenko
+// Author: Vladimir Ivanchenko make a class for Laslo Urban model
 //
-// Creation date: 03.01.2002
-//
-// Modifications:
-//
-// 09-12-02 remove warnings (V.Ivanchenko)
-// 28-12-02 add method Dispersion (V.Ivanchenko)
-// 07-02-03 change signature (V.Ivanchenko)
-// 13-02-03 Add name (V.Ivanchenko)
-// 16-10-03 Changed interface to Initialisation (V.Ivanchenko)
-// 07-02-05 define problim = 5.e-3 (mma)
-//
-// Modified for standalone use in CMSSW. danek k. 2/06
+// Modified for standalone use in CMSSW. Danek K. 02/2006
 //
 // Class Description:
 //
-// Implementation of energy loss fluctuations
+// Implementation of energy loss fluctuations in Silicon 
 
 // -------------------------------------------------------------------
 //
@@ -58,12 +22,10 @@ namespace CLHEP{
   class HepRandomEngine;
 }
 
-//#include "G4VEmFluctuationModel.hh"
-
 class SiG4UniversalFluctuation {
 public:
 
-  SiG4UniversalFluctuation();
+  explicit SiG4UniversalFluctuation();
 
   ~SiG4UniversalFluctuation();
 
@@ -76,28 +38,11 @@ public:
                             const double meanLoss,
                             CLHEP::HepRandomEngine*);
    
-  //G4double SampleFluctuations(const G4Material*,
-  //                      const G4DynamicParticle*,
-  //			G4double&,
-  //                            G4double&,
-  //                            G4double&);
-
-  //G4double Dispersion(    const G4Material*,
-  //                      const G4DynamicParticle*,
-  //			G4double&,
-  //                           G4double&);
-  //void InitialiseMe(const G4ParticleDefinition*);
-
-protected:
-
 private:
 
   // hide assignment operator
-  //SiG4UniversalFluctuation & operator=(const  SiG4UniversalFluctuation &right);
-  //SiG4UniversalFluctuation(const  SiG4UniversalFluctuation&);
-
-  //const G4ParticleDefinition* particle;
-  //const G4Material* lastMaterial;
+  SiG4UniversalFluctuation & operator=(const SiG4UniversalFluctuation &right);
+  SiG4UniversalFluctuation(const SiG4UniversalFluctuation&);
 
   double particleMass;
   double chargeSquare;
@@ -105,7 +50,6 @@ private:
   // data members to speed up the fluctuation calculation
   double ipotFluct;
   double electronDensity;
-  //  double zeff;
   
   double f1Fluct;
   double f2Fluct;

--- a/SimTracker/Common/interface/SiG4UniversalFluctuation.h
+++ b/SimTracker/Common/interface/SiG4UniversalFluctuation.h
@@ -4,7 +4,7 @@
 //
 // File name:   SiG4UniversalFluctuation 
 //
-// Author: Vladimir Ivanchenko make a class for Laslo Urban model
+// Author: Vladimir Ivanchenko make a class for Laszlo Urban model
 //
 // Modified for standalone use in CMSSW. Danek K. 02/2006
 //

--- a/SimTracker/Common/src/SiG4UniversalFluctuation.cc
+++ b/SimTracker/Common/src/SiG4UniversalFluctuation.cc
@@ -1,53 +1,3 @@
-//
-// ********************************************************************
-// * DISCLAIMER                                                       *
-// *                                                                  *
-// * The following disclaimer summarizes all the specific disclaimers *
-// * of contributors to this software. The specific disclaimers,which *
-// * govern, are listed with their locations in:                      *
-// *   http://cern.ch/geant4/license                                  *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.                                                             *
-// *                                                                  *
-// * This  code  implementation is the  intellectual property  of the *
-// * GEANT4 collaboration.                                            *
-// * By copying,  distributing  or modifying the Program (or any work *
-// * based  on  the Program)  you indicate  your  acceptance of  this *
-// * statement, and all its terms.                                    *
-// ********************************************************************
-//
-// GEANT4 tag $Name:  $
-//
-// -------------------------------------------------------------------
-//
-// GEANT4 Class file
-//
-//
-// File name:     G4UniversalFluctuation
-//
-// Author:        Vladimir Ivanchenko 
-// 
-// Creation date: 03.01.2002
-//
-// Modifications: 
-//
-// 28-12-02 add method Dispersion (V.Ivanchenko)
-// 07-02-03 change signature (V.Ivanchenko)
-// 13-02-03 Add name (V.Ivanchenko)
-// 16-10-03 Changed interface to Initialisation (V.Ivanchenko)
-// 07-11-03 Fix problem of rounding of double in G4UniversalFluctuations
-// 06-02-04 Add control on big sigma > 2*meanLoss (V.Ivanchenko)
-// 26-04-04 Comment out the case of very small step (V.Ivanchenko)
-// 07-02-05 define problim = 5.e-3 (mma)
-// 03-05-05 conditions of Gaussian fluctuation changed (bugfix)
-//          + smearing for very small loss (L.Urban)
-//  
-// Modified for standalone use in CMSSW. danek k. 2/06        
-// 25-04-13 Used vdt::log, added check a3>0 (V.Ivanchenko & D. Nikolopoulos)         
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -75,7 +25,6 @@ SiG4UniversalFluctuation::SiG4UniversalFluctuation()
    nmaxCont2(16.)
 {
   sumalim = -log(problim);
-  //lastMaterial = 0;
   
   // Add these definitions d.k.
   chargeSquare   = 1.;  //Assume all particles have charge 1
@@ -103,7 +52,6 @@ SiG4UniversalFluctuation::SiG4UniversalFluctuation()
 SiG4UniversalFluctuation::~SiG4UniversalFluctuation()
 {
 }
-
 
 double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
 						    const double mass,
@@ -140,7 +88,6 @@ double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
       (1.+massrate*(2.*gam+massrate)) ;
     if (tmaxkine <= 2.*tmax)   
     {
-      //electronDensity = material->GetElectronDensity();
       siga  = (1.0/beta2 - 0.5) * twopi_mc2_rcl2 * tmax * length
                                 * electronDensity * chargeSquare;
       siga = sqrt(siga);

--- a/SimTracker/SiStripDigitizer/BuildFile.xml
+++ b/SimTracker/SiStripDigitizer/BuildFile.xml
@@ -17,7 +17,7 @@
 <use   name="SimTracker/Common"/>
 <use   name="boost"/>
 <use   name="gsl"/>
-<use   name="vdt"/>
+<use   name="vdt_header"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/SimTracker/TrackAssociation/plugins/StripCompactDigiSimLinksProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/StripCompactDigiSimLinksProducer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,10 +23,10 @@
   #define DEBUG(X)
 #endif
 
-class StripCompactDigiSimLinksProducer : public edm::EDProducer {
+class StripCompactDigiSimLinksProducer : public edm::one::EDProducer<> {
     public:
         StripCompactDigiSimLinksProducer(const edm::ParameterSet &iConfig) ;
-        ~StripCompactDigiSimLinksProducer();
+        virtual ~StripCompactDigiSimLinksProducer();
 
         virtual void produce(edm::Event&, const edm::EventSetup&) override;
 

--- a/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
@@ -16,7 +16,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -33,7 +33,7 @@
 // class decleration
 //
 
-class QualityCutsAnalyzer : public edm::EDAnalyzer
+class QualityCutsAnalyzer : public edm::one::EDAnalyzer<>
 {
 
 public:

--- a/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
@@ -11,7 +11,7 @@
 #include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -34,7 +34,7 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-class SVTagInfoValidationAnalyzer : public edm::EDAnalyzer
+class SVTagInfoValidationAnalyzer : public edm::one::EDAnalyzer<>
 {
 
 public:

--- a/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
@@ -18,7 +18,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -32,7 +32,7 @@
 // class decleration
 //
 
-class TrackHistoryAnalyzer : public edm::EDAnalyzer
+class TrackHistoryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 
@@ -41,7 +41,7 @@ public:
 
 private:
 
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
     virtual void beginJob() override ;
     virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
@@ -17,7 +17,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -31,7 +31,7 @@
 // class decleration
 //
 
-class VertexHistoryAnalyzer : public edm::EDAnalyzer
+class VertexHistoryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 
@@ -39,7 +39,7 @@ public:
 
 private:
 
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
+    virtual void beginRun(const edm::Run&,const edm::EventSetup&);
     virtual void beginJob() override ;
     virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/SimTracker/TrackerFilters/interface/CosmicTIFTrigFilter.h
+++ b/SimTracker/TrackerFilters/interface/CosmicTIFTrigFilter.h
@@ -4,21 +4,20 @@
 
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-//#include "CLHEP/Vector/ThreeVector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace cms{
 
-class CosmicTIFTrigFilter : public edm::EDFilter {
+  class CosmicTIFTrigFilter : public edm::stream::EDFilter<> {
   public:
   CosmicTIFTrigFilter(const edm::ParameterSet& conf);
   virtual ~CosmicTIFTrigFilter() {}
   bool filter(edm::Event & iEvent, edm::EventSetup const& c);
   bool Sci_trig(const HepMC::FourVector&, const  HepMC::FourVector&,const  HepMC::FourVector&);
-  //  bool Sci_trig(CLHEP::Hep3Vector,  CLHEP::Hep3Vector, CLHEP::Hep3Vector);
 
  private:
   edm::ParameterSet conf_;
@@ -28,6 +27,7 @@ class CosmicTIFTrigFilter : public edm::EDFilter {
   int tottrig;
   int trig1, trig2, trig3;
   std::vector<double> trigS1, trigS2, trigS3, trigS4;
+  edm::EDGetTokenT<edm::HepMCProduct> m_Token;
   };
 }
 #endif 

--- a/SimTracker/TrackerFilters/plugins/CosmicTIFTrigFilter.cc
+++ b/SimTracker/TrackerFilters/plugins/CosmicTIFTrigFilter.cc
@@ -4,8 +4,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+//#include "MagneticField/Engine/interface/MagneticField.h"
+//#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "HepMC/GenVertex.h"
 #include <map>
 #include <vector>
@@ -14,13 +14,14 @@ using namespace std;
 namespace cms
 
 {
-  CosmicTIFTrigFilter::CosmicTIFTrigFilter(const edm::ParameterSet& conf):    conf_(conf)
+  CosmicTIFTrigFilter::CosmicTIFTrigFilter(const edm::ParameterSet& conf): 
+    m_Token(consumes<edm::HepMCProduct>(conf.getParameter<edm::ParameterSet>("Generator").getParameter<std::string>("HepMCProductLabel")))
   {
-    trigconf  = conf_.getParameter<int>("trig_conf");
-    trigS1  = conf_.getParameter<std::vector<double> >("PosScint1");
-    trigS2  = conf_.getParameter<std::vector<double> >("PosScint2");
-    trigS3  = conf_.getParameter<std::vector<double> >("PosScint3");
-    trigS4  = conf_.getParameter<std::vector<double> >("PosScint4");
+    trigconf  = conf.getParameter<int>("trig_conf");
+    trigS1  = conf.getParameter<std::vector<double> >("PosScint1");
+    trigS2  = conf.getParameter<std::vector<double> >("PosScint2");
+    trigS3  = conf.getParameter<std::vector<double> >("PosScint3");
+    trigS4  = conf.getParameter<std::vector<double> >("PosScint4");
 
     /*
     std::cout << "S1 = " << trigS1[0] << ", " <<  trigS1[1] << ", " <<trigS1[2]
@@ -33,10 +34,10 @@ namespace cms
   
   bool CosmicTIFTrigFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   {
-    
-    
-    edm::Handle<edm::HepMCProduct>HepMCEvt;
-    iEvent.getByLabel("source","",HepMCEvt);
+        
+    edm::Handle<edm::HepMCProduct> HepMCEvt;
+    iEvent.getByToken(m_Token, HepMCEvt);
+
     const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();
     
     bool hit1=false;
@@ -44,13 +45,11 @@ namespace cms
     bool hit3=false;
     bool hit4=false;
     
-    
     for(HepMC::GenEvent::particle_const_iterator i=MCEvt->particles_begin(); i != MCEvt->particles_end();++i)
       {
 	int myId = (*i)->pdg_id();
 	if (abs(myId)==13)
-	  {
-	    
+	  {	    
 	    // Get the muon position and momentum
 	    HepMC::GenVertex* pv = (*i)->production_vertex();
 	    HepMC::FourVector vertex = pv->position();
@@ -62,17 +61,6 @@ namespace cms
 	    
 	    if(trigconf==1){
 
-/*
-	      HepMC::FourVector S1(350.,1600.,500.,0.);
-	      HepMC::FourVector S2(350.,-1600.,400.,0.);
-	      HepMC::FourVector S3(350.,1600.,1600.,0.);
-*/
-/*
-//numbers taken from real data
-	     HepMC::FourVector S1(150.,1600.,550.,0.);
- 	     HepMC::FourVector S2(400.,-1600.,50.,0.);
-	     HepMC::FourVector S3(0.,1600.,2400.,0.);
-*/
 	      HepMC::FourVector S1(trigS1[0],trigS1[1],trigS1[2],0.);
 	      HepMC::FourVector S2(trigS2[0],trigS2[1],trigS2[2],0.);
 	      HepMC::FourVector S3(trigS3[0],trigS3[1],trigS3[2],0.);
@@ -96,16 +84,9 @@ namespace cms
 		}
 	    }else if(trigconf ==2) {
 
-	      /*
-	      HepMC::FourVector S1(350.,1600.,850.,0.);
-	      HepMC::FourVector S2(0.,-1550.,-1650.,0.);
-	      HepMC::FourVector S3(350.,1600.,2300.,0.);
-	      */
-
 	      HepMC::FourVector S1(trigS1[0],trigS1[1],trigS1[2],0.);
 	      HepMC::FourVector S2(trigS2[0],trigS2[1],trigS2[2],0.);
 	      HepMC::FourVector S3(trigS3[0],trigS3[1],trigS3[2],0.);
-
 	      
 	      hit1=Sci_trig(vertex, momentum, S1);
 	      hit2=Sci_trig(vertex, momentum, S2);
@@ -126,26 +107,11 @@ namespace cms
 		}
 
 	    }else if(trigconf ==3) {
-/*
-	      HepMC::FourVector S1(350.,1600.,850.,0.);
-	      HepMC::FourVector S2(350.,-1600.,400.,0.);
-	      HepMC::FourVector S3(350.,1600.,2300.,0.);
-	      HepMC::FourVector S4(0.,-1600.,-2000.,0.);
-*/
-/*
-//new configuration from data
-	      HepMC::FourVector S1(150.,1600.,900.,0.);
-	      HepMC::FourVector S2(400.,-1600.,100.,0.);
-	      HepMC::FourVector S3(50.,1600.,2450.,0.);
-  	      HepMC::FourVector S4(-250.,-1600.,-2050.,0.);
-*/	      
-
 	      HepMC::FourVector S1(trigS1[0],trigS1[1],trigS1[2],0.);
 	      HepMC::FourVector S2(trigS2[0],trigS2[1],trigS2[2],0.);
 	      HepMC::FourVector S3(trigS3[0],trigS3[1],trigS3[2],0.);
 	      HepMC::FourVector S4(trigS4[0],trigS4[1],trigS4[2],0.);
 	      
-
 	      /*	      std::cout << "S1 = " << S1.x() << "," << S1.y() << ", " << S1.z()  
 			<< "\nS2 = " << S2.x() << "," << S2.y() << ", " << S2.z()  
 			<< "\nS3 = " << S3.x() << "," << S3.y() << ", " << S3.z()  
@@ -192,9 +158,7 @@ namespace cms
     float Sy=S.y();
     float Sz=S.z();
     
-    //float ys=Sy;
     float zs=(Sy-y0)*(pz0/py0)+z0;
-    //	  float xs=((Sy-y0)*(pz0/py0)-z0)*(px0/pz0)+x0;
     float xs=(Sy-y0)*(px0/py0)+x0;
     
     //    std::cout << Sx << " " << Sz << " " << xs << " " << zs << std::endl;
@@ -209,8 +173,6 @@ namespace cms
       {
 	return false;
       }
-    
   }
-  
 }
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -6,7 +6,7 @@
 
 #include "boost/format.hpp"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
@@ -80,7 +80,7 @@ std::ostream & operator<<(std::ostream & out, const math::XYZVector & v) {
   return out << "(" << v.rho() << ", " << v.z() << ", " << v.phi() << ")";
 }
 
-class ListGroups : public edm::EDAnalyzer
+class ListGroups : public edm::one::EDAnalyzer<>
 {
 public:
   ListGroups(const edm::ParameterSet &);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -2,7 +2,7 @@
 #include <vector>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -65,7 +65,7 @@ std::ostream & operator<<(std::ostream & out, const math::XYZVector & v) {
   return out << "(" << v.rho() << ", " << v.z() << ", " << v.phi() << ")";
 }
 
-class ListIds : public edm::EDAnalyzer
+class ListIds : public edm::one::EDAnalyzer<>
 {
 public:
   ListIds(const edm::ParameterSet &);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -13,10 +13,10 @@
 #include "MaterialAccountingGroup.h"
 #include "TrackingMaterialPlotter.h"
 
-class TrackingMaterialAnalyser : public edm::EDAnalyzer
+class TrackingMaterialAnalyser : public edm::one::EDAnalyzer<>
 {
 public:
-  TrackingMaterialAnalyser(const edm::ParameterSet &);
+  explicit TrackingMaterialAnalyser(const edm::ParameterSet &);
   virtual ~TrackingMaterialAnalyser();
   
 private:


### PR DESCRIPTION
Code clean-up:
1. Fixed static analyser warnings; removed empty lines; removed obsolete commented lines.
2. Removed few obsolete Geant4 disclaimers.
3. Substitute link of vdt by vdt_header.
4. A part of cout is substituted by LogInfo.

Part of fixed code is used in production but this PR should not change any result.
