### PR TITLE
RPCRecHit with timing and y-coordinate information for iRPC

### DIFF
--- a/DataFormats/RPCRecHit/interface/RPCRecHit.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHit.h
@@ -91,6 +91,12 @@ class RPCRecHit : public RecHit2DLocalPos {
     theLocalPosition = pos;
     theLocalError = err;
   }
+
+  /// Set the time and its error
+  void setTimeAndError(float time, float err ) {
+    theTime = time;
+    theTimeError = err;
+  }
   
 
   /// Return the rpcId
@@ -110,6 +116,14 @@ class RPCRecHit : public RecHit2DLocalPos {
     return theClusterSize;
   }
 
+  float time() const {
+    return theTime;
+  }
+
+  float timeError() const {
+    return theTimeError;
+  }
+
   /// Comparison operator, based on the rpcId and the digi time
   bool operator==(const RPCRecHit& hit) const;
 
@@ -121,6 +135,7 @@ class RPCRecHit : public RecHit2DLocalPos {
   // Position and error in the Local Ref. Frame of the RPCLayer
   LocalPoint theLocalPosition;
   LocalError theLocalError;
+  float theTime, theTimeError;
 
 };
 #endif

--- a/DataFormats/RPCRecHit/src/RPCRecHit.cc
+++ b/DataFormats/RPCRecHit/src/RPCRecHit.cc
@@ -9,18 +9,21 @@
 
 
 RPCRecHit::RPCRecHit(const RPCDetId& rpcId, int bx) :  RecHit2DLocalPos(rpcId),
-  theRPCId(rpcId), theBx(bx),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError() 
+  theRPCId(rpcId), theBx(bx),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError(),
+  theTime(0), theTimeError(0)
 {
 }
 
 RPCRecHit::RPCRecHit() :  RecHit2DLocalPos(),
-  theRPCId(), theBx(99),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError() 
+  theRPCId(), theBx(99),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError(),
+  theTime(0), theTimeError(0)
 {
 }
 
 
 RPCRecHit::RPCRecHit(const RPCDetId& rpcId, int bx, const LocalPoint& pos) :  RecHit2DLocalPos(rpcId),
-  theRPCId(rpcId), theBx(bx), theFirstStrip(99),theClusterSize(99), theLocalPosition(pos) 
+  theRPCId(rpcId), theBx(bx), theFirstStrip(99),theClusterSize(99), theLocalPosition(pos),
+  theTime(0), theTimeError(0)
 {
   float stripResolution = 3.0 ; //cm  this sould be taken from trimmed cluster size times strip size 
                                  //    taken out from geometry service i.e. topology
@@ -35,7 +38,8 @@ RPCRecHit::RPCRecHit(const RPCDetId& rpcId,
 		     int bx,
 		     const LocalPoint& pos,
 		     const LocalError& err) :  RecHit2DLocalPos(rpcId),
-  theRPCId(rpcId), theBx(bx),theFirstStrip(99), theClusterSize(99), theLocalPosition(pos), theLocalError(err) 
+  theRPCId(rpcId), theBx(bx),theFirstStrip(99), theClusterSize(99), theLocalPosition(pos), theLocalError(err),
+  theTime(0), theTimeError(0)
 {
 }
 
@@ -47,7 +51,8 @@ RPCRecHit::RPCRecHit(const RPCDetId& rpcId,
 		     int clustSize,
 		     const LocalPoint& pos,
 		     const LocalError& err) :  RecHit2DLocalPos(rpcId),
-  theRPCId(rpcId), theBx(bx),theFirstStrip(firstStrip), theClusterSize(clustSize), theLocalPosition(pos), theLocalError(err) 
+  theRPCId(rpcId), theBx(bx),theFirstStrip(firstStrip), theClusterSize(clustSize), theLocalPosition(pos), theLocalError(err),
+  theTime(0), theTimeError(0)
 {
 }
 

--- a/DataFormats/RPCRecHit/src/classes_def.xml
+++ b/DataFormats/RPCRecHit/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 <selection>
-  <class name="RPCRecHit" splitLevel="0" ClassVersion="11">
+  <class name="RPCRecHit" splitLevel="0" ClassVersion="12">
+   <version ClassVersion="12" checksum="1466455177"/>
    <version ClassVersion="11" checksum="2419885627"/>
    <version ClassVersion="10" checksum="247761974"/>
   </class>

--- a/RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCRecHitBaseAlgo.h
@@ -48,7 +48,8 @@ class RPCRecHitBaseAlgo {
   virtual bool compute(const RPCRoll& roll,
                        const RPCCluster& cl,
                        LocalPoint& Point,
-                       LocalError& error) const = 0;
+                       LocalError& error,
+                       float& time, float& timeErr) const = 0;
 
   /// local recHit computation accounting for track direction and 
   /// absolute position
@@ -57,6 +58,7 @@ class RPCRecHitBaseAlgo {
                        const float& angle,
                        const GlobalPoint& globPos, 
                        LocalPoint& Point,
-                       LocalError& error) const = 0;
+                       LocalError& error,
+                       float& time, float& timeErr) const = 0;
 };
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
@@ -1,71 +1,84 @@
 #include "RPCCluster.h"
 #include <iostream>
 #include <fstream>
+#include <cmath>
 
 using namespace std;
 
-RPCCluster::RPCCluster() : fstrip(0), lstrip(0), bunchx(0)
+RPCCluster::RPCCluster():
+  fstrip(0), lstrip(0), bunchx(0),
+  sumTime(0), sumTime2(0), nTime(0), sumY(0), sumY2(0), nY(0)
 {
 }
 
-RPCCluster::RPCCluster(int fs, int ls, int bx) : 
-  fstrip(fs), lstrip(ls), bunchx(bx)
+RPCCluster::RPCCluster(int fs, int ls, int bx) :
+  fstrip(fs), lstrip(ls), bunchx(bx),
+  sumTime(0), sumTime2(0), nTime(0), sumY(0), sumY2(0), nY(0)
 {
 }
 
-RPCCluster::~RPCCluster()
+RPCCluster::~RPCCluster() {}
+
+int RPCCluster::firstStrip() const { return fstrip; }
+int RPCCluster::lastStrip() const { return lstrip; }
+int RPCCluster::clusterSize() const { return -(fstrip-lstrip)+1; }
+int RPCCluster::bx() const { return bunchx; }
+
+bool RPCCluster::hasTime() const { return nTime > 0; }
+float RPCCluster::time() const { return hasTime() ? sumTime/nTime : 0; }
+float RPCCluster::timeRMS2() const { return hasTime() ? (sumTime2*nTime - sumTime*sumTime)/nTime : 0; }
+float RPCCluster::timeRMS() const { return sqrt(timeRMS2()); }
+
+bool RPCCluster::hasY() const { return nY > 0; }
+float RPCCluster::y() const { return hasY() ? sumY/nY : 0; }
+float RPCCluster::yRMS2() const { return hasY() ? (sumY2*nY - sumY*sumY)/nY : 0; }
+float RPCCluster::yRMS() const { return sqrt(yRMS2()); }
+
+bool RPCCluster::isAdjacent(const RPCCluster& cl) const
 {
+  return ((cl.firstStrip() == this->firstStrip()-1) &&
+	        (cl.bx() == this->bx()));
 }
 
-int
-RPCCluster::firstStrip() const
+void RPCCluster::addTime(const float time)
 {
-  return fstrip;
+  ++nTime;
+  sumTime  += time;
+  sumTime2 += time*time;
 }
 
-int
-RPCCluster::lastStrip() const
+void RPCCluster::addY(const float y)
 {
-  return lstrip;
+  ++nY;
+  sumY  += y;
+  sumY2 += y*y;
 }
 
-int
-RPCCluster::clusterSize() const
+void RPCCluster::merge(const RPCCluster& cl)
 {
-  return -(fstrip-lstrip)+1;
+  if ( !this->isAdjacent(cl) ) return;
+
+  fstrip = cl.firstStrip();
+
+  nTime    += cl.nTime;
+  sumTime  += cl.sumTime;
+  sumTime2 += cl.sumTime2;
+
+  nY    += cl.nY;
+  sumY  += cl.sumY;
+  sumY2 += cl.sumY2;
 }
 
-int
-RPCCluster::bx() const
+bool RPCCluster::operator<(const RPCCluster& cl) const
 {
-  return bunchx;
+  if(cl.bx() == this->bx()) return cl.firstStrip()<this->firstStrip();
+
+  return cl.bx()<this->bx();
 }
 
-bool RPCCluster::isAdjacent(const RPCCluster& cl) const{
-  
-    return ((cl.firstStrip() == this->firstStrip()-1) &&
-	    (cl.bx() == this->bx()));
-}
-
-void RPCCluster::merge(const RPCCluster& cl){
-  
-   if(this->isAdjacent(cl))
-     { 
-       fstrip = cl.firstStrip();  
-     }
-}
-
-bool RPCCluster::operator<(const RPCCluster& cl) const{
-  
-if(cl.bx() == this->bx())
- return cl.firstStrip()<this->firstStrip();
-else 
- return cl.bx()<this->bx();
-}
-
-bool 
-RPCCluster::operator==(const RPCCluster& cl) const {
+bool  RPCCluster::operator==(const RPCCluster& cl) const
+{
   return ( (this->clusterSize() == cl.clusterSize()) &&
-	   (this->bx()          == cl.bx())          && 
-	   (this->firstStrip()  == cl.firstStrip()) );
+           (this->bx()          == cl.bx())          &&
+           (this->firstStrip()  == cl.firstStrip()) );
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
@@ -21,18 +21,16 @@ RPCCluster::~RPCCluster() {}
 
 int RPCCluster::firstStrip() const { return fstrip; }
 int RPCCluster::lastStrip() const { return lstrip; }
-int RPCCluster::clusterSize() const { return -(fstrip-lstrip)+1; }
+int RPCCluster::clusterSize() const { return lstrip-fstrip+1; }
 int RPCCluster::bx() const { return bunchx; }
 
 bool RPCCluster::hasTime() const { return nTime > 0; }
 float RPCCluster::time() const { return hasTime() ? sumTime/nTime : 0; }
-float RPCCluster::timeRMS2() const { return hasTime() ? (sumTime2*nTime - sumTime*sumTime)/nTime : 0; }
-float RPCCluster::timeRMS() const { return sqrt(timeRMS2()); }
+float RPCCluster::timeRMS() const { return hasTime() ? sqrt((sumTime2*nTime - sumTime*sumTime)/nTime) : -1; }
 
 bool RPCCluster::hasY() const { return nY > 0; }
 float RPCCluster::y() const { return hasY() ? sumY/nY : 0; }
-float RPCCluster::yRMS2() const { return hasY() ? (sumY2*nY - sumY*sumY)/nY : 0; }
-float RPCCluster::yRMS() const { return sqrt(yRMS2()); }
+float RPCCluster::yRMS() const { return hasY() ? sqrt((sumY2*nY - sumY*sumY)/nY) : -1; }
 
 bool RPCCluster::isAdjacent(const RPCCluster& cl) const
 {

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
@@ -15,12 +15,10 @@ class RPCCluster{
   bool hasTime() const;
   float time() const;
   float timeRMS() const;
-  float timeRMS2() const;
 
   bool hasY() const;
   float y() const;
   float yRMS() const;
-  float yRMS2() const;
 
   void addTime(const float time);
   void addY(const float y);

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
@@ -12,6 +12,18 @@ class RPCCluster{
   int clusterSize() const;
   int bx() const;
 
+  bool hasTime() const;
+  float time() const;
+  float timeRMS() const;
+  float timeRMS2() const;
+
+  bool hasY() const;
+  float y() const;
+  float yRMS() const;
+  float yRMS2() const;
+
+  void addTime(const float time);
+  void addY(const float y);
   void merge(const RPCCluster& cl);
 
   bool operator<(const RPCCluster& cl) const;
@@ -22,5 +34,11 @@ class RPCCluster{
   uint16_t fstrip;
   uint16_t lstrip;
   int16_t bunchx;
+
+  float sumTime, sumTime2;
+  uint16_t nTime;
+
+  float sumY, sumY2;
+  uint16_t nY;
 };
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/RPCClusterizer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCClusterizer.cc
@@ -8,7 +8,10 @@ RPCClusterContainer RPCClusterizer::doAction(const RPCDigiCollection::Range& dig
 
   // Start from single digi recHits
   for ( auto digi = digiRange.first; digi != digiRange.second; ++digi ) {
-    initialCluster.insert(RPCCluster(digi->strip(), digi->strip(), digi->bx()));
+    RPCCluster cl(digi->strip(), digi->strip(), digi->bx());
+    if ( digi->hasTime() ) cl.addTime(digi->time());
+    if ( digi->hasY() ) cl.addY(digi->coordinateY());
+    initialCluster.insert(cl);
   }
   if ( initialCluster.empty() ) return finalCluster; // Confirm the collection is valid
 
@@ -33,6 +36,5 @@ RPCClusterContainer RPCClusterizer::doAction(const RPCDigiCollection::Range& dig
   finalCluster.insert(prev);
 
   return finalCluster;
-} 
-
+}
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
@@ -30,15 +30,17 @@ edm::OwnVector<RPCRecHit> RPCRecHitBaseAlgo::reconstruct(const RPCRoll& roll,
   for ( auto cl : cls ) {
     LocalError tmpErr;
     LocalPoint point;
+    float time = 0, timeErr = -1;
 
     // Call the compute method
-    const bool OK = this->compute(roll, cl, point, tmpErr);
+    const bool OK = this->compute(roll, cl, point, tmpErr, time, timeErr);
     if (!OK) continue;
 
     // Build a new pair of 1D rechit
     const int firstClustStrip = cl.firstStrip();
     const int clusterSize = cl.clusterSize();
     RPCRecHit* recHit = new RPCRecHit(rpcId,cl.bx(),firstClustStrip,clusterSize,point,tmpErr);
+    if ( timeErr > 0 ) recHit->setTimeAndError(time, timeErr);
 
     result.push_back(recHit);
   }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
@@ -40,7 +40,7 @@ edm::OwnVector<RPCRecHit> RPCRecHitBaseAlgo::reconstruct(const RPCRoll& roll,
     const int firstClustStrip = cl.firstStrip();
     const int clusterSize = cl.clusterSize();
     RPCRecHit* recHit = new RPCRecHit(rpcId,cl.bx(),firstClustStrip,clusterSize,point,tmpErr);
-    if ( timeErr > 0 ) recHit->setTimeAndError(time, timeErr);
+    if ( timeErr >= 0 ) recHit->setTimeAndError(time, timeErr);
 
     result.push_back(recHit);
   }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
@@ -43,6 +43,10 @@ bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
     time = cluster.time();
     timeErr = cluster.timeRMS();
   }
+  else {
+    time = 0;
+    timeErr = -1;
+  }
 
   return true;
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
@@ -16,17 +16,22 @@
 bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
 				    const RPCCluster& cluster,
 				    LocalPoint& Point,
-				    LocalError& error)  const
+				    LocalError& error,
+            float& time, float& timeErr)  const
 {
   // Get Average Strip position
   const float fstrip = (roll.centreOfStrip(cluster.firstStrip())).x();
   const float lstrip = (roll.centreOfStrip(cluster.lastStrip())).x();
   const float centreOfCluster = (fstrip + lstrip)/2;
 
-  LocalPoint loctemp2(centreOfCluster,0.,0.);
+  Point = LocalPoint(centreOfCluster,cluster.y(),0);
+  error = LocalError(roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.).xx(),
+                     0, cluster.yRMS2());
 
-  Point = loctemp2;
-  error = roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.);
+  if ( cluster.hasTime() ) {
+    time = cluster.time();
+    timeErr = cluster.timeRMS();
+  }
 
   return true;
 }
@@ -36,9 +41,10 @@ bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
                                     const float& angle,
                                     const GlobalPoint& globPos,
                                     LocalPoint& Point,
-                                    LocalError& error)  const
+                                    LocalError& error,
+                                    float& time, float& timeErr)  const
 {
-  this->compute(roll,cl,Point,error);
+  this->compute(roll,cl,Point,error,time,timeErr);
   return true;
 }
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
@@ -24,7 +24,8 @@ class RPCRecHitStandardAlgo : public RPCRecHitBaseAlgo {
   virtual bool compute(const RPCRoll& roll,
                        const RPCCluster& cluster,
                        LocalPoint& point,
-                       LocalError& error) const;
+                       LocalError& error,
+                       float& time, float& timeErr) const;
 
 
   virtual bool compute(const RPCRoll& roll,
@@ -32,7 +33,8 @@ class RPCRecHitStandardAlgo : public RPCRecHitBaseAlgo {
                        const float& angle,
                        const GlobalPoint& globPos,
                        LocalPoint& point,
-                       LocalError& error) const;
+                       LocalError& error,
+                       float& time, float& timeErr) const;
 };
 #endif
 


### PR DESCRIPTION
This PR changes RPC local reconstruction and dataformat to include timing and y-coordinate information from the RPCDigis.
The clustering algorithm is unchanged from the standard algorithm, timing and y position are computed as average of digis clustered into a RecHit, only when the digi contains valid timing/y info.

There are DataFormat changes to include RecHit average timing and its error (2 float variables and setter/getter functions).

I don't expect physics change with this PR, since it is addition of information and no change in the algorithm itself.

(modified)
Presented at the [RPC upgrade meeting in July 19](https://indico.cern.ch/event/557713/contributions/2248040/attachments/1311545/1962762/RPC_phase2_July_19_TJ.pdf) by Taejeong, 
and [RPC upgrade workshop in July 22](https://indico.cern.ch/event/558264/contributions/2251307/attachments/1313942/1967511/simulation_summary_RPCUpgradeWrokshop_v1.pdf) by Boris.

Uncertainty for the iRPC rolls are left to be tuned later at this moment - taking the RMS for the timing error, and distance to the boundary times 2/sqrt(12) for y coordinate error as a maximum estimate of error.

@bapavlov @mileva @monttj 
