### PR TITLE
Fix bugs in code that detects missing ROOT dictionaries

### DIFF
--- a/CondFormats/Common/src/classes_def.xml
+++ b/CondFormats/Common/src/classes_def.xml
@@ -5,6 +5,7 @@
 
  <class name="FileBlob" class_version="0">
  </class>
+ <class name="std::vector<FileBlob>"/>
  <class name="FileBlobCollection" class_version="0"/>
  <class name="edm::Wrapper<FileBlobCollection>" class_version="0"/>
 

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -21,12 +21,18 @@
   <class name="TotemRPUVPattern" ClassVersion="2">
     <version ClassVersion="2" checksum="3530058029"/>
   </class>
+  <class name="edm::DetSet<TotemRPUVPattern>"/>
+  <class name="std::vector<TotemRPUVPattern>"/>
+  <class name="std::vector<edm::DetSet<TotemRPUVPattern> >"/>
   <class name="edm::DetSetVector<TotemRPUVPattern>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPUVPattern>>"/>
 
   <class name="TotemRPLocalTrack" ClassVersion="2">
     <version ClassVersion="2" checksum="3328119645"/>
   </class>
+  <class name="edm::DetSet<TotemRPLocalTrack>"/>
+  <class name="std::vector<TotemRPLocalTrack>"/>
+  <class name="std::vector<edm::DetSet<TotemRPLocalTrack> >"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack>>"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>"/>

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -5,7 +5,6 @@
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/OffsetToBase.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
 #include <typeinfo>

--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -2,7 +2,6 @@
 
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"

--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -11,6 +11,8 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrackExtra.h"
 #include "DataFormats/L1TMuon/interface/EMTFHitExtra.h"
 
+#include <vector>
+
 namespace {
   struct dictionary {
     l1t::MuonCaloSumBxCollection caloSum;

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -2,10 +2,12 @@
  <selection>
 
   <class name="l1t::RegionalMuonCand"/>
+  <class name="std::vector<l1t::RegionalMuonCand>"/>
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
   <class name="l1t::MuonCaloSum"/>
+  <class name="std::vector<l1t::MuonCaloSum>"/>
   <class name="l1t::MuonCaloSumBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonCaloSumBxCollection>"/>
 

--- a/DataFormats/PatCandidates/src/classes_def_other.xml
+++ b/DataFormats/PatCandidates/src/classes_def_other.xml
@@ -65,6 +65,7 @@
   <class name="vid::CutFlowResult" ClassVersion="2">
     <version ClassVersion="2" checksum="3732644629"/>
   </class>
+  <class name="std::vector<vid::CutFlowResult>"/>
   <class name="edm::ValueMap<vid::CutFlowResult>"/>
   <class name="edm::Wrapper<vid::CutFlowResult>"/>
   <class name="edm::Wrapper<edm::ValueMap<vid::CutFlowResult> >"/>

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -13,7 +13,6 @@
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
-#include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/array.hpp"
@@ -27,7 +26,10 @@
 #include <vector>
 
 namespace edm {
+
   class ProductResolverIndexHelper;
+  class TypeID;
+  class TypeWithDict;
 
   class ProductRegistry {
 
@@ -53,7 +55,7 @@ namespace edm {
 
     void setFrozen(bool initializeLookupInfo = true);
 
-    void setFrozen(std::set<TypeID> const& typesConsumed);
+    void setFrozen(std::set<TypeID> const& productTypesConsumed, std::set<TypeID> const& elementTypesConsumed);
 
     std::string merge(ProductRegistry const& other,
         std::string const& fileName,
@@ -111,14 +113,6 @@ namespace edm {
     bool productProduced(BranchType branchType) const {return transient_.productProduced_[branchType];}
     bool anyProductProduced() const {return transient_.anyProductProduced_;}
 
-    std::vector<TypeID> const& missingDictionaries() const {
-      return transient_.missingDictionaries_;
-    }
-
-    std::vector<TypeID>& missingDictionariesForUpdate() {
-      return transient_.missingDictionaries_;
-    }
-
     std::vector<std::pair<std::string, std::string> > const& aliasToOriginal() const {
       return transient_.aliasToOriginal_;
     }
@@ -155,8 +149,6 @@ namespace edm {
 
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 
-      std::vector<TypeID> missingDictionaries_;
-
       std::vector<std::pair<std::string, std::string> > aliasToOriginal_;
     };
 
@@ -168,7 +160,14 @@ namespace edm {
 
     void freezeIt(bool frozen = true) {transient_.frozen_ = frozen;}
 
-    void initializeLookupTables(std::set<TypeID> const* typesConsumed);
+    void initializeLookupTables(std::set<TypeID> const* productTypesConsumed,
+                                std::set<TypeID> const* elementTypesConsumed);
+
+    void checkDictionariesOfConsumedTypes(std::set<TypeID> const* productTypesConsumed,
+                                          std::set<TypeID> const* elementTypesConsumed,
+                                          std::map<TypeID, TypeID> const& containedTypeMap,
+                                          std::map<TypeID, std::vector<TypeWithDict> >& containedTypeToBaseTypesMap);
+
     virtual void addCalled(BranchDescription const&, bool iFromListener);
     void throwIfNotFrozen() const;
     void throwIfFrozen() const;

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -64,6 +64,8 @@ ProductRegistry is frozen.
 
 namespace edm {
 
+  class TypeWithDict;
+
   namespace productholderindexhelper {
     // The next function supports views. For the given wrapped type,
     // which must be Wrapper<T>,
@@ -176,15 +178,14 @@ namespace edm {
            char const* moduleLabel,
            char const* instance,
            char const* process,
-           TypeID const& containedTypeID);
+           TypeID const& containedTypeID,
+           std::vector<TypeWithDict>* baseTypesOfContainedType);
 
     ProductResolverIndex
     insert(TypeID const& typeID,
            char const* moduleLabel,
            char const* instance,
-           char const* process) {
-      return insert(typeID, moduleLabel, instance, process, productholderindexhelper::getContainedType(typeID));
-    }
+           char const* process);
 
     // Before the object is frozen the accessors above will
     // fail to find a match. Once frozen, no more new entries

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -19,9 +19,12 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
+#include "TDictAttributeMap.h"
+
 #include <cassert>
 #include <iterator>
 #include <limits>
+#include <set>
 #include <sstream>
 #include <ostream>
 
@@ -43,8 +46,7 @@ namespace edm {
       lumiNextIndexValue_(0),
       runNextIndexValue_(0),
 
-      branchIDToIndex_(),
-      missingDictionaries_() {
+      branchIDToIndex_() {
     for(bool& isProduced : productProduced_) isProduced = false;
   }
 
@@ -64,7 +66,6 @@ namespace edm {
     runNextIndexValue_ = 0;
 
     branchIDToIndex_.clear();
-    missingDictionaries_.clear();
   }
 
   ProductRegistry::ProductRegistry(ProductList const& productList, bool toBeFrozen) :
@@ -158,16 +159,17 @@ namespace edm {
     if(frozen()) return;
     freezeIt();
     if(initializeLookupInfo) {
-      initializeLookupTables(nullptr);
+      initializeLookupTables(nullptr, nullptr);
     }
     sort_all(transient_.aliasToOriginal_);
   }
 
   void
-  ProductRegistry::setFrozen(std::set<TypeID> const& typesConsumed) {
+  ProductRegistry::setFrozen(std::set<TypeID> const& productTypesConsumed,
+                             std::set<TypeID> const& elementTypesConsumed) {
     if(frozen()) return;
     freezeIt();
-    initializeLookupTables(&typesConsumed);
+    initializeLookupTables(&productTypesConsumed, &elementTypesConsumed);
     sort_all(transient_.aliasToOriginal_);
   }
 
@@ -273,10 +275,15 @@ namespace edm {
     return differences.str();
   }
 
-  void ProductRegistry::initializeLookupTables(std::set<TypeID> const* typesConsumed) {
+  void ProductRegistry::initializeLookupTables(std::set<TypeID> const* productTypesConsumed,
+                                               std::set<TypeID> const* elementTypesConsumed) {
 
     std::map<TypeID, TypeID> containedTypeMap;
-    TypeSet missingDicts;
+    std::map<TypeID, std::vector<TypeWithDict> > containedTypeToBaseTypesMap;
+
+    std::vector<std::string> missingDictionaries;
+    std::vector<std::string> branchNamesForMissing;
+    std::vector<std::string> producedTypes;
 
     transient_.branchIDToIndex_.clear();
 
@@ -289,65 +296,130 @@ namespace edm {
 
       //only do the following if the data is supposed to be available in the event
       if(desc.present()) {
-        if(!bool(desc.unwrappedType())) {
-          missingDicts.insert(TypeID(desc.unwrappedType().typeInfo()));
-        } else if(!bool(desc.wrappedType())) {
-          missingDicts.insert(TypeID(desc.wrappedType().typeInfo()));
-        } else {
-          TypeID wrappedTypeID(desc.wrappedType().typeInfo());
-          TypeID typeID(desc.unwrappedType().typeInfo());
-          TypeID containedTypeID;
-          auto const& iter = containedTypeMap.find(typeID);
-          if(iter != containedTypeMap.end()) {
-             containedTypeID = iter->second;
-          } else {
-             containedTypeID = productholderindexhelper::getContainedTypeFromWrapper(wrappedTypeID, typeID.className());
-             containedTypeMap.emplace(typeID, containedTypeID);
+
+        // Check dictionaries (we already checked for the produced ones earlier somewhere else).
+        // We have to have the dictionaries to properly setup the lookup tables for support of
+        // Views. Also we need them to determine which present products are declared to be
+        // consumed in the case where the consumed type is a View<T>.
+        if (!desc.produced()) {
+          if (!checkDictionary(missingDictionaries, desc.className(), desc.unwrappedType())) {
+            checkDictionaryOfWrappedType(missingDictionaries, desc.className());
+            branchNamesForMissing.emplace_back(desc.branchName());
+            producedTypes.emplace_back(desc.className() + std::string(" (read from input)"));
+            continue;
           }
-          if(typesConsumed != nullptr && !desc.produced()) {
-            bool mainTypeConsumed = (typesConsumed->find(typeID) != typesConsumed->end());
-            bool hasContainedType = (containedTypeID != TypeID(typeid(void)) && containedTypeID != TypeID());
-            bool containedTypeConsumed = hasContainedType && (typesConsumed->find(containedTypeID) != typesConsumed->end());
-            if(hasContainedType && !containedTypeConsumed) {
-              TypeWithDict containedType(containedTypeID.typeInfo());
+        }
+        TypeID typeID(desc.unwrappedType().typeInfo());
+
+        auto iter = containedTypeMap.find(typeID);
+        bool alreadySawThisType = (iter != containedTypeMap.end());
+
+        if (!desc.produced() && !alreadySawThisType) {
+          if (!checkDictionary(missingDictionaries, desc.wrappedName(), desc.wrappedType())) {
+            branchNamesForMissing.emplace_back(desc.branchName());
+            producedTypes.emplace_back(desc.className() + std::string(" (read from input)"));
+            continue;
+          }
+        }
+
+        TypeID wrappedTypeID(desc.wrappedType().typeInfo());
+
+        TypeID containedTypeID;
+        if (alreadySawThisType) {
+          containedTypeID = iter->second;
+        } else {
+          containedTypeID = productholderindexhelper::getContainedTypeFromWrapper(wrappedTypeID, typeID.className());
+        }
+        bool hasContainedType = (containedTypeID != TypeID(typeid(void)) && containedTypeID != TypeID());
+
+        std::vector<TypeWithDict>* baseTypesOfContainedType = nullptr;
+
+        if (!alreadySawThisType) {
+          bool alreadyCheckedConstituents = desc.produced() && !desc.transient();
+          if (!alreadyCheckedConstituents && !desc.transient()) {
+            // This checks dictionaries of the wrapped class and all its constituent classes
+            if (!checkClassDictionaries(missingDictionaries, desc.wrappedName(), desc.wrappedType())) {
+              branchNamesForMissing.emplace_back(desc.branchName());
+              producedTypes.emplace_back(desc.className() + std::string(" (read from input)"));
+              continue;
+            }
+          }
+
+          if (hasContainedType) {
+            auto iter = containedTypeToBaseTypesMap.find(containedTypeID);
+            if (iter == containedTypeToBaseTypesMap.end()) {
               std::vector<TypeWithDict> baseTypes;
-              public_base_classes(containedType, baseTypes);
-              for(TypeWithDict const& baseType : baseTypes) {
-                 if(typesConsumed->find(TypeID(baseType.typeInfo())) != typesConsumed->end()) {
-                   containedTypeConsumed = true;
-                   break;
-                 }
+              if (!public_base_classes(missingDictionaries, containedTypeID, baseTypes)) {
+                branchNamesForMissing.emplace_back(desc.branchName());
+                if (desc.produced()) {
+                  producedTypes.emplace_back(desc.className() + std::string(" (produced in current process)"));
+                } else {
+                  producedTypes.emplace_back(desc.className() + std::string(" (read from input)"));
+                }
+                continue;
+              }
+              iter = containedTypeToBaseTypesMap.insert(std::make_pair(containedTypeID, baseTypes)).first;
+            }
+            baseTypesOfContainedType = &iter->second;
+          }
+
+          // Do this after the dictionary checks of constituents so the list of branch names for missing types
+          // is complete
+          containedTypeMap.emplace(typeID, containedTypeID);
+        } else {
+          if (hasContainedType) {
+            auto iter = containedTypeToBaseTypesMap.find(containedTypeID);
+            if (iter != containedTypeToBaseTypesMap.end()) {
+              baseTypesOfContainedType = &iter->second;
+            }
+          }
+        }
+
+        if(productTypesConsumed != nullptr && !desc.produced()) {
+          bool mainTypeConsumed = (productTypesConsumed->find(typeID) != productTypesConsumed->end());
+          bool containedTypeConsumed = hasContainedType && (elementTypesConsumed->find(containedTypeID) != elementTypesConsumed->end());
+          if(hasContainedType && !containedTypeConsumed && baseTypesOfContainedType != nullptr) {
+            for(TypeWithDict const& baseType : *baseTypesOfContainedType) {
+              if(elementTypesConsumed->find(TypeID(baseType.typeInfo())) != elementTypesConsumed->end()) {
+                containedTypeConsumed = true;
+                break;
               }
             }
-            if(!containedTypeConsumed) {
-              if(mainTypeConsumed) {
-                // The main type is consumed, but either
-                // there is no contained type, or if there is,
-                // neither it nor any of its base classes are consumed.
-                // Set the contained type, if there is one, to void,
-                if(hasContainedType) {
-		  containedTypeID = TypeID(typeid(void)); 
-                }
-              } else {
-                // The main type is not consumed, and either
-                // there is no contained type, or if there is,
-                // neither it nor any of its base classes are consumed.
-                // Don't insert anything in the lookup tables.
-                continue;
-              } 
+          }
+          if(!containedTypeConsumed) {
+            if(mainTypeConsumed) {
+              // The main type is consumed, but either
+              // there is no contained type, or if there is,
+              // neither it nor any of its base classes are consumed.
+              // Set the contained type, if there is one, to void,
+              if(hasContainedType) {
+	        containedTypeID = TypeID(typeid(void));
+              }
+            } else {
+              // The main type is not consumed, and either
+              // there is no contained type, or if there is,
+              // neither it nor any of its base classes are consumed.
+              // Don't insert anything in the lookup tables.
+              continue;
             }
           }
-          ProductResolverIndex index =
-            productLookup(desc.branchType())->insert(typeID,
-                                                     desc.moduleLabel().c_str(),
-                                                     desc.productInstanceName().c_str(),
-                                                     desc.processName().c_str(),
-                                                     containedTypeID);
-
-          transient_.branchIDToIndex_[desc.branchID()] = index;
         }
+        ProductResolverIndex index =
+          productLookup(desc.branchType())->insert(typeID,
+                                                   desc.moduleLabel().c_str(),
+                                                   desc.productInstanceName().c_str(),
+                                                   desc.processName().c_str(),
+                                                   containedTypeID,
+                                                   baseTypesOfContainedType);
+
+        transient_.branchIDToIndex_[desc.branchID()] = index;
       }
     }
+    if (!missingDictionaries.empty()) {
+      std::string context("Calling ProductRegistry::initializeLookupTables");
+      throwMissingDictionariesException(missingDictionaries, context, producedTypes, branchNamesForMissing);
+    }
+
     productLookup(InEvent)->setFrozen();
     productLookup(InLumi)->setFrozen();
     productLookup(InRun)->setFrozen();
@@ -363,9 +435,88 @@ namespace edm {
         ++nextIndexValue(desc.branchType());
       }
     }
+    checkDictionariesOfConsumedTypes(productTypesConsumed, elementTypesConsumed, containedTypeMap, containedTypeToBaseTypesMap);
+  }
 
-    missingDictionariesForUpdate().reserve(missingDicts.size());
-    copy_all(missingDicts, std::back_inserter(missingDictionariesForUpdate()));
+  void
+  ProductRegistry::checkDictionariesOfConsumedTypes(std::set<TypeID> const* productTypesConsumed,
+                                                    std::set<TypeID> const* elementTypesConsumed,
+                                                    std::map<TypeID, TypeID> const& containedTypeMap,
+                                                    std::map<TypeID, std::vector<TypeWithDict> >& containedTypeToBaseTypesMap) {
+
+    std::vector<std::string> missingDictionaries;
+    std::set<std::string> consumedTypesWithMissingDictionaries;
+
+    if (productTypesConsumed) {
+
+
+      // Check dictionaries for all classes declared to be consumed
+      for (auto const& consumedTypeID : *productTypesConsumed) {
+
+        // We use the containedTypeMap to see which types have already
+        // had their dictionaries checked. We do not waste time rechecking
+        // those dictionaries.
+        if (containedTypeMap.find(consumedTypeID) == containedTypeMap.end()) {
+
+          std::string wrappedName = wrappedClassName(consumedTypeID.className());
+          TypeWithDict wrappedType = TypeWithDict::byName(wrappedName);
+          if (!checkDictionary(missingDictionaries, wrappedName, wrappedType)) {
+            checkDictionary(missingDictionaries, consumedTypeID);
+            consumedTypesWithMissingDictionaries.emplace(consumedTypeID.className());
+            continue;
+          }
+          bool transient = false;
+          TDictAttributeMap* wp = wrappedType.getClass()->GetAttributeMap();
+          if (wp && wp->HasKey("persistent") && !strcmp(wp->GetPropertyAsString("persistent"), "false")) {
+            transient = true;
+          }
+          if (transient) {
+            if(!checkDictionary(missingDictionaries, consumedTypeID)) {
+              consumedTypesWithMissingDictionaries.emplace(consumedTypeID.className());
+            }
+
+            TypeID containedTypeID = productholderindexhelper::getContainedTypeFromWrapper(TypeID(wrappedType.typeInfo()), consumedTypeID.className());
+            bool hasContainedType = (containedTypeID != TypeID(typeid(void)) && containedTypeID != TypeID());
+            if (hasContainedType) {
+              if (containedTypeToBaseTypesMap.find(containedTypeID) == containedTypeToBaseTypesMap.end()) {
+                std::vector<TypeWithDict> bases;
+                // Run this to check for missing dictionaries, bases is not really used
+                if (!public_base_classes(missingDictionaries, containedTypeID, bases)) {
+                  consumedTypesWithMissingDictionaries.emplace(consumedTypeID.className());
+                }
+                containedTypeToBaseTypesMap.insert(std::make_pair(containedTypeID, bases));
+              }
+            }
+          } else {
+            if (!checkClassDictionaries(missingDictionaries, wrappedName, wrappedType)) {
+              consumedTypesWithMissingDictionaries.emplace(consumedTypeID.className());
+            }
+          }
+        }
+      }
+      if (!missingDictionaries.empty()) {
+        std::string context("Calling ProductRegistry::initializeLookupTables, checking dictionaries for consumed products");
+        throwMissingDictionariesException(missingDictionaries, context, consumedTypesWithMissingDictionaries, false);
+      }
+    }
+
+    if (elementTypesConsumed) {
+      missingDictionaries.clear();
+      consumedTypesWithMissingDictionaries.clear();
+      for (auto const& consumedTypeID : *elementTypesConsumed) {
+        if (containedTypeToBaseTypesMap.find(consumedTypeID) == containedTypeToBaseTypesMap.end()) {
+          std::vector<TypeWithDict> bases;
+          // Run this to check for missing dictionaries, bases is not really used
+          if (!public_base_classes(missingDictionaries, consumedTypeID, bases)) {
+            consumedTypesWithMissingDictionaries.emplace(consumedTypeID.className());
+          }
+        }
+      }
+      if (!missingDictionaries.empty()) {
+        std::string context("Calling ProductRegistry::initializeLookupTables, checking dictionaries for elements of products consumed using View");
+        throwMissingDictionariesException(missingDictionaries, context, consumedTypesWithMissingDictionaries, true);
+      }
+    }
   }
 
   ProductResolverIndex ProductRegistry::indexFrom(BranchID const& iID) const {

--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -20,6 +20,7 @@
  <class name="std::vector<std::pair<std::basic_string<char>,double> >"/>
  <class name="std::vector<std::pair<std::basic_string<char>,float> >"/>
  <class name="std::vector<std::pair<std::basic_string<char>,int> >"/>
+ <class name="std::vector<std::pair<std::basic_string<char>,std::basic_string<char> > >"/>
  <class name="std::vector<std::pair<std::vector<std::pair<double,std::vector<double> > >,bool> >"/>
  <class name="std::vector<std::pair<unsigned int,bool> >"/>
  <class name="std::vector<std::pair<unsigned int,double> >"/>

--- a/DataFormats/StdDictionaries/src/classes_vector.h
+++ b/DataFormats/StdDictionaries/src/classes_vector.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace DataFormats_StdDictionaries {

--- a/DataFormats/TestObjects/interface/MissingDictionaryTestObject.h
+++ b/DataFormats/TestObjects/interface/MissingDictionaryTestObject.h
@@ -1,0 +1,93 @@
+#ifndef DataFormats_TestObjects_MissingDictionaryTestObject_h
+#define DataFormats_TestObjects_MissingDictionaryTestObject_h
+
+#include <vector>
+
+namespace edmtest {
+
+  class MissingDictionaryTestK {
+  public:
+    ~MissingDictionaryTestK() { }
+    MissingDictionaryTestK() : k(0) { }
+    int k;
+  };
+
+  class MissingDictionaryTestJ {
+  public:
+    ~MissingDictionaryTestJ() { }
+    MissingDictionaryTestJ() : j(0) { }
+    int j;
+  };
+
+  class MissingDictionaryTestI : public MissingDictionaryTestJ {
+  public:
+    ~MissingDictionaryTestI() { }
+    MissingDictionaryTestI() : i(0) { }
+    int i;
+    MissingDictionaryTestK k;
+  };
+
+  class MissingDictionaryTestH {
+  public:
+    ~MissingDictionaryTestH() { }
+    MissingDictionaryTestH() : h(0) { }
+    int h;
+  };
+
+  class MissingDictionaryTestG {
+  public:
+    ~MissingDictionaryTestG() { }
+    MissingDictionaryTestG() : g(0) { }
+    int g;
+  };
+
+  class MissingDictionaryTestF : public MissingDictionaryTestG {
+  public:
+    ~MissingDictionaryTestF() { }
+    MissingDictionaryTestF() : f(0) { }
+    int f;
+    MissingDictionaryTestH h;
+  };
+
+  class MissingDictionaryTestE {
+  public:
+    ~MissingDictionaryTestE() { }
+    MissingDictionaryTestE() : e(0) { }
+    int e;
+  };
+
+  class MissingDictionaryTestD {
+  public:
+    ~MissingDictionaryTestD() { }
+    MissingDictionaryTestD() : d(0) { }
+    int d;
+  };
+
+  class MissingDictionaryTestC {
+  public:
+    ~MissingDictionaryTestC() { }
+    MissingDictionaryTestC() : c(0) { }
+    int c;
+    MissingDictionaryTestD d;
+  };
+
+  class MissingDictionaryTestB : public MissingDictionaryTestC {
+  public:
+    ~MissingDictionaryTestB() { }
+    MissingDictionaryTestB() : b(0) { }
+    int b;
+    MissingDictionaryTestE e;
+  };
+
+  class MissingDictionaryTestA : public MissingDictionaryTestB {
+  public:
+    ~MissingDictionaryTestA() { }
+    MissingDictionaryTestA() : a(0) { }
+    int a;
+    MissingDictionaryTestF f;
+    std::vector<MissingDictionaryTestI> vi;
+  };
+
+}
+
+#endif

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -10,6 +10,7 @@
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
+#include "DataFormats/TestObjects/interface/MissingDictionaryTestObject.h"
 #include "DataFormats/TestObjects/interface/OtherThingCollection.h"
 #include "DataFormats/TestObjects/interface/ThingCollection.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -30,6 +31,8 @@
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <list>
 
 namespace DataFormats_TestObjects {
 struct dictionary {

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -51,7 +51,9 @@
  </class>
  <class name="edm::SortedCollection<edmtest::Simple, edm::StrictWeakOrdering<edmtest::Simple> >"/>
  <class name="edm::OwnVector<edmtest::Simple, edm::ClonePolicy<edmtest::Simple> >"/>
+ <class name="std::vector<edmtest::Simple*>"/>
  <class name="edm::OwnVector<edmtest::SimpleDerived, edm::ClonePolicy<edmtest::SimpleDerived> >"/>
+ <class name="std::vector<edmtest::SimpleDerived*>"/>
  <class name="std::vector<edmtest::Simple>"/>
  <class name="edm::Wrapper<std::vector<edmtest::Simple> >"/>
  <class name="std::vector<edmtest::SimpleDerived>"/>
@@ -69,6 +71,7 @@
    <field name="transientVector_" transient="true"/>
  </class>
  <class name="std::pair<edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,edmtest::Simple>"/>
+ <class name="edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >"/>
  <ioread sourceClass = "edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" version="[1-]" targetClass = "edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" source = "" target="transientVector_">
    <![CDATA[delete transientVector_; transientVector_=nullptr;
    ]]>
@@ -184,4 +187,48 @@
  <class name="edm::Wrapper<edm::EventID>"/>
  <class name="edm::Wrapper<edm::ProductID>"/>
 
+ <class name="edmtest::MissingDictionaryTestA" ClassVersion="10">
+  <version ClassVersion="10" checksum="924871709"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestB" ClassVersion="10">
+  <version ClassVersion="10" checksum="3237077045"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestC" ClassVersion="10">
+  <version ClassVersion="10" checksum="276188887"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestD" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992233"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestE" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992341"/>
+ </class>
+<!--
+Commenting this out to intentionally cause the missing dictionary
+exception when running testMissingDictionaryChecking_cfg.py.
+ <class name="edmtest::MissingDictionaryTestF" ClassVersion="10">
+  <version ClassVersion="10" checksum="3318785451"/>
+ </class>
+-->
+ <class name="edmtest::MissingDictionaryTestG" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992557"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestH" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992665"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestI" ClassVersion="10">
+  <version ClassVersion="10" checksum="325955792"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestJ" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992881"/>
+ </class>
+ <class name="edmtest::MissingDictionaryTestK" ClassVersion="10">
+  <version ClassVersion="10" checksum="525992989"/>
+ </class>
+
+ <class name="std::vector<edmtest::MissingDictionaryTestA>"/>
+ <class name="std::list<edmtest::MissingDictionaryTestA>"/>
+ <class name="std::vector<edmtest::MissingDictionaryTestI>"/>
+ <class name="edm::Wrapper<edmtest::MissingDictionaryTestA>"/>
+ <class name="edm::Wrapper<std::vector<edmtest::MissingDictionaryTestA> >"/>
+ <class name="edm::Wrapper<std::list<edmtest::MissingDictionaryTestA> >"/>
 </lcgdict>

--- a/DataFormats/TestObjects/test/Enum_t.cpp
+++ b/DataFormats/TestObjects/test/Enum_t.cpp
@@ -1,7 +1,5 @@
 // Test of the DictionaryTools functions.
 
-
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"

--- a/DataFormats/TotemDigi/src/classes_def.xml
+++ b/DataFormats/TotemDigi/src/classes_def.xml
@@ -18,6 +18,9 @@
     <version ClassVersion="2" checksum="3003040825"/>
     <version ClassVersion="3" checksum="1439138260"/>
   </class>
+  <class name="edm::DetSet<TotemVFATStatus>"/>
+  <class name="std::vector<TotemVFATStatus>"/>
+  <class name="std::vector<edm::DetSet<TotemVFATStatus> >"/>
   <class name="edm::Wrapper<TotemVFATStatus>"/>
   <class name="edm::DetSetVector<TotemVFATStatus>"/>
   <class name="edm::Wrapper< edm::DetSetVector<TotemVFATStatus> >"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -403,6 +403,7 @@
      <class name="std::pair<edm::RefToBase<reco::Track>,double>" />
      <class name="std::vector<std::pair<edm::RefToBase<reco::Track>,double> >" />
 
+     <class name="edm::reftobase::BaseVectorHolder<reco::Track>" />
      <class name="reco::TrackBaseRefVector"/>
      <class name="edm::Wrapper<reco::TrackBaseRefVector>"/>
 

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -143,9 +143,11 @@
   <class name="std::vector<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> > >"/>
   <class name="edm::Wrapper<std::vector<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> > > >"/>
 
+  <class name="std::vector<FastTrackerRecHit*>" />
   <class name="edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >"/>
   <class name="edm::Wrapper<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> > >"/>
 
+  <class name="edm::Ref<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit> >" />
   <class name="std::vector<edm::Ref<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit> > >"/>
   <class name="edm::Wrapper<std::vector<edm::Ref<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<FastTrackerRecHit,edm::ClonePolicy<FastTrackerRecHit> >,FastTrackerRecHit> > > >"/>
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -25,6 +25,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "SharedResourcesRegistry.h"
@@ -139,6 +140,13 @@ namespace edm {
                                                  trueBranchIDToKeptBranchDesc);
 
     EDGetToken token;
+
+    std::vector<std::string> missingDictionaries;
+    if (!checkDictionary(missingDictionaries, desc.className(), desc.unwrappedType())) {
+      std::string context("Calling OutputModule::keepThisBranch, checking dictionaries for kept types");
+      throwMissingDictionariesException(missingDictionaries, context);
+    }
+
     switch (desc.branchType()) {
     case InEvent:
       {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -20,6 +20,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
@@ -50,7 +51,7 @@ namespace edm {
     bool binary_search_string(std::vector<std::string> const& v, std::string const& s) {
       return std::binary_search(v.begin(), v.end(), s);
     }
-    
+
     // Here we make the trigger results inserter directly.  This should
     // probably be a utility in the WorkerRegistry or elsewhere.
 
@@ -61,17 +62,17 @@ namespace edm {
                  ExceptionToActionTable const& actions,
                  std::shared_ptr<ActivityRegistry> areg,
                  std::shared_ptr<ProcessConfiguration> processConfiguration) {
-      
+
       ParameterSet* trig_pset = proc_pset.getPSetForUpdate("@trigger_paths");
       trig_pset->registerIt();
-      
+
       WorkerParams work_args(trig_pset, preg, &iPrealloc, processConfiguration, actions);
       ModuleDescription md(trig_pset->id(),
                            "TriggerResultInserter",
                            "TriggerResults",
                            processConfiguration.get(),
                            ModuleDescription::getUniqueID());
-      
+
       areg->preModuleConstructionSignal_(md);
       bool postCalled = false;
       std::shared_ptr<TriggerResultInserter> returnValue;
@@ -98,7 +99,7 @@ namespace edm {
       return returnValue;
     }
 
-    
+
     void
     checkAndInsertAlias(std::string const& friendlyClassName,
                         std::string const& moduleLabel,
@@ -134,7 +135,7 @@ namespace edm {
       }
       auto iter = aliasKeys.find(aliasKey);
       if(iter != aliasKeys.end()) {
-        // The alias matches a previous one.  If the same alias is used for different product, throw. 
+        // The alias matches a previous one.  If the same alias is used for different product, throw.
         if(iter->second != key) {
           throw Exception(errors::Configuration, "EDAlias conflict\n")
             << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
@@ -183,7 +184,7 @@ namespace edm {
           VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
           for(ParameterSet& pset : vPSet) {
             desc.validate(pset);
-            std::string friendlyClassName = pset.getParameter<std::string>("type"); 
+            std::string friendlyClassName = pset.getParameter<std::string>("type");
             std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
             std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
             if(productInstanceName == star) {
@@ -221,14 +222,14 @@ namespace edm {
       // Now add the new alias entries to the product registry.
       for(auto const& aliasEntry : aliasMap) {
         ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
-        assert(it != preg.productList().end()); 
+        assert(it != preg.productList().end());
         preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
       }
 
     }
 
     typedef std::vector<std::string> vstring;
-    
+
     void reduceParameterSet(ParameterSet& proc_pset,
                             vstring const& end_path_name_list,
                             vstring& modulesInConfig,
@@ -243,7 +244,7 @@ namespace edm {
       // ParameterSet: Remove that labels from @all_modules and from all the
       // end paths. If this makes any end paths empty, then remove the end path
       // name from @end_paths, and @paths.
-      
+
       // First make a list of labels to drop
       vstring outputModuleLabels;
       std::string edmType;
@@ -252,7 +253,7 @@ namespace edm {
       std::string const edAnalyzer("EDAnalyzer");
       std::string const edFilter("EDFilter");
       std::string const edProducer("EDProducer");
-      
+
       std::set<std::string> modulesInConfigSet(modulesInConfig.begin(), modulesInConfig.end());
 
       //need a list of all modules on paths in order to determine
@@ -289,7 +290,7 @@ namespace edm {
         }
         if(edmType == edAnalyzer) {
           if(modulesOnPaths.end()==modulesOnPaths.find(modLabel)) {
-            labelsToBeDropped.push_back(modLabel);            
+            labelsToBeDropped.push_back(modLabel);
           }
         }
       }
@@ -300,12 +301,12 @@ namespace edm {
 
       // drop the parameter sets used to configure the modules
       for_all(labelsToBeDropped, std::bind(&ParameterSet::eraseOrSetUntrackedParameterSet, std::ref(proc_pset), _1));
-      
+
       // drop the labels from @all_modules
       vstring::iterator endAfterRemove = std::remove_if(modulesInConfig.begin(), modulesInConfig.end(), std::bind(binary_search_string, std::ref(labelsToBeDropped), _1));
       modulesInConfig.erase(endAfterRemove, modulesInConfig.end());
       proc_pset.addParameter<vstring>(std::string("@all_modules"), modulesInConfig);
-      
+
       // drop the labels from all end paths
       vstring endPathsToBeDropped;
       vstring labels;
@@ -315,7 +316,7 @@ namespace edm {
         labels = proc_pset.getParameter<vstring>(*iEndPath);
         vstring::iterator iSave = labels.begin();
         vstring::iterator iBegin = labels.begin();
-        
+
         for (vstring::iterator iLabel = labels.begin(), iEnd = labels.end();
              iLabel != iEnd; ++iLabel) {
           if (binary_search_string(labelsToBeDropped, *iLabel)) {
@@ -339,18 +340,18 @@ namespace edm {
         }
       }
       sort_all(endPathsToBeDropped);
-      
+
       // remove empty end paths from @paths
       endAfterRemove = std::remove_if(scheduledPaths.begin(), scheduledPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledPaths.erase(endAfterRemove, scheduledPaths.end());
       proc_pset.addParameter<vstring>(std::string("@paths"), scheduledPaths);
-      
+
       // remove empty end paths from @end_paths
       vstring scheduledEndPaths = proc_pset.getParameter<vstring>("@end_paths");
       endAfterRemove = std::remove_if(scheduledEndPaths.begin(), scheduledEndPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledEndPaths.erase(endAfterRemove, scheduledEndPaths.end());
       proc_pset.addParameter<vstring>(std::string("@end_paths"), scheduledEndPaths);
-      
+
     }
 
     bool printDependencies(ParameterSet const& pset) {
@@ -366,7 +367,7 @@ namespace edm {
         if(rng.isAvailable()) {
           rng->consumes(consumesCollector());
           for (auto const& consumesInfo : this->consumesInfo()) {
-            typesConsumed.emplace(consumesInfo.type()); 
+            typesConsumed.emplace(consumesInfo.type());
           }
         }
       }
@@ -411,7 +412,7 @@ namespace edm {
         StreamID{i},
         processContext));
     }
-    
+
     //TriggerResults are injected automatically by StreamSchedules and are
     // unknown to the ModuleRegistry
     const std::string kTriggerResults("TriggerResults");
@@ -441,7 +442,7 @@ namespace edm {
       modulesToUse,
       proc_pset, preg, prealloc,
       actions,areg,processConfiguration,processContext);
-    
+
     //TriggerResults is not in the top level ParameterSet so the call to
     // reduceParameterSet would fail to find it. Just remove it up front.
     std::set<std::string> usedModuleLabels;
@@ -467,7 +468,7 @@ namespace edm {
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
         all_output_communicators_.emplace_back(std::shared_ptr<OutputModuleCommunicator>{comm.release()});
-      }      
+      }
     });
     // Now that the output workers are filled in, set any output limits or information.
     limitOutput(proc_pset, branchIDListHelper.branchIDLists());
@@ -491,22 +492,27 @@ namespace edm {
 
     {
       // We now get a collection of types that may be consumed.
-      std::set<TypeID> typesConsumed; 
+      std::set<TypeID> productTypesConsumed;
+      std::set<TypeID> elementTypesConsumed;
       // Loop over all modules
       for (auto const& worker : allWorkers()) {
         for (auto const& consumesInfo : worker->consumesInfo()) {
-          typesConsumed.emplace(consumesInfo.type()); 
+          if (consumesInfo.kindOfType() == PRODUCT_TYPE) {
+            productTypesConsumed.emplace(consumesInfo.type());
+          } else {
+            elementTypesConsumed.emplace(consumesInfo.type());
+          }
         }
       }
       // The SubProcess class is not a module, yet it may consume.
       if(hasSubprocesses) {
-        typesConsumed.emplace(typeid(TriggerResults)); 
+        productTypesConsumed.emplace(typeid(TriggerResults));
       }
       // The RandomNumberGeneratorService is not a module, yet it consumes.
       {
-         RngEDConsumer rngConsumer = RngEDConsumer(typesConsumed);
+         RngEDConsumer rngConsumer = RngEDConsumer(productTypesConsumed);
       }
-      preg.setFrozen(typesConsumed);
+      preg.setFrozen(productTypesConsumed, elementTypesConsumed);
     }
 
     for (auto& c : all_output_communicators_) {
@@ -517,31 +523,31 @@ namespace edm {
       std::vector<const ModuleDescription*> modDesc;
       const auto& workers = allWorkers();
       modDesc.reserve(workers.size());
-      
+
       std::transform(workers.begin(),workers.end(),
                      std::back_inserter(modDesc),
                      [](const Worker* iWorker) -> const ModuleDescription* {
                        return iWorker->descPtr();
                      });
-      
+
       // propagate_const<T> has no reset() function
       summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(
                                                     prealloc.numberOfStreams(),
                                                     modDesc,
                                                     tns);
       auto timeKeeperPtr = summaryTimeKeeper_.get();
-      
+
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
       areg->watchPostModuleEvent(timeKeeperPtr, &SystemTimeKeeper::stopModuleEvent);
       areg->watchPreModuleEventDelayedGet(timeKeeperPtr, &SystemTimeKeeper::pauseModuleEvent);
       areg->watchPostModuleEventDelayedGet(timeKeeperPtr,&SystemTimeKeeper::restartModuleEvent);
-      
+
       areg->watchPreSourceEvent(timeKeeperPtr, &SystemTimeKeeper::startEvent);
       areg->watchPostEvent(timeKeeperPtr, &SystemTimeKeeper::stopEvent);
-      
+
       areg->watchPrePathEvent(timeKeeperPtr, &SystemTimeKeeper::startPath);
       areg->watchPostPathEvent(timeKeeperPtr, &SystemTimeKeeper::stopPath);
-      
+
       areg->watchPostBeginJob(timeKeeperPtr, &SystemTimeKeeper::startProcessingLoop);
       areg->watchPreEndJob(timeKeeperPtr, &SystemTimeKeeper::stopProcessingLoop);
       //areg->preModuleEventSignal_.connect([timeKeeperPtr](StreamContext const& iContext, ModuleCallingContext const& iMod) {
@@ -551,7 +557,7 @@ namespace edm {
 
   } // Schedule::Schedule
 
-  
+
   void
   Schedule::limitOutput(ParameterSet const& proc_pset, BranchIDLists const& branchIDLists) {
     std::string const output("output");
@@ -618,9 +624,9 @@ namespace edm {
     {
       TriggerReport tr;
       getTriggerReport(tr);
-      
+
       // The trigger report (pass/fail etc.):
-      
+
       LogVerbatim("FwkSummary") << "";
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Event  Summary ------------";
       if(!tr.trigPathSummaries.empty()) {
@@ -635,7 +641,7 @@ namespace edm {
         << " passed = " << tr.eventSummary.totalEvents
         << " failed = 0";
       }
-      
+
       LogVerbatim("FwkSummary") << "";
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
@@ -661,7 +667,7 @@ namespace edm {
       std::vector<int>::const_iterator epe = empty_trig_paths_.end();
       std::vector<std::string>::const_iterator  epn = empty_trig_path_names_.begin();
       for (; epi != epe; ++epi, ++epn) {
-        
+
         LogVerbatim("FwkSummary") << "TrigReport "
         << std::right << std::setw(5) << 1
         << std::right << std::setw(5) << *epi << " "
@@ -672,7 +678,7 @@ namespace edm {
         << *epn << "";
       }
        */
-      
+
       LogVerbatim("FwkSummary") << "";
       LogVerbatim("FwkSummary") << "TrigReport " << "-------End-Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
@@ -692,7 +698,7 @@ namespace edm {
         << std::right << std::setw(10) << p.timesExcept << " "
         << p.name << "";
       }
-      
+
       for (auto const& p: tr.trigPathSummaries) {
         LogVerbatim("FwkSummary") << "";
         LogVerbatim("FwkSummary") << "TrigReport " << "---------- Modules in Path: " << p.name << " ------------";
@@ -703,7 +709,7 @@ namespace edm {
         << std::right << std::setw(10) << "Failed" << " "
         << std::right << std::setw(10) << "Error" << " "
         << "Name" << "";
-        
+
         unsigned int bitpos = 0;
         for (auto const& mod: p.moduleInPathSummaries) {
           LogVerbatim("FwkSummary") << "TrigReport "
@@ -717,7 +723,7 @@ namespace edm {
           ++bitpos;
         }
       }
-      
+
       for (auto const& p: tr.endPathSummaries) {
         LogVerbatim("FwkSummary") << "";
         LogVerbatim("FwkSummary") << "TrigReport " << "------ Modules in End-Path: " << p.name << " ------------";
@@ -728,7 +734,7 @@ namespace edm {
         << std::right << std::setw(10) << "Failed" << " "
         << std::right << std::setw(10) << "Error" << " "
         << "Name" << "";
-        
+
         unsigned int bitpos=0;
         for (auto const& mod: p.moduleInPathSummaries) {
           LogVerbatim("FwkSummary") << "TrigReport "
@@ -742,7 +748,7 @@ namespace edm {
           ++bitpos;
         }
       }
-      
+
       LogVerbatim("FwkSummary") << "";
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Module Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
@@ -782,7 +788,7 @@ namespace edm {
     LogVerbatim("FwkSummary") << "TimeReport"
                               << std::setprecision(6) << std::fixed
                               << " efficiency CPU/Real/thread = " << tr.eventSummary.cpuTime/tr.eventSummary.realTime/preallocConfig_.numberOfThreads();
-    
+
     constexpr int kColumn1Size = 10;
     constexpr int kColumn2Size = 12;
     constexpr int kColumn3Size = 12;
@@ -938,15 +944,15 @@ namespace edm {
 
   void Schedule::beginJob(ProductRegistry const& iRegistry) {
     checkForCorrectness();
-    
+
     globalSchedule_->beginJob(iRegistry);
   }
-  
+
   void Schedule::beginStream(unsigned int iStreamID) {
     assert(iStreamID<streamSchedules_.size());
     streamSchedules_[iStreamID]->beginStream();
   }
-  
+
   void Schedule::endStream(unsigned int iStreamID) {
     assert(iStreamID<streamSchedules_.size());
     streamSchedules_[iStreamID]->endStream();
@@ -974,15 +980,15 @@ namespace edm {
     if (nullptr == found) {
       return false;
     }
-    
+
     auto newMod = moduleRegistry_->replaceModule(iLabel,iPSet,preallocConfig_);
-    
+
     globalSchedule_->replaceModule(newMod,iLabel);
 
     for(auto& s: streamSchedules_) {
       s->replaceModule(newMod,iLabel);
     }
-    
+
     {
       //Need to updateLookup in order to make getByToken work
       auto const runLookup = iRegistry.productLookup(InRun);
@@ -1012,7 +1018,7 @@ namespace edm {
   Schedule::allWorkers() const {
     return globalSchedule_->allWorkers();
   }
-  
+
   void
   Schedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {
     streamSchedules_[0]->availablePaths(oLabelsToFill);
@@ -1092,7 +1098,7 @@ namespace edm {
   Schedule::endPathsEnabled() const {
     return endpathsAreActive_;
   }
-                          
+
   void
   Schedule::getTriggerReport(TriggerReport& rep) const {
     rep.eventSummary.totalEvents = 0;
@@ -1102,7 +1108,7 @@ namespace edm {
       s->getTriggerReport(rep);
     }
   }
-                          
+
   void
   Schedule::getTriggerTimingReport(TriggerTimingReport& rep) const {
     rep.eventSummary.totalEvents = 0;
@@ -1119,7 +1125,7 @@ namespace edm {
     }
     return returnValue;
   }
-  
+
   int
   Schedule::totalEventsPassed() const {
     int returnValue = 0;
@@ -1138,14 +1144,14 @@ namespace edm {
     return returnValue;
   }
 
-  
+
   void
   Schedule::clearCounters() {
     for(auto& s: streamSchedules_) {
       s->clearCounters();
     }
   }
-  
+
   //====================================
   // Schedule::checkForCorrectness algorithm
   //
@@ -1186,23 +1192,23 @@ namespace edm {
   //  Cycle: A consumes B, B consumes C, C consumes A
   //  Since this cycle has 0 path only edges it is unrunnable.
   //====================================
-  
+
   namespace {
     typedef std::pair<unsigned int, unsigned int> SimpleEdge;
     typedef std::map<SimpleEdge, std::vector<unsigned int>> EdgeToPathMap;
-    
+
     typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS> Graph;
 
     typedef boost::graph_traits<Graph>::edge_descriptor Edge;
     struct cycle_detector : public boost::dfs_visitor<> {
-      
+
       cycle_detector(EdgeToPathMap const& iEdgeToPathMap,
                      std::vector<std::string> const& iPathNames,
                      std::map<std::string,unsigned int> const& iModuleNamesToIndex):
       m_edgeToPathMap(iEdgeToPathMap),
       m_pathNames(iPathNames),
       m_namesToIndex(iModuleNamesToIndex){}
-      
+
       void tree_edge(Edge iEdge, Graph const&) {
         m_stack.push_back(iEdge);
       }
@@ -1219,10 +1225,10 @@ namespace edm {
       void back_edge(Edge iEdge, Graph const& iGraph) {
         //NOTE: If the path containing the cycle contains two or more
         // path only edges then there is no problem
-        
+
         typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
         IndexMap const& index = get(boost::vertex_index, iGraph);
-        
+
         unsigned int vertex = index[target(iEdge,iGraph)];
 
         //Find last edge which starts with this vertex
@@ -1251,7 +1257,7 @@ namespace edm {
         tempStack.reserve(m_stack.size()+1);
         tempStack.insert(tempStack.end(),itFirst,m_stack.end());
         tempStack.emplace_back(iEdge);
-        
+
         unsigned int nPathDependencyOnly =0;
         for(auto const& edge: tempStack) {
           unsigned int in =index[source(edge,iGraph)];
@@ -1277,7 +1283,7 @@ namespace edm {
       std::string const& pathName(unsigned int iIndex) const {
         return m_pathNames[iIndex];
       }
-      
+
       std::string const& moduleName(unsigned int iIndex) const {
         for(auto const& item : m_namesToIndex) {
           if(item.second == iIndex) {
@@ -1286,7 +1292,7 @@ namespace edm {
         }
         assert(false);
       }
-      
+
       void
       throwOnError(std::vector<Edge>const& iEdges,
                    boost::property_map<Graph, boost::vertex_index_t>::type const& iIndex,
@@ -1297,14 +1303,14 @@ namespace edm {
         for(auto const& edge: iEdges) {
           unsigned int in =iIndex[source(edge,iGraph)];
           unsigned int out =iIndex[target(edge,iGraph)];
-          
+
           if(first_edge) {
             first_edge = false;
           } else {
             oStream<<", ";
           }
           oStream <<moduleName(in);
-          
+
           auto iFound = m_edgeToPathMap.find(SimpleEdge(in,out));
           bool pathDependencyOnly = true;
           for(auto dependency : iFound->second) {
@@ -1321,19 +1327,19 @@ namespace edm {
         }
         oStream<<"\n Running in the threaded framework would lead to indeterminate results."
         "\n Please change order of modules in mentioned Path(s) to avoid inconsistent module ordering.";
-        
+
         throw Exception(errors::ScheduleExecutionFailure, "Unrunnable schedule\n")
            << oStream.str() << "\n";
       }
-      
+
       EdgeToPathMap const& m_edgeToPathMap;
       std::vector<std::string> const& m_pathNames;
       std::map<std::string,unsigned int> m_namesToIndex;
-      
+
       std::list<Edge> m_stack;
     };
   }
-  
+
   void
   Schedule::checkForCorrectness() const
   {
@@ -1343,7 +1349,7 @@ namespace edm {
       moduleNamesToIndex.insert(std::make_pair(worker->description().moduleLabel(),
                                          worker->description().id()));
     }
-    
+
     //If a module to module dependency comes from a path, remember which path
     EdgeToPathMap edgeToPathMap;
 
@@ -1351,7 +1357,7 @@ namespace edm {
     std::vector<std::string> pathNames;
     {
       streamSchedules_[0]->availablePaths(pathNames);
-      
+
       std::vector<std::string> moduleNames;
       std::vector<std::string> reducedModuleNames;
       unsigned int pathIndex=0;
@@ -1359,7 +1365,7 @@ namespace edm {
         moduleNames.clear();
         reducedModuleNames.clear();
         std::set<std::string> alreadySeenNames;
-        
+
         streamSchedules_[0]->modulesInPath(path,moduleNames);
         std::string lastModuleName;
         unsigned int lastModuleIndex = 0;
@@ -1402,9 +1408,9 @@ namespace edm {
     for(auto const& edgeInfo: edgeToPathMap) {
       outList.push_back(edgeInfo.first);
     }
-    
+
     Graph g(outList.begin(),outList.end(), moduleNamesToIndex.size());
-    
+
     cycle_detector detector(edgeToPathMap,pathNames,moduleNamesToIndex);
     boost::depth_first_search(g,boost::visitor(detector));
   }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -22,7 +22,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 
 #include <algorithm>
 #include <cassert>

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -6,7 +6,6 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 
 static const std::string kFilterType("EDFilter");
 static const std::string kProducerType("EDProducer");

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -35,7 +35,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
-
+#include "FWCore/Utilities/interface/DictionaryTools.h"
 
 namespace edm {
   namespace one {
@@ -143,6 +143,13 @@ namespace edm {
                                                    trueBranchIDToKeptBranchDesc);
 
       EDGetToken token;
+
+      std::vector<std::string> missingDictionaries;
+      if (!checkDictionary(missingDictionaries, desc.className(), desc.unwrappedType())) {
+        std::string context("Calling OutputModuleBase::keepThisBranch, checking dictionaries for kept types");
+        throwMissingDictionariesException(missingDictionaries, context);
+      }
+
       switch (desc.branchType()) {
       case InEvent:
         {

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -105,7 +105,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Framework"/>
     <use   name="DataFormats/TestObjects"/>

--- a/FWCore/Integration/test/CatchCmsExceptiontest.sh
+++ b/FWCore/Integration/test/CatchCmsExceptiontest.sh
@@ -19,6 +19,10 @@ die 'Failed because expected exception was not thrown while running cmsRun Catch
 
 grep -q "Calling InputSource::beginRun" CatchCmsExceptionFromSource.log || die 'Failed to find string Calling InputSource::beginRun' $?
 
+# It is intentional that this test throws an exception. The test fails if it does not.
+cmsRun ${LOCAL_TEST_DIR}/testMissingDictionaryChecking_cfg.py &> testMissingDictionaryChecking.log && die 'Failed to get exception running testMissingDictionaryChecking_cfg.py' 1
+grep -q MissingDictionaryTestF testMissingDictionaryChecking.log || die 'Failed to print out exception message with missing dictionary listed' $?
+
 popd
 
 #grep -w ESProducer CatcheStdException.log

--- a/FWCore/Integration/test/MissingDictionaryTestProducer.cc
+++ b/FWCore/Integration/test/MissingDictionaryTestProducer.cc
@@ -1,0 +1,82 @@
+/** \class edmtest::MissingDictionaryTestProducer
+\author W. David Dagenhart, created 26 May 2016
+*/
+
+// Without manual intervention this simply tests the case where all
+// the test dictionaries are defined, which is not very interesting.
+// Its primary purpose is to be run manually where specific dictionaries
+// have been removed from classes_def.xml and checking that the proper
+// exceptions are thrown without having to generate this code from scratch.
+
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "DataFormats/TestObjects/interface/MissingDictionaryTestObject.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include <list>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class MissingDictionaryTestProducer : public edm::one::EDProducer<> {
+  public:
+
+    explicit MissingDictionaryTestProducer(edm::ParameterSet const&);
+    virtual ~MissingDictionaryTestProducer();
+
+    void produce(edm::Event&, edm::EventSetup const&) override;
+
+  private:
+
+    edm::EDGetTokenT<MissingDictionaryTestA> inputToken1_;
+    edm::EDGetTokenT<std::vector<MissingDictionaryTestA> > inputToken2_;
+    edm::EDGetTokenT<std::list<MissingDictionaryTestA> > inputToken3_;
+  };
+
+  MissingDictionaryTestProducer::MissingDictionaryTestProducer(edm::ParameterSet const& pset) {
+
+    consumes<edm::View<MissingDictionaryTestA> >(pset.getParameter<edm::InputTag>("inputTag"));
+    inputToken1_ = consumes<MissingDictionaryTestA>(pset.getParameter<edm::InputTag>("inputTag"));
+    inputToken2_ = consumes<std::vector<MissingDictionaryTestA> >(pset.getParameter<edm::InputTag>("inputTag"));
+    inputToken3_ = consumes<std::list<MissingDictionaryTestA> >(pset.getParameter<edm::InputTag>("inputTag"));
+
+    produces<MissingDictionaryTestA>();
+    produces<MissingDictionaryTestA>("anInstance");
+    produces<std::vector<MissingDictionaryTestA> >();
+    produces<std::vector<MissingDictionaryTestA> >("anInstance");
+    produces<std::list<MissingDictionaryTestA> >();
+  }
+
+  MissingDictionaryTestProducer::~MissingDictionaryTestProducer() { }
+
+  void MissingDictionaryTestProducer::produce(edm::Event& event, edm::EventSetup const&) {
+
+    edm::Handle<MissingDictionaryTestA> h1;
+    //event.getByToken(inputToken1_, h1);
+
+    edm::Handle<std::vector<MissingDictionaryTestA> > h2;
+    //event.getByToken(inputToken2_, h2);
+
+    auto result1 = std::make_unique<MissingDictionaryTestA>();
+    event.put(std::move(result1));
+
+    auto result2 = std::make_unique<MissingDictionaryTestA>();
+    event.put(std::move(result2), "anInstance");
+
+    auto result3 = std::make_unique<std::vector<MissingDictionaryTestA> >();
+    event.put(std::move(result3));
+
+    auto result4 = std::make_unique<std::vector<MissingDictionaryTestA> >();
+    event.put(std::move(result4), "anInstance");
+  }
+}
+using edmtest::MissingDictionaryTestProducer;
+DEFINE_FWK_MODULE(MissingDictionaryTestProducer);

--- a/FWCore/Integration/test/testMissingDictionaryChecking_cfg.py
+++ b/FWCore/Integration/test/testMissingDictionaryChecking_cfg.py
@@ -1,0 +1,34 @@
+# This configuration file tests the code that checks
+# for missing ROOT dictionaries. It is intentional
+# that the cmsRun job fails with an exception.
+
+# Note that this only tests one simple case,
+# but one could use this as a starting point
+# to test other cases by editing the classes_def.xml
+# to comment out dictionary definitions or the editing
+# the consumes and produces calls in
+# MissingDictionaryTestProducer to test the many other
+# possible cases in this part of the code.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testMissingDictionaries.root')
+)
+
+process.a3 = cms.EDProducer("TestMod")
+
+process.a1 = cms.EDProducer("MissingDictionaryTestProducer",
+  inputTag = cms.InputTag("a2")
+)
+
+process.p = cms.Path(process.a3 * process.a1)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -12,23 +12,59 @@ the CMS event model.
 #include <string>
 #include <vector>
 
-#include "FWCore/Utilities/interface/TypeID.h"
+class TClass;
 
 namespace edm {
 
-class TypeID;
-class TypeWithDict;
-using TypeSet = std::set<TypeID>;
+  class Exception;
+  class TypeID;
+  class TypeWithDict;
 
-bool checkClassDictionary(TypeID const& type, TypeSet& missingTypes);
-void checkClassDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive = true);
-bool checkTypeDictionary(TypeID const& type, TypeSet& missingTypes);
-void checkTypeDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive = true);
-void throwMissingDictionariesException(TypeSet const&);
-void loadMissingDictionaries(TypeSet missingTypes);
+  bool checkDictionary(std::vector<std::string>& missingDictionaries,
+                       TypeID const& typeID);
 
-void public_base_classes(TypeWithDict const& type,
-                         std::vector<TypeWithDict>& baseTypes);
+  bool checkDictionaryOfWrappedType(std::vector<std::string>& missingDictionaries,
+                                    TypeID const& unwrappedTypeID);
+
+  bool checkDictionaryOfWrappedType(std::vector<std::string>& missingDictionaries,
+                                    std::string const& unwrappedName);
+
+  bool checkDictionary(std::vector<std::string>& missingDictionaries,
+                       std::string const& name,
+                       TypeWithDict const& typeWithDict);
+
+  bool checkClassDictionaries(std::vector<std::string>& missingDictionaries,
+                              TypeID const& typeID);
+
+  bool checkClassDictionaries(std::vector<std::string>& missingDictionaries,
+                              std::string const& name,
+                              TypeWithDict const& typeWithDict);
+
+  void addToMissingDictionariesException(edm::Exception& exception,
+                                         std::vector<std::string>& missingDictionaries,
+                                         std::string const& context);
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context);
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::vector<std::string>& producedTypes);
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::vector<std::string>& producedTypes,
+                                         std::vector<std::string>& branchNames,
+                                         bool fromStreamerSource = false);
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::set<std::string>& producedTypes,
+                                         bool consumedWithView);
+
+  bool public_base_classes(std::vector<std::string>& missingDictionaries,
+                           TypeID const& typeID,
+                           std::vector<TypeWithDict>& baseTypes);
 } // namespace edm
 
 #endif // FWCore_Utilities_DictionaryTools_h

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -69,6 +69,7 @@ public:
   TypeWithDict& operator=(TypeWithDict const&);
   TypeWithDict& stripConstRef();
   explicit operator bool() const;
+  bool invalidTypeInfo() const;
   std::type_info const& typeInfo() const;
   TClass* getClass() const;
   TEnum* getEnum() const;

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -1,145 +1,365 @@
+
+/*
+
+This file defines functions used to check if ROOT dictionaries
+are missing for those types that require dictionaries.
+Also there is a utility function named public_base_classes that
+is used to find the base classes of classes used as elements in
+container products. These base classes are needed to setup the
+product lookup tables to support Views. That function also checks
+for dictionaries of that contained class and its base classes as
+it finds them.
+
+As of this writing, the dictionary checking functions are used
+in the following circumstances:
+
+1. All produced products.
+
+2. All products in the main ProductRegistry and that are present
+in the input.
+
+3. All consumed product types. Also for consumed element types (used by
+View). But for consumed element types there is only a requirement that
+the element type and its base classes have dictionaries (because there
+is no way to know if the containing product type is transient or not).
+
+4. Products declared as kept by an output module.
+
+Transient classes are an exception to the above requirements. For
+transients classes the only classes that are required to have dictionaries
+are the top level type and its wrapped type. Also if it is a container
+that can be accessed by Views, then its contained type and the base classes
+of that contained type must also have dictionaries.  But only that.
+Other contituents types of a transient type are not required to have
+dictionaries. This special treatment of transients is genuinely needed
+because there are multiple transient types in CMSSW which do not have
+dictionaries for many of their constituent types.
+
+For persistent types it checks the unwrapped type, the wrapped type, and
+all the constituent types. It uses the TClass::GetMissingDictionaries
+function from ROOT to check constituent types and depends on that.
+(Currently, there is a JIRA ticket submitted related to bugs in that
+ROOT function, JIRA-8208. We are trying to use the ROOT function for
+that instead of creating our own CMS specific code that we need to
+develop and maintain.). For transient types, TClass::GetMissingDictionaries
+is not used because it requires too many of the constituent types
+to have dictionaries.
+
+*/
+
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/BaseWithDict.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/MemberWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/WrappedClassName.h"
 
 #include "TClass.h"
-#include "TInterpreter.h"
 #include "THashTable.h"
-
-#include "boost/algorithm/string.hpp"
-#include "boost/thread/tss.hpp"
 
 #include <algorithm>
 #include <sstream>
-#include <string>
 
 namespace edm {
 
   bool
-  checkTypeDictionary(TypeID const& type, TypeSet& missingTypes) {
-    TClass *cl = TClass::GetClass(type.typeInfo(), true);
-    if(cl == nullptr) {
-      // Assume not a class
-      return true;
+  checkDictionary(std::vector<std::string>& missingDictionaries,
+                  TypeID const& typeID) {
+
+    TClass::GetClass(typeID.typeInfo());
+    if (!hasDictionary(typeID.typeInfo())) {
+      // a second attempt to load
+      TypeWithDict::byName(typeID.className());
     }
-    if(!cl->HasDictionary()) {
-      missingTypes.insert(type);
+    if (!hasDictionary(typeID.typeInfo())) {
+      missingDictionaries.emplace_back(typeID.className());
       return false;
     }
     return true;
   }
 
-  void
-  checkTypeDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive) {
-    TClass *cl = TClass::GetClass(type.typeInfo(), true);
-    if(cl == nullptr) {
-      // Assume not a class
-      return;
-    }
-    THashTable result;
-    cl->GetMissingDictionaries(result, recursive); 
-    for(auto const& item : result) {
-      TClass const* cl = static_cast<TClass const*>(item);
-      missingTypes.insert(TypeID(cl->GetTypeInfo()));
-    }
+  bool checkDictionaryOfWrappedType(std::vector<std::string>& missingDictionaries,
+                                    TypeID const& unwrappedTypeID) {
+    std::string wrappedName = wrappedClassName(unwrappedTypeID.className());
+    TypeWithDict wrappedTypeWithDict = TypeWithDict::byName(wrappedName);
+    return checkDictionary(missingDictionaries, wrappedName, wrappedTypeWithDict);
+  }
+
+  bool checkDictionaryOfWrappedType(std::vector<std::string>& missingDictionaries,
+                                    std::string const& unwrappedName) {
+    std::string wrappedName = wrappedClassName(unwrappedName);
+    TypeWithDict wrappedTypeWithDict = TypeWithDict::byName(wrappedName);
+    return checkDictionary(missingDictionaries, wrappedName, wrappedTypeWithDict);
   }
 
   bool
-  checkClassDictionary(TypeID const& type, TypeSet& missingTypes) {
-    TClass *cl = TClass::GetClass(type.typeInfo(), true);
-    if(cl == nullptr) {
-      throw Exception(errors::DictionaryNotFound)
-          << "No TClass for class: '" << type.className() << "'" << std::endl;
-    }
-    if(!cl->HasDictionary()) {
-      missingTypes.insert(type);
+  checkDictionary(std::vector<std::string>& missingDictionaries,
+                  std::string const& name,
+                  TypeWithDict const& typeWithDict) {
+    if (!bool(typeWithDict) || typeWithDict.invalidTypeInfo()) {
+      missingDictionaries.emplace_back(name);
       return false;
     }
     return true;
   }
 
-  void
-  checkClassDictionaries(TypeID const& type, TypeSet& missingTypes, bool recursive) {
-    TClass *cl = TClass::GetClass(type.typeInfo(), true);
-    if(cl == nullptr) {
-      throw Exception(errors::DictionaryNotFound)
-          << "No TClass for class: '" << type.className() << "'" << std::endl;
+  bool
+  checkClassDictionaries(std::vector<std::string>& missingDictionaries,
+                         TypeID const& typeID) {
+
+    // For a class type with a dictionary the TClass* will be
+    // non-null and hasDictionary will return true.
+    // For a type like "int", the TClass* pointer will be a
+    // nullptr and hasDictionary will return true.
+    // For a class type without a dictionary it is possible for
+    // TClass* to be non-null and hasDictionary to return false.
+
+    TClass* tClass = TClass::GetClass(typeID.typeInfo());
+    if (!hasDictionary(typeID.typeInfo())) {
+      // a second attempt to load
+      TypeWithDict::byName(typeID.className());
+      tClass = TClass::GetClass(typeID.typeInfo());
     }
-    THashTable result;
-    cl->GetMissingDictionaries(result, recursive); 
-    for(auto const& item : result) {
+    if (!hasDictionary(typeID.typeInfo())) {
+      missingDictionaries.emplace_back(typeID.className());
+      return false;
+    }
+
+    if (tClass == nullptr) {
+      return true;
+    }
+
+    bool result = true;
+
+    THashTable hashTable;
+    bool recursive = true;
+    tClass->GetMissingDictionaries(hashTable, recursive);
+
+    for(auto const& item : hashTable) {
       TClass const* cl = static_cast<TClass const*>(item);
-      missingTypes.insert(TypeID(cl->GetTypeInfo()));
+      missingDictionaries.emplace_back(cl->GetName());
+      result = false;
+    }
+    return result;
+  }
+
+  bool
+  checkClassDictionaries(std::vector<std::string>& missingDictionaries,
+                         std::string const& name,
+                         TypeWithDict const& typeWithDict) {
+    if (!bool(typeWithDict) || typeWithDict.invalidTypeInfo()) {
+      missingDictionaries.emplace_back(name);
+      return false;
+    }
+
+    TClass *tClass = typeWithDict.getClass();
+    if (tClass == nullptr) {
+      missingDictionaries.emplace_back(name);
+      return false;
+    }
+
+    THashTable hashTable;
+    bool recursive = true;
+    tClass->GetMissingDictionaries(hashTable, recursive);
+
+    bool result = true;
+
+    for(auto const& item : hashTable) {
+      TClass const* cl = static_cast<TClass const*>(item);
+      missingDictionaries.emplace_back(cl->GetName());
+      result = false;
+    }
+    return result;
+  }
+
+  void addToMissingDictionariesException(edm::Exception& exception,
+                                         std::vector<std::string>& missingDictionaries,
+                                         std::string const& context) {
+
+    std::sort(missingDictionaries.begin(), missingDictionaries.end());
+    missingDictionaries.erase(std::unique(missingDictionaries.begin(), missingDictionaries.end()), missingDictionaries.end());
+
+    std::ostringstream ostr;
+    for(auto const& item : missingDictionaries) {
+      ostr << "  " << item << "\n";
+    }
+    exception << "No data dictionary found for the following classes:\n\n"
+              << ostr.str() << "\n"
+              << "Most likely each dictionary was never generated, but it may\n"
+              << "be that it was generated in the wrong package. Please add\n"
+              << "(or move) the specification \'<class name=\"whatever\"/>\' to\n"
+              << "the appropriate classes_def.xml file along with any other\n"
+              << "information needed there. For example, if this class has any\n"
+              << "transient members, you need to specify them in classes_def.xml.\n"
+              << "Also include the class header in classes.h\n";
+
+    if (!context.empty()) {
+      exception.addContext(context);
     }
   }
 
-  void
-  throwMissingDictionariesException(TypeSet const& missingTypes) {
-    if (!missingTypes.empty()) {
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context) {
+    std::vector<std::string> empty;
+    throwMissingDictionariesException(missingDictionaries, context, empty);
+  }
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::vector<std::string>& producedTypes) {
+
+    edm::Exception exception(errors::DictionaryNotFound);
+    addToMissingDictionariesException(exception, missingDictionaries, context);
+
+    if (!producedTypes.empty()) {
+      std::sort(producedTypes.begin(), producedTypes.end());
+      producedTypes.erase(std::unique(producedTypes.begin(), producedTypes.end()), producedTypes.end());
+
       std::ostringstream ostr;
-      for(auto const& item : missingTypes) {
-        ostr << item << "\n\n";
+      for(auto const& item : producedTypes) {
+        ostr << "  " << item << "\n";
       }
-      throw Exception(errors::DictionaryNotFound)
-          << "No data dictionary found for the following classes:\n\n"
-          << ostr.str()
-          << "Most likely each dictionary was never generated,\n"
-          << "but it may be that it was generated in the wrong package.\n"
-          << "Please add (or move) the specification\n"
-          << "<class name=\"whatever\"/>\n"
-          << "to the appropriate classes_def.xml file.\n"
-          << "If the class is a template instance, you may need\n"
-          << "to define a dummy variable of this type in classes.h.\n"
-          << "Also, if this class has any transient members,\n"
-          << "you need to specify them in classes_def.xml.";
+      exception << "\nA type listed above might or might not be the same as a\n"
+                << "type declared by a producer module with the function \'produces\'.\n"
+                << "Instead it might be the type of a data member, base class,\n"
+                << "wrapped type, or other object needed by a produced type. Below\n"
+                << "is some additional information which lists the types declared\n"
+                << "to be produced by a producer module that are associated with\n"
+                << "the types whose dictionaries were not found:\n\n"
+                << ostr.str() << "\n";
     }
+    throw exception;
   }
 
-  void
-  loadMissingDictionaries(TypeSet missingTypes) {
-    while (!missingTypes.empty()) {
-      TypeSet missing(missingTypes);
-      for(auto const& item : missing) {
-        try {
-          TClass::GetClass(item.typeInfo(), kTRUE);
-        }
-        // We don't want to fail if we can't load a plug-in.
-        catch (...) {}
+
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::vector<std::string>& producedTypes,
+                                         std::vector<std::string>& branchNames,
+                                         bool fromStreamerSource) {
+
+
+    edm::Exception exception(errors::DictionaryNotFound);
+    addToMissingDictionariesException(exception, missingDictionaries, context);
+
+    if (!producedTypes.empty()) {
+      std::sort(producedTypes.begin(), producedTypes.end());
+      producedTypes.erase(std::unique(producedTypes.begin(), producedTypes.end()), producedTypes.end());
+
+      std::ostringstream ostr;
+      for(auto const& item : producedTypes) {
+        ostr << "  " << item << "\n";
       }
-      missingTypes.clear();
-      for(auto const& item : missing) {
-        checkTypeDictionaries(item, missingTypes,true);
-      }
-      if (missingTypes == missing) {
-        break;
+      if (fromStreamerSource) {
+        exception << "\nA type listed above might or might not be the same as a\n"
+                  << "type stored in the Event. Instead it might be the type of\n"
+                  << "a data member, base class, wrapped type, or other object\n"
+                  << "needed by a stored type. Below is some additional information\n"
+                  << "which lists the stored types associated with the types whose\n"
+                  << "dictionaries were not found:\n\n"
+                  << ostr.str() << "\n";
+      } else {
+        exception << "\nA type listed above might or might not be the same as a\n"
+                  << "type stored in the Event (or Lumi or Run). Instead it might\n"
+                  << "be the type of a data member, base class, wrapped type, or\n"
+                  << "other object needed by a stored type. Below is some additional\n"
+                  << "information which lists the stored types associated with the\n"
+                  << "types whose dictionaries were not found:\n\n"
+                  << ostr.str() << "\n";
       }
     }
-    if (missingTypes.empty()) {
-      return;
+
+    if (!branchNames.empty()) {
+
+      std::sort(branchNames.begin(), branchNames.end());
+      branchNames.erase(std::unique(branchNames.begin(), branchNames.end()), branchNames.end());
+
+      std::ostringstream ostr;
+      for(auto const& item : branchNames) {
+        ostr << "  " << item << "\n";
+      }
+      if (fromStreamerSource) {
+        exception  << "Missing dictionaries are associated with these branch names:\n\n"
+                   << ostr.str() << "\n";
+      } else {
+        exception  << "Missing dictionaries are associated with these branch names:\n\n"
+                   << ostr.str() << "\n"
+                   << "If you do not need these branches and they are not produced\n"
+                   << "in the current process, an alternate solution to adding\n"
+                   << "dictionaries is to drop these branches on input using the\n"
+                   << "inputCommands parameter of the PoolSource.";
+      }
     }
-    throwMissingDictionariesException(missingTypes);
+    throw exception;
   }
 
-  void
-  public_base_classes(TypeWithDict const& typeID,
+  void throwMissingDictionariesException(std::vector<std::string>& missingDictionaries,
+                                         std::string const& context,
+                                         std::set<std::string>& producedTypes,
+                                         bool consumedWithView) {
+
+    edm::Exception exception(errors::DictionaryNotFound);
+    addToMissingDictionariesException(exception, missingDictionaries, context);
+
+    if (!producedTypes.empty()) {
+
+      std::ostringstream ostr;
+      for(auto const& item : producedTypes) {
+        ostr << "  " << item << "\n";
+      }
+      if (consumedWithView) {
+        exception << "\nThe list of types above was generated while checking for\n"
+                  << "dictionaries related to products declared to be consumed\n"
+                  << "using a View. They will be either the type or a base class\n"
+                  << "of the type declared in a consumes declaration as the template\n"
+                  << "parameter of a View. Below is some additional information\n"
+                  << "which lists the type of the template parameter of the View.\n"
+                  << "(It will be the same type unless the missing dictionary is\n"
+                  << "for a base type):\n\n"
+                  << ostr.str() << "\n";
+      } else {
+        exception << "\nThe list of types above was generated while checking for\n"
+                  << "dictionaries related to products declared to be consumed.\n"
+                  << "A type listed above might or might not be a type declared\n"
+                  << "to be consumed. Instead it might be the type of a data member,\n"
+                  << "base class, wrapped type or other object needed by a consumed\n"
+                  << "type.  Below is some additional information which lists\n"
+                  << "the types declared to be consumed by a module and which\n"
+                  << "are associated with the types whose dictionaries were not\n"
+                  << "found:\n\n"
+                  << ostr.str() << "\n";
+      }
+    }
+    throw exception;
+  }
+
+
+  bool
+  public_base_classes(std::vector<std::string>& missingDictionaries,
+                      TypeID const& typeID,
                       std::vector<TypeWithDict>& baseTypes) {
-    if (!typeID.isClass()) {
-      return;
+
+    if (!checkDictionary(missingDictionaries, typeID)) {
+      return false;
     }
-    TypeWithDict type(typeID.typeInfo());
-    TypeBases bases(type);
+    TypeWithDict typeWithDict(typeID.typeInfo());
+
+    if (!typeWithDict.isClass()) {
+      return true;
+    }
+
+    TypeBases bases(typeWithDict);
+    bool returnValue = true;
     for (auto const& basex : bases) {
       BaseWithDict base(basex);
       if (!base.isPublic()) {
         continue;
       }
       TypeWithDict baseRflxType = base.typeOf();
-      if (!bool(baseRflxType)) {
+      if (!checkDictionary(missingDictionaries, baseRflxType.name(), baseRflxType)) {
+        returnValue = false;
         continue;
       }
       TypeWithDict baseType(baseRflxType.typeInfo());
@@ -148,7 +368,10 @@ namespace edm {
       if (!search_all(baseTypes, baseType)) {
         // Save the type and recursive look for its base types
         baseTypes.push_back(baseType);
-        public_base_classes(baseType, baseTypes);
+        if (!public_base_classes(missingDictionaries, TypeID(baseType.typeInfo()), baseTypes)) {
+          returnValue = false;
+          continue;
+        }
       }
       // For now just ignore it if the class appears twice,
       // After some more testing we may decide to uncomment the following
@@ -170,6 +393,7 @@ namespace edm {
       //    << "deal with this case. Class name of base class: " << baseType.Name() << "\n\n";
       //}
     }
+    return returnValue;
   }
 
 } // namespace edm

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -350,6 +350,10 @@ namespace edm {
     return false;
   }
 
+  bool TypeWithDict::invalidTypeInfo() const {
+    return *ti_ == typeid(dummyType) || isPointer() || isArray();
+  }
+
   std::type_info const&
   TypeWithDict::typeInfo() const {
     if(*ti_ == typeid(dummyType) || isPointer() || isArray()) {

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -14,7 +14,6 @@
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 

--- a/IOPool/Streamer/interface/ClassFiller.h
+++ b/IOPool/Streamer/interface/ClassFiller.h
@@ -9,6 +9,7 @@
 #include <typeinfo>
 #include <string>
 #include <set>
+#include <vector>
 
 namespace edm
 {
@@ -29,7 +30,7 @@ namespace edm
 
   void loadExtraClasses();
   TClass* getTClass(const std::type_info& ti);
-  void loadCap(const std::string& name);
+  bool loadCap(const std::string& name, std::vector<std::string>& missingDictionaries);
   void doBuildRealData(const std::string& name);
 }
 

--- a/SimTracker/TrackerHitAssociation/src/classes_def.xml
+++ b/SimTracker/TrackerHitAssociation/src/classes_def.xml
@@ -12,7 +12,8 @@
  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >,edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> > >" />
  <class name="edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> >" />
 
-  <class name="std::pair<OmniClusterRef, TrackingParticleRef>" persistent="true" /> 
+  <class name="std::pair<OmniClusterRef, TrackingParticleRef>" persistent="true" />
+  <class name="std::vector<std::pair<OmniClusterRef, TrackingParticleRef> >" />
   <class name="ClusterTPAssociation" persistent="true" />
   <class name="edm::Wrapper<ClusterTPAssociation>" />
   <class name="std::map<TrackingParticleRef, std::vector<OmniClusterRef> >" persistent="false" /> 


### PR DESCRIPTION
The changes here started when fixing the bug reported
in issue 14242 where "std::type_info*" was incorrectly
being reported as the type for missing dictionaries.
While working on this, found several other problems in
this part of the code and made significant revisions to
it.

One feature that is new is now dictionaries are checked
for all consumed types. In addition, the pre-existing
checking for dictionaries of produced types, present types,
and types selected for output is done in a more consistent
way with better and more consistent error messages.

These changes rely on the ROOT function TClass::GetMissingDictionaries
more than the previous version. A design choice was to
use this instead of developing and maintaining CMS specific
code to look for dictionaries for all the constituents
of a class. This ROOT function currently does not work as we
expect and as part of this effort we submitted bug report
JIRA-8208 to the ROOT bug tracking system. When this bug
is fixed in ROOT the missing dictionary checking will find
more dictionaries to be missing.

This also includes addition of dictionaries necessary for
runTheMatrix to run successfully with the more thorough
dictionary checking.
