### PR TITLE
Use unique_ptr, not auto_ptr, in DataFormats/Math

### DIFF
--- a/DataFormats/Math/test/WriteMath.cc
+++ b/DataFormats/Math/test/WriteMath.cc
@@ -11,7 +11,7 @@ WriteMath::WriteMath( const ParameterSet& ) {
 }
 
 void WriteMath::produce( Event & evt, const EventSetup & ) {
-  auto_ptr<vector<Vector> > v( new vector<Vector> );  
+  std::unique_ptr<vector<Vector> > v( new vector<Vector> );  
   v->push_back( Vector( 1, 2, 3 ) );
-  evt.put( v );
+  evt.put( std::move(v) );
 }


### PR DESCRIPTION
In preparation for removing framework support for auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique:ptr in DataFormats/Math.
