### PR TITLE
Update Hcal MC pulse shapes in all Global Tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,33 +10,33 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '81X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v3',
+    'run2_design'       :   '81X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v3',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v2',
+    'run1_data'         :   '81X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v2',
+    'run2_data'         :   '81X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v0',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v0',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v0',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v7',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v8',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v7',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v4) as [81X_mcRun2_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v4/81X_mcRun2_design_v3): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v4) as [81X_mcRun2cosmics_startup_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v4/81X_mcRun2cosmics_startup_peak_v3): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v4) as [81X_mcRun2_asymptotic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v4/81X_mcRun2_asymptotic_v3): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
- **RunII Startup scenario** : [81X_mcRun2_startup_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v4) as [81X_mcRun2_startup_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v4/81X_mcRun2_startup_v3): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
## RunII data
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v2) as [81X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v2/81X_dataRun2_HLT_relval_v1): 
  - updated HcalMCParams (to reflect MC pulse shapes update)
  - technical change of the Tracker Alignment tag (preparation for PCL)
- **RunII HLT relval processing** : [81X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v1) as [81X_dataRun2_HLTHI_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v1/81X_dataRun2_HLTHI_frozen_v0): 
  - updated HcalMCParams (to reflect MC pulse shapes update)
  - technical change of the Tracker Alignment tag (preparation for PCL) 
- **RunII HLT Heavy-lon processing** : [81X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v1) as [81X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v1/81X_dataRun2_HLT_frozen_v0): 
  - updated HcalMCParams (to reflect MC pulse shapes update)
  - technical change of the Tracker Alignment tag (preparation for PCL) 
- **RunII Offline relval processing** : [81X_dataRun2_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v4) as [81X_dataRun2_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v4/81X_dataRun2_relval_v3): 
  - updated HcalMCParams (to reflect MC pulse shapes update)
- **RunII Offline processing** : [81X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v3) as [81X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v3/81X_dataRun2_v2): 
  - updated HcalMCParams (to reflect MC pulse shapes update)
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v8) as [81X_upgrade2017_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v8/81X_upgrade2017_design_v7): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
- **PhaseI design scenario** : [81X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v8) as [81X_upgrade2017_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v8/81X_upgrade2017_design_v7): 
  - Updated Hcal pulse shapes to correct shift on the reco timing for HB+ iphi=54 in MC samples
