### PR TITLE
Update pixelCluster to support PhaseII

### DIFF
--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -190,12 +190,11 @@ public:
   }
   
   // ggiurgiu@fnal.gov, 01/05/12 
-  // VI  dummy until found useful
-  // Getters and setters for the newly added data members (err_x and err_y). See below. 
-  void setSplitClusterErrorX( float) { }
-  void setSplitClusterErrorY( float ) {  }
-  float getSplitClusterErrorX() const { return 0; }
-  float getSplitClusterErrorY() const { return 0; }
+  // Getters and setters for the newly added data members (err_x and err_y). See below.
+   void setSplitClusterErrorX( float errx ) { err_x = errx; }
+   void setSplitClusterErrorY( float erry ) { err_y = erry; }
+   float getSplitClusterErrorX() const { return err_x; }
+   float getSplitClusterErrorY() const { return err_y; }
   
   
 private:
@@ -209,6 +208,8 @@ private:
   uint8_t thePixelRowSpan=0; // Span pixel index in the x direction (low edge).
   uint8_t thePixelColSpan=0; // Span pixel index in the y direction (left edge).
   
+   float err_x=-99999.9f;
+   float err_y=-99999.9f;
   
 };
 

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -15,17 +15,11 @@
 //!  May   2008: Offset based packing (D.Fehling / A. Rizzi)
 //!  Sep 2012: added Max back, removed detId (V.I.)
 //!  sizeX and sizeY now clipped at 127
+//!  July 2017 make it compatible with PhaseII, remove errs....
 //---------------------------------------------------------------------------
 
 #include <vector>
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
-
-#ifndef CMS_NOCXX11
 #include <cstdint>
-#else
-#include "boost/cstdint.hpp"
-#endif
-
 #include <cassert>
 
 class PixelDigi;
@@ -74,28 +68,19 @@ public:
   typedef std::pair<PixelDigiIter,PixelDigiIter>   PixelDigiRange;
   
   
-#ifndef CMS_NOCXX11
-  static constexpr unsigned int POSBITS=10;
-  static constexpr unsigned int SPANBITS=6;
-  static constexpr unsigned int MAXSPAN=63;
-  static constexpr unsigned int MAXPOS=1023;
-#else
-  static const unsigned int POSBITS=10;
-  static const unsigned int SPANBITS=6;
-  static const unsigned int MAXSPAN=63;
-  static const unsigned int MAXPOS=1023;
-#endif  
+  static constexpr unsigned int MAXSPAN=127;
+  static constexpr unsigned int MAXPOS=2047;
   
   /** Construct from a range of digis that form a cluster and from 
    *  a DetID. The range is assumed to be non-empty.
    */
   
-  SiPixelCluster() : thePixelRow(MAXPOS), thePixelCol(MAXPOS), err_x(-99999.9), err_y(-99999.9) {}  // needed by many....
+  SiPixelCluster() {}
   
   SiPixelCluster(unsigned int isize, uint16_t const * adcs,
 		 uint16_t const * xpos,  uint16_t const * ypos, 
 		 uint16_t const  xmin,  uint16_t const  ymin) :   
-    thePixelOffset(2*isize), thePixelADC(adcs,adcs+isize), err_x(-99999.9), err_y(-99999.9) {
+    thePixelOffset(2*isize), thePixelADC(adcs,adcs+isize)  {
     uint16_t maxCol = 0;
     uint16_t maxRow = 0;
     for (unsigned int i=0; i!=isize; ++i) {
@@ -136,10 +121,10 @@ public:
   int size() const { return thePixelADC.size();}
   
   // Return cluster dimension in the x direction.
-  int sizeX() const {verifyVersion(); return rowSpan() +1;}
+  int sizeX() const { return rowSpan() +1;}
   
   // Return cluster dimension in the y direction.
-  int sizeY() const {verifyVersion(); return colSpan() +1;}
+  int sizeY() const { return colSpan() +1;}
   
   
   inline float charge() const {
@@ -150,10 +135,10 @@ public:
     return qm;
   } // Return total cluster charge.
   
-  inline int minPixelRow() const { return thePixelRow&MAXPOS;} // The min x index.
-  inline int maxPixelRow() const { verifyVersion(); return minPixelRow() + rowSpan();} // The max x index.
-  inline int minPixelCol() const { return thePixelCol&MAXPOS;} // The min y index.
-  inline int maxPixelCol() const { verifyVersion(); return minPixelCol() + colSpan();} // The max y index.
+  inline int minPixelRow() const { return theMinPixelRow;} // The min x index.
+  inline int maxPixelRow() const { return minPixelRow() + rowSpan();} // The max x index.
+  inline int minPixelCol() const { return theMinPixelCol;} // The min y index.
+  inline int maxPixelCol() const { return minPixelCol() + colSpan();} // The max y index.
   
   
   const std::vector<uint8_t> & pixelOffset() const { return thePixelOffset;}
@@ -180,64 +165,37 @@ public:
   
 private:
   
-  static int span_(uint16_t packed) { return packed >> POSBITS;}
-  static int overflow_(uint16_t packed) { return span_(packed)==uint16_t(MAXSPAN);}
-  static uint16_t pack_(uint16_t zmin, unsigned  short zspan) {
-    zspan = std::min(zspan, uint16_t(MAXSPAN));
-    return (zspan<<POSBITS) | zmin;
-  }
+  static int overflow_(uint16_t span) { return span==uint16_t(MAXSPAN);}
+
 public:
   
-  int colSpan() const {return span_(thePixelCol); }
+  int colSpan() const {return thePixelColSpan; }
   
-  int rowSpan() const { return span_(thePixelRow); }
+  int rowSpan() const { return thePixelRowSpan; }
   
   
-  bool overflowCol() const { return overflow_(thePixelCol); }
+  bool overflowCol() const { return overflow_(thePixelColSpan); }
   
-  bool overflowRow() const { return overflow_(thePixelRow); }
+  bool overflowRow() const { return overflow_(thePixelRowSpan); }
   
   bool overflow() const { return  overflowCol() || overflowRow(); }
   
   void packCol(uint16_t ymin, uint16_t yspan) {
-    thePixelCol = pack_(ymin,yspan);
+    theMinPixelCol = ymin;
+    thePixelColSpan = std::min(yspan, uint16_t(MAXSPAN));
   }
   void packRow(uint16_t xmin, uint16_t xspan) {
-    thePixelRow = pack_(xmin,xspan);
-  }
-  
-  
-  
-  /// mostly to be compatible for <610 
-  void verifyVersion() const {
-    if unlikely( thePixelRow<MAXPOS && thePixelCol<MAXPOS)
-		 const_cast<SiPixelCluster*>(this)->computeMax();
-  }
-  
-  /// moslty to be compatible for <610 
-  void computeMax()  {
-    int maxRow = 0;
-    int maxCol = 0;
-    int isize  = thePixelADC.size();
-    for (int i=0; i!=isize; ++i) {
-      int xsize  = thePixelOffset[i*2];
-      if (xsize > maxRow) maxRow = xsize;
-      int ysize = thePixelOffset[i*2+1] ;
-      if (ysize > maxCol) maxCol = ysize;
-    }
-    // assume minimum is correct
-    int minCol= minPixelCol();
-    packCol(minCol,maxCol);
-    int minRow= minPixelRow();
-    packRow(minRow,maxRow);
+    theMinPixelRow = xspan;
+    thePixelRowSpan = std::min(xspan, uint16_t(MAXSPAN));
   }
   
   // ggiurgiu@fnal.gov, 01/05/12 
+  // VI  dummy until found useful
   // Getters and setters for the newly added data members (err_x and err_y). See below. 
-  void setSplitClusterErrorX( float errx ) { err_x = errx; }
-  void setSplitClusterErrorY( float erry ) { err_y = erry; }
-  float getSplitClusterErrorX() const { return err_x; }
-  float getSplitClusterErrorY() const { return err_y; }
+  void setSplitClusterErrorX( float) { }
+  void setSplitClusterErrorY( float ) {  }
+  float getSplitClusterErrorX() const { return 0; }
+  float getSplitClusterErrorY() const { return 0; }
   
   
 private:
@@ -246,20 +204,11 @@ private:
   std::vector<uint16_t> thePixelADC;
   
   
-  uint16_t thePixelRow; // Minimum and span pixel index in the x direction (low edge).
-  uint16_t thePixelCol; // Minimum and span pixel index in the y direction (left edge).
-  // Need 10 bits for Postion information. the other 6 used for span
+  uint16_t theMinPixelRow=MAXPOS; // Minimum pixel index in the x direction (low edge).
+  uint16_t theMinPixelCol=MAXPOS; // Minimum pixel index in the y direction (left edge).
+  uint8_t thePixelRowSpan=MAXSPAN; // Span pixel index in the x direction (low edge).
+  uint8_t thePixelColSpan=MAXSPAN; // Span pixel index in the y direction (left edge).
   
-  // ggiurgiu@fnal.gov, 01/05/12
-  // Add cluster errors to be used by rechits from split clusters. 
-  // A rechit from a split cluster has larger errors than rechits from normal clusters. 
-  // However, when presented with a cluster, the CPE does not know if the cluster comes 
-  // from a splitting procedure or not. That's why we have to instruct the CPE to use 
-  // appropriate errors for split clusters.
-  // To avoid increase of data size on disk,these new data members are set as transient in: 
-  // DataFormats/SiPixelCluster/src/classes_def.xml
-  float err_x;
-  float err_y;
   
 };
 

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -206,13 +206,14 @@ private:
   
   uint16_t theMinPixelRow=MAXPOS; // Minimum pixel index in the x direction (low edge).
   uint16_t theMinPixelCol=MAXPOS; // Minimum pixel index in the y direction (left edge).
-  uint8_t thePixelRowSpan=MAXSPAN; // Span pixel index in the x direction (low edge).
-  uint8_t thePixelColSpan=MAXSPAN; // Span pixel index in the y direction (left edge).
+  uint8_t thePixelRowSpan=0; // Span pixel index in the x direction (low edge).
+  uint8_t thePixelColSpan=0; // Span pixel index in the y direction (left edge).
   
   
 };
 
-// Comparison operators  (no clue...)
+
+// Comparison operators  (needed by DetSetVector)
 inline bool operator<( const SiPixelCluster& one, const SiPixelCluster& other) {
   if ( one.minPixelRow() < other.minPixelRow() ) {
     return true;
@@ -224,6 +225,7 @@ inline bool operator<( const SiPixelCluster& one, const SiPixelCluster& other) {
     return false;
   }
 }
+
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -185,7 +185,7 @@ public:
     thePixelColSpan = std::min(yspan, uint16_t(MAXSPAN));
   }
   void packRow(uint16_t xmin, uint16_t xspan) {
-    theMinPixelRow = xspan;
+    theMinPixelRow = xmin;
     thePixelRowSpan = std::min(xspan, uint16_t(MAXSPAN));
   }
   

--- a/DataFormats/SiPixelCluster/src/SiPixelCluster.cc
+++ b/DataFormats/SiPixelCluster/src/SiPixelCluster.cc
@@ -50,8 +50,8 @@ void SiPixelCluster::add( const SiPixelCluster::PixelPos& pix, int adc) {
     for (int i=0; i<isize; ++i) {
       int xoffset = thePixelOffset[i*2]  + ominRow - minRow;
       int yoffset = thePixelOffset[i*2+1]  + ominCol -minCol;
-      thePixelOffset[i*2] = std::min(63,xoffset);
-      thePixelOffset[i*2+1] = std::min(63,yoffset);
+      thePixelOffset[i*2] = std::min(int(MAXSPAN),xoffset);
+      thePixelOffset[i*2+1] = std::min(int(MAXSPAN),yoffset);
       if (xoffset > maxRow) maxRow = xoffset; 
       if (yoffset > maxCol) maxCol = yoffset; 
     }
@@ -66,6 +66,6 @@ void SiPixelCluster::add( const SiPixelCluster::PixelPos& pix, int adc) {
     packCol(minCol,pix.col()-minCol);
   
   thePixelADC.push_back( adc );
-  thePixelOffset.push_back( std::min(63,pix.row() - minRow) );
-  thePixelOffset.push_back( std::min(63,pix.col() - minCol) );
+  thePixelOffset.push_back( std::min(int(MAXSPAN),pix.row() - minRow) );
+  thePixelOffset.push_back( std::min(int(MAXSPAN),pix.col() - minCol) );
 }

--- a/DataFormats/SiPixelCluster/src/SiPixelCluster.cc
+++ b/DataFormats/SiPixelCluster/src/SiPixelCluster.cc
@@ -16,15 +16,8 @@
 
 
 SiPixelCluster::SiPixelCluster( const SiPixelCluster::PixelPos& pix, int adc) :
-  thePixelRow(pix.row()),
-  thePixelCol(pix.col()),
-    // ggiurgiu@fnal.gov, 01/05/12
-  // Initialize the split cluster errors to un-physical values.
-  // The CPE will check these errors and if they are not un-physical, 
-  // it will recognize the clusters as split and assign these (increased) 
-  // errors to the corresponding rechit. 
-  err_x(-99999.9),
-  err_y(-99999.9)
+  theMinPixelRow(pix.row()),
+  theMinPixelCol(pix.col())
 {
   // First pixel in this cluster.
   thePixelADC.push_back( adc );

--- a/DataFormats/SiPixelCluster/src/classes_def.xml
+++ b/DataFormats/SiPixelCluster/src/classes_def.xml
@@ -4,6 +4,8 @@
    <version ClassVersion="11" checksum="1473312403"/>
    <version ClassVersion="12" checksum="2042538185"/>
    <version ClassVersion="13" checksum="2314992115"/>
+   <field name="err_x" transient="true"/>
+   <field name="err_y" transient="true"/>
   <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelCol" target="theMinPixelCol">
    <![CDATA[theMinPixelCol = onfile.thePixelCol&1023;]]>
    </ioread>

--- a/DataFormats/SiPixelCluster/src/classes_def.xml
+++ b/DataFormats/SiPixelCluster/src/classes_def.xml
@@ -1,16 +1,21 @@
 <lcgdict>
-  <class name="SiPixelCluster" ClassVersion="12">
-   <field name="err_x" transient="true"/>
-   <field name="err_y" transient="true"/>
+  <class name="SiPixelCluster" ClassVersion="13">
    <version ClassVersion="10" checksum="2468063768"/>
    <version ClassVersion="11" checksum="1473312403"/>
    <version ClassVersion="12" checksum="2042538185"/>
-   <ioread sourceClass="SiPixelCluster" version="[1-10]" targetClass="SiPixelCluster" source="uint16_t theMinPixelCol" target="thePixelCol">
-   <![CDATA[thePixelCol = onfile.theMinPixelCol;]]>
-   </ioread>  
-   <ioread sourceClass="SiPixelCluster" version="[1-10]" targetClass="SiPixelCluster" source="uint16_t theMinPixelRow" target="thePixelRow">
-   <![CDATA[thePixelRow = onfile.theMinPixelRow;]]>
-   </ioread>  
+   <version ClassVersion="13" checksum="2314992115"/>
+  <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelCol" target="theMinPixelCol">
+   <![CDATA[theMinPixelCol = onfile.thePixelCol&1023;]]>
+   </ioread>
+   <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelRow" target="theMinPixelRow">
+   <![CDATA[theMinPixelRow = onfile.thePixelRow&1023;]]>
+   </ioread>
+  <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelCol" target="thePixelColSpan">
+   <![CDATA[thePixelColSpan = onfile.thePixelCol>>6;]]>
+   </ioread>
+   <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelRow" target="thePixelRowSpan">
+   <![CDATA[thePixelRowSpan = onfile.thePixelRow>>6;]]>
+   </ioread>
   </class>
   <class name="SiPixelCluster::Pixel" ClassVersion="11">
    <version ClassVersion="10" checksum="387573196"/>

--- a/DataFormats/SiPixelCluster/src/classes_def.xml
+++ b/DataFormats/SiPixelCluster/src/classes_def.xml
@@ -11,10 +11,10 @@
    <![CDATA[theMinPixelRow = onfile.thePixelRow&1023;]]>
    </ioread>
   <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelCol" target="thePixelColSpan">
-   <![CDATA[thePixelColSpan = onfile.thePixelCol>>6;]]>
+   <![CDATA[thePixelColSpan = onfile.thePixelCol>>10;]]>
    </ioread>
    <ioread sourceClass="SiPixelCluster" version="[11-12]" targetClass="SiPixelCluster" source="uint16_t thePixelRow" target="thePixelRowSpan">
-   <![CDATA[thePixelRowSpan = onfile.thePixelRow>>6;]]>
+   <![CDATA[thePixelRowSpan = onfile.thePixelRow>>10;]]>
    </ioread>
   </class>
   <class name="SiPixelCluster::Pixel" ClassVersion="11">

--- a/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
+++ b/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
@@ -1,6 +1,7 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include<cassert>
 #include<cstdio>
+#include<iostream>
 
 typedef SiPixelCluster::PixelPos PiPos;
 typedef SiPixelCluster::Pixel Pixel;
@@ -56,6 +57,7 @@ bool verify(PiPos const (&pos)[N], bool ox, bool oy) {
 
 int main() {
 
+  std::cout << "size " << sizeof(SiPixelCluster) << std::endl;
 
   bool ok=true;
 

--- a/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
+++ b/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
@@ -4,6 +4,7 @@
 
 typedef SiPixelCluster::PixelPos PiPos;
 typedef SiPixelCluster::Pixel Pixel;
+#define MAXSPAN 127
 
 template<int N>
 inline
@@ -43,8 +44,8 @@ bool verify(PiPos const (&pos)[N], bool ox, bool oy) {
  for (int i=0; i!=clus.size(); ++i) {
     auto const p = clus.pixel(i);
     auto const p2 = clus2.pixel(i);
-      ok &=  (pos[i].row()-cxmin>63) ? p.x==63+cxmin : p.x==pos[i].row(); 
-      ok &=  (pos[i].col()-cymin>63) ? p.y==63+cymin : p.y==pos[i].col();
+      ok &=  (pos[i].row()-cxmin>MAXSPAN) ? p.x==MAXSPAN+cxmin : p.x==pos[i].row(); 
+      ok &=  (pos[i].col()-cymin>MAXSPAN) ? p.y==MAXSPAN+cymin : p.y==pos[i].col();
       printf("%d,%d %d,%d %d,%d\n",pos[i].row(),pos[i].col(), p.x,p.y, p2.x,p2.y);
   }
 


### PR DESCRIPTION
Update pixelCluster to support PhaseII

to test reading old reco I refit an event and the result is the same as refitting a new reco file...

in principle one may observe regressions due to the change in maxsize of clusters from 64 to 128

once this is validated and integrated PhaseII wf have to be modified to use standard Run2 or PhaseII sequences (and all specific PhaseII pixel code removed for good)
