### PR TITLE
Use standard tracking validation for phase2

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -1,5 +1,6 @@
 autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLiteTracking','validationHarvesting'],
                    'trackingOnlyValidation' : ['globalPrevalidationTrackingOnly','globalValidationTrackingOnly','postValidation_trackingOnly'],
+                   'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'],
                    'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
                    'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
                    'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
@@ -7,7 +8,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'standardValidation' : ['prevalidation','validation','validationHarvesting']
                  }
 
-_phase2_allowed = ['baseValidation','trackingOnlyValidation','muonOnlyValidation','JetMETOnlyValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([autoValidation[m][i] for m in _phase2_allowed])

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -40,10 +40,13 @@ from Validation.L1T.L1Validator_cfi import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 
 # filter/producer "pre-" sequence for globalValidation
-globalPrevalidation = cms.Sequence( 
+globalPrevalidationTracking = cms.Sequence(
     simHitTPAssocProducer
   * tracksValidation
   * vertexValidation
+)
+globalPrevalidation = cms.Sequence(
+    globalPrevalidationTracking
   * photonPrevalidationSequence
   * produceDenoms
   * prebTagSequenceMC

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -20,10 +20,13 @@ from Validation.RecoMET.METPostProcessor_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *
 
 
+postValidationTracking = cms.Sequence(
+      postProcessorTrackSequence
+    + postProcessorVertexSequence
+)
 postValidation = cms.Sequence(
       recoMuonPostProcessors
-    + postProcessorTrackSequence
-    + postProcessorVertexSequence
+    + postValidationTracking
     + MuIsoValPostProcessor
     + calotowersPostProcessor
     + hcalSimHitsPostProcessor


### PR DESCRIPTION
This PR switches phase2 validation to use the standard tracking validation instead of `trackingOnly` validation (the latter has significantly more histograms that are interesting for tuning tracking, but are not necessary for release validation).

Tested in CMSSW_8_1_X_2016-08-11-2300 (rebased on top of CMSSW_8_1_X_2016-08-18-1100), no changes expected for phase0/phase1. For phase2, the following folders in `Tracking` should disappear
- `TrackSeeding`
- `TrackBuilding`
- From `TrackAllTPEffic`, everything else except `general_...` and `cutsRecoHp_...`
- From `TrackFromPV`, everything else except `general_...`, `cutsRecoHp_...`, and `simulation`
- From `TrackFromPVAllTP`, everything else except `general_...` and `cutsRecoHp_...`

and the following appear
- `TrackGsf`
- In `TrackConversion`, `ckfInOutFromConversions_...` and `ckfOutInFromConversions_...`
- In `Track`, `cutsRecoAK4PFJets`

As a consequence,  `globalEfficiencies` and `..._coll` histograms under the folders above have changes too, and many `..._Mean` and `..._Sigma` histograms produced by `DQMGenericClient` may show tiny numerical differences.

@rovere @VinInn @ebrondol @kpedro88 
