### PR TITLE
Don't produce GEMCoPadDigi in 2016 WFs

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -49,6 +49,11 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   gemPadDigiProducer_ = conf.existsAs<edm::InputTag>("GEMPadDigiProducer")?conf.getParameter<edm::InputTag>("GEMPadDigiProducer"):edm::InputTag("");
   rpcDigiProducer_ = conf.existsAs<edm::InputTag>("RPCDigiProducer")?conf.getParameter<edm::InputTag>("RPCDigiProducer"):edm::InputTag("");
   checkBadChambers_ = conf.getParameter<bool>("checkBadChambers");
+
+  const edm::ParameterSet commonParam(conf.getParameter<edm::ParameterSet>("commonParam"));
+  runME11ILT_ = commonParam.existsAs<bool>("runME11ILT")?commonParam.getParameter<bool>("runME11ILT"):false;
+  runME21ILT_ = commonParam.existsAs<bool>("runME21ILT")?commonParam.getParameter<bool>("runME21ILT"):false;
+
   lctBuilder_.reset( new CSCTriggerPrimitivesBuilder(conf) ); // pass on the conf
   
   wire_token_ = consumes<CSCWireDigiCollection>(wireDigiProducer_);
@@ -62,7 +67,8 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   produces<CSCCLCTPreTriggerCollection>();
   produces<CSCCorrelatedLCTDigiCollection>();
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
-  produces<GEMCoPadDigiCollection>();
+  if (runME11ILT_ or runME21ILT_)
+    produces<GEMCoPadDigiCollection>();
   usesResource("CSCTriggerGeometry");
   consumes<CSCComparatorDigiCollection>(compDigiProducer_);
   consumes<CSCWireDigiCollection>(wireDigiProducer_);
@@ -194,5 +200,6 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev,
   ev.put(std::move(oc_pretrig));
   ev.put(std::move(oc_lct));
   ev.put(std::move(oc_sorted_lct),"MPCSORTED");
-  ev.put(std::move(oc_gemcopad));
+  if (runME11ILT_ or runME21ILT_)
+    ev.put(std::move(oc_gemcopad));
 }

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -59,6 +59,8 @@ class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<edm::one::Share
   bool debugParameters_;
   // switch to for enabling checking against the list of bad chambers
   bool checkBadChambers_;
+  bool runME11ILT_;
+  bool runME21ILT_;
   std::unique_ptr<CSCTriggerPrimitivesBuilder> lctBuilder_;
 };
 


### PR DESCRIPTION
GEMCoPadDigiCollection is only produced and put in the event when the GEM-CSC integrated local triggers are on. I compiled and tested the code with <PRE> runTheMatrix.py -l 1330.0 -i all </PRE>
