### PR TITLE
fix: eval_auto_bounds returns good value for pt==pt_low

### DIFF
--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -160,7 +160,7 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   float pt_for_eval = pt;
   bool is_out_of_bounds = false;
 
-  if (pt < sf_bounds.first) {
+  if (pt <= sf_bounds.first) {
     pt_for_eval = sf_bounds.first + .0001;
     is_out_of_bounds = true;
   } else if (pt > sf_bounds.second) {


### PR DESCRIPTION
This fixes an error where eval_auto_bounds would return zero if the pt value at lower bound is given.
