### PR TITLE
Downgrade ROOT error from "Inverter::Dinv"

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -198,8 +198,9 @@ namespace {
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||
           (el_location.find("TUnixSystem::SetDisplay") != std::string::npos) ||
           (el_location.find("TGClient::GetFontByName") != std::string::npos) ||
-	        (el_message.find("nbins is <=0 - set to nbins = 1") != std::string::npos) ||
-	        (el_message.find("nbinsy is <=0 - set to nbinsy = 1") != std::string::npos) ||
+          (el_location.find("Inverter::Dinv") != std::string::npos) ||
+          (el_message.find("nbins is <=0 - set to nbins = 1") != std::string::npos) ||
+          (el_message.find("nbinsy is <=0 - set to nbinsy = 1") != std::string::npos) ||
           (level < kError and
            (el_location.find("CINTTypedefBuilder::Setup")!= std::string::npos) and
            (el_message.find("possible entries are in use!") != std::string::npos))) {


### PR DESCRIPTION
ROOT recently added an error message about matrix inversion failure.
Since the code returns a false if it fails, there is no need to convert
this to an exception. Instead we just forward to the MessageLogger.
