### PR TITLE
Use unique_ptr, not auto_ptr, in Analysis packages

### DIFF
--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
@@ -60,7 +60,7 @@ CalibratedElectronProducerRun2T<T>::produce( edm::Event & iEvent, const edm::Eve
     edm::Handle<edm::View<T> > in;
     iEvent.getByToken(theElectronToken, in);
 
-    std::auto_ptr<std::vector<T> > out(new std::vector<T>());
+    std::unique_ptr<std::vector<T> > out(new std::vector<T>());
     out->reserve(in->size());   
 
     for (const T &ele : *in) {
@@ -68,7 +68,7 @@ CalibratedElectronProducerRun2T<T>::produce( edm::Event & iEvent, const edm::Eve
         theEnCorrectorRun2.calibrate(out->back(), iEvent.id().run(), iEvent.streamID());
     }
     
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 typedef CalibratedElectronProducerRun2T<reco::GsfElectron> CalibratedElectronProducerRun2;

--- a/TauAnalysis/MCEmbeddingTools/interface/ParticleReplacerBase.h
+++ b/TauAnalysis/MCEmbeddingTools/interface/ParticleReplacerBase.h
@@ -37,7 +37,7 @@ class ParticleReplacerBase
   virtual void endRun() {}
   virtual void endJob() {}
 
-  virtual std::auto_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* evtVtx = 0, const HepMC::GenEvent* genEvt = 0, MCParticleReplacer* = 0) = 0;
+  virtual std::unique_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* evtVtx = 0, const HepMC::GenEvent* genEvt = 0, MCParticleReplacer* = 0) = 0;
 
   unsigned int tried_;
   unsigned int passed_;

--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloRecHitMixer.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloRecHitMixer.h
@@ -1,4 +1,3 @@
-
 /** \class CaloRecHitMixer
  *
  * Merge collections of calorimeter recHits
@@ -185,9 +184,9 @@ void CaloRecHitMixer<T>::produce(edm::Event& evt, const edm::EventSetup& es)
     updateRecHitInfos(*recHitCollection1, 0);
     updateRecHitInfos(*recHitCollection2, 1);
     
-    std::auto_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
-    std::auto_ptr<double> removedEnergyMuPlus(new double(0.));
-    std::auto_ptr<double> removedEnergyMuMinus(new double(0.));
+    std::unique_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
+    std::unique_ptr<double> removedEnergyMuPlus(new double(0.));
+    std::unique_ptr<double> removedEnergyMuMinus(new double(0.));
 
     double muPlusEnergySum  = 0.;
     double muMinusEnergySum = 0.;
@@ -275,13 +274,13 @@ void CaloRecHitMixer<T>::produce(edm::Event& evt, const edm::EventSetup& es)
     }    
 
     std::string instanceLabel = todoItem->srcRecHitCollection1_.instance();
-    evt.put(recHitCollection_output, instanceLabel);
+    evt.put(std::move(recHitCollection_output), instanceLabel);
     std::string instanceLabel_removedEnergyMuMinus = "removedEnergyMuMinus";
     if ( instanceLabel != "" ) instanceLabel_removedEnergyMuMinus.append("#").append(instanceLabel);
-    evt.put(removedEnergyMuMinus, instanceLabel_removedEnergyMuMinus.data());
+    evt.put(std::move(removedEnergyMuMinus), instanceLabel_removedEnergyMuMinus.data());
     std::string instanceLabel_removedEnergyMuPlus = "removedEnergyMuPlus";
     if ( instanceLabel != "" ) instanceLabel_removedEnergyMuPlus.append("#").append(instanceLabel);
-    evt.put(removedEnergyMuPlus, instanceLabel_removedEnergyMuPlus.data());
+    evt.put(std::move(removedEnergyMuPlus), instanceLabel_removedEnergyMuPlus.data());
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/CandViewCountEventSelFlagProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CandViewCountEventSelFlagProducer.cc
@@ -10,8 +10,7 @@ CandViewCountEventSelFlagProducer::CandViewCountEventSelFlagProducer(const edm::
 
 void CandViewCountEventSelFlagProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<bool> boolPtr(new bool(eventSelector_(evt, es)));
-  evt.put(boolPtr);
+  evt.put(std::make_unique<bool>(eventSelector_(evt, es)));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/DummyBoolEventSelFlagProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/DummyBoolEventSelFlagProducer.cc
@@ -14,8 +14,7 @@ DummyBoolEventSelFlagProducer::~DummyBoolEventSelFlagProducer()
 
 void DummyBoolEventSelFlagProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<bool> boolPtr(new bool(true));
-  evt.put(boolPtr);
+  evt.put(std::make_unique<bool>(true));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/ElectronSeedTrackRefUpdater.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ElectronSeedTrackRefUpdater.cc
@@ -110,8 +110,8 @@ ElectronSeedTrackRefUpdater::produce(edm::Event& iEvent, const edm::EventSetup& 
    using namespace std;
    using namespace reco;
 
-   auto_ptr<ElectronSeedCollection> output_preid(new ElectronSeedCollection);
-   auto_ptr<PreIdCollection> output_preidinfo(new PreIdCollection);
+   std::unique_ptr<ElectronSeedCollection> output_preid(new ElectronSeedCollection);
+   std::unique_ptr<PreIdCollection> output_preidinfo(new PreIdCollection);
 
    edm::Handle<reco::TrackCollection> hTargetTracks;
    iEvent.getByLabel( _targetTracks, hTargetTracks);
@@ -183,8 +183,8 @@ ElectronSeedTrackRefUpdater::produce(edm::Event& iEvent, const edm::EventSetup& 
 
 
 
-   iEvent.put(output_preid,preidgsf_);
-   iEvent.put(output_preidinfo,preidname_);
+   iEvent.put(std::move(output_preid),preidgsf_);
+   iEvent.put(std::move(output_preidinfo),preidname_);
 
    //iEvent.put(newCol);
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/ElectronSeedTrackRefUpdaterAndMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ElectronSeedTrackRefUpdaterAndMerger.cc
@@ -115,8 +115,8 @@ ElectronSeedTrackRefUpdaterAndMerger::produce(edm::Event& iEvent, const edm::Eve
    using namespace std;
    using namespace reco;
 
-   auto_ptr<ElectronSeedCollection> output_preid(new ElectronSeedCollection);
-   auto_ptr<PreIdCollection> output_preidinfo(new PreIdCollection);
+   std::unique_ptr<ElectronSeedCollection> output_preid(new ElectronSeedCollection);
+   std::unique_ptr<PreIdCollection> output_preidinfo(new PreIdCollection);
 
    edm::Handle<reco::TrackCollection> hTargetTracks;
    iEvent.getByLabel( _targetTracks, hTargetTracks);
@@ -209,8 +209,8 @@ ElectronSeedTrackRefUpdaterAndMerger::produce(edm::Event& iEvent, const edm::Eve
    }
 
 
-   iEvent.put(output_preid,preidgsf_);
-   iEvent.put(output_preidinfo,preidname_);
+   iEvent.put(std::move(output_preid),preidgsf_);
+   iEvent.put(std::move(output_preidinfo),preidname_);
 
    //iEvent.put(newCol);
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingKineReweightProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingKineReweightProducer.cc
@@ -20,7 +20,7 @@ EmbeddingKineReweightProducer::EmbeddingKineReweightProducer(const edm::Paramete
   if ( inputFileName.location() == edm::FileInPath::Unknown) 
     throw cms::Exception("EmbeddingReweightProducer") 
       << " Failed to find File = " << inputFileName << " !!\n";
-  std::auto_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
+  std::unique_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
 
   edm::ParameterSet cfgLUTs = cfg.getParameter<edm::ParameterSet>("lutNames"); 
   std::vector<std::string> variables = cfgLUTs.getParameterNamesForType<std::string>();
@@ -77,8 +77,7 @@ void EmbeddingKineReweightProducer::produce(edm::Event& evt, const edm::EventSet
     if ( verbosity_ ) {
       std::cout << " " << (*lutEntry)->variableName_ << " = " << weight << std::endl;
     }
-    std::auto_ptr<double> weightPtr(new double(weight));
-    evt.put(weightPtr, (*lutEntry)->variableName_);
+    evt.put(std::make_unique<double>(weight), (*lutEntry)->variableName_);
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/GSFElectronsMixer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GSFElectronsMixer.cc
@@ -104,7 +104,7 @@ GSFElectronsMixer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    cols.push_back(tks1);
    cols.push_back(tks2);
 
-   std::auto_ptr<reco::GsfElectronCollection> finalCollection( new reco::GsfElectronCollection ) ;
+   std::unique_ptr<reco::GsfElectronCollection> finalCollection( new reco::GsfElectronCollection ) ;
 
    //std::cout << "##########################################\n";
    //int i  = 0;
@@ -126,7 +126,7 @@ GSFElectronsMixer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    }
 
-   iEvent.put(finalCollection);
+   iEvent.put(std::move(finalCollection));
 
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/GenMuonRadiationFilter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GenMuonRadiationFilter.cc
@@ -142,8 +142,7 @@ bool GenMuonRadiationFilter::filter(edm::Event& evt, const edm::EventSetup& es)
     if ( invert_ != isMuonRadiation ) return false; // reject events with muon -> muon + photon radiation
     else return true;
   } else {
-    std::auto_ptr<bool> filter_result(new bool(invert_ != !isMuonRadiation));
-    evt.put(filter_result);
+    evt.put(std::make_unique<bool>(invert_ != !isMuonRadiation));
     return true;
   }
 }

--- a/TauAnalysis/MCEmbeddingTools/plugins/GenParticlesFromZsSelectorForMCEmbedding.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GenParticlesFromZsSelectorForMCEmbedding.cc
@@ -139,7 +139,7 @@ void GenParticlesFromZsSelectorForMCEmbedding::produce(edm::Event& evt, const ed
     }
   }
   
-  std::auto_ptr<reco::GenParticleCollection> genParticlesFromZs(new reco::GenParticleCollection());
+  std::unique_ptr<reco::GenParticleCollection> genParticlesFromZs(new reco::GenParticleCollection());
   
   int idx = 0;
   for ( std::vector<const reco::GenParticle*>::const_iterator genParticleFromZ_beforeFSR = genParticlesFromZs_tmp.begin();
@@ -166,7 +166,7 @@ void GenParticlesFromZsSelectorForMCEmbedding::produce(edm::Event& evt, const ed
     ++idx;
   }
   
-  evt.put(genParticlesFromZs);
+  evt.put(std::move(genParticlesFromZs));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/GlobalMuonTrackCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GlobalMuonTrackCleaner.cc
@@ -67,7 +67,7 @@ void GlobalMuonTrackCleaner::produceTrackExtras(edm::Event& evt, const edm::Even
 
   for ( typename std::vector<todoListEntryType>::const_iterator todoItem = todoList_.begin();
 	todoItem != todoList_.end(); ++todoItem ) {
-    std::auto_ptr<MuonTrackLinksCollection> trackLinks_cleaned(new MuonTrackLinksCollection());
+    std::unique_ptr<MuonTrackLinksCollection> trackLinks_cleaned(new MuonTrackLinksCollection());
     
     for ( std::map<reco::TrackRef, reco::TrackRef>::const_iterator cleanedToUncleanedTrackAssociation = todoItem->trackRefMap_.begin();
 	  cleanedToUncleanedTrackAssociation != todoItem->trackRefMap_.end(); ++cleanedToUncleanedTrackAssociation ) {
@@ -103,7 +103,7 @@ void GlobalMuonTrackCleaner::produceTrackExtras(edm::Event& evt, const edm::Even
       }
     }
     
-    evt.put(trackLinks_cleaned, todoItem->srcTracks_.instance());
+    evt.put(std::move(trackLinks_cleaned), todoItem->srcTracks_.instance());
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/GlobalMuonTrackMixer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GlobalMuonTrackMixer.cc
@@ -83,7 +83,7 @@ void GlobalMuonTrackMixer::produceTrackExtras(edm::Event& evt, const edm::EventS
     edm::Handle<MuonTrackLinksCollection> trackLinksCollection2;
     evt.getByLabel(todoItem->srcTrackCollection2_, trackLinksCollection2);
 
-    std::auto_ptr<MuonTrackLinksCollection> trackLinks_output(new MuonTrackLinksCollection());
+    std::unique_ptr<MuonTrackLinksCollection> trackLinks_output(new MuonTrackLinksCollection());
 
     for ( MuonTrackLinksCollection::const_iterator trackLink = trackLinksCollection1->begin();
 	  trackLink != trackLinksCollection1->end(); ++trackLink ) {
@@ -109,7 +109,7 @@ void GlobalMuonTrackMixer::produceTrackExtras(edm::Event& evt, const edm::EventS
       }
     }
 
-    evt.put(trackLinks_output, todoItem->srcTrackCollection1_.instance());
+    evt.put(std::move(trackLinks_output), todoItem->srcTrackCollection1_.instance());
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/GsfTrackMixer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/GsfTrackMixer.cc
@@ -117,11 +117,11 @@ GsfTrackMixer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    // see RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
    // and RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
-   //std::auto_ptr<TrackingRecHitCollection> outputRHColl (new TrackingRecHitCollection);
-   std::auto_ptr<reco::GsfTrackCollection> outputTColl(new reco::GsfTrackCollection);
-   std::auto_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
-   std::auto_ptr<reco::GsfTrackExtraCollection> outputGsfTEColl(new reco::GsfTrackExtraCollection);
-   //std::auto_ptr<std::vector<Trajectory> >    outputTrajectoryColl(new std::vector<Trajectory>);
+   //std::unique_ptr<TrackingRecHitCollection> outputRHColl (new TrackingRecHitCollection);
+   std::unique_ptr<reco::GsfTrackCollection> outputTColl(new reco::GsfTrackCollection);
+   std::unique_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
+   std::unique_ptr<reco::GsfTrackExtraCollection> outputGsfTEColl(new reco::GsfTrackExtraCollection);
+   //std::unique_ptr<std::vector<Trajectory> >    outputTrajectoryColl(new std::vector<Trajectory>);
  
    reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
    reco::GsfTrackExtraRefProd rGsfTrackExtras = iEvent.getRefBeforePut<reco::GsfTrackExtraCollection>();
@@ -162,9 +162,9 @@ GsfTrackMixer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
 
-   iEvent.put(outputTColl);
-   iEvent.put(outputTEColl);
-   iEvent.put(outputGsfTEColl);
+   iEvent.put(std::move(outputTColl));
+   iEvent.put(std::move(outputTEColl));
+   iEvent.put(std::move(outputGsfTEColl));
 
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/HepMCSplitter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/HepMCSplitter.cc
@@ -211,10 +211,10 @@ HepMCSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //std::cout << " Z vertices identified "  << barcodesZ.size() << std::endl;
 
   // prepare final products
-  //     std::auto_ptr<edm::HepMCProduct> prodTauTau(new edm::HepMCProduct());  
+  //     std::unique_ptr<edm::HepMCProduct> prodTauTau(new edm::HepMCProduct());  
 
-  std::auto_ptr<HepMC::GenEvent> evtUE(new HepMC::GenEvent());
-  std::auto_ptr<HepMC::GenEvent> evtTauTau(new HepMC::GenEvent());
+  std::unique_ptr<HepMC::GenEvent> evtUE(new HepMC::GenEvent());
+  std::unique_ptr<HepMC::GenEvent> evtTauTau(new HepMC::GenEvent());
   
   // Copy the vertices
   itVtx = prodIn->GetEvent()->vertices_begin();
@@ -370,19 +370,19 @@ HepMCSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //   evtUE->print();
   
   if (_doUe){
-    std::auto_ptr<edm::HepMCProduct> prodUE(new edm::HepMCProduct());  
+    std::unique_ptr<edm::HepMCProduct> prodUE(new edm::HepMCProduct());  
     prodUE->addHepMCData( evtUE.release() );
-    if (_doZtautau) iEvent.put( prodUE, "UE");
-    else iEvent.put( prodUE);
+    if (_doZtautau) iEvent.put(std::move(prodUE), "UE");
+    else iEvent.put(std::move(prodUE));
   }
 
   if (_doZtautau) {
-    std::auto_ptr<edm::HepMCProduct> prodTauTau(new edm::HepMCProduct());  
+    std::unique_ptr<edm::HepMCProduct> prodTauTau(new edm::HepMCProduct());  
 //     std::cout << "===================================== " << iEvent.id() << std::endl;
 //     evtTauTau->print();
     prodTauTau->addHepMCData( evtTauTau.release() );
-    if (_doUe ) iEvent.put( prodTauTau, "Ztautau");
-    else iEvent.put( prodTauTau);
+    if (_doUe ) iEvent.put(std::move(prodTauTau), "Ztautau");
+    else iEvent.put(std::move(prodTauTau));
   }
 
   

--- a/TauAnalysis/MCEmbeddingTools/plugins/L1ExtraMEtMixerPlugin.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/L1ExtraMEtMixerPlugin.cc
@@ -49,7 +49,7 @@ void L1ExtraMEtMixerPlugin::produce(edm::Event& evt, const edm::EventSetup& es)
   edm::Handle<detIdToFloatMap> distanceMapMuMinus;
   evt.getByLabel(srcDistanceMapMuMinus_, distanceMapMuMinus);
 
-  std::auto_ptr<l1extra::L1EtMissParticleCollection> metSum(new l1extra::L1EtMissParticleCollection());
+  std::unique_ptr<l1extra::L1EtMissParticleCollection> metSum(new l1extra::L1EtMissParticleCollection());
 
   // CV: entries in MET collections refer to different bunch-crossings.
   //     The number of entries in the two MET collections is not necessarily the same
@@ -191,7 +191,7 @@ void L1ExtraMEtMixerPlugin::produce(edm::Event& evt, const edm::EventSetup& es)
     metSum->push_back(metSum_bx);					       
   }
   
-  evt.put(metSum, instanceLabel_);
+  evt.put(std::move(metSum), instanceLabel_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/L1ExtraMixerPluginT.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/L1ExtraMixerPluginT.cc
@@ -86,14 +86,14 @@ void L1ExtraMixerPluginT<T>::produce(edm::Event& evt, const edm::EventSetup& es)
   higherPtT<const T*> higherPt;
   std::sort(l1ExtraObjects_sorted.begin(), l1ExtraObjects_sorted.end(), higherPt);
 
-  std::auto_ptr<l1ExtraCollection> l1ExtraObjects_output(new l1ExtraCollection());
+  std::unique_ptr<l1ExtraCollection> l1ExtraObjects_output(new l1ExtraCollection());
 
   size_t numL1ExtraObjects = l1ExtraObjects_sorted.size();
   for ( size_t iObject = 0; iObject < TMath::Min(numL1ExtraObjects, maxNumL1ExtraObjects); ++iObject ) {
     l1ExtraObjects_output->push_back(*l1ExtraObjects_sorted.at(iObject));
   }
 
-  evt.put(l1ExtraObjects_output, instanceLabel_);
+  evt.put(std::move(l1ExtraObjects_output), instanceLabel_);
 }
 
 #include "DataFormats/L1Trigger/interface/L1EmParticle.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/MCParticleReplacer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MCParticleReplacer.cc
@@ -68,7 +68,7 @@ MCParticleReplacer::produce(edm::Event& evt, const edm::EventSetup& es)
 	
   evt_ = &evt;
 
-  std::auto_ptr<HepMC::GenEvent> hepMC;
+  std::unique_ptr<HepMC::GenEvent> hepMC;
   if ( hepMcMode_ == kReplace ) {
     edm::Handle<edm::HepMCProduct> HepMCHandle;	 
     evt.getByLabel(srcHepMC_, HepMCHandle);
@@ -80,13 +80,12 @@ MCParticleReplacer::produce(edm::Event& evt, const edm::EventSetup& es)
       << "Invalid hepMcMode " << hepMcMode_ << " !!" << std::endl;
 
   if ( hepMC.get() != 0 ) {
-    std::auto_ptr<edm::HepMCProduct> bare_product(new edm::HepMCProduct());  
+    std::unique_ptr<edm::HepMCProduct> bare_product(new edm::HepMCProduct());  
     bare_product->addHepMCData(hepMC.release()); // transfer ownership of the HepMC:GenEvent to bare_product
     
-    evt.put(bare_product);
+    evt.put(std::move(bare_product));
     
-    std::auto_ptr<GenFilterInfo> info(new GenFilterInfo(replacer_->tried_, replacer_->passed_));
-    evt.put(info, std::string("minVisPtFilter"));
+    evt.put(std::make_unique<GenFilterInfo>(replacer_->tried_, replacer_->passed_), std::string("minVisPtFilter"));
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/MCParticleReplacer.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MCParticleReplacer.h
@@ -51,9 +51,9 @@ class MCParticleReplacer : public edm::EDProducer
   }
 
   template <typename T>
-  void call_put(T& product, const std::string& instanceName)
+  void call_put(T product, const std::string& instanceName)
   {
-    evt_->put(product, instanceName);
+    evt_->put(std::move(product), instanceName);
   }
 
   edm::StreamID getStreamID() const { assert(evt_ != nullptr); return evt_->streamID(); }

--- a/TauAnalysis/MCEmbeddingTools/plugins/MixedGenMEtProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MixedGenMEtProducer.cc
@@ -82,7 +82,7 @@ void MixedGenMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     }
   }
   
-  std::auto_ptr<reco::GenMETCollection> genMETs(new reco::GenMETCollection());
+  std::unique_ptr<reco::GenMETCollection> genMETs(new reco::GenMETCollection());
   SpecificGenMETData genMEtData; // WARNING: not filled
   genMEtData.NeutralEMEtFraction  = 0.;
   genMEtData.NeutralHadEtFraction = 0.;
@@ -93,7 +93,7 @@ void MixedGenMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   reco::Candidate::Point vtx(0.0, 0.0, 0.0);  
   genMETs->push_back(reco::GenMET(genMEtData, genSumEt, genMEtP4, vtx));
 
-  evt.put(genMETs);
+  evt.put(std::move(genMETs));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloCleanerAllCrossed.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloCleanerAllCrossed.cc
@@ -36,8 +36,8 @@ MuonCaloCleanerAllCrossed::~MuonCaloCleanerAllCrossed()
 
 void MuonCaloCleanerAllCrossed::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<detIdToFloatMap> energyDepositsMuPlus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> energyDepositsMuMinus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositsMuPlus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositsMuMinus(new detIdToFloatMap());
   
   std::vector<reco::CandidateBaseRef> selMuons = getSelMuons(evt, srcSelectedMuons_);
   const reco::CandidateBaseRef muPlus  = getTheMuPlus(selMuons);
@@ -46,8 +46,8 @@ void MuonCaloCleanerAllCrossed::produce(edm::Event& evt, const edm::EventSetup& 
   if ( muPlus.isNonnull()  ) fillEnergyDepositMap(evt, es, &(*muPlus), *energyDepositsMuPlus);
   if ( muMinus.isNonnull() ) fillEnergyDepositMap(evt, es, &(*muMinus), *energyDepositsMuMinus);
 
-  evt.put(energyDepositsMuPlus, "energyDepositsMuPlus");
-  evt.put(energyDepositsMuMinus, "energyDepositsMuMinus");
+  evt.put(std::move(energyDepositsMuPlus), "energyDepositsMuPlus");
+  evt.put(std::move(energyDepositsMuMinus), "energyDepositsMuMinus");
 }
 
 void MuonCaloCleanerAllCrossed::fillEnergyDepositMap(edm::Event& evt, const edm::EventSetup& es, const reco::Candidate* muon, detIdToFloatMap& energyDepositMap)

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloCleanerByDistance.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloCleanerByDistance.cc
@@ -41,8 +41,8 @@ MuonCaloCleanerByDistance::~MuonCaloCleanerByDistance()
 
 void MuonCaloCleanerByDistance::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<detIdToFloatMap> energyDepositsMuPlus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> energyDepositsMuMinus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositsMuPlus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositsMuMinus(new detIdToFloatMap());
 
   edm::Handle<detIdToFloatMap> distanceMapMuPlus;
   evt.getByLabel(srcDistanceMapMuPlus_, distanceMapMuPlus);
@@ -53,11 +53,11 @@ void MuonCaloCleanerByDistance::produce(edm::Event& evt, const edm::EventSetup& 
   const reco::CandidateBaseRef muPlus  = getTheMuPlus(selMuons);
   const reco::CandidateBaseRef muMinus = getTheMuMinus(selMuons);
 
-  std::auto_ptr<double> totalDistanceMuPlus(new double(0.));
-  std::auto_ptr<double> totalEnergyDepositMuPlus(new double(0.));
+  std::unique_ptr<double> totalDistanceMuPlus(new double(0.));
+  std::unique_ptr<double> totalEnergyDepositMuPlus(new double(0.));
   if ( muPlus.isNonnull() ) fillEnergyDepositMap(*muPlus, *distanceMapMuPlus, *energyDepositsMuPlus, *totalDistanceMuPlus, *totalEnergyDepositMuPlus);
-  std::auto_ptr<double> totalDistanceMuMinus(new double(0.));
-  std::auto_ptr<double> totalEnergyDepositMuMinus(new double(0.));
+  std::unique_ptr<double> totalDistanceMuMinus(new double(0.));
+  std::unique_ptr<double> totalEnergyDepositMuMinus(new double(0.));
   if ( muMinus.isNonnull() ) fillEnergyDepositMap(*muMinus, *distanceMapMuMinus, *energyDepositsMuMinus, *totalDistanceMuMinus, *totalEnergyDepositMuMinus);
 
   if ( verbosity_ ) {
@@ -66,12 +66,12 @@ void MuonCaloCleanerByDistance::produce(edm::Event& evt, const edm::EventSetup& 
     std::cout << " mu-: distance = " << (*totalDistanceMuMinus) << ", expected(EnergyDeposits) = " << (*totalEnergyDepositMuMinus) << std::endl;
   }
 
-  evt.put(energyDepositsMuPlus, "energyDepositsMuPlus");
-  evt.put(totalDistanceMuPlus, "totalDistanceMuPlus");
-  evt.put(totalEnergyDepositMuPlus, "totalEnergyDepositMuPlus");
-  evt.put(energyDepositsMuMinus, "energyDepositsMuMinus");
-  evt.put(totalDistanceMuMinus, "totalDistanceMuMinus");
-  evt.put(totalEnergyDepositMuMinus, "totalEnergyDepositMuMinus");
+  evt.put(std::move(energyDepositsMuPlus), "energyDepositsMuPlus");
+  evt.put(std::move(totalDistanceMuPlus), "totalDistanceMuPlus");
+  evt.put(std::move(totalEnergyDepositMuPlus), "totalEnergyDepositMuPlus");
+  evt.put(std::move(energyDepositsMuMinus), "energyDepositsMuMinus");
+  evt.put(std::move(totalDistanceMuMinus), "totalDistanceMuMinus");
+  evt.put(std::move(totalEnergyDepositMuMinus), "totalEnergyDepositMuMinus");
 }
 
 void MuonCaloCleanerByDistance::fillEnergyDepositMap(const reco::Candidate& muon, const detIdToFloatMap& distanceMap, detIdToFloatMap& energyDepositMap,

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloDistanceProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonCaloDistanceProducer.cc
@@ -44,10 +44,10 @@ MuonCaloDistanceProducer::~MuonCaloDistanceProducer()
 
 void MuonCaloDistanceProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<detIdToFloatMap> distanceMuPlus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> distanceMuMinus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> depositMuPlus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> depositMuMinus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> distanceMuPlus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> distanceMuMinus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> depositMuPlus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> depositMuMinus(new detIdToFloatMap());
 
   std::vector<reco::CandidateBaseRef> selMuons = getSelMuons(evt, srcSelectedMuons_);
   const reco::CandidateBaseRef muPlus  = getTheMuPlus(selMuons);
@@ -56,20 +56,20 @@ void MuonCaloDistanceProducer::produce(edm::Event& evt, const edm::EventSetup& e
   if ( muPlus.isNonnull()  ) fillDistanceMap(evt, es, &(*muPlus), *distanceMuPlus, *depositMuPlus);
   if ( muMinus.isNonnull() ) fillDistanceMap(evt, es, &(*muMinus), *distanceMuMinus, *depositMuMinus);
 
-  std::auto_ptr<reco::CandidateCollection> muons(new reco::CandidateCollection);
+  std::unique_ptr<reco::CandidateCollection> muons(new reco::CandidateCollection);
   if ( muPlus.isNonnull()  ) muons->push_back(new reco::ShallowCloneCandidate(muPlus));
   if ( muMinus.isNonnull() ) muons->push_back(new reco::ShallowCloneCandidate(muMinus));
 
   // References to the muons themselves
-  evt.put(muons, "muons");
+  evt.put(std::move(muons), "muons");
 
   // maps of detId to distance traversed by muon through calorimeter cell
-  evt.put(distanceMuPlus, "distancesMuPlus");
-  evt.put(distanceMuMinus, "distancesMuMinus");
+  evt.put(std::move(distanceMuPlus), "distancesMuPlus");
+  evt.put(std::move(distanceMuMinus), "distancesMuMinus");
 
   // maps of detId to energy deposited in calorimeter cell
-  evt.put(depositMuPlus, "depositsMuPlus");
-  evt.put(depositMuMinus, "depositsMuMinus");
+  evt.put(std::move(depositMuPlus), "depositsMuPlus");
+  evt.put(std::move(depositMuMinus), "depositsMuMinus");
 }
 
 void MuonCaloDistanceProducer::fillDistanceMap(edm::Event& evt, const edm::EventSetup& es, const reco::Candidate* muon, detIdToFloatMap& distanceMap, detIdToFloatMap& depositMap)

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
@@ -33,8 +33,8 @@ MuonDetCleaner::~MuonDetCleaner()
 
 void MuonDetCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<detIdToIntMap> hitsMuPlus(new detIdToIntMap());
-  std::auto_ptr<detIdToIntMap> hitsMuMinus(new detIdToIntMap());
+  std::unique_ptr<detIdToIntMap> hitsMuPlus(new detIdToIntMap());
+  std::unique_ptr<detIdToIntMap> hitsMuMinus(new detIdToIntMap());
   
   std::vector<reco::CandidateBaseRef> selMuons = getSelMuons(evt, srcSelectedMuons_);
   const reco::CandidateBaseRef muPlus  = getTheMuPlus(selMuons);
@@ -43,8 +43,8 @@ void MuonDetCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
   if ( muPlus.isNonnull()  ) fillHitMap(evt, es, &(*muPlus), *hitsMuPlus);
   if ( muMinus.isNonnull() ) fillHitMap(evt, es, &(*muMinus), *hitsMuMinus);
 
-  evt.put(hitsMuPlus, "hitsMuPlus");
-  evt.put(hitsMuMinus, "hitsMuMinus");
+  evt.put(std::move(hitsMuPlus), "hitsMuPlus");
+  evt.put(std::move(hitsMuMinus), "hitsMuMinus");
 }
 
 namespace

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetRecHitMixer.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetRecHitMixer.h
@@ -129,7 +129,7 @@ void MuonDetRecHitMixer<T1,T2>::produce(edm::Event& evt, const edm::EventSetup& 
     addRecHits(recHits_output, *recHitCollection1, todoItem->cleanCollection1_, *hitMapMuPlus, *hitMapMuMinus, numHits_cleaned);
     addRecHits(recHits_output, *recHitCollection2, todoItem->cleanCollection2_, *hitMapMuPlus, *hitMapMuMinus, numHits_cleaned);
 
-    std::auto_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
+    std::unique_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
     for ( typename std::map<T1, std::vector<T2> >::const_iterator recHit = recHits_output.begin();
 	  recHit != recHits_output.end(); ++recHit ) {
       recHitCollection_output->put(recHit->first, recHit->second.begin(), recHit->second.end());
@@ -145,7 +145,7 @@ void MuonDetRecHitMixer<T1,T2>::produce(edm::Event& evt, const edm::EventSetup& 
       if ( verbosity_ >= 2 ) printHitMapRH(es, *recHitCollection_output);
       std::cout << " #Hits = " << numHits_cleaned << " removed during cleaning." << std::endl;   
     }    
-    evt.put(recHitCollection_output, instanceLabel);
+    evt.put(std::move(recHitCollection_output), instanceLabel);
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonPFCandidateCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonPFCandidateCleaner.cc
@@ -137,7 +137,7 @@ void MuonPFCandidateCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   evt.getByLabel(srcPFCandidates_, pfCandidates);
 
-  std::auto_ptr<reco::PFCandidateCollection> pfCandidates_woMuons(new reco::PFCandidateCollection());   
+  std::unique_ptr<reco::PFCandidateCollection> pfCandidates_woMuons(new reco::PFCandidateCollection());   
    
 //--- iterate over list of reconstructed PFCandidates, 
 //    add PFCandidate to output collection in case it does not correspond to any selected muon
@@ -195,7 +195,7 @@ void MuonPFCandidateCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
     if ( removedPFCandidates.size() < selMuons.size() ) ++numWarnings_tooFew_;
   }
 
-  evt.put(pfCandidates_woMuons);
+  evt.put(std::move(pfCandidates_woMuons));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonRadiationCorrWeightProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonRadiationCorrWeightProducer.cc
@@ -23,7 +23,7 @@ MuonRadiationCorrWeightProducer::MuonRadiationCorrWeightProducer(const edm::Para
   if ( inputFileName.location() == edm::FileInPath::Unknown)
     throw cms::Exception("MuonRadiationCorrWeightProducer") 
       << " Failed to find File = " << inputFileName << " !!\n";
-  std::auto_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
+  std::unique_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
 
   typedef std::vector<double> vdouble;
   vdouble binningMuonEn = cfg.getParameter<vdouble>("binningMuonEn");
@@ -225,12 +225,9 @@ void MuonRadiationCorrWeightProducer::produce(edm::Event& evt, const edm::EventS
     std::cout << "--> weight = " << weight << " + " << (weightUp - weight) << " - " << (weight - weightDown) << std::endl;
   }
 
-  std::auto_ptr<double> weightPtr(new double(weight));
-  evt.put(weightPtr, "weight");
-  std::auto_ptr<double> weightUpPtr(new double(weightUp));
-  evt.put(weightUpPtr, "weightUp");
-  std::auto_ptr<double> weightDownPtr(new double(weightDown));
-  evt.put(weightDownPtr, "weightDown");
+  evt.put(std::make_unique<double>(weight), "weight");
+  evt.put(std::make_unique<double>(weightUp), "weightUp");
+  evt.put(std::make_unique<double>(weightDown), "weightDown");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonRadiationFilter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonRadiationFilter.cc
@@ -102,8 +102,7 @@ bool MuonRadiationFilter::filter(edm::Event& evt, const edm::EventSetup& es)
     if ( invert_ != isMuonRadiation ) return false; // reject events with muon -> muon + photon radiation
     else return true;
   } else {
-    std::auto_ptr<bool> filter_result(new bool(invert_ != !isMuonRadiation));
-    evt.put(filter_result);
+    evt.put(std::make_unique<bool>(invert_ != !isMuonRadiation));
     return true;
   }
 }

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonWithPFIsoProducerCopy.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonWithPFIsoProducerCopy.cc
@@ -78,13 +78,13 @@ void MuonWithPFIsoProducerCopy::endJob(){
 void MuonWithPFIsoProducerCopy::produce(edm::Event& ev, const edm::EventSetup& iSetup) {
 
       // Initialize pointer to new output muon collection
-      std::auto_ptr<reco::MuonCollection> newmuons (new reco::MuonCollection);
+      std::unique_ptr<reco::MuonCollection> newmuons (new reco::MuonCollection);
 
       // Get Muon collection
       edm::Handle<edm::View<reco::Muon> > muonCollection;
       if (!ev.getByLabel(muonTag_, muonCollection)) {
             edm::LogError("") << ">>> Muon collection does not exist !!!";
-            ev.put(newmuons);
+            ev.put(std::move(newmuons));
             return;
       }
 
@@ -92,7 +92,7 @@ void MuonWithPFIsoProducerCopy::produce(edm::Event& ev, const edm::EventSetup& i
       edm::Handle<edm::View<reco::PFCandidate> > pfCollection;
       if (!ev.getByLabel(pfTag_, pfCollection)) {
             edm::LogError("") << ">>> PFCandidate collection does not exist !!!";
-            ev.put(newmuons);
+            ev.put(std::move(newmuons));
             return;
       }
 
@@ -182,7 +182,7 @@ void MuonWithPFIsoProducerCopy::produce(edm::Event& ev, const edm::EventSetup& i
       }
 
       // Add output collection to event
-      ev.put(newmuons);
+      ev.put(std::move(newmuons));
 }
 
 DEFINE_FWK_MODULE(MuonWithPFIsoProducerCopy);

--- a/TauAnalysis/MCEmbeddingTools/plugins/PFCandidateMixer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/PFCandidateMixer.cc
@@ -149,7 +149,7 @@ void PFCandidateMixer::mix(edm::Event& iEvent, const edm::Handle<reco::TrackColl
    colVec.push_back(&pfIn1);
    colVec.push_back(&pfIn2);
 
-   std::auto_ptr<std::vector< reco::PFCandidate > > pOut(new std::vector< reco::PFCandidate  > );
+   std::unique_ptr<std::vector< reco::PFCandidate > > pOut(new std::vector< reco::PFCandidate  > );
    
    std::vector<const reco::PFCandidateCollection*>::iterator itCol= colVec.begin();
    std::vector<const reco::PFCandidateCollection*>::iterator itColE= colVec.end();
@@ -236,7 +236,7 @@ void PFCandidateMixer::mix(edm::Event& iEvent, const edm::Handle<reco::TrackColl
      ++iCol;
    }
 
-   edm::OrphanHandle<reco::PFCandidateCollection> newColl = iEvent.put(pOut);
+   edm::OrphanHandle<reco::PFCandidateCollection> newColl = iEvent.put(std::move(pOut));
 
    // Now fixup the references and write the valuemap
    if(electronCol.isValid())
@@ -253,11 +253,11 @@ void PFCandidateMixer::mix(edm::Event& iEvent, const edm::Handle<reco::TrackColl
          values[i] = candPtr;
       }
 
-      std::auto_ptr<edm::ValueMap<reco::PFCandidatePtr> > pfMap_p(new edm::ValueMap<reco::PFCandidatePtr>());
+      std::unique_ptr<edm::ValueMap<reco::PFCandidatePtr> > pfMap_p(new edm::ValueMap<reco::PFCandidatePtr>());
       edm::ValueMap<reco::PFCandidatePtr>::Filler filler(*pfMap_p);
       filler.insert(electronCol, values.begin(), values.end());
       filler.fill();
-      iEvent.put(pfMap_p, "electrons");
+      iEvent.put(std::move(pfMap_p), "electrons");
    }
 
    // TODO: Do the same for muons

--- a/TauAnalysis/MCEmbeddingTools/plugins/PFMuonCaloCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/PFMuonCaloCleaner.cc
@@ -35,8 +35,8 @@ PFMuonCaloCleaner::PFMuonCaloCleaner(const edm::ParameterSet& cfg)
 
 void PFMuonCaloCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  std::auto_ptr<detIdToFloatMap> energyDepositMuPlus(new detIdToFloatMap());
-  std::auto_ptr<detIdToFloatMap> energyDepositMuMinus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositMuPlus(new detIdToFloatMap());
+  std::unique_ptr<detIdToFloatMap> energyDepositMuMinus(new detIdToFloatMap());
 
   std::vector<reco::CandidateBaseRef > selMuons = getSelMuons(evt, srcSelectedMuons_);
   const reco::CandidateBaseRef muPlus  = getTheMuPlus(selMuons);
@@ -49,8 +49,8 @@ void PFMuonCaloCleaner::produce(edm::Event& evt, const edm::EventSetup& es)
   if ( muPlus.isNonnull()  ) fillEnergyDepositMap(dynamic_cast<const reco::Muon*>(&*muPlus), *pfCandidates, *energyDepositMuPlus);
   if ( muMinus.isNonnull() ) fillEnergyDepositMap(dynamic_cast<const reco::Muon*>(&*muMinus), *pfCandidates, *energyDepositMuMinus);
 
-  evt.put(energyDepositMuPlus, "energyDepositsMuPlus");
-  evt.put(energyDepositMuMinus, "energyDepositsMuMinus");
+  evt.put(std::move(energyDepositMuPlus), "energyDepositsMuPlus");
+  evt.put(std::move(energyDepositMuMinus), "energyDepositsMuMinus");
 }
 
 namespace

--- a/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerParticleGun.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerParticleGun.cc
@@ -70,12 +70,11 @@ void ParticleReplacerParticleGun::endJob()
   }
 }
 
-std::auto_ptr<HepMC::GenEvent> ParticleReplacerParticleGun::produce(const std::vector<reco::Particle>& muons, const reco::Vertex* evtVtx, const HepMC::GenEvent* genEvt, MCParticleReplacer* producer) 
+std::unique_ptr<HepMC::GenEvent> ParticleReplacerParticleGun::produce(const std::vector<reco::Particle>& muons, const reco::Vertex* evtVtx, const HepMC::GenEvent* genEvt, MCParticleReplacer* producer) 
 {
   if(genEvt != 0)
     throw cms::Exception("UnimplementedFeature") << "ParticleReplacerParticleGun does NOT support merging at HepMC level" << std::endl;
 
-  std::auto_ptr<HepMC::GenEvent> evt(0);
   std::vector<HepMC::FourVector> muons_corrected;
   muons_corrected.reserve(muons.size());
   correctTauMass(muons, muons_corrected);
@@ -194,7 +193,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerParticleGun::produce(const std::v
   call_pyhepc(1); // pythia -> hepevt
 
   HepMC::IO_HEPEVT conv;
-  evt = std::auto_ptr<HepMC::GenEvent>(new HepMC::GenEvent(*conv.read_next_event()));
+  std::unique_ptr<HepMC::GenEvent> evt = std::make_unique<HepMC::GenEvent>(*conv.read_next_event());
 
   if(verbosity_) {
     evt->print();

--- a/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerParticleGun.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerParticleGun.h
@@ -31,7 +31,7 @@ class ParticleReplacerParticleGun: public ParticleReplacerBase
   virtual void beginJob();
   virtual void endJob();
 
-  std::auto_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* = 0, const HepMC::GenEvent* = 0, MCParticleReplacer* = 0);
+  std::unique_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* = 0, const HepMC::GenEvent* = 0, MCParticleReplacer* = 0);
 
  private:
   void correctTauMass(const std::vector<reco::Particle>&, std::vector<HepMC::FourVector>&);

--- a/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerZtautau.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerZtautau.cc
@@ -231,7 +231,7 @@ namespace
   }
 }
 
-std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vector<reco::Particle>& muons, const reco::Vertex* evtVtx, const HepMC::GenEvent* genEvt, MCParticleReplacer* producer)
+std::unique_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vector<reco::Particle>& muons, const reco::Vertex* evtVtx, const HepMC::GenEvent* genEvt, MCParticleReplacer* producer)
 {
   edm::Service<edm::RandomNumberGenerator> rng;
   if ( !rng.isAvailable() ) 
@@ -246,8 +246,8 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
   if ( evtVtx != 0 ) throw cms::Exception("Configuration") 
     << "ParticleReplacerZtautau does NOT support using primary vertex as the origin for taus !!\n";
 
-  std::auto_ptr<ParticleCollection> muonsBeforeRad(new ParticleCollection());
-  std::auto_ptr<ParticleCollection> muonsAfterRad(new ParticleCollection());
+  std::unique_ptr<ParticleCollection> muonsBeforeRad(new ParticleCollection());
+  std::unique_ptr<ParticleCollection> muonsAfterRad(new ParticleCollection());
 
 //--- transform the muons to the desired gen. particles
   std::vector<reco::Particle> embedParticles;	
@@ -256,7 +256,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
     if ( muons.size() != 2 ) {
       edm::LogError ("Replacer") 
 	<< "The decay mode Z->ll requires exactly two muons --> returning empty HepMC event !!" << std::endl;
-      return std::auto_ptr<HepMC::GenEvent>(0);
+      return nullptr;
     }
 
     switch ( transformationMode_ ) {
@@ -292,7 +292,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
     if ( muons.size() != 2 ) {
       edm::LogError ("Replacer") 
 	<< "The decay mode W->taunu requires exactly two muons --> returning empty HepMC event !!" << std::endl;
-      return std::auto_ptr<HepMC::GenEvent>(0);
+      return nullptr;
     }
     
     targetParticle1Mass_     = tauMass;
@@ -312,7 +312,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
     if ( muons.size() != 2 ) {
       edm::LogError ("Replacer") 
 	<< "The decay mode W->taunu requires exactly two gen. leptons --> returning empty HepMC event !!" << std::endl;
-      return std::auto_ptr<HepMC::GenEvent>(0);
+      return nullptr;
     }
 
     targetParticle1Mass_     = tauMass;
@@ -335,7 +335,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
   if ( embedParticles.size() != 2 ){
     edm::LogError ("Replacer") 
       << "The creation of gen. particles failed somehow --> returning empty HepMC event !!" << std::endl;	
-    return std::auto_ptr<HepMC::GenEvent>(0);
+    return nullptr;
   }
 
   HepMC::GenEvent* genEvt_output = 0;
@@ -562,7 +562,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
       std::cout << " muon #" << idx << " (charge = " << muon->charge() << "): Pt = " << muon->pt() << ", eta = " << muon->eta() << ", phi = " << muon->phi() << std::endl;
       ++idx;
     }
-    return std::auto_ptr<HepMC::GenEvent>(0);
+    return nullptr;
   }
 
   // use PYTHIA to decay unstable hadrons (e.g. pi0 -> gamma gamma)
@@ -681,7 +681,7 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
       << " differs from transverse momentum of replaced muons = " << sumMuonP4_replaced.pt() << " !!" << std::endl;
   }
 
-  std::auto_ptr<HepMC::GenEvent> passedEvt_output_ptr(passedEvt_output);    
+  std::unique_ptr<HepMC::GenEvent> passedEvt_output_ptr(passedEvt_output);    
   if ( verbosity_ ) {
     passedEvt_output_ptr->print(std::cout);
     std::cout << " numEvents: tried = " << numEvents_tried << ", passed = " << numEvents_passed << std::endl;
@@ -690,8 +690,8 @@ std::auto_ptr<HepMC::GenEvent> ParticleReplacerZtautau::produce(const std::vecto
   delete genVtx_output;
   delete genEvt_output;
   
-  producer->call_put(muonsBeforeRad, "muonsBeforeRad");
-  producer->call_put(muonsAfterRad, "muonsAfterRad");
+  producer->call_put(std::move(muonsBeforeRad), "muonsBeforeRad");
+  producer->call_put(std::move(muonsAfterRad), "muonsAfterRad");
 
   return passedEvt_output_ptr;
 }

--- a/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerZtautau.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ParticleReplacerZtautau.h
@@ -45,7 +45,7 @@ class ParticleReplacerZtautau : public ParticleReplacerBase
 
   virtual void declareExtraProducts(MCParticleReplacer*);
 
-  virtual std::auto_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* = 0, const HepMC::GenEvent* = 0, MCParticleReplacer* = 0);
+  virtual std::unique_ptr<HepMC::GenEvent> produce(const std::vector<reco::Particle>&, const reco::Vertex* = 0, const HepMC::GenEvent* = 0, MCParticleReplacer* = 0);
   virtual void beginRun(edm::Run&, const edm::EventSetup&);
   virtual void beginJob();
   virtual void endJob();

--- a/TauAnalysis/MCEmbeddingTools/plugins/RochesterCorrMuonProducerT.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/RochesterCorrMuonProducerT.h
@@ -55,7 +55,7 @@ class RochesterCorrMuonProducerT : public edm::EDProducer
   {
     //std::cout << "<RochesterCorrMuonProducer>:" << std::endl;
 
-    std::auto_ptr<MuonCollection> correctedMuonCollection(new MuonCollection);
+    std::unique_ptr<MuonCollection> correctedMuonCollection(new MuonCollection);
 
     edm::Handle<MuonCollection> uncorrectedMuonCollection;
     evt.getByLabel(src_, uncorrectedMuonCollection);
@@ -83,7 +83,7 @@ class RochesterCorrMuonProducerT : public edm::EDProducer
       ++idx;
     }
 
-    evt.put(correctedMuonCollection);
+    evt.put(std::move(correctedMuonCollection));
   }
 
   std::string moduleLabel_;

--- a/TauAnalysis/MCEmbeddingTools/plugins/SelectReplacementCandidates.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/SelectReplacementCandidates.cc
@@ -39,22 +39,19 @@ void SelectReplacementCandidates::produce(edm::Event& iEvent, const edm::EventSe
 	vector<uint32_t> hits ;	
 	getRawIDsAdvanced(iEvent, iSetup, &hits, &muon1, false);
 	getRawIDsAdvanced(iEvent, iSetup, &hits, &muon2, false);
-	std::auto_ptr< vector<uint32_t> > selectedHitsAutoPtr(new vector<uint32_t>(hits) );
-	iEvent.put( selectedHitsAutoPtr );
+	iEvent.put(std::make_unique<std::vector<uint32_t>>(hits));
 
 	vector<uint32_t> assoc_hits_withHCAL;   
 	getRawIDsAdvanced(iEvent, iSetup, &assoc_hits_withHCAL, &muon1, true);
 	getRawIDsAdvanced(iEvent, iSetup, &assoc_hits_withHCAL, &muon2, true);
 	std::cout << "found in total " << assoc_hits_withHCAL.size() << " cells with associated hits with hcal\n";
-	std::auto_ptr< vector<uint32_t> > selectedAssocHitsWithHCALAutoPtr(new vector<uint32_t>(assoc_hits_withHCAL) );
-	iEvent.put( selectedAssocHitsWithHCALAutoPtr, "assocHitsWithHCAL");
+	iEvent.put(std::make_unique<std::vector<uint32_t>>(assoc_hits_withHCAL), "assocHitsWithHCAL");
                                                 	
 	std::vector<reco::Muon> muons;
 	transformMuMu2TauTau(&muon1, &muon2);
 	muons.push_back(muon1);
 	muons.push_back(muon2);
-	std::auto_ptr< std::vector<reco::Muon> > selectedMuonsPtr(new std::vector<reco::Muon>(muons) );
-	iEvent.put( selectedMuonsPtr );
+	iEvent.put(std::make_unique<std::vector<reco::Muon>>(muons));
 
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/TeVMuonTrackCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TeVMuonTrackCleaner.cc
@@ -103,7 +103,7 @@ void TeVMuonTrackCleaner::produceTrackExtras(edm::Event& evt, const edm::EventSe
       }
     }
 
-    std::auto_ptr<TrackToTrackMap> trackToTrackMap_cleaned(new TrackToTrackMap(globalMuons_cleaned, trackToTrackMap->refProd().val));
+    std::unique_ptr<TrackToTrackMap> trackToTrackMap_cleaned(new TrackToTrackMap(globalMuons_cleaned, trackToTrackMap->refProd().val));
     
     size_t numGlobalMuons_cleaned = globalMuons_cleaned->size();
     for ( size_t iGlobalMuons_cleaned = 0; iGlobalMuons_cleaned < numGlobalMuons_cleaned; ++iGlobalMuons_cleaned ) {
@@ -128,7 +128,7 @@ void TeVMuonTrackCleaner::produceTrackExtras(edm::Event& evt, const edm::EventSe
       }
     }
     
-    evt.put(trackToTrackMap_cleaned, todoItem->srcTracks_.instance());
+    evt.put(std::move(trackToTrackMap_cleaned), todoItem->srcTracks_.instance());
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/TeVMuonTrackMixer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TeVMuonTrackMixer.cc
@@ -118,7 +118,7 @@ void TeVMuonTrackMixer::produceTrackExtras(edm::Event& evt, const edm::EventSetu
 
     TrackToTrackMap::ref_type::value_type refProd = trackToTrackMap1->refProd().val;
     if(trackToTrackMap1->empty()) refProd = trackToTrackMap2->refProd().val;
-    std::auto_ptr<TrackToTrackMap> trackToTrackMap_output(new TrackToTrackMap(globalMuons_cleaned, refProd));
+    std::unique_ptr<TrackToTrackMap> trackToTrackMap_output(new TrackToTrackMap(globalMuons_cleaned, refProd));
 
     size_t numGlobalMuons_cleaned = globalMuons_cleaned->size();
     for ( size_t iGlobalMuons_cleaned = 0; iGlobalMuons_cleaned < numGlobalMuons_cleaned; ++iGlobalMuons_cleaned ) {
@@ -144,7 +144,7 @@ void TeVMuonTrackMixer::produceTrackExtras(edm::Event& evt, const edm::EventSetu
       }
     }
 
-    evt.put(trackToTrackMap_output, todoItem->srcTrackCollection1_.instance());
+    evt.put(std::move(trackToTrackMap_output), todoItem->srcTrackCollection1_.instance());
   }
 }
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/UniqueObjectSelector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/UniqueObjectSelector.cc
@@ -68,10 +68,10 @@ bool UniqueObjectSelector<T>::filter(edm::Event& evt, const edm::EventSetup& es)
   std::sort(selectedObjects.begin(), selectedObjects.end(), higherRank);
 
   // store in output collection the object which passes selection and is of highest rank
-  std::auto_ptr<ObjectCollection> objects_output(new ObjectCollection());
+  std::unique_ptr<ObjectCollection> objects_output(new ObjectCollection());
   if ( selectedObjects.size() > 0 ) objects_output->push_back(*selectedObjects.front().object_);
 
-  evt.put(objects_output);
+  evt.put(std::move(objects_output));
 
   if ( filter_ ) return (objects_output->size() > 0);
   else return true;

--- a/TauAnalysis/MCEmbeddingTools/plugins/ZmumuEvtSelEffCorrWeightProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/ZmumuEvtSelEffCorrWeightProducer.cc
@@ -24,7 +24,7 @@ ZmumuEvtSelEffCorrWeightProducer::ZmumuEvtSelEffCorrWeightProducer(const edm::Pa
   if ( inputFileName.location() == edm::FileInPath::Unknown) 
     throw cms::Exception("MuonRadiationCorrWeightProducer") 
       << " Failed to find File = " << inputFileName << " !!\n";
-  std::auto_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
+  std::unique_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
 
   std::string lutEfficiencyPtName = cfg.getParameter<std::string>("lutEfficiencyPt");
   TH2* lutEfficiencyPt = dynamic_cast<TH2*>(inputFile->Get(lutEfficiencyPtName.data()));
@@ -129,12 +129,9 @@ void ZmumuEvtSelEffCorrWeightProducer::produce(edm::Event& evt, const edm::Event
     std::cout << "--> weight = " << weight << " + " << (weightUp - weight) << " - " << (weight - weightDown) << std::endl;
   }
 
-  std::auto_ptr<double> weightPtr(new double(weight));
-  evt.put(weightPtr, "weight");
-  std::auto_ptr<double> weightUpPtr(new double(weightUp));
-  evt.put(weightUpPtr, "weightUp");
-  std::auto_ptr<double> weightDownPtr(new double(weightDown));
-  evt.put(weightDownPtr, "weightDown");
+  evt.put(std::make_unique<double>(weight), "weight");
+  evt.put(std::make_unique<double>(weightUp), "weightUp");
+  evt.put(std::make_unique<double>(weightDown), "weightDown");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/src/MuonTrackCleanerBase.cc
+++ b/TauAnalysis/MCEmbeddingTools/src/MuonTrackCleanerBase.cc
@@ -147,7 +147,7 @@ void MuonTrackCleanerBase::produceTracks(edm::Event& evt, const edm::EventSetup&
     edm::Handle<reco::TrackCollection> tracks;
     evt.getByLabel(todoItem->srcTracks_, tracks);
     
-    std::auto_ptr<reco::TrackCollection> tracks_cleaned(new reco::TrackCollection());
+    std::unique_ptr<reco::TrackCollection> tracks_cleaned(new reco::TrackCollection());
 
     reco::TrackRefProd trackCollectionRefProd_cleaned = evt.getRefBeforePut<reco::TrackCollection>(todoItem->srcTracks_.instance());
     size_t idxTrack_cleaned = 0;
@@ -214,6 +214,6 @@ void MuonTrackCleanerBase::produceTracks(edm::Event& evt, const edm::EventSetup&
       if ( removedTracks.size() < selMuons.size() ) ++numWarnings_tooFew_;
     }
     
-    evt.put(tracks_cleaned, todoItem->srcTracks_.instance());
+    evt.put(std::move(tracks_cleaned), todoItem->srcTracks_.instance());
   }
 }

--- a/TauAnalysis/MCEmbeddingTools/src/TrackMixerBase.cc
+++ b/TauAnalysis/MCEmbeddingTools/src/TrackMixerBase.cc
@@ -58,7 +58,7 @@ void TrackMixerBase::produceTracks(edm::Event& evt, const edm::EventSetup& es)
 		<< " #entries = " << trackCollection2->size() << std::endl;
     }
 
-    std::auto_ptr<reco::TrackCollection> trackCollection_output(new reco::TrackCollection());
+    std::unique_ptr<reco::TrackCollection> trackCollection_output(new reco::TrackCollection());
 
     reco::TrackRefProd trackCollectionRefProd_output = evt.getRefBeforePut<reco::TrackCollection>(todoItem->srcTrackCollection1_.instance());
     size_t idxTrack_output = 0;
@@ -91,6 +91,6 @@ void TrackMixerBase::produceTracks(edm::Event& evt, const edm::EventSetup& es)
       }
     }  
 
-    evt.put(trackCollection_output, todoItem->srcTrackCollection1_.instance());
+    evt.put(std::move(trackCollection_output), todoItem->srcTrackCollection1_.instance());
   }
 }


### PR DESCRIPTION
In preparation for removing framework support for auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in the two Analysis packages that still put auto_ptrs.
Also, std::make_unique is used when appropriate in put() calls. Also, one function that passed an auto_ptr by reference (a bad practice) is modified to pass the unique_ptr by value, so that the transfer of ownership is explicit rather than obscured.
