### PR TITLE
Enable pixel inefficiency for Phase I

### DIFF
--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -5,35 +5,6 @@ import FWCore.ParameterSet.Config as cms
 # SiPixelSimBlock definition.
 from Configuration.StandardSequences.Eras import eras
 
-def _modifyPixelDigitizerForRun2Bunchspacing25( digitizer ) :
-    """
-    Function that modifies the pixel digitiser for Run 2 with 25ns bunchspacing.
-    First argument is the pixelDigitizer object.
-    """
-    # DynamicInefficency - 13TeV - 25ns case
-    digitizer.theInstLumiScaleFactor = cms.double(364)
-    digitizer.theLadderEfficiency_BPix1 = cms.vdouble( [1]*20 ) # this syntax makes an array with 20 copies of "1"
-    digitizer.theLadderEfficiency_BPix2 = cms.vdouble( [1]*32 )
-    digitizer.theLadderEfficiency_BPix3 = cms.vdouble( [1]*44 )
-    digitizer.theModuleEfficiency_BPix1 = cms.vdouble( 1, 1, 1, 1, )
-    digitizer.theModuleEfficiency_BPix2 = cms.vdouble( 1, 1, 1, 1, )
-    digitizer.theModuleEfficiency_BPix3 = cms.vdouble( 1, 1, 1, 1 )
-    digitizer.thePUEfficiency_BPix1 = cms.vdouble( 1.00023, -3.18350e-06, 5.08503e-10, -6.79785e-14 )
-    digitizer.thePUEfficiency_BPix2 = cms.vdouble( 9.99974e-01, -8.91313e-07, 5.29196e-12, -2.28725e-15 )
-    digitizer.thePUEfficiency_BPix3 = cms.vdouble( 1.00005, -6.59249e-07, 2.75277e-11, -1.62683e-15 )
-
-def _modifyPixelDigitizerForRun2Bunchspacing50( digitizer ) :
-    """
-    Function that modifies the pixel digitiser for Run 2 with 50ns bunchspacing.
-    
-    First argument is the pixelDigitizer object.
-    """
-    # DynamicInefficency - 13TeV - 50ns case
-    digitizer.theInstLumiScaleFactor = cms.double(246.4)
-    digitizer.theLadderEfficiency_BPix1 = cms.vdouble( [0.979259,0.976677]*10 ) # This syntax makes a 20 element array of alternating numbers
-    digitizer.theLadderEfficiency_BPix2 = cms.vdouble( [0.994321,0.993944]*16 )
-    digitizer.theLadderEfficiency_BPix3 = cms.vdouble( [0.996787,0.996945]*22 )
-
 def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     """
     Function that modifies the pixel digitiser for the Phase 1 pixel detector.
@@ -59,51 +30,6 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     digitizer.BPix_SignalResponse_p1 = cms.double(0.711)
     digitizer.BPix_SignalResponse_p2 = cms.double(203.)
     digitizer.BPix_SignalResponse_p3 = cms.double(148.)
-    digitizer.thePixelColEfficiency_BPix1 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_BPix2 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_BPix3 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_BPix4 = cms.double(0.999)
-    digitizer.thePixelEfficiency_BPix1 = cms.double(0.999)
-    digitizer.thePixelEfficiency_BPix2 = cms.double(0.999)
-    digitizer.thePixelEfficiency_BPix3 = cms.double(0.999)
-    digitizer.thePixelEfficiency_BPix4 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_BPix1 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_BPix2 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_BPix3 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_BPix4 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_FPix1 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_FPix2 = cms.double(0.999)
-    digitizer.thePixelColEfficiency_FPix3 = cms.double(0.999)
-    digitizer.thePixelEfficiency_FPix1 = cms.double(0.999)
-    digitizer.thePixelEfficiency_FPix2 = cms.double(0.999)
-    digitizer.thePixelEfficiency_FPix3 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_FPix1 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_FPix2 = cms.double(0.999)
-    digitizer.thePixelChipEfficiency_FPix3 = cms.double(0.999)
-    # something broken in the configs above - turn off for now
-    digitizer.AddPixelInefficiency = cms.bool(False)
-
-def _modifyPixelDigitizerForPhase1PixelWithPileup( processObject ) :
-    """
-    Function that checks if there is pileup being used then modifies the
-    pixel digitiser for the Phase 1 pixel detector accordingly.
-    
-    First argument is the "process" object. This function can only be applied
-    with a <era>.makeProcessModifier() command, since it can only be applied
-    at the end because the number of pileup interactions is not known yet.
-    """
-    if hasattr(processObject,'mix'): 
-        n=0
-        if hasattr(processObject.mix,'input'):
-            n=processObject.mix.input.nbPileupEvents.averageNumber.value()
-        if n>0:
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_BPix1 = cms.double(1.0-(0.0238*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_BPix2 = cms.double(1.0-(0.0046*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_BPix3 = cms.double(1.0-(0.0018*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_BPix4 = cms.double(1.0-(0.0008*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_FPix1 = cms.double(1.0-(0.0018*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_FPix2 = cms.double(1.0-(0.0018*n/50.0))
-            processObject.mix.digitizers.pixel.thePixelColEfficiency_FPix3 = cms.double(1.0-(0.0018*n/50.0))
 
 
 SiPixelSimBlock = cms.PSet(
@@ -162,11 +88,7 @@ SiPixelSimBlock = cms.PSet(
 #
 # Apply the changes for the different Run 2 running scenarios
 #
-eras.run2_25ns_specific.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForRun2Bunchspacing25 )
-eras.run2_50ns_specific.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForRun2Bunchspacing50 )
 eras.phase1Pixel.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForPhase1Pixel )
-# Note that this object must have a unique name, so I'll call it "modify<python filename>ForPhase1WithPileup_"
-modifySimGeneralMixingModuleSiPixelSimParametersForPhase1WithPileup_ = eras.phase1Pixel.makeProcessModifier( _modifyPixelDigitizerForPhase1PixelWithPileup )
 
 # Threshold in electrons are the Official CRAFT09 numbers:
 # FPix(smearing)/BPix(smearing) = 2480(160)/2730(200)

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock, modifySimGeneralMixingModuleSiPixelSimParametersForPhase1WithPileup_
+from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
 
 pixelDigitizer = cms.PSet(
     SiPixelSimBlock,


### PR DESCRIPTION
This PR enables the use of new Phase I Pixel failure/inefficiency scenarios.

Content of the PR:
- Enable pixel inefficiency simulation for the Phase I detector
- Remove deprecated configuration settings in the era file, corresponding to 25/50ns operation
- modifyPixelDigitizerForPhase1PixelWithPileup function no longer needed, a similar/same DB content can be provided to replace it

By default the current content in the database have inefficiencies of 0.999, therefore the effect of this change is minimal.
