### PR TITLE
retuning FPix nclusters limit

### DIFF
--- a/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
+++ b/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
@@ -27,7 +27,7 @@
      <PARAM name="error">0.75</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
      <PARAM name="ymin">1.0</PARAM> 
-     <PARAM name="ymax">5.0</PARAM> 
+     <PARAM name="ymax">6.5</PARAM> 
 </QTEST>
 <!-- nRecHits in PixelBarrel: -->
 <QTEST name="Yrange:Barrel:nRecHits" activate="false"> 

--- a/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
+++ b/DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml
@@ -208,7 +208,7 @@
      <PARAM name="error">0.75</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
      <PARAM name="ymin">1.15</PARAM> 
-     <PARAM name="ymax">1.65</PARAM> 
+     <PARAM name="ymax">1.85</PARAM> 
 </QTEST>
 <!-- nRecHits in PixelEndcap: -->
 <QTEST name="Yrange:Endcap:nRecHits" activate="false"> 


### PR DESCRIPTION
retune the mean value of nclusters in FPix to pair with the increasing luminosity of the machine
