### PR TITLE
hip monitoring

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -35,6 +35,8 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 class TrackAnalyzer;
@@ -84,6 +86,8 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
 
+	edm::EDGetTokenT<LumiScalersCollection>  lumiscalersToken_;	
+
 	edm::InputTag stripClusterInputTag_;
 	edm::InputTag pixelClusterInputTag_;
 	edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
@@ -123,13 +127,35 @@ class TrackingMonitor : public DQMEDAnalyzer
         MonitorElement* NumberOfTrkVsPixelClus;
 
 	// Monitoring vs LS
+	MonitorElement* NumberEventsOfVsLS;
 	MonitorElement* NumberOfTracksVsLS;
 	MonitorElement* GoodTracksFractionVsLS;
 	MonitorElement* NumberOfRecHitsPerTrackVsLS;
+	MonitorElement* NumberOfGoodPVtxVsLS;
+
+	// Monitoring vs BX
+	MonitorElement* NumberEventsOfVsBX;
+	MonitorElement* NumberOfTracksVsBX;
+	MonitorElement* GoodTracksFractionVsBX;
+	MonitorElement* NumberOfRecHitsPerTrackVsBX;
+	MonitorElement* NumberOfGoodPVtxVsBX;
+
+	MonitorElement* NumberOfTracksVsBXlumi;
 
 	// Monitoring PU
-	MonitorElement *NumberOfTracksVsGoodPVtx, *NumberOfTracksVsPUPVtx;
-	MonitorElement* NumberOfTracksVsBXlumi;
+	MonitorElement *NumberOfTracksVsGoodPVtx;
+	MonitorElement* NumberOfTracksVsPUPVtx;
+	MonitorElement* NumberEventsOfVsGoodPVtx;
+	MonitorElement* GoodTracksFractionVsGoodPVtx;
+	MonitorElement* NumberOfRecHitsPerTrackVsGoodPVtx;
+	MonitorElement* NumberOfPVtxVsGoodPVtx;
+
+	// Monitoring vs lumi
+	MonitorElement* NumberEventsOfVsLUMI;
+	MonitorElement* NumberOfTracksVsLUMI;
+	MonitorElement* GoodTracksFractionVsLUMI;
+	MonitorElement* NumberOfRecHitsPerTrackVsLUMI;
+	MonitorElement* NumberOfGoodPVtxVsLUMI;
 
 	// add in order to deal with LS transitions
         MonitorElement * NumberOfTracks_lumiFlag;
@@ -154,6 +180,8 @@ class TrackingMonitor : public DQMEDAnalyzer
 	bool doPUmonitoring_;
 	bool doPlotsVsBXlumi_;
 	bool doPlotsVsGoodPVtx_;
+	bool doPlotsVsLUMI_;
+	bool doPlotsVsBX_;
 	bool doFractionPlot_;
 
         GenericTriggerEventFlag* genTriggerEventFlag_;

--- a/DQM/TrackingMonitor/interface/V0Monitor.h
+++ b/DQM/TrackingMonitor/interface/V0Monitor.h
@@ -84,20 +84,26 @@ private:
   MonitorElement* v0_Lxy_vs_pt_;
   MonitorElement* v0_Lxy_vs_eta_;
 
+  MonitorElement* n_vs_BX_;
   MonitorElement* v0_N_vs_BX_;
   MonitorElement* v0_mass_vs_BX_;
   MonitorElement* v0_Lxy_vs_BX_;
   MonitorElement* v0_deltaMass_vs_BX_;
 
+  MonitorElement* n_vs_lumi_;
   MonitorElement* v0_N_vs_lumi_;
   MonitorElement* v0_mass_vs_lumi_;
   MonitorElement* v0_Lxy_vs_lumi_;
   MonitorElement* v0_deltaMass_vs_lumi_;
 
+  MonitorElement* n_vs_PU_;
   MonitorElement* v0_N_vs_PU_;
   MonitorElement* v0_mass_vs_PU_;
   MonitorElement* v0_Lxy_vs_PU_;
   MonitorElement* v0_deltaMass_vs_PU_;
+
+  MonitorElement* n_vs_LS_;
+  MonitorElement* v0_N_vs_LS_;
 
   MEbinning mass_binning_;
   MEbinning pt_binning_;
@@ -106,7 +112,7 @@ private:
   MEbinning chi2oNDF_binning_;
   MEbinning lumi_binning_;
   MEbinning pu_binning_;
-
+  MEbinning ls_binning_;
 };
 
 #endif // LUMIMONITOR_H

--- a/DQM/TrackingMonitor/interface/V0Monitor.h
+++ b/DQM/TrackingMonitor/interface/V0Monitor.h
@@ -40,7 +40,7 @@ class V0Monitor : public DQMEDAnalyzer
 {
 public:
   V0Monitor( const edm::ParameterSet& );
-  ~V0Monitor() = default;
+  ~V0Monitor();
 
 protected:
 

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -85,6 +85,8 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     doPUmonitoring                      = cms.bool(False),
     doPlotsVsBXlumi                     = cms.bool(False),
     doPlotsVsGoodPVtx                   = cms.bool(True),
+    doPlotsVsLUMI                       = cms.bool(False),
+    doPlotsVsBX                         = cms.bool(False),
     doHIPlots                           = cms.bool(False),                              
     qualityString = cms.string("highPurity"),                      
     #which seed plots to do
@@ -381,6 +383,10 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     GoodPVtxBin = cms.int32(60),
     GoodPVtxMin = cms.double( 0.),
     GoodPVtxMax = cms.double(60.),
+
+    LUMIBin  = cms.int32 ( 3700 ),
+    LUMIMin  = cms.double(    0.),
+    LUMIMax  = cms.double(14000.),
 
 #    # BXlumi                          
 #    BXlumiBin = cms.int32(400),

--- a/DQM/TrackingMonitor/python/V0Monitor_cff.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.V0Monitor_cfi import *
 
-KshortMonitor = v0Monitor.clone()
-KshortMonitor.FolderName = cms.string("Tracking/V0Monitoring/Ks")
-KshortMonitor.v0         = cms.InputTag('generalV0Candidates:Kshort')
-KshortMonitor.histoPSet.massPSet = cms.PSet(
+KshortMonitoring = v0Monitor.clone()
+KshortMonitoring.FolderName = cms.string("Tracking/V0Monitoring/Ks")
+KshortMonitoring.v0         = cms.InputTag('generalV0Candidates:Kshort')
+KshortMonitoring.histoPSet.massPSet = cms.PSet(
    nbins = cms.int32 ( 100 ),
    xmin  = cms.double( 0.400),
    xmax  = cms.double( 0.600),
@@ -21,7 +21,7 @@ LambdaMonitoring.histoPSet.massPSet = cms.PSet(
 )
 
 voMonitoringSequence = cms.Sequence(
-    KshortMonitor
+    KshortMonitoring
     + LambdaMonitoring
 )
 
@@ -29,31 +29,81 @@ voMonitoringSequence = cms.Sequence(
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 
 # tracker ON
-KshortMonitorCommon = KshortMonitor.clone()
-KshortMonitorCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
-KshortMonitorCommon.setLabel("KshortMonitorCommon")
+KshortMonitoringCommon = KshortMonitoring.clone()
+KshortMonitoringCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+KshortMonitoringCommon.setLabel("KshortMonitoringCommon")
 
 LambdaMonitoringCommon = LambdaMonitoring.clone()
 LambdaMonitoringCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
 LambdaMonitoringCommon.setLabel("LambdaMonitoringCommon")
 
 voMonitoringCommonSequence = cms.Sequence(
-    KshortMonitorCommon
+    KshortMonitoringCommon
     + LambdaMonitoringCommon
 )
 
 
 # tracker ON + ZeroBias selection
-KshortMonitorMB = KshortMonitor.clone()
-KshortMonitorMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
-KshortMonitorMB.setLabel("KshortMonitorMB")
+KshortMonitoringMB = KshortMonitoring.clone()
+KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks")
+KshortMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+KshortMonitoringMB.setLabel("KshortMonitoringMB")
 
 LambdaMonitoringMB = LambdaMonitoring.clone()
+KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda")
 LambdaMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 LambdaMonitoringMB.setLabel("LambdaMonitoringMB")
 
+# tracker ON + no HIP no OOT selection (HLT_ZeroBias_FirstCollisionAfterAbortGap)
+KshortMonitoringZBnoHIPnoOOT = KshortMonitoring.clone()
+KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Ks")
+KshortMonitoringZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+KshortMonitoringZBnoHIPnoOOT.setLabel("KshortMonitoringZBnoHIPnoOOT")
+
+LambdaMonitoringZBnoHIPnoOOT = LambdaMonitoring.clone()
+LambdaMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Lambda")
+LambdaMonitoringZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+LambdaMonitoringZBnoHIPnoOOT.setLabel("LambdaMonitoringZBnoHIPnoOOT")
+
+# tracker ON + HIP no OOT selection (HLT_ZeroBias_FirstCollisionInTrain)
+KshortMonitoringZBHIPnoOOT = KshortMonitoring.clone()
+KshortMonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Ks")
+KshortMonitoringZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+KshortMonitoringZBHIPnoOOT.setLabel("KshortMonitoringZBHIPnoOOT")
+
+LambdaMonitoringZBHIPnoOOT = LambdaMonitoring.clone()
+LambdaMonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Lambda")
+LambdaMonitoringZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+LambdaMonitoringZBHIPnoOOT.setLabel("LambdaMonitoringZBHIPnoOOT")
+
+# tracker ON + HIP OOT selection (HLT_ZeroBias_FirstBXAfterTrain)
+KshortMonitoringZBHIPOOT = KshortMonitoring.clone()
+KshortMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Ks")
+KshortMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+KshortMonitoringZBHIPOOT.setLabel("KshortMonitoringZBHIPOOT")
+
+LambdaMonitoringZBHIPOOT = LambdaMonitoring.clone()
+LambdaMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOT_noINpu/Lambda")
+LambdaMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+LambdaMonitoringZBHIPOOT.setLabel("LambdaMonitoringZBHIPOOT")
+
 voMonitoringMBSequence = cms.Sequence(
-    KshortMonitorMB
+    KshortMonitoringMB
     + LambdaMonitoringMB
+)
+
+voMonitoringZBnoHIPnoOOTSequence = cms.Sequence(
+    KshortMonitoringZBnoHIPnoOOT
+    + LambdaMonitoringZBnoHIPnoOOT
+)
+
+voMonitoringZBHIPnoOOTSequence = cms.Sequence(
+    KshortMonitoringZBHIPnoOOT
+    + LambdaMonitoringZBHIPnoOOT
+)
+
+voMonitoringZBHIPOOTSequence = cms.Sequence(
+    KshortMonitoringZBHIPOOT
+    + LambdaMonitoringZBHIPOOT
 )
 

--- a/DQM/TrackingMonitor/python/V0Monitor_cff.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cff.py
@@ -45,12 +45,12 @@ voMonitoringCommonSequence = cms.Sequence(
 
 # tracker ON + ZeroBias selection
 KshortMonitoringMB = KshortMonitoring.clone()
-KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks")
+KshortMonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks")
 KshortMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 KshortMonitoringMB.setLabel("KshortMonitoringMB")
 
 LambdaMonitoringMB = LambdaMonitoring.clone()
-KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda")
+LambdaMonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda")
 LambdaMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 LambdaMonitoringMB.setLabel("LambdaMonitoringMB")
 
@@ -83,7 +83,7 @@ KshortMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullT
 KshortMonitoringZBHIPOOT.setLabel("KshortMonitoringZBHIPOOT")
 
 LambdaMonitoringZBHIPOOT = LambdaMonitoring.clone()
-LambdaMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOT_noINpu/Lambda")
+LambdaMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Lambda")
 LambdaMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
 LambdaMonitoringZBHIPOOT.setLabel("LambdaMonitoringZBHIPOOT")
 

--- a/DQM/TrackingMonitor/python/V0Monitor_cfi.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cfi.py
@@ -44,5 +44,10 @@ v0Monitor = cms.EDAnalyzer("V0Monitor",
             xmin  = cms.double( -0.5),
             xmax  = cms.double( 59.5),
       ),
+      lsPSet = cms.PSet(
+            nbins = cms.int32 ( 2000 ),
+            xmin  = cms.double(    0.),
+            xmax  = cms.double( 2000.),
+      ),
    ),
 )

--- a/DQM/TrackingMonitor/python/V0Monitor_cfi.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 v0Monitor = cms.EDAnalyzer("V0Monitor",
-   FolderName                  = cms.string("Tracking/V0Monitoring"),
+   FolderName    = cms.string("Tracking/V0Monitoring"),
    v0            = cms.InputTag('generalV0Candidates:Kshort'), # generalV0Candidates:Lambda
    beamSpot      = cms.InputTag('offlineBeamSpot'),
    primaryVertex = cms.InputTag('offlinePrimaryVertices'),

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -49,16 +49,31 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     , NumberOfSeeds_lumiFlag(NULL)
     , NumberOfTrackCandidates(NULL)
 				//    , NumberOfGoodTrkVsClus(NULL)
+    , NumberEventsOfVsLS(NULL)
     , NumberOfTracksVsLS(NULL)
 				//    , NumberOfGoodTracksVsLS(NULL)
     , GoodTracksFractionVsLS(NULL)
 				//    , GoodTracksNumberOfRecHitsPerTrackVsLS(NULL)
 				// ADD by Mia for PU monitoring
 				// vertex plots to be moved in ad hoc class
+    , NumberOfGoodPVtxVsLS(NULL)
+    , NumberEventsOfVsBX (NULL)
+    , NumberOfTracksVsBX(NULL)
+    , GoodTracksFractionVsBX(NULL)
+    , NumberOfRecHitsPerTrackVsBX(NULL)
+    , NumberOfGoodPVtxVsBX(NULL)
+    , NumberOfTracksVsBXlumi(NULL)
     , NumberOfTracksVsGoodPVtx(NULL)
     , NumberOfTracksVsPUPVtx(NULL)
-    , NumberOfTracksVsBXlumi(NULL)
-
+    , NumberEventsOfVsGoodPVtx(NULL)
+    , GoodTracksFractionVsGoodPVtx(NULL)
+    , NumberOfRecHitsPerTrackVsGoodPVtx(NULL)
+    , NumberOfPVtxVsGoodPVtx(NULL)
+    , NumberEventsOfVsLUMI(NULL)
+    , NumberOfTracksVsLUMI(NULL)
+    , GoodTracksFractionVsLUMI(NULL)
+    , NumberOfRecHitsPerTrackVsLUMI(NULL)
+    , NumberOfGoodPVtxVsLUMI(NULL)
     , NumberOfTracks_lumiFlag(NULL)
 				//    , NumberOfGoodTracks_lumiFlag(NULL)
 
@@ -85,6 +100,8 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   bsSrcToken_ = consumes<reco::BeamSpot>(bsSrc_);
   pvSrcToken_ = mayConsume<reco::VertexCollection>(pvSrc_);
 
+  lumiscalersToken_ = consumes<LumiScalersCollection>(conf_.getParameter<edm::InputTag>("scal") );
+
   edm::InputTag alltrackProducer = conf_.getParameter<edm::InputTag>("allTrackProducer");
   edm::InputTag trackProducer    = conf_.getParameter<edm::InputTag>("TrackProducer");
   edm::InputTag tcProducer       = conf_.getParameter<edm::InputTag>("TCProducer");
@@ -110,7 +127,8 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   if ( doPlotsVsBXlumi_ )
       theLumiDetails_ = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
   doPlotsVsGoodPVtx_ = conf_.getParameter<bool>("doPlotsVsGoodPVtx");
- 
+  doPlotsVsLUMI_     = conf_.getParameter<bool>("doPlotsVsLUMI");
+  doPlotsVsBX_       = conf_.getParameter<bool>("doPlotsVsBX");
 
   if ( doPUmonitoring_ ) {
     
@@ -119,7 +137,6 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     std::vector<std::string>   pvLabels                  = conf_.getParameter<std::vector<std::string> >  ("pvLabels");
      
     if (primaryVertexInputTags.size()==pvLabels.size() and primaryVertexInputTags.size()==selPrimaryVertexInputTags.size()) {
-      //      for (auto const& tag : primaryVertexInputTags) {
       for (size_t i=0; i<primaryVertexInputTags.size(); i++) {
  	edm::InputTag iPVinputTag    = primaryVertexInputTags[i];
  	edm::InputTag iSelPVinputTag = selPrimaryVertexInputTags[i];
@@ -271,6 +288,21 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("#Lumi section",1);
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("Mean number of Valid RecHits per track",2);
   
+     histname = "NumberEventsVsLS_" + CategoryName;
+     NumberEventsOfVsLS = ibooker.book1D(histname,histname, LSBin,LSMin,LSMax);
+     NumberEventsOfVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+     NumberEventsOfVsLS->setAxisTitle("#Lumi section",1);
+     NumberEventsOfVsLS->setAxisTitle("Number of events",2);
+  
+     double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
+     double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
+
+     histname = "NumberOfGoodPVtxVsLS_" + CategoryName;
+     NumberOfGoodPVtxVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,GoodPVtxMin,GoodPVtxMax,"");
+     NumberOfGoodPVtxVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+     NumberOfGoodPVtxVsLS->setAxisTitle("#Lumi section",1);
+     NumberOfGoodPVtxVsLS->setAxisTitle("Mean number of good PV",2);
+
      if (doFractionPlot_) {
        histname = "GoodTracksFractionVsLS_"+ CategoryName;
        GoodTracksFractionVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0,1.1,"");
@@ -278,6 +310,44 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        GoodTracksFractionVsLS->setAxisTitle("#Lumi section",1);
        GoodTracksFractionVsLS->setAxisTitle("Fraction of Good Tracks",2);
      }
+
+     if ( doPlotsVsBX_ || doAllPlots ) {
+       ibooker.setCurrentFolder(MEFolderName+"/BXanalysis");
+       int BXBin = 3564; double BXMin = 0.5; double BXMax = 3564.5;
+       
+       histname = "NumberEventsVsBX_" + CategoryName;
+       NumberEventsOfVsBX = ibooker.book1D(histname,histname, BXBin,BXMin,BXMax);
+       NumberEventsOfVsBX->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberEventsOfVsBX->setAxisTitle("BX",1);
+       NumberEventsOfVsBX->setAxisTitle("Number of events",2);
+       
+       histname = "NumberOfTracksVsBX_"+ CategoryName;
+       NumberOfTracksVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax, TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
+       NumberOfTracksVsBX->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfTracksVsBX->setAxisTitle("BX",1);
+       NumberOfTracksVsBX->setAxisTitle("Number of  Tracks",2);
+       
+       histname = "NumberOfRecHitsPerTrackVsBX_" + CategoryName;
+       NumberOfRecHitsPerTrackVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,0.,40.,"");
+       NumberOfRecHitsPerTrackVsBX->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfRecHitsPerTrackVsBX->setAxisTitle("BX",1);
+       NumberOfRecHitsPerTrackVsBX->setAxisTitle("Mean number of Valid RecHits per track",2);
+       
+       histname = "NumberOfGoodPVtxVsBX_" + CategoryName;
+       NumberOfGoodPVtxVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,GoodPVtxMin,GoodPVtxMax,"");
+       NumberOfGoodPVtxVsBX->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfGoodPVtxVsBX->setAxisTitle("BX",1);
+       NumberOfGoodPVtxVsBX->setAxisTitle("Mean number of good PV",2);
+       
+       if (doFractionPlot_) {
+	 histname = "GoodTracksFractionVsBX_"+ CategoryName;
+	 GoodTracksFractionVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,0,1.1,"");
+	 GoodTracksFractionVsBX->getTH1()->SetCanExtend(TH1::kAllAxes);
+	 GoodTracksFractionVsBX->setAxisTitle("BX",1);
+	 GoodTracksFractionVsBX->setAxisTitle("Fraction of Good Tracks",2);
+       }
+     }
+
    }
 
    // book PU monitoring plots :  
@@ -308,8 +378,78 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        NumberOfTracksVsPUPVtx->setAxisTitle("Number of PU",1);
        NumberOfTracksVsPUPVtx->setAxisTitle("Mean number of Tracks per PUvtx",2);
 
+       histname = "NumberEventsVsGoodPVtx";
+       NumberEventsOfVsGoodPVtx = ibooker.book1D(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax);
+       NumberEventsOfVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberEventsOfVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
+       NumberEventsOfVsGoodPVtx->setAxisTitle("Number of events",2);
+
+       if (doFractionPlot_) {
+	 histname = "GoodTracksFractionVsGoodPVtx";
+	 GoodTracksFractionVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0., 400.,"");
+	 GoodTracksFractionVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+	 GoodTracksFractionVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
+	 GoodTracksFractionVsGoodPVtx->setAxisTitle("Mean fraction of good tracks",2);
+       }
+
+       histname = "NumberOfRecHitsPerTrackVsGoodPVtx";
+       NumberOfRecHitsPerTrackVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0., 100.,"");
+       NumberOfRecHitsPerTrackVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
+       NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Mean number of valid rechits per Tracks",2);
+
+       histname = "NumberOfPVtxVsGoodPVtx";
+       NumberOfPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0., 100.,"");
+       NumberOfPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
+       NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of vertices",2);
      }
   
+
+     if ( doPlotsVsLUMI_ || doAllPlots ) {
+       ibooker.setCurrentFolder(MEFolderName+"/LUMIanalysis");
+       int LUMIBin = conf_.getParameter<int>("LUMIBin");
+       float LUMIMin = conf_.getParameter<double>("LUMIMin");
+       float LUMIMax = conf_.getParameter<double>("LUMIMax");
+       
+       histname = "NumberEventsVsLUMI";
+       NumberEventsOfVsLUMI = ibooker.book1D(histname,histname,LUMIBin,LUMIMin,LUMIMax);
+       NumberEventsOfVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberEventsOfVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
+       NumberEventsOfVsLUMI->setAxisTitle("Number of events",2);
+       
+       histname = "NumberOfTracksVsLUMI";
+       NumberOfTracksVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 400.,"");
+       NumberOfTracksVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfTracksVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
+       NumberOfTracksVsLUMI->setAxisTitle("Mean number of vertices",2);
+       
+       if (doFractionPlot_) {
+	 histname = "GoodTracksFractionVsLUMI";
+	 GoodTracksFractionVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 100.,"");
+	 GoodTracksFractionVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
+	 GoodTracksFractionVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
+	 GoodTracksFractionVsLUMI->setAxisTitle("Mean number of vertices",2);
+       }
+
+       histname = "NumberOfRecHitsPerTrackVsLUMI";
+       NumberOfRecHitsPerTrackVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 20.,"");
+       NumberOfRecHitsPerTrackVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
+       NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("Mean number of vertices",2);
+
+       int GoodPVtxBin      = conf_.getParameter<int>("GoodPVtxBin");
+       double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
+       double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
+       
+       histname = "NumberOfGoodPVtxVsLUMI";
+       NumberOfGoodPVtxVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,GoodPVtxMin,GoodPVtxMax,"");
+       NumberOfGoodPVtxVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfGoodPVtxVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
+       NumberOfGoodPVtxVsLUMI->setAxisTitle("Mean number of vertices",2);
+     }
+     
+
      if ( doPlotsVsBXlumi_ ) {
        ibooker.setCurrentFolder(MEFolderName+"/PUmonitoring");
        // get binning from the configuration
@@ -492,20 +632,34 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     // Filter out events if Trigger Filtering is requested
     if (genTriggerEventFlag_->on()&& ! genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
 
+    float lumi = -1.;
+    edm::Handle<LumiScalersCollection> lumiScalers;
+    iEvent.getByToken(lumiscalersToken_, lumiScalers);
+    if ( lumiScalers.isValid() && lumiScalers->size() ) {
+      LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
+      lumi = scalit->instantLumi();
+    } else 
+      lumi = -1.;
+
+    if (doPlotsVsLUMI_ || doAllPlots) 
+      NumberEventsOfVsLUMI->Fill(lumi);
+    
     //  Analyse the tracks
     //  if the collection is empty, do not fill anything
     // ---------------------------------------------------------------------------------//
+
+    size_t bx = iEvent.bunchCrossing();
+    if ( doPlotsVsBX_ || doAllPlots )
+      NumberEventsOfVsBX->Fill(bx);
 
     // get the track collection
     edm::Handle<reco::TrackCollection> trackHandle;
     iEvent.getByToken(trackToken_, trackHandle);
 
-    //    int numberOfAllTracks = 0;
     int numberOfTracks_den = 0;
     edm::Handle<reco::TrackCollection> allTrackHandle;
     iEvent.getByToken(allTrackToken_,allTrackHandle);
     if (allTrackHandle.isValid()) {
-      //      numberOfAllTracks = allTrackHandle->size();
       for (reco::TrackCollection::const_iterator track = allTrackHandle->begin();
 	   track!=allTrackHandle->end(); ++track) {
 	if ( denSelection_(*track) )
@@ -541,6 +695,8 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       for (reco::TrackCollection::const_iterator track = trackCollection.begin();
 	   track!=trackCollection.end(); ++track) {
 	
+	if ( doPlotsVsBX_ || doAllPlots )
+	  NumberOfRecHitsPerTrackVsBX->Fill(bx,track->numberOfValidHits());
 	if ( numSelection_(*track) ) {
 	  numberOfTracks_num++;
           if (pv0 && std::abs(track->dz(pv0->position()))<0.15) ++numberOfTracks_pv0;
@@ -548,6 +704,9 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 	if ( doProfilesVsLS_ || doAllPlots)
 	  NumberOfRecHitsPerTrackVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),track->numberOfValidHits());
+
+	if (doPlotsVsLUMI_ || doAllPlots) 
+	  NumberOfRecHitsPerTrackVsLUMI->Fill(lumi,track->numberOfValidHits());
 
 	totalRecHits    += track->numberOfValidHits();
 	totalLayers     += track->hitPattern().trackerLayersWithMeasurement();
@@ -562,9 +721,20 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       
       if (doGeneralPropertiesPlots_ || doAllPlots){
 	NumberOfTracks       -> Fill(numberOfTracks);
-	if (doFractionPlot_)
-	  FractionOfGoodTracks -> Fill(frac);
+	if ( doPlotsVsBX_ || doAllPlots )
+	  NumberOfTracksVsBX   -> Fill(bx,numberOfTracks);
+	if (doPlotsVsLUMI_ || doAllPlots) 
+	  NumberOfTracksVsLUMI -> Fill(lumi,numberOfTracks);
+	if (doFractionPlot_) {
+	  FractionOfGoodTracks     -> Fill(frac);
 
+	  if (doFractionPlot_) {
+	    if ( doPlotsVsBX_ || doAllPlots )
+	      GoodTracksFractionVsBX   -> Fill(bx,  frac);
+	    if (doPlotsVsLUMI_ || doAllPlots) 
+	      GoodTracksFractionVsLUMI -> Fill(lumi,frac);
+	  }
+	}
 	if( numberOfTracks > 0 ) {
 	  double meanRecHits = static_cast<double>(totalRecHits) / static_cast<double>(numberOfTracks);
 	  double meanLayers  = static_cast<double>(totalLayers)  / static_cast<double>(numberOfTracks);
@@ -574,9 +744,11 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       }
       
       if ( doProfilesVsLS_ || doAllPlots) {
-	NumberOfTracksVsLS    ->Fill(static_cast<double>(iEvent.id().luminosityBlock()),numberOfTracks);
+	float nLS = static_cast<double>(iEvent.id().luminosityBlock());
+	NumberEventsOfVsLS    ->Fill(nLS);
+	NumberOfTracksVsLS    ->Fill(nLS,numberOfTracks);
 	if (doFractionPlot_) 
-	  GoodTracksFractionVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),frac);
+	  GoodTracksFractionVsLS->Fill(nLS,frac);
       }
       
       if ( doLumiAnalysis ) {
@@ -702,8 +874,26 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	      totalNumGoodPV++;
 	    }
 	    
-            NumberOfTracksVsGoodPVtx	   -> Fill( totalNumGoodPV, numberOfTracks	);
+	    NumberEventsOfVsGoodPVtx       -> Fill( float(totalNumGoodPV) );
+            NumberOfTracksVsGoodPVtx	   -> Fill( float(totalNumGoodPV), numberOfTracks	);
 	    if (totalNumGoodPV>1) NumberOfTracksVsPUPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
+	    NumberOfPVtxVsGoodPVtx          -> Fill(float(totalNumGoodPV),pvHandle->size());
+
+	    for (reco::TrackCollection::const_iterator track = trackCollection.begin();
+		 track!=trackCollection.end(); ++track) {
+	      NumberOfRecHitsPerTrackVsGoodPVtx -> Fill(float(totalNumGoodPV), track->numberOfValidHits());
+	    }
+
+	    if ( doProfilesVsLS_ || doAllPlots)
+	      NumberOfGoodPVtxVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),totalNumGoodPV);
+	    if ( doPlotsVsBX_ || doAllPlots )
+	      NumberOfGoodPVtxVsBX->Fill(bx,  float(totalNumGoodPV));
+
+	    if (doFractionPlot_)
+	      GoodTracksFractionVsGoodPVtx->Fill(float(totalNumGoodPV),frac);
+
+	    if ( doPlotsVsLUMI_ || doAllPlots )	    
+	      NumberOfGoodPVtxVsLUMI->Fill(lumi,float(totalNumGoodPV));
 	  }
 
 	

--- a/DQM/TrackingMonitor/src/V0Monitor.cc
+++ b/DQM/TrackingMonitor/src/V0Monitor.cc
@@ -42,21 +42,26 @@ V0Monitor::V0Monitor( const edm::ParameterSet& iConfig ) :
   v0_Lxy_vs_pt_        = nullptr;
   v0_Lxy_vs_eta_       = nullptr;
   
+  n_vs_BX_            = nullptr;
   v0_N_vs_BX_         = nullptr;
   v0_mass_vs_BX_      = nullptr;
   v0_Lxy_vs_BX_       = nullptr;
   v0_deltaMass_vs_BX_ = nullptr;
   
+  n_vs_lumi_            = nullptr;
   v0_N_vs_lumi_         = nullptr;
   v0_mass_vs_lumi_      = nullptr;
   v0_Lxy_vs_lumi_       = nullptr;
   v0_deltaMass_vs_lumi_ = nullptr;
   
+  n_vs_PU_            = nullptr;
   v0_N_vs_PU_         = nullptr;
   v0_mass_vs_PU_      = nullptr;
   v0_Lxy_vs_PU_       = nullptr;
   v0_deltaMass_vs_PU_ = nullptr;
 
+  n_vs_LS_    = nullptr;
+  v0_N_vs_LS_ = nullptr;
 
   edm::ParameterSet histoPSet    = iConfig.getParameter<edm::ParameterSet>("histoPSet");
   getHistoPSet(histoPSet.getParameter<edm::ParameterSet>("massPSet"),     mass_binning_    );
@@ -66,6 +71,7 @@ V0Monitor::V0Monitor( const edm::ParameterSet& iConfig ) :
   getHistoPSet(histoPSet.getParameter<edm::ParameterSet>("chi2oNDFPSet"), chi2oNDF_binning_);
   getHistoPSet(histoPSet.getParameter<edm::ParameterSet>("lumiPSet"),     lumi_binning_    );
   getHistoPSet(histoPSet.getParameter<edm::ParameterSet>("puPSet"),       pu_binning_      );
+  getHistoPSet(histoPSet.getParameter<edm::ParameterSet>("lsPSet"),       ls_binning_      );
 
 }
 
@@ -140,22 +146,28 @@ void V0Monitor::bookHistograms(DQMStore::IBooker     & ibooker,
   v0_Lxy_vs_eta_       = bookProfile(ibooker,"v0_Lxy_vs_eta",      "L_{xy} vs #eta",     "#eta",             "L_{xy} [cm]",eta_binning_, Lxy_binning_);
 
   MEbinning bx_binning; bx_binning.nbins = 3564; bx_binning.xmin = 0.5; bx_binning.xmax = 3564.5;
+  n_vs_BX_          = bookHisto1D(ibooker,"n_vs_BX","# events vs BX","BX", "# events",bx_binning);
   v0_N_vs_BX_         = bookProfile(ibooker,"v0_N_vs_BX",        "# v0 vs BX",     "BX", "# v0",             bx_binning, N_binning   );
   v0_mass_vs_BX_      = bookProfile(ibooker,"v0_mass_vs_BX",     "mass vs BX",     "BX", "mass [GeV]",       bx_binning, mass_binning_);
   v0_Lxy_vs_BX_       = bookProfile(ibooker,"v0_Lxy_vs_BX",      "L_{xy} vs BX",   "BX", "L_{xy} [cm]",      bx_binning, Lxy_binning_ );
   v0_deltaMass_vs_BX_ = bookProfile(ibooker,"v0_deltaMass_vs_BX","deltaMass vs BX","BX", "m-m_{PDG}/m_{DPG}",bx_binning, delta_binning);
 
+  n_vs_lumi_            = bookHisto1D(ibooker,"n_vs_lumi","# events vs lumi","inst. lumi x10^{30} [Hz cm^{-2}]", "# events",lumi_binning_);
   v0_N_vs_lumi_         = bookProfile(ibooker,"v0_N_vs_lumi",        "# v0 vs lumi",     "inst. lumi x10^{30} [Hz cm^{-2}]", "# v0",             lumi_binning_, N_binning   );
   v0_mass_vs_lumi_      = bookProfile(ibooker,"v0_mass_vs_lumi",     "mass vs lumi",     "inst. lumi x10^{30} [Hz cm^{-2}]", "mass [GeV]",       lumi_binning_, mass_binning_);
   v0_Lxy_vs_lumi_       = bookProfile(ibooker,"v0_Lxy_vs_lumi",      "L_{xy} vs lumi",   "inst. lumi x10^{30} [Hz cm^{-2}]", "L_{xy} [cm]",      lumi_binning_, Lxy_binning_ );
   v0_deltaMass_vs_lumi_ = bookProfile(ibooker,"v0_deltaMass_vs_lumi","deltaMass vs lumi","inst. lumi x10^{30} [Hz cm^{-2}]", "m-m_{PDG}/m_{DPG}",lumi_binning_, delta_binning);
 
-
+  n_vs_PU_            = bookHisto1D(ibooker,"n_vs_PU","# events vs PU","# good PV", "# events",pu_binning_);
   v0_N_vs_PU_         = bookProfile(ibooker,"v0_N_vs_PU",        "# v0 vs PU",     "# good PV", "# v0",             pu_binning_, N_binning   );
   v0_mass_vs_PU_      = bookProfile(ibooker,"v0_mass_vs_PU",     "mass vs PU",     "# good PV", "mass [GeV]",       pu_binning_, mass_binning_);
   v0_Lxy_vs_PU_       = bookProfile(ibooker,"v0_Lxy_vs_PU",      "L_{xy} vs PU",   "# good PV", "L_{xy} [cm]",      pu_binning_, Lxy_binning_ );
   v0_deltaMass_vs_PU_ = bookProfile(ibooker,"v0_deltaMass_vs_PU","deltaMass vs PU","# good PV", "m-m_{PDG}/m_{DPG}",pu_binning_, delta_binning);
 
+
+  n_vs_LS_    = bookHisto1D(ibooker,"n_vs_LS",   "# events vs LS","LS", "# events",ls_binning_);
+  v0_N_vs_LS_ = bookProfile(ibooker,"v0_N_vs_LS","# v0 vs LS",    "LS", "# v0",    ls_binning_, N_binning );
+  v0_N_vs_LS_->getTH1()->SetCanExtend(TH1::kAllAxes);
 
   // Initialize the GenericTriggerEventFlag
   if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );  
@@ -169,12 +181,8 @@ void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
 
   //  int ls = iEvent.id().luminosityBlock();
   
-  edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle;
-  iEvent.getByToken(v0Token_, v0Handle);
-  if (!v0Handle.isValid() or v0Handle->size() == 0)
-    return;
-
   size_t bx = iEvent.bunchCrossing();
+  n_vs_BX_->Fill(bx);
 
   float lumi = -1.;
   edm::Handle<LumiScalersCollection> lumiScalers;
@@ -184,6 +192,7 @@ void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
     lumi = scalit->instantLumi();
   } else 
     lumi = -1.;
+  n_vs_lumi_->Fill(lumi);
 
   edm::Handle<reco::BeamSpot> beamspotHandle;
   iEvent.getByToken(bsToken_,beamspotHandle);
@@ -210,13 +219,24 @@ void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
       ++nPV;
     }
   }
+  n_vs_PU_->Fill(nPV);
 
-  reco::VertexCompositeCandidateCollection v0s = *v0Handle.product();
-  size_t n = v0s.size();
+  float nLS = static_cast<float>(iEvent.id().luminosityBlock());
+  n_vs_LS_->Fill(nLS);
+
+  edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle;
+  iEvent.getByToken(v0Token_, v0Handle);
+  int n = ( v0Handle.isValid() ? v0Handle->size() : -1 );
   v0_N_         -> Fill(n);
   v0_N_vs_BX_   -> Fill(bx,  n);
   v0_N_vs_lumi_ -> Fill(lumi,n);
   v0_N_vs_PU_   -> Fill(nPV, n);
+  v0_N_vs_LS_   -> Fill(nLS, n);
+
+  if ( !v0Handle.isValid() or n==0)
+    return;
+  
+  reco::VertexCompositeCandidateCollection v0s = *v0Handle.product();    
   for ( auto v0 : v0s ) {
     float mass     = v0.mass();
     float pt       = v0.pt();

--- a/DQM/TrackingMonitor/src/V0Monitor.cc
+++ b/DQM/TrackingMonitor/src/V0Monitor.cc
@@ -69,6 +69,11 @@ V0Monitor::V0Monitor( const edm::ParameterSet& iConfig ) :
 
 }
 
+V0Monitor::~V0Monitor()
+{
+  if (genTriggerEventFlag_) delete genTriggerEventFlag_;
+}
+
 void V0Monitor::getHistoPSet(edm::ParameterSet pset, MEbinning& mebinning)
 {
   mebinning.nbins = pset.getParameter<int32_t>("nbins");
@@ -152,9 +157,15 @@ void V0Monitor::bookHistograms(DQMStore::IBooker     & ibooker,
   v0_deltaMass_vs_PU_ = bookProfile(ibooker,"v0_deltaMass_vs_PU","deltaMass vs PU","# good PV", "m-m_{PDG}/m_{DPG}",pu_binning_, delta_binning);
 
 
+  // Initialize the GenericTriggerEventFlag
+  if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );  
+
 }
 
 void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+
+  // Filter out events if Trigger Filtering is requested
+  if (genTriggerEventFlag_->on()&& ! genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
 
   //  int ls = iEvent.id().luminosityBlock();
   

--- a/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
@@ -8,10 +8,28 @@ TrackerCollisionTrackMonCommon = DQM.TrackingMonitor.TrackerCollisionTrackingMon
 TrackerCollisionTrackMonCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
 TrackerCollisionTrackMonCommon.setLabel("TrackerCollisionTrackMonCommon")
 
-# Clone for TrackingMonitor for MinBias ###
+# Clone for TrackingMonitor for ZeroBias ###
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 TrackerCollisionTrackMonMB = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
 TrackerCollisionTrackMonMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
 TrackerCollisionTrackMonMB.doPrimaryVertexPlots    = cms.bool(True)
 TrackerCollisionTrackMonMB.setLabel("TrackerCollisionTrackMonMB")
+
+# Clone for TrackingMonitor for ZeroBias, no hip, no OOT pu (1st collision after abort gap) ###
+TrackerCollisionTrackMonZBnoHIPnoOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
+TrackerCollisionTrackMonZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+TrackerCollisionTrackMonZBnoHIPnoOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBnoHIPnoOOT.setLabel("TrackerCollisionTrackMonZBnoHIPnoOOT")
+
+# Clone for TrackingMonitor for ZeroBias, hip, no OOT pu (1st collision in train) ###
+TrackerCollisionTrackMonZBHIPnoOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
+TrackerCollisionTrackMonZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+TrackerCollisionTrackMonZBHIPnoOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBHIPnoOOT.setLabel("TrackerCollisionTrackMonZBHIPnoOOT")
+
+# Clone for TrackingMonitor for ZeroBias, hip, OOT pu (1st collision after train) ###
+TrackerCollisionTrackMonZBHIPOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
+TrackerCollisionTrackMonZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+TrackerCollisionTrackMonZBHIPOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBHIPOOT.setLabel("TrackerCollisionTrackMonZBHIPOOT")
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -51,12 +51,124 @@ for tracks in selectedTracks :
 #    locals()[label].doStopSource                        = doStopSource                        [tracks]    
     locals()[label].setLabel(label)
     
-
+    # ZeroBias
     label = 'TrackerCollisionSelectedTrackMonMB' + str(tracks)                       
     locals()[label] = TrackerCollisionTrackMonMB.clone()
     locals()[label].TrackProducer    = cms.InputTag(tracks)
     locals()[label].FolderName       = cms.string(mainfolderName[tracks])
     locals()[label].PVFolderName     = cms.string(vertexfolderName[tracks])
+    locals()[label].TrackPtMin       = trackPtMin[tracks]
+    locals()[label].TrackPtBin       = trackPtN[tracks]
+    locals()[label].TrackPtMax       = trackPtMax[tracks]
+    locals()[label].TrackPBin        = trackPtN[tracks]
+    locals()[label].TrackPMin        = trackPtMin[tracks]
+    locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].doDCAPlots       = doPlotsPCA[tracks]
+    locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
+    locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].doSIPPlots       = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
+    locals()[label].doGoodTracksPlots                   = doGoodTracksPlots                   [tracks]
+    locals()[label].doTrackerSpecific                   = doTrackerSpecific                   [tracks]
+    locals()[label].doHitPropertiesPlots                = doHitPropertiesPlots                [tracks]
+    locals()[label].doGeneralPropertiesPlots            = doGeneralPropertiesPlots            [tracks]
+    locals()[label].doBeamSpotPlots                     = doBeamSpotPlots                     [tracks]
+    locals()[label].doSeedParameterHistos               = doSeedParameterHistos               [tracks]
+    locals()[label].doRecHitVsPhiVsEtaPerTrack          = doRecHitVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackRecHitVsPhiVsEtaPerTrack = doGoodTrackRecHitVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doLayersVsPhiVsEtaPerTrack          = doLayersVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackLayersVsPhiVsEtaPerTrack = doGoodTrackLayersVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
+    locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
+    locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
+    locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
+    locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
+    locals()[label].doStopSource                        = doStopSource                        [tracks]    
+    locals()[label].setLabel(label)
+
+    # ZeroBias, no hip, no OOT pu (1st collision after abort gap) ###
+    label = 'TrackerCollisionSelectedTrackMonZBnoHIPnoOOT' + str(tracks)                       
+    locals()[label] = TrackerCollisionTrackMonZBnoHIPnoOOT.clone()
+    locals()[label].TrackProducer    = cms.InputTag(tracks)
+    locals()[label].FolderName       = cms.string(mainfolderName[tracks]+"/noHIP_noOOT_INpu")
+    locals()[label].PVFolderName     = cms.string(vertexfolderName[tracks]+"/noHIP_noOOT_INpu")
+    locals()[label].TrackPtMin       = trackPtMin[tracks]
+    locals()[label].TrackPtBin       = trackPtN[tracks]
+    locals()[label].TrackPtMax       = trackPtMax[tracks]
+    locals()[label].TrackPBin        = trackPtN[tracks]
+    locals()[label].TrackPMin        = trackPtMin[tracks]
+    locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].doDCAPlots       = doPlotsPCA[tracks]
+    locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
+    locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].doSIPPlots       = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
+    locals()[label].doGoodTracksPlots                   = doGoodTracksPlots                   [tracks]
+    locals()[label].doTrackerSpecific                   = doTrackerSpecific                   [tracks]
+    locals()[label].doHitPropertiesPlots                = doHitPropertiesPlots                [tracks]
+    locals()[label].doGeneralPropertiesPlots            = doGeneralPropertiesPlots            [tracks]
+    locals()[label].doBeamSpotPlots                     = doBeamSpotPlots                     [tracks]
+    locals()[label].doSeedParameterHistos               = doSeedParameterHistos               [tracks]
+    locals()[label].doRecHitVsPhiVsEtaPerTrack          = doRecHitVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackRecHitVsPhiVsEtaPerTrack = doGoodTrackRecHitVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doLayersVsPhiVsEtaPerTrack          = doLayersVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackLayersVsPhiVsEtaPerTrack = doGoodTrackLayersVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
+    locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
+    locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
+    locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
+    locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
+    locals()[label].doStopSource                        = doStopSource                        [tracks]    
+    locals()[label].setLabel(label)
+
+    # ZeroBias, hip, no OOT pu (1st collision in train) ###
+    label = 'TrackerCollisionSelectedTrackMonZBHIPnoOOT' + str(tracks)                       
+    locals()[label] = TrackerCollisionTrackMonZBHIPnoOOT.clone()
+    locals()[label].TrackProducer    = cms.InputTag(tracks)
+    locals()[label].FolderName       = cms.string(mainfolderName[tracks]+"/HIP_noOOT_INpu")
+    locals()[label].PVFolderName     = cms.string(vertexfolderName[tracks]+"/HIP_noOOT_INpu")
+    locals()[label].TrackPtMin       = trackPtMin[tracks]
+    locals()[label].TrackPtBin       = trackPtN[tracks]
+    locals()[label].TrackPtMax       = trackPtMax[tracks]
+    locals()[label].TrackPBin        = trackPtN[tracks]
+    locals()[label].TrackPMin        = trackPtMin[tracks]
+    locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].doDCAPlots       = doPlotsPCA[tracks]
+    locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
+    locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].doSIPPlots       = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
+    locals()[label].doGoodTracksPlots                   = doGoodTracksPlots                   [tracks]
+    locals()[label].doTrackerSpecific                   = doTrackerSpecific                   [tracks]
+    locals()[label].doHitPropertiesPlots                = doHitPropertiesPlots                [tracks]
+    locals()[label].doGeneralPropertiesPlots            = doGeneralPropertiesPlots            [tracks]
+    locals()[label].doBeamSpotPlots                     = doBeamSpotPlots                     [tracks]
+    locals()[label].doSeedParameterHistos               = doSeedParameterHistos               [tracks]
+    locals()[label].doRecHitVsPhiVsEtaPerTrack          = doRecHitVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackRecHitVsPhiVsEtaPerTrack = doGoodTrackRecHitVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doLayersVsPhiVsEtaPerTrack          = doLayersVsPhiVsEtaPerTrack          [tracks]
+    locals()[label].doGoodTrackLayersVsPhiVsEtaPerTrack = doGoodTrackLayersVsPhiVsEtaPerTrack [tracks]
+    locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
+    locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
+    locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
+    locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
+    locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
+    locals()[label].doStopSource                        = doStopSource                        [tracks]    
+    locals()[label].setLabel(label)
+
+
+    # ZeroBias, hip, OOT pu (1st collision after train) ###
+    label = 'TrackerCollisionSelectedTrackMonZBHIPOOT' + str(tracks)                       
+    locals()[label] = TrackerCollisionTrackMonZBHIPOOT.clone()
+    locals()[label].TrackProducer    = cms.InputTag(tracks)
+    locals()[label].FolderName       = cms.string(mainfolderName[tracks]+"/HIP_OOT_noINpu")
+    locals()[label].PVFolderName     = cms.string(vertexfolderName[tracks]+"/HIP_OOT_noINpu")
     locals()[label].TrackPtMin       = trackPtMin[tracks]
     locals()[label].TrackPtBin       = trackPtN[tracks]
     locals()[label].TrackPtMax       = trackPtMax[tracks]
@@ -233,14 +345,21 @@ TrackingDQMSourceTier0MinBias += dedxHarmonicSequence * dEdxMonCommon * dEdxHitM
 for tracks in selectedTracks :
     if tracks != 'generalTracks':
         TrackingDQMSourceTier0MinBias += sequenceName[tracks]
-    label = 'TrackerCollisionSelectedTrackMonMB' + str(tracks)
-    TrackingDQMSourceTier0MinBias += locals()[label]
+
+    for topology in [ 'MB', 'ZBnoHIPnoOOT', 'ZBHIPnoOOT', 'ZBHIPOOT']:
+        label = 'TrackerCollisionSelectedTrackMon' + str(topology) + str(tracks)
+        TrackingDQMSourceTier0MinBias += locals()[label]
 # seeding monitoring
 TrackingDQMSourceTier0MinBias += TrackSeedMonSequence
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonMB'
     TrackingDQMSourceTier0MinBias += locals()[label]
+# V0 monitoring
 TrackingDQMSourceTier0MinBias += voMonitoringMBSequence
+TrackingDQMSourceTier0MinBias += voMonitoringZBnoHIPnoOOTSequence
+TrackingDQMSourceTier0MinBias += voMonitoringZBHIPnoOOTSequence
+TrackingDQMSourceTier0MinBias += voMonitoringZBHIPOOTSequence
+
 TrackingDQMSourceTier0MinBias += dqmInfoTracking
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -82,6 +82,8 @@ for tracks in selectedTracks :
     locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
     locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
     locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doPlotsVsLUMI                       = cms.bool(True)
+    locals()[label].doPlotsVsBX                         = cms.bool(True)
     locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
     locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
     locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
@@ -119,6 +121,8 @@ for tracks in selectedTracks :
     locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
     locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
     locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doPlotsVsLUMI                       = cms.bool(True)
+    locals()[label].doPlotsVsBX                         = cms.bool(True)
     locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
     locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
     locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
@@ -156,6 +160,8 @@ for tracks in selectedTracks :
     locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
     locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
     locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doPlotsVsLUMI                       = cms.bool(True)
+    locals()[label].doPlotsVsBX                         = cms.bool(True)
     locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
     locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
     locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)
@@ -194,6 +200,8 @@ for tracks in selectedTracks :
     locals()[label].doPUmonitoring                      = doPUmonitoring                      [tracks]
     locals()[label].doPlotsVsBXlumi                     = doPlotsVsBXlumi                     [tracks]
     locals()[label].doPlotsVsGoodPVtx                   = doPlotsVsGoodPVtx                   [tracks]
+    locals()[label].doPlotsVsLUMI                       = cms.bool(True)
+    locals()[label].doPlotsVsBX                         = cms.bool(True)
     locals()[label].doEffFromHitPatternVsPU             = doEffFromHitPatternVsPU             [tracks]
     locals()[label].doEffFromHitPatternVsBX             = doEffFromHitPatternVsBX             [tracks]
     locals()[label].doEffFromHitPatternVsLUMI           = cms.bool(True)

--- a/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
+++ b/DQM/TrackingMonitorSource/python/pset4GenericTriggerEventFlag_cfi.py
@@ -28,3 +28,48 @@ genericTriggerEventFlag4fullTrackerAndHLTdb = cms.PSet(
    errorReplyHlt = cms.bool( False ),
    verbosityLevel = cms.uint32(1)
 )
+
+genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+   dbLabel       = cms.string("SiStripDQMTrigger"), #("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True),# True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring(""), # HLT_ZeroBias_FirstCollisionAfterAbortGap_*
+   hltDBKey      = cms.string("Tracking_HLT_noHIP_noOOT"),
+   errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
+)
+
+genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+   dbLabel       = cms.string("SiStripDQMTrigger"), #("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True),# True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring(""), # HLT_ZeroBias_FirstCollisionInTrain_*
+   hltDBKey      = cms.string("Tracking_HLT_HIP_noOOT"),
+   errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
+)
+
+genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+   dbLabel       = cms.string("SiStripDQMTrigger"), #("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True),# True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring(""), # HLT_ZeroBias_FirstBXAfterTrain_*
+   hltDBKey      = cms.string("Tracking_HLT_HIP_OOT"),
+   errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
+)


### PR DESCRIPTION
this PR is needed for adding plots to the tracking DQM
in order to monitor the hip in different set of events (w/ or w/o OOT pu, w/ or w/o IN pu, etc)
in the ZeroBias PD
and to monitor few observables as function of the BX, lumi and PU
as requested/suggested by @VinInn @rovere 

I tested both running
runTheMatrix -l limited
and a modification of the 136.732 tests
the change was needed because the test --as it is currently setup-- 
does not run the DQM configuration which is actually run @tier0

everything seems to work as expected

the needed 3 new "keys" in the AlCaRecoTriggerBitsRcd payload
should be added by arun.kumar@cern.ch as discussed w/ @mmusich 
as soon as the PR is integrated in 80x

the corresponding trigger paths should be integrated in the next days
as described in [https://its.cern.ch/jira/browse/CMSHLT-981](https://its.cern.ch/jira/browse/CMSHLT-981)

I really hope (and somehow request) to have this PR integrated w/in few days
because we need this plots by next week in the GUI for the studies related to the hip
as requested by the HIP task force
@dmitrijus @vanbesien 

thanks much
