### PR TITLE
Include also V0 post-processor to trackingOnly postValidation

### DIFF
--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -65,7 +65,7 @@ postValidation_common = cms.Sequence()
 
 postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly
-    + postProcessorVertex
+    + postProcessorVertexSequence
 )
 
 postValidation_muons = cms.Sequence(


### PR DESCRIPTION
Title says it all. This PR is a bug fix, since the V0 validation itself is included in trackingOnly validation.

Tested in CMSSW_8_1_X_2016-08-11-2300, no changes expected in phase0/phase1 full-reco workflows. In workflows using trackingOnly validation (e.g. `1325.1`, or phase2 at the moment) there should be no changes in existing histograms, only V0 efficiency and fake rate histograms should appear.

@rovere @VinInn 
