### PR TITLE
80x: fix SiPixelAli PCL update logic

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -60,17 +60,8 @@ class MillePedeFileReader {
     double Cutoffs[6] = {  Xcut_,  Ycut_,  Zcut_,
                           tXcut_, tYcut_, tZcut_};
 
-    bool PedeSuccess = false;
-    bool Movements   = false;
-    bool Error       = false;
-    bool Significant = false;
     bool updateDB    = false;
-    bool HitMax      = false;
-    bool HitErrorMax = false;
-
     int Nrec = 0;
-
-
 
     std::array<double, 6> Xobs     = {{0.,0.,0.,0.,0.,0.}};
     std::array<double, 6> XobsErr  = {{0.,0.,0.,0.,0.,0.}};

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -157,31 +157,33 @@ void MillePedeFileReader
           tZobsErr[det] = ObsErr;
         }
 
-        if (std::abs(ObsMove) > maxMoveCut_) {
+	if (std::abs(ObsMove) > maxMoveCut_) {
           Movements   = false;
           Error       = false;
           Significant = false;
-          updateDB   = false;
+          updateDB    = false;
           HitMax      = false;
           continue;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
-          Movements = true;
 
-          if (std::abs(ObsErr) > maxErrorCut_) {
+          Movements = true;
+	  if (std::abs(ObsErr) > maxErrorCut_) {
             Error       = false;
             Significant = false;
-            updateDB   = false;
+            updateDB    = false;
             HitErrorMax = true;
             continue;
           } else {
             Error = true;
-            if (std::abs(ObsMove/ObsErr) > sigCut_) {
+	    if (std::abs(ObsMove/ObsErr) > sigCut_) {
               Significant = true;
-            }
+            } else {
+	      continue;
+	    } 
           }
+	  updateDB = true;
         }
-        updateDB = true;
       }
     }
   } else {

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -91,6 +91,7 @@ void MillePedeFileReader
 void MillePedeFileReader
 ::readMillePedeResultFile()
 {
+  updateDB = false;	
   std::ifstream resFile;
   resFile.open(millePedeResFile_.c_str());
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -67,10 +67,6 @@ void MillePedeFileReader
         iss >> trash >> trash >> Nrec;
 
         if (Nrec < 25000) {
-          PedeSuccess = false;
-          Movements   = false;
-          Error       = false;
-          Significant = false;
           updateDB   = false;
         }
       }
@@ -79,10 +75,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede log-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }
@@ -112,7 +104,6 @@ void MillePedeFileReader
       }
 
       if (tokens.size() > 4 /*3*/) {
-        PedeSuccess = true;
 
         int alignable      = std::stoi(tokens[0]);
         int alignableIndex = alignable % 10 - 1;
@@ -159,29 +150,18 @@ void MillePedeFileReader
         }
 
 	if (std::abs(ObsMove) > maxMoveCut_) {
-          Movements   = false;
-          Error       = false;
-          Significant = false;
           updateDB    = false;
-          HitMax      = false;
           break;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
-
-          Movements = true;
+	  
 	  if (std::abs(ObsErr) > maxErrorCut_) {
-            Error       = false;
-            Significant = false;
             updateDB    = false;
-            HitErrorMax = true;
             break;
           } else {
-            Error = true;
-	    if (std::abs(ObsMove/ObsErr) > sigCut_) {
-              Significant = true;
-            } else {
+  	    if (std::abs(ObsMove/ObsErr) < sigCut_) {
 	      continue;
-	    } 
+            } 
           }
 	  updateDB = true;
         }
@@ -190,10 +170,6 @@ void MillePedeFileReader
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede result-file.";
 
-    PedeSuccess = false;
-    Movements   = false;
-    Error       = false;
-    Significant = false;
     updateDB   = false;
     Nrec = 0;
   }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -164,7 +164,7 @@ void MillePedeFileReader
           Significant = false;
           updateDB    = false;
           HitMax      = false;
-          continue;
+          break;
 
         } else if (std::abs(ObsMove) > Cutoffs[alignableIndex]) {
 
@@ -174,7 +174,7 @@ void MillePedeFileReader
             Significant = false;
             updateDB    = false;
             HitErrorMax = true;
-            continue;
+            break;
           } else {
             Error = true;
 	    if (std::abs(ObsMove/ObsErr) > sigCut_) {


### PR DESCRIPTION
Backport of #15385
- SiPixelAli workflow activated when Tier-0 moved to 80X_dataRun2_Express_v12 [Tier-0 HN](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1471/1/1/1/1.html)
- 5 uploads performed in the period 2016-08-04 / 2016-08-06
  - link to [ConditionsUoploader Logs](https://cms-conddb.cern.ch/logs/dropBox/searchUserLog?beginDate=2016-07-01&fileName=SiPixelAli&endDate=2016-08-08&metadata=&fileHash=&userText=&username=&backend=&statusCode=Any)
- Runs used to compute uploads:
  - 278167: [ALCAPROMPT DQM](https://goo.gl/r7AU0W)  (not justified)
  - 278175: [ALCAPROMPT DQM](https://goo.gl/2U5msD) (justified)
  - 278193: [ALCAPROMPT DQM](https://goo.gl/b9X9AS)  (not justified)
  - 278239: [ALCAPROMPT DQM](https://goo.gl/uajZvz)  (not justified)
  - 278240: [ALCAPROMPT DQM](https://goo.gl/jBtPa6)  (not justified)

Unexpected upload pattern understood as a bug in the applied corrections size check → reverted the last update of the DropBoxMetadaRcd, to redirecting alignment producer output to the pre-DB (latest since is at run 278272). Consumed uploads are not problematic, issue only with the rate.
We’ll revert this change, when bug in PCL code fixed.
