### PR TITLE
Bugfix for hlt iso mu24 eta2p1

### DIFF
--- a/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
@@ -6,8 +6,8 @@ HltBTagPostValidation = cms.EDAnalyzer("HLTBTagHarvestingAnalyzer",
 	'HLT_PFMET120_',
 	'HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele27_eta2p1_',
-	'HLT_IsoMu22_'
+	'HLT_Ele32_eta2p1_',
+	'HLT_IsoMu21_eta2p1_'
 	),
 	histoName	= cms.vstring(
 	'hltCombinedSecondaryVertexBJetTagsCalo',

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -28,8 +28,8 @@ HltVertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
 	'HLT_QuadPFJet_VBF',
 	'HLT_QuadPFJet_VBF',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele27_eta2p1_',
-	'HLT_IsoMu22_'
+	'HLT_Ele32_eta2p1_',
+	'HLT_IsoMu21_eta2p1_'
 	),
 	Vertex = cms.VInputTag(
 		cms.InputTag("hltVerticesL3"), 
@@ -46,8 +46,8 @@ hltbTagValidation = cms.EDAnalyzer("HLTBTagPerformanceAnalyzer",
 	'HLT_PFMET120_',
 	'HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_',
 	'HLT_QuadPFJet_VBF',
-	'HLT_Ele27_eta2p1_',
-	'HLT_IsoMu22_'
+	'HLT_Ele32_eta2p1_',
+	'HLT_IsoMu21_eta2p1_'
 	),
 	JetTag = cms.VInputTag(
 		cms.InputTag("hltCombinedSecondaryVertexBJetTagsCalo"),

--- a/HLTriggerOffline/Btag/test/config.ini
+++ b/HLTriggerOffline/Btag/test/config.ini
@@ -4,7 +4,7 @@ maxevents=-1
 processname=HLT
 hltjets=ak4GenJetsNoNu
 cmsswver= CMSSW_X_Y_Z
-files= root://xrootd.ba.infn.it///store/relval/CMSSW_7_5_0_pre6/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PU25ns_75X_mcRun2_asymptotic_v1-v1/00000/00DE8AFD-1D1C-E511-988E-0025905A612C.root
+files= root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre7/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v0-v1/10000/1E660EDB-F135-E611-9E57-0CC47A4D76C8.root
 
 ;Paths names and btag variables that you want to monitor
 [btag]
@@ -20,7 +20,7 @@ HLT_QuadPFJet_VBF:
 HLT_Ele32_eta2p1_:
 	hltCombinedSecondaryVertexBJetTagsPF
 
-HLT_IsoMu24_eta2p1_:
+HLT_IsoMu21_eta2p1_:
 	hltCombinedSecondaryVertexBJetTagsPF
 
 ;Paths names and vertex variables that you want to monitor
@@ -44,6 +44,6 @@ HLT_QuadPFJet_VBF:
 HLT_Ele32_eta2p1_:
 	hltVerticesPF
 
-HLT_IsoMu24_eta2p1_:
+HLT_IsoMu21_eta2p1_:
 	hltVerticesPF
 

--- a/HLTriggerOffline/Btag/test/testSequences.py
+++ b/HLTriggerOffline/Btag/test/testSequences.py
@@ -12,7 +12,7 @@ process.DQM_BTag = cms.Path(    process.hltbtagValidationSequence + process.HltB
 
 
 process.source = cms.Source("PoolSource",
-	fileNames = cms.untracked.vstring("root://xrootd.ba.infn.it//store/relval/CMSSW_8_0_11/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/80X_mcRun2_asymptotic_v14_reHLT_HS-v1/10000/1AAA874F-0D33-E611-B99E-0CC47A4D75EE.root")
+	fileNames = cms.untracked.vstring("root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre7/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v0-v1/10000/1E660EDB-F135-E611-9E57-0CC47A4D76C8.root")
 #	fileNames = cms.untracked.vstring("file:RelVal750pre3.root")
 )
 


### PR DESCRIPTION
 DQM folder corresponding to HLT_IsoMu24_eta2p1 has no filled histograms. The reason was that no trigger by this name is available in the trigger menu. In order to remove this issue, the name of the trigger has been changed from HLT_IsoMu24_eta2p1 to HLT_IsoMu21_eta2p1. The changes has been done in the files in python and test directories. 
