### PR TITLE
JetMET validation for Phase2 full reco

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -1,12 +1,13 @@
 autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLiteTracking','validationHarvesting'],
                    'trackingOnlyValidation' : ['globalPrevalidationTrackingOnly','globalValidationTrackingOnly','postValidation_trackingOnly'],
                    'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
+                   'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
                    'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
                    'miniAODValidation' : ['prevalidationMiniAOD','validationMiniAOD','validationHarvestingMiniAOD'],
                    'standardValidation' : ['prevalidation','validation','validationHarvesting']
                  }
 
-_phase2_allowed = ['baseValidation','trackingOnlyValidation','muonOnlyValidation']
+_phase2_allowed = ['baseValidation','trackingOnlyValidation','muonOnlyValidation','JetMETOnlyValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([autoValidation[m][i] for m in _phase2_allowed])

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -126,6 +126,17 @@ globalPrevalidationTrackingOnly = cms.Sequence(
 )
 globalValidationTrackingOnly = cms.Sequence()
 
+
+globalValidationJetMETonly = cms.Sequence(
+                                   JetValidation 
+                                 + METValidation
+)
+
+globalPrevalidationJetMETOnly = cms.Sequence(
+				   jetPreValidSeq
+				  +metPreValidSeq
+)
+
 globalPrevalidationMuons = cms.Sequence(
       gemSimValid
     + me0SimValid

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -75,6 +75,10 @@ postValidation_muons = cms.Sequence(
     + MuonGEMRecHitsPostProcessors
     + rpcRecHitPostValidation_step
 )
+
+postValidation_JetMET = cms.Sequence(
+    METPostProcessor
+)
  
 postValidation_gen = cms.Sequence(
     EventGeneratorPostProcessor


### PR DESCRIPTION
JetMet validation (w/o DQM portion) for the Phase2 full reco.
This is only a temporary solution until all other sub-systems are prepared for running the standard validation

Supersedes PR15407

@kpedro88 
