### PR TITLE
use hash table for speed in HcalCalibrationsSet classes

### DIFF
--- a/CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h
@@ -5,7 +5,8 @@
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
-#include <vector>
+#include <unordered_map>
+#include <stdint.h>
 
 /** \class HcalCalibrationWidthsSet
   *  
@@ -16,7 +17,6 @@ public:
   HcalCalibrationWidthsSet();
   const HcalCalibrationWidths& getCalibrationWidths(const DetId id) const;
   void setCalibrationWidths(const DetId id, const HcalCalibrationWidths& ca);
-  void sort();
   void clear();
 private:
   struct CalibWidthSetObject {
@@ -30,8 +30,7 @@ private:
   };
   typedef CalibWidthSetObject Item;
   HcalCalibrationWidths dummy;
-  std::vector<CalibWidthSetObject> mItems;
-  bool sorted_;
+  std::unordered_map<uint32_t,CalibWidthSetObject> mItems;
 };
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h
@@ -5,7 +5,8 @@
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
-#include <vector>
+#include <unordered_map>
+#include <stdint.h>
 
 /** \class HcalCalibrationsSet
   *  
@@ -16,7 +17,6 @@ public:
   HcalCalibrationsSet();
   const HcalCalibrations& getCalibrations(const DetId id) const;
   void setCalibrations(const DetId id, const HcalCalibrations& ca);
-  void sort();
   void clear();
 private:
   struct CalibSetObject {
@@ -30,8 +30,7 @@ private:
   };
   typedef CalibSetObject Item;
   HcalCalibrations dummy;
-  std::vector<CalibSetObject> mItems;
-  bool sorted_;
+  std::unordered_map<uint32_t,CalibSetObject> mItems;
 };
 
 #endif

--- a/CalibFormats/HcalObjects/src/HcalCalibrationWidthsSet.cc
+++ b/CalibFormats/HcalObjects/src/HcalCalibrationWidthsSet.cc
@@ -3,40 +3,28 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <algorithm>
 #include <iostream>
-
+#include <utility>
 
 HcalCalibrationWidthsSet::HcalCalibrationWidthsSet() 
-  : sorted_ (false) {}
+{}
 
 const HcalCalibrationWidths& HcalCalibrationWidthsSet::getCalibrationWidths(const DetId fId) const {
-  Item target(fId);
-  std::vector<Item>::const_iterator cell;
-  if (sorted_) {
-    cell = std::lower_bound (mItems.begin(), mItems.end(), target);
-  } else {
-    cell = std::find(mItems.begin(),mItems.end(), target);
-  }
-  if ((cell == mItems.end()) || (!hcalEqualDetId(cell->id.rawId(),fId)))
+  DetId fId2(hcalTransformedId(fId));
+  auto cell = mItems.find(fId2);
+  if ((cell == mItems.end()) || (!hcalEqualDetId(cell->first,fId2)))
     throw cms::Exception ("Conditions not found") << "Unavailable HcalCalibrationWidths for cell " << HcalGenericDetId(fId);
-  return cell->calib;
+  return cell->second.calib;
 }
 
 void HcalCalibrationWidthsSet::setCalibrationWidths(DetId fId, const HcalCalibrationWidths& ca) {
-  sorted_=false;
-  std::vector<Item>::iterator cell=std::find(mItems.begin(),mItems.end(),Item(fId)); //slow, but guaranteed
+  DetId fId2(hcalTransformedId(fId));
+  auto cell = mItems.find(fId2);
   if (cell==mItems.end()) {
-    mItems.push_back(Item(fId));
-    mItems.at(mItems.size()-1).calib=ca;
+    auto result = mItems.emplace(fId2,fId2);
+    result.first->second.calib=ca;
     return;
   }
-  cell->calib=ca;
-}
-
-void HcalCalibrationWidthsSet::sort () {
-  if (!sorted_) {
-    std::sort (mItems.begin(), mItems.end());
-    sorted_ = true;
-  }
+  cell->second.calib=ca;
 }
 
 void HcalCalibrationWidthsSet::clear() {

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -72,7 +72,6 @@ void HcalDbService::buildCalibrations() const {
         if (ok) ptr->setCalibrations(*id,tool);
         //    std::cout << "Hcal calibrations built... detid no. " << HcalGenericDetId(*id) << std::endl;
       }
-      ptr->sort();
       HcalCalibrationsSet const * cptr = ptr;
       HcalCalibrationsSet const * expect = nullptr;
       bool exchanged = mCalibSet.compare_exchange_strong(expect, cptr, std::memory_order_acq_rel);
@@ -103,8 +102,6 @@ void HcalDbService::buildCalibWidths() const {
         if (ok) ptr->setCalibrationWidths(*id,tool);
         //    std::cout << "Hcal calibrations built... detid no. " << HcalGenericDetId(*id) << std::endl;
       }
-      ptr->sort();
-
       HcalCalibrationWidthsSet const *  cptr =	ptr;
       HcalCalibrationWidthsSet const * expect = nullptr;
       bool exchanged = mCalibWidthSet.compare_exchange_strong(expect, cptr, std::memory_order_acq_rel);


### PR DESCRIPTION
It turns out that running `std::find()` and `push_back()` on a vector _n_ times is an O(_n_<sup>2</sup>) operation, and when you have 700,000 cells*, it takes about an hour. This is suboptimal.

Since these classes are CalibFormats, not CondFormats, and therefore not serialized, there is no reason not to use a hash table.

attn: @bsunanda, @lgray

*in the fine-segmented BH case for HGCal
