### PR TITLE
Backport HIP mitigation to 80X

### DIFF
--- a/RecoMuon/GlobalMuonProducer/python/globalMuons_cff.py
+++ b/RecoMuon/GlobalMuonProducer/python/globalMuons_cff.py
@@ -12,11 +12,11 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi impo
 from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilderWithoutRefit_cfi import *
 from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 from RecoMuon.GlobalMuonProducer.globalMuons_cfi import *
-Chi2EstimatorForMuRefit = cms.ESProducer("Chi2MeasurementEstimatorESProducer",
-    ComponentName = cms.string('Chi2EstimatorForMuRefit'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(100000.0)
-)
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+Chi2EstimatorForMuRefit = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
+Chi2EstimatorForMuRefit.ComponentName = cms.string('Chi2EstimatorForMuRefit')
+Chi2EstimatorForMuRefit.nSigma = 3.0
+Chi2EstimatorForMuRefit.MaxChi2 = 100000.0
 
 
 from TrackingTools.TrackFitters.TrackFitters_cff import *

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.KalmanUpdators.KFUpdatorESProducer_cfi import *
 from TrackingTools.GeomPropagators.SmartPropagator_cff import *
 from RecoMuon.TrackingTools.MuonUpdatorAtVertex_cff import *
-Chi2EstimatorForMuonTrackLoader = cms.ESProducer("Chi2MeasurementEstimatorESProducer",
-    ComponentName = cms.string('Chi2EstimatorForMuonTrackLoader'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(100000.0)
-)
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+Chi2EstimatorForMuonTrackLoader = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
+Chi2EstimatorForMuonTrackLoader.ComponentName = cms.string('Chi2EstimatorForMuonTrackLoader')
+Chi2EstimatorForMuonTrackLoader.nSigma = 3.0
+Chi2EstimatorForMuonTrackLoader.MaxChi2 = 100000.0
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 KFSmootherForMuonTrackLoader = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
@@ -14,7 +14,7 @@ Chi2MeasurementEstimatorForP5.MaxChi2 = 100.
 Chi2MeasurementEstimatorForP5.nSigma = 4.
 Chi2MeasurementEstimatorForP5.MaxDisplacement = 100
 Chi2MeasurementEstimatorForP5.MaxSagitta=-1
-
+Chi2MeasurementEstimatorForP5.MinPtForHitRecoveryInGluedDet=100000
 # PropagatorWithMaterialESProducer
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
 # PropagatorWithMaterialESProducer

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
@@ -14,7 +14,7 @@ Chi2MeasurementEstimatorForP5.MaxChi2 = 100.
 Chi2MeasurementEstimatorForP5.nSigma = 4.
 Chi2MeasurementEstimatorForP5.MaxDisplacement = 100
 Chi2MeasurementEstimatorForP5.MaxSagitta=-1
-Chi2MeasurementEstimatorForP5.MinPtForHitRecoveryInGluedDet=100000
+
 # PropagatorWithMaterialESProducer
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
 # PropagatorWithMaterialESProducer

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -2,10 +2,9 @@ def esproducers_by_type(process, *types):
     return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
 def customizeMinPtForHitRecoveryInGluedDet(process,value):
    for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
-       esp.MinPtForHitRecoveryInGluedDet = 100000
-def customizeHitRecoveryInGluedDetOff(process):
-   for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
-       customizeMinPtForHitRecoveryInGluedDet(process,1000000)
-
+       esp.MinPtForHitRecoveryInGluedDet = value
    return process
+def customizeHitRecoveryInGluedDetOff(process):
+   return customizeMinPtForHitRecoveryInGluedDet(process,1000000)
+
 

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -1,0 +1,7 @@
+def esproducers_by_type(process, *types):
+    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
+def customizeMinPtForHitRecoveryInGluedDet(process):
+   for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
+       esp.MinPtForHitRecoveryInGluedDet = 100000
+   return process
+

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -1,7 +1,11 @@
 def esproducers_by_type(process, *types):
     return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
-def customizeMinPtForHitRecoveryInGluedDet(process):
+def customizeMinPtForHitRecoveryInGluedDet(process,value):
    for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
        esp.MinPtForHitRecoveryInGluedDet = 100000
+def customizeHitRecoveryInGluedDetOff(process):
+   for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
+       customizeMinPtForHitRecoveryInGluedDet(process,1000000)
+
    return process
 

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -1,8 +1,9 @@
+import FWCore.ParameterSet.Config as cms
 def esproducers_by_type(process, *types):
     return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
 def customizeMinPtForHitRecoveryInGluedDet(process,value):
    for esp in esproducers_by_type(process, "Chi2MeasurementEstimatorESProducer", "Chi2ChargeMeasurementEstimatorESProducer"):
-       esp.MinPtForHitRecoveryInGluedDet = value
+       esp.MinPtForHitRecoveryInGluedDet = cms.double(value)
    return process
 def customizeHitRecoveryInGluedDetOff(process):
    return customizeMinPtForHitRecoveryInGluedDet(process,1000000)

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -7,5 +7,7 @@ def customizeMinPtForHitRecoveryInGluedDet(process,value):
    return process
 def customizeHitRecoveryInGluedDetOff(process):
    return customizeMinPtForHitRecoveryInGluedDet(process,1000000)
+def customizeHitRecoveryInGluedDetOn(process):
+   return customizeMinPtForHitRecoveryInGluedDet(process,0.9)
 
 

--- a/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
+++ b/RecoTracker/Configuration/python/customizeMinPtForHitRecoveryInGluedDet.py
@@ -8,6 +8,9 @@ def customizeMinPtForHitRecoveryInGluedDet(process,value):
 def customizeHitRecoveryInGluedDetOff(process):
    return customizeMinPtForHitRecoveryInGluedDet(process,1000000)
 def customizeHitRecoveryInGluedDetOn(process):
-   return customizeMinPtForHitRecoveryInGluedDet(process,0.9)
+   process = customizeMinPtForHitRecoveryInGluedDet(process,0.9)
+   if hasattr(process, "Chi2MeasurementEstimatorForP5"): # keep disabled for cosmics
+       process.Chi2MeasurementEstimatorForP5.MinPtForHitRecoveryInGluedDet = 100000
+   return process
 
 

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -127,6 +127,7 @@ Chi2ChargeMeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDes
   desc.add<double>("MaxDisplacement",0.5); 
   desc.add<double>("MaxSagitta",2.);
   desc.add<double>("MinimalTolerance",0.5);
+  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
   desc.add<std::string>("ComponentName","Chi2Charge");
   desc.add<double>("pTChargeCutThreshold",-1.);
   edm::ParameterSetDescription descCCC = getFilledConfigurationDescription4CCC();
@@ -153,13 +154,14 @@ Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord
   auto maxDis  = m_pset.getParameter<double>("MaxDisplacement");
   auto maxSag  = m_pset.getParameter<double>("MaxSagitta");
   auto minTol  = m_pset.getParameter<double>("MinimalTolerance");
+  auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
   auto minGoodPixelCharge  = 0;
   auto minGoodStripCharge  =  clusterChargeCut(m_pset);
   auto pTChargeCutThreshold=   m_pset.getParameter<double>("pTChargeCutThreshold");
 
   m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(
 	new Chi2ChargeMeasurementEstimator(minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold,
-                                            maxChi2,nSigma, maxDis, maxSag, minTol) ); 
+                                            maxChi2,nSigma, maxDis, maxSag, minTol,minpt) ); 
 
   return m_estimator;
 }

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -98,8 +98,7 @@ bool Chi2ChargeMeasurementEstimator::preFilter(const TrajectoryStateOnSurface& t
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include <boost/shared_ptr.hpp>
 
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h"
 
 
 namespace {
@@ -120,14 +119,7 @@ class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
 void
 Chi2ChargeMeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
-  //  edm::ParameterSetDescription desc = Chi2MeasurementEstimatorESProducer::getFilledConfigurationDescription();
-  edm::ParameterSetDescription desc;
-  desc.add<double>("MaxChi2",30);
-  desc.add<double>("nSigma",3);
-  desc.add<double>("MaxDisplacement",0.5); 
-  desc.add<double>("MaxSagitta",2.);
-  desc.add<double>("MinimalTolerance",0.5);
-  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
+  auto desc = chi2MeasurementEstimatorParams::getFilledConfigurationDescription();
   desc.add<std::string>("ComponentName","Chi2Charge");
   desc.add<double>("pTChargeCutThreshold",-1.);
   edm::ParameterSetDescription descCCC = getFilledConfigurationDescription4CCC();

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -136,7 +136,7 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    auto id = geomDet().geographicalId().subdetId()-3;
    auto l = TOBDetId(geomDet().geographicalId()).layer();
    bool killHIP = (1==l) && (2==id); //TOB1
-   killHIP &= stateOnThisDet.globalMomentum().perp2()>0.81f;
+   killHIP &= stateOnThisDet.globalMomentum().perp2()>est.minPt2ForHitRecoveryInGluedDet();
    if (killHIP) {
         result.add(theInactiveHit, 0.F); 
         return true;

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -130,6 +130,11 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    
    if (result.size()>oldSize) return true;
    
+   auto id = geomDet().geographicalId().subdetId()-3;
+   auto barrel = 0==(id%2);  // TIB1,2 TOB1,2	always inactive
+   if (barrel) { result.add(theInactiveHit, 0.F); return true;}
+
+
    //LogDebug("TkStripMeasurementDet") << "No hit found on TkGlued. Testing strips...  ";
    const BoundPlane &gluedPlane = geomDet().surface();
    if (  // sorry for the big IF, but I want to exploit short-circuiting of logic
@@ -147,6 +152,9 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
 				      ) /*Stereo OK*/ 
 				      ) /* State has errors */
 	 ) {
+     auto id = geomDet().geographicalId().subdetId()-3;
+     auto barrel = 0==(id%2);  // TIB1,2 TOB1,2 always inactive
+     if (barrel) { result.add(theInactiveHit, 0.F); return true;}
      result.add(theMissingHit, 0.F);
      return false;
    } 

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -145,22 +145,41 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
 
    //LogDebug("TkStripMeasurementDet") << "No hit found on TkGlued. Testing strips...  ";
    const BoundPlane &gluedPlane = geomDet().surface();
-   if (  // sorry for the big IF, but I want to exploit short-circuiting of logic
-       stateOnThisDet.hasError() && ( /* do this only if the state has uncertainties, otherwise it will throw 
-					 (states without uncertainties are passed to this code from seeding */
+   bool addMissingHit = false;
+   if(est.minPt2ForHitRecoveryInGluedDet() < 1e9f) {// HIP mitigation is active
+     // sorry for duplicating the big IF below, but to keep exloiting
+     // short-circuiting logic that's the easiest
+     addMissingHit = stateOnThisDet.hasError() && ( /* do this only if the state has uncertainties, otherwise it will throw 
+                                                       (states without uncertainties are passed to this code from seeding */
 				     (theMonoDet->isActive(data) && 
 				      (theMonoDet->hasAllGoodChannels() || 
 				       testStrips(stateOnThisDet,gluedPlane,*theMonoDet)
 				       )
-				      ) /*Mono OK*/ 
-                                     && // was || 
+				      ) /*Mono OK*/ &&
 				     (theStereoDet->isActive(data) && 
 				      (theStereoDet->hasAllGoodChannels() || 
 				       testStrips(stateOnThisDet,gluedPlane,*theStereoDet)
 				       )
 				      ) /*Stereo OK*/ 
-				      ) /* State has errors */
-	 ) {
+				      ); /* State has errors */
+   }
+   else {
+     // sorry for the big IF, but I want to exploit short-circuiting of logic
+     addMissingHit = stateOnThisDet.hasError() && ( /* do this only if the state has uncertainties, otherwise it will throw 
+					 (states without uncertainties are passed to this code from seeding */
+				     (theMonoDet->isActive(data) && 
+				      (theMonoDet->hasAllGoodChannels() || 
+				       testStrips(stateOnThisDet,gluedPlane,*theMonoDet)
+				       )
+				      ) /*Mono OK*/ ||
+				     (theStereoDet->isActive(data) && 
+				      (theStereoDet->hasAllGoodChannels() || 
+				       testStrips(stateOnThisDet,gluedPlane,*theStereoDet)
+				       )
+				      ) /*Stereo OK*/ 
+				      ); /* State has errors */
+   }
+   if(addMissingHit) {
      result.add(theMissingHit, 0.F);
      return false;
    } 

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -137,6 +137,7 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    // auto barrel = 0==(id%2);  // TIB1,2 TOB1,2	always inactive
    auto l = TOBDetId(geomDet().geographicalId()).layer();
    bool killHIP = (1==l) && (2==id); //TOB1
+   killHIP &= stateOnThisDet.globalMomentum().perp2()>0.81f;
    if (killHIP) {
         result.add(theInactiveHit, 0.F); 
         return true;

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -153,7 +153,8 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
 				      (theMonoDet->hasAllGoodChannels() || 
 				       testStrips(stateOnThisDet,gluedPlane,*theMonoDet)
 				       )
-				      ) /*Mono OK*/ || 
+				      ) /*Mono OK*/ 
+                                     && // was || 
 				     (theStereoDet->isActive(data) && 
 				      (theStereoDet->hasAllGoodChannels() || 
 				       testStrips(stateOnThisDet,gluedPlane,*theStereoDet)

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -16,6 +16,9 @@
 
 #include <typeinfo>
 
+#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
+
+
 namespace {
   inline
   std::pair<LocalPoint,LocalError> projectedPos(const TrackingRecHit& hit,
@@ -131,8 +134,13 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    if (result.size()>oldSize) return true;
    
    auto id = geomDet().geographicalId().subdetId()-3;
-   auto barrel = 0==(id%2);  // TIB1,2 TOB1,2	always inactive
-   if (barrel) { result.add(theInactiveHit, 0.F); return true;}
+   // auto barrel = 0==(id%2);  // TIB1,2 TOB1,2	always inactive
+   auto l = TOBDetId(geomDet().geographicalId()).layer();
+   bool killHIP = (1==l) && (2==id); //TOB1
+   if (killHIP) {
+        result.add(theInactiveHit, 0.F); 
+        return true;
+   }
 
 
    //LogDebug("TkStripMeasurementDet") << "No hit found on TkGlued. Testing strips...  ";
@@ -152,9 +160,6 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
 				      ) /*Stereo OK*/ 
 				      ) /* State has errors */
 	 ) {
-     auto id = geomDet().geographicalId().subdetId()-3;
-     auto barrel = 0==(id%2);  // TIB1,2 TOB1,2 always inactive
-     if (barrel) { result.add(theInactiveHit, 0.F); return true;}
      result.add(theMissingHit, 0.F);
      return false;
    } 

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -134,7 +134,6 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    if (result.size()>oldSize) return true;
    
    auto id = geomDet().geographicalId().subdetId()-3;
-   // auto barrel = 0==(id%2);  // TIB1,2 TOB1,2	always inactive
    auto l = TOBDetId(geomDet().geographicalId()).layer();
    bool killHIP = (1==l) && (2==id); //TOB1
    killHIP &= stateOnThisDet.globalMomentum().perp2()>0.81f;

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -149,7 +149,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 			    gluedDet, trdir, chelper);
   }
 
-  if (ts.globalMomentum().perp2()>0.81f) {
+  if (ts.globalMomentum().perp2()> collector.estimator().minPt2ForHitRecoveryInGluedDet()) {
     // if no match found try add mon than try to add stereo...
     if (0==collector.size()) 
       projectOnGluedDet( collector, monoHits, glbDir);

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -151,7 +151,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 
 
   auto id = geomDet().geographicalId().subdetId();
-  if (id==5 && ts.globalMomentum().perp2()>0.81f) { // tob
+  if ( (id==3 || id==5) && ts.globalMomentum().perp2()>0.81f) { // tob & tib
   // if no match found try add mon than try to add stereo...
   if (0==collector.size()) 
     projectOnGluedDet( collector, monoHits, glbDir);

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -151,7 +151,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 
 
   auto id = geomDet().geographicalId().subdetId();
-  if (id==5) { // tob
+  if (id==5 && ts.globalMomentum().perp2()>0.81f) { // tob
   // if no match found try add mon than try to add stereo...
   if (0==collector.size()) 
     projectOnGluedDet( collector, monoHits, glbDir);

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -149,9 +149,6 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 			    gluedDet, trdir, chelper);
   }
 
-
-  // auto id = geomDet().geographicalId().subdetId();
-  // if ( (id==3 || id==5) &&  // tob & tib
   if (ts.globalMomentum().perp2()>0.81f) {
     // if no match found try add mon than try to add stereo...
     if (0==collector.size()) 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -155,8 +155,8 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   // if no match found try add mon than try to add stereo...
   if (0==collector.size()) 
     projectOnGluedDet( collector, monoHits, glbDir);
-//  if (0==collector.size())
-//    projectOnGluedDet( collector, stereoHits, glbDir);
+  if (0==collector.size())
+    projectOnGluedDet( collector, stereoHits, glbDir);
   }
   /*
   // recover hits outside 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -150,13 +150,14 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   }
 
 
-  auto id = geomDet().geographicalId().subdetId();
-  if ( (id==3 || id==5) && ts.globalMomentum().perp2()>0.81f) { // tob & tib
-  // if no match found try add mon than try to add stereo...
-  if (0==collector.size()) 
-    projectOnGluedDet( collector, monoHits, glbDir);
-  if (0==collector.size())
-    projectOnGluedDet( collector, stereoHits, glbDir);
+  // auto id = geomDet().geographicalId().subdetId();
+  // if ( (id==3 || id==5) &&  // tob & tib
+  if (ts.globalMomentum().perp2()>0.81f) {
+    // if no match found try add mon than try to add stereo...
+    if (0==collector.size()) 
+      projectOnGluedDet( collector, monoHits, glbDir);
+    if (0==collector.size())
+      projectOnGluedDet( collector, stereoHits, glbDir);
   }
   /*
   // recover hits outside 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -149,12 +149,15 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 			    gluedDet, trdir, chelper);
   }
 
+
+  auto id = geomDet().geographicalId().subdetId();
+  if (id==5) { // tob
   // if no match found try add mon than try to add stereo...
-//  if (0==collector.size()) 
-//    projectOnGluedDet( collector, monoHits, glbDir);
+  if (0==collector.size()) 
+    projectOnGluedDet( collector, monoHits, glbDir);
 //  if (0==collector.size())
 //    projectOnGluedDet( collector, stereoHits, glbDir);
-  
+  }
   /*
   // recover hits outside 
   if ( collector.filter() && 0==collector.size())  {

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -162,7 +162,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
   std::unique_ptr<Propagator> localProp(prop->clone());
 
   //use negative sigma=-3.0 in order to use a more conservative definition of isInside() for Bounds classes.
-  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5);  // same as defauts....
+  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,0.9);  // same as defauts....
 
   // WARNING: At the moment the trajectories has the measurements with reversed sorting after the track smoothing. 
   // Therefore the lastMeasurement is the inner one (for LHC-like tracks)

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -162,7 +162,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
   std::unique_ptr<Propagator> localProp(prop->clone());
 
   //use negative sigma=-3.0 in order to use a more conservative definition of isInside() for Bounds classes.
-  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,0.9);  // same as defauts....
+  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,std::numeric_limits<float>::max());  // same as defauts....
 
   // WARNING: At the moment the trajectories has the measurements with reversed sorting after the track smoothing. 
   // Therefore the lastMeasurement is the inner one (for LHC-like tracks)

--- a/TrackingTools/DetLayers/interface/MeasurementEstimator.h
+++ b/TrackingTools/DetLayers/interface/MeasurementEstimator.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 #include "DataFormats/GeometryVector/interface/LocalTag.h"
-#include <utility>
+#include<limits>
 
 class Plane;
 class TrajectoryStateOnSurface;
@@ -26,9 +26,11 @@ public:
 
 
   MeasurementEstimator() {}
-  MeasurementEstimator(float maxSag, float minToll) :
+  MeasurementEstimator(float maxSag, float minToll, float mpt) :
      m_maxSagitta(maxSag),
-     m_minTolerance2(minToll*minToll){}
+     m_minTolerance2(minToll*minToll),
+     m_minPt2ForHitRecoveryInGluedDet(mpt*mpt)
+     {}
 
   virtual ~MeasurementEstimator() {}
 
@@ -75,12 +77,18 @@ public:
 
   float maxSagitta() const { return m_maxSagitta;}
   float	minTolerance2() const { return m_minTolerance2;}
-
+  float	minPt2ForHitRecoveryInGluedDet() const { return m_minPt2ForHitRecoveryInGluedDet;}
 
 private:
+  /*
+   *  why here? 
+   * MeasurementEstimator is the only configurable item that percolates down to geometry event by event (actually hit by hit) and not at initialization time
+   * It is therefore the natural candidate to collect all parameters that affect pattern-recongnition 
+   * and require to be controlled with higher granularity than job level (such as iteration by iteration)
+   */ 
   float m_maxSagitta=-1.; // maximal sagitta for linear approximation
   float m_minTolerance2=100.; // square of minimum tolerance ot be considered inside a detector
-
+  float m_minPt2ForHitRecoveryInGluedDet=std::numeric_limits<float>::max();
 };
 
 #endif // Tracker_MeasurementEstimator_H

--- a/TrackingTools/DetLayers/interface/MeasurementEstimator.h
+++ b/TrackingTools/DetLayers/interface/MeasurementEstimator.h
@@ -88,7 +88,7 @@ private:
    */ 
   float m_maxSagitta=-1.; // maximal sagitta for linear approximation
   float m_minTolerance2=100.; // square of minimum tolerance ot be considered inside a detector
-  float m_minPt2ForHitRecoveryInGluedDet=std::numeric_limits<float>::max();
+  float m_minPt2ForHitRecoveryInGluedDet=0.81;   // FIXME std::numeric_limits<float>::max();
 };
 
 #endif // Tracker_MeasurementEstimator_H

--- a/TrackingTools/DetLayers/interface/MeasurementEstimator.h
+++ b/TrackingTools/DetLayers/interface/MeasurementEstimator.h
@@ -88,7 +88,7 @@ private:
    */ 
   float m_maxSagitta=-1.; // maximal sagitta for linear approximation
   float m_minTolerance2=100.; // square of minimum tolerance ot be considered inside a detector
-  float m_minPt2ForHitRecoveryInGluedDet=0.81;   // FIXME std::numeric_limits<float>::max();
+  float m_minPt2ForHitRecoveryInGluedDet=std::numeric_limits<float>::max();
 };
 
 #endif // Tracker_MeasurementEstimator_H

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidatesChi2_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidatesChi2_cfi.py
@@ -4,10 +4,10 @@ import FWCore.ParameterSet.Config as cms
 # Looser chi2 estimator for electron trajectory building
 #   (definition should be moved?)
 #
-electronChi2 = cms.ESProducer("Chi2MeasurementEstimatorESProducer",
-    ComponentName = cms.string('electronChi2'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(100.0)
-)
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+electronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
+electronChi2.ComponentName = cms.string('electronChi2')
+electronChi2.nSigma = 3.0
+electronChi2.MaxChi2 = 100.0
 
 

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h
@@ -22,9 +22,10 @@ public:
   explicit Chi2MeasurementEstimatorBase(double maxChi2, double nSigma = 3., float maxDisp=std::numeric_limits<float>::max()) : 
     theMaxChi2(maxChi2), theNSigma(nSigma), theMaxDisplacement(maxDisp) {}
 
+  template<typename... Args>
   Chi2MeasurementEstimatorBase(double maxChi2, double nSigma, float maxDisp,
-                               float maxSag, float minToll) : 
-    MeasurementEstimator(maxSag,minToll),
+                               Args && ...args) :
+    MeasurementEstimator(args...),
     theMaxChi2(maxChi2), theNSigma(nSigma), theMaxDisplacement(maxDisp)  {}
 
 

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h
@@ -1,0 +1,18 @@
+#ifndef TrackingToolsKalmanUpdatorsChi2MeasurementEstimatorParams_H
+#define TrackingToolsKalmanUpdatorsChi2MeasurementEstimatorParams_H
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+namespace chi2MeasurementEstimatorParams { 
+inline
+edm::ParameterSetDescription getFilledConfigurationDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("MaxChi2",30);
+  desc.add<double>("nSigma",3);
+  desc.add<double>("MaxDisplacement",0.5);
+  desc.add<double>("MaxSagitta",2.);
+  desc.add<double>("MinimalTolerance",0.5);
+  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
+  return desc;
+}
+}
+#endif

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h
@@ -11,7 +11,7 @@ edm::ParameterSetDescription getFilledConfigurationDescription() {
   desc.add<double>("MaxDisplacement",0.5);
   desc.add<double>("MaxSagitta",2.);
   desc.add<double>("MinimalTolerance",0.5);
-  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
+  desc.add<double>("MinPtForHitRecoveryInGluedDet", 1000000);
   return desc;
 }
 }

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -44,8 +44,9 @@ Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRe
   auto maxDis  = m_pset.getParameter<double>("MaxDisplacement");
   auto maxSag  = m_pset.getParameter<double>("MaxSagitta");
   auto minTol = m_pset.getParameter<double>("MinimalTolerance");
+  auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
    
-  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new Chi2MeasurementEstimator(maxChi2,nSigma, maxDis, maxSag, minTol));
+  m_estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(new Chi2MeasurementEstimator(maxChi2,nSigma, maxDis, maxSag, minTol,minpt));
   return m_estimator;
 }
 
@@ -60,6 +61,7 @@ Chi2MeasurementEstimatorESProducer::getFilledConfigurationDescription() {
   desc.add<double>("MaxDisplacement",0.5); 
   desc.add<double>("MaxSagitta",2.);
   desc.add<double>("MinimalTolerance",0.5);
+  desc.add<double>("MinPtForHitRecoveryInGluedDet",9);
   return desc;
 }
   */
@@ -74,6 +76,7 @@ Chi2MeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<double>("MaxDisplacement",0.5); 
   desc.add<double>("MaxSagitta",2.);
   desc.add<double>("MinimalTolerance",0.5);
+  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
   desc.add<std::string>("ComponentName","Chi2");
   descriptions.add("Chi2MeasurementEstimator", desc);
 }

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -3,9 +3,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h"
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,7 +20,6 @@ class  Chi2MeasurementEstimatorESProducer: public edm::ESProducer{
   boost::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  //  static edm::ParameterSetDescription getFilledConfigurationDescription();
 
  private:
   boost::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
@@ -51,32 +48,10 @@ Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRe
 }
 
 
-  /*
-edm::ParameterSetDescription 
-Chi2MeasurementEstimatorESProducer::getFilledConfigurationDescription() {
- 
-  edm::ParameterSetDescription desc;
-  desc.add<double>("MaxChi2",30);
-  desc.add<double>("nSigma",3);
-  desc.add<double>("MaxDisplacement",0.5); 
-  desc.add<double>("MaxSagitta",2.);
-  desc.add<double>("MinimalTolerance",0.5);
-  desc.add<double>("MinPtForHitRecoveryInGluedDet",9);
-  return desc;
-}
-  */
- 
 void 
 Chi2MeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
-  //  edm::ParameterSetDescription desc = Chi2MeasurementEstimatorESProducer::getFilledConfigurationDescription();
-  edm::ParameterSetDescription desc;
-  desc.add<double>("MaxChi2",30);
-  desc.add<double>("nSigma",3);
-  desc.add<double>("MaxDisplacement",0.5); 
-  desc.add<double>("MaxSagitta",2.);
-  desc.add<double>("MinimalTolerance",0.5);
-  desc.add<double>("MinPtForHitRecoveryInGluedDet",0.9);
+  auto desc = chi2MeasurementEstimatorParams::getFilledConfigurationDescription();
   desc.add<std::string>("ComponentName","Chi2");
   descriptions.add("Chi2MeasurementEstimator", desc);
 }

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -28,7 +28,6 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
-#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h" 


### PR DESCRIPTION
This PR backports CMSSW_8_1_X PRs #15114 and #15194 to CMSSW_8_0_X. Original descriptions by @VinInn 
#15114

> HIP Mitigation as extensively presented and discussed.
> See for instance:
> https://indico.cern.ch/event/539401/contributions/2207119/attachments/1296862/1934523/HipMitigation3.pdf
#15194

> The title say all.
> in principle bitwise compatible with previous version...
> but for cosmics

The configuration of the mitigation is turned to the opposite wrt. 81X, i.e. disabled by default, and can be enabled with the following parameter to `cmsDriver`

```
--customise RecoTracker/Configuration/customizeMinPtForHitRecoveryInGluedDet.customizeHitRecoveryInGluedDetOn
```

Nevertheless, this PR with "HIP mitigation disabled" causes tiny differences in tracking (I'll point the piece of code responsible).

Tested in CMSSW_8_0_14.

@VinInn @rovere @slava77 
