### PR TITLE
update of Strip hit efficiency code - 80X version

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <fstream>
+#include <sstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -22,6 +24,11 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
+#include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h"
@@ -71,6 +78,7 @@
 #include "TGraphAsymmErrors.h"
 #include "TLatex.h"
 #include "TLegend.h"
+#include "TEfficiency.h"
 
 using namespace edm;
 using namespace reco;
@@ -98,6 +106,9 @@ class SiStripHitEffFromCalibTree : public ConditionDBWriter<SiStripBadStrip> {
     void makeSQLite();
     void totalStatistics();
     void makeSummary();
+    void makeSummaryVsBx();
+    TString GetLayerName(Long_t k);
+    TString GetLayerSideName(Long_t k);
     float calcPhi(float x, float y);
 
     edm::Service<TFileService> fs;
@@ -106,21 +117,39 @@ class SiStripHitEffFromCalibTree : public ConditionDBWriter<SiStripBadStrip> {
     SiStripQuality* quality_;
     SiStripBadStrip* getNewObject() override;
     
-    TFile* CalibTreeFile;
-    TTree* CalibTree;
-    TString CalibTreeFilename; 
+    TChain* CalibTree;
+    vector<string> CalibTreeFilenames; 
     float threshold;
     unsigned int nModsMin;
     unsigned int doSummary;
+    string _badModulesFile;
+    unsigned int _clusterMatchingMethod;
     float _ResXSig;
+    float _clusterTrajDist;
+    float _stripsApvEdge;
     unsigned int _bunchx;
+    unsigned int _spaceBetweenTrains;
+    bool _showEndcapSides;
+    bool  _showRings;
+    bool  _showTOB6TEC9;
+    float _tkMapMin;
+    float _effPlotMin;
+    TString _title;
+	
+    unsigned int nTEClayers;
+	
     vector<hit> hits[23];
     vector<TH2F*> HotColdMaps;
     map< unsigned int, pair< unsigned int, unsigned int> > modCounter[23];
     TrackerMap *tkmap;
     TrackerMap *tkmapbad;
+    TrackerMap *tkmapeff;
+    TrackerMap *tkmapnum;
+    TrackerMap *tkmapden;
     int layerfound[23];
     int layertotal[23];
+    map< unsigned int, vector<int> > layerfound_perBx;
+    map< unsigned int, vector<int> > layertotal_perBx;
     int goodlayertotal[35];
     int goodlayerfound[35];
     int alllayertotal[35];
@@ -132,13 +161,27 @@ SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& 
   ConditionDBWriter<SiStripBadStrip>(conf),
   FileInPath_("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat")
 {
-  CalibTreeFilename = conf.getParameter<std::string>("CalibTreeFilename"); 
+  CalibTreeFilenames = conf.getUntrackedParameter<vector<std::string> >("CalibTreeFilenames");
   threshold = conf.getParameter<double>("Threshold");
   nModsMin = conf.getParameter<int>("nModsMin");
   doSummary = conf.getParameter<int>("doSummary");
+  _badModulesFile = conf.getUntrackedParameter<std::string>("BadModulesFile", ""); 
+  _clusterMatchingMethod = conf.getUntrackedParameter<int>("ClusterMatchingMethod",0);
   _ResXSig = conf.getUntrackedParameter<double>("ResXSig",-1);
+  _clusterTrajDist = conf.getUntrackedParameter<double>("ClusterTrajDist",64.0);
+  _stripsApvEdge = conf.getUntrackedParameter<double>("StripsApvEdge",10.0);
   _bunchx = conf.getUntrackedParameter<int>("BunchCrossing",0);
+  _spaceBetweenTrains = conf.getUntrackedParameter<int>("SpaceBetweenTrains",25);
+  _showEndcapSides = conf.getUntrackedParameter<bool>("ShowEndcapSides",true);
+  _showRings = conf.getUntrackedParameter<bool>("ShowRings",false);
+  _showTOB6TEC9 = conf.getUntrackedParameter<bool>("ShowTOB6TEC9",false);
+  _tkMapMin = conf.getUntrackedParameter<double>("TkMapMin",0.9);
+  _effPlotMin = conf.getUntrackedParameter<double>("EffPlotMin",0.9);
+  _title = conf.getParameter<std::string>("Title"); 
   reader = new SiStripDetInfoFileReader(FileInPath_.fullPath());
+  
+  nTEClayers = 9; // number of wheels
+  if(_showRings) nTEClayers = 7; // number of rings
   
   quality_ = new SiStripQuality;
 }
@@ -156,15 +199,44 @@ void SiStripHitEffFromCalibTree::algoEndJob() {
 }
 
 void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::EventSetup& c) {
+
+  edm::ESHandle<TrackerGeometry> tracker;
+  c.get<TrackerDigiGeometryRecord>().get( tracker );
+  const TrackerGeometry * tkgeom=&(* tracker);
+  
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   c.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
+  // read bad modules to mask
+  ifstream badModules_file;
+  set<uint32_t> badModules_list;
+  if(_badModulesFile!="") {
+	badModules_file.open(_badModulesFile.c_str());
+	uint32_t badmodule_detid;
+	int mods, fiber1, fiber2, fiber3;
+	if(badModules_file.is_open()) {
+      string line;
+	  while ( getline (badModules_file,line) ) {
+		if(badModules_file.eof()) continue;
+		stringstream ss(line);
+		ss >> badmodule_detid >> mods >> fiber1 >> fiber2 >> fiber3;
+		if(badmodule_detid!=0 && mods==1 && (fiber1==1 || fiber2==1 || fiber3==1) )
+	      badModules_list.insert(badmodule_detid);
+	  }
+      badModules_file.close();
+	}
+  }
+  if(badModules_list.size()) cout<<"Remove additionnal bad modules from the analysis: "<<endl;
+  set<uint32_t>::iterator itBadMod;
+  for (itBadMod=badModules_list.begin(); itBadMod!=badModules_list.end(); ++itBadMod) 
+    cout<<" "<<*itBadMod<<endl;
+
   //Open the ROOT Calib Tree
-  CalibTreeFile = TFile::Open(CalibTreeFilename,"READ");
-  CalibTreeFile->cd("anEff"); 
-  CalibTree = (TTree*)(gDirectory->Get("traj")) ;
+  CalibTree = new TChain("hitefftree");
+  for( unsigned int ifile=0; ifile < CalibTreeFilenames.size(); ifile++)
+    CalibTree->Add((CalibTreeFilenames[ifile]+"/anEff/traj").c_str());
   TLeaf* BadLf = CalibTree->GetLeaf("ModIsBad");
   TLeaf* sistripLf = CalibTree->GetLeaf("SiStripQualBad");
   TLeaf* idLf = CalibTree->GetLeaf("Id");
@@ -175,19 +247,26 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
   TLeaf* yLf = CalibTree->GetLeaf("TrajGlbY");
   TLeaf* zLf = CalibTree->GetLeaf("TrajGlbZ");
   TLeaf* ResXSigLf = CalibTree->GetLeaf("ResXSig");
-  TLeaf* BunchLf(0);
+  TLeaf* TrajLocXLf = CalibTree->GetLeaf("TrajLocX");
+  TLeaf* TrajLocYLf = CalibTree->GetLeaf("TrajLocY");
+  TLeaf* ClusterLocXLf = CalibTree->GetLeaf("ClusterLocX");
+  TLeaf* BunchLf = CalibTree->GetLeaf("bunchx");
   for(int l=0; l < 35; l++) {
     goodlayertotal[l] = 0;
     goodlayerfound[l] = 0;
     alllayertotal[l] = 0;
     alllayerfound[l] = 0;
   }
-  if(_bunchx != 0) {
-    BunchLf = CalibTree->GetLeaf("bunchx");
-  }
+
   int nevents = CalibTree->GetEntries();
   cout << "Successfully loaded analyze function with " << nevents << " events!\n";
   cout << "A module is bad if efficiency < " << threshold << " and has at least " << nModsMin << " nModsMin." << endl;
+
+  TH1F* resolutionPlots[23];
+  for(Long_t ilayer = 0; ilayer <23; ilayer++) {
+    resolutionPlots[ilayer] = fs->make<TH1F>(Form("resol_layer_%i",(int)(ilayer)),GetLayerName(ilayer),125,-125,125);
+    resolutionPlots[ilayer]->GetXaxis()->SetTitle("trajX-clusX [strip unit]");
+  }
 
   //Loop through all of the events
   for(int j =0; j < nevents; j++) {
@@ -196,16 +275,27 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     unsigned int quality = (unsigned int)sistripLf->GetValue();
     unsigned int id = (unsigned int)idLf->GetValue();
     unsigned int accept = (unsigned int)acceptLf->GetValue();
-    unsigned int layer = (unsigned int)layerLf->GetValue();
+    unsigned int layer_wheel = (unsigned int)layerLf->GetValue();
+    unsigned int layer = layer_wheel;
+    if(_showRings && layer >10) { // use rings instead of wheels
+      if(layer<14) layer = 10 + ((id>>9)&0x3); //TID   3 disks and also 3 rings -> use the same container
+      else layer = 13 + ((id>>5)&0x7); //TEC
+    }
     unsigned int nHits = (unsigned int)nHitsLf->GetValue();
     double x = xLf->GetValue();
     double y = yLf->GetValue();
     double z = zLf->GetValue();
     double resxsig = ResXSigLf->GetValue();
+    double TrajLocX = TrajLocXLf->GetValue();
+    double TrajLocY = TrajLocYLf->GetValue();
+    double ClusterLocX = ClusterLocXLf->GetValue();
+    double TrajLocXMid;
+    double stripTrajMid;
+    double stripCluster;
     bool badquality = false;
-    if(_bunchx != 0) {
-      if(_bunchx != BunchLf->GetValue()) continue;
-    }
+    unsigned int bx = (unsigned int)BunchLf->GetValue();
+    if(_bunchx > 0 && _bunchx != bx) continue;
+
     //We have two things we want to do, both an XY color plot, and the efficiency measurement
     //First, ignore anything that isn't in acceptance and isn't good quality
     
@@ -213,16 +303,97 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     if(accept != 1 || nHits < 8) continue;
     if(quality == 1) badquality = true;
     
+    // don't compute efficiencies in modules from TOB6 and TEC9
+    if(!_showTOB6TEC9 && (layer_wheel==10 || layer_wheel==22)) continue; 
+			
+	// don't use bad modules given in the bad module list
+	itBadMod = badModules_list.find(id);
+	if(itBadMod!=badModules_list.end()) continue;
+
+
     //Now that we have a good event, we need to look at if we expected it or not, and the location
     //if we didn't
     //Fill the missing hit information first
     bool badflag = false;
+	
+	// By default uses the old matching method
     if(_ResXSig < 0) {
-      if(isBad == 1) badflag = true;
+      if(isBad == 1) badflag = true; // isBad set to false in the tree when resxsig<999.0
     }
     else {
       if(isBad == 1 || resxsig > _ResXSig) badflag = true;
     }
+
+	// Conversion of positions in strip unit
+    int   nstrips = -9; 
+    float Pitch   = -9.0; 
+
+    if (resxsig==1000.0) { // special treatment, no GeomDetUnit associated in some cases when no cluster found
+      Pitch = 0.0205;  // maximum
+      nstrips = 768;  // maximum
+      stripTrajMid   =    TrajLocX/Pitch + nstrips/2.0 ;      
+      stripCluster   = ClusterLocX/Pitch + nstrips/2.0 ;
+    }
+    else {
+		DetId ClusterDetId(id);
+		const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)tkgeom->idToDetUnit(ClusterDetId);
+		const StripTopology& Topo  = stripdet->specificTopology();
+		nstrips = Topo.nstrips();
+		Pitch = stripdet->surface().bounds().width() / Topo.nstrips();
+		stripTrajMid   =    TrajLocX/Pitch + nstrips/2.0 ; //layer01->10
+		stripCluster   = ClusterLocX/Pitch + nstrips/2.0 ;
+
+		// For trapezoidal modules: extrapolation of x trajectory position to the y middle of the module
+		//  for correct comparison with cluster position
+    	float hbedge   = 0;
+    	float htedge   = 0;
+    	float hapoth   = 0;
+		if(layer>=11) {
+		  const BoundPlane plane = stripdet->surface();
+		  const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
+		  std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters(); 
+		  hbedge         = parameters[0];
+		  htedge         = parameters[1];
+		  hapoth         = parameters[3];
+		  TrajLocXMid = TrajLocX / (1 + (htedge-hbedge)*TrajLocY/(htedge+hbedge)/hapoth) ; // radialy extrapolated x loc position at middle  
+		  stripTrajMid   =    TrajLocXMid/Pitch + nstrips/2.0 ;
+		}
+	}
+	
+	
+	if(!badquality && layer<23) {
+	  if(resxsig!=1000.0) resolutionPlots[layer]->Fill(stripTrajMid-stripCluster);
+	  else resolutionPlots[layer]->Fill(1000);
+	}
+	
+		
+	// New matching methods
+    int   tapv   = -9;
+    int   capv    = -9;
+	float stripInAPV = 64.;
+	
+    if ( _clusterMatchingMethod >=1 ) { 
+      badflag = false;  // reset 
+      if(resxsig == 1000.0) { // default value when no cluster found in the module
+        badflag = true; // consider the module inefficient in this case
+      }
+      else{
+		if (_clusterMatchingMethod==2 || _clusterMatchingMethod==4) { // check the distance between cluster and trajectory position
+		  if ( abs(stripCluster - stripTrajMid) > _clusterTrajDist ) badflag = true;
+		}
+		if (_clusterMatchingMethod==3 || _clusterMatchingMethod==4) { // cluster and traj have to be in the same APV (don't take edges into accounts)
+		  tapv = (int) stripTrajMid/128;
+		  capv = (int) stripCluster/128;
+		  stripInAPV = stripTrajMid-tapv*128;
+
+		  if(stripInAPV<_stripsApvEdge || stripInAPV>128-_stripsApvEdge) continue;
+		  if(tapv != capv) badflag = true;
+		} 	
+      }
+	}
+	
+	
+	
     if(badflag && !badquality) {   
       hit temphit;         
       temphit.x = x;
@@ -244,6 +415,14 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
         ((*it).second.first)++;
         if(!badflag) ((*it).second.second)++;
       }
+
+	  if(layerfound_perBx.find(bx)==layerfound_perBx.end()) {
+	    layerfound_perBx[bx] = vector<int>(23, 0);
+	    layertotal_perBx[bx] = vector<int>(23, 0);
+	  }
+	  if(!badflag) layerfound_perBx[bx][layer]++;
+	  layertotal_perBx[bx][layer]++;
+
       //Have to do the decoding for which side to go on (ugh)
       if(layer <= 10) {
         if(!badflag) goodlayerfound[layer]++;
@@ -265,8 +444,8 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
           goodlayertotal[layer+3]++;
 	}
 	else if( ((id>>18)&0x3) == 2) {
-	  if(!badflag) goodlayerfound[layer+12]++;
-          goodlayertotal[layer+12]++;
+	  if(!badflag) goodlayerfound[layer+3+nTEClayers]++;
+          goodlayertotal[layer+3+nTEClayers]++;
 	}
       } 
     }
@@ -291,18 +470,18 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
         alllayertotal[layer+3]++;
       }
       else if( ((id>>18)&0x3) == 2) {
-        if(!badflag) alllayerfound[layer+12]++;
-        alllayertotal[layer+12]++;
+        if(!badflag) alllayerfound[layer+3+nTEClayers]++;
+        alllayertotal[layer+3+nTEClayers]++;
       }
     }  
     //At this point, both of our maps are loaded with the correct information
   }
-  //CalibTreeFile->Close();
   makeHotColdMaps();
   makeTKMap();
   makeSQLite();
   totalStatistics();
   makeSummary();
+  makeSummaryVsBx();
   
   ////////////////////////////////////////////////////////////////////////
   //try to write out what's in the quality record
@@ -472,6 +651,27 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
   for (int i=10;i<19;++i)
     cout << "\nTEC- Disk " << i-9 << " :" << ssV[3][i].str();
 
+  // store also bad modules in log file
+  ofstream badModules;
+  badModules.open("BadModules.log");
+  badModules << "\n----------------------------------------------------------------\n\t\t   Detid  \tModules Fibers Apvs\n----------------------------------------------------------------";
+  for (int i=1;i<5;++i)
+    badModules << "\nTIB Layer " << i << " :" << ssV[0][i].str();
+  badModules << "\n";
+  for (int i=1;i<4;++i)
+    badModules << "\nTID+ Disk " << i << " :" << ssV[1][i].str();
+  for (int i=4;i<7;++i)
+    badModules << "\nTID- Disk " << i-3 << " :" << ssV[1][i].str();
+  badModules << "\n";
+  for (int i=1;i<7;++i)
+    badModules << "\nTOB Layer " << i << " :" << ssV[2][i].str();
+  badModules << "\n";
+  for (int i=1;i<10;++i)
+    badModules << "\nTEC+ Disk " << i << " :" << ssV[3][i].str();
+  for (int i=10;i<19;++i)
+    badModules << "\nTEC- Disk " << i-9 << " :" << ssV[3][i].str();
+  badModules.close();
+  
 }
 
 void SiStripHitEffFromCalibTree::makeHotColdMaps() {
@@ -608,27 +808,36 @@ void SiStripHitEffFromCalibTree::makeTKMap() {
   cout << "Entering TKMap generation!\n";
   tkmap = new TrackerMap("  Detector Inefficiency  ");
   tkmapbad = new TrackerMap("  Inefficient Modules  ");
+  tkmapeff = new TrackerMap(_title.Data());
+  tkmapnum = new TrackerMap(" Detector numerator   ");
+  tkmapden = new TrackerMap(" Detector denominator ");
+  
+  double myeff, mynum, myden;
+  
   for(Long_t i = 1; i <= 22; i++) {
-    layertotal[i] = 0;
-    layerfound[i] = 0;
-    //Loop over every layer, extracting the information from
-    //the map of the efficiencies
+	//Loop over every layer, extracting the information from
+	//the map of the efficiencies
+	layertotal[i] = 0;
+	layerfound[i] = 0;
     map<unsigned int, pair<unsigned int, unsigned int> >::const_iterator ih;
     for( ih = modCounter[i].begin(); ih != modCounter[i].end(); ih++) {
       //We should be in the layer in question, and looping over all of the modules in said layer
       //Generate the list for the TKmap, and the bad module list
-      double myeff = (double)(((*ih).second).second)/(((*ih).second).first);
-      if ( ((((*ih).second).first) >= nModsMin) && (myeff < threshold) ) {
+	  mynum = (double)(((*ih).second).second);
+	  myden = (double)(((*ih).second).first);
+      if(myden>0) myeff = mynum/myden;
+	  else myeff=0;
+      if ( (myden >= nModsMin) && (myeff < threshold) ) {
         //We have a bad module, put it in the list!
-	BadModules[(*ih).first] = myeff;
-	tkmapbad->fillc((*ih).first,255,0,0);
-	cout << "Layer " << i << " module " << (*ih).first << " efficiency " << myeff << " " << (((*ih).second).second) << "/" << (((*ih).second).first) << endl;
+		BadModules[(*ih).first] = myeff;
+		tkmapbad->fillc((*ih).first,255,0,0);
+		cout << "Layer " << i << " module " << (*ih).first << " efficiency " << myeff << " " << (((*ih).second).second) << "/" << (((*ih).second).first) << endl;
       }
       else {
         //Fill the bad list with empty results for every module
         tkmapbad->fillc((*ih).first,255,255,255);
       }
-      if((((*ih).second).first) < 100 ) {
+      if(myden < 50 ) {
         cout << "Module " << (*ih).first << " layer " << i << " is under occupancy at " << (((*ih).second).first) << endl;
       }
       //Put any module into the TKMap
@@ -638,13 +847,19 @@ void SiStripHitEffFromCalibTree::makeTKMap() {
 	//cout << "Which is " << ((*ih).second).second << "/" << ((*ih).second).first << endl;
       //}
       tkmap->fill((*ih).first,1.-myeff);
+      tkmapeff->fill((*ih).first,myeff);
+      tkmapnum->fill((*ih).first,mynum);
+      tkmapden->fill((*ih).first,myden);
       //Find the total number of hits in the module
-      layertotal[i] += int(((*ih).second).first);
-      layerfound[i] += int(((*ih).second).second);
+      layertotal[i] += int(myden);
+      layerfound[i] += int(mynum);
     }
   }
   tkmap->save(true, 0, 0, "SiStripHitEffTKMap.png");
   tkmapbad->save(true, 0, 0, "SiStripHitEffTKMapBad.png");
+  tkmapeff->save(true, _tkMapMin, 1., "SiStripHitEffTKMapEff.png");
+  tkmapnum->save(true, 0, 0, "SiStripHitEffTKMapNum.png");
+  tkmapden->save(true, 0, 0, "SiStripHitEffTKMapDen.png");
   cout << "Finished TKMap Generation\n";
 }
 
@@ -682,19 +897,39 @@ void SiStripHitEffFromCalibTree::totalStatistics() {
   int totalfound = 0;
   int totaltotal = 0;
   double layereff;
+  int subdetfound[5];
+  int subdettotal[5];
+  
+  for(Long_t i=1; i<5; i++) {subdetfound[i]=0; subdettotal[i]=0;}
+  
   for(Long_t i=1; i<=22; i++) {
     layereff = double(layerfound[i])/double(layertotal[i]);
     cout << "Layer " << i << " has total efficiency " << layereff << " " << layerfound[i] << "/" << layertotal[i] << endl;
     totalfound += layerfound[i];
     totaltotal += layertotal[i];
+	if(i<5) {subdetfound[1]+=layerfound[i]; subdettotal[1]+=layertotal[i];}
+	if(i>=5 && i<11) {subdetfound[2]+=layerfound[i]; subdettotal[2]+=layertotal[i];}
+	if(i>=11 && i<14) {subdetfound[3]+=layerfound[i]; subdettotal[3]+=layertotal[i];}
+	if(i>=14) {subdetfound[4]+=layerfound[i]; subdettotal[4]+=layertotal[i];}
+	
   }
+  
   cout << "The total efficiency is " << double(totalfound)/double(totaltotal) << endl;
+  cout << "      TIB: " << double(subdetfound[1])/subdettotal[1] << endl;
+  cout << "      TOB: " << double(subdetfound[2])/subdettotal[2] << endl;
+  cout << "      TID: " << double(subdetfound[3])/subdettotal[3] << endl;
+  cout << "      TEC: " << double(subdetfound[4])/subdettotal[4] << endl;
 }
 
 void SiStripHitEffFromCalibTree::makeSummary() {
   //setTDRStyle();
   
   int nLayers = 34;
+  if(_showRings) nLayers = 30;
+  if(!_showEndcapSides) {
+    if(!_showRings) nLayers=22;
+    else nLayers=20;
+  }
   
   TH1F *found = fs->make<TH1F>("found","found",nLayers+1,0,nLayers+1);
   TH1F *all = fs->make<TH1F>("all","all",nLayers+1,0,nLayers+1);
@@ -704,33 +939,61 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   found->SetBinContent(0,-1);
   all->SetBinContent(0,1);
   
+  // new ROOT version: TGraph::Divide don't handle null or negative values
+  for (Long_t i=1; i< nLayers+2; ++i) {
+  	found->SetBinContent(i,1e-6);
+	all->SetBinContent(i,1);
+  	found2->SetBinContent(i,1e-6);
+	all2->SetBinContent(i,1);
+  }
+  
   TCanvas *c7 =new TCanvas("c7"," test ",10,10,800,600);
   c7->SetFillColor(0);
   c7->SetGrid();
 
-  for (Long_t i=1; i< nLayers+1; ++i) {
-    if (i==10) i++;
-    if (i==25) i++;
-    if (i==34) break;
-
+  int nLayers_max=nLayers+1; // barrel+endcap
+  if(!_showEndcapSides) nLayers_max=11; // barrel 
+  for (Long_t i=1; i< nLayers_max; ++i) {
     cout << "Fill only good modules layer " << i << ":  S = " << goodlayerfound[i] << "    B = " << goodlayertotal[i] << endl;
     if (goodlayertotal[i] > 5) {
       found->SetBinContent(i,goodlayerfound[i]);
       all->SetBinContent(i,goodlayertotal[i]);
-    } else {
-      found->SetBinContent(i,0);
-      all->SetBinContent(i,10);
     }
     
     cout << "Filling all modules layer " << i << ":  S = " << alllayerfound[i] << "    B = " << alllayertotal[i] << endl;
     if (alllayertotal[i] > 5) {
       found2->SetBinContent(i,alllayerfound[i]);
       all2->SetBinContent(i,alllayertotal[i]);
-    } else {
-      found2->SetBinContent(i,0);
-      all2->SetBinContent(i,10);
     }
 
+  }
+
+  // endcap - merging sides
+  if(!_showEndcapSides) {
+    for (Long_t i=11; i< 14; ++i) { // TID disks
+      cout << "Fill only good modules layer " << i << ":  S = " << goodlayerfound[i]+goodlayerfound[i+3] << "    B = " << goodlayertotal[i]+goodlayertotal[i+3] << endl;
+      if (goodlayertotal[i]+goodlayertotal[i+3] > 5) {
+        found->SetBinContent(i,goodlayerfound[i]+goodlayerfound[i+3]);
+        all->SetBinContent(i,goodlayertotal[i]+goodlayertotal[i+3]);
+      }
+      cout << "Filling all modules layer " << i << ":  S = " << alllayerfound[i]+alllayerfound[i+3] << "    B = " << alllayertotal[i]+alllayertotal[i+3] << endl;
+      if (alllayertotal[i]+alllayertotal[i+3] > 5) {
+        found2->SetBinContent(i,alllayerfound[i]+alllayerfound[i+3]);
+        all2->SetBinContent(i,alllayertotal[i]+alllayertotal[i+3]);
+      }
+	}
+    for (Long_t i=17; i< 17+nTEClayers; ++i) { // TEC disks
+      cout << "Fill only good modules layer " << i-3 << ":  S = " << goodlayerfound[i]+goodlayerfound[i+nTEClayers] << "    B = " << goodlayertotal[i]+goodlayertotal[i+nTEClayers] << endl;
+      if (goodlayertotal[i]+goodlayertotal[i+nTEClayers] > 5) {
+        found->SetBinContent(i-3,goodlayerfound[i]+goodlayerfound[i+nTEClayers]);
+        all->SetBinContent(i-3,goodlayertotal[i]+goodlayertotal[i+nTEClayers]);
+      }
+      cout << "Filling all modules layer " << i-3 << ":  S = " << alllayerfound[i]+alllayerfound[i+nTEClayers] << "    B = " << alllayertotal[i]+alllayertotal[i+nTEClayers] << endl;
+      if (alllayertotal[i]+alllayertotal[i+nTEClayers] > 5) {
+        found2->SetBinContent(i-3,alllayerfound[i]+alllayerfound[i+nTEClayers]);
+        all2->SetBinContent(i-3,alllayertotal[i]+alllayertotal[i+nTEClayers]);
+      }
+	}
   }
 
   found->Sumw2();
@@ -756,9 +1019,12 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   gr->SetLineColor(2);
   gr->SetLineWidth(4);
   gr->SetMarkerStyle(20);
-  gr->SetMinimum(0.90);
+  gr->SetMinimum(_effPlotMin);
   gr->SetMaximum(1.001);
   gr->GetYaxis()->SetTitle("Efficiency");
+  gStyle->SetTitleFillColor(0);
+  gStyle->SetTitleBorderSize(0);
+  gr->SetTitle(_title);
 
   gr2->GetXaxis()->SetLimits(0,nLayers);
   gr2->SetMarkerColor(1);
@@ -766,31 +1032,40 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   gr2->SetLineColor(1);
   gr2->SetLineWidth(4);
   gr2->SetMarkerStyle(21);
-  gr2->SetMinimum(0.90);
+  gr2->SetMinimum(_effPlotMin);
   gr2->SetMaximum(1.001);
   gr2->GetYaxis()->SetTitle("Efficiency");
-  //cout << "starting labels" << endl;
-  //for ( int k=1; k<nLayers+1; k++) {
+  gr2->SetTitle(_title);
+
   for ( Long_t k=1; k<nLayers+1; k++) {
-    if (k==10) k++;
-    if (k==25) k++;
-    if (k==34) break;
-    TString label;
-    if (k<5) {
-      label = TString("TIB  ") + k;
-    } else if (k>4&&k<11) {
-      label = TString("TOB  ")+(k-4);
-    } else if (k>10&&k<14) {
-      label = TString("TID- ")+(k-10);
-    } else if (k>13&&k<17) {
-      label = TString("TID+ ")+(k-13);
-    } else if (k>16&&k<26) {
-      label = TString("TEC- ")+(k-16);
-    } else if (k>25) {
-      label = TString("TEC+ ")+(k-25);
-    }
-    gr->GetXaxis()->SetBinLabel(((k+1)*100)/(nLayers)-2,label);
-    gr2->GetXaxis()->SetBinLabel(((k+1)*100)/(nLayers)-2,label);
+        TString label;
+	if(_showEndcapSides) label = GetLayerSideName(k);
+	else label = GetLayerName(k);
+	if(!_showTOB6TEC9) {
+	  if(k==10) label="";
+	  if(!_showRings && k==nLayers) label="";
+	  if(!_showRings && _showEndcapSides && k==25) label="";
+        }
+	if(!_showRings) {
+	  if(_showEndcapSides) {
+            gr->GetXaxis()->SetBinLabel(((k+1)*100+2)/(nLayers)-4,label);
+            gr2->GetXaxis()->SetBinLabel(((k+1)*100+2)/(nLayers)-4,label);
+	  }
+	  else {
+            gr->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-6,label);
+            gr2->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-6,label);
+	  }
+	}
+	else {
+	  if(_showEndcapSides) {
+	    gr->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-4,label);
+            gr2->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-4,label);
+	  }
+	  else {
+	    gr->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-7,label);
+            gr2->GetXaxis()->SetBinLabel((k+1)*100/(nLayers)-7,label);
+	  }
+	}
   }
   
   gr->Draw("AP");
@@ -805,7 +1080,7 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   overlay->cd();
   gr2->Draw("AP");
 
-  TLegend *leg = new TLegend(0.70,0.20,0.92,0.39);
+  TLegend *leg = new TLegend(0.70,0.27,0.88,0.40);
   leg->AddEntry(gr,"Good Modules","p");
   leg->AddEntry(gr2,"All Modules","p");
   leg->SetTextSize(0.020);
@@ -813,6 +1088,125 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   leg->Draw("same");
   
   c7->SaveAs("Summary.png");
+}
+
+void SiStripHitEffFromCalibTree::makeSummaryVsBx() {
+  cout<<"Computing efficiency vs bx"<<endl;
+  
+  unsigned int nLayers = 22;
+  if(_showRings) nLayers = 20;
+  
+  for(unsigned int ilayer=1; ilayer<nLayers; ilayer++) {
+    TH1F *hfound = fs->make<TH1F>(Form("foundVsBx_layer%i", ilayer),Form("layer %i", ilayer),3565,0,3565);
+    TH1F *htotal = fs->make<TH1F>(Form("totalVsBx_layer%i", ilayer),Form("layer %i", ilayer),3565,0,3565);
+	
+	for(unsigned int ibx=0; ibx<3566; ibx++){
+	  hfound->SetBinContent(ibx, 1e-6);
+	  htotal->SetBinContent(ibx, 1);
+	}
+	map<unsigned int, vector<int> >::iterator iterMapvsBx;
+	for(iterMapvsBx=layerfound_perBx.begin(); iterMapvsBx!=layerfound_perBx.end(); ++iterMapvsBx) 
+	  hfound->SetBinContent( iterMapvsBx->first, iterMapvsBx->second[ilayer]);
+	for(iterMapvsBx=layertotal_perBx.begin(); iterMapvsBx!=layertotal_perBx.end(); ++iterMapvsBx)
+	  if(iterMapvsBx->second[ilayer]>0) htotal->SetBinContent( iterMapvsBx->first, iterMapvsBx->second[ilayer]);
+		
+	hfound->Sumw2();
+	htotal->Sumw2();
+	
+	TGraphAsymmErrors *geff = fs->make<TGraphAsymmErrors>(3564);
+	geff->SetName(Form("effVsBx_layer%i", ilayer));
+	geff->SetTitle("Hit Efficiency vs bx - "+GetLayerName(ilayer));
+	geff->BayesDivide(hfound,htotal);
+	
+	//Average over trains
+	TGraphAsymmErrors *geff_avg = fs->make<TGraphAsymmErrors>();
+	geff_avg->SetName(Form("effVsBxAvg_layer%i", ilayer));
+	geff_avg->SetTitle("Hit Efficiency vs bx - "+GetLayerName(ilayer));
+	geff_avg->SetMarkerStyle(20);
+	int ibx=0;
+	int previous_bx=-80;
+	int delta_bx=0;
+	int nbx=0;
+	int found=0;
+	int total=0;
+	double sum_bx=0;
+	int ipt=0;
+	float low, up, eff;
+	int firstbx=0;
+	for(iterMapvsBx=layertotal_perBx.begin(); iterMapvsBx!=layertotal_perBx.end(); ++iterMapvsBx){
+	  ibx=iterMapvsBx->first;
+	  delta_bx=ibx-previous_bx;
+	  // consider a new train
+	  if(delta_bx>(int)_spaceBetweenTrains && nbx>0 && total>0){
+	    eff=found/(float)total;
+	    //cout<<"new train "<<ipt<<" "<<sum_bx/nbx<<" "<<eff<<endl;
+	    geff_avg->SetPoint(ipt, sum_bx/nbx, eff);
+	    low = TEfficiency::Bayesian(total, found, .683, 1, 1, false);
+	    up = TEfficiency::Bayesian(total, found, .683, 1, 1, true);
+	    geff_avg->SetPointError(ipt, sum_bx/nbx-firstbx, previous_bx-sum_bx/nbx, eff-low, up-eff);
+	    ipt++;
+	    sum_bx=0;
+	    found=0;
+	    total=0;
+	    nbx=0;
+	    firstbx=ibx;
+	  }
+	  sum_bx+=ibx;
+	  found+=hfound->GetBinContent(ibx);
+	  total+=htotal->GetBinContent(ibx);
+	  nbx++;
+	  
+	  previous_bx=ibx;
+	}
+	//last train
+	eff=found/(float)total;
+	//cout<<"new train "<<ipt<<" "<<sum_bx/nbx<<" "<<eff<<endl;
+	geff_avg->SetPoint(ipt, sum_bx/nbx, eff);
+	low = TEfficiency::Bayesian(total, found, .683, 1, 1, false);
+	up = TEfficiency::Bayesian(total, found, .683, 1, 1, true);
+	geff_avg->SetPointError(ipt, sum_bx/nbx-firstbx, previous_bx-sum_bx/nbx, eff-low, up-eff);
+  }
+}
+
+
+TString SiStripHitEffFromCalibTree::GetLayerName(Long_t k) {
+
+    TString layername="";
+    TString ringlabel="D";
+    if(_showRings) ringlabel="R";
+    if (k>0 && k<5) {
+      layername = TString("TIB L") + k;
+    } else if (k>4 && k<11) {
+      layername = TString("TOB L")+(k-4);
+    } else if (k>10 && k<14) {
+      layername = TString("TID ")+ringlabel+(k-10);
+    } else if (k>13 && k<14+nTEClayers) {
+      layername = TString("TEC ")+ringlabel+(k-13);
+	}
+   
+    return layername;
+}
+
+TString SiStripHitEffFromCalibTree::GetLayerSideName(Long_t k) {
+
+    TString layername="";
+    TString ringlabel="D";
+    if(_showRings) ringlabel="R";
+    if (k>0 && k<5) {
+      layername = TString("TIB L") + k;
+    } else if (k>4&&k<11) {
+      layername = TString("TOB L")+(k-4);
+    } else if (k>10&&k<14) {
+      layername = TString("TID- ")+ringlabel+(k-10);
+    } else if (k>13&&k<17) {
+      layername = TString("TID+ ")+ringlabel+(k-13);
+    } else if (k>16&&k<17+nTEClayers) {
+      layername = TString("TEC- ")+ringlabel+(k-16);
+    } else if (k>16+nTEClayers) {
+      layername = TString("TEC+ ")+ringlabel+(k-16-nTEClayers);
+    }
+   
+    return layername;
 }
 
 SiStripBadStrip* SiStripHitEffFromCalibTree::getNewObject() {

--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HitEff")
-process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag

--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HitEff")
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')  
 
 process.source = cms.Source("EmptyIOVSource",
     firstValue = cms.uint64(newrun),
@@ -12,15 +17,26 @@ process.source = cms.Source("EmptyIOVSource",
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1))
 
 process.SiStripHitEff = cms.EDFilter("SiStripHitEffFromCalibTree",
-    CalibTreeFilename = cms.string('rfio:newfilelocation'),
+    CalibTreeFilenames = cms.untracked.vstring('root://cms-xrd-globale.cern.ch//newfilelocation'),
     Threshold         = cms.double(0.1),
     nModsMin          = cms.int32(25),
     doSummary         = cms.int32(0),
-    ResXSig           = cms.untracked.double(5),
+    #ResXSig           = cms.untracked.double(5),
     SinceAppendMode   = cms.bool(True),
     IOVMode           = cms.string('Run'),
     Record            = cms.string('SiStripBadStrip'),
-    doStoreOnDB       = cms.bool(True)
+    doStoreOnDB       = cms.bool(True),
+    BadModulesFile    = cms.untracked.string("BadModules_input.txt"),   # default "" no input
+    ClusterMatchingMethod  = cms.untracked.int32(4),     # default 0  case0,1,2,3,4
+    ClusterTrajDist   = cms.untracked.double(64),   # default 64
+    StripsApvEdge     = cms.untracked.double(10),   # default 10  
+    SpaceBetweenTrains = cms.untracked.int32(25),   # default 25
+    ShowEndcapSides   = cms.untracked.bool(True),  # default True
+    ShowRings         = cms.untracked.bool(True),  # default False
+    showTOB6TEC9      = cms.untracked.bool(False),  # default False
+    TkMapMin          = cms.untracked.double(0.95), # default 0.90
+    EffPlotMin        = cms.untracked.double(0.90), # default 0.90
+    Title             = cms.string(' Hit Efficiency ')
 )
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",


### PR DESCRIPTION
This is the equivalent of the code merged in 81X (PR #15192) 
I recall the description:
Only 2 files have been modified to improve the functionalities of the hit efficiency analysis:

```
new cluster matching methods
more flexibility in the way results are shown (for disks/rings, endcaps merged)
results as a function of bx
possibility to exclude some bad modules
more plots stored in the root file
```

PLease note that during the process of backporting I noticed a small typo in the config file in 81X version  (geometry) fixed in 81X thanks to this PR #15341 - the fix is included in this 80X version.

@jlagram , @dimattia , @fioriNTU , FYI
