### PR TITLE
Recover 2016 Hcal Trigger Primitives

### DIFF
--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -205,11 +205,10 @@ private:
 	 kHEhalf = 1296 ,
 	 kHOhalf = 1080 ,
 	 kHFhalf = 864  ,
-	 kHThalf = 2088 ,
+	 kHThalf = 2088,
 	 kZDChalf = 11,
 	 kCASTORhalf = 224,
 	 kCALIBhalf = 693,
-	 kHThalfPhase1 = 2520 ,
 	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf } ;
   enum { kSizeForDenseIndexingPreLS1 = 2*kHcalhalf } ;
   enum { kHBSizePreLS1 = 2*kHBhalf } ;
@@ -217,7 +216,7 @@ private:
   enum { kHOSizePreLS1 = 2*kHOhalf } ;
   enum { kHFSizePreLS1 = 2*kHFhalf } ;
   enum { kHTSizePreLS1 = 2*kHThalf } ;
-  enum { kHTSizePhase1 = 2*kHThalfPhase1 } ;
+  enum { kHTSizePhase1 = (kHTSizePreLS1+(2*12*36)) } ;
   enum { kCALIBSizePreLS1 = 2*kCALIBhalf };
 };
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -204,7 +204,7 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
   if (id.iphi()<1 || id.iphi()>IPHI_MAX || id.ieta()==0)  return false;
   if (id.depth() != 0)                              return false;
   if (id.version()==0) {
-    if ((triggerMode_==HcalTopologyMode::tm_LHC_1x1 && id.ietaAbs()>29) ||
+    if ((triggerMode_==HcalTopologyMode::tm_LHC_1x1 && id.ietaAbs()>28) ||
 	(id.ietaAbs()>32))                          return false;
     int ietaMax = (triggerMode_==HcalTopologyMode::tm_LHC_1x1) ? 29 : 28;
     if (id.ietaAbs()>ietaMax && ((id.iphi()%4)!=1)) return false;

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -86,7 +86,7 @@ public:
   double                    getRZ(int subdet, int ieta, int depth) const;
   std::vector<HcalActiveLength>    getThickActive(const int type) const;
   int                       getTopoMode() const {return ((hpar->topologyMode)&0xFF);}
-  int                       getTriggerMode() const {return ((((hpar->topologyMode)&0xFF) == 0) ? 0 : (((hpar->topologyMode)>>8)&0xFF));}
+  int                       getTriggerMode() const {return (((hpar->topologyMode)>>8)&0xFF);}
   std::vector<HcalCellType> HcalCellTypes(HcalSubdetector) const;
   bool                      isBH() const {return hcons.isBH();}
   int                       maxHFDepth(int ieta, int iphi) const {return hcons.maxHFDepth(ieta,iphi);}


### PR DESCRIPTION
Partially reverts a commit that caused us to loose 2016 Hcal trigger primitives while solving a collision with the 2017 TP geometry.

This re-instates the code that was in place up to `CMSSW_8_1_0_pre6`, and which is able to re-emulate 2016 TP. It solves collisions in dense ID for 2017 by marking Hcal trigger towers with `abs(ieta) == 29 && version == 0` as invalid. HCAL HE in 2017 will not include a tower at `ieta` 29, and neither will HCAL HF.

@bsunanda, can you have a look at this?
