### PR TITLE
Added missing header files needed for gcc 6

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/OccupancyPlotMacros.cc
+++ b/DPGAnalysis/SiStripTools/bin/OccupancyPlotMacros.cc
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <iostream>
 #include <math.h>
+#include <algorithm>
 #include "TROOT.h"
 #include "DPGAnalysis/SiStripTools/interface/CommonAnalyzer.h"
 #include "OccupancyPlotMacros.h"

--- a/SimDataFormats/CaloAnalysis/src/SimCluster.cc
+++ b/SimDataFormats/CaloAnalysis/src/SimCluster.cc
@@ -2,7 +2,9 @@
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <numeric>
 
 const unsigned int SimCluster::longLivedTag = 65536;
 


### PR DESCRIPTION
The gcc 6 compilation was failing without explicit inclusion of additional C++ headers.
