### PR TITLE
Update cfg files for offline analysis

### DIFF
--- a/DPGAnalysis/SiStripTools/test/README.md
+++ b/DPGAnalysis/SiStripTools/test/README.md
@@ -1,0 +1,25 @@
+##Configurations
+
+###OccupancyPlotsTest_cfg.py
+this configurations produces cluster occupancy plots for different regions of the detector. A set of histograms is produced for each run.
+The input should be a RECO file containing SiStripClusters, SiPixelClusters and a collection of tracks that is configurable. In case no RECO file is available for your purpose, it can be used also on RAW data setting the relevant option (fromRAW=1).
+This configuration can be used on Cosmics or Collisions data.
+To run on cosmics (RAW data) you can use the following command:
+
+cmsRun OccupancyPlotsTest_cfg.py fromRAW=1 onCosmics=1 globalTag=<your-GT> inputFiles=<your-RAW-data-file>
+
+To run on Collisions data you can use the following command:
+
+cmsRun OccupancyPlotsTest_cfg.py fromRAW=1 onCosmics=0 trackCollection=generalTracks globalTag=<your-GT> inputFiles=<your-RAW-data-file>
+
+there are other options that can be set in the command line:
+
+1) "tag" add a suffix to the output file name
+2) "maxEvents" to choose what is the number of events to be used (default -1)
+3) "triggerPath" to choose the HLT path to filter your data (currently not working)
+4) "HLTprocess" to choose which process to use for HLT selection default is "HLT"
+
+NOTE: if you need to run on data older than 2016, the era is to be changed manually from "Run2_2016" to what reported in Configuration/StandardSequences/Eras.py
+
+###crabOccupancy.py
+is a sample crab3 configuration to run the above configuration on the grid. 

--- a/DPGAnalysis/SiStripTools/test/crabOccupancy.py
+++ b/DPGAnalysis/SiStripTools/test/crabOccupancy.py
@@ -1,0 +1,24 @@
+from CRABClient.UserUtilities import config
+config = config()
+
+config.General.requestName = 'Analysis'
+config.General.workArea = 'CosmicsOccupancy2016B_v1REAL'
+config.General.transferOutputs = True
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'OccupancyPlotsTest_cfg.py'
+config.JobType.pyCfgParams = ['globalTag=80X_dataRun2_Express_v6', 'tag=out', 'fromRAW=1', 'onCosmics=1']
+
+#config.Data.primaryDataset = 'MinimumBias'
+config.Data.inputDataset ='/Cosmics/Run2016B-v1/RAW'
+#config.Data.inputDBS = 'phys03'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 10
+config.Data.ignoreLocality = True
+#config.Data.totalUnits = 1 #500000
+config.Data.outLFNDirBase = '/store/user/fiori/' # or '/store/group/<subdir>'
+config.Data.publication = False
+#config.Data.publishDataName = 'Bc2S1_AODSIM_RAW_8TeV_V1'
+config.Site.storageSite ='T2_IT_Pisa'
+#config.Site.whitelist =['T2_IT_Pisa']  #'T2_IT_Pisa' #'T3_TW_NTU_HEP'


### PR DESCRIPTION
Update of OccupancyPlotTest_cfg.py to work also on RAW data, both collisions and cosmics data
Adding a crab configuration to run it on the grid
Adding a README.md for documentation
(the same as #15361 for 81X)
