### PR TITLE
Update Run-I Global Tags with FEMapRcd and Phase-I reconstruction Geometry

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v1',
+    'run1_design'       :   '81X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v1',
+    'run1_mc'           :   '81X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '81X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '81X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
@@ -34,9 +34,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v5',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v6',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v5',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunI simulation
- **RunI Ideal scenario** : [81X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v2) as [81X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_design_v2/81X_mcRun1_design_v1): 
  - Added `HcalFrontEndMapRcd` for Run1 simulation
- **RunI Heavy Ions scenario** : [81X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v2) as [81X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_HeavyIon_v2/81X_mcRun1_HeavyIon_v1): 
  - Added `HcalFrontEndMapRcd` for Run1 simulation
- **RunI Realistic scenario** : [81X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v2) as [81X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_realistic_v2/81X_mcRun1_realistic_v1): 
  - Added `HcalFrontEndMapRcd` for Run1 simulation
- **RunI Proton-Lead scenario** : [81X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v2) as [81X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_pA_v2/81X_mcRun1_pA_v1): 
  - Added `HcalFrontEndMapRcd` for Run1 simulation
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v6) as [81X_upgrade2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v6/81X_upgrade2017_realistic_v5): 
  - updated Phase-I Tracker Reco geometry (tag "v6" for geometry) as in #15110
- **PhaseI design scenario** : [81X_upgrade2017_design_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v6) as [81X_upgrade2017_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v6/81X_upgrade2017_design_v5): 
  - updated Phase-I Tracker Reco geometry (tag "v6" for geometry) as in #15110
