### PR TITLE
Switching BoostedDoubleSV tagger to v3 training

### DIFF
--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
@@ -8,7 +8,7 @@ candidateBoostedDoubleSecondaryVertexAK8Computer = cms.ESProducer("CandidateBoos
     R0 = cms.double(0.8),
     maxSVDeltaRToJet = cms.double(0.7),
     useCondDB = cms.bool(False),
-    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v2.weights.xml.gz'),
+    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v3.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False),
     trackPairV0Filter = cms.PSet(k0sMassWindow = cms.double(0.03))

--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexCA15Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexCA15Computer_cfi.py
@@ -8,7 +8,7 @@ candidateBoostedDoubleSecondaryVertexCA15Computer = cms.ESProducer("CandidateBoo
     R0 = cms.double(1.5),
     maxSVDeltaRToJet = cms.double(1.3),
     useCondDB = cms.bool(False),
-    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_CA15_BDT_v2.weights.xml.gz'),
+    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_CA15_BDT_v3.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False),
     trackPairV0Filter = cms.PSet(k0sMassWindow = cms.double(0.03))

--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexCA15Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexCA15Computer_cfi.py
@@ -6,7 +6,7 @@ candidateBoostedDoubleSecondaryVertexCA15Computer = cms.ESProducer("CandidateBoo
     trackSelectionBlock,
     beta = cms.double(1.0),
     R0 = cms.double(1.5),
-    maxSVDeltaRToJet = cms.double(1.3),
+    maxSVDeltaRToJet = cms.double(1.0),
     useCondDB = cms.bool(False),
     weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_CA15_BDT_v3.weights.xml.gz'),
     useGBRForest = cms.bool(True),


### PR DESCRIPTION
The updated training was announced in slide 7 of the News slides in the b tag meeting during the June CMS Week (https://indico.cern.ch/event/543002/contributions/2205056/attachments/1295645/1932587/BTV_news_2016_06_21.pdf).

The performance is slightly improved wrt the old training v2 training produced in the 74X release cycle. In addition, for CA15 jets the dR(SV,jet) cut used to associated secondary vertices to jets was reduced from 1.3 to 1.0 in order to reduce the fake rate and consequently improve the overall performance.
