### PR TITLE
bsunanda:Run2-hcx88 Make use of FrontEndMap

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -60,13 +60,9 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 			  &HcalDbProducer::zsThresholdsCallback &
 			  &HcalDbProducer::L1triggerObjectsCallback &
 			  &HcalDbProducer::electronicsMapCallback &
-<<<<<<< HEAD
-//			  &HcalDbProducer::frontEndMapCallback &
+			  &HcalDbProducer::frontEndMapCallback &
 //			  &HcalDbProducer::SiPMParametersCallback &
 //			  &HcalDbProducer::SiPMCharacteristicsCallback &
-=======
-			  &HcalDbProducer::frontEndMapCallback &
->>>>>>> Make use of FrontEndMap
 			  &HcalDbProducer::lutMetadataCallback 
 			  )
 		   );
@@ -82,11 +78,10 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 }
 
 
-HcalDbProducer::~HcalDbProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+HcalDbProducer::~HcalDbProducer() {
+
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
   if (mDumpStream != &std::cout) delete mDumpStream;
 }
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -60,9 +60,13 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 			  &HcalDbProducer::zsThresholdsCallback &
 			  &HcalDbProducer::L1triggerObjectsCallback &
 			  &HcalDbProducer::electronicsMapCallback &
+<<<<<<< HEAD
 //			  &HcalDbProducer::frontEndMapCallback &
 //			  &HcalDbProducer::SiPMParametersCallback &
 //			  &HcalDbProducer::SiPMCharacteristicsCallback &
+=======
+			  &HcalDbProducer::frontEndMapCallback &
+>>>>>>> Make use of FrontEndMap
 			  &HcalDbProducer::lutMetadataCallback 
 			  )
 		   );

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -12,6 +12,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalFrontEndId.h"
 // 
 class HcalFrontEndMap {
 public:
@@ -35,6 +36,8 @@ public:
   /// brief lookup the RM associated with the given logical id
   //return Null item if no such mapping
   const int lookupRM(DetId fId) const;
+  const int lookupRMIndex(DetId fId) const;
+  const int maxRMIndex() const {return HcalFrontEndId::maxRmIndex;}
 
   /// brief lookup the RBX associated with the given logical id
   //return Null item if no such mapping

--- a/CondFormats/HcalObjects/src/HcalFrontEndMap.cc
+++ b/CondFormats/HcalObjects/src/HcalFrontEndMap.cc
@@ -70,9 +70,16 @@ bool HcalFrontEndMap::loadObject(DetId fId, int rm, std::string rbx ) {
   }
 }
 
-const int HcalFrontEndMap::lookupRM(DetId fId ) const {
+const int HcalFrontEndMap::lookupRM(DetId fId) const {
   const PrecisionItem* item = findById (fId.rawId ());
   return (item ? item->mRM : 0);
+}
+
+const int HcalFrontEndMap::lookupRMIndex(DetId fId) const {
+  const PrecisionItem* item = findById (fId.rawId ());
+  HcalFrontEndId id;
+  if (item) id = HcalFrontEndId(item->mRBX,item->mRM,0,1,0,1,0);
+  return id.rmIndex();
 }
 
 const std::string HcalFrontEndMap::lookupRBX(DetId fId) const {

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
@@ -5,18 +5,23 @@
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-#include "CondFormats/HcalObjects/interface/HcalLogicalMap.h"
+#include "CondFormats/HcalObjects/interface/HcalFrontEndMap.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 class HBHEStatusBitSetter
 {
 public:
   HBHEStatusBitSetter(double nominalPedestal,double hitEnergyMinimum,int hitMultiplicityThreshold,const std::vector<edm::ParameterSet>& pulseShapeParameterSets);
   ~HBHEStatusBitSetter();
+<<<<<<< HEAD
 
+=======
+  void SetFrontEndMap(const HcalFrontEndMap* m); 
+>>>>>>> Make use of FrontEndMap
   void Clear();
   void setTopo(const HcalTopology* topo);
   void SetFlagsFromDigi(HBHERecHit& hbhe, const HBHEDataFrame& digi,
@@ -31,7 +36,7 @@ private:
   double hitEnergyMinimum_;
   int hitMultiplicityThreshold_;
   double nominalPedestal_;
-  HcalLogicalMap *logicalMap_;
+  const HcalFrontEndMap *frontEndMap_;
   std::vector<int> hpdMultiplicity_;
   std::vector< std::vector<double> > pulseShapeParameters_;
 };

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
@@ -12,16 +12,13 @@
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
-class HBHEStatusBitSetter
-{
+class HBHEStatusBitSetter {
 public:
+  HBHEStatusBitSetter();
   HBHEStatusBitSetter(double nominalPedestal,double hitEnergyMinimum,int hitMultiplicityThreshold,const std::vector<edm::ParameterSet>& pulseShapeParameterSets);
   ~HBHEStatusBitSetter();
-<<<<<<< HEAD
 
-=======
   void SetFrontEndMap(const HcalFrontEndMap* m); 
->>>>>>> Make use of FrontEndMap
   void Clear();
   void setTopo(const HcalTopology* topo);
   void SetFlagsFromDigi(HBHERecHit& hbhe, const HBHEDataFrame& digi,

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
@@ -2,57 +2,30 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-<<<<<<< HEAD
-=======
 HBHEStatusBitSetter::HBHEStatusBitSetter() : frontEndMap_(0) {
-
   nominalPedestal_=3.0;
   hitEnergyMinimum_=2.0;
   hitMultiplicityThreshold_=17;
 }
 
->>>>>>> Make use of FrontEndMap
 HBHEStatusBitSetter::HBHEStatusBitSetter(double nominalPedestal,
 					 double hitEnergyMinimum,
 					 int hitMultiplicityThreshold,
-					 const std::vector<edm::ParameterSet>& pulseShapeParameterSets
-					 )
-    : hitEnergyMinimum_(hitEnergyMinimum),
-      hitMultiplicityThreshold_(hitMultiplicityThreshold),
-      nominalPedestal_(nominalPedestal),
-      logicalMap_(nullptr),
-      hpdMultiplicity_(HcalFrontEndId::maxRmIndex, 0)
-{
-<<<<<<< HEAD
+					 const std::vector<edm::ParameterSet>& pulseShapeParameterSets)
+  : hitEnergyMinimum_(hitEnergyMinimum),
+    hitMultiplicityThreshold_(hitMultiplicityThreshold),
+    nominalPedestal_(nominalPedestal),
+    frontEndMap_(0),
+    hpdMultiplicity_(HcalFrontEndId::maxRmIndex, 0) {
   const unsigned sz = pulseShapeParameterSets.size();
   pulseShapeParameters_.reserve(sz);
   for (unsigned iPSet=0; iPSet<sz; iPSet++) {
     const edm::ParameterSet& pset=pulseShapeParameterSets[iPSet];
     const std::vector<double>& params=pset.getParameter<std::vector<double> >("pulseShapeParameters");
-=======
-  nominalPedestal_=nominalPedestal;
-  hitEnergyMinimum_=hitEnergyMinimum;
-  hitMultiplicityThreshold_=hitMultiplicityThreshold;
-
-  for (unsigned int iPSet=0;iPSet<pulseShapeParameterSets.size();iPSet++) {
-    edm::ParameterSet pset=pulseShapeParameterSets.at(iPSet);
-    std::vector<double> params=pset.getParameter<std::vector<double> >("pulseShapeParameters");
->>>>>>> Make use of FrontEndMap
     pulseShapeParameters_.push_back(params);
   }
 }
 
-<<<<<<< HEAD
-HBHEStatusBitSetter::~HBHEStatusBitSetter() {
-    delete logicalMap_;
-}
-
-void HBHEStatusBitSetter::Clear()
-{
-    const unsigned sz = hpdMultiplicity_.size();
-    for (unsigned i=0; i<sz; i++)
-        hpdMultiplicity_[i] = 0;
-=======
 HBHEStatusBitSetter::~HBHEStatusBitSetter() { }
 
 void HBHEStatusBitSetter::SetFrontEndMap(const HcalFrontEndMap* m) {
@@ -65,52 +38,31 @@ void HBHEStatusBitSetter::SetFrontEndMap(const HcalFrontEndMap* m) {
 }
 
 void HBHEStatusBitSetter::Clear() {
-  for (unsigned int i=0;i<hpdMultiplicity_.size();i++) hpdMultiplicity_[i]=0;
->>>>>>> Make use of FrontEndMap
+  const unsigned sz = hpdMultiplicity_.size();
+  for (unsigned i=0; i<sz; i++)
+    hpdMultiplicity_[i] = 0;
 }
 
-void HBHEStatusBitSetter::setTopo(const HcalTopology* topo)
-{
-<<<<<<< HEAD
-    delete logicalMap_;
-    logicalMap_ = nullptr;
-    HcalLogicalMapGenerator gen;
-    logicalMap_=new HcalLogicalMap(gen.createMap(topo));
-}
-=======
+void HBHEStatusBitSetter::setTopo(const HcalTopology*) { }
+  
+void HBHEStatusBitSetter::rememberHit(const HBHERecHit& hbhe) {
   if (frontEndMap_==0) {
     edm::LogError("HcalHitSelection") << "No HcalFrontEndMap in SetFlagsFromDigi";
     return;
   }
-  
->>>>>>> Make use of FrontEndMap
-
-void HBHEStatusBitSetter::rememberHit(const HBHERecHit& hbhe)
-{
-    assert(logicalMap_);
-
-<<<<<<< HEAD
-    //increment hit multiplicity
-    if (hbhe.energy()>hitEnergyMinimum_) {
-        int index=logicalMap_->getHcalFrontEndId(hbhe.detid()).rmIndex();
-        hpdMultiplicity_.at(index)++;
-    }
-}
-
-void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe, 
-					   const HBHEDataFrame& digi,
-					   const HcalCoder& coder,
-					   const HcalCalibrations& calib)
-{
-  rememberHit(hbhe);
-=======
   //increment hit multiplicity
   if (hbhe.energy()>hitEnergyMinimum_) {
     int index=frontEndMap_->lookupRMIndex(hbhe.detid());
     hpdMultiplicity_.at(index)++;
   }
->>>>>>> Make use of FrontEndMap
+}
 
+void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe, 
+					   const HBHEDataFrame& digi,
+					   const HcalCoder& coder,
+					   const HcalCalibrations& calib) {
+  rememberHit(hbhe);
+  
   //set pulse shape bits
   // Shuichi's algorithm uses the "correct" charge & pedestals, while Ted's uses "nominal" values.
   // Perhaps we should correct Ted's algorithm in the future, though that will mean re-tuning thresholds for his cuts. -- Jeff, 28 May 2010
@@ -123,22 +75,21 @@ void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe,
  
   CaloSamples tool;
   coder.adc2fC(digi,tool);
-
+  
   //  int capid=-1;
-  for (unsigned int iSlice=0;iSlice<size;iSlice++) 
-    {
-      //      capid  = digi.sample(iSlice).capid();
-      //shuichi_charge_total+=tool[iSlice]-calib.pedestal(capid);
-      nominal_charge_total+=digi[iSlice].nominal_fC()-nominalPedestal_;
+  for (unsigned int iSlice=0;iSlice<size;iSlice++) {
+    //      capid  = digi.sample(iSlice).capid();
+    //shuichi_charge_total+=tool[iSlice]-calib.pedestal(capid);
+    nominal_charge_total+=digi[iSlice].nominal_fC()-nominalPedestal_;
 
-      if (iSlice<2) continue;
-      // digi[i].nominal_fC() could be replaced by tool[iSlice], I think...  -- Jeff, 11 April 2011
-      double qsum3=digi[iSlice].nominal_fC() + digi[iSlice-1].nominal_fC() + digi[iSlice-2].nominal_fC() - 3*nominalPedestal_;
-      if (qsum3>charge_max3) {
-	charge_max3=qsum3;
-	slice_max3=iSlice;
-      }
+    if (iSlice<2) continue;
+    // digi[i].nominal_fC() could be replaced by tool[iSlice], I think...  -- Jeff, 11 April 2011
+    double qsum3=digi[iSlice].nominal_fC() + digi[iSlice-1].nominal_fC() + digi[iSlice-2].nominal_fC() - 3*nominalPedestal_;
+    if (qsum3>charge_max3) {
+      charge_max3=qsum3;
+      slice_max3=iSlice;
     }
+  }
 
   if ((4+slice_max3)>size) return;
   charge_late3=digi[slice_max3+1].nominal_fC() + digi[slice_max3+2].nominal_fC() + digi[slice_max3+3].nominal_fC() - 3*nominalPedestal_;
@@ -154,18 +105,13 @@ void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe,
   
 }
 
-<<<<<<< HEAD
+
 void HBHEStatusBitSetter::SetFlagsFromRecHits(HBHERecHitCollection& rec) {
-=======
-void HBHEStatusBitSetter::SetFlagsFromRecHits(const HcalTopology* topo, HBHERecHitCollection& rec) {
 
   if (frontEndMap_==0) {
     edm::LogError("HcalHitSelection") << "No HcalFrontEndMap in SetFlagsFromRecHits";
     return;
   }
->>>>>>> Make use of FrontEndMap
-
-  assert(logicalMap_);
 
   for (HBHERecHitCollection::iterator iHBHE=rec.begin();iHBHE!=rec.end();++iHBHE) {
     int index=frontEndMap_->lookupRMIndex(iHBHE->detid());

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
@@ -15,8 +15,7 @@ HBHEStatusBitSetter::HBHEStatusBitSetter(double nominalPedestal,
   : hitEnergyMinimum_(hitEnergyMinimum),
     hitMultiplicityThreshold_(hitMultiplicityThreshold),
     nominalPedestal_(nominalPedestal),
-    frontEndMap_(0),
-    hpdMultiplicity_(HcalFrontEndId::maxRmIndex, 0) {
+    frontEndMap_(0) {
   const unsigned sz = pulseShapeParameterSets.size();
   pulseShapeParameters_.reserve(sz);
   for (unsigned iPSet=0; iPSet<sz; iPSet++) {

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHEStatusBitSetter.cc
@@ -1,9 +1,17 @@
 #include <cassert>
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "CalibCalorimetry/HcalAlgos/interface/HcalLogicalMapGenerator.h"
-#include "CondFormats/HcalObjects/interface/HcalLogicalMap.h"
 
+<<<<<<< HEAD
+=======
+HBHEStatusBitSetter::HBHEStatusBitSetter() : frontEndMap_(0) {
+
+  nominalPedestal_=3.0;
+  hitEnergyMinimum_=2.0;
+  hitMultiplicityThreshold_=17;
+}
+
+>>>>>>> Make use of FrontEndMap
 HBHEStatusBitSetter::HBHEStatusBitSetter(double nominalPedestal,
 					 double hitEnergyMinimum,
 					 int hitMultiplicityThreshold,
@@ -15,15 +23,26 @@ HBHEStatusBitSetter::HBHEStatusBitSetter(double nominalPedestal,
       logicalMap_(nullptr),
       hpdMultiplicity_(HcalFrontEndId::maxRmIndex, 0)
 {
+<<<<<<< HEAD
   const unsigned sz = pulseShapeParameterSets.size();
   pulseShapeParameters_.reserve(sz);
   for (unsigned iPSet=0; iPSet<sz; iPSet++) {
     const edm::ParameterSet& pset=pulseShapeParameterSets[iPSet];
     const std::vector<double>& params=pset.getParameter<std::vector<double> >("pulseShapeParameters");
+=======
+  nominalPedestal_=nominalPedestal;
+  hitEnergyMinimum_=hitEnergyMinimum;
+  hitMultiplicityThreshold_=hitMultiplicityThreshold;
+
+  for (unsigned int iPSet=0;iPSet<pulseShapeParameterSets.size();iPSet++) {
+    edm::ParameterSet pset=pulseShapeParameterSets.at(iPSet);
+    std::vector<double> params=pset.getParameter<std::vector<double> >("pulseShapeParameters");
+>>>>>>> Make use of FrontEndMap
     pulseShapeParameters_.push_back(params);
   }
 }
 
+<<<<<<< HEAD
 HBHEStatusBitSetter::~HBHEStatusBitSetter() {
     delete logicalMap_;
 }
@@ -33,20 +52,44 @@ void HBHEStatusBitSetter::Clear()
     const unsigned sz = hpdMultiplicity_.size();
     for (unsigned i=0; i<sz; i++)
         hpdMultiplicity_[i] = 0;
+=======
+HBHEStatusBitSetter::~HBHEStatusBitSetter() { }
+
+void HBHEStatusBitSetter::SetFrontEndMap(const HcalFrontEndMap* m) {
+  frontEndMap_ = m;
+  if (frontEndMap_) {
+    for (int iRm=0; iRm<frontEndMap_->maxRMIndex(); iRm++) {
+      hpdMultiplicity_.push_back(0);
+    }
+  }
+}
+
+void HBHEStatusBitSetter::Clear() {
+  for (unsigned int i=0;i<hpdMultiplicity_.size();i++) hpdMultiplicity_[i]=0;
+>>>>>>> Make use of FrontEndMap
 }
 
 void HBHEStatusBitSetter::setTopo(const HcalTopology* topo)
 {
+<<<<<<< HEAD
     delete logicalMap_;
     logicalMap_ = nullptr;
     HcalLogicalMapGenerator gen;
     logicalMap_=new HcalLogicalMap(gen.createMap(topo));
 }
+=======
+  if (frontEndMap_==0) {
+    edm::LogError("HcalHitSelection") << "No HcalFrontEndMap in SetFlagsFromDigi";
+    return;
+  }
+  
+>>>>>>> Make use of FrontEndMap
 
 void HBHEStatusBitSetter::rememberHit(const HBHERecHit& hbhe)
 {
     assert(logicalMap_);
 
+<<<<<<< HEAD
     //increment hit multiplicity
     if (hbhe.energy()>hitEnergyMinimum_) {
         int index=logicalMap_->getHcalFrontEndId(hbhe.detid()).rmIndex();
@@ -60,6 +103,13 @@ void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe,
 					   const HcalCalibrations& calib)
 {
   rememberHit(hbhe);
+=======
+  //increment hit multiplicity
+  if (hbhe.energy()>hitEnergyMinimum_) {
+    int index=frontEndMap_->lookupRMIndex(hbhe.detid());
+    hpdMultiplicity_.at(index)++;
+  }
+>>>>>>> Make use of FrontEndMap
 
   //set pulse shape bits
   // Shuichi's algorithm uses the "correct" charge & pedestals, while Ted's uses "nominal" values.
@@ -104,12 +154,21 @@ void HBHEStatusBitSetter::SetFlagsFromDigi(HBHERecHit& hbhe,
   
 }
 
+<<<<<<< HEAD
 void HBHEStatusBitSetter::SetFlagsFromRecHits(HBHERecHitCollection& rec) {
+=======
+void HBHEStatusBitSetter::SetFlagsFromRecHits(const HcalTopology* topo, HBHERecHitCollection& rec) {
+
+  if (frontEndMap_==0) {
+    edm::LogError("HcalHitSelection") << "No HcalFrontEndMap in SetFlagsFromRecHits";
+    return;
+  }
+>>>>>>> Make use of FrontEndMap
 
   assert(logicalMap_);
 
   for (HBHERecHitCollection::iterator iHBHE=rec.begin();iHBHE!=rec.end();++iHBHE) {
-    int index=logicalMap_->getHcalFrontEndId(iHBHE->detid()).rmIndex();
+    int index=frontEndMap_->lookupRMIndex(iHBHE->detid());
     if (hpdMultiplicity_.at(index)<hitMultiplicityThreshold_) continue;
     iHBHE->setFlagField(1,HcalCaloFlagLabels::HBHEHpdHitMultiplicity);
   }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -350,8 +350,10 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
     edm::ESHandle<HcalFrontEndMap> hfemap;
     es.get<HcalFrontEndMapRcd>().get(hfemap);
     if (hfemap.isValid()) {
-      std::cout << "Gets the FrontEndMap" << std::endl;
+//    std::cout << "Gets the FrontEndMap" << std::endl;
       hbheFlagSetter_->SetFrontEndMap(hfemap.product());
+    } else {
+      edm::LogWarning("Configuration") << "HcalHitReconstructor cannot get HcalFrontEndMap!" << std::endl;
     }
   }
 

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -350,7 +350,6 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
     edm::ESHandle<HcalFrontEndMap> hfemap;
     es.get<HcalFrontEndMapRcd>().get(hfemap);
     if (hfemap.isValid()) {
-//    std::cout << "Gets the FrontEndMap" << std::endl;
       hbheFlagSetter_->SetFrontEndMap(hfemap.product());
     } else {
       edm::LogWarning("Configuration") << "HcalHitReconstructor cannot get HcalFrontEndMap!" << std::endl;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -345,11 +345,8 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
       HFDigiTimeParams->setTopo(htopo.product());
     }
 
-<<<<<<< HEAD
-  if (hbheFlagSetter_)
-      hbheFlagSetter_->setTopo(htopo.product());
-=======
   if (hbheFlagSetter_) {
+    hbheFlagSetter_->setTopo(htopo.product());
     edm::ESHandle<HcalFrontEndMap> hfemap;
     es.get<HcalFrontEndMapRcd>().get(hfemap);
     if (hfemap.isValid()) {
@@ -357,7 +354,6 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
       hbheFlagSetter_->SetFrontEndMap(hfemap.product());
     }
   }
->>>>>>> Make use of FrontEndMap
 
   reco_.beginRun(es);
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -11,9 +11,11 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "CondFormats/DataRecord/interface/HcalFrontEndMapRcd.h"
 #include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
 #include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
 #include "CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h"
+#include "CondFormats/HcalObjects/interface/HcalFrontEndMap.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrData.h"
 #include <iostream>
@@ -343,8 +345,19 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
       HFDigiTimeParams->setTopo(htopo.product());
     }
 
+<<<<<<< HEAD
   if (hbheFlagSetter_)
       hbheFlagSetter_->setTopo(htopo.product());
+=======
+  if (hbheFlagSetter_) {
+    edm::ESHandle<HcalFrontEndMap> hfemap;
+    es.get<HcalFrontEndMapRcd>().get(hfemap);
+    if (hfemap.isValid()) {
+      std::cout << "Gets the FrontEndMap" << std::endl;
+      hbheFlagSetter_->SetFrontEndMap(hfemap.product());
+    }
+  }
+>>>>>>> Make use of FrontEndMap
 
   reco_.beginRun(es);
 }

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
@@ -16,7 +16,6 @@
 #include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
 #include "CondFormats/HcalObjects/interface/HcalLongRecoParams.h"
 #include "CondFormats/HcalObjects/interface/HcalLongRecoParam.h" 
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalTimingCorrector.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHETimeProfileStatusBitSetter.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHETimingShapedFlag.h"
@@ -44,7 +43,6 @@ class HcalTopology;
       ZdcSimpleRecAlgo reco_;
       HcalADCSaturationFlag* saturationFlagSetter_;
       HFTimingTrustFlag* HFTimingTrustFlagSetter_;
-      HBHEStatusBitSetter* hbheFlagSetter_;
       HBHETimeProfileStatusBitSetter* hbheHSCPFlagSetter_;
       HBHETimingShapedFlagSetter* hbheTimingShapedFlagSetter_;
       HcalHFStatusBitFromRecHits* hfrechitbit_;


### PR DESCRIPTION
First use of HcalFrontEndMap. If OK has to be done in other parts of the code
Avoid using HcalLogicalMap (which is supposed to be a static object valid for the current detector configuration) in all parts of offline code. Instead we use condition object HcalFrontEndMap. This is the first application of this map and there are other parts of the HCAL code which needs action. They will be attended in the next round.
