### PR TITLE
Use unique_ptr, not auto_ptr, in 2 L1 packages

### DIFF
--- a/L1Trigger/L1TCommon/plugins/L1TMuonLegacyConverter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TMuonLegacyConverter.cc
@@ -104,7 +104,7 @@ L1TMuonLegacyConverter::produce( edm::Event& iEvent,
    // ~~~~~~~~~~~~~~~~~~~~ Muons ~~~~~~~~~~~~~~~~~~~~
    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   auto_ptr< MuonBxCollection > imdMuonsLegacy( new MuonBxCollection() );
+   std::unique_ptr< MuonBxCollection > imdMuonsLegacy( new MuonBxCollection() );
 
    if( produceMuonParticles_ )
    {
@@ -187,7 +187,7 @@ L1TMuonLegacyConverter::produce( edm::Event& iEvent,
 	}
    }
    
-   iEvent.put( imdMuonsLegacy, "imdMuonsLegacy" );
+   iEvent.put( std::move(imdMuonsLegacy), "imdMuonsLegacy" );
 
 } // closing produce
 

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
@@ -14,7 +14,7 @@ template< >
 void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
   /// Prepare output
-  std::auto_ptr< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > TTClusterDSVForOutput( new edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > );
+  std::unique_ptr< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > TTClusterDSVForOutput( new edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > );
   std::map< DetId, std::vector< Ref_Phase2TrackerDigi_ > > rawHits;
   this->RetrieveRawHits( rawHits, iEvent );
 
@@ -76,7 +76,7 @@ void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, co
     } /// End of loop over detector elements     
   
   /// Put output in the event   
-  iEvent.put( TTClusterDSVForOutput, "ClusterInclusive" );
+  iEvent.put( std::move(TTClusterDSVForOutput), "ClusterInclusive" );
 }
 
 /// Retrieve hits from the event

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
@@ -116,10 +116,10 @@ void TTStubBuilder< T >::produce( edm::Event& iEvent, const edm::EventSetup& iSe
   const TrackerGeometry* const theTrackerGeom = tGeomHandle.product();
 
   /// Prepare output
-  std::auto_ptr< edmNew::DetSetVector< TTCluster< T > > > TTClusterDSVForOutput( new edmNew::DetSetVector< TTCluster< T > > );
-  std::auto_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputTemp( new edmNew::DetSetVector< TTStub< T > > );
-  std::auto_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputAccepted( new edmNew::DetSetVector< TTStub< T > > );
-  std::auto_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputRejected( new edmNew::DetSetVector< TTStub< T > > );
+  std::unique_ptr< edmNew::DetSetVector< TTCluster< T > > > TTClusterDSVForOutput( new edmNew::DetSetVector< TTCluster< T > > );
+  std::unique_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputTemp( new edmNew::DetSetVector< TTStub< T > > );
+  std::unique_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputAccepted( new edmNew::DetSetVector< TTStub< T > > );
+  std::unique_ptr< edmNew::DetSetVector< TTStub< T > > > TTStubDSVForOutputRejected( new edmNew::DetSetVector< TTStub< T > > );
 
   /// Get the Clusters already stored away
   edm::Handle< edmNew::DetSetVector< TTCluster< T > > > clusterHandle;
@@ -302,7 +302,7 @@ void TTStubBuilder< T >::produce( edm::Event& iEvent, const edm::EventSetup& iSe
 
   /// Put output in the event (1)
   /// Get also the OrphanHandle of the accepted clusters
-  edm::OrphanHandle< edmNew::DetSetVector< TTCluster< T > > > TTClusterAcceptedHandle = iEvent.put( TTClusterDSVForOutput, "ClusterAccepted" );
+  edm::OrphanHandle< edmNew::DetSetVector< TTCluster< T > > > TTClusterAcceptedHandle = iEvent.put( std::move(TTClusterDSVForOutput), "ClusterAccepted" );
 
   /// Now, correctly reset the output
   typename edmNew::DetSetVector< TTStub< T > >::const_iterator stubDetIter;
@@ -377,8 +377,8 @@ void TTStubBuilder< T >::produce( edm::Event& iEvent, const edm::EventSetup& iSe
   } /// End of loop over stub DetSetVector
     
   /// Put output in the event (2)
-  iEvent.put( TTStubDSVForOutputAccepted, "StubAccepted" );
-  iEvent.put( TTStubDSVForOutputRejected, "StubRejected" );
+  iEvent.put( std::move(TTStubDSVForOutputAccepted), "StubAccepted" );
+  iEvent.put( std::move(TTStubDSVForOutputRejected), "StubRejected" );
 }
 
 /// Sort routine for stub ordering


### PR DESCRIPTION
In preparation for removing framework support for auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique:ptr in the two L1 packages that still put auto_ptrs.
