### PR TITLE
Pr81x  FatEvent Filters to use event count from TCDS FED 1024

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -39,6 +39,7 @@ Implementation:
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
+#include "EventFilter/FEDInterface/interface/FED1024.h"
 
 //
 // class declaration
@@ -102,12 +103,14 @@ L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSet
     return false;
   }
 
-  const FEDRawData& l1tRcd = feds->FEDData(1024);
+  const FEDRawData& tcdsRcd = feds->FEDData(1024);
 
-  const unsigned char *data = l1tRcd.data();
-  FEDHeader header(data);
+  const unsigned char *data = tcdsRcd.data();
 
-  bool fatEvent = (header.lvl1ID() % period_ == 0 );
+  evf::evtn::TCDSRecord record((unsigned char *)tcdsRcd.data());
+  int64_t l1_evt = record.getHeader().getData().header.triggerCount;
+
+  bool fatEvent = (l1_evt % period_ == 0 );
 
   return fatEvent;
 

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -55,6 +55,9 @@ private:
   const int fedId_;
   /// if invert_=true, invert that event accept decision
   const bool invert_;
+  /// use 64-bit L1 count from TCDS FED 1024
+  const bool useFED1024L1Count_;
+
 };
 
 #endif

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -58,7 +58,7 @@ HLTL1NumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<unsigned int>("period",4096);
   desc.add<bool>("invert",true);
   desc.add<int>("fedId",812);
-  desc.add<int>("useFED1024L1Count",false);
+  desc.add<bool>("useFED1024L1Count",false);
   descriptions.add("hltL1NumberFilter",desc);
 }
 //

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -27,6 +27,7 @@ Implementation:
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "EventFilter/FEDInterface/interface/FED1024.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //
@@ -37,7 +38,8 @@ HLTL1NumberFilter::HLTL1NumberFilter(const edm::ParameterSet& config) :
   inputToken_( consumes<FEDRawDataCollection>(config.getParameter<edm::InputTag>("rawInput")) ),
   period_( config.getParameter<unsigned int>("period") ),
   fedId_(  config.getParameter<int>("fedId") ),
-  invert_( config.getParameter<bool>("invert") )
+  invert_( config.getParameter<bool>("invert") ),
+  useFED1024L1Count_( config.getParameter<bool>("useFED1024L1Count") ) 
 {
 }
 
@@ -56,6 +58,7 @@ HLTL1NumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<unsigned int>("period",4096);
   desc.add<bool>("invert",true);
   desc.add<int>("fedId",812);
+  desc.add<int>("useFED1024L1Count",false);
   descriptions.add("hltL1NumberFilter",desc);
 }
 //
@@ -74,8 +77,18 @@ HLTL1NumberFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSet
     iEvent.getByToken(inputToken_,theRaw) ;
     const FEDRawData& data = theRaw->FEDData(fedId_) ;
     if (data.data() && data.size() > 0){
-      FEDHeader header(data.data()) ;
-      if (period_!=0) accept = ( ( (header.lvl1ID())%period_ ) == 0 );
+
+      int64_t l1count;
+      if (useFED1024L1Count_) {
+	evf::evtn::TCDSRecord record((unsigned char *)data.data());
+	l1count = record.getHeader().getData().header.triggerCount;
+      }
+      else {
+	FEDHeader header(data.data()) ;
+	l1count = header.lvl1ID();
+      }
+
+      if (period_!=0) accept = ( ( l1count%period_ ) == 0 );
       if (invert_) accept = !accept;
       return accept;
     } else{


### PR DESCRIPTION
Fixes to fat event filters, to use 64-bit L1 event count from TCDS FED 1024, instead of 24-bit L1 event number from DAQ header.  (from PR https://github.com/cms-l1t-offline/cmssw/pull/367)
