### PR TITLE
Small modifications based on code review of asynchronous prefetching

### DIFF
--- a/FWCore/Framework/interface/SharedResourcesAcquirer.h
+++ b/FWCore/Framework/interface/SharedResourcesAcquirer.h
@@ -1,8 +1,8 @@
-#ifndef Subsystem_Package_SharedResourcesAcquirer_h
-#define Subsystem_Package_SharedResourcesAcquirer_h
+#ifndef FWCore_Framework_SharedResourcesAcquirer_h
+#define FWCore_Framework_SharedResourcesAcquirer_h
 // -*- C++ -*-
 //
-// Package:     Subsystem/Package
+// Package:     FWCore/Framework
 // Class  :     SharedResourcesAcquirer
 // 
 /**\class SharedResourcesAcquirer SharedResourcesAcquirer.h "SharedResourcesAcquirer.h"
@@ -38,7 +38,7 @@ namespace edm {
     
     SharedResourcesAcquirer() = default;
     explicit SharedResourcesAcquirer(std::vector<std::recursive_mutex*>&& iResources, std::shared_ptr<SerialTaskQueue> iQueue = std::shared_ptr<SerialTaskQueue>()):
-    m_resources(iResources),
+    m_resources(std::move(iResources)),
     m_queue(iQueue){}
     
     SharedResourcesAcquirer(SharedResourcesAcquirer&&) = default;

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -304,6 +304,8 @@ namespace edm {
       auto t = make_waiting_task(tbb::task::allocate_root(),
                                  [this,&principal, skipCurrentProcess,sra,mcc](std::exception_ptr const* iPtr)
       {
+        //The exception is being rethrown because resolveProductImpl sets the ProductResolver to a failed
+        // state for the case where an exception occurs during the call to the function.
         try {
           resolveProductImpl<true>([iPtr]() {
             if ( iPtr) {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -561,15 +561,16 @@ namespace edm {
                                    ParentContext const& parentContext,
                                    typename T::Context const* context) {
     try {
-      //pre was called in prefetchAsync
-      actReg_->postModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
-
-      if(iEPtr) {
-        assert(*iEPtr);
-        moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid,ParentContext(),nullptr);
-        std::rethrow_exception(*iEPtr);
-      }
       convertException::wrap([&]() {
+        //pre was called in prefetchAsync
+        actReg_->postModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
+        
+        if(iEPtr) {
+          assert(*iEPtr);
+          moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid,ParentContext(),nullptr);
+          std::rethrow_exception(*iEPtr);
+        }
+
         runModule<T>(ep,es,streamID,parentContext,context);
       });
     } catch( cms::Exception& iException) {


### PR DESCRIPTION
Although the first argument to the constructor is an lvalue reference, it is still required to use std::move to get the benefits.
