### PR TITLE
Replacing C-style arrays with std::array

### DIFF
--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -19,7 +19,8 @@
    <class name="HFPreRecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="224636588"/>
    </class>
-   <class name="HBHEChannelInfo" ClassVersion="3">
+   <class name="HBHEChannelInfo" ClassVersion="4">
+    <version ClassVersion="4" checksum="2457756773"/>
     <version ClassVersion="3" checksum="184305963"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">


### PR DESCRIPTION
C-style arrays are replaced with std::array, as requested in the discussion of PR #15092
