### PR TITLE
Backport of #13959: SpeedUp ParticleFlow for HLT; and #14070: remove memory fence

### DIFF
--- a/CommonTools/Utils/interface/DynArray.h
+++ b/CommonTools/Utils/interface/DynArray.h
@@ -7,6 +7,15 @@ public:
    T * a=nullptr;
    unsigned int s=0;
 public :
+   using size_type = unsigned int;
+   using value_type = T;
+   using reference = T&;
+   using const_reference = T const&;
+
+  DynArray(){}
+
+  explicit DynArray(unsigned char * storage) : a((T*)(storage)), s(0){}
+
   DynArray(unsigned char * storage, unsigned int isize) : a((T*)(storage)), s(isize){
     for (auto i=0U; i<s; ++i) new((begin()+i)) T();
   }
@@ -14,17 +23,38 @@ public :
     for (auto i=0U; i<s; ++i) new((begin()+i)) T(it);
   }
 
+  DynArray(DynArray const&) = delete;
+  DynArray & operator=(DynArray const &) = delete;
+
+  DynArray(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr;}
+  DynArray & operator=(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr; return *this;}
+
+
   ~DynArray() { for (auto i=0U; i<s; ++i) a[i].~T(); }
 
    T & operator[](unsigned int i) { return a[i];}
    T * begin() { return a;}
    T * end() { return a+s;}
+   T & front() { return a[0];}
+   T & back() { return a[s-1];}
+
    T const & operator[](unsigned int i) const { return a[i];}
    T const * begin() const { return a;}
    T const * end() const { return a+s;}
    unsigned int size() const { return s;}
+   bool empty() const { return 0==s;}
+
+   T const &front() const { return a[0];}
+   T const & back() const { return a[s-1];}
+
+   void pop_back() {back().~T(); --s;}
+   void push_back(T const& t) {new((begin()+s)) T(t);++s;}
+   void	push_back(T && t) {new((begin()+s)) T(t);++s;}
+
+
 };
 
+#define unInitDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage)
 #define declareDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n)
 #define initDynArray(T,n,x,i)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n,i)
 

--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -41,3 +41,8 @@
   <use name="CommonTools/Utils"/>
 </bin>
 
+
+<bin file="testDynArray.cpp">
+</bin>
+
+

--- a/CommonTools/Utils/test/testDynArray.cpp
+++ b/CommonTools/Utils/test/testDynArray.cpp
@@ -3,7 +3,8 @@
 
 
 struct A {
-
+A(){}
+A(int ii) : i(ii){}
 int i=-3;
 double k=0.1;
 
@@ -14,6 +15,7 @@ virtual ~A(){}
 
 #include<cassert>
 #include<iostream>
+#include<queue>
 
 int main(int s, char **) {
 
@@ -29,6 +31,8 @@ int main(int s, char **) {
   // T b[n];
   declareDynArray(T,n,b);
 
+  b[0].i=42;
+  b[n-1].i=-42;
 
   auto pa = [&](auto i) { a[1].k=0.3; return a[i].k; };
   auto pb = [&](auto i) { b[1].k=0.5; return b[i].k; };
@@ -38,8 +42,42 @@ int main(int s, char **) {
   std::cout << a[n-1].k << ' ' << pa(1) << ' ' << loop(2.3) << std::endl;
   std::cout << b[n-1].k << ' ' << pb(1) << std::endl;
 
+  assert(b.back().i==-42);
+  assert(b.front().i==42);
+
   initDynArray(bool,n,q,true);
   if (q[n-1]) std::cout << "ok" << std::endl;	
 
+  auto sn = 2*n;
+  unInitDynArray(T,sn+n,c);
+  assert(c.size()==0);
+  for(int i=0;i<int(sn);++i) c.push_back(i);
+  assert(c.size()==sn);
+  assert(c.front().i==0);
+  assert(c.back().i==int(sn-1));
+
+  c = std::move(a);  
+
+  assert(c.size()==n);
+  assert(a.empty());
+  assert(c[1].k==0.3);
+
+  auto cmp = [](int i, int j){return i<j;};
+
+  unInitDynArray(int,sn,qst); // queue storage
+  std::priority_queue<int,DynArray<int>,decltype(cmp)> qq(cmp,std::move(qst));
+  assert(qq.empty());
+  for(int i=0;i<int(sn);++i) qq.push(i+1);
+  assert(qq.size()==sn);
+  for(int i=0;i<int(sn);++i) {
+   assert(qq.size()==sn-i);
+   assert(qq.top()==int(sn-i));
+   qq.pop();
+  }
+
+  assert(qq.empty());
+  qq.push(3); qq.push(7); qq.push(-3);
+  assert(qq.top()==7);
+  
   return 0;
 };

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -32,12 +32,13 @@ namespace edm {
     RefCore& operator=(RefCore const&);
 
     RefCore( RefCore && iOther) noexcept :
-      cachePtr_(iOther.cachePtr_.load()),
       processIndex_(iOther.processIndex_),
-      productIndex_(iOther.productIndex_) {}
+      productIndex_(iOther.productIndex_) {
+         cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+     }
 
     RefCore& operator=( RefCore && iOther) noexcept{
-      cachePtr_ = iOther.cachePtr_.load();
+      cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
       processIndex_ = iOther.processIndex_;
       productIndex_ = iOther.productIndex_;
       return *this;

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -31,9 +31,19 @@ namespace edm {
     
     RefCore& operator=(RefCore const&);
 
-    RefCore( RefCore&& iOther) : cachePtr_(iOther.cachePtr_.load()), processIndex_(iOther.processIndex_),
-    productIndex_(iOther.productIndex_) {}
-    RefCore& operator=(RefCore&&) = default;
+    RefCore( RefCore && iOther) noexcept :
+      cachePtr_(iOther.cachePtr_.load()),
+      processIndex_(iOther.processIndex_),
+      productIndex_(iOther.productIndex_) {}
+
+    RefCore& operator=( RefCore && iOther) noexcept{
+      cachePtr_ = iOther.cachePtr_.load();
+      processIndex_ = iOther.processIndex_;
+      productIndex_ = iOther.productIndex_;
+      return *this;
+    }
+
+    ~RefCore() = default;
     
     ProductID id() const {ID_IMPL;}
 

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -23,7 +23,7 @@ namespace edm {
     // Since we need to freely convert one to the other the friendship is used
     friend class RefCoreWithIndex;
   public:
-    RefCore() :  cachePtr_(0),processIndex_(0),productIndex_(0){}
+    RefCore() :  cachePtr_(nullptr),processIndex_(0),productIndex_(0){}
 
     RefCore(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient);
 
@@ -43,7 +43,7 @@ namespace edm {
       return *this;
     }
 
-    ~RefCore() = default;
+    ~RefCore() noexcept {}
     
     ProductID id() const {ID_IMPL;}
 
@@ -100,7 +100,7 @@ namespace edm {
 
     void nullPointerForTransientException(std::type_info const& type) const;
 
-    void swap(RefCore &);
+    void swap(RefCore &) noexcept;
     
     bool isTransient() const {ISTRANSIENT_IMPL;}
 
@@ -153,7 +153,7 @@ namespace edm {
 
   inline 
   void
-  RefCore::swap(RefCore & other) {
+  RefCore::swap(RefCore & other) noexcept {
     std::swap(processIndex_, other.processIndex_);
     std::swap(productIndex_, other.productIndex_);
     other.cachePtr_.store(cachePtr_.exchange(other.cachePtr_.load()));

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -33,9 +33,17 @@ namespace edm {
     
     RefCoreWithIndex& operator=(RefCoreWithIndex const&);
 
-    RefCoreWithIndex( RefCoreWithIndex&& iOther): cachePtr_(iOther.cachePtr_.load()),processIndex_(iOther.processIndex_),
+    RefCoreWithIndex( RefCoreWithIndex&& iOther) noexcept : cachePtr_(iOther.cachePtr_.load()),processIndex_(iOther.processIndex_),
     productIndex_(iOther.productIndex_),elementIndex_(iOther.elementIndex_) {}
-    RefCoreWithIndex& operator=(RefCoreWithIndex&&) = default;
+    RefCoreWithIndex& operator=(RefCoreWithIndex&& iOther) noexcept {
+       cachePtr_ = iOther.cachePtr_.load();
+       processIndex_ = iOther.processIndex_;
+       productIndex_ = iOther.productIndex_;
+       elementIndex_ = iOther.elementIndex_;
+       return *this;
+    }
+
+    ~RefCoreWithIndex() noexcept {}
 
     ProductID id() const {ID_IMPL;}
 

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -33,10 +33,14 @@ namespace edm {
     
     RefCoreWithIndex& operator=(RefCoreWithIndex const&);
 
-    RefCoreWithIndex( RefCoreWithIndex&& iOther) noexcept : cachePtr_(iOther.cachePtr_.load()),processIndex_(iOther.processIndex_),
-    productIndex_(iOther.productIndex_),elementIndex_(iOther.elementIndex_) {}
+    RefCoreWithIndex( RefCoreWithIndex&& iOther) noexcept : 
+    processIndex_(iOther.processIndex_),
+    productIndex_(iOther.productIndex_),elementIndex_(iOther.elementIndex_) {
+      cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    }
+
     RefCoreWithIndex& operator=(RefCoreWithIndex&& iOther) noexcept {
-       cachePtr_ = iOther.cachePtr_.load();
+       cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
        processIndex_ = iOther.processIndex_;
        productIndex_ = iOther.productIndex_;
        elementIndex_ = iOther.elementIndex_;

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -69,6 +69,9 @@ namespace edm {
 
     RefToBase();
     RefToBase(RefToBase const& other);
+    RefToBase(RefToBase && other);
+    RefToBase & operator=(RefToBase && other);
+
     template <typename C1, typename T1, typename F1>
     explicit RefToBase(Ref<C1, T1, F1> const& r);
     template <typename C>
@@ -137,6 +140,18 @@ namespace edm {
   RefToBase<T>::RefToBase(RefToBase const& other) :
     holder_(other.holder_  ? other.holder_->clone() : nullptr)
   { }
+
+  template <class T>
+  inline
+  RefToBase<T>::RefToBase(RefToBase && other) :
+    holder_(other.holder_) { other.holder_=nullptr;}
+
+  template <class T>
+  inline
+  RefToBase<T>& RefToBase<T>::operator=(RefToBase && other) {
+    holder_=other.holder_; other.holder_=nullptr; return *this;
+  }
+
 
   template <class T>
   template <typename C1, typename T1, typename F1>

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -69,8 +69,8 @@ namespace edm {
 
     RefToBase();
     RefToBase(RefToBase const& other);
-    RefToBase(RefToBase && other);
-    RefToBase & operator=(RefToBase && other);
+    RefToBase(RefToBase && other) noexcept;
+    RefToBase & operator=(RefToBase && other) noexcept;
 
     template <typename C1, typename T1, typename F1>
     explicit RefToBase(Ref<C1, T1, F1> const& r);
@@ -83,7 +83,7 @@ namespace edm {
     RefToBase(std::unique_ptr<reftobase::BaseHolder<value_type>>);
     RefToBase(std::shared_ptr<reftobase::RefHolderBase> p);
 
-    ~RefToBase();
+    ~RefToBase() noexcept;
 
     RefToBase& operator= (RefToBase const& rhs);
 
@@ -143,13 +143,13 @@ namespace edm {
 
   template <class T>
   inline
-  RefToBase<T>::RefToBase(RefToBase && other) :
+  RefToBase<T>::RefToBase(RefToBase && other) noexcept :
     holder_(other.holder_) { other.holder_=nullptr;}
 
   template <class T>
   inline
-  RefToBase<T>& RefToBase<T>::operator=(RefToBase && other) {
-    holder_=other.holder_; other.holder_=nullptr; return *this;
+  RefToBase<T>& RefToBase<T>::operator=(RefToBase && other) noexcept {
+    delete holder_; holder_=other.holder_; other.holder_=nullptr; return *this;
   }
 
 
@@ -197,7 +197,7 @@ namespace edm {
 
   template <class T>
   inline
-  RefToBase<T>::~RefToBase()
+  RefToBase<T>::~RefToBase() noexcept
   {
     delete holder_;
   }

--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -19,7 +19,6 @@ RefVector: A template for a vector of interproduct references.
 #include "DataFormats/Common/interface/RefVectorTraits.h"
 #include "DataFormats/Common/interface/traits.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 #include <algorithm>
 #include <stdexcept>
@@ -52,16 +51,25 @@ namespace edm {
     /// Default constructor needed for reading from persistent
     /// store. Not for direct use.
     RefVector() : refVector_() {}
+    ~RefVector() = default;
+
     RefVector(RefVector const& rh) : refVector_(rh.refVector_){}
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
     RefVector(RefVector && rh)  noexcept : refVector_(std::move(rh.refVector_)){}
-#endif
+
+    RefVector& operator=(RefVector const& rhs);
+    RefVector& operator=(RefVector  && rhs)  noexcept {
+      refVector_ = std::move(rhs.refVector_);
+      return *this;
+    }
+
+
 
     RefVector(ProductID const& iId) : refVector_(iId) {}
     /// Add a Ref<C, T> to the RefVector
     void push_back(value_type const& ref) {
       refVector_.pushBack(ref.refCore(), ref.key());
     }
+    
 
     /// Retrieve an element of the RefVector
     value_type const operator[](size_type idx) const {
@@ -141,14 +149,6 @@ namespace edm {
     /// Swap two vectors.
     void swap(RefVector<C, T, F> & other)  noexcept;
 
-    /// Copy assignment.
-    RefVector& operator=(RefVector const& rhs);
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
-    RefVector& operator=(RefVector  && rhs)  noexcept { 
-      refVector_ = std::move(rhs.refVector_);
-      return *this;
-    }
-#endif
     /// Checks if product is in memory.
     bool hasProductCache() const {return refVector_.refCore().productPtr() != 0;}
 
@@ -187,7 +187,6 @@ namespace edm {
     a.swap(b);
   }
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
   template<typename C, typename T, typename F>
   void
   RefVector<C,T,F>::fillView(ProductID const&,
@@ -204,7 +203,6 @@ namespace edm {
       helpers.emplace_back(i->id(),i->key());
     }
   }
-#endif
 
   template<typename C, typename T, typename F>
   inline

--- a/DataFormats/Common/interface/RefVectorBase.h
+++ b/DataFormats/Common/interface/RefVectorBase.h
@@ -12,7 +12,6 @@ RefVectorBase: Base class for a vector of interproduct references.
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "DataFormats/Common/interface/RefCore.h"
 #include <vector>
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 namespace edm {
 
@@ -37,14 +36,27 @@ namespace edm {
     RefVectorBase() : product_(), keys_() {}
     RefVectorBase( RefVectorBase const & rhs) : product_(rhs.product_), keys_(rhs.keys_),
                                                 memberPointersHolder_(rhs.memberPointersHolder_) {}
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
     RefVectorBase( RefVectorBase && rhs)  noexcept : product_(std::move(rhs.product_)), keys_(std::move(rhs.keys_)),
                                                      memberPointersHolder_(std::move(rhs.memberPointersHolder_)) {}
-#endif
+
+    RefVectorBase& operator=(RefVectorBase const& rhs) {
+      RefVectorBase temp(rhs);
+      this->swap(temp);
+      return *this;
+    }
+    RefVectorBase& operator=(RefVectorBase && rhs)  noexcept {
+      product_ = std::move(rhs.product_);
+      keys_ =std::move(rhs.keys_);
+      memberPointersHolder_ = std::move(rhs.memberPointersHolder_);
+      return *this;
+    }
+
+
 
     explicit RefVectorBase(ProductID const& productID, void const* prodPtr = 0,
                            EDProductGetter const* prodGetter = 0) :
       product_(productID, prodPtr, prodGetter, false), keys_() {}
+
 
     /// Destructor
     ~RefVectorBase() noexcept {}
@@ -108,20 +120,6 @@ namespace edm {
       memberPointersHolder_.memberPointers().swap(other.memberPointersHolder_.memberPointers());
     }
 
-    /// Copy assignment
-    RefVectorBase& operator=(RefVectorBase const& rhs) {
-      RefVectorBase temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
-    RefVectorBase& operator=(RefVectorBase && rhs)  noexcept {
-      product_ = std::move(rhs.product_); 
-      keys_ =std::move(rhs.keys_);
-      memberPointersHolder_ = std::move(rhs.memberPointersHolder_);
-      return *this;
-    }
-#endif
 
     //Needed for ROOT storage
     CMS_CLASS_VERSION(13)

--- a/DataFormats/Common/src/RefCore.cc
+++ b/DataFormats/Common/src/RefCore.cc
@@ -45,12 +45,13 @@ namespace edm {
       }
   
   RefCore::RefCore( RefCore const& iOther) :
-      cachePtr_(iOther.cachePtr_.load()),
       processIndex_(iOther.processIndex_),
-      productIndex_(iOther.productIndex_) {}
+      productIndex_(iOther.productIndex_) {
+       cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+     }
   
   RefCore& RefCore::operator=( RefCore const& iOther) {
-    cachePtr_ = iOther.cachePtr_.load();
+    cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     processIndex_ = iOther.processIndex_;
     productIndex_ = iOther.productIndex_;
     return *this;

--- a/DataFormats/Common/src/RefCoreWithIndex.cc
+++ b/DataFormats/Common/src/RefCoreWithIndex.cc
@@ -23,19 +23,21 @@ namespace edm {
       }
 
   RefCoreWithIndex::RefCoreWithIndex(RefCore const& iCore, unsigned int iIndex):
-  cachePtr_(iCore.cachePtr_.load()),
   processIndex_(iCore.processIndex_),
   productIndex_(iCore.productIndex_),
-  elementIndex_(iIndex){}
+  elementIndex_(iIndex){
+     cachePtr_.store(iCore.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+  }
   
   RefCoreWithIndex::RefCoreWithIndex( RefCoreWithIndex const& iOther) :
-    cachePtr_(iOther.cachePtr_.load()),
     processIndex_(iOther.processIndex_),
     productIndex_(iOther.productIndex_),
-    elementIndex_(iOther.elementIndex_){}
+    elementIndex_(iOther.elementIndex_){
+    cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+  }
   
   RefCoreWithIndex& RefCoreWithIndex::operator=( RefCoreWithIndex const& iOther) {
-    cachePtr_ = iOther.cachePtr_.load();
+    cachePtr_.store(iOther.cachePtr_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     processIndex_ = iOther.processIndex_;
     productIndex_ = iOther.productIndex_;
     elementIndex_ = iOther.elementIndex_;

--- a/DataFormats/EcalDetId/interface/ESDetId.h
+++ b/DataFormats/EcalDetId/interface/ESDetId.h
@@ -111,5 +111,34 @@ class ESDetId : public DetId {
 
 std::ostream& operator<<(std::ostream&,const ESDetId& id);
 
+inline
+ESDetId::ESDetId( const DetId& gen ) : DetId(gen) 
+{
+#ifdef EDM_ML_DEBUG
+   if( !gen.null() &&
+       ( gen.det()	!= Ecal          ||
+         gen.subdetId() != EcalPreshower    ) )
+   {
+      throw cms::Exception("InvalidDetId");
+   }
+#endif
+}
+
+inline
+ESDetId&
+ESDetId::operator=( const DetId& gen )
+{
+#ifdef EDM_ML_DEBUG
+   if (!gen.null() &&
+       ( gen.det()      != Ecal          ||                              
+         gen.subdetId() != EcalPreshower    ) )
+   {
+      throw cms::Exception("InvalidDetId");
+   }
+#endif
+   id_=gen.rawId();
+   return *this;
+}
+
 
 #endif

--- a/DataFormats/EcalDetId/src/ESDetId.cc
+++ b/DataFormats/EcalDetId/src/ESDetId.cc
@@ -3,18 +3,6 @@
 
 #include <ostream>
 
-ESDetId::ESDetId( const DetId& gen ) 
-{
-   if( !gen.null() && 
-       ( gen.det()      != Ecal          ||
-	 gen.subdetId() != EcalPreshower    ) ) 
-   {
-      throw cms::Exception("InvalidDetId");
-   }
-   id_ = gen.rawId() ;
-}
-
-
 void ESDetId::verify( int strip,
                  int ixs,
                  int iys,
@@ -52,19 +40,6 @@ ESDetId::validDetId( int istrip,
 		0 == hxy2[ixs-1][iys-1]  )    ) ) ;
 }
   
-ESDetId& 
-ESDetId::operator=( const DetId& gen ) 
-{
-   if (!gen.null() &&
-       ( gen.det()      != Ecal          ||
-	 gen.subdetId() != EcalPreshower    ) ) 
-   {
-      throw cms::Exception("InvalidDetId");
-   }
-   id_=gen.rawId();
-   return *this;
-}
-
 int 
 ESDetId::hashedIndex() const 
 {

--- a/DataFormats/EcalRecHit/test/testEcalRecHit.cppunit.cc
+++ b/DataFormats/EcalRecHit/test/testEcalRecHit.cppunit.cc
@@ -83,8 +83,8 @@ void testEcalRecHit::testOne() {
   CPPUNIT_ASSERT_DOUBLES_EQUAL(urh.jitterError()*25, rh.timeError(), 0.00001);
 
   // test energyError
-  rh.setEnergyError(0.51);
-  CPPUNIT_ASSERT_DOUBLES_EQUAL(0.51, rh.energyError(), 0.01);
-  rh.setEnergyError(50.8);
-  CPPUNIT_ASSERT_DOUBLES_EQUAL(50.8, rh.energyError(), 0.01);
+  for (float x=0.0011; x<10.e4; x*=5.){
+    rh.setEnergyError(x);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(x, rh.energyError(), 0.01*x);
+  }
 }

--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 
 <flags LCG_DICT_HEADER="classes_1.h classes_2.h"/>
 <flags LCG_DICT_XML="classes_def_1.xml classes_def_2.xml"/>

--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>
+<use   name="vdt"/>
 
 <flags LCG_DICT_HEADER="classes_1.h classes_2.h"/>
 <flags LCG_DICT_XML="classes_def_1.xml classes_def_2.xml"/>

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -154,11 +154,12 @@ namespace reco {
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     template<typename pruner>
-      void pruneUsing(pruner prune) {
-      hitsAndFractions_.clear();
-      std::vector<reco::PFRecHitFraction>::iterator iter = 
+    void pruneUsing(pruner prune) {
+      auto iter = 
 	std::stable_partition(rechits_.begin(),rechits_.end(),prune);
+      if (iter==rechits_.end()) return;
       rechits_.erase(iter,rechits_.end());
+      hitsAndFractions_.clear();
       hitsAndFractions_.reserve(rechits_.size());
       for( const auto& hitfrac : rechits_ ) {
 	hitsAndFractions_.emplace_back(hitfrac.recHitRef()->detId(),

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -72,7 +72,7 @@ namespace reco {
 
 
     /// destructor
-    ~PFRecHit(){}
+    ~PFRecHit()=default;
 
     void setEnergy( double energy) { energy_ = energy; }
 

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -39,6 +39,7 @@ namespace reco {
     // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
     // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
     // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+
     typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
 
     typedef std::vector<REPPoint> REPPointVector;
@@ -64,10 +65,14 @@ namespace reco {
              double axisx, double axisy, double axisz);    
 
     /// copy
-    PFRecHit(const PFRecHit& other);
+    PFRecHit(const PFRecHit& other) = default;
+    PFRecHit(PFRecHit&& other) = default;
+    PFRecHit & operator=(const PFRecHit& other) = default;
+    PFRecHit & operator=(PFRecHit&& other) = default;
+
 
     /// destructor
-    virtual ~PFRecHit();
+    ~PFRecHit(){}
 
     void setEnergy( double energy) { energy_ = energy; }
 

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
@@ -27,10 +27,6 @@ namespace reco {
                      double fraction ) 
       : recHitRef_(recHitRef), fraction_(fraction) {}
     
-    /// copy
-    //    PFRecHitFraction(const PFRecHitFraction& other) 
-    //  : recHitRef_(other.recHitRef_), fraction_(other.fraction_) {}
-    
     /// \return index to rechit
     const PFRecHitRef& recHitRef() const {return recHitRef_;} 
     

--- a/DataFormats/ParticleFlowReco/src/PFRecHit.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHit.cc
@@ -2,7 +2,49 @@
 using namespace reco;
 using namespace std;
 
+#include "vdt/vdtMath.h"
+#include "Math/GenVector/etaMax.h"
+
 const unsigned    PFRecHit::nCorners_ = 4;
+
+namespace {
+  
+  // an implementation of Eta_FromRhoZ of root libraries using vdt
+  template<typename Scalar>
+  inline Scalar Eta_FromRhoZ_fast(Scalar rho, Scalar z) {    
+    using namespace ROOT::Math;
+    // value to control Taylor expansion of sqrt
+    constexpr Scalar big_z_scaled =
+      std::pow(std::numeric_limits<Scalar>::epsilon(),static_cast<Scalar>(-.25));
+    if (rho > 0) {      
+      Scalar z_scaled = z/rho;
+      if (std::fabs(z_scaled) < big_z_scaled) {
+        return vdt::fast_log(z_scaled+std::sqrt(z_scaled*z_scaled+1.0));
+      } else {
+        // apply correction using first order Taylor expansion of sqrt
+        return  z>0 ? vdt::fast_log(2.0*z_scaled + 0.5/z_scaled) : -vdt::fast_log(-2.0*z_scaled);
+      }
+    }
+    // case vector has rho = 0
+    else if (z==0) {
+      return 0;
+    }
+    else if (z>0) {
+      return z + etaMax<Scalar>();
+    }
+    else {
+      return z - etaMax<Scalar>();
+    }    
+  }
+
+  inline void calculateREP(const math::XYZPoint& pos, double& rho, double& eta, double& phi) {
+    const double z = pos.z();
+    rho = pos.Rho();    
+    eta = Eta_FromRhoZ_fast<double>(rho,z);
+    phi = (pos.x()==0 && pos.y()==0) ? 0 : vdt::fast_atan2(pos.y(), pos.x());
+  }
+
+}
 
 PFRecHit::PFRecHit() : 
   detId_(0),
@@ -110,23 +152,31 @@ void PFRecHit::setNECorner( double posx, double posy, double posz ) {
 void PFRecHit::setCorner( unsigned i, double posx, double posy, double posz ) {
   assert( cornersxyz_.size() == nCorners_);
   assert( i<cornersxyz_.size() );
+  double rho(0), eta(0), phi(0);
 
   cornersxyz_[i] = math::XYZPoint( posx, posy, posz);
-  cornersrep_[i] = REPPoint( cornersxyz_[i].Rho(),
-			     cornersxyz_[i].Eta(),
-			     cornersxyz_[i].Phi() );
+  const auto& corner = cornersxyz_[i];
+  calculateREP(corner, rho, eta, phi);  
+  cornersrep_[i] = REPPoint( rho,
+			     eta,
+			     phi );
 }
 
 void
 PFRecHit::calculatePositionREP() {
-  positionrep_.SetCoordinates( position_.Rho(), 
-			       position_.Eta(), 
-			       position_.Phi() );
+  double rho(0), eta(0), phi(0);
+  calculateREP(position_,rho,eta,phi);
+
+  positionrep_.SetCoordinates( rho, 
+			       eta, 
+			       phi );
   cornersrep_.resize(cornersxyz_.size());
   for( unsigned i = 0; i < cornersxyz_.size(); ++i ) {
-    cornersrep_[i].SetCoordinates(cornersxyz_[i].Rho(),
-				  cornersxyz_[i].Eta(),
-				  cornersxyz_[i].Phi());
+    const auto& corner = cornersxyz_[i];
+    calculateREP(corner,rho,eta,phi);
+    cornersrep_[i].SetCoordinates( rho,
+                                   eta,
+                                   phi );
   }
 }
 
@@ -139,9 +189,9 @@ void PFRecHit::addNeighbour(short x,short y,short z,const PFRecHitRef& ref) {
   //bit 8 side for z 
   //bits 9,10,11 : abs(z) wrt the center
 
-  unsigned short absx = abs(x);
-  unsigned short absy = abs(y);
-  unsigned short absz = abs(z);
+  unsigned short absx = std::abs(x);
+  unsigned short absy = std::abs(y);
+  unsigned short absz = std::abs(z);
 
   unsigned short bitmask=0;
 

--- a/DataFormats/ParticleFlowReco/src/PFRecHit.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHit.cc
@@ -14,7 +14,7 @@ namespace {
   inline Scalar Eta_FromRhoZ_fast(Scalar rho, Scalar z) {    
     using namespace ROOT::Math;
     // value to control Taylor expansion of sqrt
-    constexpr Scalar big_z_scaled =
+    const Scalar big_z_scaled =
       std::pow(std::numeric_limits<Scalar>::epsilon(),static_cast<Scalar>(-.25));
     if (rho > 0) {      
       Scalar z_scaled = z/rho;

--- a/DataFormats/ParticleFlowReco/src/PFRecHit.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHit.cc
@@ -105,28 +105,6 @@ PFRecHit::PFRecHit(unsigned detId,
 }    
 
 
-PFRecHit::PFRecHit(const PFRecHit& other) :
-  originalRecHit_(other.originalRecHit_),
-  detId_(other.detId_), 
-  layer_(other.layer_), 
-  energy_(other.energy_), 
-  time_(other.time_),
-  depth_(other.depth_),
-  position_(other.position_), 
-  positionrep_(other.positionrep_),
-  axisxyz_(other.axisxyz_),
-  cornersxyz_(other.cornersxyz_),
-  cornersrep_(other.cornersrep_),
-  neighbours_(other.neighbours_),
-  neighbourInfos_(other.neighbourInfos_),
-  neighbours4_(other.neighbours4_),
-  neighbours8_(other.neighbours8_)
-{}
-
-
-
-PFRecHit::~PFRecHit() 
-{}
 
 
 void PFRecHit::setNWCorner( double posx, double posy, double posz ) {

--- a/Geometry/CaloTopology/src/EcalPreshowerTopology.cc
+++ b/Geometry/CaloTopology/src/EcalPreshowerTopology.cc
@@ -3,12 +3,9 @@
 #include <stdexcept>
 
 ESDetId EcalPreshowerTopology::incrementIy(const ESDetId& id) const {
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
 
-  ESDetId nextPoint;
   //Strips orientend along x direction for plane 2
   if (id.plane() == 2)
     {
@@ -17,16 +14,12 @@ ESDetId EcalPreshowerTopology::incrementIy(const ESDetId& id) const {
 	  //Incrementing just strip number
 	  if (ESDetId::validDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside()))
 	    nextPoint=ESDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside());
-	  else
-	    return ESDetId(0); 
 	}
       else
 	{
 	  //Changing wafer
 	  if (ESDetId::validDetId(1,id.six(),id.siy()+1,id.plane(),id.zside()))
 	    nextPoint=ESDetId(1,id.six(),id.siy()+1,id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
     }
   //Strips orientend along y direction for plane 1
@@ -35,25 +28,16 @@ ESDetId EcalPreshowerTopology::incrementIy(const ESDetId& id) const {
       //Changing wafer
       if (ESDetId::validDetId(id.strip(),id.six(),id.siy()+1,id.plane(),id.zside()))
 	nextPoint=ESDetId(id.strip(),id.six(),id.siy()+1,id.plane(),id.zside());
-      else
-	return ESDetId(0);
     }
-  else
-    return ESDetId(0);
   
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
-    return nextPoint;
-  else
-    return ESDetId(0);
+  return nextPoint;
 } 
 
 
 ESDetId EcalPreshowerTopology::decrementIy(const ESDetId& id) const {
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }
-  ESDetId nextPoint;
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
+
   //Strips orientend along x direction for plane 2
   if (id.plane() == 2)
     {
@@ -62,16 +46,12 @@ ESDetId EcalPreshowerTopology::decrementIy(const ESDetId& id) const {
 	  //Decrementing just strip number
 	  if (ESDetId::validDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside()))
 	    nextPoint=ESDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
       else
 	{
 	  //Changing wafer
 	  if (ESDetId::validDetId(32,id.six(),id.siy()-1,id.plane(),id.zside()))
 	    nextPoint=ESDetId(32,id.six(),id.siy()-1,id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
     }
   //Strips orientend along y direction for plane 1
@@ -80,26 +60,14 @@ ESDetId EcalPreshowerTopology::decrementIy(const ESDetId& id) const {
       //Changing wafer
       if (ESDetId::validDetId(id.strip(),id.six(),id.siy()-1,id.plane(),id.zside()))
 	nextPoint=ESDetId(id.strip(),id.six(),id.siy()-1,id.plane(),id.zside());
-      else
-	return ESDetId(0);
     }
-  else
-    return ESDetId(0);
-
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
-    return nextPoint;
-  else
-    return ESDetId(0);
+   return nextPoint;
 } 
 
 
 ESDetId EcalPreshowerTopology::incrementIx(const ESDetId& id) const {
-
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }      
-  ESDetId nextPoint;
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
 
   //Strips orientend along x direction for plane 2
   if (id.plane() == 2)
@@ -107,8 +75,6 @@ ESDetId EcalPreshowerTopology::incrementIx(const ESDetId& id) const {
       //Changing wafer
       if (ESDetId::validDetId(id.strip(),id.six()+1,id.siy(),id.plane(),id.zside()))
 	nextPoint=ESDetId(id.strip(),id.six()+1,id.siy(),id.plane(),id.zside());
-      else
-        return ESDetId(0);
     }
   //Strips orientend along y direction for plane 1
   else if (id.plane() == 1)
@@ -118,43 +84,29 @@ ESDetId EcalPreshowerTopology::incrementIx(const ESDetId& id) const {
 	//Incrementing just strip number
 	  if (ESDetId::validDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside())) 
 	    nextPoint=ESDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
       else
 	{
 	//Changing wafer
 	  if (ESDetId::validDetId(1,id.six()+1,id.siy(),id.plane(),id.zside()))
 	    nextPoint=ESDetId(1,id.six()+1,id.siy(),id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
     }
-  else
-    return ESDetId(0);
 
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
     return nextPoint;
-  else
-    return ESDetId(0);
 } 
 
 
 ESDetId EcalPreshowerTopology::decrementIx(const ESDetId& id) const {
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
 
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }      
-  ESDetId nextPoint;
   //Strips orientend along x direction for plane 2
   if (id.plane() == 2)
     {
       //Changing wafer
       if (ESDetId::validDetId(id.strip(),id.six()-1,id.siy(),id.plane(),id.zside()))
 	nextPoint=ESDetId(id.strip(),id.six()-1,id.siy(),id.plane(),id.zside());
-      else
-	return ESDetId(0);
     }
   //Strips orientend along y direction for plane 1
   else if (id.plane() == 1)
@@ -164,64 +116,38 @@ ESDetId EcalPreshowerTopology::decrementIx(const ESDetId& id) const {
 	  //Decrementing just strip number
 	  if (ESDetId::validDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside()))
 	    nextPoint=ESDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside());
-	  else
-	    return ESDetId(0);
 	}
       else
 	{
 	  //Changing wafer
 	  if (ESDetId::validDetId(32,id.six()-1,id.siy(),id.plane(),id.zside()))
 	    nextPoint=ESDetId(32,id.six()-1,id.siy(),id.plane(),id.zside());
-	  else
-            return ESDetId(0);
 	}
     }
-  else
-    return ESDetId(0);
-  
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
-    return nextPoint;
-  else
-    return ESDetId(0);
+   return nextPoint;
 } 
 
 
 ESDetId EcalPreshowerTopology::incrementIz(const ESDetId& id) const {
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
 
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }      
-  ESDetId nextPoint;
   if (ESDetId::validDetId(id.strip(),id.six(),id.siy(),id.plane()+1,id.zside()))
     nextPoint=ESDetId(id.strip(),id.six(),id.siy(),id.plane()+1,id.zside());
-  else
-    return ESDetId(0);
 
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
-    return nextPoint;
-  else
-    return ESDetId(0);
+  return nextPoint;
 } 
 
 
 
 ESDetId EcalPreshowerTopology::decrementIz(const ESDetId& id) const {
+  ESDetId nextPoint(0);
+  if (id==nextPoint) return nextPoint;
 
-  if (!(*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(id))
-    {
-      return ESDetId(0);
-    }      
-  ESDetId nextPoint;
   if (ESDetId::validDetId(id.strip(),id.six(),id.siy(),id.plane()-1,id.zside()))
     nextPoint=ESDetId(id.strip(),id.six(),id.siy(),id.plane()-1,id.zside());
-  else
-    return ESDetId(0);
   
-  if ((*theGeom_).getSubdetectorGeometry(DetId::Ecal,EcalPreshower)->present(nextPoint))
-    return nextPoint;
-  else
-    return ESDetId(0);
+  return nextPoint;
 } 
 
 

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -9,6 +9,7 @@
 #include "CondFormats/AlignmentRecord/interface/ESAlignmentRcd.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "Geometry/Records/interface/PEcalPreshowerRcd.h"
+#include "Geometry/CaloGeometry/interface/CaloGenericDetId.h"
 #include <vector>
 
 class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
@@ -86,9 +87,23 @@ class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
 			    const DetId&       detId   ) ;
+
+
+  /// is this detid present in the geometry?
+  bool present( const DetId& id ) const override {
+    if(id==DetId(0)) return false;
+    // not needed???
+    auto index = CaloGenericDetId( id ).denseIndex();
+    return index < m_cellVec.size();
+  }
+
+  /// Get the cell geometry of a given detector id.  Should return nulptr if not found.
+  // const CaloCellGeometry* getGeometry( const DetId& id ) const override;
+
+
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override;
 
    private:
 

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -11,7 +11,7 @@
 #include "Geometry/Records/interface/PEcalPreshowerRcd.h"
 #include <vector>
 
-class EcalPreshowerGeometry : public CaloSubdetectorGeometry
+class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 {
    public:
 

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -259,7 +259,7 @@ EcalPreshowerGeometry::newCell( const GlobalPoint& f1 ,
 const CaloCellGeometry* 
 EcalPreshowerGeometry::cellGeomPtr( uint32_t index ) const
 {
-   const CaloCellGeometry* cell ( &m_cellVec[ index ] ) ;
-   return ( m_cellVec.size() < index ||
-	    0 == cell->param() ? 0 : cell ) ;
+   if (index >= m_cellVec.size()) return nullptr;
+   const CaloCellGeometry* cell = &m_cellVec[ index ];
+   return cell->param() ? cell : nullptr ;
 }

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -259,7 +259,8 @@ EcalPreshowerGeometry::newCell( const GlobalPoint& f1 ,
 const CaloCellGeometry* 
 EcalPreshowerGeometry::cellGeomPtr( uint32_t index ) const
 {
-   if (index >= m_cellVec.size()) return nullptr;
-   const CaloCellGeometry* cell = &m_cellVec[ index ];
-   return cell->param() ? cell : nullptr ;
+   if (index >= m_cellVec.size()) return nullptr; // needed only if called with detId=0
+   const CaloCellGeometry* cell ( &m_cellVec[ index ] ) ;
+   //assert( cell->param() );
+   return cell; 
 }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
@@ -95,12 +95,12 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
 	}
 	else continue;
 
-	reco::PFRecHit rh( detid.rawId(),Layer,
+	out->emplace_back( detid.rawId(),Layer,
 			   energy, 
 			   position.x(), position.y(), position.z(), 
 			   axis.x(), axis.y(), axis.z() ); 
 
-
+        auto & rh = out->back();
 	//ECAL has no segmentation so put 1
 	
 	const CaloCellGeometry::CornersVec& corners = thisCell->getCorners();
@@ -125,10 +125,12 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
 	if(keep) {
 	  rh.setTime(time);
 	  rh.setDepth(1);
-	  out->push_back(std::move(rh));
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(std::move(rh));
+	} 
+        else {
+	  if (rcleaned) 
+	    cleaned->push_back(std::move(out->back()));
+          out->pop_back();
+        }
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
@@ -125,10 +125,10 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
 	if(keep) {
 	  rh.setTime(time);
 	  rh.setDepth(1);
-	  out->push_back(rh);
+	  out->push_back(std::move(rh));
 	}
 	else if (rcleaned) 
-	  cleaned->push_back(rh);
+	  cleaned->push_back(std::move(rh));
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -108,10 +108,10 @@ class PFHBHERecHitCreator :  public  PFRecHitCreatorBase {
 	}
 	  
 	if(keep) {
-	  out->push_back(rh);
+	  out->push_back(std::move(rh));
 	}
 	else if (rcleaned) 
-	  cleaned->push_back(rh);
+	  cleaned->push_back(std::move(rh));
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -114,10 +114,10 @@ class PFPSRecHitCreator :  public  PFRecHitCreatorBase {
 	}
 	
 	if(keep) {
-	  out->push_back(rh);
+	  out->push_back(std::move(rh));
 	}
 	else if (rcleaned) 
-	  cleaned->push_back(rh);
+	  cleaned->push_back(std::move(rh));
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -85,12 +85,12 @@ class PFPSRecHitCreator :  public  PFRecHitCreatorBase {
 	position.SetCoordinates ( point.x(),
 				  point.y(),
 				  point.z() );
-  
-	reco::PFRecHit rh( detid.rawId(),layer,
+
+        out->emplace_back(  detid.rawId(),layer,
 			   energy, 
 			   position.x(), position.y(), position.z(), 
 			   0.0,0.0,0.0);
-
+        auto & rh = out->back();
 	rh.setDepth(detid.plane());
 	rh.setTime(erh.time());
 	
@@ -113,11 +113,10 @@ class PFPSRecHitCreator :  public  PFRecHitCreatorBase {
 	  }
 	}
 	
-	if(keep) {
-	  out->push_back(std::move(rh));
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(std::move(rh));
+        if (rcleaned) 
+	  cleaned->push_back(std::move(out->back()));
+        if(!keep) 
+          out->pop_back();
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -39,12 +39,11 @@ class PFRecHitNavigatorBase {
  protected:
 
   void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi,short depth) {
-    const reco::PFRecHit temp(id,PFLayer::NONE,0.0,math::XYZPoint(0,0,0),math::XYZVector(0,0,0),std::vector<math::XYZPoint>());
     auto found_hit = std::lower_bound(hits->begin(),hits->end(),
-				      temp,
+				      id,
 				      [](const reco::PFRecHit& a, 
-					 const reco::PFRecHit& b){
-					return a.detId() < b.detId();
+					 const DetId& id){
+					return a.detId() < id;
 				      });
     if( found_hit != hits->end() && found_hit->detId() == id.rawId() ) {
       hit.addNeighbour(eta,phi,depth,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -33,7 +33,7 @@ namespace {
     if( eeclus.z()*psclus.z() < 0 ) return -1.0;
     auto deta= std::abs(eepos.eta() - pspos.eta());
     if( deta > 0.3 ) return -1.0;
-    auto dphi= deltaPhi(eepos.phi(),  pspos.phi());
+    auto dphi= std::abs(deltaPhi(eepos.phi(),  pspos.phi()));
     if( dphi > 0.6 ) return -1.0;    
     return LinkByRecHit::testECALAndPSByRecHit(eeclus,psclus,false);
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -16,37 +16,26 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h"
 #include "RecoParticleFlow/PFClusterTools/interface/LinkByRecHit.h"
-#include "TVector2.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 namespace {
   typedef reco::PFCluster::EEtoPSAssociation::value_type EEPSPair;
   bool sortByKey(const EEPSPair& a, const EEPSPair& b) {
     return a.first < b.first;
   } 
-  double testPreshowerDistance(const edm::Ptr<reco::PFCluster>& eeclus,
-			       const edm::Ptr<reco::PFCluster>& psclus) {
-    if( psclus.isNull() ) return -1.0;
-    /* 
-    // commented out since PFCluster::layer() uses a lot of CPU
-    // and since 
-    if( PFLayer::ECAL_ENDCAP != eeclus->layer() ) return -1.0;
-    if( PFLayer::PS1 != psclus->layer() &&
-	PFLayer::PS2 != psclus->layer()    ) {
-      throw cms::Exception("testPreshowerDistance")
-	<< "The second argument passed to this function was "
-	<< "not a preshower cluster!" << std::endl;
-    } 
-    */
-    const reco::PFCluster::REPPoint& pspos = psclus->positionREP();
-    const reco::PFCluster::REPPoint& eepos = eeclus->positionREP();
+
+  // why, why -1 and not <double>::max() ????
+  double testPreshowerDistance(reco::PFCluster const & eeclus,
+			       reco::PFCluster const & psclus) {
+    auto const & pspos = psclus.positionREP();
+    auto const & eepos = eeclus.positionREP();
     // lazy continue based on geometry
-    if( eeclus->z()*psclus->z() < 0 ) return -1.0;
-    const double dphi= std::abs(TVector2::Phi_mpi_pi(eepos.phi() - 
-						     pspos.phi()));
+    if( eeclus.z()*psclus.z() < 0 ) return -1.0;
+    auto deta= std::abs(eepos.eta() - pspos.eta());
+    if( deta > 0.3 ) return -1.0;
+    auto dphi= deltaPhi(eepos.phi(),  pspos.phi());
     if( dphi > 0.6 ) return -1.0;    
-    const double deta= std::abs(eepos.eta() - pspos.eta());    
-    if( deta > 0.3 ) return -1.0; 
-    return LinkByRecHit::testECALAndPSByRecHit(*eeclus,*psclus,false);
+    return LinkByRecHit::testECALAndPSByRecHit(eeclus,psclus,false);
   }
 }
 
@@ -83,46 +72,45 @@ DEFINE_FWK_MODULE(CorrectedECALPFClusterProducer);
 
 void CorrectedECALPFClusterProducer::
 produce(edm::Event& e, const edm::EventSetup& es) {
-  std::auto_ptr<reco::PFClusterCollection> clusters_out;
-  clusters_out.reset(new reco::PFClusterCollection);    
-  std::auto_ptr<reco::PFCluster::EEtoPSAssociation> association_out;
-  association_out.reset(new reco::PFCluster::EEtoPSAssociation);
+  std::unique_ptr<reco::PFClusterCollection> clusters_out(new reco::PFClusterCollection);    
+  std::unique_ptr<reco::PFCluster::EEtoPSAssociation> association_out(new reco::PFCluster::EEtoPSAssociation);
   
   edm::Handle<reco::PFClusterCollection> handleECAL;
   e.getByToken(_inputECAL,handleECAL);
   edm::Handle<reco::PFClusterCollection> handlePS;
   e.getByToken(_inputPS,handlePS);
-  
-  clusters_out->reserve(handleECAL->size());
-  association_out->reserve(handleECAL->size());
+
+  auto const & ecals = *handleECAL;
+  auto const & pss = *handlePS;
+
+  clusters_out->reserve(ecals.size());
+  association_out->reserve(ecals.size());
   clusters_out->insert(clusters_out->end(),
-		       handleECAL->begin(),handleECAL->end());
+		       ecals.begin(),ecals.end());
   //build the EE->PS association
-  double dist = -1.0, min_dist = -1.0;
-  for( unsigned i = 0; i < handlePS->size(); ++i ) {      
-    switch( handlePS->at(i).layer() ) { // just in case this isn't the ES...
+  for( unsigned i = 0; i < pss.size(); ++i ) {      
+    switch( pss[i].layer() ) { // just in case this isn't the ES...
     case PFLayer::PS1:
     case PFLayer::PS2:
       break;
     default:
       continue;
     }    
-    edm::Ptr<reco::PFCluster> psclus(handlePS,i);
-    if( psclus->energy() < _minimumPSEnergy ) continue;
-    edm::Ptr<reco::PFCluster> eematch,eeclus;
-    dist = min_dist = -1.0; // reset
-    for( size_t ic = 0; ic < handleECAL->size(); ++ic ) {
-      if( handleECAL->at(ic).layer() != PFLayer::ECAL_ENDCAP ) continue;
-      eeclus = edm::Ptr<reco::PFCluster>(handleECAL,ic);	
-      dist = testPreshowerDistance(eeclus,psclus);      
-      if( dist == -1.0 || (min_dist != -1.0 && dist > min_dist) ) continue;
-      if( dist < min_dist || min_dist == -1.0 ) {
-	eematch = eeclus;
+    if(  pss[i].energy() < _minimumPSEnergy ) continue;
+    int eematch = -1;
+    auto min_dist = std::numeric_limits<double>::max();
+    for( size_t ic = 0; ic < ecals.size(); ++ic ) {
+      if( ecals[ic].layer() != PFLayer::ECAL_ENDCAP ) continue;
+      auto dist = testPreshowerDistance(ecals[ic],pss[i]);      
+      if (dist == -1.0) dist=std::numeric_limits<double>::max(); 
+      if( dist < min_dist ) {
+	eematch = ic;
 	min_dist = dist;
       }
     } // loop on EE clusters      
-    if( eematch.isNonnull() ) {      
-      association_out->push_back(std::make_pair(eematch.key(),psclus));
+    if( eematch>=0 ) {
+      edm::Ptr<reco::PFCluster> psclus(handlePS,i);
+      association_out->push_back(std::make_pair(eematch,psclus));
     }
   }
   std::sort(association_out->begin(),association_out->end(),sortByKey);
@@ -130,9 +118,11 @@ produce(edm::Event& e, const edm::EventSetup& es) {
   _corrector->correctEnergies(e,es,*association_out,*clusters_out);
   
   association_out->shrink_to_fit();
+
+  // std::cout << "ass " << association_out->size() << std::endl;
   
-  e.put(association_out);
-  e.put(clusters_out);
+  e.put(std::move(association_out));
+  e.put(std::move(clusters_out));
 }
 
 void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -119,8 +119,6 @@ produce(edm::Event& e, const edm::EventSetup& es) {
   
   association_out->shrink_to_fit();
 
-  // std::cout << "ass " << association_out->size() << std::endl;
-  
   e.put(std::move(association_out));
   e.put(std::move(clusters_out));
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -1,10 +1,14 @@
 #include "RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h"
+#include "FWCore/Utilities/interface/RunningAverage.h"
 
 namespace {
   bool sortByDetId(const reco::PFRecHit& a,
 		   const reco::PFRecHit& b) {
     return a.detId() < b.detId();
   }
+
+ edm::RunningAverage localRA1;
+ edm::RunningAverage localRA2;
 }
 
  PFRecHitProducer:: PFRecHitProducer(const edm::ParameterSet& iConfig)
@@ -48,13 +52,15 @@ void
 
    navigator_->beginEvent(iSetup);
 
-   out->reserve(10000);
-   cleaned->reserve(10000);
+   out->reserve(localRA1.upper());
+   cleaned->reserve(localRA2.upper());
    for( const auto& creator : creators_ ) {
      creator->importRecHits(out,cleaned,iEvent,iSetup);
    }
    out->shrink_to_fit();
    cleaned->shrink_to_fit();
+   localRA1.update(out->size());
+   localRA2.update(cleaned->size());
    std::sort(out->begin(),out->end(),sortByDetId);
 
    //create a refprod here

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -48,10 +48,13 @@ void
 
    navigator_->beginEvent(iSetup);
 
+   out->reserve(10000);
+   cleaned->reserve(10000);
    for( const auto& creator : creators_ ) {
      creator->importRecHits(out,cleaned,iEvent,iSetup);
    }
-
+   out->shrink_to_fit();
+   cleaned->shrink_to_fit();
    std::sort(out->begin(),out->end(),sortByDetId);
 
    //create a refprod here

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -57,8 +57,8 @@ void
    for( const auto& creator : creators_ ) {
      creator->importRecHits(out,cleaned,iEvent,iSetup);
    }
-   out->shrink_to_fit();
-   cleaned->shrink_to_fit();
+   if (out->capacity()>2*out->size()) out->shrink_to_fit();
+   if (cleaned->capacity()>2*cleaned->size()) cleaned->shrink_to_fit();
    localRA1.update(out->size());
    localRA2.update(cleaned->size());
    std::sort(out->begin(),out->end(),sortByDetId);

--- a/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
@@ -1,12 +1,13 @@
 #include "LocalMaximumSeedFinder.h"
 
-const reco::PFRecHitRefVector LocalMaximumSeedFinder::_noNeighbours;
+#include <algorithm>
+#include <queue>
+#include <cfloat>
+#include "CommonTools/Utils/interface/DynArray.h"
+
 
 namespace {
-  bool greaterByEnergy(const std::pair<unsigned,double>& a,
-		       const std::pair<unsigned,double>& b) {
-    return a.second > b.second;
-  }
+  const reco::PFRecHitRefVector _noNeighbours;
 }
 
 LocalMaximumSeedFinder::
@@ -21,7 +22,7 @@ LocalMaximumSeedFinder(const edm::ParameterSet& conf) :
 	      {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
 	      {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
               // hack to deal with ring1 in HO 
-	      {"HCAL_BARREL2_RING1",100*(int)PFLayer::HCAL_BARREL2}, 
+	      {"HCAL_BARREL2_RING1", 19}, 
 	      {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
 	      {"HF_EM",(int)PFLayer::HF_EM},
 	      {"HF_HAD",(int)PFLayer::HF_HAD} }) {
@@ -38,8 +39,8 @@ LocalMaximumSeedFinder(const edm::ParameterSet& conf) :
 	<< "Detector layer : " << det << " is not in the list of recognized"
 	<< " detector layers!";
     }
-    _thresholds.emplace(_layerMap.find(det)->second, 
-			std::make_pair(thresh_E,thresh_pT2));
+    _thresholds[entry->second+layerOffset]= 
+			std::make_pair(thresh_E,thresh_pT2);
   }
 }
 
@@ -48,32 +49,38 @@ void LocalMaximumSeedFinder::
 findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
 	   const std::vector<bool>& mask,
 	   std::vector<bool>& seedable ) {
-  std::vector<bool> usable(input->size(),true);
+
+  auto nhits = input->size();
+  initDynArray(bool,nhits,usable,true);
   //need to run over energy sorted rechits
-  std::vector<std::pair<unsigned,double> > ordered_hits;
-  ordered_hits.reserve(input->size());
-  for( unsigned i = 0; i < input->size(); ++i ) {
-    std::pair<unsigned,double> val = std::make_pair(i,input->at(i).energy());
-    auto pos = std::upper_bound(ordered_hits.begin(),ordered_hits.end(),
-				val, greaterByEnergy);
-    ordered_hits.insert(pos,val);
+  declareDynArray(float,nhits,energies);
+  unInitDynArray(int,nhits,qst); // queue storage
+  auto cmp = [&](int i, int j) { return energies[i] < energies[j]; };
+  std::priority_queue<int, DynArray<int>, decltype(cmp)> ordered_hits(cmp,std::move(qst));
+
+  for( unsigned i = 0; i < nhits; ++i ) {
+    if( !mask[i] ) continue; // cannot seed masked objects
+    const auto & maybeseed = (*input)[i];
+    energies[i]=maybeseed.energy();
+    int seedlayer = (int)maybeseed.layer();
+    if( seedlayer == PFLayer::HCAL_BARREL2 &&
+        std::abs(maybeseed.positionREP().eta()) > 0.34 ) {
+      seedlayer = 19;
+    }
+    auto const & thresholds = _thresholds[seedlayer+layerOffset];
+    if( maybeseed.energy() < thresholds.first ||
+        maybeseed.pt2() < thresholds.second   ) usable[i] = false;
+    if( !usable[i] ) continue;
+    ordered_hits.push(i);
   }      
 
-  for( const auto& idx_e : ordered_hits ) {    
-    const unsigned idx = idx_e.first;    
-    if( !mask[idx] ) continue; // cannot seed masked objects
-    const reco::PFRecHit& maybeseed = input->at(idx);
-    int seedlayer = (int)maybeseed.layer();
-    if( seedlayer == PFLayer::HCAL_BARREL2 && 
-	std::abs(maybeseed.positionREP().eta()) > 0.34 ) {
-      seedlayer *= 100;
-    }    
-    const std::pair<double,double>& thresholds =
-      _thresholds.find(seedlayer)->second;
-    if( maybeseed.energy() < thresholds.first || 
-	maybeseed.pt2() < thresholds.second   ) usable[idx] = false;      
+
+  while(!ordered_hits.empty() ) {
+    auto idx = ordered_hits.top();
+    ordered_hits.pop();  
     if( !usable[idx] ) continue;
     //get the neighbours of this seed
+    const auto & maybeseed = (*input)[idx];
     const reco::PFRecHitRefVector* myNeighbours;
     switch( _nNeighbours ) {
     case -1:
@@ -95,7 +102,8 @@ findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
     seedable[idx] = true;
     for( const reco::PFRecHitRef& neighbour : *myNeighbours ) {
       if( !mask[neighbour.key()] ) continue;
-      if( neighbour->energy() > maybeseed.energy() ) {
+      if( energies[neighbour.key()] > energies[idx] ) {
+//        std::cout << "how this can be?" << std::endl;
 	seedable[idx] = false;	
 	break;
       }
@@ -106,4 +114,8 @@ findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
       }
     }
   }
+
+  // auto ns = std::count(seedable.begin(),seedable.end(),true);
+  // std::cout << "seeds " << ns << std::endl;
+
 }

--- a/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
@@ -115,7 +115,6 @@ findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
     }
   }
 
-  // auto ns = std::count(seedable.begin(),seedable.end(),true);
-  // std::cout << "seeds " << ns << std::endl;
+  LogDebug("LocalMaximumSeedFinder") << " found " << std::count(seedable.begin(),seedable.end(),true) << " seeds";
 
 }

--- a/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.cc
@@ -4,7 +4,7 @@
 #include <queue>
 #include <cfloat>
 #include "CommonTools/Utils/interface/DynArray.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace {
   const reco::PFRecHitRefVector _noNeighbours;

--- a/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/src/LocalMaximumSeedFinder.h
@@ -5,7 +5,7 @@
 
 #include <unordered_map>
 
-class LocalMaximumSeedFinder : public SeedFinderBase {
+class LocalMaximumSeedFinder final : public SeedFinderBase {
  public:
   LocalMaximumSeedFinder(const edm::ParameterSet& conf);
   LocalMaximumSeedFinder(const LocalMaximumSeedFinder&) = delete;
@@ -18,10 +18,9 @@ class LocalMaximumSeedFinder : public SeedFinderBase {
  private:  
   const int _nNeighbours;
 
-  static const reco::PFRecHitRefVector _noNeighbours;
   const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,std::pair<double,double> > 
-    _thresholds;
+  std::array<std::pair<double,double>, 35> _thresholds;
+  static constexpr int layerOffset = 15;
 };
 
 DEFINE_EDM_PLUGIN(SeedFinderFactory,

--- a/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
@@ -39,7 +39,7 @@ class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   }
 };
 
-class PFRecHitEcalBarrelNavigator : public PFRecHitCaloNavigator<EBDetId,EcalBarrelTopology> {
+class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId,EcalBarrelTopology> {
  public:
   PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig) {
 
@@ -52,7 +52,7 @@ class PFRecHitEcalBarrelNavigator : public PFRecHitCaloNavigator<EBDetId,EcalBar
   }
 };
 
-class PFRecHitEcalEndcapNavigator : public PFRecHitCaloNavigator<EEDetId,EcalEndcapTopology> {
+class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId,EcalEndcapTopology> {
  public:
   PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig) {
 
@@ -65,7 +65,7 @@ class PFRecHitEcalEndcapNavigator : public PFRecHitCaloNavigator<EEDetId,EcalEnd
   }
 };
 
-class PFRecHitPreshowerNavigator : public PFRecHitCaloNavigator<ESDetId,EcalPreshowerTopology> {
+class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId,EcalPreshowerTopology> {
  public:
   PFRecHitPreshowerNavigator(const edm::ParameterSet& iConfig) {
 
@@ -80,7 +80,7 @@ class PFRecHitPreshowerNavigator : public PFRecHitCaloNavigator<ESDetId,EcalPres
 };
 
 
-class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId,HcalTopology,false> {
+class PFRecHitHCALNavigator final : public PFRecHitCaloNavigator<HcalDetId,HcalTopology,false> {
  public:
   PFRecHitHCALNavigator(const edm::ParameterSet& iConfig) {
 

--- a/RecoParticleFlow/PFClusterProducer/src/SpikeAndDoubleSpikeCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SpikeAndDoubleSpikeCleaner.cc
@@ -2,10 +2,6 @@
 #include <cmath>
 
 namespace {
-  bool greaterByEnergy(const std::pair<unsigned,double>& a,
-		       const std::pair<unsigned,double>& b) {
-    return a.second > b.second;
-  }
   std::pair<double,double> dCrack(double phi, double eta) {
     constexpr double oneOverCrystalSize=1.0/0.0175;
     constexpr double pi=M_PI;
@@ -105,18 +101,16 @@ void SpikeAndDoubleSpikeCleaner::
 clean(const edm::Handle<reco::PFRecHitCollection>& input,
       std::vector<bool>& mask ) {
   //need to run over energy sorted rechits
-  std::vector<std::pair<unsigned,double> > ordered_hits;
-  for( unsigned i = 0; i < input->size(); ++i ) {
-    std::pair<unsigned,double> val = std::make_pair(i,input->at(i).energy());
-    auto pos = std::upper_bound(ordered_hits.begin(),ordered_hits.end(),
-				val, greaterByEnergy);
-    ordered_hits.insert(pos,val);
-  }  
+  auto const & hits = *input;
+  std::vector<unsigned > ordered_hits(hits.size());
+  for( unsigned i = 0; i < hits.size(); ++i ) ordered_hits[i]=i;
+  std::sort(ordered_hits.begin(),ordered_hits.end(),[&](unsigned i, unsigned j) { return hits[i].energy()>hits[j].energy();});
+    
 
-  for( const auto& idx_e : ordered_hits ) {
-    const unsigned i = idx_e.first;
+  for( const auto& idx : ordered_hits ) {
+    const unsigned i = idx;
     if( !mask[i] ) continue; // don't need to re-mask things :-)
-    const reco::PFRecHit& rechit = input->at(i);
+    const reco::PFRecHit& rechit = hits[i];
     int hitlayer = (int)rechit.layer();
     if( hitlayer == PFLayer::HCAL_BARREL2 && 
 	std::abs(rechit.positionREP().eta()) > 0.34 ) {

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -4,6 +4,9 @@
 
 #include <algorithm>
 #include <cfloat>
+#include "CommonTools/Utils/interface/DynArray.h"
+
+
 
 template <unsigned int N>
 CloseComponentsMerger<N>::CloseComponentsMerger (int maxNumberOfComponents,


### PR DESCRIPTION
This PR backports #13959 and #14070 from CMSSW_8_1_X to CMSSW_8_0_X. Original descriptions by @VinInn 
#13959

> Technical mods to ParticleFlow (and some core classes) to speedup creation for PFRecHIt and PFClusters.
> Most of it is trivial.
> I did not observe any regression on TTBAR PU35 reco.
> Includes contribution by @lgray
> 
> added major speedup in ES geometry and EcalRecHit creation
> 
> p.s. shrink_to_fit is still calling RefCore copy constructor instead of moving as it should....
#14070

> avoid stalls due to memory fence.

The first commit (7cf0c3b) is actually from #13831. It is included here because #13959 depends on it, and the dependence is only a single commit whose intention is not to change any behaviour. The entire #13831 is not backported at this time because it causes tiny regressions due to numerics.
#14070 is included because it depends on #13959, and causes no changes in RECO quantities.

Tested in CMSSW_8_0_14, no changes expected in RECO quantities in here either.

@fwyzard @gennai @slava77 @VinInn @lgray 
