### PR TITLE
80X: MC updates for trancheIV

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,15 +10,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v17',
+    'run2_design'       :   '80X_mcRun2_design_v18',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_Candidate_2016_09_02_09_19_47',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v17',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_Candidate_2016_09_02_09_21_09',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v18',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v15',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v16',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v10',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v11',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '80X_mcRun2_pA_Candidate_2016_09_02_10_22_08',
     # GlobalTag for Run1 data reprocessing
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_Candidate_2016_09_02_10_25_48',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v16',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_Candidate_2016_09_02_10_24_47',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,17 +10,17 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v18',
+    'run2_design'       :   '80X_mcRun2_design_v19',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v17',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v18',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v18',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v19',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v16',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v17',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v11',
+    'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v12',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '80X_mcRun2_pA_Candidate_2016_09_02_10_22_08',
+    'run2_mc_pa'        :   '80X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_Candidate_2016_09_02_10_26_48',
     # GlobalTag for Run2 data reprocessing
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v16',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v17',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_v8',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
- See: [Talk at PPD general 11.08.2016](https://indico.cern.ch/event/562065/contributions/2270369/)
- Changes in Physics performance for Tranche-IV 2016 MC production are expected
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v19) as [80X_mcRun2_design_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v19/80X_mcRun2_design_v17): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Jet Energy Corrections to Spring16_25nsV6 version
  - updated/add Jet Energy resolution / resolution scale factor to Spring16_25nsV6 version 
  - updated btag Jet Probability tagger calibration for BTV HIP mitigation
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v19) as [80X_mcRun2_asymptotic_Candidate_2016_09_02_09_21_09](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_Candidate_2016_09_02_09_21_09) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v19/80X_mcRun2_asymptotic_Candidate_2016_09_02_09_21_09): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Pixel channel status (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
  - updated Tracker Alignment fixing z-shrinkage effect  
  - updated Jet Energy Corrections to Spring16_25nsV6 
  - updated Beamspot for new Tracker alignment 
  - updated Btag Jet Probability tagger calibration for BTV HIP mitigation
- **RunII Startup scenario** : [80X_mcRun2_startup_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v18) as [80X_mcRun2_startup_Candidate_2016_09_02_09_19_47](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_Candidate_2016_09_02_09_19_47) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v18/80X_mcRun2_startup_Candidate_2016_09_02_09_19_47): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Pixel channel status (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
- **RunII Proton-Lead scenario** : [80X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v1) as [80X_mcRun2_pA_Candidate_2016_09_02_10_22_08](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_Candidate_2016_09_02_10_22_08) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_pA_v1/80X_mcRun2_pA_Candidate_2016_09_02_10_22_08): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Pixel channel status (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
  - updated Tracker Alignment fixing z-shrinkage effect  
  - updated Jet Energy Corrections to Spring16_25nsV6 
  - updated Beamspot for new Tracker alignment 
  - updated Btag Jet Probability tagger calibration for BTV HIP mitigation
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v17) as [80X_mcRun2cosmics_startup_peak_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v17/80X_mcRun2cosmics_startup_peak_v15): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Pixel channel status (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
- **RunII Heavy Ions scenario** : [80X_mcRun2_HeavyIon_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v12) as [80X_mcRun2_HeavyIon_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_HeavyIon_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_HeavyIon_v12/80X_mcRun2_HeavyIon_v10): 
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated SiPixel dynamic inefficiency for 2016 data (high PU)
  - updated Pixel channel status (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
  - updated Btag Jet Probability tagger calibration for BTV HIP mitigation
## Upgrade
- **PhaseI realistic scenario** : [80X_upgrade2017_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_realistic_v9) as [80X_upgrade2017_realistic_Candidate_2016_09_02_10_24_47](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_realistic_Candidate_2016_09_02_10_24_47) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_realistic_v9/80X_upgrade2017_realistic_Candidate_2016_09_02_10_24_47): 
  - updated AlCaRecoTriggerBits for EcalTrg AlCaReco
  - updated MC pulse shape for HB iPhi=+54 
  - updated EcalChannelStatus (as in Aug 2016)
  - updated Strip channel status (as in Aug 2016)
  - updated Btag Jet Probability tagger calibration for BTV HIP mitigation
  - updated Jet Energy Corrections to Spring16_25nsV6 
- **PhaseI design scenario** : [80X_upgrade2017_design_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v17) as [80X_upgrade2017_design_Candidate_2016_09_02_10_25_48](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_Candidate_2016_09_02_10_25_48) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v17/80X_upgrade2017_design_Candidate_2016_09_02_10_25_48): 
  - updated AlCaRecoTriggerBits for EcalTrg AlCaReco
  - updated MC pulse shape for HB iPhi=+54 
  - updated Btag Jet Probability tagger calibration for BTV HIP mitigation
  - updated Jet Energy Corrections to Spring16_25nsV6 
