### PR TITLE
Fix LS reports: only use RawData.

### DIFF
--- a/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
@@ -20,6 +20,7 @@ ecalRawDataClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
+            perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('Summary of the raw data (DCC and front-end) quality. A channel is red if it has nonzero events with FE status that is different from any of ENABLED, DISABLED, SUPPRESSED, FIFOFULL, FIFOFULL_L1ADESYNC, and FORCEDZS. A FED can also go red if its number of L1A desynchronization errors is greater than ' + str(synchErrThresholdFactor) + ' * log10(total entries).')
         ),
         ErrorsSummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -132,8 +132,7 @@ namespace ecaldqm
 
       // Fill Global Quality Summary
       int status(kGood);
-      //if(integrity == kBad || presample == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
-      if(integrity == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
+      if(integrity == kBad || presample == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
         status = kBad;
       else if(integrity == kUnknown && presample == kUnknown && timing == kUnknown && rawdata == kUnknown && trigprim == kUnknown)
         status = kUnknown;

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -86,16 +86,18 @@ namespace ecaldqm
     MESet const* sHotCell(using_("HotCell") ? &sources_.at("HotCell") : 0);
 
     float totalChannels(0.);
-    float totalGood(0.);
+    float totalGood(0.), totalGoodRaw(0);
 
     double dccChannels[nDCC];
     std::fill_n(dccChannels, nDCC, 0.);
-    double dccGood[nDCC];
-    std::fill_n(dccGood, nDCC, 0.);
+    double dccGood[nDCC], dccGoodRaw[nDCC];
+    std::fill_n(dccGood,    nDCC, 0.);
+    std::fill_n(dccGoodRaw, nDCC, 0.);
 
     std::map<uint32_t, int> badChannelsCount;
 
     // Override IntegrityByLumi check if Desync errors present
+    // Used to set an entire FED to BAD
     MESet const& sBXSRP(sources_.at("BXSRP"));
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC,false);
@@ -110,33 +112,34 @@ namespace ecaldqm
       DetId id(qItr->getId());
       unsigned iDCC(dccId(id) - 1);
 
+      // Initialize individual Quality Summaries
+      // NOTE: These represent quality over *cumulative* statistics
       int integrity(sIntegrity ? sIntegrity->getBinContent(id) : kUnknown);
-
       if(integrity == kUnknown || integrity == kMUnknown){
         qItr->setBinContent(integrity);
         if ( onlineMode_ ) continue;
       }
-
       int presample(sPresample ? sPresample->getBinContent(id) : kUnknown);
       int hotcell(sHotCell ? sHotCell->getBinContent(id) : kUnknown);
       int timing(sTiming ? sTiming->getBinContent(id) : kUnknown);
       int trigprim(sTriggerPrimitives ? sTriggerPrimitives->getBinContent(id) : kUnknown);
-
       int rawdata(sRawData.getBinContent(id));
 
+      // If there are no RawData or Integrity errors in this LS, set them back to GOOD
       //if(integrity == kBad && integrityByLumi[iDCC] == 0.) integrity = kGood;
       if(integrity == kBad && integrityByLumi[iDCC] == 0. && !hasMismatchDCC[iDCC]) integrity = kGood;
       if(rawdata == kBad && rawDataByLumi[iDCC] == 0.) rawdata = kGood;
 
+      // Fill Global Quality Summary
       int status(kGood);
       //if(integrity == kBad || presample == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
       if(integrity == kBad || timing == kBad || rawdata == kBad || trigprim == kBad || hotcell == kBad)
         status = kBad;
       else if(integrity == kUnknown && presample == kUnknown && timing == kUnknown && rawdata == kUnknown && trigprim == kUnknown)
         status = kUnknown;
-
       qItr->setBinContent(status);
 
+      // Keep running count of good/bad channels/towers
       if(status == kBad){
         if(id.subdetId() == EcalBarrel) badChannelsCount[EBDetId(id).tower().rawId()] += 1;
         if(id.subdetId() == EcalEndcap) badChannelsCount[EEDetId(id).sc().rawId()] += 1;
@@ -147,10 +150,20 @@ namespace ecaldqm
       }
       dccChannels[iDCC] += 1.;
       totalChannels += 1.;
-    }
+
+      // Keep running count of good channels in RawData only:
+      // Only RawData used in by LS reporting to save memory
+      if(rawdata != kBad){
+        dccGoodRaw[iDCC] += 1.;
+        totalGoodRaw += 1.;
+      }
+
+    } // qItr channel loop
 
     // search clusters of bad towers
     if(onlineMode_){
+
+      // EB
       for(int iz(-1); iz < 2; iz += 2){
         for(int ieta(0); ieta < 17; ++ieta){
           if(iz == 1 && ieta == 0) continue;
@@ -167,16 +180,17 @@ namespace ecaldqm
 
                 if(badChannelsCount[ttid.rawId()] > towerBadFraction_ * 25.)
                   badTowers += 1;
-              }
-            }
-
+              } // dphi
+            } // deta
             if(badTowers > 2){
               for(unsigned iD(0); iD < 4; ++iD)
                 dccGood[dccId(ttids[iD]) - 1] = 0.;
             }
-          }
-        }
-      }
+          } // iphi
+        } // ieta
+      } // iz
+
+      // EE
       for(int iz(-1); iz <= 1; iz += 2){
         for(int ix(1); ix < 20; ++ix){
           for(int iy(1); iy < 20; ++iy){
@@ -193,9 +207,8 @@ namespace ecaldqm
 
                 if(badChannelsCount[scid.rawId()] > towerBadFraction_ * scConstituents(scid).size())
                   badTowers += 1;
-              }
-            }
-
+              } // dy
+            } // dx
             // contiguous towers bad -> [(00)(11)] [(11)(00)] [(01)(01)] [(10)(10)] []=>x ()=>y
             if(badTowers > 2){
               for(unsigned iD(0); iD < 4; ++iD){
@@ -204,30 +217,36 @@ namespace ecaldqm
                 dccGood[dccId(scid) - 1] = 0.;
               }
             }
-          }
-        }
-      }
-    }
+          } // iy
+        } // ix
+      } // iz
 
+    } // cluster search
+
+    // Fill Report Summaries
     double nBad(0.);
     for(unsigned iDCC(0); iDCC < nDCC; ++iDCC){
       if(dccChannels[iDCC] < 1.) continue;
 
       int dccid(iDCC + 1);
       float frac(dccGood[iDCC] / dccChannels[iDCC]);
+      float fracRaw(dccGoodRaw[iDCC] / dccChannels[iDCC]);
       meReportSummaryMap.setBinContent(dccid, frac);
-      meReportSummaryContents.fill(dccid, frac);
+      float fracLS(onlineMode_ ? frac : fracRaw);
+      meReportSummaryContents.fill(dccid, fracLS); // reported by LS
 
       if(1. - frac > fedBadFraction_) nBad += 1.;
     }
 
-    if(totalChannels > 0.) meReportSummary.fill(totalGood / totalChannels);
+    float totalGoodLS(onlineMode_ ? totalGood : totalGoodRaw);
+    if(totalChannels > 0.) meReportSummary.fill(totalGoodLS / totalChannels); // reported by LS
 
     if(onlineMode_){
       if(totalChannels > 0.) MEs_.at("GlobalSummary").setBinContent(1, totalGood / totalChannels);
       MEs_.at("NBadFEDs").setBinContent(1, nBad);
     }
-  }
+
+  } // producePlots()
 
   DEFINE_ECALDQM_WORKER(SummaryClient);
 }

--- a/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
@@ -276,6 +276,7 @@ ecalRawDataTask = cms.untracked.PSet(
             ),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('SuperCrystal'),
+            perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('FE status counter.')
         )
     )


### PR DESCRIPTION
**Fix LS-based reporting in SummaryClient so that we correctly show % of good channels per LS in offline DQM**
- Set the monitor elements (1) ecalRawDataClient.MEs.QualitySummary, and (2) ecalRawDataTask.MEs.FEStatus to be run by lumi to correctly feed information to SummaryClient in offline DQM where these are normally only run at run end
- Modify LS-based reports in SummaryClient to only use RawData quality as basis for "good" channels to keep memory usage low
- Does not affect operation of SummaryClient in online DQM where these MEs are already produced every LS

Also, re-enable presample check in global quality summary.

In conjunction with 80X PR https://github.com/cms-sw/cmssw/pull/15411
