### PR TITLE
Fix HcalHitsV for FastSim

### DIFF
--- a/Validation/HcalHits/interface/SimHitsValidationHcal.h
+++ b/Validation/HcalHits/interface/SimHitsValidationHcal.h
@@ -31,7 +31,7 @@ public:
 
   SimHitsValidationHcal(const edm::ParameterSet& ps);
   ~SimHitsValidationHcal();
-
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 protected:
 

--- a/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
+++ b/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
@@ -9,6 +9,5 @@ hcalSimHitStudy = cms.EDAnalyzer("HcalSimHitStudy",
 
 
 from Configuration.StandardSequences.Eras import eras
-if eras.fastSim.isChosen():
-    hcalSimHitStudy.ModuleLabel = cms.untracked.string('famosSimHits')
+eras.fastSim.toModify( hcalSimHitStudy, ModuleLabel = cms.untracked.string('famosSimHits') )
     

--- a/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
+++ b/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
@@ -1,15 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 simHitsValidationHcal = cms.EDAnalyzer("SimHitsValidationHcal",
-    ModuleLabel   = cms.untracked.string('g4SimHits'),
-    HitCollection = cms.untracked.string('HcalHits'),
-    Verbose       = cms.untracked.bool(False),
-    TestNumber    = cms.untracked.bool(False),
+    ModuleLabel   = cms.string('g4SimHits'),
+    HitCollection = cms.string('HcalHits'),
+    Verbose       = cms.bool(False),
+    TestNumber    = cms.bool(False),
 )
 
 from Configuration.StandardSequences.Eras import eras
-if eras.fastSim.isChosen():
-    simHitsValidationHcal.ModuleLabel = cms.untracked.string("famosSimHits")
-    
-
-
+eras.fastSim.toModify( simHitsValidationHcal, ModuleLabel = cms.string("famosSimHits") )

--- a/Validation/HcalHits/src/SimHitsValidationHcal.cc
+++ b/Validation/HcalHits/src/SimHitsValidationHcal.cc
@@ -3,14 +3,14 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "SimDataFormats/CaloTest/interface/HcalTestNumbering.h"
 
-//#define DebugLog
+#define DebugLog
 
 SimHitsValidationHcal::SimHitsValidationHcal(const edm::ParameterSet& ps) {
 
-  g4Label_  = ps.getUntrackedParameter<std::string>("moduleLabel","g4SimHits");
-  hcalHits_ = ps.getUntrackedParameter<std::string>("HitCollection","HcalHits");
-  verbose_  = ps.getUntrackedParameter<bool>("Verbose", false);
-  testNumber_= ps.getUntrackedParameter<bool>("TestNumber", false);
+  g4Label_  = ps.getParameter<std::string>("ModuleLabel");
+  hcalHits_ = ps.getParameter<std::string>("HitCollection");
+  verbose_  = ps.getParameter<bool>("Verbose");
+  testNumber_= ps.getParameter<bool>("TestNumber");
 
   tok_hits_ = consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_,hcalHits_));
 
@@ -442,6 +442,16 @@ std::vector<std::pair<std::string,std::string> > SimHitsValidationHcal::getHisto
   }
 
   return divisions;
+}
+
+void SimHitsValidationHcal::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ModuleLabel","g4SimHits");
+  desc.add<std::string>("HitCollection","HcalHits");
+  desc.add<bool>("Verbose",false);
+  desc.add<bool>("TestNumber",false);
+
+  descriptions.addDefault(desc);
 }
 
 DEFINE_FWK_MODULE(SimHitsValidationHcal);


### PR DESCRIPTION
The issue was a difference of capitalization for the "ModuleLabel" parameter between the python config and the C++ analyzer code. It was not immediately obvious because the parameter was specified as untracked with a default value provided.

Let this be a lesson to all: untracked parameters are not a valid substitute for a proper fillDescriptions.*

In addition to fixing the capitalization problem, I added fillDescriptions for this analyzer and also cleaned up the FastSim Era usage in the python area. Hopefully the validation team can add fillDescriptions for the other analyzers at some point.

*Unless for some reason the validation/DQM code needs to use untracked parameters, in which case I can revert that part of the change, but I doubt this is the case.
