### PR TITLE
Add support for filelist: to cmsDriver --pileup_input

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -703,6 +703,8 @@ class ConfigBuilder(object):
 			if self._options.pileup_input:
 				if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
 					mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
+				elif self._options.pileup_input.startswith("filelist:"):
+					mixingDict['F']=(filesFromList(self._options.pileup_input[9:]))[0]
 				else:
 					mixingDict['F']=self._options.pileup_input.split(',')
 			specialization=defineMixing(mixingDict)


### PR DESCRIPTION
I was trying to use cmsDriver with `--pileup_input filelist:...` but that didn't work as expected. Copy-pasting the lines from https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/Configuration/Applications/python/ConfigBuilder.py#L1469 to here too seemed to do the job.

Tested in 8_1_0_pre6, no changes exepcted.
