### PR TITLE
fix duplicate customise_commands in cmsDriver

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2219,7 +2219,7 @@ class ConfigBuilder(object):
 		self.process=cleanUnscheduled(self.process)
 
 
-	self.pythonCfgCode += self.addCustomise(1)
+		self.pythonCfgCode += self.addCustomise(1)
 
 
 	# make the .io file


### PR DESCRIPTION
For a while, I've noticed that using `customise_commands` in `cmsDriver` resulted in the commands being printed twice at the end of the generated config. The handling of this was changed most recently in #6492.

I finally found the cause of the duplication: the second call to `addCustomise()` for unscheduled mode was in the wrong block for the current logic. The fixed version works for both the example in #6492 and regular (scheduled) examples, e.g.:

```
cmsDriver.py SinglePiE50HCAL_pythia8_cfi --python_filename run_step1_noCT.py --conditions auto:phase1_2017_design -n 10 --era Run2_2017 --geometry Configuration.Geometry.GeometryExtended2017dev_cff,Configuration.Geometry.GeometryExtended2017devReco_cff --eventcontent FEVTDEBUGHLT -s GEN,SIM,DIGI:pdigi_valid --datatier GEN-SIM-DIGI-RAW-HLTDEBUG --beamspot Realistic50ns13TeVCollision --fileout file:step1_noCT.root --customise SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Full --customise_commands "process.mix.digitizers.hcal.he.sipmCrossTalk = cms.double(0)" --no_exec
```
