### PR TITLE
Fix http proxy setting in curl for Tier0 DataService query of the Event Display online application

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -85,7 +85,7 @@ class Tier0Handler( object ):
         userAgent = "User-Agent: DQMIntegration/2.0 python/%d.%d.%d PycURL/%s" % ( sys.version_info[ :3 ] + ( pycurl.version_info()[ 1 ], ) )
 
         proxy = ""
-        if self._proxy: proxy = ' --proxy=%s ' % self._proxy
+        if self._proxy: proxy = ' --proxy %s ' % self._proxy
         
         debug = " -s -S "
         if self._debug: debug = " -v "


### PR DESCRIPTION
Fix http proxy setting in `curl` for Tier0 DataService query in `DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py`: the invalid parameter was causing the event display to always fall back to the default Express GT.
