### PR TITLE
Fixing phase-I Tracker Alignment for change in geometry in PR #14726

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,9 +34,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v4',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v5',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v4',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v5) as [81X_upgrade2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v5/81X_upgrade2017_realistic_v4): 
  - updated phase-I tracker alignment to be in synch with geometry payloads vs `81YV5` (Updated Phase 1 BPIX Geometry #14726)
- **PhaseI design scenario** : [81X_upgrade2017_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v5) as [81X_upgrade2017_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v5/81X_upgrade2017_design_v4): 
  - updated phase-I tracker alignment to be in synch with geometry payloads vs `81YV5` (Updated Phase 1 BPIX Geometry #14726)
# 

attn: @ghellwig @makortel 

@davidlange6 possibly to include this one in pre9, since it fixes a regression observed in pre8 relvals.
