### PR TITLE
Updating HBHEPulseShapeFlag and HBHEStatusBitSetter for Phase 1

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
@@ -21,6 +21,7 @@
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 //---------------------------------------------------------------------------
 class HBHEPulseShapeFlagSetter;
 struct TriangleFitResult;
@@ -28,15 +29,14 @@ struct TriangleFitResult;
 class HBHEPulseShapeFlagSetter
 {
 public:
-   HBHEPulseShapeFlagSetter();
    HBHEPulseShapeFlagSetter(double MinimumChargeThreshold,
-             double TS4TS5ChargeThreshold,
-	     double TS3TS4ChargeThreshold,
-	     double TS3TS4UpperChargeThreshold,
-	     double TS5TS6ChargeThreshold,
-	     double TS5TS6UpperChargeThreshold,
-	     double R45PlusOneRange,
-	     double R45MinusOneRange,
+                            double TS4TS5ChargeThreshold,
+                            double TS3TS4ChargeThreshold,
+                            double TS3TS4UpperChargeThreshold,
+                            double TS5TS6ChargeThreshold,
+                            double TS5TS6UpperChargeThreshold,
+                            double R45PlusOneRange,
+                            double R45MinusOneRange,
 			    unsigned int TrianglePeakTS,
 			    const std::vector<double>& LinearThreshold, 
 			    const std::vector<double>& LinearCut,
@@ -48,17 +48,22 @@ public:
 			    const std::vector<double>& RightSlopeCut,
 			    const std::vector<double>& RightSlopeSmallThreshold, 
 			    const std::vector<double>& RightSlopeSmallCut,
-             const std::vector<double>& TS4TS5UpperThreshold,
-             const std::vector<double>& TS4TS5UpperCut,
-             const std::vector<double>& TS4TS5LowerThreshold,
-             const std::vector<double>& TS4TS5LowerCut,
+                            const std::vector<double>& TS4TS5UpperThreshold,
+                            const std::vector<double>& TS4TS5UpperCut,
+                            const std::vector<double>& TS4TS5LowerThreshold,
+                            const std::vector<double>& TS4TS5LowerCut,
 			    bool UseDualFit,
-			    bool TriangleIgnoreSlow);
+			    bool TriangleIgnoreSlow,
+                            bool setLegacyFlags = true);
+
    ~HBHEPulseShapeFlagSetter();
+
    void Clear();
-   void SetPulseShapeFlags(HBHERecHit& hbhe, const HBHEDataFrame &digi,
-      const HcalCoder &coder, const HcalCalibrations &calib);
    void Initialize();
+
+   template<class Dataframe>
+   void SetPulseShapeFlags(HBHERecHit& hbhe, const Dataframe& digi,
+                           const HcalCoder& coder, const HcalCalibrations& calib);
 private:
    double mMinimumChargeThreshold;
    double mTS4TS5ChargeThreshold;
@@ -80,6 +85,7 @@ private:
    std::vector<std::pair<double, double> > mTS4TS5LowerCut;
    bool mUseDualFit;
    bool mTriangleIgnoreSlow;
+   bool mSetLegacyFlags;
    std::vector<double> CumulativeIdealPulse;
 private:
    TriangleFitResult PerformTriangleFit(const std::vector<double> &Charge);
@@ -104,5 +110,126 @@ struct TriangleFitResult
    double RightSlope;
 };
 //---------------------------------------------------------------------------
-#endif
 
+template<class Dataframe>
+void HBHEPulseShapeFlagSetter::SetPulseShapeFlags(
+    HBHERecHit& hbhe, const Dataframe& digi,
+    const HcalCoder& coder, const HcalCalibrations& calib)
+{
+   //
+   // Decide if a digi/pulse is good or bad using fit-based discriminants
+   //
+   // SetPulseShapeFlags determines the total charge in the digi.
+   // If the charge is above the minimum threshold, the code then
+   // runs the flag-setting algorithms to determine whether the
+   // flags should be set.
+   //
+
+   // hack to exclude ieta=28/29 for the moment... 
+   int abseta = hbhe.id().ietaAbs();
+   if(abseta == 28 || abseta == 29)  return;
+
+   CaloSamples Tool;
+   coder.adc2fC(digi, Tool);
+
+   //   mCharge.clear();  // mCharge is a vector of (pedestal-subtracted) Charge values vs. time slice
+   const unsigned nRead = digi.size();
+   mCharge.resize(nRead);
+
+   double TotalCharge = 0.0;
+   for (unsigned i = 0; i < nRead; ++i)
+   {
+      mCharge[i] = Tool[i] - calib.pedestal(digi[i].capid());
+      TotalCharge += mCharge[i];
+   }
+
+   // No flagging if TotalCharge is less than threshold
+   if(TotalCharge < mMinimumChargeThreshold)
+      return;
+
+   if (mSetLegacyFlags)
+   {
+       double NominalChi2 = 0; 
+       if (mUseDualFit == true)
+           NominalChi2=PerformDualNominalFit(mCharge); 
+       else
+           NominalChi2=PerformNominalFit(mCharge);
+
+       double LinearChi2 = PerformLinearFit(mCharge);
+
+       double RMS8Max = CalculateRMS8Max(mCharge);
+       TriangleFitResult TriangleResult = PerformTriangleFit(mCharge);
+
+       // Set the HBHEFlatNoise and HBHESpikeNoise flags
+       if(CheckPassFilter(TotalCharge, log(LinearChi2) - log(NominalChi2), mLambdaLinearCut, -1) == false)
+           hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEFlatNoise);
+       if(CheckPassFilter(TotalCharge, log(RMS8Max) * 2 - log(NominalChi2), mLambdaRMS8MaxCut, -1) == false)
+           hbhe.setFlagField(1, HcalCaloFlagLabels::HBHESpikeNoise);
+
+       // Set the HBHETriangleNoise flag
+       if ((int)mCharge.size() >= mTrianglePeakTS)  // can't compute flag if peak TS isn't present; revise this at some point?
+       {
+           // initial values
+           double TS4Left = 1000;
+           double TS4Right = 1000;
+ 
+           // Use 'if' statements to protect against slopes that are either 0 or very small
+           if (TriangleResult.LeftSlope > 1e-5)
+               TS4Left = mCharge[mTrianglePeakTS] / TriangleResult.LeftSlope;
+           if (TriangleResult.RightSlope < -1e-5)
+               TS4Right = mCharge[mTrianglePeakTS] / -TriangleResult.RightSlope;
+     
+           if(TS4Left > 1000 || TS4Left < -1000)
+               TS4Left = 1000;
+           if(TS4Right > 1000 || TS4Right < -1000)
+               TS4Right = 1000;
+     
+           if(mTriangleIgnoreSlow == false)   // the slow-rising and slow-dropping edges won't be useful in 50ns/75ns
+           {
+               if(CheckPassFilter(mCharge[mTrianglePeakTS], TS4Left, mLeftSlopeCut, 1) == false)
+                   hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETriangleNoise);
+               else if(CheckPassFilter(mCharge[mTrianglePeakTS], TS4Right, mRightSlopeCut, 1) == false)
+                   hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETriangleNoise);
+           }
+     
+           // fast-dropping ones should be checked in any case
+           if(CheckPassFilter(mCharge[mTrianglePeakTS], TS4Right, mRightSlopeSmallCut, -1) == false)
+               hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETriangleNoise);
+       }
+   }
+
+   if(mCharge[4] + mCharge[5] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
+   {
+      double TS4TS5 = (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]);
+      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5UpperCut, 1) == false)
+         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
+      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5LowerCut, -1) == false)
+         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
+      
+      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5UpperCut, 1) == false            && // TS4TS5 is above envelope
+         mCharge[3] + mCharge[4] > mTS3TS4ChargeThreshold       &&       mTS3TS4ChargeThreshold>0 && // enough charge in 34
+         mCharge[5] + mCharge[6] < mTS5TS6UpperChargeThreshold  &&  mTS5TS6UpperChargeThreshold>0 && // low charge in 56
+      	 fabs( (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]) - 1.0 ) < mR45PlusOneRange    ) // R45 is around +1
+   	{
+           double TS3TS4 = (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]);
+           if(CheckPassFilter(mCharge[3] + mCharge[4], TS3TS4, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[3] + mCharge[4], TS3TS4, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+	      TS3TS4>(mR45MinusOneRange-1)                                                   ) // horizontal cut on R34 (R34>-0.8)
+	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS3TS4.
+   	}
+
+      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5LowerCut, -1) == false            && // TS4TS5 is below envelope
+         mCharge[3] + mCharge[4] < mTS3TS4UpperChargeThreshold  &&  mTS3TS4UpperChargeThreshold>0  && // low charge in 34
+         mCharge[5] + mCharge[6] > mTS5TS6ChargeThreshold       &&       mTS5TS6ChargeThreshold>0  && // enough charge in 56
+         fabs( (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]) + 1.0 ) < mR45MinusOneRange    ) // R45 is around -1
+        {
+           double TS5TS6 = (mCharge[5] - mCharge[6]) / (mCharge[5] + mCharge[6]);
+           if(CheckPassFilter(mCharge[5] + mCharge[6], TS5TS6, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[5] + mCharge[6], TS5TS6, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+	      TS5TS6<(1-mR45PlusOneRange)                                                    ) // horizontal cut on R56 (R56<+0.8)
+	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
+        }
+   }
+}
+
+#endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
@@ -11,23 +11,25 @@
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 
-class HBHEStatusBitSetter {
- public:
-  HBHEStatusBitSetter();
+class HBHEStatusBitSetter
+{
+public:
   HBHEStatusBitSetter(double nominalPedestal,double hitEnergyMinimum,int hitMultiplicityThreshold,const std::vector<edm::ParameterSet>& pulseShapeParameterSets);
   ~HBHEStatusBitSetter();
+
   void Clear();
-  void SetFlagsFromDigi(const HcalTopology* topo,HBHERecHit& hbhe, const HBHEDataFrame& digi, const HcalCoder& coder,
-			const HcalCalibrations& calib,
-			int firstSample=3,
-			int samplesToAdd=4
-			);
-  void SetFlagsFromRecHits(const HcalTopology* topo,HBHERecHitCollection& rec);
- private:
+  void setTopo(const HcalTopology* topo);
+  void SetFlagsFromDigi(HBHERecHit& hbhe, const HBHEDataFrame& digi,
+                        const HcalCoder& coder, const HcalCalibrations& calib);
+  void rememberHit(const HBHERecHit& hbhe);
+  void SetFlagsFromRecHits(HBHERecHitCollection& rec);
+
+private:
+  HBHEStatusBitSetter(const HBHEStatusBitSetter&);
+  HBHEStatusBitSetter& operator=(const HBHEStatusBitSetter&);
+  
   double hitEnergyMinimum_;
   int hitMultiplicityThreshold_;
-  unsigned int firstSample_;
-  unsigned int samplesToAdd_;
   double nominalPedestal_;
   HcalLogicalMap *logicalMap_;
   std::vector<int> hpdMultiplicity_;

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHEPulseShapeFlag.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHEPulseShapeFlag.cc
@@ -517,7 +517,7 @@ double HBHEPulseShapeFlagSetter::CalculateRMS8Max(const std::vector<double> &Cha
    if(RMS8Max < 1e-5)   // protection against zero
       RMS8Max = 1e-5;
 
-   return RMS / TempCharge[DigiSize-1];
+   return RMS8Max;
 }
 //---------------------------------------------------------------------------
 double HBHEPulseShapeFlagSetter::PerformLinearFit(const std::vector<double> &Charge)

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -340,12 +340,11 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
       edm::ESHandle<HcalFlagHFDigiTimeParams> p;
       es.get<HcalFlagHFDigiTimeParamsRcd>().get(p);
       HFDigiTimeParams.reset( new HcalFlagHFDigiTimeParams( *p ) );
-
-      edm::ESHandle<HcalTopology> htopo;
-      es.get<HcalRecNumberingRecord>().get(htopo);
       HFDigiTimeParams->setTopo(htopo.product());
-
     }
+
+  if (hbheFlagSetter_)
+      hbheFlagSetter_->setTopo(htopo.product());
 
   reco_.beginRun(es);
 }
@@ -557,7 +556,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	if (hbheTimingShapedFlagSetter_!=0)
 	  hbheTimingShapedFlagSetter_->SetTimingShapedFlags(rec->back());
 	if (setNoiseFlags_)
-	  hbheFlagSetter_->SetFlagsFromDigi(&(*topo),rec->back(),*i,coder,calibrations,first,toadd);
+	  hbheFlagSetter_->SetFlagsFromDigi(rec->back(), *i, coder, calibrations);
 	if (setPulseShapeFlags_)
 	  hbhePulseShapeFlagSetter_->SetPulseShapeFlags(rec->back(), *i, coder, calibrations);
 	if (setNegativeFlags_)
@@ -580,7 +579,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
       } // loop over HBHE digis
 
 
-      if (setNoiseFlags_) hbheFlagSetter_->SetFlagsFromRecHits(&(*topo),*rec);
+      if (setNoiseFlags_) hbheFlagSetter_->SetFlagsFromRecHits(*rec);
       if (setHSCPFlags_)  hbheHSCPFlagSetter_->hbheSetTimeFlagsFromDigi(rec.get(), HBDigis, RecHitIndex);
       // return result
       e.put(rec);


### PR DESCRIPTION
Updating HBHEPulseShapeFlag and HBHEStatusBitSetter classes so that they can be used with Phase 1 reco code.
Removing unnecessary default constructors.
Minor bug fix for HBHEStatusBitSetter: update internal HcalLogicalMap every run instead of just once.
This PR should not affect any workflow results in any way.
