### PR TITLE
Subjet TagInfo updates

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
@@ -125,9 +125,9 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 
     // construct the Jet from the ref -> save ref to original object
     unsigned int idx = itJet - jets->begin();
-    edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
-    edm::Ptr<reco::Jet> jetPtr = jets->ptrAt(idx);
-    Jet ajet( edm::RefToBase<Jet>(jetRef.castTo<JetRef>()) );
+    const edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
+    const edm::RefToBase<Jet> patJetRef(jetRef.castTo<JetRef>());
+    Jet ajet( patJetRef );
 
     if (addJetCorrFactors_) {
       // undo previous jet energy corrections
@@ -197,6 +197,10 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     if ( useUserData_ ) {
       userDataHelper_.add( ajet, iEvent, iSetup );
     }
+
+    // reassign the original object reference to preserve reference to the original jet the input PAT jet was derived from
+    // (this needs to be done at the end since cloning the input PAT jet would interfere with adding UserData)
+    ajet.refToOrig_ = patJetRef->originalObjectRef();
 
     patJets->push_back(ajet);
   }

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -159,14 +159,15 @@ def setupJetCorrections(process, knownModules, jetCorrections, jetSource, pvSour
             setattr(process, 'patMETs'+labelName+postfix, patMETs.clone(metSource = cms.InputTag(jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix), addMuonCorrections = False))
 
 
-def setupSVClustering(btagInfo, algo, rParam, fatJets=cms.InputTag(''), groomedFatJets=cms.InputTag('')):
-    btagInfo.useSVClustering = cms.bool(True)
-    btagInfo.jetAlgorithm    = cms.string(algo)
-    btagInfo.rParam          = cms.double(rParam)
-    ## if the jets is actually a subjet
-    if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
-        btagInfo.fatJets        = fatJets
-        btagInfo.groomedFatJets = groomedFatJets
+def setupSVClustering(btagInfo, svClustering, algo, rParam, fatJets=cms.InputTag(''), groomedFatJets=cms.InputTag('')):
+    btagInfo.useSVClustering = cms.bool(svClustering)
+    btagInfo.jetAlgorithm = cms.string(algo)
+    btagInfo.rParam = cms.double(rParam)
+    ## if the jet is actually a subjet
+    if fatJets != cms.InputTag(''):
+        btagInfo.fatJets = fatJets
+        if groomedFatJets != cms.InputTag(''):
+            btagInfo.groomedFatJets = groomedFatJets
 
 
 def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSource, elSource, muSource, runIVF, loadStdRecoBTag, svClustering, fatJets, groomedFatJets,
@@ -225,16 +226,16 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 setattr(process, btagInfo+labelName+postfix, btag.pfSecondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+labelName+postfix)))
             if btagInfo == 'pfInclusiveSecondaryVertexFinderTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.pfInclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+labelName+postfix), extSVCollection=svSource))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfInclusiveSecondaryVertexFinderAK8TagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.pfInclusiveSecondaryVertexFinderAK8TagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterAK8TagInfos'+labelName+postfix), extSVCollection=svSource))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfInclusiveSecondaryVertexFinderCA15TagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.pfInclusiveSecondaryVertexFinderCA15TagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterCA15TagInfos'+labelName+postfix), extSVCollection=svSource))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfInclusiveSecondaryVertexFinderCvsLTagInfos':
                 setattr(
                     process, 
@@ -244,8 +245,8 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                         extSVCollection=svSource
                         )
                     )
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfInclusiveSecondaryVertexFinderCvsBTagInfos':
                 setattr(
                     process, 
@@ -255,8 +256,8 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                         extSVCollection=svSource
                         )
                     )
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos':
                  setattr(
                     process,
@@ -266,8 +267,8 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                         extSVCollection=svSource
                         )
                     )
-                 if svClustering:
-                     setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                 if svClustering or fatJets != cms.InputTag(''):
+                     setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfGhostTrackVertexTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.pfGhostTrackVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+labelName+postfix)))
             if btagInfo == 'pfGhostTrackTagVertexInfosAK8':
@@ -276,30 +277,30 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 setattr(process, btagInfo+labelName+postfix, btag.pfSecondaryVertexNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+labelName+postfix)))
             if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.pfInclusiveSecondaryVertexFinderNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+labelName+postfix), extSVCollection=svSource))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'impactParameterTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.impactParameterTagInfos.clone(jetTracks = cms.InputTag('jetTracksAssociatorAtVertex'+labelName+postfix), primaryVertex=pvSource))
             if btagInfo == 'secondaryVertexTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.secondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
             if btagInfo == 'inclusiveSecondaryVertexFinderTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.inclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'inclusiveSecondaryVertexFinderFilteredTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.inclusiveSecondaryVertexFinderFilteredTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'secondaryVertexNegativeTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.secondaryVertexNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
             if btagInfo == 'inclusiveSecondaryVertexFinderNegativeTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.inclusiveSecondaryVertexFinderNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'inclusiveSecondaryVertexFinderFilteredNegativeTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+labelName+postfix)))
-                if svClustering:
-                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), algo, rParam, fatJets, groomedFatJets)
+                if svClustering or fatJets != cms.InputTag(''):
+                    setupSVClustering(getattr(process, btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'softMuonTagInfos':
                 setattr(process, btagInfo+labelName+postfix, btag.softMuonTagInfos.clone(jets = jetSource, primaryVertex=pvSource))
             if btagInfo == 'softPFMuonsTagInfos':

--- a/PhysicsTools/PatAlgos/test/patTuple_updateJets_fromMiniAOD_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_updateJets_fromMiniAOD_cfg.py
@@ -27,7 +27,7 @@ updateJetCollection(
 )
 process.updatedPatJets.userData.userFloats.src += ['oldJetMass']
 
-## An example where the jet correction is undone
+## An example where the jet corrections are undone
 updateJetCollection(
    process,
    labelName = 'UndoneJEC',
@@ -36,7 +36,7 @@ updateJetCollection(
 )
 process.updatedPatJetsUndoneJEC.userData.userFloats.src = []
 
-## An example where the jet correction are reapplied
+## An example where the jet corrections are reapplied
 updateJetCollection(
    process,
    labelName = 'ReappliedJEC',
@@ -44,6 +44,22 @@ updateJetCollection(
    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None')
 )
 process.updatedPatJetsReappliedJEC.userData.userFloats.src = []
+
+## An example where the jet energy corrections are updated to the current GlobalTag
+## and specified b-tag discriminators are rerun and added to SoftDrop subjets
+updateJetCollection(
+   process,
+   labelName = 'SoftDropSubjets',
+   jetSource = cms.InputTag('slimmedJetsAK8PFCHSSoftDropPacked:SubJets'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+   btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags'],
+   explicitJTA = True,          # needed for subjet b tagging
+   svClustering = False,        # needed for subjet b tagging (IMPORTANT: Needs to be set to False to disable ghost-association which does not work with slimmed jets)
+   fatJets = cms.InputTag('slimmedJetsAK8'), # needed for subjet b tagging
+   rParam = 0.8,                # needed for subjet b tagging
+   algo = 'ak'                  # has to be defined but is not used with svClustering=False
+)
+process.updatedPatJetsSoftDropSubjets.userData.userFloats.src = []
 
 ## ------------------------------------------------------
 #  In addition you usually want to change the following

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -21,6 +21,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -127,6 +128,9 @@ class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
 			  const edm::Handle<edm::View<reco::Jet> >& groomedJets,
 			  const edm::Handle<std::vector<IPTI> >& subjets,
 			  std::vector<std::vector<int> >& matchedIndices);
+	void matchSubjets(const edm::Handle<edm::View<reco::Jet> >& fatJets,
+			  const edm::Handle<std::vector<IPTI> >& subjets,
+			  std::vector<std::vector<int> >& matchedIndices);
 	
 	const reco::Jet * toJet(const reco::Jet & j) { return &j; }
 	const reco::Jet * toJet(const IPTI & j) { return &(*(j.jet())); }
@@ -164,6 +168,7 @@ class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
 	double				ghostRescaling;
 	double				relPtTolerance;
 	bool				useFatJets;
+	bool				useGroomedFatJets;
 	edm::EDGetTokenT<edm::View<reco::Jet> > token_fatJets;
 	edm::EDGetTokenT<edm::View<reco::Jet> > token_groomedFatJets;
 	
@@ -273,15 +278,16 @@ TemplatedSecondaryVertexProducer<IPTI,VTX>::TemplatedSecondaryVertexProducer(
 	    constraint == CONSTRAINT_BEAMSPOT ||
 	    constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT )
 	    token_BeamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpotTag"));
-        useExternalSV = false;
-        if(params.existsAs<bool>("useExternalSV")) useExternalSV = params.getParameter<bool> ("useExternalSV");
-        if(useExternalSV) {
+	useExternalSV = false;
+	if(params.existsAs<bool>("useExternalSV")) useExternalSV = params.getParameter<bool> ("useExternalSV");
+	if(useExternalSV) {
 	   token_extSVCollection =  consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));
-       	   extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");
-        }
-        useSVClustering = ( params.existsAs<bool>("useSVClustering") ? params.getParameter<bool>("useSVClustering") : false );
+	   extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");
+	}
+	useSVClustering = ( params.existsAs<bool>("useSVClustering") ? params.getParameter<bool>("useSVClustering") : false );
 	useSVMomentum = ( params.existsAs<bool>("useSVMomentum") ? params.getParameter<bool>("useSVMomentum") : false );
-        useFatJets = ( useExternalSV && params.exists("fatJets") && params.exists("groomedFatJets") );
+	useFatJets = ( useExternalSV && params.exists("fatJets") );
+	useGroomedFatJets = ( useExternalSV && params.exists("groomedFatJets") );
 	if( useSVClustering )
 	{
 	  jetAlgorithm = params.getParameter<std::string>("jetAlgorithm");
@@ -301,11 +307,9 @@ TemplatedSecondaryVertexProducer<IPTI,VTX>::TemplatedSecondaryVertexProducer(
 	    throw cms::Exception("InvalidJetAlgorithm") << "Jet clustering algorithm is invalid: " << jetAlgorithm << ", use CambridgeAachen | Kt | AntiKt" << std::endl;
 	}
 	if( useFatJets )
-	{
 	  token_fatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("fatJets"));
+	if( useGroomedFatJets )
 	  token_groomedFatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("groomedFatJets"));
-	}
-	
 	if( useFatJets && !useSVClustering )
 	  rParam = params.getParameter<double>("rParam"); // will be used later as a dR cut
 	
@@ -342,10 +346,14 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	if( useFatJets )
 	{
 	  event.getByToken(token_fatJets, fatJetsHandle);
-	  event.getByToken(token_groomedFatJets, groomedFatJetsHandle);
 	
-	  if( groomedFatJetsHandle->size() > fatJetsHandle->size() )
-            edm::LogError("TooManyGroomedJets") << "There are more groomed (" << groomedFatJetsHandle->size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the two jet collections belong to each other.";
+	  if( useGroomedFatJets )
+	  {
+	    event.getByToken(token_groomedFatJets, groomedFatJetsHandle);
+	
+	    if( groomedFatJetsHandle->size() > fatJetsHandle->size() )
+	      edm::LogError("TooManyGroomedJets") << "There are more groomed (" << groomedFatJetsHandle->size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the two jet collections belong to each other.";
+	  }
 	}
 
 	edm::Handle<BeamSpot> beamSpot;
@@ -444,7 +452,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	  if( useFatJets )
 	  {
 	    if( inclusiveJets.size() < fatJetsHandle->size() )
-             edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
+	      edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
 
 	    // match reclustered and original fat jets
 	    std::vector<int> reclusteredIndices;
@@ -452,11 +460,15 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 
 	    // match groomed and original fat jets
 	    std::vector<int> groomedIndices;
-	    matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
+	    if( useGroomedFatJets )
+	      matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
 
 	    // match subjets and original fat jets
 	    std::vector<std::vector<int> > subjetIndices;
-	    matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
+	    if( useGroomedFatJets )
+	      matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
+	    else
+	      matchSubjets(fatJetsHandle,trackIPTagInfos,subjetIndices);
 	
 	    // collect clustered SVs
 	    for(size_t i=0; i<fatJetsHandle->size(); ++i)
@@ -572,11 +584,15 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	{
 	  // match groomed and original fat jets
 	  std::vector<int> groomedIndices;
-	  matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
+	  if( useGroomedFatJets )
+	    matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
 
 	  // match subjets and original fat jets
 	  std::vector<std::vector<int> > subjetIndices;
-	  matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
+	  if( useGroomedFatJets )
+	    matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
+	  else
+	    matchSubjets(fatJetsHandle,trackIPTagInfos,subjetIndices);
 
 	  // loop over fat jets
 	  for(size_t i=0; i<fatJetsHandle->size(); ++i)
@@ -1124,6 +1140,60 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const std::vector<
 
        if( subjetIndices.size() == 0 )
          edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the groomed fat jet and subjet collections belong to each other.";
+
+       matchedIndices.push_back(subjetIndices);
+     }
+     else
+       matchedIndices.push_back(subjetIndices);
+   }
+}
+
+// ------------ method that matches subjets and original fat jets ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const edm::Handle<edm::View<reco::Jet> >& fatJets,
+                                                              const edm::Handle<std::vector<IPTI> >& subjets,
+                                                              std::vector<std::vector<int> >& matchedIndices)
+{
+   for(size_t fj=0; fj<fatJets->size(); ++fj)
+   {
+     std::vector<int> subjetIndices;
+     size_t nSubjetCollections = 0;
+     size_t nSubjets = 0;
+
+     const pat::Jet * fatJet = dynamic_cast<const pat::Jet *>( fatJets->ptrAt(fj).get() );
+
+     if( !fatJet )
+       edm::LogError("WrongJetType") << "Wrong jet type for input fat jets. Please check that the input fat jets are of the pat::Jet type.";
+     else
+       nSubjetCollections = fatJet->subjetCollectionNames().size();
+
+     if( nSubjetCollections>0 )
+     {
+       for(size_t coll=0; coll<nSubjetCollections; ++coll)
+       {
+         const pat::JetPtrCollection & fatJetSubjets = fatJet->subjets(coll);
+
+         for(size_t fjsj=0; fjsj<fatJetSubjets.size(); ++fjsj)
+         {
+           ++nSubjets;
+
+           for(size_t sj=0; sj<subjets->size(); ++sj)
+           {
+             const pat::Jet * subJet = dynamic_cast<const pat::Jet *>( subjets->at(sj).jet().get() );
+             if( !subJet )
+               edm::LogError("WrongJetType") << "Wrong jet type for input subjets. Please check that the input subjets are of the pat::Jet type.";
+
+             if( subJet->originalObjectRef() == fatJetSubjets.at(fjsj)->originalObjectRef() )
+             {
+               subjetIndices.push_back(sj);
+               break;
+             }
+           }
+         }
+       }
+
+       if( subjetIndices.size() == 0 && nSubjets > 0)
+         edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the fat jet and subjet collections belong to each other.";
 
        matchedIndices.push_back(subjetIndices);
      }

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -1163,42 +1163,56 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const edm::Handle<
      const pat::Jet * fatJet = dynamic_cast<const pat::Jet *>( fatJets->ptrAt(fj).get() );
 
      if( !fatJet )
-       edm::LogError("WrongJetType") << "Wrong jet type for input fat jets. Please check that the input fat jets are of the pat::Jet type.";
+     {
+       if( fj==0 ) edm::LogError("WrongJetType") << "Wrong jet type for input fat jets. Please check that the input fat jets are of the pat::Jet type.";
+
+       matchedIndices.push_back(subjetIndices);
+       continue;
+     }
      else
+     {
        nSubjetCollections = fatJet->subjetCollectionNames().size();
 
-     if( nSubjetCollections>0 )
-     {
-       for(size_t coll=0; coll<nSubjetCollections; ++coll)
+       if( nSubjetCollections>0 )
        {
-         const pat::JetPtrCollection & fatJetSubjets = fatJet->subjets(coll);
-
-         for(size_t fjsj=0; fjsj<fatJetSubjets.size(); ++fjsj)
+         for(size_t coll=0; coll<nSubjetCollections; ++coll)
          {
-           ++nSubjets;
+           const pat::JetPtrCollection & fatJetSubjets = fatJet->subjets(coll);
 
-           for(size_t sj=0; sj<subjets->size(); ++sj)
+           for(size_t fjsj=0; fjsj<fatJetSubjets.size(); ++fjsj)
            {
-             const pat::Jet * subJet = dynamic_cast<const pat::Jet *>( subjets->at(sj).jet().get() );
-             if( !subJet )
-               edm::LogError("WrongJetType") << "Wrong jet type for input subjets. Please check that the input subjets are of the pat::Jet type.";
+             ++nSubjets;
 
-             if( subJet->originalObjectRef() == fatJetSubjets.at(fjsj)->originalObjectRef() )
+             for(size_t sj=0; sj<subjets->size(); ++sj)
              {
-               subjetIndices.push_back(sj);
-               break;
+               const pat::Jet * subJet = dynamic_cast<const pat::Jet *>( subjets->at(sj).jet().get() );
+
+               if( !subJet )
+               {
+                 if( fj==0 && coll==0 && fjsj==0 && sj==0 ) edm::LogError("WrongJetType") << "Wrong jet type for input subjets. Please check that the input subjets are of the pat::Jet type.";
+
+                 break;
+               }
+               else
+               {
+                 if( subJet->originalObjectRef() == fatJetSubjets.at(fjsj)->originalObjectRef() )
+                 {
+                   subjetIndices.push_back(sj);
+                   break;
+                 }
+               }
              }
            }
          }
+
+         if( subjetIndices.size() == 0 && nSubjets > 0)
+           edm::LogError("SubjetMatchingFailed") << "Matching subjets to fat jets failed. Please check that the fat jet and subjet collections belong to each other.";
+
+         matchedIndices.push_back(subjetIndices);
        }
-
-       if( subjetIndices.size() == 0 && nSubjets > 0)
-         edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the fat jet and subjet collections belong to each other.";
-
-       matchedIndices.push_back(subjetIndices);
+       else
+         matchedIndices.push_back(subjetIndices);
      }
-     else
-       matchedIndices.push_back(subjetIndices);
    }
 }
 


### PR DESCRIPTION
This PR adds new features to the SV TagInfo producer that allow making subjet TagInfos using simple cone-based instead of ghost association to fat jets. The code now also makes it possible to perform such association using PATified fat jets and subjets. To fully exploit this last feature it was necessary to update the PATJetUpdater so that PAT jets are cloned (not constructed from a reference) in order to preserve the reference to the original object the PAT jet was derived from (this is necessary for re-establishing references between updated PAT fat jets and subjets). Finally, minor changes were added to jetTools.py to properly configure the updated SV TagInfo producer.

This is purely an analysis level update. There should be no impact on the standard reconstruction or MiniAOD production.
