### PR TITLE
Fixing static analyzer errors in PFCandidate.cc

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -158,6 +158,7 @@ PFCandidate::PFCandidate( PFCandidate const& iOther) :
   if(nullptr != tmp) {
     elementsInBlocks_.store( new ElementsInBlocks{*tmp}, std::memory_order_release);
   }
+    delete tmp;
 }
 
 PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
@@ -168,6 +169,7 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   } else {
     delete elementsInBlocks_.exchange(nullptr, std::memory_order_acq_rel);
   }
+  delete tmp;
   blocksStorage_=iOther.blocksStorage_;
   elementsStorage_=iOther.elementsStorage_;
   sourcePtr_=iOther.sourcePtr_;
@@ -680,7 +682,6 @@ const math::XYZPoint & PFCandidate::vertex() const {
 
 const PFCandidate::ElementsInBlocks& 
 PFCandidate::elementsInBlocks() const { 
-      
   if (nullptr == elementsInBlocks_.load(std::memory_order_acquire))
     {
       std::unique_ptr<ElementsInBlocks> temp( new ElementsInBlocks(blocksStorage_.size()));
@@ -690,6 +691,7 @@ PFCandidate::elementsInBlocks() const {
       if(elementsInBlocks_.compare_exchange_strong(expected,temp.get(),std::memory_order_acq_rel)) {
 	temp.release();
       }
+      temp.get_deleter();
     }
   return *(elementsInBlocks_.load(std::memory_order_acquire));
 }


### PR DESCRIPTION
Fixing Memory Leaks in DataFormats/ParticleFlowCandidate/src/PFCandidate.cc

Error 1: DataFormats/ParticleFlowCandidate/src/PFCandidate.cc [Memory error] [Memory Leak] [PFCandidate]—line 161 —Memory is Allocated but not released.

https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-08-08-1100/slc6_amd64_gcc530/llvm-analysis/report-18b31d.html#EndPath

> Fix it by :  delete tmp; in line 161

Error 2: /DataFormats/ParticleFlowCandidate/src/PFCandidate.cc [Memory error] [Memory Leak] [operator=]-line 167

https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-08-08-1100/slc6_amd64_gcc530/llvm-analysis/report-3a4600.html#EndPath

> Fix it by :  delete tmp; in line 172

Error 3: DataFormats/ParticleFlowCandidate/src/PFCandidate.cc [Memory error] [Memory Leak] [elementsInBlocks]—line 694

https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-08-08-1100/slc6_amd64_gcc530/llvm-analysis/report-4dc31c.html#EndPath

> temp.get_deleter(); in 695

Regarding the memory leak in [elementsInBlocks]—line 694:
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-08-08-1100/slc6_amd64_gcc530/llvm-analysis/report-4dc31c.html#EndPath

I am a little confused by this, why do we have a memory leak error here when unique_ptr is a smart pointer and the object managed by it in this instance should be destroyed and its memory deallocated when it goes out of scope. However, since it shows up as an error, in my fix the object is destroyed using "get_deleter()". The deleter calls the destructor of the object and dispenses the memory. 
