### PR TITLE
80X - Added CSC Unpacker check for FED/DDU<->chamber mapping inconsistencies

### DIFF
--- a/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
@@ -89,7 +89,8 @@ void CSCDCCEventData::unpack_data(unsigned short *buf, CSCDCCExaminer* examiner)
   if (debug) LogTrace ("CSCDCCEventData|CSCRawToDigi") <<"decoding DCC trailer";
   memcpy(&theDCCTrailer, buf, theDCCTrailer.sizeInWords()*2);
   if (debug) LogTrace("CSCDCCEventData|CSCRawToDigi") << "checking DDU Trailer" << theDCCTrailer.check(); 
-  buf += theDCCTrailer.sizeInWords();
+ 
+  // buf += theDCCTrailer.sizeInWords(); /* =VB= Commented out to please static analyzer */ 
 
   //std::cout << " DCC Size: " << std::dec << theSizeInWords << std::endl;
   //std::cout << "LastBuf: "  << std::hex << inputBuf[theSizeInWords-4] << std::endl;

--- a/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
@@ -51,7 +51,7 @@ std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) 
         {
           CFEBnData.push_back(getData()[i] & 0xFFF);
         }
-      idCFEB = -1;
+      // idCFEB = -1; /* =VB= Commented out to please static analyzer */
     }
 
   std::vector<int> Layer0, Layer1, Layer2, Layer3, Layer4, Layer5;


### PR DESCRIPTION
- Added check to CSC Unpacker for FED/DDU<->chamber mapping inconsistencies to prevent CSC reco crashes in case of rare data corruptions (a case when faulty chamber sends corrupted data posing as chamber with different ID). 
- Handled few reported CMSSW static analyzer warnings.
