### PR TITLE
Resonance decay filter quark equivalence

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -20,6 +20,8 @@ private:
   bool eMuAsEquivalent_;
   bool eMuTauAsEquivalent_;
   bool allNuAsEquivalent_;
+  bool udscAsEquivalent_;
+  bool udscbAsEquivalent_;
   std::vector<int> mothers_;
   std::vector<int> daughters_;
   

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -58,6 +58,8 @@ bool Py8InterfaceBase::readSettings( int )
    fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent",false);
+   fMasterGen->settings.addFlag("ResonanceDecayFilter:udscAsEquivalent",false);
+   fMasterGen->settings.addFlag("ResonanceDecayFilter:udscbAsEquivalent",false);
    fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers",std::vector<int>(),false,false,0,0);
    fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters",std::vector<int>(),false,false,0,0);   
    

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -30,10 +30,10 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
     if ( (did == 14 || did == 16) && allNuAsEquivalent_) {
       did = 12;
     }
-    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscAsEquivalent_) {
+    if ( (did == 2 || did==3 || did==4 ) && udscAsEquivalent_) {
       did = 1;
     }
-    if ( (did == 2 || did==3 || did==4 || did==5 || did==6) && udscbAsEquivalent_) {
+    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscbAsEquivalent_) {
       did = 1;
     }
 
@@ -66,10 +66,10 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event& process) {
     if ( (did == 14 || did == 16) && allNuAsEquivalent_) {
       did = 12;
     }   
-    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscAsEquivalent_) {
+    if ( (did == 2 || did==3 || did==4 ) && udscAsEquivalent_) {
       did = 1;
     }
-    if ( (did == 2 || did==3 || did==4 || did==5 || did==6) && udscbAsEquivalent_) {
+    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscbAsEquivalent_) {
       did = 1;
     } 
     

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -11,6 +11,8 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
   eMuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuAsEquivalent");
   eMuTauAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuTauAsEquivalent");
   allNuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:allNuAsEquivalent");
+  udscAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscAsEquivalent");
+  udscbAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscbAsEquivalent");
   mothers_ = settingsPtr->mvec("ResonanceDecayFilter:mothers");
   daughters_ = settingsPtr->mvec("ResonanceDecayFilter:daughters");
   
@@ -28,7 +30,13 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
     if ( (did == 14 || did == 16) && allNuAsEquivalent_) {
       did = 12;
     }
-    
+    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscAsEquivalent_) {
+      did = 1;
+    }
+    if ( (did == 2 || did==3 || did==4 || did==5 || did==6) && udscbAsEquivalent_) {
+      did = 1;
+    }
+
     ++requestedDaughters_[std::abs(did)];
   }
   
@@ -57,7 +65,13 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event& process) {
     }
     if ( (did == 14 || did == 16) && allNuAsEquivalent_) {
       did = 12;
-    }    
+    }   
+    if ( (did == 2 || did==3 || did==4 || did==5 ) && udscAsEquivalent_) {
+      did = 1;
+    }
+    if ( (did == 2 || did==3 || did==4 || did==5 || did==6) && udscbAsEquivalent_) {
+      did = 1;
+    } 
     
     int mid = p.mother1()>0 ? std::abs(process[p.mother1()].id()) : 0;
     

--- a/GeneratorInterface/Pythia8Interface/test/resonanceDecayFilter.py
+++ b/GeneratorInterface/Pythia8Interface/test/resonanceDecayFilter.py
@@ -42,9 +42,11 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
             '23:mMin = 0.05',
             'ResonanceDecayFilter:filter = on',
             'ResonanceDecayFilter:exclusive = off', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
-            'ResonanceDecayFilter:eMuAsEquivalent = off', #on: treat electrons and muons as equivalent
-            'ResonanceDecayFilter:eMuTauAsEquivalent = on', #on: treat electrons, muons , and taus as equivalent
-            'ResonanceDecayFilter:allNuAsEquivalent = on', #on: treat all three neutrino flavours as equivalent
+            'ResonanceDecayFilter:eMuAsEquivalent    = off', #on: treat electrons and muons as equivalent
+            'ResonanceDecayFilter:eMuTauAsEquivalent = on',  #on: treat electrons, muons , and taus as equivalent
+            'ResonanceDecayFilter:allNuAsEquivalent  = on',  #on: treat all three neutrino flavours as equivalent
+            'ResonanceDecayFilter:udscAsEquivalent   = off', #on: treat u,d,s,c quarks as equivalent
+            'ResonanceDecayFilter:udscbAsEquivalent  = off', #on: treat u,d,s,c,b quarks as equivalent
             #'ResonanceDecayFilter:mothers =', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
             'ResonanceDecayFilter:daughters = 11,11,11,11',
           ),


### PR DESCRIPTION
Added option to ResonanceDecayFilter to allow treatment of udcs or udcsb quarks as equivalent in pythia fragments, for example for Z->jj where you want to allow all quark decays and need to specify daughters precisely.
