### PR TITLE
Replacing unreliable array initialization in SiPixelTemplateReco.cc

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -216,7 +216,8 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	
     if(deadpix) {
 	   fypix = BYM3; lypix = -1;
-       	   memset(nyzero, 0, TYSIZE * sizeof(int));
+	for(i=0; i<nclusy; ++i) {	   
+           memset(nyzero, 0, TYSIZE * sizeof(int));
            memset(ysum, 0, BYSIZE * sizeof(float));
 // Do preliminary cluster projection in y
 	      for(j=0; j<nclusx; ++j) {
@@ -227,7 +228,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 		     if(i < fypix) {fypix = i;}
 			 if(i > lypix) {lypix = i;}
 		  }
-	   
+	   }
 	   
 // Now loop over dead pixel list and "fix" everything	
 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -216,8 +216,8 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	
     if(deadpix) {
 	   fypix = BYM3; lypix = -1;
-       for(i=0; i<nclusy; ++i) {
-	      ysum[i] = 0.f; nyzero[i] = 0;
+       	   memset(nyzero, 0, TYSIZE * sizeof(int));
+           memset(ysum, 0, BYSIZE * sizeof(float));
 // Do preliminary cluster projection in y
 	      for(j=0; j<nclusx; ++j) {
 		     ysum[i] += cluster(j,i);
@@ -227,7 +227,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 		     if(i < fypix) {fypix = i;}
 			 if(i > lypix) {lypix = i;}
 		  }
-	   }
+	   
 	   
 // Now loop over dead pixel list and "fix" everything	
 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -216,9 +216,9 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 	
     if(deadpix) {
 	   fypix = BYM3; lypix = -1;
+	memset(nyzero, 0, TYSIZE * sizeof(int));
+        memset(ysum, 0, BYSIZE * sizeof(float));
 	for(i=0; i<nclusy; ++i) {	   
-           memset(nyzero, 0, TYSIZE * sizeof(int));
-           memset(ysum, 0, BYSIZE * sizeof(float));
 // Do preliminary cluster projection in y
 	      for(j=0; j<nclusx; ++j) {
 		     ysum[i] += cluster(j,i);


### PR DESCRIPTION
arrays nyzero and ysum initialized to zero without using the for loop in line 220. The for loop is unreliable because the bound of the loop is an input argument that need not match the size of the array
