### PR TITLE
Fix subtle bug in PixelDigiSimLink creation

### DIFF
--- a/SimTracker/Common/interface/SimHitInfoForLinks.h
+++ b/SimTracker/Common/interface/SimHitInfoForLinks.h
@@ -8,10 +8,20 @@
 // Contains only the information needed to be make DigiSimLinks.
 // Include the simHit's index in the source collection, collection name suffix index.
 
-  struct SimHitInfoForLinks {
+  class SimHitInfoForLinks {
+  public:
     explicit SimHitInfoForLinks(PSimHit const* hitp, size_t hitindex, unsigned int tofbin) :
       eventId_(hitp->eventId()), trackIds_(1, hitp->trackId()), hitIndex_(hitindex), tofBin_(tofbin) {
     }
+
+    const EncodedEventId& eventId() const { return eventId_; }
+    const std::vector<unsigned int>& trackIds() const { return trackIds_; }
+    std::vector<unsigned int>& trackIds() { return trackIds_; } // needed ATM in phase2 digitizer
+    unsigned int trackId() const { return trackIds_[0]; }
+    size_t hitIndex() const { return hitIndex_; }
+    unsigned int tofBin() const { return tofBin_; }
+
+  private:
     EncodedEventId eventId_;
     std::vector<unsigned int> trackIds_;
     size_t hitIndex_;

--- a/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
@@ -30,7 +30,7 @@ namespace DigitizerUtility {
       // the MC information are removed
       if (_frac[0] < -0.5) {
 	_frac.pop_back();
-	_hitInfo->trackIds_.pop_back();
+	_hitInfo->trackIds().pop_back();
       }
     }
 
@@ -38,7 +38,7 @@ namespace DigitizerUtility {
     operator float() const {return _amp;}
     float ampl() const {return _amp;}
     std::vector<float> individualampl() const {return _frac;}
-    const std::vector<unsigned int>& trackIds() const {return _hitInfo->trackIds_;}
+    const std::vector<unsigned int>& trackIds() const {return _hitInfo->trackIds();}
     const std::shared_ptr<SimHitInfoForLinks>& hitInfo() const {return _hitInfo;}
 
     void operator+= (const Amplitude& other) {
@@ -48,9 +48,9 @@ namespace DigitizerUtility {
       // the MC information are removed
       if (other._frac.size() > 0 && other._frac[0] >- 0.5) {
         if (other._hitInfo) {
-          std::vector<unsigned int>& otherTrackIds = other._hitInfo->trackIds_;
+          const std::vector<unsigned int>& otherTrackIds = other._hitInfo->trackIds();
           if (_hitInfo) {
-            std::vector<unsigned int>& trackIds = _hitInfo->trackIds_;
+            std::vector<unsigned int>& trackIds = _hitInfo->trackIds();
 	    trackIds.insert(trackIds.end(), otherTrackIds.begin(), otherTrackIds.end());
           } 
 	  else 
@@ -60,13 +60,13 @@ namespace DigitizerUtility {
       }
     }
     const EncodedEventId& eventId() const {
-      return _hitInfo->eventId_;
+      return _hitInfo->eventId();
     }
     const unsigned int hitIndex() const {
-      return _hitInfo->hitIndex_;
+      return _hitInfo->hitIndex();
     }
     const unsigned int tofBin() const {
-      return _hitInfo->tofBin_;
+      return _hitInfo->tofBin();
     }
     void operator+= (const float& amp) {
       _amp += amp;

--- a/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
@@ -37,7 +37,7 @@ namespace DigitizerUtility {
     // can be used as a float by convers.
     operator float() const {return _amp;}
     float ampl() const {return _amp;}
-    std::vector<float> individualampl() const {return _frac;}
+    const std::vector<float>& individualampl() const {return _frac;}
     const std::vector<unsigned int>& trackIds() const {return _hitInfo->trackIds();}
     const std::shared_ptr<SimHitInfoForLinks>& hitInfo() const {return _hitInfo;}
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1322,10 +1322,8 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
 
 	  //sum the contribution of the same trackid
           for(const auto& info: (*i).second.hitInfos()) {
-            const auto trackId = info.trackId();
-
-            // track already processed, so skip
-            auto found = simi.find(std::make_pair(trackId, info.eventId().rawId()));
+            // skip if track already processed
+            auto found = simi.find(std::make_pair(info.trackId(), info.eventId().rawId()));
             if(found == simi.end())
               continue;
 
@@ -1334,7 +1332,7 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
 	    if(fraction>1.f) fraction=1.f;
 
             // Approximation: pick hitIndex and tofBin only from the first SimHit
-	    simlinks.emplace_back((*i).first, trackId, info.hitIndex(), info.tofBin(), info.eventId(), fraction);
+	    simlinks.emplace_back((*i).first, info.trackId(), info.hitIndex(), info.tofBin(), info.eventId(), fraction);
             simi.erase(found);
 	  }
           simi.clear(); // although should be empty already

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1316,16 +1316,16 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
           for(const auto& info: (*i).second.hitInfos()) {
             // note: according to C++ standard operator[] does
             // value-initializiation, which for float means initial value of 0
-            simi[std::make_pair(info.trackIds_[0], info.eventId_.rawId())] += (*i).second.individualampl()[il];
+            simi[std::make_pair(info.trackId(), info.eventId().rawId())] += (*i).second.individualampl()[il];
             il++;
           }
 
 	  //sum the contribution of the same trackid
           for(const auto& info: (*i).second.hitInfos()) {
-            const auto trackId = info.trackIds_[0];
+            const auto trackId = info.trackId();
 
             // track already processed, so skip
-            auto found = simi.find(std::make_pair(trackId, info.eventId_.rawId()));
+            auto found = simi.find(std::make_pair(trackId, info.eventId().rawId()));
             if(found == simi.end())
               continue;
 
@@ -1334,7 +1334,7 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
 	    if(fraction>1.f) fraction=1.f;
 
             // Approximation: pick hitIndex and tofBin only from the first SimHit
-	    simlinks.emplace_back((*i).first, trackId, info.hitIndex_, info.tofBin_, info.eventId_, fraction);
+	    simlinks.emplace_back((*i).first, trackId, info.hitIndex(), info.tofBin(), info.eventId(), fraction);
             simi.erase(found);
 	  }
           simi.clear(); // although should be empty already

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -93,7 +93,7 @@ class SiPixelDigitizerAlgorithm  {
   public:
     Amplitude() : _amp(0.0) {}
     Amplitude( float amp, float frac) :
-      _amp(amp), _frac(1, frac), _hitInfo() {
+      _amp(amp), _frac(1, frac) {
     //in case of digi from noisypixels
       //the MC information are removed 
       if (_frac[0]<-0.5) {
@@ -102,13 +102,15 @@ class SiPixelDigitizerAlgorithm  {
     }
 
     Amplitude( float amp, const PSimHit* hitp, size_t hitIndex, unsigned int tofBin, float frac) :
-      _amp(amp), _frac(1, frac), _hitInfo(new SimHitInfoForLinks(hitp, hitIndex, tofBin) ) {
+      _amp(amp), _frac(1, frac) {
 
     //in case of digi from noisypixels
       //the MC information are removed 
       if (_frac[0]<-0.5) {
 	_frac.pop_back();
-	_hitInfo->trackIds_.pop_back();
+      }
+      else {
+        _hitInfos.emplace_back(hitp, hitIndex, tofBin);
       }
     }
 
@@ -116,37 +118,19 @@ class SiPixelDigitizerAlgorithm  {
     operator float() const { return _amp;}
     float ampl() const {return _amp;}
     std::vector<float> individualampl() const {return _frac;}
-    const std::vector<unsigned int>& trackIds() const {
-      return _hitInfo->trackIds_;
-    }
-    const std::shared_ptr<SimHitInfoForLinks>& hitInfo() const {return _hitInfo;}
+    const std::vector<SimHitInfoForLinks>& hitInfos() const { return _hitInfos; }
 
     void operator+=( const Amplitude& other) {
       _amp += other._amp;
       //in case of contribution of noise to the digi
       //the MC information are removed 
       if (other._frac[0]>-0.5){
-        if(other._hitInfo) {
-          std::vector<unsigned int>& otherTrackIds = other._hitInfo->trackIds_;
-          if(_hitInfo) {
-            std::vector<unsigned int>& trackIds = _hitInfo->trackIds_;
-	    trackIds.insert(trackIds.end(), otherTrackIds.begin(), otherTrackIds.end());
-          } else {
-            _hitInfo.reset(new SimHitInfoForLinks(*other._hitInfo));
-          }
+        if(!other._hitInfos.empty()) {
+          _hitInfos.insert(_hitInfos.end(), other._hitInfos.begin(), other._hitInfos.end());
         }
 	_frac.insert(_frac.end(), other._frac.begin(), other._frac.end());
       }
-   }
-   const EncodedEventId& eventId() const {
-     return _hitInfo->eventId_;
-   }
-   const unsigned int hitIndex() const {
-     return _hitInfo->hitIndex_;
-   }
-   const unsigned int tofBin() const {
-     return _hitInfo->tofBin_;
-   }
+    }
     void operator+=( const float& amp) {
       _amp += amp;
     }
@@ -160,7 +144,7 @@ class SiPixelDigitizerAlgorithm  {
   private:
     float _amp;
     std::vector<float> _frac;
-    std::shared_ptr<SimHitInfoForLinks> _hitInfo;
+    std::vector<SimHitInfoForLinks> _hitInfos;
   };  // end class Amplitude
 
   // Define a class to hold the calibration parameters per pixel

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -272,7 +272,6 @@ class SiPixelDigitizerAlgorithm  {
     typedef std::map<int, Amplitude, std::less<int> > signal_map_type;  // from Digi.Skel.
     typedef signal_map_type::iterator          signal_map_iterator; // from Digi.Skel.  
     typedef signal_map_type::const_iterator    signal_map_const_iterator; // from Digi.Skel.  
-    typedef std::map<unsigned int, std::vector<float>,std::less<unsigned int> > simlink_map;
     typedef std::map<uint32_t, signal_map_type> signalMaps;
     typedef GloballyPositioned<double>      Frame;
     typedef std::vector<edm::ParameterSet> Parameters;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -117,7 +117,7 @@ class SiPixelDigitizerAlgorithm  {
     // can be used as a float by convers.
     operator float() const { return _amp;}
     float ampl() const {return _amp;}
-    std::vector<float> individualampl() const {return _frac;}
+    const std::vector<float>& individualampl() const {return _frac;}
     const std::vector<SimHitInfoForLinks>& hitInfos() const { return _hitInfos; }
 
     void operator+=( const Amplitude& other) {


### PR DESCRIPTION
I believe there is a subtle bug in how `PixelDigiSimLinks` are created. What happens is that if there are two `SimTracks` (say trackIds _a_ and _b_) from different pileup events (say _A_ and _B_) that induce signal to the same channel, the `EncodedEventId` of only one of them is saved (say _A_). It follows that the digi is linked to `SimTracks` with the ids _a_ and _b_ with the same `EncodedEventId` _A_, even though the link to `SimTrack` _b_ should have used `EncodedEventId` B. As a consequence some digis get linked to wrong `SimTracks`, and some `SimTrack`-links are missing. Also the `SimHit` index is affected in the same way as `EncodedEventId`.

Interpreting the code (I'm not an expert), I believe the problem stems from
- `SimTrack` ids are not unique within the full, mixed event (or so it seems)
  - i.e. same id can appear in multiple pileup events (and signal event)
- `SiPixelDigitizerAlgorithm::Amplitude` uses `SimHitInfoForLinks` ([link](https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h#L163))
- `SimHitInfoForLinks` can store multiple `SimTrack` ids, but takes `EncodedEventId` (and `SimHit` index) only from the `SimHit` given to the constructor ([link](https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimTracker/Common/interface/SimHitInfoForLinks.h))
- when `Amplitudes` are added together, the `SimTrack` ids are appended, but the `EncodedEventId` and `SimHit` index are not changed in any way ([link](https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h#L124))

In addition, in `PixelDigiSimLink` creation ([link](https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc#L1330)), when contributions from the same `SimTrack` are summed together, only `SimTrack` id is used (omitting `EncodedEventId`).

The main idea in my fix attempt is to, instead of storing only the ids of `SimTracks` inducing signal to a single channel, store also the `EncodedEventIds` and `SimHit` indices. I have applied the fix only to `SiPixelDigitizerAlgorithm`, but I suspect the phase2 digitizer to be also affected. I can try that too (or leave to phase2 digitizer experts if they prefer), but I'd like first to get a confirmation that my diagnosis above and the proposed fix are correct.

Tested in 8_1_0_pre6. The effect in tracker/tracking validation should be small though. For tracking, there should be no changes in noPU samples, while tiny changes may appear in PU samples (although I didn't observe any within runTheMatrix statistics). Pixel hit validation shows tiny changes already in noPU samples (most significantly the number of matched SimHits/RecHit increases).

@rovere @VinInn @veszpv @venturia @mdhildreth 
