### PR TITLE
Backport of #14247: Small improvements in Pixel track reconstruction

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
@@ -25,7 +25,6 @@ public:
      const TrackingRegion& region) const;
 
 private:
-  int getCharge(const std::vector<GlobalPoint> & points) const;
   float getCotThetaAndUpdateZip
     (const GlobalPoint& inner, const GlobalPoint& outer,
      float radius, float phi, float d0, float& zip) const;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -7,20 +7,12 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 
 #include <vector>
 
-//namespace edm {class ParameterSet;}
-class TransientTrackingRecHitBuilder;
-class TrackerGeometry;
-class MagneticField;
-class TrackerDigiGeometryRecord;
-class IdealMagneticFieldRecord;
-class TransientRecHitRecord;
 
 
-class PixelFitterByHelixProjections : public PixelFitter {
+class PixelFitterByHelixProjections final : public PixelFitter {
 public:
   PixelFitterByHelixProjections(  const edm::ParameterSet& cfg);
   virtual ~PixelFitterByHelixProjections() {}
@@ -42,13 +34,7 @@ private:
   */
 private:
   edm::ParameterSet theConfig;
-
-  mutable const TrackerGeometry * theTracker;
   mutable const MagneticField * theField;
-  mutable const TransientTrackingRecHitBuilder * theTTRecHitBuilder;
-
-  mutable edm::ESWatcher<TrackerDigiGeometryRecord> theTrackerWatcher;
-  mutable edm::ESWatcher<IdealMagneticFieldRecord> theFieldWatcher;
-  mutable edm::ESWatcher<TransientRecHitRecord> theTTRecHitBuilderWatcher;
+ 
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleaner.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleaner.h
@@ -7,6 +7,7 @@ Discards reconstructed tracks that reflects one real track.
 **/
 
 #include "RecoPixelVertexing/PixelTrackFitting/interface/TracksWithHits.h"
+#include<cassert>
 
 class TrackerTopology;
 
@@ -16,11 +17,21 @@ public:
 
   virtual ~PixelTrackCleaner(){}
 
+  // used by HI?
   typedef pixeltrackfitting::TracksWithRecHits TracksWithRecHits;
-  virtual TracksWithRecHits cleanTracks(const TracksWithRecHits & tracksWithRecHits,
-					const TrackerTopology *tTopo) = 0;
+  virtual TracksWithRecHits cleanTracks(const TracksWithRecHits & tracksWithRecHits, const TrackerTopology *tTopo){
+    assert(false); 
+    return TracksWithRecHits();
+  }
 
-private:
+
+  // fast
+  using TracksWithTTRHs = pixeltrackfitting::TracksWithTTRHs;
+  virtual void cleanTracks(TracksWithTTRHs & tracksWithRecHits,
+					const TrackerTopology *tTopo) const {assert(false);}
+
+
+  bool fast=false;
 
 };
 

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
@@ -14,15 +14,17 @@
 
 class TrackerTopology;
 
-class PixelTrackCleanerBySharedHits : public PixelTrackCleaner {
+class PixelTrackCleanerBySharedHits final : public PixelTrackCleaner {
 
 public:
   PixelTrackCleanerBySharedHits( const edm::ParameterSet& cfg);
 
-  virtual ~PixelTrackCleanerBySharedHits();
+ ~PixelTrackCleanerBySharedHits();
 
-  typedef pixeltrackfitting::TracksWithRecHits TracksWithRecHits;
-  virtual TracksWithRecHits cleanTracks(const TracksWithRecHits & tracksWithRecHits, const TrackerTopology *tTopo);
+  using TrackWithTTRHs = pixeltrackfitting::TrackWithTTRHs;
+  using TracksWithTTRHs = pixeltrackfitting::TracksWithTTRHs;
+  void cleanTracks(TracksWithTTRHs & tracksWithRecHits,
+                                        const TrackerTopology *tTopo) const override;
 
 
 };

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
@@ -15,8 +15,8 @@ public:
   virtual bool operator()(const reco::Track*) const;
   virtual bool operator()(const reco::Track*, const PixelTrackFilter::Hits & hits) const;
 private:
-  double thePtMin, theNSigmaInvPtTolerance; 
-  double theTIPMax, theNSigmaTipMaxTolerance;
-  double theChi2Max;
+  float theoPtMin, theNSigmaInvPtTolerance; 
+  float theTIPMax, theNSigmaTipMaxTolerance;
+  float theChi2Max;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -104,7 +104,7 @@ reco::Track* PixelFitterByHelixProjections::run(
   int nhits = hits.size();
   if (nhits <2) return 0;
 
-  if (!theField) { 
+  {  
     edm::ESHandle<MagneticField> fieldESH;
     es.get<IdealMagneticFieldRecord>().get(fieldESH);
     theField = fieldESH.product();

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -2,9 +2,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -16,16 +13,15 @@
 //#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "CommonTools/Statistics/interface/LinearFit.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -36,11 +32,13 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackErrorParam.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"
 
+#include "CommonTools/Utils/interface/DynArray.h"
+
 using namespace std;
 
 namespace {
 
-  int charge(const std::vector<GlobalPoint> & points) {
+  int charge(DynArray<GlobalPoint> const & points) {
     // the cross product will tell me...
     float dir = (points[1].x()-points[0].x())*(points[2].y()-points[1].y())
       - (points[1].y()-points[0].y())*(points[2].x()-points[1].x());
@@ -74,12 +72,14 @@ namespace {
     
     float phi0 = phi_p - Geom::fhalfPi();
     GlobalPoint pca(d0*std::cos(phi0), d0*std::sin(phi0),0.);
-    
+
+
+    constexpr float o24 = 1.f/24.f;    
     float rho2 = curv*curv;
     float r1s = (pinner-pca).perp2();
-    double phi1 = std::sqrt(r1s)*(curv*0.5f)*(1.f+r1s*(rho2/24.f));
+    double phi1 = std::sqrt(r1s)*(curv*0.5f)*(1.f+r1s*(rho2*o24));
     float r2s = (pouter-pca).perp2();
-    double phi2 = std::sqrt(r2s)*(curv*0.5f)*(1.f+r2s*(rho2/24.f));
+    double phi2 = std::sqrt(r2s)*(curv*0.5f)*(1.f+r2s*(rho2*o24));
     double z1 = pinner.z();
     double z2 = pouter.z();
 
@@ -94,7 +94,7 @@ namespace {
   
 PixelFitterByHelixProjections::PixelFitterByHelixProjections(
    const edm::ParameterSet& cfg) 
- : theConfig(cfg), theTracker(0), theField(0), theTTRecHitBuilder(0) {}
+ : theConfig(cfg), theField(nullptr) {}
 
 reco::Track* PixelFitterByHelixProjections::run(
     const edm::EventSetup& es,
@@ -104,36 +104,20 @@ reco::Track* PixelFitterByHelixProjections::run(
   int nhits = hits.size();
   if (nhits <2) return 0;
 
-  vector<GlobalPoint> points(nhits);
-  vector<GlobalError> errors(nhits);
-  vector<bool> isBarrel(nhits);
-  
-  if (theTrackerWatcher.check(es)) {
-    edm::ESHandle<TrackerGeometry> trackerESH;
-    es.get<TrackerDigiGeometryRecord>().get(trackerESH);
-    theTracker = trackerESH.product();
-  }
-
-  if (theFieldWatcher.check(es)) {
+  if (!theField) { 
     edm::ESHandle<MagneticField> fieldESH;
     es.get<IdealMagneticFieldRecord>().get(fieldESH);
     theField = fieldESH.product();
   }
 
-  if (theTTRecHitBuilderWatcher.check(es)) {
-    edm::ESHandle<TransientTrackingRecHitBuilder> ttrhbESH;
-    std::string builderName = theConfig.getParameter<std::string>("TTRHBuilder");
-    es.get<TransientRecHitRecord>().get(builderName,ttrhbESH);
-    theTTRecHitBuilder = ttrhbESH.product();
-  }
-
+  declareDynArray(GlobalPoint,nhits, points);
+  declareDynArray(GlobalError,nhits, errors);
+  declareDynArray(bool,nhits, isBarrel);
+  
 
   for ( int i=0; i!=nhits; ++i) {
     auto const & recHit = hits[i];
-    points[i]  = GlobalPoint( recHit->globalPosition().x()-region.origin().x(), 
-			      recHit->globalPosition().y()-region.origin().y(),
-			      recHit->globalPosition().z()-region.origin().z() 
-			      );
+    points[i]  = GlobalPoint( recHit->globalPosition().basicVector()-region.origin().basicVector()); 
     errors[i] = recHit->globalPositionError();
     isBarrel[i] = recHit->detUnit()->type().isBarrel();
   }
@@ -148,7 +132,7 @@ reco::Track* PixelFitterByHelixProjections::run(
   float curvature = circle.curvature();
 
   if ((curvature > 1.e-4)&&
-	(likely(theField->inTesla(GlobalPoint(0.,0.,0.)).z()>0.01))) {
+	(likely(PixelRecoUtilities::fieldInInvGev(es)>0.01))) {
     float invPt = PixelRecoUtilities::inversePt( circle.curvature(), es);
     valPt = (invPt > 1.e-4f) ? 1.f/invPt : 1.e4f;
     CircleFromThreePoints::Vector2D center = circle.center();
@@ -158,12 +142,12 @@ reco::Track* PixelFitterByHelixProjections::run(
   else {
     valPt = 1.e4f; 
     GlobalVector direction(points[1]-points[0]);
-    valPhi =  direction.phi(); 
+    valPhi =  direction.barePhi(); 
     valTip = -points[0].x()*sin(valPhi) + points[0].y()*cos(valPhi); 
   }
 
   float valCotTheta = cotTheta(points[0],points[1]);
-  float valEta = asinh(valCotTheta);
+  float valEta = std::asinh(valCotTheta);
   float valZip = zip(valTip, valPhi, curvature, points[0],points[1]);
 
   PixelTrackErrorParam param(valEta, valPt);

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -10,61 +10,51 @@ using namespace reco;
 using namespace pixeltrackfitting;
 
 PixelTrackCleanerBySharedHits::PixelTrackCleanerBySharedHits( const edm::ParameterSet& cfg)
-{}
+{fast=true;}
 
 PixelTrackCleanerBySharedHits::~PixelTrackCleanerBySharedHits()
 {}
 
 
-TracksWithRecHits PixelTrackCleanerBySharedHits::cleanTracks(const TracksWithRecHits & trackHitPairs,
-							     const TrackerTopology *tTopo)
+void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
+                                        const TrackerTopology *tTopo) const 
 {
-  typedef std::vector<const TrackingRecHit *> RecHits;
-  vector<TrackWithRecHits> cleanedTracks;
 
   LogDebug("PixelTrackCleanerBySharedHits") << "Cleanering tracks" << "\n";
   unsigned int size = trackHitPairs.size();
-  if (size == 0) return cleanedTracks;
+  if (size <= 1) return;
 
-  bool trackOk[size];
-  for (auto i = 0U; i < size; i++) trackOk[i] = true;
+  auto kill = [&](unsigned int i) { delete trackHitPairs[i].first; trackHitPairs[i].first=nullptr;};
 
   for (auto iTrack1 = 0U; iTrack1 < size; iTrack1++) {
 
-    if (!trackOk[iTrack1]) continue;
-
     auto track1 = trackHitPairs[iTrack1].first;
-    const RecHits& recHits1 = trackHitPairs[iTrack1].second;
+    if (!track1) continue;
 
+    auto const & recHits1 = trackHitPairs[iTrack1].second;
+    auto s1 = recHits1.size();
     for (auto iTrack2 = iTrack1 + 1U; iTrack2 < size; iTrack2++)
     {
-      if ( !trackOk[iTrack2]) continue; 
-
       auto track2 = trackHitPairs[iTrack2].first;
-      const RecHits& recHits2 = trackHitPairs[iTrack2].second;
+      if (!track2) continue;
+      auto const & recHits2 = trackHitPairs[iTrack2].second;
 
       auto commonRecHits = 0U;
-      for (auto iRecHit1 = 0U; iRecHit1 < recHits1.size(); iRecHit1++) {
-        for (auto iRecHit2 = 0U; iRecHit2 < recHits2.size(); iRecHit2++) {
+      for (auto iRecHit1 = 0U; s1; iRecHit1++) {
+        auto s2 = recHits2.size();
+        for (auto iRecHit2 = 0U; iRecHit2 < s2; iRecHit2++) {
           if (recHits1[iRecHit1] == recHits2[iRecHit2]) { commonRecHits++; break;} // if a hit is common, no other can be the same!
         }
 	if (commonRecHits > 1) break;
       }
       
       if (commonRecHits > 1) {
-	if (track1->pt() > track2->pt()) trackOk[iTrack2] = false;
-	else { trackOk[iTrack1] = false; break;}
+	if (track1->pt() > track2->pt()) kill(iTrack2);
+	else { kill(iTrack1); break;}
       }
 
     }
   }
 
-  // we should use one vector only... (and unique_ptr)
-  cleanedTracks.reserve(size);
-  for (auto i = 0U; i < size; i++)
-  {
-    if (trackOk[i]) cleanedTracks.push_back(trackHitPairs[i]);
-    else delete trackHitPairs[i].first;
-  }
-  return cleanedTracks;
+  trackHitPairs.erase(std::remove_if(trackHitPairs.begin(),trackHitPairs.end(),[&](TrackWithTTRHs & v){ return nullptr==v.first;}),trackHitPairs.end());
 }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include <boost/function_output_iterator.hpp>
 
 using namespace std;
 using namespace reco;
@@ -15,6 +16,14 @@ PixelTrackCleanerBySharedHits::PixelTrackCleanerBySharedHits( const edm::Paramet
 PixelTrackCleanerBySharedHits::~PixelTrackCleanerBySharedHits()
 {}
 
+namespace {
+  inline
+  bool recHitsLess(const TrackingRecHit *recHit1, const TrackingRecHit *recHit2) {
+    if (recHit1->geographicalId() < recHit2->geographicalId()) return true;
+    if (recHit1->geographicalId() == recHit2->geographicalId()) return recHit1 < recHit2;
+    return false;
+  }
+}
 
 void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
                                         const TrackerTopology *tTopo) const 
@@ -32,21 +41,35 @@ void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
     if (!track1) continue;
 
     auto const & recHits1 = trackHitPairs[iTrack1].second;
+    auto f1 = recHits1.data();
     auto s1 = recHits1.size();
+    auto e1 = f1+s1;
+    /*
+    {
+      auto f2 = recHits1.data();
+      auto s2 = recHits1.size();
+      auto e2 = f2+s1;
+      auto commonRecHits = 0U;
+      std::set_intersection(f1,e1,f2,e2,
+                            boost::make_function_output_iterator([&](const TrackingRecHit *) {++commonRecHits;}),recHitsLess);
+      assert(commonRecHits==s2);
+    }
+    */
+
+    // for (auto iRecHit1 = 1U; iRecHit1 < s1; ++iRecHit1) assert(recHitsLess(recHits1[iRecHit1-1],recHits1[iRecHit1]));
+
     for (auto iTrack2 = iTrack1 + 1U; iTrack2 < size; iTrack2++)
     {
       auto track2 = trackHitPairs[iTrack2].first;
       if (!track2) continue;
       auto const & recHits2 = trackHitPairs[iTrack2].second;
+      auto f2 = recHits2.data();
       auto s2 = recHits2.size();
-      auto f2=0U;
+      auto e2 = f2+s2;
       auto commonRecHits = 0U;
-      for (auto iRecHit1 = 0U; iRecHit1 < s1; ++iRecHit1) {
-        for (auto iRecHit2 = f2; iRecHit2 < s2; ++iRecHit2) {
-          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { ++commonRecHits; f2=iRecHit2+1; break;} // if a hit is common, no other can be the same!
-        }
-	if (commonRecHits > 1) break;
-      }
+      std::set_intersection(f1,e1,f2,e2,
+                            boost::make_function_output_iterator([&](const TrackingRecHit *) {++commonRecHits;}),
+                            recHitsLess);
       
       if (commonRecHits > 1) {
 	if (track1->pt() > track2->pt()) kill(iTrack2);

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -40,10 +40,10 @@ void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
       auto const & recHits2 = trackHitPairs[iTrack2].second;
 
       auto commonRecHits = 0U;
-      for (auto iRecHit1 = 0U; s1; iRecHit1++) {
+      for (auto iRecHit1 = 0U; iRecHit1 < s1; ++iRecHit1) {
         auto s2 = recHits2.size();
-        for (auto iRecHit2 = 0U; iRecHit2 < s2; iRecHit2++) {
-          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { commonRecHits++; break;} // if a hit is common, no other can be the same!
+        for (auto iRecHit2 = 0U; iRecHit2 < s2; ++iRecHit2) {
+          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { ++commonRecHits; break;} // if a hit is common, no other can be the same!
         }
 	if (commonRecHits > 1) break;
       }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include <boost/function_output_iterator.hpp>
 
 using namespace std;
 using namespace reco;
@@ -16,36 +15,6 @@ PixelTrackCleanerBySharedHits::PixelTrackCleanerBySharedHits( const edm::Paramet
 PixelTrackCleanerBySharedHits::~PixelTrackCleanerBySharedHits()
 {}
 
-namespace {
-  inline
-  bool recHitsLess(const TrackingRecHit *recHit1, const TrackingRecHit *recHit2) {
-    return recHit1->geographicalId() < recHit2->geographicalId();
-  }
-  inline 
-  bool recHitsEqu(const TrackingRecHit *recHit1, const TrackingRecHit *recHit2) {
-    return recHit1 ==recHit2;
-  }
-
-template<class InputIt1, class InputIt2, class Compare, class Equal>
-unsigned int count_intersection(InputIt1 first1, InputIt1 last1,
-                               InputIt2 first2, InputIt2 last2,
-                               Compare comp, Equal equ)
-{    
-    unsigned int n=0;
-    while (first1 != last1 && first2 != last2) {
-        if (comp(*first1, *first2)) {
-            ++first1;
-        } else {
-            if (!comp(*first2, *first1)) {
-                if (equ(*first1++,*first2)) ++n;
-            }
-            ++first2;
-        }
-    }
-    return n;
-}
-
-}
 
 void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
                                         const TrackerTopology *tTopo) const 
@@ -63,32 +32,21 @@ void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
     if (!track1) continue;
 
     auto const & recHits1 = trackHitPairs[iTrack1].second;
-    auto f1 = recHits1.data();
     auto s1 = recHits1.size();
-    auto e1 = f1+s1;
-    /*
-    {
-      auto f2 = recHits1.data();
-      auto s2 = recHits1.size();
-      auto e2 = f2+s1;
-      auto commonRecHits = 
-      count_intersection(f1,e1,f2,e2,recHitsLess,recHitsEqu);
-      assert(commonRecHits==s2);
-    }
-    */
-
-    // for (auto iRecHit1 = 1U; iRecHit1 < s1; ++iRecHit1) assert(recHitsLess(recHits1[iRecHit1-1],recHits1[iRecHit1]));
-
     for (auto iTrack2 = iTrack1 + 1U; iTrack2 < size; iTrack2++)
     {
       auto track2 = trackHitPairs[iTrack2].first;
       if (!track2) continue;
       auto const & recHits2 = trackHitPairs[iTrack2].second;
-      auto f2 = recHits2.data();
       auto s2 = recHits2.size();
-      auto e2 = f2+s2;
-      auto commonRecHits =    
-        count_intersection(f1,e1,f2,e2,recHitsLess,recHitsEqu);
+      auto f2=0U;
+      auto commonRecHits = 0U;
+      for (auto iRecHit1 = 0U; iRecHit1 < s1; ++iRecHit1) {
+        for (auto iRecHit2 = f2; iRecHit2 < s2; ++iRecHit2) {
+          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { ++commonRecHits; f2=iRecHit2+1; break;} // if a hit is common, no other can be the same!
+        }
+	if (commonRecHits > 1) break;
+      }
       
       if (commonRecHits > 1) {
 	if (track1->pt() > track2->pt()) kill(iTrack2);

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -38,12 +38,12 @@ void PixelTrackCleanerBySharedHits::cleanTracks(TracksWithTTRHs & trackHitPairs,
       auto track2 = trackHitPairs[iTrack2].first;
       if (!track2) continue;
       auto const & recHits2 = trackHitPairs[iTrack2].second;
-
+      auto s2 = recHits2.size();
+      auto f2=0U;
       auto commonRecHits = 0U;
       for (auto iRecHit1 = 0U; iRecHit1 < s1; ++iRecHit1) {
-        auto s2 = recHits2.size();
-        for (auto iRecHit2 = 0U; iRecHit2 < s2; ++iRecHit2) {
-          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { ++commonRecHits; break;} // if a hit is common, no other can be the same!
+        for (auto iRecHit2 = f2; iRecHit2 < s2; ++iRecHit2) {
+          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { ++commonRecHits; f2=iRecHit2+1; break;} // if a hit is common, no other can be the same!
         }
 	if (commonRecHits > 1) break;
       }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackCleanerBySharedHits.cc
@@ -15,16 +15,6 @@ PixelTrackCleanerBySharedHits::PixelTrackCleanerBySharedHits( const edm::Paramet
 PixelTrackCleanerBySharedHits::~PixelTrackCleanerBySharedHits()
 {}
 
-namespace {
-  inline
-  bool recHitsAreEqual(const TrackingRecHit *recHit1, const TrackingRecHit *recHit2) {
-    if (recHit1->geographicalId() != recHit2->geographicalId()) return false;
-    LocalPoint pos1 = recHit1->localPosition();
-    LocalPoint pos2 = recHit2->localPosition();
-    return ((pos1.x() == pos2.x()) && (pos1.y() == pos2.y()));
-  }
-  
-}
 
 TracksWithRecHits PixelTrackCleanerBySharedHits::cleanTracks(const TracksWithRecHits & trackHitPairs,
 							     const TrackerTopology *tTopo)
@@ -40,10 +30,11 @@ TracksWithRecHits PixelTrackCleanerBySharedHits::cleanTracks(const TracksWithRec
   for (auto i = 0U; i < size; i++) trackOk[i] = true;
 
   for (auto iTrack1 = 0U; iTrack1 < size; iTrack1++) {
-    auto track1 = trackHitPairs[iTrack1].first;
-    const RecHits& recHits1 = trackHitPairs[iTrack1].second;
 
     if (!trackOk[iTrack1]) continue;
+
+    auto track1 = trackHitPairs[iTrack1].first;
+    const RecHits& recHits1 = trackHitPairs[iTrack1].second;
 
     for (auto iTrack2 = iTrack1 + 1U; iTrack2 < size; iTrack2++)
     {
@@ -55,7 +46,7 @@ TracksWithRecHits PixelTrackCleanerBySharedHits::cleanTracks(const TracksWithRec
       auto commonRecHits = 0U;
       for (auto iRecHit1 = 0U; iRecHit1 < recHits1.size(); iRecHit1++) {
         for (auto iRecHit2 = 0U; iRecHit2 < recHits2.size(); iRecHit2++) {
-          if (recHitsAreEqual(recHits1[iRecHit1], recHits2[iRecHit2])) { commonRecHits++; break;} // if a hit is common, no other can be the same!
+          if (recHits1[iRecHit1] == recHits2[iRecHit2]) { commonRecHits++; break;} // if a hit is common, no other can be the same!
         }
 	if (commonRecHits > 1) break;
       }
@@ -68,6 +59,8 @@ TracksWithRecHits PixelTrackCleanerBySharedHits::cleanTracks(const TracksWithRec
     }
   }
 
+  // we should use one vector only... (and unique_ptr)
+  cleanedTracks.reserve(size);
   for (auto i = 0U; i < size; i++)
   {
     if (trackOk[i]) cleanedTracks.push_back(trackHitPairs[i]);

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -109,7 +109,8 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
   const TrackerTopology *tTopo=tTopoHand.product();
 
   if (theFilter) theFilter->update(ev, es);
-
+  
+  std::vector<const TrackingRecHit *> hits;hits.reserve(4); 
   for (IR ir=regions.begin(), irEnd=regions.end(); ir < irEnd; ++ir) {
     const TrackingRegion & region = **ir;
 
@@ -122,11 +123,10 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
     for (unsigned int iTuplet = 0; iTuplet < nTuplets; ++iTuplet) {
       const SeedingHitSet & tuplet = tuplets[iTuplet];
 
-      std::vector<const TrackingRecHit *> hits;
-      for (unsigned int iHit = 0, nHits = tuplet.size(); iHit < nHits; ++iHit) {
-        hits.push_back( tuplet[iHit]->hit() );
-      }
-
+      /// FIXME at some point we need to migrate the fitter...
+      auto nHits = tuplet.size(); hits.resize(nHits);
+      for (unsigned int iHit = 0; iHit < nHits; ++iHit) hits[iHit] = tuplet[iHit];
+   
       // fitting
       reco::Track* track = theFitter->run( ev, es, hits, region);
       if (!track) continue;
@@ -140,7 +140,7 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
       }
 
       // add tracks
-      tracks.push_back(TrackWithTTRHs(track, tuplet));
+      tracks.emplace_back(track, tuplet);
     }
     theGenerator->clear();
   }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -146,5 +146,11 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
   }
 
   // skip ovelrapped tracks
-  if (theCleaner) tracks = PixelTrackCleanerWrapper(theCleaner).clean(tracks,tTopo);
+  
+  if (theCleaner) {
+    if (theCleaner->fast)
+       theCleaner->cleanTracks(tracks,tTopo);
+    else
+      tracks = PixelTrackCleanerWrapper(theCleaner).clean(tracks,tTopo);
+  }
 }

--- a/RecoPixelVertexing/PixelTrackFitting/src/RZLine.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/RZLine.cc
@@ -19,11 +19,11 @@ RZLine::RZLine(const std::vector<float> & aR,
   } 
 }
 
-RZLine::RZLine(const vector<GlobalPoint> & points, 
-	       const vector<GlobalError> & errors, 
-	       const vector<bool>& isBarrel) : 
-  storage(3*points.size()) {
-  nPoints = points.size();
+RZLine::RZLine( const GlobalPoint * points,
+          const GlobalError * errors,
+          const bool * isBarrel, unsigned int size):
+  storage(3*size) {
+  nPoints = size;
   r = &storage.front();
   z = r+nPoints;
   errZ2 = z+nPoints;

--- a/RecoPixelVertexing/PixelTrackFitting/src/RZLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/src/RZLine.h
@@ -3,15 +3,20 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
+#include "CommonTools/Utils/interface/DynArray.h"
 #include <vector>
 
 class RZLine {
 public:
 
 
-  RZLine( const std::vector<GlobalPoint> & points, 
-          const std::vector<GlobalError> & errors, 
-          const std::vector<bool>& isBarrel);
+  RZLine( const DynArray<GlobalPoint> & points, 
+          const DynArray<GlobalError> & errors, 
+          const DynArray<bool>& isBarrel) : RZLine(points.begin(),errors.begin(),isBarrel.begin(),points.size()){}
+  RZLine( const GlobalPoint * points,
+          const GlobalError * errors,
+          const bool * isBarrel, unsigned int size);
+
   RZLine( const std::vector<float> & aR, 
           const std::vector<float> & aZ, 
           const std::vector<float> & aErrZ);

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -208,7 +208,7 @@ limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, Te
       // ---
 
       if ( meas.empty()) {
-	if ( qualityFilter( *traj)) addToResult(sharedSeed, *traj, result);
+	addToResult(sharedSeed, *traj, result);
       }
       else {
 	std::vector<TM>::const_iterator last;
@@ -228,7 +228,7 @@ limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, Te
 	    newCand.push_back(std::move(newTraj));  std::push_heap(newCand.begin(),newCand.end(),trajCandLess);
 	  }
 	  else {
-	    if ( qualityFilter(newTraj))  addToResult(sharedSeed, newTraj, result);
+	    addToResult(sharedSeed, newTraj, result);
 	    //// don't know yet
 	  }
 	}

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -20,7 +20,7 @@ public:
   // A RecHit extension that caches the phi angle for fast access
   class HitWithPhi {
   public:
-    HitWithPhi( const Hit & hit) : theHit(hit), thePhi(hit->globalPosition().phi()) {}
+    HitWithPhi( const Hit & hit) : theHit(hit), thePhi(hit->globalPosition().barePhi()) {}
     HitWithPhi( const Hit & hit,float phi) : theHit(hit), thePhi(phi) {}
     HitWithPhi( float phi) : theHit(0), thePhi(phi) {}
     float phi() const {return thePhi;}

--- a/RecoTracker/TkHitPairs/src/RecHitsSortedInPhi.cc
+++ b/RecoTracker/TkHitPairs/src/RecHitsSortedInPhi.cc
@@ -18,9 +18,9 @@ RecHitsSortedInPhi::RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint
   // cosmic region never used here
   // assert(origin.x()==0 && origin.y()==0);
 
-  for (std::vector<Hit>::const_iterator i=hits.begin(); i!=hits.end(); i++) {
-    theHits.push_back(HitWithPhi(*i));
-  }
+  theHits.reserve(hits.size());
+  for (auto const & hp : hits) theHits.emplace_back(hp);
+  
   std::sort( theHits.begin(), theHits.end(), HitLessPhi());
 
   for (unsigned int i=0; i!=theHits.size(); ++i) {

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -506,9 +506,9 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 	}
 
 	//gc: add the chi2 cut
-	vector<GlobalPoint> gp(3);
-	vector<GlobalError> ge(3);
-	vector<bool> bl(3);
+	declareDynArray(GlobalPoint,3, gp);
+	declareDynArray(GlobalError,3, ge);
+	declareDynArray(bool,3, bl);
 	gp[0] = hit0->globalPosition();
 	ge[0] = hit0->globalPositionError();
 	int subid0 = hit0->geographicalId().subdetId();

--- a/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
@@ -41,6 +41,8 @@ public:
   }
   
 
+  ConstRecHitPointer const * data() const { return theRecHits;}
+
   unsigned int size() const { return theRecHits[3] ? 4 : (theRecHits[2] ? 3 : ( theRecHits[1] ? 2 : 0 ) ); }
 
   ConstRecHitPointer  get(unsigned int i) const { return theRecHits[i]; }


### PR DESCRIPTION
This PR backports PR #14247 from CMSSW_8_1_X to CMSSW_8_0_X. Original description by @VinInn 

> relevant almost exclusively for HLT.
> No regression expected 
> (in reco notably as little of the modified code run offline)

The first commit (7cf0c3b) is actually from #13831, but is needed here because of dependence. The commit is already included in #15240.

Tested in 8_0_14 (rebased on top of 8_0_16), no changes observed in RECO quantities. Tiny changes (level of 1e-14) are observed in HLT pixel track "point of closest approach wrt. BeamSpot" as shown in https://github.com/cms-sw/cmssw/issues/15151#issuecomment-234061713.

@fwyzard @gennai @slava77 @VinInn 
