### PR TITLE
[8.0.X] Prevent negative jet smearing factor

### DIFF
--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -252,6 +252,17 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     std::cout << "Impossible to smear this jet" << std::endl;
                 }
 
+                if (jet.energy() * smearFactor < MIN_JET_ENERGY) {
+                    // Negative or too small smearFactor. We would change direction of the jet
+                    // and this is not what we want.
+                    // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY
+                    double newSmearFactor = MIN_JET_ENERGY / jet.energy();
+                    if (m_debug) {
+                        std::cout << "The smearing factor (" << smearFactor << ") is either negative or too small. Fixing it to " << newSmearFactor << " to avoid change of direction." << std::endl;
+                    }
+                    smearFactor = newSmearFactor;
+                }
+
                 T smearedJet = jet;
                 smearedJet.scaleEnergy(smearFactor);
 
@@ -269,6 +280,8 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
         }
 
     private:
+        static constexpr const double MIN_JET_ENERGY = 1e-2;
+
         edm::EDGetTokenT<JetCollection> m_jets_token;
         edm::EDGetTokenT<double> m_rho_token;
         bool m_enabled;


### PR DESCRIPTION
Backport of  #15249 for 8.0.X

---

If the smearing factor is negative, the energy becomes negative, and the
jet direction is inverted. Avoid this problem by setting a minimum valid
energy for the jet. If, after smearing, the jet energy is smaller than
this limit, the smearing factor is recomputed.

Tested and working as expected. Fixes a bug reported on the [HN](https://hypernews.cern.ch/HyperNews/CMS/get/jes/619.html).
