### PR TITLE
fixing typo in geometry in Strip hit efficiency tool 

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HitEff")
-process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag

--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HitEff")
-process.load("Configuration/Geometry.GeometryExtended2015Reco_cff")
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag


### PR DESCRIPTION
Trivial fix in our template for the strip hit efficiency tool (loading the right geom file )
@jlagram @dimattia , FYI
