### PR TITLE
Minor maintenance improvements to WaitingTaskList

### DIFF
--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -33,38 +33,17 @@ using namespace edm;
 // constructors and destructor
 //
 WaitingTaskList::WaitingTaskList(unsigned int iInitialSize):
-m_head{0},
+m_head{nullptr},
 m_nodeCache{new WaitNode[iInitialSize]},
 m_nodeCacheSize{iInitialSize},
 m_lastAssignedCacheIndex{0},
 m_waiting{true}
 {
-  for(auto it = m_nodeCache, itEnd = m_nodeCache+m_nodeCacheSize; it!=itEnd; ++it) {
+  auto nodeCache = m_nodeCache.get();
+  for(auto it = nodeCache, itEnd = nodeCache+m_nodeCacheSize; it!=itEnd; ++it) {
     it->m_fromCache=true;
   }
 }
-
-// WaitingTaskList::WaitingTaskList(const WaitingTaskList& rhs)
-// {
-//    // do actual copying here;
-// }
-
-WaitingTaskList::~WaitingTaskList()
-{
-  delete [] m_nodeCache;
-}
-
-//
-// assignment operators
-//
-// const WaitingTaskList& WaitingTaskList::operator=(const WaitingTaskList& rhs)
-// {
-//   //An exception safe implementation is
-//   WaitingTaskList temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
 
 //
 // member functions
@@ -73,20 +52,21 @@ void
 WaitingTaskList::reset()
 {
   m_exceptionPtr = std::exception_ptr{};
-  m_waiting = true;
   unsigned int nSeenTasks = m_lastAssignedCacheIndex;
   m_lastAssignedCacheIndex = 0;
-  assert(m_head == 0);
+  assert(m_head == nullptr);
   if (nSeenTasks > m_nodeCacheSize) {
     //need to expand so next time we don't have to do any
     // memory requests
-    delete [] m_nodeCache;
     m_nodeCacheSize = nSeenTasks;
-    m_nodeCache = new WaitNode[nSeenTasks];
-    for(auto it = m_nodeCache, itEnd = m_nodeCache+m_nodeCacheSize; it!=itEnd; ++it) {
+    m_nodeCache.reset( new WaitNode[nSeenTasks] );
+    auto nodeCache = m_nodeCache.get();
+    for(auto it = nodeCache, itEnd = nodeCache+m_nodeCacheSize; it!=itEnd; ++it) {
       it->m_fromCache=true;
     }
   }
+  //this will make sure all cores see the changes
+  m_waiting = true;
 }
 
 WaitingTaskList::WaitNode*
@@ -96,7 +76,7 @@ WaitingTaskList::createNode(WaitingTask* iTask)
   
   WaitNode* returnValue;
   if( index < m_nodeCacheSize) {
-    returnValue = m_nodeCache+index;
+    returnValue = m_nodeCache.get()+index;
   } else {
     returnValue = new WaitNode;
     returnValue->m_fromCache=false;
@@ -121,14 +101,15 @@ WaitingTaskList::add(WaitingTask* iTask) {
   } else {
     WaitNode* newHead = createNode(iTask);
     WaitNode* oldHead = m_head.exchange(newHead);
-    if(oldHead) {
-      newHead->setNextNode(oldHead);
-      //NOTE: even if 'm_waiting' changed, we don't
-      // have to recheck since we beat 'announce()' in
-      // the ordering of 'm_head.exchange' call so iTask
-      // is guaranteed to be in the link list
-    } else {
-      newHead->setNextNode(0);
+    newHead->setNextNode(oldHead);
+
+    //For the case where oldHead != nullptr,
+    // even if 'm_waiting' changed, we don't
+    // have to recheck since we beat 'announce()' in
+    // the ordering of 'm_head.exchange' call so iTask
+    // is guaranteed to be in the link list
+
+    if(nullptr == oldHead) {
       if(!m_waiting) {
         //if finished waiting right before we did the
         // exchange our task will not be spawned. Also,
@@ -137,7 +118,6 @@ WaitingTaskList::add(WaitingTask* iTask) {
         // It is safe to call announce from multiple threads
         announce();
       }
-      
     }
   }
 }
@@ -148,7 +128,7 @@ WaitingTaskList::announce()
   //Need a temporary storage since one of these tasks could
   // cause the next event to start processing which would refill
   // this waiting list after it has been reset
-  WaitNode* n = m_head.exchange(0);
+  WaitNode* n = m_head.exchange(nullptr);
   WaitNode* next;
   while(n) {
     //it is possible that 'WaitingTaskList::add' is running in a different

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -77,8 +77,7 @@ void WaitingTaskList_test::addThenDone()
   
    edm::WaitingTaskList waitList;
    {
-      std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-                                                 [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+      auto waitTask = edm::make_empty_waiting_task();
       waitTask->set_ref_count(2);
       //NOTE: allocate_child does NOT increment the ref_count of waitTask!
       auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
@@ -102,8 +101,7 @@ void WaitingTaskList_test::addThenDone()
    {
       std::exception_ptr excPtr;
 
-      std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-                                                 [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+      auto waitTask = edm::make_empty_waiting_task();
       waitTask->set_ref_count(2);
    
       auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
@@ -127,8 +125,7 @@ void WaitingTaskList_test::doneThenAdd()
 
    edm::WaitingTaskList waitList;
    {
-     std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-                                              [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+      auto waitTask = edm::make_empty_waiting_task();
       waitTask->set_ref_count(2);
    
       auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
@@ -151,8 +148,7 @@ void WaitingTaskList_test::addThenDoneFailed()
   {
     std::exception_ptr excPtr;
     
-    std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-      [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+    auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(2);
     
     auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
@@ -176,8 +172,7 @@ void WaitingTaskList_test::doneThenAddFailed()
   
   edm::WaitingTaskList waitList;
   {
-    std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-      [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+    auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(2);
     
     auto t = new (waitTask->allocate_child()) TestCalledTask{called,excPtr};
@@ -210,8 +205,7 @@ void WaitingTaskList_test::stressTest()
    const unsigned int nTasks = 10000;
    while(0 != --index) {
       called = false;
-     std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-                                                [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+      auto waitTask = edm::make_empty_waiting_task();
       waitTask->set_ref_count(3);
       tbb::task* pWaitTask=waitTask.get();
       

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -618,8 +618,7 @@ namespace edm {
     bool expected = false;
     if(not workStarted_.compare_exchange_strong(expected, true) ) {
       //another thread beat us here
-      std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-        [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+      auto waitTask = edm::make_empty_waiting_task();
       waitTask->increment_ref_count();
       
       waitingTasks_.add(waitTask.get());
@@ -655,8 +654,8 @@ namespace edm {
             waitingTasks_.doneWaiting(nullptr);
             return;
           }
-          std::shared_ptr<edm::WaitingTask> waitTask{new (tbb::task::allocate_root()) edm::EmptyWaitingTask{},
-            [](edm::WaitingTask* iTask){tbb::task::destroy(*iTask);} };
+          auto waitTask = edm::make_empty_waiting_task();
+          //set count to 2 since wait_for_all requires value to not go to 0
           waitTask->set_ref_count(2);
           
           prefetchAsync(waitTask.get(),parentContext, ep);


### PR DESCRIPTION
-Used C++11 more effectively
-added CMS_THREAD_GUARD for annotating intent
-created make_empty_waiting_task to avoid copy and paste errors and to switch to std::unique_ptr instead of std::shared_ptr to avoid an unnecessary call to new.
