### PR TITLE
80x Fireworks: new version of ECAL detail view

### DIFF
--- a/Fireworks/Calo/interface/FWBoxRecHit.h
+++ b/Fireworks/Calo/interface/FWBoxRecHit.h
@@ -1,0 +1,70 @@
+#ifndef _FWBOXRECHIT_H_
+#define _FWBOXRECHIT_H_
+
+// -*- C++ -*-
+//
+// Package:     ParticleFlow
+// Class  :     FWBoxRecHit
+// 
+// Implementation:
+//     <Notes on implementation>
+//
+// Original Author:  Simon Harris
+//
+
+// System include files
+#include "TEveBox.h"
+#include "TEveCompound.h"
+#include "TEveStraightLineSet.h"
+
+#include "TEveCaloData.h"
+#include "TEveChunkManager.h"
+
+// User include files
+#include "Fireworks/Core/interface/FWViewContext.h"
+#include "Fireworks/Core/interface/FWViewEnergyScale.h"
+#include "Fireworks/Core/interface/Context.h"
+
+// Forward declarations
+class FWProxyBuilderBase;
+
+//-----------------------------------------------------------------------------
+// FWBoxRechHit
+//-----------------------------------------------------------------------------
+class FWBoxRecHit
+{
+ public:
+  // ---------------- Constructor(s)/Destructor ----------------------
+  FWBoxRecHit( const std::vector<TEveVector> &corners, TEveElement *comp,float e , float et);
+  virtual ~FWBoxRecHit(){}
+
+  // --------------------- Member Functions --------------------------
+  void updateScale( float scale, float maxLogVal, bool plotEt);
+  void setSquareColor( Color_t c ) { m_ls->SetMarkerColor(c); m_ls->SetLineColor(kBlack); }
+
+  TEveBox *getTower() { return m_tower; }
+  void  setLine(int idx, float x1, float y1, float z1, float x2, float y2, float z2);
+  void  addLine( float x1, float y1, float z1, float x2, float y2, float z2 );
+  void  addLine( const TEveVector &v1, const TEveVector &v2 );
+  float getEnergy( bool b ) const { return b ? m_et : m_energy; }
+  bool  isTallest() const { return m_isTallest; }
+  void  setIsTallest( );
+
+ private:
+  FWBoxRecHit( const FWBoxRecHit& );                    // Disable default
+  const FWBoxRecHit& operator=( const FWBoxRecHit& );   // Disable default
+
+  // --------------------- Member Functions --------------------------
+  void setupEveBox( std::vector<TEveVector> &corners, float scale );
+  void buildTower( const std::vector<TEveVector> &corners);
+  void buildLineSet( const std::vector<TEveVector> &corners);
+
+  // ----------------------- Data Members ----------------------------
+  TEveBox                          *m_tower;
+  TEveStraightLineSet              *m_ls;
+  float                            m_energy;
+  float                            m_et;
+  bool                             m_isTallest;
+};
+#endif
+//=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_=_

--- a/Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h
@@ -1,0 +1,92 @@
+#include "Rtypes.h"
+#include <map>
+#include <vector>
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+namespace edm {
+   class EventBase;
+}
+
+class FWGeometry;
+class TEveCaloDataVec;
+class TEveCaloLego;
+/*
+
+// Less than operator for sorting clusters according to eta
+class superClsterEtaLess : public std::binary_function<const reco::CaloCluster&, const reco::CaloCluster&, bool>
+{
+public:
+   bool operator()(const reco::CaloCluster &lhs, const reco::CaloCluster &rhs)
+   {
+      return ( lhs.eta() < rhs.eta()) ;
+   }
+};
+*/
+
+// builder class for ecal detail view
+class FWECALCaloDataDetailViewBuilder {
+
+public:
+
+   // construct an ecal detail view builder
+   // the arguments are the event, a pointer to geometry object,
+   // the eta and phi position to show,
+   // the half width of the region (in indices, e.g. iEta) and
+   // the default color for the hits.
+   FWECALCaloDataDetailViewBuilder(const edm::EventBase *event, const FWGeometry* geom,
+                           float eta, float phi, int size = 50,
+                           Color_t defaultColor = kMagenta+1)
+      : m_event(event), m_geom(geom),
+        m_eta(eta), m_phi(phi), m_size(size),
+        m_defaultColor(defaultColor){
+   }
+
+   // draw the ecal information with the preset colors
+   // (if any colors have been preset)
+   TEveCaloLego* build();
+   
+   TEveCaloData* buildCaloData(bool xyEE);
+
+   // set colors of some predefined detids
+   void setColor(Color_t color, const std::vector<DetId> &detIds);
+
+   // show superclusters using two alternating colors
+   // to make adjacent clusters visible
+   void showSuperClusters(Color_t color1=kGreen+2, Color_t color2=kTeal);
+
+   // show a specific supercluster in a specific color
+   void showSuperCluster(const reco::SuperCluster &cluster, Color_t color=kYellow);
+
+   // add legends; returns final y
+   double makeLegend(double x0 = 0.02, double y0 = 0.95,
+                     Color_t clustered1=kGreen+1, Color_t clustered2=kTeal,
+                     Color_t supercluster=kYellow);
+
+private:
+
+   // fill data
+   void fillData(const EcalRecHitCollection *hits,
+                 TEveCaloDataVec *data, bool xyEE);
+   const edm::EventBase *m_event;                               // the event
+   const FWGeometry     *m_geom;                                // the geometry
+   float m_eta;                                                 // eta position view centred on
+   float m_phi;                                                 // phi position view centred on
+   int m_size;                                                  // view half width in number of crystals
+   Color_t m_defaultColor;                                      // default color for crystals
+
+   // for keeping track of what det id goes in what slice
+   std::map<DetId, int> m_detIdsToColor;
+
+   // for keeping track of the colors to use for each slice
+   std::vector<Color_t> m_colors;
+
+   // sorting function to sort super clusters by eta.
+   static bool superClusterEtaLess(const reco::CaloCluster &lhs, const reco::CaloCluster &rhs)
+   {
+      return ( lhs.eta() < rhs.eta());
+   }
+
+};

--- a/Fireworks/Calo/interface/FWECALDetailViewBase.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBase.h
@@ -1,0 +1,37 @@
+#ifndef Fireworks_Core_FWFWEcalDetailViewBase_h
+#define Fireworks_Core_FWFWEcalDetailViewBase_h
+
+// #include "TEveViewer.h"
+#include "Fireworks/Core/interface/FWDetailViewGL.h"
+
+class TEveCaloData;
+class TEveCaloLego;
+class TLegend;
+class FWECALDetailViewBuilder;
+
+template <typename T>
+class FWECALDetailViewBase : public FWDetailViewGL<T> {
+  public:
+   FWECALDetailViewBase ();//: m_data(0), m_builder(0), m_legend(0) {}
+   virtual ~FWECALDetailViewBase();// { delete m_data; }
+  
+  
+protected:
+   TEveCaloData            *m_data;
+   FWECALDetailViewBuilder *m_builder;
+   TLegend                 *m_legend;
+
+private:
+   using FWDetailView<T>::build;
+   void build(const FWModelId &id, const T*);
+
+   using FWDetailViewGL<T>::setTextInfo;
+   void setTextInfo(const FWModelId &id, const T*);
+
+};
+
+
+#include "Fireworks/Calo/src/FWECALDetailViewBase.icc"
+
+#endif
+

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -68,6 +68,11 @@ private:
    // fill data
    void fillData(const EcalRecHitCollection *hits,
                  TEveCaloDataVec *data, bool xyEE);
+
+   
+   void fillDataEtaPhi(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
+   void fillDataXY(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
+
    const edm::EventBase *m_event;                               // the event
    const FWGeometry     *m_geom;                                // the geometry
    float m_eta;                                                 // eta position view centred on

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -5,6 +5,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "Fireworks/Calo/interface/FWBoxRecHit.h"
 
 namespace edm {
    class EventBase;
@@ -35,12 +36,8 @@ public:
    // the half width of the region (in indices, e.g. iEta) and
    // the default color for the hits.
    FWECALDetailViewBuilder(const edm::EventBase *event, const FWGeometry* geom,
-                           float eta, float phi, int size = 50,
-                           Color_t defaultColor = kMagenta+1)
-      : m_event(event), m_geom(geom),
-        m_eta(eta), m_phi(phi), m_size(size),
-        m_defaultColor(defaultColor), m_coordinatesEtaPhi(true){
-   }
+                           float eta, float phi, int size = 50 , Color_t defaultColor = kMagenta+1);
+
 
    // draw the ecal information with the preset colors
    // (if any colors have been preset)
@@ -69,7 +66,6 @@ private:
    void fillData(TEveCaloDataVec *data);
    
    void fillEtaPhi(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
-   void fillXY(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
 
    const edm::EventBase *m_event;                               // the event
    const FWGeometry     *m_geom;                                // the geometry
@@ -77,12 +73,18 @@ private:
    float m_phi;                                                 // phi position view centred on
    int   m_size;                                                  // view half width in number of crystals
    Color_t m_defaultColor;                                      // default color for crystals
-   bool m_coordinatesEtaPhi;
+
+
+   std::vector<FWBoxRecHit*> m_boxes;
+
    // for keeping track of what det id goes in what slice
    std::map<DetId, int> m_detIdsToColor;
 
    // for keeping track of the colors to use for each slice
    std::vector<Color_t> m_colors;
+
+
+   TEveElement* m_towerList;
 
    // sorting function to sort super clusters by eta.
    static bool superClusterEtaLess(const reco::CaloCluster &lhs, const reco::CaloCluster &rhs)

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -80,10 +80,6 @@ private:
    // for keeping track of what det id goes in what slice
    std::map<DetId, int> m_detIdsToColor;
 
-   // for keeping track of the colors to use for each slice
-   std::vector<Color_t> m_colors;
-
-
    TEveElement* m_towerList;
 
    // sorting function to sort super clusters by eta.

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -39,7 +39,7 @@ public:
                            Color_t defaultColor = kMagenta+1)
       : m_event(event), m_geom(geom),
         m_eta(eta), m_phi(phi), m_size(size),
-        m_defaultColor(defaultColor){
+        m_defaultColor(defaultColor), m_coordinatesEtaPhi(true){
    }
 
    // draw the ecal information with the preset colors
@@ -77,9 +77,9 @@ private:
    const FWGeometry     *m_geom;                                // the geometry
    float m_eta;                                                 // eta position view centred on
    float m_phi;                                                 // phi position view centred on
-   int m_size;                                                  // view half width in number of crystals
+   int   m_size;                                                  // view half width in number of crystals
    Color_t m_defaultColor;                                      // default color for crystals
-
+   bool m_coordinatesEtaPhi;
    // for keeping track of what det id goes in what slice
    std::map<DetId, int> m_detIdsToColor;
 
@@ -91,5 +91,8 @@ private:
    {
       return ( lhs.eta() < rhs.eta());
    }
+
+   float sizeRad() const;
+   float sizeXY() const;
 
 };

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -66,12 +66,10 @@ public:
 private:
 
    // fill data
-   void fillData(const EcalRecHitCollection *hits,
-                 TEveCaloDataVec *data, bool xyEE);
-
+   void fillData(TEveCaloDataVec *data);
    
-   void fillDataEtaPhi(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
-   void fillDataXY(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
+   void fillEtaPhi(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
+   void fillXY(const EcalRecHitCollection *hits, TEveCaloDataVec *data);
 
    const edm::EventBase *m_event;                               // the event
    const FWGeometry     *m_geom;                                // the geometry

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -93,6 +93,5 @@ private:
    }
 
    float sizeRad() const;
-   float sizeXY() const;
 
 };

--- a/Fireworks/Calo/src/FWBoxRecHit.cc
+++ b/Fireworks/Calo/src/FWBoxRecHit.cc
@@ -68,7 +68,6 @@ FWBoxRecHit::buildLineSet( const std::vector<TEveVector> &corners )
 {
    m_ls = new TEveStraightLineSet( "EcalRecHitLineSet" );
 
- 
 
    const float *data;
    TEveVector c;
@@ -130,14 +129,10 @@ float val = plotEt ? m_et : m_energy;
 
    if(  m_isTallest )
    {
-       if (m_ls->GetMarkerPlex().N() < 5) {
-           m_ls->AddLine( c.fX, c.fY, c.fZ , c.fX, c.fY, c.fZ);
-           m_ls->AddLine( c.fX, c.fY, c.fZ , c.fX, c.fY, c.fZ);
-       }
 
-      // This is the tallest tower and hence two additional lines needs scaling
-      setLine( 4, c.fX - d, c.fY - d, z, c.fX + d, c.fY + d, z );
-      setLine( 5, c.fX - d, c.fY + d, z, c.fX + d, c.fY - d, z );
+       m_ls->AddLine( c.fX - d, c.fY - d, z, c.fX + d, c.fY + d, z );
+       m_ls->AddLine( c.fX - d, c.fY + d, z, c.fX + d, c.fY - d, z );
+       m_ls->GetMarkerPlex().Refit();
    }
 
    TEveStraightLineSet::Marker_t* m = ((TEveStraightLineSet::Marker_t*)(m_ls->GetMarkerPlex().Atom(0)));

--- a/Fireworks/Calo/src/FWBoxRecHit.cc
+++ b/Fireworks/Calo/src/FWBoxRecHit.cc
@@ -1,0 +1,192 @@
+#include "Fireworks/Calo/interface/FWBoxRecHit.h"
+#include "Fireworks/Core/interface/Context.h"
+#include "Fireworks/Core/interface/FWViewEnergyScale.h"
+#include "Fireworks/Core/interface/CmsShowCommon.h"
+
+
+//______________________________________________________________________________
+FWBoxRecHit::FWBoxRecHit( const std::vector<TEveVector> &corners, TEveElement *comp,float e , float et):
+    m_tower(0), m_ls(0), m_energy(e), m_et(et), m_isTallest(false)
+{
+   buildTower( corners);
+   buildLineSet( corners);
+
+   comp->AddElement( m_tower);
+   comp->AddElement( m_ls );
+}
+
+//______________________________________________________________________________
+/*
+ FWViewEnergyScale*
+ FWBoxRecHit::getEnergyScale() const
+ {
+    return  fireworks::Context::getInstance()->commonPrefs()->getEnergyScale();
+ }
+*/
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::setupEveBox( std::vector<TEveVector> &corners, float scale )
+{
+    // printf("---\n");
+   //   TEveVector z(0.f, 0.f, 0.f);
+   for( size_t i = 0; i < 4; ++i)
+   {
+      int j = i + 4;
+      corners[i+4].fZ =  scale;
+      m_tower->SetVertex( i, corners[i] );
+      m_tower->SetVertex( j, corners[j] );
+      //  printf("%ld -> %f, %f , height=%f \n",i, corners[i].fX, corners[i].fY, scale);
+   }
+
+   m_tower->SetPickable( true );
+   m_tower->SetDrawFrame(false);
+   m_tower->SetLineWidth( 1.0 );
+   m_tower->SetLineColor( kBlack );
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::buildTower( const std::vector<TEveVector> &corners )
+{
+   m_tower = new TEveBox( "EcalRecHitTower" );
+   std::vector<TEveVector> towerCorners = corners;
+   /*
+   FWViewEnergyScale *caloScale = 1;//getEnergyScale();
+   float val = caloScale->getPlotEt() ? m_et : m_energy;
+   float scale = caloScale->getScaleFactorLego() * val;
+
+   if( scale < 0 )
+      scale *= -1;
+   */
+   setupEveBox( towerCorners, 0.01f );
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::buildLineSet( const std::vector<TEveVector> &corners )
+{
+   m_ls = new TEveStraightLineSet( "EcalRecHitLineSet" );
+
+ 
+
+   const float *data;
+   TEveVector c;
+   for( unsigned int i = 0; i < 4; ++i )
+   {
+      data = m_tower->GetVertex( i );
+      c.fX += data[0];
+      c.fY += data[1];
+      m_ls->AddLine( data[0], data[1], 0, data[0], data[1], 0);
+
+   }
+   c *= 0.25;
+
+   
+   // last line is trick to add a marker in line set
+   m_ls->SetMarkerStyle( 1 );
+   m_ls->AddLine( c.fX, c.fY, c.fZ, c.fX, c.fY, c.fZ );
+   m_ls->AddMarker( 0, 0. );
+
+
+   m_ls->ResetBBox();
+   m_ls->ComputeBBox();
+   float* bb = m_ls->GetBBox();
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::updateScale(float scaleFac, float maxLogVal, bool plotEt )
+{
+    //   FWViewEnergyScale *caloScale = getEnergyScale();
+    // 
+    //float scale = caloScale->getScaleFactorLego() * val;
+
+   // printf("scale %f %f\n",  caloScale->getValToHeight(), val);
+float val = plotEt ? m_et : m_energy;
+ float scale = scaleFac * val;
+   // Reposition top points of tower
+   const float *data;
+   TEveVector c;
+   for( unsigned int i = 0; i < 4; ++i )
+   {
+      data = m_tower->GetVertex( i );
+      c.fX += data[0];
+      c.fY += data[1];
+      m_tower->SetVertex( i, data[0], data[1], 0 );
+      m_tower->SetVertex( i+4,  data[0], data[1], scale);
+   }
+   c *= 0.25;
+   if (0) c.Dump();
+   
+   // Scale lineset 
+   float s = log( 1 + val ) / maxLogVal;
+   float d = 0.5 * ( m_tower->GetVertex(1)[0]  -m_tower->GetVertex(0)[0]);
+   d *= s;
+   float z =  scale * 1.001;
+   setLine(0, c.fX - d, c.fY -d, z, c.fX + d, c.fY -d, z);
+   setLine(1, c.fX + d, c.fY -d, z, c.fX + d, c.fY +d, z);
+   setLine(2, c.fX + d, c.fY +d, z, c.fX - d, c.fY +d, z);
+   setLine(3, c.fX - d, c.fY +d, z, c.fX - d, c.fY -d, z);
+
+   if(  m_isTallest )
+   {
+       if (m_ls->GetMarkerPlex().N() < 5) {
+           m_ls->AddLine( c.fX, c.fY, c.fZ , c.fX, c.fY, c.fZ);
+           m_ls->AddLine( c.fX, c.fY, c.fZ , c.fX, c.fY, c.fZ);
+       }
+
+      // This is the tallest tower and hence two additional lines needs scaling
+      setLine( 4, c.fX - d, c.fY - d, z, c.fX + d, c.fY + d, z );
+      setLine( 5, c.fX - d, c.fY + d, z, c.fX + d, c.fY - d, z );
+   }
+
+   TEveStraightLineSet::Marker_t* m = ((TEveStraightLineSet::Marker_t*)(m_ls->GetMarkerPlex().Atom(0)));
+    m->fV[0] = c.fX; m->fV[1] = c.fY; m->fV[2] = z;
+   
+   // stamp changed elements
+
+   m_ls->ComputeBBox();
+   //   float* bb = m_ls->GetBBox();
+   m_tower->StampTransBBox();
+   m_ls->StampTransBBox();
+}
+
+//______________________________________________________________________________
+void FWBoxRecHit::setLine(int idx, float x1, float y1, float z1, float x2, float y2, float z2)
+{
+   // AMT: this func should go in TEveStraightLineSet class
+
+   TEveStraightLineSet::Line_t* l = ((TEveStraightLineSet::Line_t*)(m_ls->GetLinePlex().Atom(idx)));
+
+   l->fV1[0] = x1;
+   l->fV1[1] = y1;
+   l->fV1[2] = z1; 
+
+   l->fV2[0] = x2;
+   l->fV2[1] = y2;
+   l->fV2[2] = z2;
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::setIsTallest( )
+{
+   m_isTallest = true;
+   
+   
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::addLine( float x1, float y1, float z1, float x2, float y2, float z2 )
+{
+   m_ls->AddLine( x1, y1, z1, x2, y2, z2 );
+}
+
+//______________________________________________________________________________
+void
+FWBoxRecHit::addLine( const TEveVector &v1, const TEveVector &v2 )
+{
+   m_ls->AddLine(v1.fX, v1.fY, v1.fZ, v2.fX, v2.fY, v2.fZ);
+}

--- a/Fireworks/Calo/src/FWBoxRecHit.cc
+++ b/Fireworks/Calo/src/FWBoxRecHit.cc
@@ -91,7 +91,6 @@ FWBoxRecHit::buildLineSet( const std::vector<TEveVector> &corners )
 
    m_ls->ResetBBox();
    m_ls->ComputeBBox();
-   float* bb = m_ls->GetBBox();
 }
 
 //______________________________________________________________________________

--- a/Fireworks/Calo/src/FWBoxRecHit.cc
+++ b/Fireworks/Calo/src/FWBoxRecHit.cc
@@ -1,3 +1,5 @@
+#include "TEveCompound.h"
+
 #include "Fireworks/Calo/interface/FWBoxRecHit.h"
 #include "Fireworks/Core/interface/Context.h"
 #include "Fireworks/Core/interface/FWViewEnergyScale.h"
@@ -11,8 +13,12 @@ FWBoxRecHit::FWBoxRecHit( const std::vector<TEveVector> &corners, TEveElement *c
    buildTower( corners);
    buildLineSet( corners);
 
-   comp->AddElement( m_tower);
-   comp->AddElement( m_ls );
+   TEveCompound* h = new TEveCompound();
+   h->CSCApplyMainColorToAllChildren();
+
+   h->AddElement( m_tower);
+   h->AddElement( m_ls );
+   comp->AddElement(h);
 }
 
 //______________________________________________________________________________

--- a/Fireworks/Calo/src/FWBoxRecHit.cc
+++ b/Fireworks/Calo/src/FWBoxRecHit.cc
@@ -7,18 +7,17 @@
 
 
 //______________________________________________________________________________
-FWBoxRecHit::FWBoxRecHit( const std::vector<TEveVector> &corners, TEveElement *comp,float e , float et):
+FWBoxRecHit::FWBoxRecHit( const std::vector<TEveVector> &corners, TEveElement *list,float e , float et):
     m_tower(0), m_ls(0), m_energy(e), m_et(et), m_isTallest(false)
 {
    buildTower( corners);
    buildLineSet( corners);
 
-   TEveCompound* h = new TEveCompound();
+   TEveCompound* h = new TEveCompound("rechit box", "tower");
+   list->AddElement(h);
    h->CSCApplyMainColorToAllChildren();
-
    h->AddElement( m_tower);
    h->AddElement( m_ls );
-   comp->AddElement(h);
 }
 
 //______________________________________________________________________________
@@ -45,8 +44,6 @@ FWBoxRecHit::setupEveBox( std::vector<TEveVector> &corners, float scale )
       //  printf("%ld -> %f, %f , height=%f \n",i, corners[i].fX, corners[i].fY, scale);
    }
 
-   m_tower->SetPickable( true );
-   m_tower->SetDrawFrame(false);
    m_tower->SetLineWidth( 1.0 );
    m_tower->SetLineColor( kBlack );
 }

--- a/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALCaloDataDetailViewBuilder.cc
@@ -1,0 +1,453 @@
+// FIXME - needed to set fixed eta-phi limits. Without the
+//         visible area may change widely depending on energy
+//         deposition availability
+
+#include "TEveCaloData.h"
+#include "TEveViewer.h"
+#include "TEveCalo.h"
+#include "TAxis.h"
+#include "TMath.h"
+#include "THLimitsFinder.h"
+#include "TLatex.h"
+
+#include "Fireworks/Core/interface/FWDetailViewBase.h"
+#include "Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fw3dlego_xbins.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+#include "DataFormats/FWLite/interface/Handle.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+
+#include "TGeoMatrix.h"
+#include "TEveTrans.h"
+
+#include <utility>
+
+TEveCaloData* FWECALCaloDataDetailViewBuilder::buildCaloData(bool xyEE)
+{
+   // get the hits from the event
+
+   edm::Handle<EcalRecHitCollection> handle_hits;
+   const EcalRecHitCollection *hits = 0;
+
+   if (fabs(m_eta) < 1.5)
+   {
+      try
+      {
+         edm::InputTag tag("ecalRecHit", "EcalRecHitsEB");
+         m_event->getByLabel(tag, handle_hits);
+	 if (handle_hits.isValid())
+         {
+	    hits = &*handle_hits;
+         }
+      }
+      catch (...)
+      {
+         fwLog(fwlog::kWarning) <<"FWECALCaloDataDetailViewBuilder::build():: Failed to access EcalRecHitsEB collection." << std::endl;
+      }
+      if ( ! handle_hits.isValid()) {
+         try{
+            edm::InputTag tag("reducedEcalRecHitsEB");
+            m_event->getByLabel(tag, handle_hits);
+            if (handle_hits.isValid())
+            {
+               hits = &*handle_hits;
+            }
+
+         }
+         catch (...)
+         {
+            fwLog(fwlog::kWarning) <<"FWECALCaloDataDetailViewBuilder::build():: Failed to access reducedEcalRecHitsEB collection." << std::endl;
+         }
+      }   
+   }
+   else
+   {
+      try
+      {
+         edm::InputTag tag("ecalRecHit", "EcalRecHitsEE");
+         m_event->getByLabel(tag, handle_hits);
+	 if (handle_hits.isValid())
+	    hits = &*handle_hits;
+      }
+      catch (...)
+      {
+         fwLog(fwlog::kWarning) <<"FWECALCaloDataDetailViewBuilder::build():: Failed to access ecalRecHitsEE collection." << std::endl;
+      }
+
+      if ( ! handle_hits.isValid()) {
+         try {
+            edm::InputTag tag("reducedEcalRecHitsEE");
+            m_event->getByLabel(tag, handle_hits);
+            if (handle_hits.isValid())
+            {
+               hits = &*handle_hits;
+            }
+
+         }
+         catch (...)
+         {     
+            fwLog(fwlog::kWarning) <<"FWECALCaloDataDetailViewBuilder::build():: Failed to access reducedEcalRecHitsEE collection." << std::endl;
+         }
+      }
+   }
+     
+   // data
+   TEveCaloDataVec* data = new TEveCaloDataVec( 1 + m_colors.size() );
+   data->RefSliceInfo(0).Setup("hits (not clustered)", 0.0, m_defaultColor );
+   for( size_t i = 0; i < m_colors.size(); ++i )
+   {
+      data->RefSliceInfo(i + 1).Setup( "hits (clustered)", 0.0, m_colors[i] );
+   }
+
+   if( handle_hits.isValid() ) 
+   {
+      fillData( hits, data, xyEE );
+   }
+
+   // axis
+   Double_t etaMin(0), etaMax(0), phiMin(0), phiMax(0);
+   if (data->Empty())
+   {
+      fwLog(fwlog::kWarning) <<"FWECALCaloDataDetailViewBuilder::build():: No hits found in " << Form("FWECALCaloDataDetailViewBuilder::build():: No hits found in eta[%f] phi[%f] region", m_eta, m_phi)<<".\n";
+
+      // add dummy background
+      float x = m_size*TMath::DegToRad();
+      if (fabs(m_eta) < 1.5 || xyEE == false) {
+         etaMin = m_eta -x;
+         etaMax = m_eta +x;
+         phiMin = m_phi -x;
+         phiMax = m_phi +x;
+         data->AddTower(etaMin, etaMax, phiMin, phiMax);
+      }
+      else
+      {
+         float theta = TEveCaloData::EtaToTheta(m_eta);
+         float r = TMath::Tan(theta) * 290;
+         phiMin = r * TMath::Cos(m_phi - x) -300;
+         phiMax = r * TMath::Cos(m_phi + x) + 300;
+         etaMin = r * TMath::Sin(m_phi - x) - 300;
+         etaMax = r * TMath::Sin(m_phi + x) + 300;
+         data->AddTower(TMath::Min(etaMin, etaMax), TMath::Max(etaMin, etaMax),
+                        TMath::Min(phiMin, phiMax), TMath::Max(phiMin, phiMax));
+
+      }
+      data->FillSlice(0, 0.1);      
+   }
+
+ 
+   TAxis* eta_axis = 0;
+   TAxis* phi_axis = 0; 
+   data->GetEtaLimits(etaMin, etaMax);
+   data->GetPhiLimits(phiMin, phiMax);
+   //  printf("data rng %f %f %f %f\n",etaMin, etaMax, phiMin, phiMax );
+
+   if (fabs(m_eta) > 1.5 && xyEE ) {
+      eta_axis = new TAxis(10, etaMin, etaMax);
+      phi_axis = new TAxis(10, phiMin, phiMax);
+      eta_axis->SetTitle("X[cm]");
+      phi_axis->SetTitle("Y[cm]");
+      phi_axis->SetTitleSize(0.05);
+      eta_axis->SetTitleSize(0.05);
+   } else {
+      std::vector<double> etaBinsWithinLimits;
+      etaBinsWithinLimits.push_back(etaMin);
+      for (unsigned int i=0; i<83; ++i)
+         if ( fw3dlego::xbins[i] > etaMin && fw3dlego::xbins[i] < etaMax )
+            etaBinsWithinLimits.push_back(fw3dlego::xbins[i]);
+      etaBinsWithinLimits.push_back(etaMax);
+
+      std::vector<double> phiBinsWithinLimits;
+      phiBinsWithinLimits.push_back(phiMin);
+      for ( double phi = -M_PI; phi < M_PI; phi += M_PI/36 )
+         if ( phi > phiMin && phi < phiMax )
+            phiBinsWithinLimits.push_back(phi);
+      phiBinsWithinLimits.push_back(phiMax);
+
+      eta_axis = new TAxis((int)etaBinsWithinLimits.size() -1, &etaBinsWithinLimits[0]);
+      phi_axis = new TAxis((int)phiBinsWithinLimits.size() -1, &phiBinsWithinLimits[0]);
+
+      eta_axis->SetTitleFont(122);
+      eta_axis->SetTitle("h");
+      eta_axis->SetTitleSize(0.07);
+      phi_axis->SetTitleFont(122);
+      phi_axis->SetTitle("f");
+      phi_axis->SetTitleSize(0.07);
+   }
+   eta_axis->SetNdivisions(510);
+   phi_axis->SetNdivisions(510);
+   data->SetEtaBins(eta_axis);
+   data->SetPhiBins(phi_axis);
+   return data;
+}
+
+//_______________________________________________________________   
+TEveCaloLego* FWECALCaloDataDetailViewBuilder::build()
+{
+   TEveCaloData* data = buildCaloData(true);   
+   
+   double etaMin, etaMax, phiMin, phiMax;
+   data->GetEtaLimits(etaMin, etaMax);
+   data->GetPhiLimits(phiMin, phiMax);
+   
+   // lego
+   TEveCaloLego *lego = new TEveCaloLego(data);
+   lego->SetDrawNumberCellPixels(100);
+   // scale and translate to real world coordinates
+   lego->SetEta(etaMin, etaMax);
+   lego->SetPhiWithRng((phiMin+phiMax)*0.5, (phiMax-phiMin)*0.5); // phi range = 2* phiOffset
+   Double_t legoScale = ((etaMax - etaMin) < (phiMax - phiMin)) ? (etaMax - etaMin) : (phiMax - phiMin);
+   lego->InitMainTrans();
+   lego->RefMainTrans().SetScale(legoScale, legoScale, legoScale*0.5);
+   lego->RefMainTrans().SetPos((etaMax+etaMin)*0.5, (phiMax+phiMin)*0.5, 0);
+   lego->SetAutoRebin(kFALSE);
+   lego->Set2DMode(TEveCaloLego::kValSizeOutline);
+   lego->SetName("ECALDetail Lego");
+   return lego;
+
+}
+
+void FWECALCaloDataDetailViewBuilder::setColor(Color_t color, const std::vector<DetId> &detIds)
+{
+
+   m_colors.push_back(color);
+
+   // get the slice for this group of detIds
+   // note that the zeroth slice is the default one (all else)
+   int slice = m_colors.size();
+   // take a note of which slice these detids are going to go into
+   for (size_t i = 0; i < detIds.size(); ++i)
+      m_detIdsToColor[detIds[i]] = slice;
+}
+
+void
+FWECALCaloDataDetailViewBuilder::showSuperCluster( const reco::SuperCluster &cluster, Color_t color )
+{
+   std::vector<DetId> clusterDetIds;
+   const std::vector<std::pair<DetId, float> > &hitsAndFractions = cluster.hitsAndFractions();
+   for (size_t j = 0; j < hitsAndFractions.size(); ++j)
+   {
+      clusterDetIds.push_back(hitsAndFractions[j].first);
+   }
+
+   setColor( color, clusterDetIds );
+}
+
+void
+FWECALCaloDataDetailViewBuilder::showSuperClusters( Color_t color1, Color_t color2 )
+{
+   // get the superclusters from the event
+   edm::Handle<reco::SuperClusterCollection> collection;
+
+   if( fabs( m_eta ) < 1.5 ) {
+      try {
+         m_event->getByLabel(edm::InputTag("correctedHybridSuperClusters"), collection);
+      }
+      catch (...)
+      {
+         fwLog(fwlog::kWarning) <<"no barrel superclusters are available" << std::endl;
+      }
+   } else {
+      try {
+         m_event->getByLabel(edm::InputTag("correctedMulti5x5SuperClustersWithPreshower"), collection);
+      }
+      catch (...)
+      {
+         fwLog(fwlog::kWarning) <<"no endcap superclusters are available" << std::endl;
+      }
+   }
+   if( collection.isValid() )
+   {
+      unsigned int colorIndex = 0;
+      // sort clusters in eta so neighboring clusters have distinct colors
+      reco::SuperClusterCollection sorted = *collection.product();
+      std::sort( sorted.begin(), sorted.end(), superClusterEtaLess );
+      for( size_t i = 0; i < sorted.size(); ++i )
+      {
+	 if( !(fabs(sorted[i].eta() - m_eta) < (m_size*0.0172)
+	       && fabs(sorted[i].phi() - m_phi) < (m_size*0.0172)) )
+	   continue;
+
+	 if( colorIndex %2 == 0 )
+	    showSuperCluster( sorted[i], color1 );
+	 else
+	    showSuperCluster( sorted[i], color2 );
+	 ++colorIndex;
+      }
+   }
+}
+
+void
+FWECALCaloDataDetailViewBuilder::fillData( const EcalRecHitCollection *hits,
+                                  TEveCaloDataVec *data, bool xyEE )
+{
+   const float barrelCR = m_size*0.0172; // barrel cell range
+   
+   // loop on all the detids
+   for( EcalRecHitCollection::const_iterator k = hits->begin(), kEnd = hits->end();
+       k != kEnd; ++k )
+   {
+      // get reco geometry
+      double centerEta = 0;
+      double centerPhi = 0;
+      const float* points = m_geom->getCorners( k->id().rawId());
+      if( points != 0 )
+      {
+         TEveVector v;
+         int j = 0;
+         for( int i = 0; i < 8; ++i )
+         {	 
+            v += TEveVector( points[j], points[j + 1], points[j + 2] );
+            j +=3;
+         }
+         centerEta = v.Eta();
+         centerPhi = v.Phi();
+      }
+      else
+         fwLog( fwlog::kInfo ) << "cannot get geometry for DetId: "<< k->id().rawId() << ". Ignored.\n";
+      
+      double size = k->energy() / cosh( centerEta );
+      
+      // check what slice to put in
+      int slice = 0;
+      std::map<DetId, int>::const_iterator itr = m_detIdsToColor.find(k->id());
+      if (itr != m_detIdsToColor.end()) slice = itr->second;
+      
+      // if in the EB
+      if( k->id().subdetId() == EcalBarrel || xyEE == false )
+      {
+         // do phi wrapping
+         if( centerPhi > m_phi + M_PI) centerPhi -= 2 * M_PI;
+         if( centerPhi < m_phi - M_PI) centerPhi += 2 * M_PI;
+         
+         // check if the hit is in the window to be drawn
+         if( !( fabs( centerEta - m_eta ) < barrelCR
+               && fabs( centerPhi - m_phi ) < barrelCR )) continue;
+         
+         double minEta(10), maxEta(-10), minPhi(4), maxPhi(-4);
+         if( points != 0 )
+         {
+            // calorimeter crystalls have slightly non-symetrical form in eta-phi projection
+            // so if we simply get the largest eta and phi, cells will overlap
+            // therefore we get a smaller eta-phi range representing the inner square
+            // we also should use only points from the inner face of the crystal, since
+            // non-projecting direction of crystals leads to large shift in eta on outter
+            // face.
+            int j = 0;
+            float eps = 0.005;
+            for( unsigned int i = 0; i < 8; ++i )
+            {
+               TEveVector crystal( points[j], points[j + 1], points[j + 2] );
+               j += 3;
+               double eta = crystal.Eta();
+               double phi = crystal.Phi();
+               if ( ((k->id().subdetId() == EcalBarrel)  && (crystal.Perp() > 135) )||  ((k->id().subdetId() == EcalEndcap) && (crystal.Perp() > 155))) continue;
+               if ( minEta - eta > eps) minEta = eta;
+               if ( eta - minEta > 0 && eta - minEta < eps ) minEta = eta;
+               if ( eta - maxEta > eps) maxEta = eta;
+               if ( maxEta - eta > 0 && maxEta - eta < eps ) maxEta = eta;
+               if ( minPhi - phi > eps) minPhi = phi;
+               if ( phi - minPhi > 0 && phi - minPhi < eps ) minPhi = phi;
+               if ( phi - maxPhi > eps) maxPhi = phi;
+               if ( maxPhi - phi > 0 && maxPhi - phi < eps ) maxPhi = phi;
+            }
+         }
+         else 
+         {
+            double delta = 0.0172 * 0.5;
+            minEta = centerEta - delta;
+            maxEta = centerEta + delta;
+            minPhi = centerPhi - delta;
+            maxPhi = centerPhi + delta;
+         }
+         if( minPhi >= ( m_phi - barrelCR ) && maxPhi <= ( m_phi + barrelCR ) &&
+            minEta >= ( m_eta - barrelCR ) && maxEta <= ( m_eta + barrelCR ))
+         {
+            // printf("add %f %f %f %f \n",minEta, maxEta, minPhi, maxPhi );
+            data->AddTower( minEta, maxEta, minPhi, maxPhi );
+            data->FillSlice( slice, size );
+         }
+         // otherwise in the EE
+      }
+      else if( k->id().subdetId() == EcalEndcap )
+      {
+         // check if the hit is in the window to be drawn
+         double crystalSize = m_size * 0.0172;
+         if( !( fabs( centerEta - m_eta ) < ( crystalSize )
+               && fabs( centerPhi - m_phi ) < ( crystalSize )))
+            continue;
+         
+         if( points != 0 )
+         {
+            double minX(9999), maxX(-9999), minY(9999), maxY(-9999);
+            int j = 0;
+            for( unsigned int i = 0; i < 8; ++i )
+            {
+               TEveVector crystal( points[j], points[j + 1], points[j + 2] );
+               j += 3;
+               double x = crystal.fX;
+               double y = crystal.fY;
+               if( fabs( crystal.fZ ) > 330 ) continue;
+               if( minX - x > 0.01 ) minX = x;
+               if( x - maxX > 0.01 ) maxX = x;
+               if( minY - y > 0.01 ) minY = y;
+               if( y - maxY > 0.01 ) maxY = y;
+            }
+            data->AddTower( minX, maxX, minY, maxY );
+            // printf("EE add %f %f %f %f \n",minX, maxX, minY, maxY );
+         }
+         data->FillSlice( slice, size );
+      }
+   } // end loop on hits
+   
+   data->DataChanged();
+}
+
+double
+FWECALCaloDataDetailViewBuilder::makeLegend( double x0, double y0,
+                                    Color_t clustered1, Color_t clustered2,
+                                    Color_t supercluster
+                                    )
+{
+   Double_t fontsize = 0.07;
+   TLatex* latex = new TLatex();
+   Double_t x = x0;
+   Double_t y = y0;
+   Double_t boxH = 0.25*fontsize;
+   Double_t yStep = 0.04;
+   
+   y -= yStep;
+   latex->DrawLatex(x, y, "Energy types:");
+   y -= yStep;
+   
+   Double_t pos[4];
+   pos[0] = x+0.05;
+   pos[2] = x+0.20;
+   
+   pos[1] = y; pos[3] = pos[1] + boxH;
+   FWDetailViewBase::drawCanvasBox(pos, m_defaultColor);
+   latex->DrawLatex(x+0.25, y, "unclustered");
+   y -= yStep;
+   if (clustered1<0) return y;
+   
+   pos[1] = y; pos[3] = pos[1] + boxH;
+   FWDetailViewBase::drawCanvasBox(pos, clustered1);
+   latex->DrawLatex(x+0.25, y, "clustered");
+   y -= yStep;
+   if (clustered2<0) return y;
+   
+   pos[1] = y; pos[3] = pos[1] + boxH;
+   FWDetailViewBase::drawCanvasBox(pos, clustered2);
+   latex->DrawLatex(x+0.25, y, "clustered");
+   y -= yStep;
+   if (supercluster<0) return y;
+   
+   pos[1] = y; pos[3] = pos[1] + boxH;
+   FWDetailViewBase::drawCanvasBox(pos, supercluster);
+   latex->DrawLatex(x+0.25, y, "super-cluster");
+   y -= yStep;
+   
+   return y;
+}

--- a/Fireworks/Calo/src/FWECALDetailViewBase.icc
+++ b/Fireworks/Calo/src/FWECALDetailViewBase.icc
@@ -72,7 +72,7 @@ void FWECALDetailViewBase<T>::build( const FWModelId &id, const T* element )
    FWDetailViewGL<T>::viewerGL()->AddOverlayElement( overlay );
    }
    // set event handler and flip camera to top view at beginning
-   FWDetailViewGL<T>::viewerGL()->SetCurrentCamera( TGLViewer::kCameraPerspXOY );
+   FWDetailViewGL<T>::viewerGL()->SetCurrentCamera( TGLViewer::kCameraOrthoXOY );
    FWGLEventHandler* eh =
       new FWGLEventHandler( (TGWindow*) FWDetailViewGL<T>::viewerGL()->GetGLWidget(), (TObject*) FWDetailViewGL<T>::viewerGL(), lego );
    FWDetailViewGL<T>::viewerGL()->SetEventHandler( eh );

--- a/Fireworks/Calo/src/FWECALDetailViewBase.icc
+++ b/Fireworks/Calo/src/FWECALDetailViewBase.icc
@@ -72,7 +72,7 @@ void FWECALDetailViewBase<T>::build( const FWModelId &id, const T* element )
    FWDetailViewGL<T>::viewerGL()->AddOverlayElement( overlay );
    }
    // set event handler and flip camera to top view at beginning
-   //  FWDetailViewGL<T>::viewerGL()->SetCurrentCamera( TGLViewer::kCameraOrthoXOY );
+   FWDetailViewGL<T>::viewerGL()->SetCurrentCamera( TGLViewer::kCameraPerspXOY );
    FWGLEventHandler* eh =
       new FWGLEventHandler( (TGWindow*) FWDetailViewGL<T>::viewerGL()->GetGLWidget(), (TObject*) FWDetailViewGL<T>::viewerGL(), lego );
    FWDetailViewGL<T>::viewerGL()->SetEventHandler( eh );

--- a/Fireworks/Calo/src/FWECALDetailViewBase.icc
+++ b/Fireworks/Calo/src/FWECALDetailViewBase.icc
@@ -1,0 +1,119 @@
+
+// ROOT includes
+#include "TLatex.h"
+#include "TEveCalo.h"
+#include "TEveStraightLineSet.h"
+#include "TEvePointSet.h"
+#include "TEveScene.h"
+#include "TEveViewer.h"
+#include "TGLViewer.h"
+#include "TGLOverlay.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TEveCaloLegoOverlay.h"
+#include "TRootEmbeddedCanvas.h"
+
+// Fireworks includes
+#include "Fireworks/Calo/interface/FWECALDetailViewBase.h"
+#include "Fireworks/Calo/interface/FWECALDetailViewBuilder.h"
+#include "Fireworks/Core/interface/FWColorManager.h"
+#include "Fireworks/Core/interface/FWModelId.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGLEventHandler.h"
+
+// CMSSW includes
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+
+
+template <typename T>
+FWECALDetailViewBase<T>::FWECALDetailViewBase () : m_data(0), m_builder(0), m_legend(0)
+{
+}
+template <typename T>
+FWECALDetailViewBase<T>::~FWECALDetailViewBase () 
+{
+   FWDetailViewGL<T>::m_eveViewer->GetGLViewer()->DeleteOverlayElements(TGLOverlayElement::kUser);
+
+   delete m_builder;
+   if (m_data) m_data->DecDenyDestroy();
+}
+
+template <typename T>
+void FWECALDetailViewBase<T>::build( const FWModelId &id, const T* element )
+{
+   double eta = element->eta();
+   double phi = element->phi();
+
+   // build ECAL objects
+   m_builder = new FWECALDetailViewBuilder( id.item()->getEvent(), id.item()->getGeom(), eta, phi, 25);
+					   
+   TEveCaloLego* lego = m_builder->build();
+   m_data = lego->GetData();
+   m_data->IncDenyDestroy(); // needed ??? 
+   FWDetailViewGL<T>::m_eveScene->AddElement( lego );
+
+   m_legend = new TLegend(0.01, 0.01, 0.99, 0.99, 0, "NDC");
+   m_legend->SetTextSize(0.075);
+   m_legend->SetBorderSize(0);
+   m_legend->SetMargin(0.15);
+   m_legend->SetEntrySeparation(0.05);
+
+   
+   // draw axis at the window corners
+   if (1)
+   {
+   TEveCaloLegoOverlay* overlay = new TEveCaloLegoOverlay();
+   overlay->SetShowPlane( kFALSE );
+   overlay->SetShowPerspective( kFALSE );
+   overlay->SetCaloLego( lego );
+   overlay->SetShowScales( 1 ); // temporary
+
+   FWDetailViewGL<T>::viewerGL()->AddOverlayElement( overlay );
+   }
+   // set event handler and flip camera to top view at beginning
+   //  FWDetailViewGL<T>::viewerGL()->SetCurrentCamera( TGLViewer::kCameraOrthoXOY );
+   FWGLEventHandler* eh =
+      new FWGLEventHandler( (TGWindow*) FWDetailViewGL<T>::viewerGL()->GetGLWidget(), (TObject*) FWDetailViewGL<T>::viewerGL(), lego );
+   FWDetailViewGL<T>::viewerGL()->SetEventHandler( eh );
+   FWDetailViewGL<T>::viewerGL()->ResetCamerasAfterNextUpdate();
+   FWDetailViewGL<T>::viewerGL()->UpdateScene(kFALSE);
+   gEve->Redraw3D();
+
+   setTextInfo( id, element );
+}
+
+template <typename T>
+void FWECALDetailViewBase<T>::setTextInfo( const FWModelId& id, const  T* element )
+{
+   FWDetailViewGL<T>::m_infoCanvas->cd();
+
+   float_t x  = 0.02;
+   float   y  = 0.95;
+
+   TLatex* latex = new TLatex( x, y, "" );
+   const double textsize( 0.1 );
+   latex->SetTextSize( textsize );
+
+   latex->DrawLatex( x, y, id.item()->modelName( id.index() ).c_str() );
+   y -= latex->GetTextSize()*0.8;
+
+   latex->SetTextSize( textsize * 0.8 );
+   float lineH = latex->GetTextSize()*0.6;
+
+   latex->DrawLatex( x, y, Form( "#eta = %0.2f" , element->eta()));
+   y -= lineH;
+   latex->DrawLatex( x, y, Form( "#phi = %0.2f" , element->phi()));
+   y -= lineH;
+   // summary
+   if( element->charge() > 0 )
+      latex->DrawLatex( x, y, "charge = +1" );
+   else
+      latex->DrawLatex( x, y, "charge = -1" );
+   y -= lineH;
+
+   m_legend->SetY2(y);
+   m_legend->Draw();
+   m_legend = 0; // Deleted together with TPad.
+}
+

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -45,15 +45,9 @@ TEveCaloData* FWECALDetailViewBuilder::buildCaloData(bool)
    // get the hits from the event
 
    // data
-   TEveCaloDataVec* data = new TEveCaloDataVec( 1 + m_colors.size() );
+   TEveCaloDataVec* data = new TEveCaloDataVec( 1);
    data->SetWrapTwoPi(false);
    data->RefSliceInfo(0).Setup("hits (not clustered)", 0.0, m_defaultColor );
-   for( size_t i = 0; i < m_colors.size(); ++i )
-   {
-      data->RefSliceInfo(i + 1).Setup( "hits (clustered)", 0.0, m_colors[i] );
-   }
-
-
    
    fillData(data);
 
@@ -153,15 +147,8 @@ TEveCaloLego* FWECALDetailViewBuilder::build()
 
 void FWECALDetailViewBuilder::setColor(Color_t color, const std::vector<DetId> &detIds)
 {
-
-   m_colors.push_back(color);
-
-   // get the slice for this group of detIds
-   // note that the zeroth slice is the default one (all else)
-   int slice = m_colors.size();
-   // take a note of which slice these detids are going to go into
    for (size_t i = 0; i < detIds.size(); ++i)
-      m_detIdsToColor[detIds[i]] = slice;
+      m_detIdsToColor[detIds[i]] = color;
 }
 
 void
@@ -221,14 +208,6 @@ FWECALDetailViewBuilder::showSuperClusters( Color_t color1, Color_t color2 )
    }
 }
 
-/*
-
-            if (fabs(fabs(centerPhi) -TMath::Pi()) < 0.06 ){
-               // if (dump) printf("fixing phi %f, ceneter %f\n", phi, centerPhi);
-               if (centerPhi < 0 && phi > 0 ) phi -= TMath::TwoPi();
-               if (centerPhi > 0 && phi < 0 ) phi += TMath::TwoPi();
-            }
-*/
 
 namespace {
 float
@@ -321,8 +300,6 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
        m_boxes.back()->getTower()->SetTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
 
    } // loop hits
-
-
 
 }
 

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -321,7 +321,14 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
 
        energy = hitIt->energy();
        et = calculateEt( center, energy );
+       Color_t bcolor = m_defaultColor;
+       std::map<DetId, int>::const_iterator itr = m_detIdsToColor.find(hitIt->id());
+       if (itr != m_detIdsToColor.end()) bcolor = itr->second;
+
        m_boxes.push_back(new FWBoxRecHit( etaphiCorners, m_towerList, energy, et ));
+       m_boxes.back()->getTower()->SetMainColor(bcolor);
+       m_boxes.back()->getTower()->SetTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
+
    } // loop hits
 
 

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -123,7 +123,7 @@ TEveCaloLego* FWECALDetailViewBuilder::build()
    Double_t legoScale = sizeRad() *2;
    lego->InitMainTrans();
    lego->RefMainTrans().SetScale(legoScale, legoScale, legoScale*0.5);
-   lego->RefMainTrans().SetPos(m_eta, m_phi, 0);
+   lego->RefMainTrans().SetPos(m_eta, m_phi, -0.01);
    lego->SetAutoRebin(kFALSE);
    lego->SetName("ECALDetail Lego");
 
@@ -406,9 +406,10 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
 
    // AMT ... max size can be an external parameter
    float scale = 0.3/maxEnergy;
-    for (auto & i : m_boxes) 
+   for (auto & i : m_boxes) {
         i->updateScale(scale, log(maxEnergy), plotEt);
-
+        i->getTower()->SetDrawFrame(true);
+   }
    data->DataChanged();
 }
 

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -40,7 +40,7 @@ FWECALDetailViewBuilder::FWECALDetailViewBuilder(const edm::EventBase *event, co
 }
 
 
-TEveCaloData* FWECALDetailViewBuilder::buildCaloData(bool xyEE)
+TEveCaloData* FWECALDetailViewBuilder::buildCaloData(bool)
 {
    // get the hits from the event
 
@@ -249,7 +249,7 @@ calculateEt( const TEveVector &centre, float e )
 void
 FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDataVec *data)
 {
-   
+    // printf("filletaphi \n");  
    const float area = sizeRad(); // barrel cell range, AMT this is available in context
 
    double eta1 = m_eta - area;
@@ -258,15 +258,6 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
    double phi2 = m_phi + area;
 
 
-   //  float  maxEnergyLog = 0,  maxEnergy = 0, maxEt = 0, maxEtLog = 0;
-   /*
-   // check if we are in -Pi|Pi area
-   int wrapPhi = 0;
-   if (TMath::Abs(phi1) > TMath::Pi() || TMath::Abs(phi2) > TMath::Pi()) {
-      wrapPhi = m_phi > 0 ? 1 : -1;
-      //printf("wrap phi %d \n", wrapPhi);
-      //printf("phi range [%f, %f]\n", phi1, phi2);
-      }*/
    std::vector<FWBoxRecHit*>  boxes;
    for( EcalRecHitCollection::const_iterator hitIt = hits->begin(); hitIt != hits->end(); ++hitIt)
    {    
@@ -491,10 +482,6 @@ FWECALDetailViewBuilder::makeLegend( double x0, double y0,
    return y;
 }
 //______________________________________________________________________________
-float FWECALDetailViewBuilder::sizeXY() const
-{
-   return m_size *1.5;
-}
 
 float FWECALDetailViewBuilder::sizeRad() const
 {

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -135,8 +135,8 @@ TEveCaloLego* FWECALDetailViewBuilder::build()
 
    
    TEvePointSet* ps = new TEvePointSet("origin");
-      ps->SetNextPoint(m_eta, m_phi, 0.01);
-      ps->SetMarkerSize(0.05);
+   ps->SetNextPoint(m_eta, m_phi, 0.01);
+   ps->SetMarkerSize(0.05);
    ps->SetMarkerStyle(2);
    ps->SetMainColor(kGreen);
    ps->SetMarkerColor(kGreen);
@@ -300,7 +300,8 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
        TEveElement::List_i pIt = m_boxes.back()->getTower()->BeginParents();
        TEveCompound* comp = dynamic_cast<TEveCompound*>(*pIt);
        comp->SetMainColor(bcolor);
-       comp->SetElementTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
+       m_boxes.back()->getTower()->SetPickable(true);
+       m_boxes.back()->getTower()->SetElementTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
    } // loop hits
 
 }

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -6,6 +6,7 @@
 #include "TEveViewer.h"
 #include "TEvePointSet.h"
 #include "TEveCalo.h"
+#include "TEveCompound.h"
 #include "TAxis.h"
 #include "TMath.h"
 #include "THLimitsFinder.h"
@@ -296,9 +297,10 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
        if (itr != m_detIdsToColor.end()) bcolor = itr->second;
 
        m_boxes.push_back(new FWBoxRecHit( etaphiCorners, m_towerList, energy, et ));
-       m_boxes.back()->getTower()->SetMainColor(bcolor);
-       m_boxes.back()->getTower()->SetTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
-
+       TEveElement::List_i pIt = m_boxes.back()->getTower()->BeginParents();
+       TEveCompound* comp = dynamic_cast<TEveCompound*>(*pIt);
+       comp->SetMainColor(bcolor);
+       comp->SetElementTitle(Form("rawId = %d, et = %f", hitIt->id().rawId(), et));
    } // loop hits
 
 }

--- a/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
+++ b/Fireworks/Calo/src/FWECALDetailViewBuilder.cc
@@ -313,10 +313,11 @@ FWECALDetailViewBuilder::fillEtaPhi( const EcalRecHitCollection *hits,TEveCaloDa
 void
 FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
 {
-
    { // barrel
       const EcalRecHitCollection *hitsEB = 0;
       edm::Handle<EcalRecHitCollection> handle_hitsEB;
+
+      // RECO
       try
       {
          edm::InputTag tag("ecalRecHit", "EcalRecHitsEB");
@@ -330,6 +331,9 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
       {
          fwLog(fwlog::kWarning) <<"FWECALDetailViewBuilder::fillData():: Failed to access EcalRecHitsEB collection." << std::endl;
       }
+
+
+      // AOD
       if ( ! handle_hitsEB.isValid()) {
          try{
             edm::InputTag tag("reducedEcalRecHitsEB");
@@ -346,6 +350,26 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
          }
       }
 
+      // MINIAOD
+      if ( ! handle_hitsEB.isValid()) {
+         try{
+            edm::InputTag tag("reducedEgamma", "reducedEBRecHits");
+            m_event->getByLabel(tag, handle_hitsEB);
+            if (handle_hitsEB.isValid())
+            {
+               hitsEB = &*handle_hitsEB;
+            }
+
+
+
+
+         }
+         catch (...)
+         {
+            fwLog(fwlog::kWarning) <<"FWECALDetailViewBuilder::filData():: Failed to access reducedEgamma collection." << std::endl;
+         }
+      }
+
       if( handle_hitsEB.isValid() ) 
       {
          fillEtaPhi( hitsEB, data);
@@ -356,6 +380,8 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
 
       const EcalRecHitCollection *hitsEE = 0;
       edm::Handle<EcalRecHitCollection> handle_hitsEE;
+
+      // RECO
       try
       {
          edm::InputTag tag("ecalRecHit", "EcalRecHitsEE");
@@ -368,6 +394,7 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
          fwLog(fwlog::kWarning) <<"FWECALDetailViewBuilder::fillData():: Failed to access ecalRecHitsEE collection." << std::endl;
       }
 
+      // AOD
       if ( ! handle_hitsEE.isValid()) {
          try {
             edm::InputTag tag("reducedEcalRecHitsEE");
@@ -382,6 +409,23 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
          {     
             fwLog(fwlog::kWarning) <<"FWECALDetailViewBuilder::fillData():: Failed to access reducedEcalRecHitsEE collection." << std::endl;
          }
+
+      // MINIAOD
+      if ( ! handle_hitsEE.isValid()) {
+         try {
+            edm::InputTag tag("reducedEgamma", "reducedEERecHits");
+            m_event->getByLabel(tag, handle_hitsEE);
+            if (handle_hitsEE.isValid())
+            {
+               hitsEE = &*handle_hitsEE;
+            }
+
+         }
+         catch (...)
+         {     
+            fwLog(fwlog::kWarning) <<"FWECALDetailViewBuilder::fillData():: Failed to access reducedEcalRecHitsEE collection." << std::endl;
+         }
+      }
    
       }
 
@@ -390,6 +434,8 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
           fillEtaPhi( hitsEE, data);
       }
    }
+
+   if ( m_boxes.empty()) return;
 
    bool plotEt = true;
    float maxEnergy = 0;
@@ -410,7 +456,7 @@ FWECALDetailViewBuilder::fillData(  TEveCaloDataVec *data)
    // AMT ... max size can be an external parameter
    float scale = 0.3/maxEnergy;
    for (auto & i : m_boxes) {
-        i->updateScale(scale, log(maxEnergy), plotEt);
+        i->updateScale(scale, log(maxEnergy + 1), plotEt);
         i->getTower()->SetDrawFrame(true);
    }
    data->DataChanged();

--- a/Fireworks/Candidates/plugins/BuildFile.xml
+++ b/Fireworks/Candidates/plugins/BuildFile.xml
@@ -3,5 +3,6 @@
  <use name="Fireworks/Candidates"/>
  <use name="Fireworks/Core"/>
  <lib name="Eve"/>
+ <lib name="RGL"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
@@ -14,7 +14,14 @@ private:
 
 };
 
-REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,ecalRecHit );
-REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,reducedEcalRecHitsEB);
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL);
 
+/*
+// reco
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,ecalRecHit );
+// aod
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,reducedEcalRecHitsEB);
+// miniaod
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,reducedEgamma);
+*/
 

--- a/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
@@ -1,0 +1,20 @@
+#include "Fireworks/Calo/interface/FWECALDetailViewBase.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+class  FWCandidateECALDetailView: public FWECALDetailViewBase<reco::Candidate>
+{
+public:
+   FWCandidateECALDetailView() {}
+   virtual ~FWCandidateECALDetailView() {}
+
+private:
+   FWCandidateECALDetailView(const FWCandidateECALDetailView&); // stop default
+   const FWCandidateECALDetailView& operator=(const FWCandidateECALDetailView&); // stop default
+
+
+};
+
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,ecalRecHit );
+REGISTER_FWDETAILVIEW(FWCandidateECALDetailView, ECAL,reducedEcalRecHitsEB);
+
+

--- a/Fireworks/Core/src/CmsShowMainFrame.cc
+++ b/Fireworks/Core/src/CmsShowMainFrame.cc
@@ -264,46 +264,7 @@ CmsShowMainFrame::CmsShowMainFrame(const TGWindow *p,UInt_t w,UInt_t h,FWGUIMana
 
    menuTopFrame->AddFrame(menuBar, new TGLayoutHints(kLHintsLeft, 0, 0, 0, 0));
 
-   {
-      TGHorizontalFrame* hft = new TGHorizontalFrame(menuTopFrame);
-      menuTopFrame->AddFrame(hft, new TGLayoutHints(kLHintsLeft, 73, 0, 3, 0));
-      hft->SetBackgroundColor(backgroundColor);
-
-
-
-      TGLabel *label = new TGLabel(hft, "New palettes functions:  ");
-      label->SetTextJustify(kTextCenterX);
-      label->SetTextColor(0xaa4488);
-      label->SetBackgroundColor(backgroundColor);
-      fireworks::Context* ctx = fireworks::Context::getInstance();
-      hft->AddFrame(label, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, 2, 0));
-
-      {
-         TGTextButton* b = new TGTextButton(hft, " Change color palette ");
-         hft->AddFrame(b,new TGLayoutHints(kLHintsLeft, 0, 0, 0, 0) );
-         b->SetBackgroundColor(backgroundColor);
-         b->SetForegroundColor(0xffffff);
-         b->SetToolTipText("Also available through Common preferences dialog");
-         b->Connect("Clicked()", "CmsShowCommon", ctx->commonPrefs(), "loopPalettes()");
-      }
-      {
-         TGTextButton* b = new TGTextButton(hft, " Permute colors ");
-         hft->AddFrame(b,new TGLayoutHints(kLHintsLeft, 5, 0, 0, 0) );
-         b->SetBackgroundColor(backgroundColor);
-         b->SetForegroundColor(0xffffff);
-         b->Connect("Clicked()", "CmsShowCommon", ctx->commonPrefs(), "permuteColors()");
-
-      }
-      {
-         TGTextButton* b = new TGTextButton(hft, " Randomize colors ");
-         hft->AddFrame(b,new TGLayoutHints(kLHintsLeft, 5, 0, 0, 0) );
-         b->SetBackgroundColor(backgroundColor);
-         b->SetForegroundColor(0xffffff);
-         b->Connect("Clicked()", "CmsShowCommon", ctx->commonPrefs(), "randomizeColors()");
-
-      }
-   }
-
+   
    AddFrame(menuTopFrame, new TGLayoutHints(kLHintsExpandX, 0, 0, 0, 0));
 
    // !!!! MT Line separating menu from other window components.

--- a/Fireworks/Core/src/CmsShowModelPopup.cc
+++ b/Fireworks/Core/src/CmsShowModelPopup.cc
@@ -194,7 +194,6 @@ CmsShowModelPopup::fillModelPopup(const FWSelectionManager& iSelMgr)
          TGTextButton *button;
          for(size_t index = m_openDetailedViewButtons.size(); index < viewChoices.size(); ++index)
          { 
-            printf("add new button %s \n ",  viewChoices[index].c_str());
             button = new TGTextButton(this, "dummy", index);
             AddFrame(button, new TGLayoutHints(kLHintsExpandX, 4, 4, 4, 4));
             TGCompositeFrame* cf = (TGCompositeFrame*)button->GetParent();

--- a/Fireworks/Core/src/FW3DViewBase.cc
+++ b/Fireworks/Core/src/FW3DViewBase.cc
@@ -113,7 +113,7 @@ FW3DViewBase::FW3DViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId, un
    m_showTrackerBarrel(this, "Show Tracker Barrel", false ),
    m_showTrackerEndcap(this, "Show Tracker Endcap", false),
    m_ecalBarrel(0),
-   m_showEcalBarrel(this, "Show Ecal Barrel", typeId == FWViewType::kISpy ? true : false),
+   m_showEcalBarrel(this, "Show Ecal Barrel", false),
    m_rnrStyle(this, "Render Style", 0l, 0l, 2l),
    m_selectable(this, "Enable Tooltips", false),
    m_cameraType(this, "Camera Type", 0l, 0l, 5l),

--- a/Fireworks/Core/src/FWColorManager.cc
+++ b/Fireworks/Core/src/FWColorManager.cc
@@ -251,7 +251,6 @@ void
 FWColorManager::setBackgroundAndBrightness(BackgroundColorIndex iIndex, int b)
 {
    m_gammaOff = -b*0.1f;
-   printf("set brightnes %f\n", m_gammaOff);
    setBackgroundColorIndex(iIndex);
 }
 

--- a/Fireworks/Core/src/FWDetailViewManager.cc
+++ b/Fireworks/Core/src/FWDetailViewManager.cc
@@ -138,12 +138,12 @@ FWDetailViewManager::findViewersFor(const std::string& iType) const
    if(itFind != m_typeToViewers.end()) {
       return itFind->second;
    }
-   //create a list of the available ViewManager's
+
    std::set<std::string> detailViews;
 
-   std::vector<edmplugin::PluginInfo> available = FWDetailViewFactory::get()->available();
-   std::transform(available.begin(),
-                  available.end(),
+   std::vector<edmplugin::PluginInfo> all = edmplugin::PluginManager::get()->categoryToInfos().find(FWDetailViewFactory::get()->category())->second;
+   std::transform(all.begin(),
+                  all.end(),
                   std::inserter(detailViews,detailViews.begin()),
                   boost::bind(&edmplugin::PluginInfo::name_,_1));
    unsigned int closestMatch= 0xFFFFFFFF;

--- a/Fireworks/Core/src/FWModelContextMenuHandler.cc
+++ b/Fireworks/Core/src/FWModelContextMenuHandler.cc
@@ -41,7 +41,7 @@ enum MenuOptions {
    kSetColorMO,
    //   kPrint,
    kOpenDetailViewMO,
-   kAfterOpenDetailViewMO,
+   kAfterOpenDetailViewMO=10,
    kOpen3DRegion,
    kOpenObjectControllerMO=100,
    kOpenCollectionControllerMO,

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
@@ -34,7 +34,7 @@
 #include "Fireworks/Core/interface/FWMagField.h"
 #include "Fireworks/Core/interface/FWBeamSpot.h"
 #include "Fireworks/Core/interface/fwLog.h"
-#include "Fireworks/Calo/interface/FWECALDetailViewBuilder.h"
+#include "Fireworks/Calo/interface/FWECALCaloDataDetailViewBuilder.h"
 
 #include "Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
@@ -233,7 +233,7 @@ FWConvTrackHitsDetailView::build (const FWModelId &id, const reco::Conversion* c
       float phi = conv->pairMomentum().phi();
       float eta = conv->pairMomentum().eta();
       
-      FWECALDetailViewBuilder caloBld( id.item()->getEvent(), id.item()->getGeom(), eta, phi, 30);
+      FWECALCaloDataDetailViewBuilder caloBld( id.item()->getEvent(), id.item()->getGeom(), eta, phi, 30);
       TEveCaloData* data = caloBld.buildCaloData(false);
        // AMT!!! this is memory leak, check why it needs to be added
       TEveCalo3D* calo3d = new TEveCalo3D(data);

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
@@ -660,6 +660,9 @@ void FWConvTrackHitsDetailView::camera3Callback()
 
 }
 
-
+REGISTER_FWDETAILVIEW(FWConvTrackHitsDetailView, Conversion);
+/*
 REGISTER_FWDETAILVIEW(FWConvTrackHitsDetailView, Conversion, ecalRecHit);
 REGISTER_FWDETAILVIEW(FWConvTrackHitsDetailView, Conversion, reducedEcalRecHitsEB);
+REGISTER_FWDETAILVIEW(FWConvTrackHitsDetailView, Conversion, reducedEGamma);
+*/

--- a/Fireworks/Electrons/plugins/FWElectronDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWElectronDetailView.cc
@@ -27,7 +27,7 @@
 #include "Fireworks/Core/interface/FWGLEventHandler.h"
 
 // CMSSW includes
-#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
@@ -70,16 +70,15 @@ FWElectronDetailView::build( const FWModelId &id, const reco::GsfElectron* iElec
       eta = iElectron->eta();
       phi = iElectron->phi();
    }
-   printf("eta %f phi %f \n", eta, phi);
 
    // build ECAL objects
    m_builder = new FWECALDetailViewBuilder( id.item()->getEvent(), id.item()->getGeom(),
 					    eta, phi, 25);
-   /*
+   
    m_builder->showSuperClusters();
    if( iElectron->superCluster().isAvailable() )
       m_builder->showSuperCluster( *(iElectron->superCluster() ), kYellow);
-   */
+   
    TEveCaloLego* lego = m_builder->build();
    m_data = lego->GetData();
    m_eveScene->AddElement( lego );
@@ -195,11 +194,6 @@ FWElectronDetailView::setTextInfo( const FWModelId& id, const reco::GsfElectron 
 void
 FWElectronDetailView::drawCrossHair (const reco::GsfElectron* i, TEveCaloLego *lego, TEveElementList* tList)
 {
-   unsigned int subdetId( 0 );
-   
-   if( !i->superCluster()->seed()->hitsAndFractions().empty() )
-      subdetId = i->superCluster()->seed()->hitsAndFractions().front().first.subdetId();
-
    double ymax = lego->GetPhiMax();
    double ymin = lego->GetPhiMin();
    double xmax = lego->GetEtaMax();
@@ -211,23 +205,15 @@ FWElectronDetailView::drawCrossHair (const reco::GsfElectron* i, TEveCaloLego *l
       const double eta = i->superCluster()->seed()->position().eta() -
                          i->deltaEtaSeedClusterTrackAtCalo();
       const double phi = i->superCluster()->seed()->position().phi() -
-                         i->deltaPhiSeedClusterTrackAtCalo();
+          i->deltaPhiSeedClusterTrackAtCalo();
 
       TEveStraightLineSet *trackpositionAtCalo = new TEveStraightLineSet("sc trackpositionAtCalo");
       trackpositionAtCalo->SetPickable(kTRUE);
       trackpositionAtCalo->SetTitle("Track position at Calo propagating from the outermost state");
-      if (subdetId == EcalBarrel)
-      {
-         trackpositionAtCalo->AddLine(eta, ymin, 0, eta, ymax, 0);
-         trackpositionAtCalo->AddLine(xmin, phi, 0, xmax, phi, 0);
-      }
-      else if (subdetId == EcalEndcap)
-      {
-         TVector3 pos;
-         pos.SetPtEtaPhi(i->superCluster()->seed()->position().rho(), eta, phi);
-         trackpositionAtCalo->AddLine(pos.X(), ymin, 0, pos.X(), ymax, 0);
-         trackpositionAtCalo->AddLine(xmin, pos.Y(), 0, xmax,pos.Y(),0);
-      }
+
+      trackpositionAtCalo->AddLine(eta, ymin, 0, eta, ymax, 0);
+      trackpositionAtCalo->AddLine(xmin, phi, 0, xmax, phi, 0);
+
       trackpositionAtCalo->SetDepthTest(kFALSE);
       trackpositionAtCalo->SetLineColor(kBlue);
       tList->AddElement(trackpositionAtCalo);
@@ -244,18 +230,10 @@ FWElectronDetailView::drawCrossHair (const reco::GsfElectron* i, TEveCaloLego *l
       Double_t eta = i->caloPosition().eta() - deltaEtaSuperClusterTrackAtVtx(*i);
       Double_t phi = i->caloPosition().phi() - deltaPhiSuperClusterTrackAtVtx(*i);
 
-      if (subdetId == EcalBarrel)
-      {
-         pinposition->AddLine(eta, ymax, 0, eta, ymin, 0);
-         pinposition->AddLine(xmin, phi, 0, xmax, phi, 0);
-      }
-      else if (subdetId == EcalEndcap)
-      {
-         TVector3 pos;
-         pos.SetPtEtaPhi(i->caloPosition().rho(), eta, phi);
-         pinposition->AddLine(pos.X(),ymin, 0, pos.X(), ymax, 0);
-         pinposition->AddLine(xmin, pos.Y(), 0, xmax, pos.Y(), 0);
-      }
+
+      pinposition->AddLine(eta, ymax, 0, eta, ymin, 0);
+      pinposition->AddLine(xmin, phi, 0, xmax, phi, 0);
+
       pinposition->SetDepthTest(kFALSE);
       pinposition->SetLineColor(kRed);
       tList->AddElement(pinposition);
@@ -299,11 +277,7 @@ FWElectronDetailView::checkRange( Double_t &em, Double_t& eM, Double_t &pm, Doub
 void
 FWElectronDetailView::addTrackPointsInCaloData( const reco::GsfElectron *i, TEveCaloLego* lego )
 {
-   unsigned int subdetId(0);
-
-   if ( !i->superCluster()->seed()->hitsAndFractions().empty() )
-      subdetId = i->superCluster()->seed()->hitsAndFractions().front().first.subdetId();
-
+    return;
    TEveCaloDataVec* data = (TEveCaloDataVec*)lego->GetData();
    Double_t em, eM, pm, pM;
    data->GetEtaLimits(em, eM);
@@ -319,34 +293,17 @@ FWElectronDetailView::addTrackPointsInCaloData( const reco::GsfElectron *i, TEve
       double phi = i->superCluster()->seed()->position().phi() -
                    i->deltaPhiSeedClusterTrackAtCalo();
 
-      if (subdetId == EcalBarrel)
-      {
-         if (checkRange(em, eM, pm, pM, eta, phi))
-            changed = kTRUE;
-      }
-      else if (subdetId == EcalEndcap) {
-         TVector3 pos;
-         pos.SetPtEtaPhi(i->superCluster()->seed()->position().rho(),eta, phi);
-         if (checkRange(em, eM, pm, pM, pos.X(), pos.Y()))
-            changed = kTRUE;
 
-      }
+      if (checkRange(em, eM, pm, pM, eta, phi))
+          changed = kTRUE;
    }
    // pinposition
    {
       double eta = i->caloPosition().eta() - deltaEtaSuperClusterTrackAtVtx(*i);
       double phi = i->caloPosition().phi() - deltaPhiSuperClusterTrackAtVtx(*i);
-      if (subdetId == EcalBarrel)
-      {
-         if (checkRange(em, eM, pm, pM, eta, phi))
-            changed = kTRUE;
-      }
-      else if (subdetId == EcalEndcap) {
-         TVector3 pos;
-         pos.SetPtEtaPhi(i->caloPosition().rho(), eta, phi);
-         if (checkRange(em, eM, pm, pM, pos.X(), pos.Y()))
-            changed = kTRUE;
-      }
+
+      if (checkRange(em, eM, pm, pM, eta, phi))
+          changed = kTRUE;
    }
    if (changed)
    {
@@ -365,25 +322,17 @@ FWElectronDetailView::addTrackPointsInCaloData( const reco::GsfElectron *i, TEve
 void
 FWElectronDetailView::addSceneInfo(const reco::GsfElectron *i, TEveElementList* tList)
 {
-   unsigned int subdetId(0);
-
-   if ( !i->superCluster()->seed()->hitsAndFractions().empty() )
-      subdetId = i->superCluster()->seed()->hitsAndFractions().front().first.subdetId();
-
    // centroids
    Double_t x(0), y(0), z(0);
    Double_t delta(0.02);
-   if (subdetId == EcalEndcap) delta = 2.5;
+
    TEveStraightLineSet *scposition = new TEveStraightLineSet("sc position");
    scposition->SetPickable(kTRUE);
    scposition->SetTitle("Super cluster centroid");
-   if (subdetId == EcalBarrel) {
-      x = i->caloPosition().eta();
-      y = i->caloPosition().phi();
-   } else if (subdetId == EcalEndcap) {
-      x = i->caloPosition().x();
-      y = i->caloPosition().y();
-   }
+
+   x = i->caloPosition().eta();
+   y = i->caloPosition().phi();
+
    scposition->AddLine(x-delta,y,z,x+delta,y,z);
    scposition->AddLine(x,y-delta,z,x,y+delta,z);
    scposition->AddLine(x,y,z-delta,x,y,z+delta);
@@ -400,13 +349,10 @@ FWElectronDetailView::addSceneInfo(const reco::GsfElectron *i, TEveElementList* 
    TEveStraightLineSet *seedposition = new TEveStraightLineSet("seed position");
    seedposition->SetTitle("Seed cluster centroid");
    seedposition->SetPickable(kTRUE);
-   if (subdetId == EcalBarrel) {
+
       x  = i->superCluster()->seed()->position().eta();
       y  = i->superCluster()->seed()->position().phi();
-   } else if (subdetId == EcalEndcap) {
-      x  = i->superCluster()->seed()->position().x();
-      y  = i->superCluster()->seed()->position().y();
-   }
+
    seedposition->AddLine(x-delta,y-delta,z,x+delta,y+delta,z);
    seedposition->AddLine(x-delta,y+delta,z,x+delta,y-delta,z);
    seedposition->SetLineColor(kRed);
@@ -426,13 +372,9 @@ FWElectronDetailView::addSceneInfo(const reco::GsfElectron *i, TEveElementList* 
       TEveStraightLineSet *eldirection = new TEveStraightLineSet("seed position");
       eldirection->SetTitle("Electron direction at vertex");
       eldirection->SetPickable(kTRUE);
-      if (subdetId == EcalBarrel) {
-         x = i->eta();
-         y = i->phi();
-      }else{
-         x = 310*fabs(tan(i->theta()))*cos(i->phi());
-         y = 310*fabs(tan(i->theta()))*sin(i->phi());
-      }
+
+      x = i->eta();
+      y = i->phi();
       eldirection->AddLine(x-delta,y-delta,z,x+delta,y+delta,z);
       eldirection->AddLine(x-delta,y+delta,z,x+delta,y-delta,z);
       eldirection->SetLineColor(kGreen);

--- a/Fireworks/Electrons/plugins/FWElectronDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWElectronDetailView.cc
@@ -77,7 +77,7 @@ FWElectronDetailView::build( const FWModelId &id, const reco::GsfElectron* iElec
    
    m_builder->showSuperClusters();
    if( iElectron->superCluster().isAvailable() )
-      m_builder->showSuperCluster( *(iElectron->superCluster() ), kYellow);
+      m_builder->showSuperCluster( *(iElectron->superCluster() ), kYellow + 1);
    
    TEveCaloLego* lego = m_builder->build();
    m_data = lego->GetData();
@@ -377,7 +377,7 @@ FWElectronDetailView::addSceneInfo(const reco::GsfElectron *i, TEveElementList* 
       y = i->phi();
       eldirection->AddLine(x-delta,y-delta,z,x+delta,y+delta,z);
       eldirection->AddLine(x-delta,y+delta,z,x+delta,y-delta,z);
-      eldirection->SetLineColor(kGreen);
+      eldirection->SetLineColor(kGreen + 1);
       eldirection->SetDepthTest(kFALSE);
       tList->AddElement(eldirection);
 

--- a/Fireworks/Electrons/plugins/FWElectronDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWElectronDetailView.cc
@@ -70,14 +70,16 @@ FWElectronDetailView::build( const FWModelId &id, const reco::GsfElectron* iElec
       eta = iElectron->eta();
       phi = iElectron->phi();
    }
+   printf("eta %f phi %f \n", eta, phi);
 
    // build ECAL objects
    m_builder = new FWECALDetailViewBuilder( id.item()->getEvent(), id.item()->getGeom(),
 					    eta, phi, 25);
- 
+   /*
    m_builder->showSuperClusters();
    if( iElectron->superCluster().isAvailable() )
       m_builder->showSuperCluster( *(iElectron->superCluster() ), kYellow);
+   */
    TEveCaloLego* lego = m_builder->build();
    m_data = lego->GetData();
    m_eveScene->AddElement( lego );
@@ -89,7 +91,7 @@ FWElectronDetailView::build( const FWModelId &id, const reco::GsfElectron* iElec
    m_legend->SetEntrySeparation(0.05);
 
    // add Electron specific details
-   if( iElectron->superCluster().isAvailable() ) {
+   if( 0 &&  iElectron->superCluster().isAvailable() ) {
       addTrackPointsInCaloData( iElectron, lego );
       drawCrossHair( iElectron, lego, m_eveScene );
       addSceneInfo( iElectron, m_eveScene );

--- a/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
@@ -24,6 +24,8 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 
+#include "Fireworks/Core/interface/FWProxyBuilderConfiguration.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //   3D and RPZ proxy builder with shared track list
@@ -42,6 +44,9 @@ public:
    virtual void cleanLocal() override;
    using FWSimpleProxyBuilderTemplate<reco::GsfElectron>::buildViewType;
    virtual void buildViewType(const reco::GsfElectron& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type , const FWViewContext*) override;
+
+   using FWSimpleProxyBuilderTemplate<reco::GsfElectron>::setItem;
+   virtual void setItem(const FWEventItem* iItem);
 
    REGISTER_PROXYBUILDER_METHODS();
 
@@ -68,11 +73,24 @@ FWElectronProxyBuilder::~FWElectronProxyBuilder()
    m_common->DecDenyDestroy();
 }
 
+
+void
+FWElectronProxyBuilder::setItem(const FWEventItem* iItem)
+{
+   FWProxyBuilderBase::setItem(iItem);
+   
+   if (iItem) {
+      iItem->getConfig()->assertParam("LineWidth", long(1), long(1), long(4));
+   }
+}
+
+
 TEveElementList*
 FWElectronProxyBuilder::requestCommon()
 {
    if( m_common->HasChildren() == false )
    {
+      int width = item()->getConfig()->value<long>("LineWidth");
       for (int i = 0; i < static_cast<int>(item()->size()); ++i)
       {
          const reco::GsfElectron& electron = modelData(i);
@@ -85,6 +103,7 @@ FWElectronProxyBuilder::requestCommon()
             track = fireworks::prepareCandidate( electron,
                                                  context().getTrackPropagator());
          track->MakeTrack();
+         track->SetLineWidth(width);
          setupElement( track );
          m_common->AddElement( track );
       }

--- a/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
@@ -50,7 +50,7 @@ void FWPhotonDetailView::build (const FWModelId &id, const reco::Photon* iPhoton
    m_builder->showSuperClusters();
 
    if ( iPhoton->superCluster().isAvailable() )
-      m_builder->showSuperCluster(*(iPhoton->superCluster()), kYellow);
+      m_builder->showSuperCluster(*(iPhoton->superCluster()), kYellow + 1);
 
    TEveCaloLego* lego = m_builder->build();
    m_data = lego->GetData();

--- a/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
@@ -140,5 +140,10 @@ FWPhotonDetailView::addSceneInfo(const reco::Photon *i, TEveElementList* tList)
    tList->AddElement(seedposition);
 }
 
+REGISTER_FWDETAILVIEW(FWPhotonDetailView,Photon);
+
+/*
 REGISTER_FWDETAILVIEW(FWPhotonDetailView,Photon,ecalRecHit);
 REGISTER_FWDETAILVIEW(FWPhotonDetailView,Photon,reducedEcalRecHitsEB);
+REGISTER_FWDETAILVIEW(FWPhotonDetailView,Photon,reducedEGamma);
+*/

--- a/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWPhotonDetailView.cc
@@ -11,7 +11,7 @@
 #include "TCanvas.h"
 #include "TEveCaloLegoOverlay.h"
 
-#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 #include "Fireworks/Electrons/plugins/FWPhotonDetailView.h"
@@ -109,22 +109,16 @@ FWPhotonDetailView::setTextInfo(const FWModelId& id, const reco::Photon *photon)
 void
 FWPhotonDetailView::addSceneInfo(const reco::Photon *i, TEveElementList* tList)
 {
-   unsigned int subdetId(0);
-   if ( !i->superCluster()->seed()->hitsAndFractions().empty() )
-      subdetId = i->superCluster()->seed()->hitsAndFractions().front().first.subdetId();
 
    // points for centroids
    Double_t x(0), y(0), z(0);
    TEvePointSet *scposition = new TEvePointSet("sc position");
    scposition->SetPickable(kTRUE);
    scposition->SetTitle("Super cluster centroid");
-   if (subdetId == EcalBarrel) {
-      x = i->caloPosition().eta();
-      y = i->caloPosition().phi();
-   } else if (subdetId == EcalEndcap) {
-      x = i->caloPosition().x();
-      y = i->caloPosition().y();
-   }
+
+   x = i->caloPosition().eta();
+   y = i->caloPosition().phi();
+
    scposition->SetNextPoint(x,y,z);
    scposition->SetMarkerSize(1);
    scposition->SetMarkerStyle(4);
@@ -135,15 +129,11 @@ FWPhotonDetailView::addSceneInfo(const reco::Photon *i, TEveElementList* tList)
    TEvePointSet *seedposition = new TEvePointSet("seed position");
    seedposition->SetTitle("Seed cluster centroid");
    seedposition->SetPickable(kTRUE);
-   if (subdetId == EcalBarrel) {
-      x  = i->superCluster()->seed()->position().eta();
-      y  = i->superCluster()->seed()->position().phi();
-      seedposition->SetMarkerSize(0.01);
-   } else if (subdetId == EcalEndcap) {
-      x  = i->superCluster()->seed()->position().x();
-      y  = i->superCluster()->seed()->position().y();
-      seedposition->SetMarkerSize(1);
-   }
+
+   x  = i->superCluster()->seed()->position().eta();
+   y  = i->superCluster()->seed()->position().phi();
+   seedposition->SetMarkerSize(0.01);
+
    seedposition->SetNextPoint(x, y, z);
    seedposition->SetMarkerStyle(2);
    seedposition->SetMarkerColor(kRed);

--- a/Fireworks/Muons/plugins/FWMuonDetailView.cc
+++ b/Fireworks/Muons/plugins/FWMuonDetailView.cc
@@ -232,5 +232,9 @@ FWMuonDetailView::addSceneInfo(const reco::Muon *i, TEveElementList* tList)
 }
 
 
+REGISTER_FWDETAILVIEW(FWMuonDetailView,Muon);
+/*
+REGISTER_FWDETAILVIEW(FWMuonDetailView,Muon,reducedEGamma);
 REGISTER_FWDETAILVIEW(FWMuonDetailView,Muon,ecalRecHit);
 REGISTER_FWDETAILVIEW(FWMuonDetailView,Muon,reducedEcalRecHitsEB);
+*/

--- a/Fireworks/Tracks/plugins/BuildFile.xml
+++ b/Fireworks/Tracks/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
  <use name="DataFormats/GeometrySurface"/>
  <use name="Fireworks/Core"/>
  <use name="Fireworks/Tracks"/>
+ <use name="Fireworks/Calo"/>
  <use name="rootinteractive"/>
  <use name="rootphysics"/>
 

--- a/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
@@ -14,7 +14,9 @@ private:
 
 };
 
+REGISTER_FWDETAILVIEW(FWTrackECALDetailView, ECAL );
+/*
 REGISTER_FWDETAILVIEW(FWTrackECALDetailView, ECAL,ecalRecHit );
 REGISTER_FWDETAILVIEW(FWTrackECALDetailView, ECAL,reducedEcalRecHitsEB);
-
-
+REGISTER_FWDETAILVIEW(FWPhotonDetailView,Photon,reducedEGamma);
+*/

--- a/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
@@ -1,0 +1,20 @@
+#include "Fireworks/Calo/interface/FWECALDetailViewBase.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+
+class  FWTrackECALDetailView: public FWECALDetailViewBase<reco::TrackBase>
+{
+public:
+   FWTrackECALDetailView() {}
+   virtual ~FWTrackECALDetailView() {}
+
+private:
+   FWTrackECALDetailView(const FWTrackECALDetailView&); // stop default
+   const FWTrackECALDetailView& operator=(const FWTrackECALDetailView&); // stop default
+
+
+};
+
+REGISTER_FWDETAILVIEW(FWTrackECALDetailView, ECAL,ecalRecHit );
+REGISTER_FWDETAILVIEW(FWTrackECALDetailView, ECAL,reducedEcalRecHitsEB);
+
+


### PR DESCRIPTION
- draw un-uniform shapes with boxes to represent ecal EB and EE energy deposit in detail views for:
  - Electron
  - Photon
  - Candidate
  - Muon
  - CaloTower
  - TrackBase

![screen shot 2016-08-16 at 4 34 13 pm](https://cloud.githubusercontent.com/assets/2516492/17719449/6fab7dce-63cf-11e6-9762-c60d8b246435.png)

![screen shot 2016-08-16 at 4 34 29 pm](https://cloud.githubusercontent.com/assets/2516492/17719448/6fab1762-63cf-11e6-9e2c-9b8c66086d40.png)
- remove the new color palette announcement in the main frame
- remove color manager printout
