### PR TITLE
Fixed case of recursive call into NoProcessProductResolver

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -333,12 +333,16 @@ namespace edm {
                              SharedResourcesAcquirer* sra,
                              ModuleCallingContext const* mcc) const;
 
+      void setCache(bool skipCurrentProcess, ProductResolverIndex index, std::exception_ptr exceptionPtr) const;
+
       std::vector<ProductResolverIndex> matchingHolders_;
       std::vector<bool> ambiguous_;
       mutable WaitingTaskList waitingTasks_;
+      mutable WaitingTaskList skippingWaitingTasks_;
       mutable std::atomic<unsigned int> lastCheckIndex_;
       mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
       mutable std::atomic<bool> prefetchRequested_;
+      mutable std::atomic<bool> skippingPrefetchRequested_;
   };
 
   class SingleChoiceNoProcessProductResolver : public ProductResolverBase {


### PR DESCRIPTION
Fixed the case where a module asks for data with the same label as
the module but from an earlier process via the skipCurrentProcess
mechanism.

This fixes the failure in workflow 136.7321 seen in CMSSW_8_1_DEVEL_X_2016-08-07-1100.
