### PR TITLE
Before collecting a stack trace, pause all CMSSW threads and print out the current modules

### DIFF
--- a/FWCore/Utilities/src/UnixSignalHandlers.cc
+++ b/FWCore/Utilities/src/UnixSignalHandlers.cc
@@ -54,6 +54,12 @@ namespace edm {
       memset(&tmpact,0,sizeof(tmpact));
       tmpact.sa_handler = SIG_IGN;
 
+      // NOTE: the omission of SIGRTMAX ('<', not '<=') is (now) intentional.
+      // SIGRTMAX is used by the stack trace "pause" functionality in
+      // FWCore/Services/plugins/InitRootHandlers.cc
+      // This mask will need to be updated if the signal used there is changed.
+      // If real time signals are adopted for other purposes, this could be
+      // modified to include a more general-purpose allocator for RT signals.
       for(int num = SIGRTMIN; num < SIGRTMAX; ++num) {
 	  MUST_BE_ZERO(sigaddset(&myset,num));
 	  MUST_BE_ZERO(sigaction(num,&tmpact,NULL));

--- a/FWCore/Utilities/src/UnixSignalHandlers.cc
+++ b/FWCore/Utilities/src/UnixSignalHandlers.cc
@@ -54,13 +54,7 @@ namespace edm {
       memset(&tmpact,0,sizeof(tmpact));
       tmpact.sa_handler = SIG_IGN;
 
-      // NOTE: the omission of SIGRTMAX ('<', not '<=') is (now) intentional.
-      // SIGRTMAX is used by the stack trace "pause" functionality in
-      // FWCore/Services/plugins/InitRootHandlers.cc
-      // This mask will need to be updated if the signal used there is changed.
-      // If real time signals are adopted for other purposes, this could be
-      // modified to include a more general-purpose allocator for RT signals.
-      for(int num = SIGRTMIN; num < SIGRTMAX; ++num) {
+      for(int num = SIGRTMIN; num <= SIGRTMAX; ++num) {
 	  MUST_BE_ZERO(sigaddset(&myset,num));
 	  MUST_BE_ZERO(sigaction(num,&tmpact,NULL));
       }


### PR DESCRIPTION
The idea for this PR is to get more informative stack traces for multithreaded jobs by pausing all CMSSW threads.  Currently these threads continue to run while the stack trace is being collected, so we get no reliable information about what the other threads were doing at the time, making it difficult to debug problems caused by interactions between threads.

The implementation uses a signal handler, triggered by SIGRTMAX (where available), that prints the current module and then pauses the thread for a configurable interval (default 5 minutes).  A tbb::task_scheduler_observer is used to collect the thread IDs of all threads created by TBB; this change does assume that all TBB created threads will have access to the CMSSW thread-local CurrentModuleOnThread.

Signal handlers are always somewhat touchy to write.  I've tried to be very careful to avoid any changes that could impact running jobs; any issues from this PR should only appear in jobs that have already received a fatal signal.  One noticeable consequence is that stack traces will now show all CMSSW threads in signal handlers, so a little more searching will have to be done to find the one in the stacktraceFromThread() signal handler.

This PR uses strlcpy()/strlcat() for low-level C-style string manipulation in the signal handlers; these are not standard on Linux, but are provided (and used heavily) by ROOT.

This also fixes a bug in FWCore/Utilities/src/UnixSignalHandlers.cc that meant SIGRTMAX wasn't being blocked.  With these changes, SIGRTMAX is now blocked (along with the rest of the RT signals) until the stack trace signal handler unblocks it for entire process.
