### PR TITLE
New pulse shape for HE 2017 SiPM

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalHardcodeParameters.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalHardcodeParameters.h
@@ -11,7 +11,7 @@ class HcalHardcodeParameters {
 		HcalHardcodeParameters() {}
 		//construct from values
 		HcalHardcodeParameters(double pedestal, double pedestalWidth, std::vector<double> gain, std::vector<double> gainWidth, 
-							   int qieType, std::vector<double> qieOffset, std::vector<double> qieSlope);
+							   int qieType, std::vector<double> qieOffset, std::vector<double> qieSlope, int mcShape, int recoShape);
 		//construct from pset
 		HcalHardcodeParameters(const edm::ParameterSet & p);
 		
@@ -27,6 +27,8 @@ class HcalHardcodeParameters {
 		const int qieType() const { return qieType_; }
 		const double qieOffset(unsigned range) const { return qieOffset_.at(range); }
 		const double qieSlope(unsigned range) const { return qieSlope_.at(range); }
+		const int mcShape() const { return mcShape_; }
+		const int recoShape() const { return recoShape_; }
 		
 	private:
 		//member variables
@@ -34,6 +36,7 @@ class HcalHardcodeParameters {
 		std::vector<double> gain_, gainWidth_;
 		int qieType_;
 		std::vector<double> qieOffset_, qieSlope_;
+		int mcShape_, recoShape_;
 };
 
 #endif

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -40,7 +40,8 @@ private:
                        float, float, float, Shape&);
   void computeHFShape();
   void computeSiPMShape();
-  Shape hpdShape_, hfShape_, siPMShape_;
+  void computeSiPMShape2017();
+  Shape hpdShape_, hfShape_, siPMShape_, siPMShape2017_;
   Shape hpdShape_v2, hpdShapeMC_v2;
   Shape hpdShape_v3, hpdShapeMC_v3;
   Shape hpdBV30Shape_v2, hpdBV30ShapeMC_v2;

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -20,7 +20,7 @@ public:
   typedef HcalPulseShape Shape;
   HcalPulseShapes();
   ~HcalPulseShapes();
-  // only needed if you'll be geting shapes by DetId
+  // only needed if you'll be getting shapes by DetId
   void beginRun(edm::EventSetup const & es);
   void endRun();
 
@@ -28,7 +28,7 @@ public:
   const Shape& heShape() const { return hpdShape_; }
   const Shape& hfShape() const { return hfShape_; }
   const Shape& hoShape(bool sipm=false) const { return sipm ? siPMShape_ : hpdShape_; }
-  //  return Shpape for given shapeType.
+  //  return Shape for given shapeType.
   const Shape& getShape(int shapeType) const;
   /// automatically figures out which shape to return
   const Shape& shape(const HcalDetId & detId) const;
@@ -38,7 +38,6 @@ public:
 private:
   void computeHPDShape(float, float, float, float, float ,
                        float, float, float, Shape&);
-  // void computeHPDShape();
   void computeHFShape();
   void computeSiPMShape();
   Shape hpdShape_, hfShape_, siPMShape_;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -10,7 +10,7 @@
 #include "DataFormats/HcalDigi/interface/HcalQIENum.h"
 
 HcalDbHardcode::HcalDbHardcode()
-: theDefaultParameters_(3.0,0.5,{0.2,0.2},{0.0,0.0},0,{0.0,0.0,0.0,0.0},{0.9,0.9,0.9,0.9}), //"generic" set of conditions
+: theDefaultParameters_(3.0,0.5,{0.2,0.2},{0.0,0.0},0,{0.0,0.0,0.0,0.0},{0.9,0.9,0.9,0.9},125,105), //"generic" set of conditions
   setHB_(false), setHE_(false), setHF_(false), setHO_(false), 
   setHBUpgrade_(false), setHEUpgrade_(false), setHFUpgrade_(false), 
   useHBUpgrade_(false), useHEUpgrade_(false), useHFUpgrade_(false), testHFQIE10_(false)
@@ -153,7 +153,7 @@ HcalQIEShape HcalDbHardcode::makeQIEShape () {
 HcalMCParam HcalDbHardcode::makeMCParam (HcalGenericDetId fId) {
 
   int r1bit[5];
-  int pulseShapeID = 125;  r1bit[0] = 9;     //  [0,9]
+                           r1bit[0] = 9;     //  [0,9]
   int syncPhase    = 0;    r1bit[1] = 1;
   int binOfMaximum = 0;    r1bit[2] = 4;
   float phase      = -25.0f;                  // [-25.0,25.0]
@@ -161,45 +161,43 @@ HcalMCParam HcalDbHardcode::makeMCParam (HcalGenericDetId fId) {
                                              // (offset 50nsec,  0.25ns step)
   int Iphase = Xphase;     r1bit[3] = 8;     // [0,256] offset 50ns, .25ns step
   int timeSmearing = 0;    r1bit[4] = 1;     //  bool
-  
+
+  const HcalHardcodeParameters& hparam(getParameters(fId));
+  int pulseShapeID = hparam.mcShape(); // a0
  
   if (fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel) { 
 
-    syncPhase    = 1;                      // a0  bool
-    binOfMaximum = 5;                      // a1
-    phase        = 5.0f;                    // a2  [-25.0,25.0]
+    syncPhase    = 1;                      // a1  bool
+    binOfMaximum = 5;                      // a2
+    phase        = 5.0f;                    // a3  [-25.0,25.0]
     Xphase       = (phase + 32.0f) * 4.0f;   // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;
-    timeSmearing = 1;                      // a3
-    pulseShapeID = 201;                    // a4   201 - Zecotec shape
-                                           //      202 - Hamamatsu
+    timeSmearing = 1;                      // a4
 
   }
 
   else if (fId.genericSubdet() == HcalGenericDetId::HcalGenEndcap) { 
 
-    syncPhase    = 1;                      // a0  bool
-    binOfMaximum = 5;                      // a1
-    phase        = 5.0f;                    // a2  [-25.0,25.0]
+    syncPhase    = 1;                      // a1  bool
+    binOfMaximum = 5;                      // a2
+    phase        = 5.0f;                    // a3  [-25.0,25.0]
     Xphase       = (phase + 32.0f) * 4.0f;   // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;
-    timeSmearing = 1;                      // a3
-    pulseShapeID = 201;                    // a4
+    timeSmearing = 1;                      // a4
 
   }
 
   else if (fId.genericSubdet() == HcalGenericDetId::HcalGenOuter) {
 
-    syncPhase    = 1;                      // a0  bool
-    binOfMaximum = 5;                      // a1
-    phase        = 5.0f;                    // a2  [-25.0,25.0]
+    syncPhase    = 1;                      // a1  bool
+    binOfMaximum = 5;                      // a2
+    phase        = 5.0f;                    // a3  [-25.0,25.0]
     Xphase       = (phase + 32.0f) * 4.0f;   // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;
-    timeSmearing = 0;                      // a3
-    pulseShapeID = 201;                    // a4
+    timeSmearing = 0;                      // a4
 
     HcalDetId cell = HcalDetId(fId);
     if (cell.ieta() == 1 && cell.iphi() == 1) pulseShapeID = 125;
@@ -208,29 +206,26 @@ HcalMCParam HcalDbHardcode::makeMCParam (HcalGenericDetId fId) {
   
   else if (fId.genericSubdet() == HcalGenericDetId::HcalGenForward) { 
 
-    syncPhase    = 1;                      // a0  bool
-    binOfMaximum = 3;                      // a1
-    phase        = 14.0f;                   // a2  [-25.0,25.0]
+    syncPhase    = 1;                      // a1  bool
+    binOfMaximum = 3;                      // a2
+    phase        = 14.0f;                   // a3  [-25.0,25.0]
     Xphase       = (phase + 32.0f) * 4.0f;   // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;
-    timeSmearing = 0;                      // a3
-    pulseShapeID = 301;                    // a4
+    timeSmearing = 0;                      // a4
  
   }
 
   else if (fId.genericSubdet() == HcalGenericDetId::HcalGenZDC) { 
 
-    //    std::cout << " >>>  ZDC  " << std::endl; 
-
-    syncPhase    = 1;                      // a0  bool
-    binOfMaximum = 5;                      // a1
-    phase        = -4.0f;                   // a2  [-25.0,25.0]
+    pulseShapeID = 401;                    // a0
+    syncPhase    = 1;                      // a1  bool
+    binOfMaximum = 5;                      // a2
+    phase        = -4.0f;                   // a3  [-25.0,25.0]
     Xphase       = (phase + 32.0f) * 4.0f;   // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;
-    timeSmearing = 0;                      // a3
-    pulseShapeID = 401;                    // a4
+    timeSmearing = 0;                      // a4
  
   }
 
@@ -241,7 +236,7 @@ HcalMCParam HcalDbHardcode::makeMCParam (HcalGenericDetId fId) {
     rshift[k+1]=rshift[k]+r1bit[k];
   }
 
-  int packingScheme  = 1;
+  int packingScheme  = 1; // a5
   unsigned int param = pulseShapeID |
     syncPhase<<rshift[1]            |
     (binOfMaximum << rshift[2])     |
@@ -268,7 +263,10 @@ HcalRecoParam HcalDbHardcode::makeRecoParam (HcalGenericDetId fId) {
                                            // (offset 50ns, 0.25ns step
   int firstSample  = 4;                    p1bit[3]=4;   // [0,9]
   int samplesToAdd = 2;                    p1bit[4]=4;   // [0,9]
-  int pulseShapeID = 105;                  p1bit[5]=9;   // [0,9]
+                                           p1bit[5]=9;   // [0,9]
+
+  const HcalHardcodeParameters& hparam(getParameters(fId));
+  int pulseShapeID = hparam.recoShape(); // a5
 
   int q2bit[10];
   //  param2.
@@ -295,7 +293,6 @@ HcalRecoParam HcalDbHardcode::makeRecoParam (HcalGenericDetId fId) {
     Iphase       = Xphase;                 // p2
     firstSample  = 4;                      // p3
     samplesToAdd = 2;                      // p4
-    pulseShapeID = 201;                    // p5
     
     //  param2.
     useLeakCorrection  = 0;                //  q0
@@ -320,7 +317,7 @@ HcalRecoParam HcalDbHardcode::makeRecoParam (HcalGenericDetId fId) {
     Iphase       = Xphase;                 // p2
     firstSample  = 4;                      // p3
     samplesToAdd = 4;                      // p4
-    pulseShapeID = 201;                    // p5
+
     //  param2.
     useLeakCorrection  = 0;                //  q0
     LeakCorrectionID   = 0;                //  q1
@@ -341,11 +338,8 @@ HcalRecoParam HcalDbHardcode::makeRecoParam (HcalGenericDetId fId) {
     float  Xphase = (phase + 32.0) * 4.0;  // never change this line 
                                            // (offset 50nsec,  0.25ns step)
     Iphase       = Xphase;                 // p2
-    pulseShapeID = 301;                    // p5
-
     firstSample  = 2;                      // p3
     samplesToAdd = 1;                      // p4
-    pulseShapeID = 301;                    // p5
     
     //  param2.
     useLeakCorrection  = 0;                //  q0
@@ -394,36 +388,6 @@ HcalRecoParam HcalDbHardcode::makeRecoParam (HcalGenericDetId fId) {
     (pileupCleaningID   << q2shift[8]) |
     (packingScheme      << q2shift[9]) ;
   
-  // Test printout
-  /*  
-    int a0=param1%2;
-    int a1=(param1/2)%2;
-    int a2=(param1/(2*2))%256;
-    int a3=(param1/(2*2*256))%16;
-    int a4=(param1/(2*2*256*16))%16;
-    int a5=(param1/(2*2*256*16*16))%512;
-    a2=(a2/4)-32;
-    
-    int b0=param2%2;
-    int b1=(param2/2)%16;
-    int b2=(param2/(2*16))%2;
-    int b3=(param2/(2*16*2))%16;
-    int b4=(param2/(2*16*2*16))%2;
-    int b5=(param2/(2*16*2*16*2))%16;
-    int b6=(param2/(2*16*2*16*2*16))%16;
-    int b7=(param2/(2*16*2*16*2*16*16))%16;
-    int b8=(param2/(2*16*2*16*2*16*16*16))%16;
-    int b9=(param2/(2*16*2*16*2*16*16*16*16))%16;
-
-    std::cout << " param1 (a012) " << a0 << " " <<a1 << " " << a2 
-	      << " (a345) " << a3 << " " << a4 << " "<< a5
-	      << " param2 (b012) " << b0 << " " << b1 << " " <<b2 
-	      << " (b345) " << b3 << " " << b4 << " " << b5 
-	      << " (b678) " << b6 << " " << b7 << " " << b8  << "   b9 " << b9
-	      << std::endl;
-  */
-
-
   HcalRecoParam result(fId.rawId(), param1, param2);
 
   return result;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -70,7 +70,7 @@ HcalPedestal HcalDbHardcode::makePedestal (HcalGenericDetId fId, bool fSmear) {
       value[i] = 0.0f;
       while (value [i] <= 0.0f)
 	// ignore correlations, assume 10K pedestal run 
-	value [i] = value0 + (float)CLHEP::RandGauss::shoot (value0, width.getWidth (i) / 100.);
+	value [i] = value0 + (float)CLHEP::RandGauss::shoot (0.0, width.getWidth (i) / 100.);
     }
   }
   HcalPedestal result (fId.rawId (), 

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -152,38 +152,6 @@ HcalQIEShape HcalDbHardcode::makeQIEShape () {
 
 HcalMCParam HcalDbHardcode::makeMCParam (HcalGenericDetId fId) {
 
-
-  /*
-  std::cout << std::endl << " HcalDbHardcode::makeMCParam   fId " 
-	    << fId 
-	    << "  fId.genericSubdet() = " << fId.genericSubdet() << std::endl;
-  if(fId.isHcalZDCDetId()) {
-    std::cout << "... ZDC " << std::endl;
- 
-
-    HcalZDCDetId cell(fId);
-    int side   = cell.zside();
-    int depth  = cell.depth();
-    int ch     = cell.channel();
-    std::cout << "ZDC  side/depth/chanel = " 
-	      << side << "  " << depth << "  " << ch 
-	      << std::endl;
-  }
-  else if (fId.isHcalDetId()) {
-    HcalDetId cell = HcalDetId(fId);
-    int sub    = cell.subdet();
-    int dep    = cell.depth();
-    int ieta   = cell.ieta();
-    int iphi   = cell.iphi();
-    
-    std::cout << "  HCAL " 
-	      << "  subdet " << sub << "  ieta " << ieta << "  iphi " << iphi
-	      << "  depth " << dep << std::endl; 
-  }
-  else {  std::cout << "...Something else ! " << std::endl; }
-
-  */
-
   int r1bit[5];
   int pulseShapeID = 125;  r1bit[0] = 9;     //  [0,9]
   int syncPhase    = 0;    r1bit[1] = 1;

--- a/CalibCalorimetry/HcalAlgos/src/HcalHardcodeParameters.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalHardcodeParameters.cc
@@ -1,14 +1,16 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalHardcodeParameters.h"
 
 HcalHardcodeParameters::HcalHardcodeParameters(double pedestal, double pedestalWidth, std::vector<double> gain, std::vector<double> gainWidth, 
-											   int qieType, std::vector<double> qieOffset, std::vector<double> qieSlope)
+											   int qieType, std::vector<double> qieOffset, std::vector<double> qieSlope, int mcShape, int recoShape)
 :	pedestal_(pedestal),
 	pedestalWidth_(pedestalWidth),
 	gain_(gain),
 	gainWidth_(gainWidth),
 	qieType_(qieType),
 	qieOffset_(qieOffset),
-	qieSlope_(qieSlope)
+	qieSlope_(qieSlope),
+	mcShape_(mcShape),
+	recoShape_(recoShape)
 {
 }
 
@@ -19,6 +21,8 @@ HcalHardcodeParameters::HcalHardcodeParameters(const edm::ParameterSet & p)
 	gainWidth_(p.getParameter<std::vector<double>>("gainWidth")),
 	qieType_(p.getParameter<int>("qieType")),
 	qieOffset_(p.getParameter<std::vector<double>>("qieOffset")),
-	qieSlope_(p.getParameter<std::vector<double>>("qieSlope"))
+	qieSlope_(p.getParameter<std::vector<double>>("qieSlope")),
+	mcShape_(p.getParameter<int>("mcShape")),
+	recoShape_(p.getParameter<int>("recoShape"))
 {
 }

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -36,6 +36,7 @@ Reco  MC
 105   125      hpdShape_v2, hpdShapeMC_v2             HPD (2011.11.12 version)
 201   201      siPMShape_                             SiPMs Zecotec shape   (HO)
 202   202      =201,                                  SiPMs Hamamatsu shape (HO)
+203   203      siPMShape2017_                         SiPMs Hamamatsu shape (HE 2017)
 301   301      hfShape_                               regular HF PMT shape
 401   401                                             regular ZDC shape
 --------------------------------------------------------------------------------------
@@ -83,9 +84,11 @@ Reco  MC
 
   computeHFShape();
   computeSiPMShape();
+  computeSiPMShape2017();
 
   theShapes[201] = &siPMShape_;
   theShapes[202] = theShapes[201];
+  theShapes[203] = &siPMShape2017_;
   theShapes[301] = &hfShape_;
   //theShapes[401] = new CaloCachedShapeIntegrator(&theZDCShape);
 
@@ -266,7 +269,7 @@ void HcalPulseShapes::computeSiPMShape()
 
   unsigned int nbin = 128; 
 
-//From Jake Anderson: numerical convolution of SiPMs  WLC shapes
+//From Jake Anderson: toy MC convolution of SiPM pulse + WLS fiber shape + SiPM nonlinear response
   std::vector<float> nt = {
     2.782980485851731e-6,
     4.518134885954626e-5,
@@ -408,6 +411,156 @@ void HcalPulseShapes::computeSiPMShape()
   for (unsigned int j = 0; j < nbin; ++j) {
     nt[j] /= norm;
     siPMShape_.setShapeBin(j,nt[j]);
+  }
+}
+
+void HcalPulseShapes::computeSiPMShape2017()
+{
+
+  unsigned int nbin = 128; 
+
+//From Kevin Pedro: numerical convolution of SiPM pulse + WLS fiber shape
+  std::vector<float> nt = {
+    0,
+    1.85771e-09,
+    1.9696e-07,
+    3.52391e-06,
+    2.12744e-05,
+    7.07217e-05,
+    0.000163262,
+    0.000300818,
+    0.000478527,
+    0.000688231,
+    0.000920541,
+    0.00116575,
+    0.0014145,
+    0.0016584,
+    0.00189028,
+    0.00210444,
+    0.00229657,
+    0.00246372,
+    0.00260414,
+    0.00271712,
+    0.0028028,
+    0.00286202,
+    0.00289615,
+    0.00290693,
+    0.00289638,
+    0.00286668,
+    0.00282009,
+    0.00275886,
+    0.00268519,
+    0.0026012,
+    0.00250889,
+    0.00241008,
+    0.00230648,
+    0.00219961,
+    0.00209083,
+    0.00198134,
+    0.00187218,
+    0.00176425,
+    0.0016583,
+    0.00155496,
+    0.00145473,
+    0.00135804,
+    0.00126517,
+    0.00117636,
+    0.00109177,
+    0.00101147,
+    0.000935512,
+    0.000863867,
+    0.000796487,
+    0.000733286,
+    0.000674152,
+    0.000618954,
+    0.000567541,
+    0.000519754,
+    0.000475424,
+    0.000434376,
+    0.000396435,
+    0.000361423,
+    0.000329166,
+    0.000299491,
+    0.000272232,
+    0.000247225,
+    0.000224316,
+    0.000203354,
+    0.000184198,
+    0.000166711,
+    0.000150766,
+    0.000136243,
+    0.000123029,
+    0.000111017,
+    0.000100108,
+    9.02108e-05,
+    8.12388e-05,
+    7.31127e-05,
+    6.57587e-05,
+    5.9109e-05,
+    5.31006e-05,
+    4.76759e-05,
+    4.27816e-05,
+    3.8369e-05,
+    3.43934e-05,
+    3.08139e-05,
+    2.75932e-05,
+    2.4697e-05,
+    2.20943e-05,
+    1.97567e-05,
+    1.76584e-05,
+    1.57759e-05,
+    1.4088e-05,
+    1.25754e-05,
+    1.12205e-05,
+    1.00076e-05,
+    8.92221e-06,
+    7.95148e-06,
+    7.08368e-06,
+    6.30824e-06,
+    5.61565e-06,
+    4.99732e-06,
+    4.44553e-06,
+    3.95331e-06,
+    3.51441e-06,
+    3.12322e-06,
+    2.77468e-06,
+    2.46425e-06,
+    2.18788e-06,
+    1.94192e-06,
+    1.72309e-06,
+    1.52848e-06,
+    1.35546e-06,
+    1.20169e-06,
+    1.06506e-06,
+    9.43716e-07,
+    8.35973e-07,
+    7.40336e-07,
+    6.55472e-07,
+    5.80189e-07,
+    5.13426e-07,
+    4.54233e-07,
+    4.01769e-07,
+    3.55281e-07,
+    3.14098e-07,
+    2.77626e-07,
+    2.45334e-07,
+    2.1675e-07,
+    1.91455e-07,
+    1.69076e-07,
+    1.49281e-07,
+    1.31776e-07,
+  };
+
+  siPMShape2017_.setNBin(nbin);
+
+  double norm = 0.;
+  for (unsigned int j = 0; j < nbin; ++j) {
+    norm += (nt[j]>0) ? nt[j] : 0.;
+  }
+
+  for (unsigned int j = 0; j < nbin; ++j) {
+    nt[j] /= norm;
+    siPMShape2017_.setShapeBin(j,nt[j]);
   }
 }
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -89,15 +89,6 @@ Reco  MC
   theShapes[301] = &hfShape_;
   //theShapes[401] = new CaloCachedShapeIntegrator(&theZDCShape);
 
-  /*
-  // backward-compatibility with old scheme
-  theShapes[0] = theShapes[101];
-  //FIXME "special" HB
-  theShapes[1] = theShapes[101];
-  theShapes[2] = theShapes[201];
-  theShapes[3] = theShapes[301];
-  //theShapes[4] = theShapes[401];
-  */
 }
 
 
@@ -123,10 +114,6 @@ void HcalPulseShapes::beginRun(edm::EventSetup const & es)
   es.get<HcalRecoParamsRcd>().get(q);
   theRecoParams = new HcalRecoParams(*q.product());
   theRecoParams->setTopo(theTopology);
-
-//      std::cout<<" skdump in HcalPulseShapes::beginRun   dupm MCParams "<<std::endl;
-//      std::ofstream skfile("skdumpMCParamsNewFormat.txt");
-//      HcalDbASCIIIO::dumpObject(skfile, (*theMCParams) );
 }
 
 
@@ -148,14 +135,6 @@ void HcalPulseShapes::computeHPDShape(float ts1, float ts2, float ts3, float thp
                                 float wd1, float wd2, float wd3, Shape &tmphpdShape_)
 {
 
-  /*
-  std::cout << "o HcalPulseShapes::computeHPDShape  " 
-            << " ts1, ts2, ts3, thpd, tpre, w1, w2, w3 =" 
-	    <<  ts1 << ", " << ts2 << ", " << ts3 << ", " 
-	    << thpd << ", " << tpre << ", " << wd1 << ", " <<  wd2 
-            << ", "  << wd3 << std::endl;
-  */
-
 // pulse shape time constants in ns
 /*
   const float ts1  = 8.;          // scintillation time constants : 1,2,3
@@ -168,7 +147,7 @@ void HcalPulseShapes::computeHPDShape(float ts1, float ts2, float ts3, float thp
   const float wd2 = 0.7;
   const float wd3 = 1.;
 */  
-  // pulse shape componnts over a range of time 0 ns to 255 ns in 1 ns steps
+  // pulse shape components over a range of time 0 ns to 255 ns in 1 ns steps
   unsigned int nbin = 256;
   tmphpdShape_.setNBin(nbin);
   std::vector<float> ntmp(nbin,0.0);  // zeroing output pulse shape
@@ -243,10 +222,8 @@ void HcalPulseShapes::computeHPDShape(float ts1, float ts2, float ts3, float thp
     norm += ntmp[i];
   }
 
-  //cout << " Convoluted SHAPE ==============  " << endl;
   for(i=0; i<nbin; i++){
     ntmp[i] /= norm;
-    //  cout << " shape " << i << " = " << ntmp[i] << endl;   
   }
 
   for(i=0; i<nbin; i++){
@@ -289,7 +266,7 @@ void HcalPulseShapes::computeSiPMShape()
 
   unsigned int nbin = 128; 
 
-//From Jake Anderson: numberical convolution of SiPMs  WLC shapes
+//From Jake Anderson: numerical convolution of SiPMs  WLC shapes
   std::vector<float> nt = {
     2.782980485851731e-6,
     4.518134885954626e-5,
@@ -434,19 +411,9 @@ void HcalPulseShapes::computeSiPMShape()
   }
 }
 
-// double HcalPulseShapes::gexp(double t, double A, double c, double t0, double s) {
-//   static double const root2(sqrt(2));
-//   return -A*0.5*exp(c*t+0.5*c*c*s*s-c*s)*(erf(-0.5*root2/s*(t-t0+c*s*s))-1);
-// }
-
-
 const HcalPulseShapes::Shape &
 HcalPulseShapes::getShape(int shapeType) const
 {
-
-  //  std::cout << "- HcalPulseShapes::Shape for type "<< shapeType 
-  //            << std::endl;
-
   ShapeMap::const_iterator shapeMapItr = theShapes.find(shapeType);
   if(shapeMapItr == theShapes.end()) {
    throw cms::Exception("HcalPulseShapes") << "unknown shapeType";
@@ -465,19 +432,6 @@ HcalPulseShapes::shape(const HcalDetId & detId) const
   }
   int shapeType = theMCParams->getValues(detId)->signalShape();
 
-  /*
-	  int sub     = detId.subdet();
-	  int depth   = detId.depth();
-	  int inteta  = detId.ieta();
-	  int intphi  = detId.iphi();
-	  
-	  std::cout << " HcalPulseShapes::shape cell:" 
-		    << " sub, ieta, iphi, depth = " 
-		    << sub << "  " << inteta << "  " << intphi 
-		    << "  " << depth  << " => ShapeId "<<  shapeType 
-		    << std::endl;
-  */
-
   ShapeMap::const_iterator shapeMapItr = theShapes.find(shapeType);
   if(shapeMapItr == theShapes.end()) {
     return defaultShape(detId);
@@ -493,19 +447,6 @@ HcalPulseShapes::shapeForReco(const HcalDetId & detId) const
     return defaultShape(detId);
   }
   int shapeType = theRecoParams->getValues(detId.rawId())->pulseShapeID();
-
-  /*
-	  int sub     = detId.subdet();
-	  int depth   = detId.depth();
-	  int inteta  = detId.ieta();
-	  int intphi  = detId.iphi();
-	  
-	  std::cout << ">> HcalPulseShapes::shapeForReco cell:" 
-		    << " sub, ieta, iphi, depth = " 
-		    << sub << "  " << inteta << "  " << intphi 
-		    << "  " << depth  << " => ShapeId "<<  shapeType 
-		    << std::endl;
-  */
 
   ShapeMap::const_iterator shapeMapItr = theShapes.find(shapeType);
   if(shapeMapItr == theShapes.end()) {

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -29,7 +29,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0.0),
         qieType       = cms.int32(0),
         qieOffset     = cms.vdouble(-0.49,1.8,7.2,37.9),
-        qieSlope      = cms.vdouble(0.912,0.917,0.922,0.923)
+        qieSlope      = cms.vdouble(0.912,0.917,0.922,0.923),
+        mcShape       = cms.int32(125),
+        recoShape     = cms.int32(105),
     ),
     he = cms.PSet(
         pedestal      = cms.double(3.0),
@@ -38,7 +40,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0),
         qieType       = cms.int32(0),
         qieOffset     = cms.vdouble(-0.38,2.0,7.6,39.6),
-        qieSlope      = cms.vdouble(0.912,0.916,0.920,0.922)
+        qieSlope      = cms.vdouble(0.912,0.916,0.920,0.922),
+        mcShape       = cms.int32(125),
+        recoShape     = cms.int32(105),
     ),
     hf = cms.PSet(
         pedestal      = cms.double(3.0),
@@ -47,7 +51,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0.0,0.0),
         qieType       = cms.int32(0),
         qieOffset     = cms.vdouble(-0.87,1.4,7.8,-29.6),
-        qieSlope      = cms.vdouble(0.359,0.358,0.360,0.367)
+        qieSlope      = cms.vdouble(0.359,0.358,0.360,0.367),
+        mcShape       = cms.int32(301),
+        recoShape     = cms.int32(301),
     ),
     ho = cms.PSet(
         pedestal      = cms.double(11.0),
@@ -56,7 +62,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0.0,0.0),
         qieType       = cms.int32(0),
         qieOffset     = cms.vdouble(-0.44,1.4,7.1,38.5),
-        qieSlope      = cms.vdouble(0.907,0.915,0.920,0.921)
+        qieSlope      = cms.vdouble(0.907,0.915,0.920,0.921),
+        mcShape       = cms.int32(201),
+        recoShape     = cms.int32(201),
     ),
     hbUpgrade = cms.PSet(
         pedestal      = cms.double(17.3),
@@ -65,7 +73,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0),
         qieType       = cms.int32(2),
         qieOffset     = cms.vdouble(0.,0.,0.,0.),
-        qieSlope      = cms.vdouble(0.333,0.333,0.333,0.333)
+        qieSlope      = cms.vdouble(0.333,0.333,0.333,0.333),
+        mcShape       = cms.int32(203),
+        recoShape     = cms.int32(203),
     ),
     heUpgrade = cms.PSet(
         pedestal      = cms.double(17.3),
@@ -74,7 +84,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0),
         qieType       = cms.int32(2),
         qieOffset     = cms.vdouble(0.,0.,0.,0.),
-        qieSlope      = cms.vdouble(0.333,0.333,0.333,0.333)
+        qieSlope      = cms.vdouble(0.333,0.333,0.333,0.333),
+        mcShape       = cms.int32(203),
+        recoShape     = cms.int32(203),
     ),
     hfUpgrade = cms.PSet(
         pedestal      = cms.double(13.33),
@@ -83,7 +95,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         gainWidth     = cms.vdouble(0.0,0.0),
         qieType       = cms.int32(1),
         qieOffset     = cms.vdouble(0.0697,-0.7405,12.38,-671.9),
-        qieSlope      = cms.vdouble(0.297,0.298,0.298,0.313)
+        qieSlope      = cms.vdouble(0.297,0.298,0.298,0.313),
+        mcShape       = cms.int32(301),
+        recoShape     = cms.int32(301),
     ),
 )
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -776,6 +776,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hb.add<std::vector<double>>("qieOffset", std::vector<double>({-0.49, 1.8, 7.2, 37.9}));
 	desc_hb.add<std::vector<double>>("qieSlope", std::vector<double>({0.912, 0.917, 0.922, 0.923}));
 	desc_hb.add<int>("qieType", 0);
+	desc_hb.add<int>("mcShape",125);
+	desc_hb.add<int>("recoShape",105);
 	desc.add<edm::ParameterSetDescription>("hb", desc_hb);
 
 	edm::ParameterSetDescription desc_hbUpgrade;
@@ -786,6 +788,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hbUpgrade.add<std::vector<double>>("qieOffset", std::vector<double>({0.0, 0.0, 0.0, 0.0}));
 	desc_hbUpgrade.add<std::vector<double>>("qieSlope", std::vector<double>({0.333, 0.333, 0.333, 0.333}));
 	desc_hbUpgrade.add<int>("qieType", 2);
+	desc_hbUpgrade.add<int>("mcShape",203);
+	desc_hbUpgrade.add<int>("recoShape",203);
 	desc.add<edm::ParameterSetDescription>("hbUpgrade", desc_hbUpgrade);
 
 	edm::ParameterSetDescription desc_he;
@@ -796,6 +800,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_he.add<std::vector<double>>("qieOffset", std::vector<double>({-0.38, 2.0, 7.6, 39.6}));
 	desc_he.add<std::vector<double>>("qieSlope", std::vector<double>({0.912, 0.916, 0.92, 0.922}));
 	desc_he.add<int>("qieType", 0);
+	desc_he.add<int>("mcShape",125);
+	desc_he.add<int>("recoShape",105);
 	desc.add<edm::ParameterSetDescription>("he", desc_he);
 
 	edm::ParameterSetDescription desc_heUpgrade;
@@ -806,6 +812,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_heUpgrade.add<std::vector<double>>("qieOffset", std::vector<double>({0.0, 0.0, 0.0, 0.0}));
 	desc_heUpgrade.add<std::vector<double>>("qieSlope", std::vector<double>({0.333, 0.333, 0.333, 0.333}));
 	desc_heUpgrade.add<int>("qieType", 2);
+	desc_heUpgrade.add<int>("mcShape",203);
+	desc_heUpgrade.add<int>("recoShape",203);
 	desc.add<edm::ParameterSetDescription>("heUpgrade", desc_heUpgrade);
 
 	edm::ParameterSetDescription desc_hf;
@@ -816,6 +824,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hf.add<std::vector<double>>("qieOffset", std::vector<double>({-0.87, 1.4, 7.8, -29.6}));
 	desc_hf.add<std::vector<double>>("qieSlope", std::vector<double>({0.359, 0.358, 0.36, 0.367}));
 	desc_hf.add<int>("qieType", 0);
+	desc_hf.add<int>("mcShape",301);
+	desc_hf.add<int>("recoShape",301);
 	desc.add<edm::ParameterSetDescription>("hf", desc_hf);
 
 	edm::ParameterSetDescription desc_hfUpgrade;
@@ -826,14 +836,16 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hfUpgrade.add<std::vector<double>>("qieOffset", std::vector<double>({0.0697, -0.7405, 12.38, -671.9}));
 	desc_hfUpgrade.add<std::vector<double>>("qieSlope", std::vector<double>({0.297, 0.298, 0.298, 0.313}));
 	desc_hfUpgrade.add<int>("qieType", 1);
+	desc_hfUpgrade.add<int>("mcShape",301);
+	desc_hfUpgrade.add<int>("recoShape",301);
 	desc.add<edm::ParameterSetDescription>("hfUpgrade", desc_hfUpgrade);
   
-  edm::ParameterSetDescription desc_hfrecal;
-  desc_hfrecal.add<std::vector<double>>("HFdepthOneParameterA", std::vector<double>());
-  desc_hfrecal.add<std::vector<double>>("HFdepthOneParameterB", std::vector<double>());
-  desc_hfrecal.add<std::vector<double>>("HFdepthTwoParameterA", std::vector<double>());
-  desc_hfrecal.add<std::vector<double>>("HFdepthTwoParameterB", std::vector<double>());
-  desc.add<edm::ParameterSetDescription>("HFRecalParameterBlock", desc_hfrecal);
+	edm::ParameterSetDescription desc_hfrecal;
+	desc_hfrecal.add<std::vector<double>>("HFdepthOneParameterA", std::vector<double>());
+	desc_hfrecal.add<std::vector<double>>("HFdepthOneParameterB", std::vector<double>());
+	desc_hfrecal.add<std::vector<double>>("HFdepthTwoParameterA", std::vector<double>());
+	desc_hfrecal.add<std::vector<double>>("HFdepthTwoParameterB", std::vector<double>());
+	desc.add<edm::ParameterSetDescription>("HFRecalParameterBlock", desc_hfrecal);
 
 	edm::ParameterSetDescription desc_ho;
 	desc_ho.add<std::vector<double>>("gain", std::vector<double>({0.006, 0.0087}));
@@ -843,6 +855,8 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_ho.add<std::vector<double>>("qieOffset", std::vector<double>({-0.44, 1.4, 7.1, 38.5}));
 	desc_ho.add<std::vector<double>>("qieSlope", std::vector<double>({0.907, 0.915, 0.92, 0.921}));
 	desc_ho.add<int>("qieType", 0);
+	desc_ho.add<int>("mcShape",201);
+	desc_ho.add<int>("recoShape",201);
 	desc.add<edm::ParameterSetDescription>("ho", desc_ho);
 
 	

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -18,7 +18,7 @@ class HcalTopology;
 class HcalShapes : public CaloShapes
 {
 public:
-  enum {HPD=101, LONG=102, ZECOTEK=201, HAMAMATSU=202, HF=301, ZDC=401};
+  enum {HPD=101, LONG=102, ZECOTEK=201, HAMAMATSU=202, HE2017=203, HF=301, ZDC=401};
   HcalShapes();
   ~HcalShapes();
 
@@ -46,6 +46,7 @@ private:
   HcalShape theHcalShape125;
   HcalShape theHcalShape201;
   HcalShape theHcalShape202;
+  HcalShape theHcalShape203;
   HcalShape theHcalShape301;
   HcalShape theHcalShape401;
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -8,9 +8,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShape.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HFShape.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/ZDCShape.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HcalSiPMShape.h"
 #include <map>
 class CaloVShape;
 class DetId;
@@ -30,16 +28,13 @@ public:
   virtual const CaloVShape * shape(const DetId & detId) const;
 
 private:
-  // hardcoded, if we can't figure it out form the DB
+  // hardcoded, if we can't figure it out from the DB
   const CaloVShape * defaultShape(const DetId & detId) const;
   HcalMCParams * theMCParams;
   const HcalTopology * theTopology;
   typedef std::map<int, const CaloVShape *> ShapeMap;
   ShapeMap theShapes;
-  // HcalShape theHcalShape;
-  // HFShape theHFShape;
   ZDCShape theZDCShape;
-  // HcalSiPMShape theSiPMShape;
   //   list of vShapes.
   HcalShape theHcalShape101;
   HcalShape theHcalShape102;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShape.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShape.cc
@@ -1,9 +1,8 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShape.h"
   
 HcalShape::HcalShape()
-// : shape_(HcalPulseShapes().hbShape())
 {
-   // no more defual shape is defined (since cmssw 5x)
+   // no default shape is defined (since cmssw 5x)
 }
 
 void HcalShape::setShape(int shapeType)

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -23,6 +23,7 @@ HcalShapes::HcalShapes()
   theHcalShape125(),
   theHcalShape201(),
   theHcalShape202(),
+  theHcalShape203(),
   theHcalShape301(),
   theHcalShape401()
  {
@@ -32,6 +33,7 @@ HcalShapes::HcalShapes()
         102 - "special" HB HPD#14 long shape
         201 - SiPMs Zecotec shape   (HO)
         202 - SiPMs Hamamatsu shape (HO)
+        203 - SiPMs Hamamatsu shape (HE 2017)
         301 - regular HF PMT shape
         401 - regular ZDC shape
   */
@@ -56,6 +58,8 @@ HcalShapes::HcalShapes()
   theShapes[201] = new CaloCachedShapeIntegrator(&theHcalShape201);
   theHcalShape202.setShape(202);                  
   theShapes[202] = new CaloCachedShapeIntegrator(&theHcalShape202);
+  theHcalShape203.setShape(203);
+  theShapes[203] = new CaloCachedShapeIntegrator(&theHcalShape203);
   theHcalShape301.setShape(301);
   theShapes[301] = new CaloCachedShapeIntegrator(&theHcalShape301);
   //    ZDC not yet defined in CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -128,13 +132,13 @@ const CaloVShape * HcalShapes::defaultShape(const DetId & detId) const
   HcalGenericDetId::HcalGenericSubdetector subdet 
     = HcalGenericDetId(detId).genericSubdet();
   if(subdet == HcalGenericDetId::HcalGenBarrel 
-  || subdet == HcalGenericDetId::HcalGenEndcap) result = theShapes.find(0)->second;
-  else if(subdet == HcalGenericDetId::HcalGenOuter) result = theShapes.find(2)->second;
-  else if(subdet == HcalGenericDetId::HcalGenForward) result = theShapes.find(3)->second;
-  else if(subdet == HcalGenericDetId::HcalGenZDC) result = theShapes.find(3)->second;
+  || subdet == HcalGenericDetId::HcalGenEndcap) result = theShapes.find(HPD)->second;
+  else if(subdet == HcalGenericDetId::HcalGenOuter) result = theShapes.find(HPD)->second;
+  else if(subdet == HcalGenericDetId::HcalGenForward) result = theShapes.find(HF)->second;
+  else if(subdet == HcalGenericDetId::HcalGenZDC) result = theShapes.find(ZDC)->second;
   else result = 0;
 
-  edm::LogWarning("HcalShapes") << "Cannot find HCAL MC Params, so the defalut one is taken for  subdet " << subdet;  
+  edm::LogWarning("HcalShapes") << "Cannot find HCAL MC Params, so the default one is taken for subdet " << subdet;  
 
   return result;
 }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -36,14 +36,6 @@ HcalShapes::HcalShapes()
         401 - regular ZDC shape
   */
 
-/*  
-  theShapes[HPD] = new CaloCachedShapeIntegrator(&theHcalShape);
-  theShapes[LONG] = theShapes[HPD];
-  theShapes[ZECOTEK] = new CaloCachedShapeIntegrator(&theSiPMShape);
-  theShapes[HAMAMATSU] = theShapes[ZECOTEK];
-  theShapes[HF] = new CaloCachedShapeIntegrator(&theHFShape);
-*/
-
   theHcalShape101.setShape(101); 
   theShapes[101] = new CaloCachedShapeIntegrator(&theHcalShape101);
   theHcalShape102.setShape(102);                  
@@ -70,17 +62,6 @@ HcalShapes::HcalShapes()
   // theHcalShape401(401);
   // theShapes[401] = new CaloCachedShapeIntegrator(&theHcalShape401);
   theShapes[ZDC] = new CaloCachedShapeIntegrator(&theZDCShape);
-
-
-
-  // backward-compatibility with old scheme
-
-  theShapes[0] = theShapes[HPD];
-  //FIXME "special" HB
-  theShapes[1] = theShapes[LONG];
-  theShapes[2] = theShapes[ZECOTEK];
-  theShapes[3] = theShapes[HF];
-  theShapes[4] = theShapes[ZDC];
 
   theMCParams=0;
   theTopology=0;
@@ -130,19 +111,6 @@ const CaloVShape * HcalShapes::shape(const DetId & detId) const
     return defaultShape(detId);
   }
   int shapeType = theMCParams->getValues(detId)->signalShape();
-  /*
-	  HcalDetId cell(detId);
-	  int sub     = cell.subdet();
-	  int depth   = cell.depth();
-	  int inteta  = cell.ieta();
-	  int intphi  = cell.iphi();
-	  
-	  std::cout << "(SIM)HcalShapes::shape  cell:" 
-		    << " sub, ieta, iphi, depth = " 
-		    << sub << "  " << inteta << "  " << intphi 
-		    << "  " << depth  << " => ShapeId "<<  shapeType 
-		    << std::endl;
-  */
   ShapeMap::const_iterator shapeMapItr = theShapes.find(shapeType);
   if(shapeMapItr == theShapes.end()) {
        edm::LogWarning("HcalShapes") << "HcalShapes::shape - shapeType ?  = "


### PR DESCRIPTION
This PR adds a new reco pulse shape for the HE SiPMs to be installed in 2017 (needed for Method 2 reconstruction). This pulse shape is computed using a numerical convolution of the simulated SiPM pulse shape and the Y11 wavelength shifting fiber pulse shape. For more details, see this recent presentation in the HCAL Phase 1 Software Task Force Meeting: https://indico.cern.ch/event/559519/contributions/2257748/attachments/1317836/1974957/sipm_pulse_shape_reco_MC.pdf.

Other changes in this PR:
- minor cleanup of the pulse-shape-related code
- mcShape and recoShape numbers are now configurable via Python in HcalHardcodeCalibrations

attn: @abdoulline, @mariadalfonso 
