### PR TITLE
81x: fix SiPixelAli PCL update logic

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -20,21 +20,6 @@ class MillePedeFileReader {
     void read();
     bool storeAlignments();
 
-    std::array<double, 6> const& getXobs()     const { return Xobs;     }
-    std::array<double, 6> const& getXobsErr()  const { return XobsErr;  }
-    std::array<double, 6> const& getTXobs()    const { return tXobs;    }
-    std::array<double, 6> const& getTXobsErr() const { return tXobsErr; }
-
-    std::array<double, 6> const& getYobs()     const { return Yobs;     }
-    std::array<double, 6> const& getYobsErr()  const { return YobsErr;  }
-    std::array<double, 6> const& getTYobs()    const { return tYobs;    }
-    std::array<double, 6> const& getTYobsErr() const { return tYobsErr; }
-
-    std::array<double, 6> const& getZobs()     const { return Zobs;     }
-    std::array<double, 6> const& getZobsErr()  const { return ZobsErr;  }
-    std::array<double, 6> const& getTZobs()    const { return tZobs;    }
-    std::array<double, 6> const& getTZobsErr() const { return tZobsErr; }
-
   //========================= PRIVATE METHODS ==================================
   private: //===================================================================
 
@@ -60,32 +45,9 @@ class MillePedeFileReader {
     double Cutoffs[6] = {  Xcut_,  Ycut_,  Zcut_,
                           tXcut_, tYcut_, tZcut_};
 
-    bool PedeSuccess = false;
-    bool Movements   = false;
-    bool Error       = false;
-    bool Significant = false;
     bool updateDB    = false;
-    bool HitMax      = false;
-    bool HitErrorMax = false;
 
     int Nrec = 0;
-
-
-
-    std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> XobsErr  = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tXobs    = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tXobsErr = {{0.,0.,0.,0.,0.,0.}};
-
-    std::array<double, 6> Yobs     = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> YobsErr  = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tYobs    = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tYobsErr = {{0.,0.,0.,0.,0.,0.}};
-
-    std::array<double, 6> Zobs     = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> ZobsErr  = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tZobs    = {{0.,0.,0.,0.,0.,0.}};
-    std::array<double, 6> tZobsErr = {{0.,0.,0.,0.,0.,0.}};
 
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -20,6 +20,21 @@ class MillePedeFileReader {
     void read();
     bool storeAlignments();
 
+    std::array<double, 6> const& getXobs()     const { return Xobs;     }
+    std::array<double, 6> const& getXobsErr()  const { return XobsErr;  }
+    std::array<double, 6> const& getTXobs()    const { return tXobs;    }
+    std::array<double, 6> const& getTXobsErr() const { return tXobsErr; }
+
+    std::array<double, 6> const& getYobs()     const { return Yobs;     }
+    std::array<double, 6> const& getYobsErr()  const { return YobsErr;  }
+    std::array<double, 6> const& getTYobs()    const { return tYobs;    }
+    std::array<double, 6> const& getTYobsErr() const { return tYobsErr; }
+
+    std::array<double, 6> const& getZobs()     const { return Zobs;     }
+    std::array<double, 6> const& getZobsErr()  const { return ZobsErr;  }
+    std::array<double, 6> const& getTZobs()    const { return tZobs;    }
+    std::array<double, 6> const& getTZobsErr() const { return tZobsErr; }
+
   //========================= PRIVATE METHODS ==================================
   private: //===================================================================
 
@@ -45,9 +60,32 @@ class MillePedeFileReader {
     double Cutoffs[6] = {  Xcut_,  Ycut_,  Zcut_,
                           tXcut_, tYcut_, tZcut_};
 
+    bool PedeSuccess = false;
+    bool Movements   = false;
+    bool Error       = false;
+    bool Significant = false;
     bool updateDB    = false;
+    bool HitMax      = false;
+    bool HitErrorMax = false;
 
     int Nrec = 0;
+
+
+
+    std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> XobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tXobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tXobsErr = {{0.,0.,0.,0.,0.,0.}};
+
+    std::array<double, 6> Yobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> YobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tYobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tYobsErr = {{0.,0.,0.,0.,0.,0.}};
+
+    std::array<double, 6> Zobs     = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> ZobsErr  = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tZobs    = {{0.,0.,0.,0.,0.,0.}};
+    std::array<double, 6> tZobsErr = {{0.,0.,0.,0.,0.,0.}};
 
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -60,17 +60,8 @@ class MillePedeFileReader {
     double Cutoffs[6] = {  Xcut_,  Ycut_,  Zcut_,
                           tXcut_, tYcut_, tZcut_};
 
-    bool PedeSuccess = false;
-    bool Movements   = false;
-    bool Error       = false;
-    bool Significant = false;
     bool updateDB    = false;
-    bool HitMax      = false;
-    bool HitErrorMax = false;
-
     int Nrec = 0;
-
-
 
     std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
     std::array<double, 6> XobsErr  = {{0.,0.,0.,0.,0.,0.}};

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -8,8 +8,6 @@
 /*** core framework functionality ***/
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-
 //=============================================================================
 //===   PUBLIC METHOD IMPLEMENTATION                                        ===
 //=============================================================================
@@ -67,10 +65,7 @@ void MillePedeFileReader
         iss >> trash >> trash >> Nrec;
 
         if (Nrec < 25000) {
-          PedeSuccess = false;
-          Movements   = false;
-          Error       = false;
-          Significant = false;
+
           updateDB   = false;
         }
       }
@@ -79,10 +74,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede log-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }
@@ -112,7 +103,6 @@ void MillePedeFileReader
       }
 
       if (tokens.size() > 4 /*3*/) {
-        PedeSuccess = true;
 
         int alignable      = std::stoi(tokens[0]);
         int alignableIndex = alignable % 10 - 1;
@@ -120,66 +110,17 @@ void MillePedeFileReader
         double ObsMove = std::stof(tokens[3]) * Multiplier[alignableIndex];
         double ObsErr  = std::stof(tokens[4]) * Multiplier[alignableIndex];
 
-        int det = -1;
-
-        if (alignable >= 60 && alignable <= 69) {
-          det = 2; // TPBHalfBarrel (x+)
-        } else if (alignable >= 8780 && alignable <= 8789) {
-          det = 3; // TPBHalfBarrel (x-)
-        } else if (alignable >= 17520 && alignable <= 17529) {
-          det = 4; // TPEHalfCylinder (x+,z+)
-        } else if (alignable >= 22380 && alignable <= 22389) {
-          det = 5; // TPEHalfCylinder (x-,z+)
-        } else if (alignable >= 27260 && alignable <= 27269) {
-          det = 0; // TPEHalfCylinder (x+,z-)
-        } else if (alignable >= 32120 && alignable <= 32129) {
-          det = 1; //TPEHalfCylinder (x-,z-)
-        } else {
-          continue;
-        }
-
-        if (alignableIndex == 0 && det >= 0 && det <= 5) {
-          Xobs[det] = ObsMove;
-          XobsErr[det] = ObsErr;
-        } else if (alignableIndex == 1 && det >= 0 && det <= 5) {
-          Yobs[det] = ObsMove;
-          YobsErr[det] = ObsErr;
-        } else if (alignableIndex == 2 && det >= 0 && det <= 5) {
-          Zobs[det] = ObsMove;
-          ZobsErr[det] = ObsErr;
-        } else if (alignableIndex == 3 && det >= 0 && det <= 5) {
-          tXobs[det] = ObsMove;
-          tXobsErr[det] = ObsErr;
-        } else if (alignableIndex == 4 && det >= 0 && det <= 5) {
-          tYobs[det] = ObsMove;
-          tYobsErr[det] = ObsErr;
-        } else if (alignableIndex == 5 && det >= 0 && det <= 5) {
-          tZobs[det] = ObsMove;
-          tZobsErr[det] = ObsErr;
-        }
-
 	if (std::abs(ObsMove) > maxMoveCut_) {
-          Movements   = false;
-          Error       = false;
-          Significant = false;
           updateDB    = false;
-          HitMax      = false;
           break;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
 
-          Movements = true;
 	  if (std::abs(ObsErr) > maxErrorCut_) {
-            Error       = false;
-            Significant = false;
             updateDB    = false;
-            HitErrorMax = true;
             break;
           } else {
-            Error = true;
-	    if (std::abs(ObsMove/ObsErr) > sigCut_) {
-              Significant = true;
-            } else {
+	    if (std::abs(ObsMove/ObsErr) < sigCut_) {
 	      continue;
 	    } 
           }
@@ -190,10 +131,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede result-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -157,31 +157,33 @@ void MillePedeFileReader
           tZobsErr[det] = ObsErr;
         }
 
-        if (std::abs(ObsMove) > maxMoveCut_) {
+	if (std::abs(ObsMove) > maxMoveCut_) {
           Movements   = false;
           Error       = false;
           Significant = false;
-          updateDB   = false;
+          updateDB    = false;
           HitMax      = false;
           continue;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
-          Movements = true;
 
-          if (std::abs(ObsErr) > maxErrorCut_) {
+          Movements = true;
+	  if (std::abs(ObsErr) > maxErrorCut_) {
             Error       = false;
             Significant = false;
-            updateDB   = false;
+            updateDB    = false;
             HitErrorMax = true;
             continue;
           } else {
             Error = true;
-            if (std::abs(ObsMove/ObsErr) > sigCut_) {
+	    if (std::abs(ObsMove/ObsErr) > sigCut_) {
               Significant = true;
-            }
+            } else {
+	      continue;
+	    } 
           }
+	  updateDB = true;
         }
-        updateDB = true;
       }
     }
   } else {

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -91,6 +91,7 @@ void MillePedeFileReader
 void MillePedeFileReader
 ::readMillePedeResultFile()
 {
+  updateDB = false;	
   std::ifstream resFile;
   resFile.open(millePedeResFile_.c_str());
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -67,10 +67,6 @@ void MillePedeFileReader
         iss >> trash >> trash >> Nrec;
 
         if (Nrec < 25000) {
-          PedeSuccess = false;
-          Movements   = false;
-          Error       = false;
-          Significant = false;
           updateDB   = false;
         }
       }
@@ -79,10 +75,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede log-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }
@@ -112,7 +104,6 @@ void MillePedeFileReader
       }
 
       if (tokens.size() > 4 /*3*/) {
-        PedeSuccess = true;
 
         int alignable      = std::stoi(tokens[0]);
         int alignableIndex = alignable % 10 - 1;
@@ -159,29 +150,18 @@ void MillePedeFileReader
         }
 
 	if (std::abs(ObsMove) > maxMoveCut_) {
-          Movements   = false;
-          Error       = false;
-          Significant = false;
           updateDB    = false;
-          HitMax      = false;
           break;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
-
-          Movements = true;
+	  
 	  if (std::abs(ObsErr) > maxErrorCut_) {
-            Error       = false;
-            Significant = false;
             updateDB    = false;
-            HitErrorMax = true;
             break;
           } else {
-            Error = true;
-	    if (std::abs(ObsMove/ObsErr) > sigCut_) {
-              Significant = true;
-            } else {
+  	    if (std::abs(ObsMove/ObsErr) < sigCut_) {
 	      continue;
-	    } 
+            } 
           }
 	  updateDB = true;
         }
@@ -190,10 +170,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede result-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -164,7 +164,7 @@ void MillePedeFileReader
           Significant = false;
           updateDB    = false;
           HitMax      = false;
-          continue;
+          break;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
 
@@ -174,7 +174,7 @@ void MillePedeFileReader
             Significant = false;
             updateDB    = false;
             HitErrorMax = true;
-            continue;
+            break;
           } else {
             Error = true;
 	    if (std::abs(ObsMove/ObsErr) > sigCut_) {


### PR DESCRIPTION
- SiPixelAli workflow activated when Tier-0 moved to 80X_dataRun2_Express_v12 [Tier-0 HN](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1471/1/1/1/1.html)
- 5 uploads performed in the period 2016-08-04 / 2016-08-06
  - link to [ConditionsUoploader Logs](https://cms-conddb.cern.ch/logs/dropBox/searchUserLog?beginDate=2016-07-01&fileName=SiPixelAli&endDate=2016-08-08&metadata=&fileHash=&userText=&username=&backend=&statusCode=Any)
- Runs used to compute uploads:
  - 278167: [ALCAPROMPT DQM](https://goo.gl/r7AU0W)  (not justified)
  - 278175: [ALCAPROMPT DQM](https://goo.gl/2U5msD) (justified)
  - 278193: [ALCAPROMPT DQM](https://goo.gl/b9X9AS)  (not justified)
  - 278239: [ALCAPROMPT DQM](https://goo.gl/uajZvz)  (not justified)
  - 278240: [ALCAPROMPT DQM](https://goo.gl/jBtPa6)  (not justified)

Unexpected upload pattern understood as a bug in the applied corrections size check → reverted the last update of the DropBoxMetadaRcd, to redirecting alignment producer output to the pre-DB (latest since is at run 278272). Consumed uploads are not problematic, issue only with the rate.
We’ll revert this change, when bug in PCL code fixed.

attn: @mschrode @ghellwig @tlampen 
