### PR TITLE
Add possibility to weigh pixel hits in QuickTrackAssociatorByHits

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -75,6 +75,7 @@ public:
                                  double qualitySimToReco,
                                  double puritySimToReco,
                                  double cutRecoToSim,
+                                 double pixelHitWeight,
                                  bool threeHitTracksAreSpecial,
                                  SimToRecoDenomType simToRecoDenominator);
   
@@ -134,7 +135,7 @@ public:
    * Return value is a vector of pairs, where first is an edm::Ref to the associated TrackingParticle, and second is
    * the number of associated hits.
    */
-  template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( const TrackerHitAssociator& hitAssociator, const T_TPCollection& trackingParticles, const TrackingParticleRefKeySet *trackingParticleKeys, iter begin, iter end ) const;
+  template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,double> > associateTrack( const TrackerHitAssociator& hitAssociator, const T_TPCollection& trackingParticles, const TrackingParticleRefKeySet *trackingParticleKeys, iter begin, iter end ) const;
   /** @brief Returns the TrackingParticle that has the most associated hits to the given track.
    *
    * See the notes for the other overload for the return type.
@@ -142,7 +143,7 @@ public:
    * Note that the trackingParticles parameter is not actually required since all the information is in clusterToTPMap,
    * but the method signature has to match the other overload because it is called from a templated method.
    */
-  template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( const ClusterTPAssociation& clusterToTPMap, const T_TPCollection& trackingParticles, const TrackingParticleRefKeySet *trackingParticleKeys, iter begin, iter end ) const;
+  template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,double> > associateTrack( const ClusterTPAssociation& clusterToTPMap, const T_TPCollection& trackingParticles, const TrackingParticleRefKeySet *trackingParticleKeys, iter begin, iter end ) const;
   
   
   /** @brief Returns true if the supplied TrackingParticle has the supplied g4 track identifiers. */
@@ -152,10 +153,10 @@ public:
    *
    * Modified 01/May/2014 to take the TrackerHitAssociator as a parameter rather than using a member.
    */
-  template<typename iter> int getDoubleCount( const TrackerHitAssociator& hitAssociator, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
+  template<typename iter> double getDoubleCount( const TrackerHitAssociator& hitAssociator, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
   /** @brief Overload for when using cluster to TrackingParticle association list.
    */
-  template<typename iter> int getDoubleCount( const ClusterTPAssociation& clusterToTPList, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
+  template<typename iter> double getDoubleCount( const ClusterTPAssociation& clusterToTPList, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
   
   /** @brief Returns a vector of pairs where first is a SimTrackIdentifiers (see typedef above) and second is the number of hits that came from that sim track.
    *
@@ -163,7 +164,7 @@ public:
    * E.g. If all the hits in the reco track come from the same sim track, then there will only be one entry with second as the number of hits in
    * the track.
    */
-  template<typename iter> std::vector< std::pair<SimTrackIdentifiers,size_t> > getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const;
+  template<typename iter> std::vector< std::pair<SimTrackIdentifiers,double> > getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const;
   
   // Added by S. Sarkar
   template<typename iter> std::vector< OmniClusterRef> getMatchedClusters( iter begin, iter end ) const;
@@ -176,6 +177,9 @@ public:
     return &(*iter);
   }
   
+  double weightedNumberOfTrackHits(const reco::Track& track) const;
+  double weightedNumberOfTrackHits(const TrajectorySeed& seed) const;
+
   /** @brief creates either a ClusterTPAssociation OR a TrackerHitAssociator and stores it in the provided unique_ptr. The other will be null.
    *
    * A decision is made whether to create a ClusterTPAssociation or a TrackerHitAssociator depending on how this
@@ -197,6 +201,7 @@ public:
   
   double qualitySimToReco_;
   double puritySimToReco_;
+  double pixelHitWeight_;
   double cutRecoToSim_;
   SimToRecoDenomType simToRecoDenominator_;
   bool threeHitTracksAreSpecial_;

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
@@ -58,6 +58,7 @@ class QuickTrackAssociatorByHitsProducer : public edm::global::EDProducer<> {
   edm::EDGetTokenT<ClusterTPAssociation> cluster2TPToken_;
   double qualitySimToReco_;
   double puritySimToReco_;
+  double pixelHitWeight_;
   double cutRecoToSim_;
   QuickTrackAssociatorByHitsImpl::SimToRecoDenomType simToRecoDenominator_;
   bool threeHitTracksAreSpecial_;
@@ -82,6 +83,7 @@ QuickTrackAssociatorByHitsProducer::QuickTrackAssociatorByHitsProducer(const edm
   trackerHitAssociatorConfig_(makeHitAssociatorParameters(iConfig), consumesCollector()),
   qualitySimToReco_( iConfig.getParameter<double>( "Quality_SimToReco" ) ),
   puritySimToReco_( iConfig.getParameter<double>( "Purity_SimToReco" ) ),
+  pixelHitWeight_( iConfig.getParameter<double>( "PixelHitWeight" ) ),
   cutRecoToSim_( iConfig.getParameter<double>( "Cut_RecoToSim" ) ),
   threeHitTracksAreSpecial_( iConfig.getParameter<bool>( "ThreeHitTracksAreSpecial" ) ),
   useClusterTPAssociation_( iConfig.getParameter<bool>( "useClusterTPAssociation" ) ),
@@ -185,6 +187,7 @@ QuickTrackAssociatorByHitsProducer::produce(edm::StreamID, edm::Event& iEvent, c
                                                                 absoluteNumberOfHits_,
                                                                 qualitySimToReco_,
                                                                 puritySimToReco_,
+                                                                pixelHitWeight_,
                                                                 cutRecoToSim_,
                                                                 threeHitTracksAreSpecial_,
                                                                 simToRecoDenominator_);

--- a/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
@@ -7,6 +7,7 @@ quickTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer"
 	Quality_SimToReco = cms.double(0.5),
 	Purity_SimToReco = cms.double(0.75),
 	ThreeHitTracksAreSpecial = cms.bool(True),
+        PixelHitWeight = cms.double(1.0),
 	associatePixel = cms.bool(True),
 	associateStrip = cms.bool(True),
         pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),


### PR DESCRIPTION
Title says it all. The motivation is that since pixel hits are more precise than strip hits, it could be useful to give them more weight (e.g. 2) when associating tracks to TrackingParticles. The default behaviour is preserved (i.e. pixel hits are weighted by 1).

Tested extensively in 7_6_0_pre6, and now again in 8_1_0_pre9, no changes expected in monitored quantities.

For those interested, I have here an old MTV showing the effect of using weight 2 for pixel hits
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_7_6_0_pre6_trackTPassoc/

@rovere @VinInn 
