### PR TITLE
Fix checking for duplicate process names

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -55,7 +55,9 @@ namespace edm {
 
     void setFrozen(bool initializeLookupInfo = true);
 
-    void setFrozen(std::set<TypeID> const& productTypesConsumed, std::set<TypeID> const& elementTypesConsumed);
+    void setFrozen(std::set<TypeID> const& productTypesConsumed,
+                   std::set<TypeID> const& elementTypesConsumed,
+                   std::string const& processName);
 
     std::string merge(ProductRegistry const& other,
         std::string const& fileName,
@@ -161,12 +163,16 @@ namespace edm {
     void freezeIt(bool frozen = true) {transient_.frozen_ = frozen;}
 
     void initializeLookupTables(std::set<TypeID> const* productTypesConsumed,
-                                std::set<TypeID> const* elementTypesConsumed);
+                                std::set<TypeID> const* elementTypesConsumed,
+                                std::string const* processName);
 
     void checkDictionariesOfConsumedTypes(std::set<TypeID> const* productTypesConsumed,
                                           std::set<TypeID> const* elementTypesConsumed,
                                           std::map<TypeID, TypeID> const& containedTypeMap,
                                           std::map<TypeID, std::vector<TypeWithDict> >& containedTypeToBaseTypesMap);
+
+    void checkForDuplicateProcessName(BranchDescription const& desc,
+                                      std::string const* processName) const;
 
     virtual void addCalled(BranchDescription const&, bool iFromListener);
     void throwIfNotFrozen() const;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -512,7 +512,7 @@ namespace edm {
       {
          RngEDConsumer rngConsumer = RngEDConsumer(productTypesConsumed);
       }
-      preg.setFrozen(productTypesConsumed, elementTypesConsumed);
+      preg.setFrozen(productTypesConsumed, elementTypesConsumed, processConfiguration->processName());
     }
 
     for (auto& c : all_output_communicators_) {

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -25,6 +25,11 @@ pushd ${LOCAL_TMP_DIR}
   rm testConsumesInfo.root
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testConsumesInfo_1.log testConsumesInfo_1.log || die "comparing testConsumesInfo_1.log" $?
 
+  #It is intentional that this cmsRun process throws an exception
+  echo "testDuplicateProcess"
+  cmsRun ${LOCAL_TEST_DIR}/testDuplicateProcess_cfg.py &> testDuplicateProcess.log && die 'Failed to get exception running testDuplicateProcess_cfg.py' 1
+  grep -q "Duplicate Process" testDuplicateProcess.log || die 'Failed to print out exception message for duplicate process name' $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/testDuplicateProcess_cfg.py
+++ b/FWCore/Integration/test/testDuplicateProcess_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD1")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testGetBy1.root'
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRepeatProcess.root')
+)
+
+process.e = cms.EndPath(process.out)


### PR DESCRIPTION
In a sequence of processes that adds data to
the output file, it is not allowed to use the
same process name more than once unless all
the products registered with that product name
and the products that depend on them from previous
processes were dropped. Previously the code that
checks for this case depended on detecting an
exact match between a newly produced branch name
and an old one. Because of TriggerResults this
worked most of the time, but failed in cases where
a new TriggerResults was not produced or the old
TriggerResults was dropped and there was no other
branch with such a name conflict. The symptom of
the bug was a completely different exception with
a confusing message from some other part of the
code that depended on the process names being
unique.

This change adds a new explicit check that always
runs in all cases.
