### PR TITLE
Two technical fixes to SeedingLayerSetsHits

### DIFF
--- a/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
@@ -138,7 +138,7 @@ public:
     const_iterator& operator++() { std::advance(iter_, seedingLayerSets_->nlayers_); return *this; }
     const_iterator operator++(int) {
       const_iterator clone(*this);
-      ++clone;
+      ++(*this);
       return clone;
     }
 

--- a/TrackingTools/TransientTrackingRecHit/src/classes_def.xml
+++ b/TrackingTools/TransientTrackingRecHit/src/classes_def.xml
@@ -1,4 +1,4 @@
 <lcgdict>
-  <class name="SeedingLayerSetsHits" persistence="false"/>
+  <class name="SeedingLayerSetsHits" persistent="false"/>
   <class name="edm::Wrapper<SeedingLayerSetsHits>" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
This PR fixes two minor bugs in `SeedingLayerSetsHits` that I noticed while developing something else:
- in postfix-`operator++`, the cloned iterator was incremented instead of `*this`.
  - apparently nobody uses the postfix-`operator++`, the bug would show up as an infinite loop
- typo in `classes_def.xml` (was "persistence" while should have been "persistent")

Tested in 8_1_0_pre9, no changes expected.

@rovere @VinInn 
