### PR TITLE
Fixed compillation with new CLHEP

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
@@ -5,6 +5,7 @@
 #include "CLHEP/Random/RandFlat.h"
 
 #include <cmath>
+#include <cassert>
 
 using std::vector;
 //345678911234567892123456789312345678941234567895123456789612345678971234567898


### PR DESCRIPTION
Backported trivial fix of compilation against updated CLHEP. This is needed for backport of Geant4 10.2 from CMSSW_8_1_X.
