### PR TITLE
Add documentation to CSC and GEM digi dataformats

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCComparatorDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCComparatorDigi.h
@@ -31,10 +31,10 @@ public:
   /// sort by time first, then by strip
   bool operator<(const CSCComparatorDigi& digi) const;
 
-  /// Get the strip number
-    int getStrip() const { return strip_; }
+  /// Get the strip number. Counts from 1.
+  int getStrip() const { return strip_; }
 
-  /// Get Comparator readings
+  /// Get Comparator readings. Can be 0 or 1.
   int getComparator() const { return comparator_; }
 
   /// Return the word with each bit corresponding to a time bin
@@ -42,6 +42,9 @@ public:
 
   /// Return bin number of first time bin which is ON. Counts from 0.
   int getTimeBin() const;
+
+  /// Get the associated halfstrip number for this comparator digi. Counts from 0.
+  int getHalfStrip() const;
 
   /** Return vector of the bin numbers for which time bins are ON.
    * e.g. if bits 0 and 13 fired, then this vector will contain the values 0 and 13

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -36,7 +36,7 @@ class CSCCorrelatedLCTDigi
   /// return the 4 bit Correlated LCT Quality
   int getQuality() const { return quality; }
 
-  /// return the key wire group
+  /// return the key wire group. counts from 0.
   int getKeyWG()   const { return keywire; }
 
   /// return the key halfstrip from 0,159

--- a/DataFormats/CSCDigi/interface/CSCStripDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCStripDigi.h
@@ -47,7 +47,7 @@ public:
   // Digis are equal if they are on the same strip and have same ADC readings
   bool operator==(const CSCStripDigi& digi) const;
 
-  // Get the strip number
+  // Get the strip number. counts from 1.
   int getStrip() const { return strip;}
 
   /// Get ADC readings

--- a/DataFormats/CSCDigi/interface/CSCWireDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCWireDigi.h
@@ -20,7 +20,7 @@ public:
   CSCWireDigi (int wire, unsigned int tbinb);  /// wiregroup#, tbin bit word
   CSCWireDigi ();                     /// default
 
-  /// return wiregroup number
+  /// return wiregroup number. counts from 1.
   int getWireGroup() const {return wire_;}
   /// return BX assigned for the wire group (16 upper bits from the wire group number)
   int getWireGroupBX() const {return wireBX_;}

--- a/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
@@ -67,6 +67,13 @@ int CSCComparatorDigi::getTimeBin() const {
   return tbin;
 }
 
+// This definition is consistent with the one used in
+// the function CSCCLCTData::add() in EventFilter/CSCRawToDigi
+// The halfstrip counts from 0!
+int CSCComparatorDigi::getHalfStrip() const {
+  return (getStrip() - 1) * 2 + getComparator();
+}
+
 std::vector<int> CSCComparatorDigi::getTimeBinsOn() const {
   std::vector<int> tbins;
   uint16_t tbit = timeBinWord_;

--- a/DataFormats/GEMDigi/interface/GEMDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMDigi.h
@@ -22,6 +22,7 @@ public:
   bool operator!=(const GEMDigi& digi) const;
   bool operator<(const GEMDigi& digi) const;
 
+  // return the strip number. counts from 1.
   int strip() const { return strip_; }
   int bx() const {return bx_; }
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -22,6 +22,7 @@ public:
   bool operator!=(const GEMPadDigi& digi) const;
   bool operator<(const GEMPadDigi& digi) const;
 
+  // return the pad number. counts from 1.
   int pad() const { return pad_; }
   int bx() const { return bx_; }
 


### PR DESCRIPTION
In this pull request:
- The conversion of (strip number, comparator reading) to halfstrip number is frequently done in the CSC trigger and DAQ step. The implementation here is based on the definition used in the function CSCCLCTData::add() in EventFilter/CSCRawToDigi. 
- I added some extra documentation in the interface of CSC and GEM digi dataformats to clarify whether a strip/wire/pad counts from 0 or 1.
