### PR TITLE
Use the latest Express GT as a fallback, and fix http proxy setting in curl for Tier0 DataService query for Event Display applications.

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -87,7 +87,7 @@ class Tier0Handler( object ):
         userAgent = "User-Agent: DQMIntegration/2.0 python/%d.%d.%d PycURL/%s" % ( sys.version_info[ :3 ] + ( pycurl.version_info()[ 1 ], ) )
 
         proxy = ""
-        if self._proxy: proxy = ' --proxy=%s ' % self._proxy
+        if self._proxy: proxy = ' --proxy %s ' % self._proxy
         
         debug = " -s -S "
         if self._debug: debug = " -v "

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -5,7 +5,7 @@ GlobalTag.pfnPrefix = cms.untracked.string("frontier://(proxyurl=http://localhos
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.
-GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v10" )
+GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v11" )
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.


### PR DESCRIPTION
The fallback GT for the Event display applications is updated to the latest version used at Tier0.
Back-port of commit https://github.com/cms-sw/cmssw/pull/15296/commits/8b9abb0db5ebed25d5ddd73f2208571609d97986 in #15296 

Fix http proxy setting in `curl` for Tier0 DataService query in `DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py`: the invalid parameter was causing the event display to always fall back to the default Express GT.
Back-port of commit https://github.com/cms-sw/cmssw/pull/15337/commits/349b25ccbf7f967293f08a599bfffd55e63162e9 in #15337 
