### PR TITLE
rhoCorr binned in eta 81X, apply rhoCorr for H/E

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -24,6 +24,17 @@ def esproducers_by_type(process, *types):
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# Module restructuring for PR #15440
+def customiseFor15440(process):
+    for producer in producers_by_type(process, "EgammaHLTBcHcalIsolationProducersRegional", "EgammaHLTEcalPFClusterIsolationProducer", "EgammaHLTHcalPFClusterIsolationProducer", "MuonHLTEcalPFClusterIsolationProducer", "MuonHLTHcalPFClusterIsolationProducer"):
+        if hasattr(producer, "effectiveAreaBarrel") and hasattr(producer, "effectiveAreaEndcap"):
+            if not hasattr(producer, "effectiveAreas") and not hasattr(producer, "absEtaLowEdges"):
+                producer.absEtaLowEdges = cms.vdouble( 0.0, 1.479 )
+                producer.effectiveAreas = cms.vdouble( producer.effectiveAreaBarrel.value(), producer.effectiveAreaEndcap.value() )
+                del producer.effectiveAreaBarrel
+                del producer.effectiveAreaEndcap
+    return process
+
 # Add quadruplet-specific pixel track duplicate cleaning mode (PR #13753)
 def customiseFor13753(process):
     for producer in producers_by_type(process, "PixelTrackProducer"):
@@ -58,6 +69,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor14356(process)
         process = customiseFor13753(process)
         process = customiseFor14833(process)
+        process = customiseFor15440(process)
 #       process = customiseFor12718(process)
         pass
 

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTBcHcalIsolationProducersRegional.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTBcHcalIsolationProducersRegional.h
@@ -45,17 +45,18 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  const bool  doRhoCorrection_;
-  const float rhoScale_;
-  const float rhoMax_;
   const bool  doEtSum_;
-  const float etMin_;
-  const float innerCone_;
-  const float outerCone_;
+  const double etMin_;
+  const double innerCone_;
+  const double outerCone_;
   const int   depth_;
-  const float effectiveAreaBarrel_;
-  const float effectiveAreaEndcap_;
   const bool  useSingleTower_;
+
+  const bool  doRhoCorrection_;
+  const double rhoScale_;
+  const double rhoMax_;
+  const std::vector<double> effectiveAreas_;
+  const std::vector<double> absEtaLowEdges_;
 
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateProducer_;
   const edm::EDGetTokenT<CaloTowerCollection>               caloTowerProducer_;

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTEcalPFClusterIsolationProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTEcalPFClusterIsolationProducer.h
@@ -56,10 +56,11 @@ class HLTEcalPFClusterIsolationProducer : public edm::stream::EDProducer<> {
   const double energyEndcap_;
 
   const bool doRhoCorrection_;
-  const float rhoMax_;
-  const float rhoScale_;
-  const float effectiveAreaBarrel_;
-  const float effectiveAreaEndcap_;
+  const double rhoMax_;
+  const double rhoScale_;
+  const std::vector<double> effectiveAreas_;
+  const std::vector<double> absEtaLowEdges_;
+
 };
 
 #endif

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTHcalPFClusterIsolationProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTHcalPFClusterIsolationProducer.h
@@ -56,13 +56,13 @@ class HLTHcalPFClusterIsolationProducer : public edm::global::EDProducer<> {
   const double etaStripEndcap_;
   const double energyBarrel_;
   const double energyEndcap_;
+  const bool useEt_;
 
   const bool doRhoCorrection_;
-  const float rhoMax_;
-  const float rhoScale_;
-  const float effectiveAreaBarrel_;
-  const float effectiveAreaEndcap_;
-  const bool useEt_;
+  const double rhoMax_;
+  const double rhoScale_;
+  const std::vector<double> effectiveAreas_;
+  const std::vector<double> absEtaLowEdges_;
 };
 
 #endif

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
@@ -148,8 +148,9 @@ void EgammaHLTBcHcalIsolationProducersRegional::produce(edm::Event& iEvent, cons
 
     if (doRhoCorrection_) {
       int iEA = -1;
+      auto scEta = std::abs(recoEcalCandRef->superCluster()->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if ( fabs(recoEcalCandRef->superCluster()->eta()) > absEtaLowEdges_.at(bIt) ) {
+        if ( scEta  > absEtaLowEdges_.at(bIt) ) {
           iEA = bIt;
           break;
         }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
@@ -4,11 +4,16 @@
  *
  */
 
+#include <iostream>
+#include <vector>
+#include <memory>
+
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTBcHcalIsolationProducersRegional.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -24,21 +29,35 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 EgammaHLTBcHcalIsolationProducersRegional::EgammaHLTBcHcalIsolationProducersRegional(const edm::ParameterSet& config) :
-  doRhoCorrection_(           config.getParameter<bool>("doRhoCorrection") ),
-  rhoScale_(                  config.getParameter<double>("rhoScale") ),
-  rhoMax_(                    config.getParameter<double>("rhoMax") ),
   doEtSum_(                   config.getParameter<bool>("doEtSum") ),
   etMin_(                     config.getParameter<double>("etMin") ),
   innerCone_(                 config.getParameter<double>("innerCone") ),
   outerCone_(                 config.getParameter<double>("outerCone") ),
   depth_(                     config.getParameter<int>("depth") ),
-  effectiveAreaBarrel_(       config.getParameter<double>("effectiveAreaBarrel") ),
-  effectiveAreaEndcap_(       config.getParameter<double>("effectiveAreaEndcap") ),
   useSingleTower_(            config.getParameter<bool>("useSingleTower") ),
+  doRhoCorrection_(           config.getParameter<bool>("doRhoCorrection") ),
+  rhoScale_(                  config.getParameter<double>("rhoScale") ),
+  rhoMax_(                    config.getParameter<double>("rhoMax") ),
+  effectiveAreas_(            config.getParameter<std::vector<double> >("effectiveAreas") ),
+  absEtaLowEdges_(            config.getParameter<std::vector<double> >("absEtaLowEdges") ),
   recoEcalCandidateProducer_( consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer")) ),
   caloTowerProducer_(         consumes<CaloTowerCollection>(config.getParameter<edm::InputTag>("caloTowerProducer")) ),
   rhoProducer_(               doRhoCorrection_ ? consumes<double>(config.getParameter<edm::InputTag>("rhoProducer")) : edm::EDGetTokenT<double>() )
 {
+
+  if (doRhoCorrection_) {
+    if (absEtaLowEdges_.size() != effectiveAreas_.size())
+      throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+    if (absEtaLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+    for (unsigned int aIt = 0; aIt < absEtaLowEdges_.size() - 1; aIt++) {
+      if ( !(absEtaLowEdges_.at( aIt ) < absEtaLowEdges_.at( aIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+    }
+  }
+
   ElectronHcalHelper::Configuration hcalCfg;
   hcalCfg.hOverEConeSize    = outerCone_;
   hcalCfg.useTowers         = true;
@@ -68,9 +87,9 @@ void EgammaHLTBcHcalIsolationProducersRegional::fillDescriptions(edm::Configurat
   desc.add<double>(("outerCone"), 0.15);
   desc.add<int>(("depth"), -1);
   desc.add<bool>(("doEtSum"), false);
-  desc.add<double>(("effectiveAreaBarrel"), 0.021);
-  desc.add<double>(("effectiveAreaEndcap"), 0.040);
   desc.add<bool>(("useSingleTower"), false);
+  desc.add<std::vector<double> >("effectiveAreas", {0.079, 0.25}); // 2016 post-ichep sinEle default
+  desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // Barrel, Endcap
   descriptions.add(("hltEgammaHLTBcHcalIsolationProducersRegional"), desc);
 }
 
@@ -119,17 +138,23 @@ void EgammaHLTBcHcalIsolationProducersRegional::produce(edm::Event& iEvent, cons
       else
 	isol = isolAlgo.getTowerEtSum(&(*recoEcalCandRef));
 
-      if (doRhoCorrection_) {
-	if (fabs(recoEcalCandRef->superCluster()->eta()) < 1.442)
-	  isol = isol - rho*effectiveAreaBarrel_;
-	else
-	  isol = isol - rho*effectiveAreaEndcap_;
-      }
     } else { //calcuate H for H/E
       if (useSingleTower_)
 	isol = hcalHelper_->hcalESumDepth1BehindClusters(towersBehindCluster) + hcalHelper_->hcalESumDepth2BehindClusters(towersBehindCluster);
       else
 	isol = hcalHelper_->hcalESum(*(recoEcalCandRef->superCluster()));
+
+    }
+
+    if (doRhoCorrection_) {
+      int iEA = -1;
+      for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
+        if ( fabs(recoEcalCandRef->superCluster()->eta()) > absEtaLowEdges_.at(bIt) ) {
+          iEA = bIt;
+          break;
+        }
+      }
+        isol = isol - rho*effectiveAreas_.at(iEA);
     }
 
     isoMap.insert(recoEcalCandRef, isol);

--- a/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
@@ -123,8 +123,9 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
 
     if (doRhoCorrection_) {
       int iEA = -1;
+      auto cEta = std::abs(candRef->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if ( fabs(candRef->eta()) > absEtaLowEdges_.at(bIt) ) {
+        if ( cEta > absEtaLowEdges_.at(bIt) ) {
           iEA = bIt;
           break;
         }

--- a/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
@@ -39,8 +39,21 @@ HLTEcalPFClusterIsolationProducer<T1>::HLTEcalPFClusterIsolationProducer(const e
   doRhoCorrection_    (config.getParameter<bool>("doRhoCorrection")),
   rhoMax_             (config.getParameter<double>("rhoMax")),
   rhoScale_           (config.getParameter<double>("rhoScale")),
-  effectiveAreaBarrel_(config.getParameter<double>("effectiveAreaBarrel")),
-  effectiveAreaEndcap_(config.getParameter<double>("effectiveAreaEndcap")) {
+  effectiveAreas_     (config.getParameter<std::vector<double> >("effectiveAreas")),
+  absEtaLowEdges_     (config.getParameter<std::vector<double> >("absEtaLowEdges")) {
+
+  if (doRhoCorrection_) {
+    if (absEtaLowEdges_.size() != effectiveAreas_.size())
+      throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+    if (absEtaLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+    for (unsigned int aIt = 0; aIt < absEtaLowEdges_.size() - 1; aIt++) {
+      if ( !(absEtaLowEdges_.at( aIt ) < absEtaLowEdges_.at( aIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+    }
+  }
 
   std::string recoCandidateProducerName = "recoCandidateProducer";
   if ((typeid(HLTEcalPFClusterIsolationProducer<T1>) == typeid(HLTEcalPFClusterIsolationProducer<reco::RecoEcalCandidate>))) recoCandidateProducerName = "recoEcalCandidateProducer";
@@ -67,8 +80,6 @@ void HLTEcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationD
   desc.add<bool>("doRhoCorrection", false);
   desc.add<double>("rhoMax", 9.9999999E7); 
   desc.add<double>("rhoScale", 1.0); 
-  desc.add<double>("effectiveAreaBarrel", 0.101);
-  desc.add<double>("effectiveAreaEndcap", 0.046);
   desc.add<double>("drMax", 0.3);
   desc.add<double>("drVetoBarrel", 0.0);
   desc.add<double>("drVetoEndcap", 0.0);
@@ -76,6 +87,8 @@ void HLTEcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationD
   desc.add<double>("etaStripEndcap", 0.0);
   desc.add<double>("energyBarrel", 0.0);
   desc.add<double>("energyEndcap", 0.0);
+  desc.add<std::vector<double> >("effectiveAreas", {0.29, 0.21}); // 2016 post-ichep sinEle default
+  desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // Barrel, Endcap
   descriptions.add(defaultModuleLabel<HLTEcalPFClusterIsolationProducer<T1>>(), desc);
 }
 
@@ -88,7 +101,7 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
     iEvent.getByToken(rhoProducer_, rhoHandle);
     rho = *(rhoHandle.product());
   }
-  
+
   if (rho > rhoMax_)
     rho = rhoMax_;
   
@@ -107,12 +120,17 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
     T1Ref candRef(recoCandHandle, iReco);
     
     float sum = isoAlgo.getSum(candRef, clusterHandle);
-    
+
     if (doRhoCorrection_) {
-      if (fabs(candRef->eta()) < 1.479) 
-	sum = sum - rho*effectiveAreaBarrel_;
-      else
-	sum = sum - rho*effectiveAreaEndcap_;
+      int iEA = -1;
+      for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
+        if ( fabs(candRef->eta()) > absEtaLowEdges_.at(bIt) ) {
+          iEA = bIt;
+          break;
+        }
+      }
+
+      sum = sum - rho*effectiveAreas_.at(iEA);
     }
 
     recoCandMap.insert(candRef, sum);

--- a/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
@@ -137,8 +137,9 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid, edm::Even
  
     if (doRhoCorrection_) {
       int iEA = -1;
+      auto cEta = std::abs(candRef->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if ( fabs(candRef->eta()) > absEtaLowEdges_.at(bIt) ) {
+        if ( cEta > absEtaLowEdges_.at(bIt) ) {
           iEA = bIt;
           break;
         }

--- a/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
@@ -31,12 +31,25 @@ HLTHcalPFClusterIsolationProducer<T1>::HLTHcalPFClusterIsolationProducer(const e
   etaStripEndcap_         ( config.getParameter<double>("etaStripEndcap")),
   energyBarrel_           ( config.getParameter<double>("energyBarrel")),
   energyEndcap_           ( config.getParameter<double>("energyEndcap")),
+  useEt_                  ( config.getParameter<bool>("useEt")),
   doRhoCorrection_        ( config.getParameter<bool>("doRhoCorrection")),
   rhoMax_                 ( config.getParameter<double>("rhoMax")),
-  rhoScale_               ( config.getParameter<double>("rhoScale")), 
-  effectiveAreaBarrel_    ( config.getParameter<double>("effectiveAreaBarrel")),
-  effectiveAreaEndcap_    ( config.getParameter<double>("effectiveAreaEndcap")),
-  useEt_                  ( config.getParameter<bool>("useEt")) {
+  rhoScale_               ( config.getParameter<double>("rhoScale")),
+  effectiveAreas_         ( config.getParameter<std::vector<double> >("effectiveAreas")) ,
+  absEtaLowEdges_         ( config.getParameter<std::vector<double> >("absEtaLowEdges")) {
+
+  if (doRhoCorrection_) {
+    if (absEtaLowEdges_.size() != effectiveAreas_.size())
+      throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+    if (absEtaLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+    for (unsigned int aIt = 0; aIt < absEtaLowEdges_.size() - 1; aIt++) {
+      if ( !(absEtaLowEdges_.at( aIt ) < absEtaLowEdges_.at( aIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+    }
+  }
   
   std::string recoCandidateProducerName = "recoCandidateProducer";
   if ((typeid(HLTHcalPFClusterIsolationProducer<T1>) == typeid(HLTHcalPFClusterIsolationProducer<reco::RecoEcalCandidate>))) recoCandidateProducerName = "recoEcalCandidateProducer";
@@ -67,8 +80,6 @@ void HLTHcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationD
   desc.add<bool>("doRhoCorrection", false);
   desc.add<double>("rhoMax", 9.9999999E7); 
   desc.add<double>("rhoScale", 1.0); 
-  desc.add<double>("effectiveAreaBarrel", 0.101);
-  desc.add<double>("effectiveAreaEndcap", 0.046);
   desc.add<double>("drMax", 0.3);
   desc.add<double>("drVetoBarrel", 0.0);
   desc.add<double>("drVetoEndcap", 0.0);
@@ -77,6 +88,8 @@ void HLTHcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationD
   desc.add<double>("energyBarrel", 0.0);
   desc.add<double>("energyEndcap", 0.0);
   desc.add<bool>("useEt", true);
+  desc.add<std::vector<double> >("effectiveAreas", {0.2, 0.25}); // 2016 post-ichep sinEle default
+  desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // Barrel, Endcap
   descriptions.add(defaultModuleLabel<HLTHcalPFClusterIsolationProducer<T1>>(), desc);
 }
 
@@ -123,10 +136,15 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid, edm::Even
     float sum = isoAlgo.getSum(candRef, clusterHandles);
  
     if (doRhoCorrection_) {
-      if (fabs(candRef->eta()) < 1.479) 
-	sum = sum - rho*effectiveAreaBarrel_;
-      else
-	sum = sum - rho*effectiveAreaEndcap_;
+      int iEA = -1;
+      for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
+        if ( fabs(candRef->eta()) > absEtaLowEdges_.at(bIt) ) {
+          iEA = bIt;
+          break;
+        }
+      }
+
+      sum = sum - rho*effectiveAreas_.at(iEA);
     }
 
     recoCandMap.insert(candRef, sum);


### PR DESCRIPTION
[ 81X clone of the #15439 ]

Pull request modifying the Egamma HLT producers so that rho correction can be applied in finer bins than 1 each for barrel/endcap.

Includes also a fix for the H producer for H/E (the original code does not do rho correction on H even if doRhoCorrection = true).

Affected modules in the HLT menu need to be reparsed. JIRA for this: CMSHLT-984

Best regards,
Afiq
