### PR TITLE
Remove BsToMuMu_13INPUT

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -379,7 +379,6 @@ steps['Higgs200ChargedTaus_13INPUT']={'INPUT':InputInfo(dataSet='/RelValHiggs200
 
 # activate GEN-SIM recycling once we'll have the first set of gen-sim
 steps['Upsilon1SToMuMu_13INPUT']={'INPUT':InputInfo(dataSet='/RelValUpsilon1SToMuMu_13/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}
-steps['BsToMuMu_13INPUT']={'INPUT':InputInfo(dataSet='/RelValBsToMuMu_13/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}
 steps['JpsiMuMu_Pt-8INPUT']={'INPUT':InputInfo(dataSet='/RelValJpsiMuMu_Pt-8/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}
 
 steps['PhiToMuMu_13INPUT']={'INPUT':InputInfo(dataSet='/RelValPhiToMuMu_13/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}


### PR DESCRIPTION
`/RelValBsToMuMu_13/CMSSW_8_1_0_pre8-81X_mcRun2_asymptotic_v1-v1/GEN-SIM`
doest not exist thus 1349.0 is failing for months. Remove
`BsToMuMu_13INPUT` and run GEN-SIM instead:

```
1349.0_BsToMuMu_13+BsToMuMu_13+DIGIUP15+RECOUP15+HARVESTUP15
Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Jul
25 09:59:11 2016-date Mon Jul 25 09:48:41 2016; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed
```

This brings 1349.0 to a working condition.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
