### PR TITLE
Remove host-based override and printout in CondDBESource and add back connection string override in the online DQM config

### DIFF
--- a/CondCore/ESSources/python/CondDBESSource_cfi.py
+++ b/CondCore/ESSources/python/CondDBESSource_cfi.py
@@ -5,11 +5,6 @@ import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 
 CondDBConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
-if socket.getfqdn().find('.cms') != -1:
-    CondDBConnection.connect = cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS')
-    print '# Conditions read from  CMS_CONDITIONS  via squid running in localhost and pointing to FrontierOnProd '
-else:
-    print '# Conditions read from  CMS_CONDITIONS  via FrontierProd '
 GlobalTag = cms.ESSource( "PoolDBESSource",
                           CondDBConnection,
                           globaltag        = cms.string( '' ),

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -4,7 +4,7 @@ GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serv
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.
-GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v10" )
+GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v11" )
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-
+GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
+GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
 GlobalTag.globaltag = "80X_dataRun2_HLT_v12"


### PR DESCRIPTION
Remove host-based override and printout: originally in #15289 
The online DQM configuration is now overriding the default connection string.
The fallback GT for the Event display applications is also updated.
