### PR TITLE
protect RawTask::_process from processing bad HcalHTRData, backport to 80x

### DIFF
--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -262,7 +262,7 @@ RawTask::RawTask(edm::ParameterSet const& ps):
 			for (int is=0; is<HcalDCCHeader::SPIGOT_COUNT; is++)
 			{
 				int r = hdcc->getSpigotData(is, htr, raw.size());
-				if (r!=0)
+				if (r!=0 || !htr.check())
 					continue;
 				HcalElectronicsId eid = HcalElectronicsId(
 					constants::FIBERCH_MIN, constants::FIBER_VME_MIN,


### PR DESCRIPTION
Backport of #14963 to 80x, requested by @davidlange6 
