### PR TITLE
2017 HCAL Trigger Primitives

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -32,8 +32,10 @@ public:
 
   HcaluLUTTPGCoder(const HcalTopology* topo);
   virtual ~HcaluLUTTPGCoder();
-  virtual void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const;
-  virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const;
+  virtual void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
+  virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
+  virtual void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
+  virtual void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const override;
   virtual void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const;
   virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const;
   virtual float getLUTPedestal(HcalDetId id) const;
@@ -58,6 +60,7 @@ private:
 
   // constants
   static const size_t INPUT_LUT_SIZE = 128;
+  static const size_t UPGRADE_LUT_SIZE = 256;
   static const int    nFi_ = 72;
   
   // member variables
@@ -68,6 +71,7 @@ private:
   int  firstHEEta_, lastHEEta_, nHEEta_, maxDepthHE_, sizeHE_;
   int  firstHFEta_, lastHFEta_, nHFEta_, maxDepthHF_, sizeHF_;
   std::vector< Lut > inputLUT_;
+  std::vector< Lut > upgradeLUT_;
   std::vector<float> gain_;
   std::vector<float> ped_;
 };

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -62,6 +62,10 @@ private:
   static const size_t INPUT_LUT_SIZE = 128;
   static const size_t UPGRADE_LUT_SIZE = 256;
   static const int    nFi_ = 72;
+
+  static const int QIE8_LUT_BITMASK = 0x3FF;
+  static const int QIE10_LUT_BITMASK = 0x7FF;
+  static const int QIE11_LUT_BITMASK = 0x3FF;
   
   // member variables
   const HcalTopology* topo_;
@@ -71,7 +75,8 @@ private:
   int  firstHEEta_, lastHEEta_, nHEEta_, maxDepthHE_, sizeHE_;
   int  firstHFEta_, lastHFEta_, nHFEta_, maxDepthHF_, sizeHF_;
   std::vector< Lut > inputLUT_;
-  std::vector< Lut > upgradeLUT_;
+  std::vector< Lut > upgradeQIE10LUT_;
+  std::vector< Lut > upgradeQIE11LUT_;
   std::vector<float> gain_;
   std::vector<float> ped_;
 };

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -325,9 +325,9 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
             QIE10DataFrame upgradeFrame(edm::DataFrame(0, data, 4));
             CaloSamples upgradeSamples(cell, 1);
             for (unsigned int adc = 0; adc < UPGRADE_LUT_SIZE; ++adc) {
-               upgradeFrame.setSample(0, adc, 0, 0, cell.ieta() > 0 ? 1 : 0, true);
+               upgradeFrame.setSample(0, adc, 0, 0, 0, true);
                coder.adc2fC(upgradeFrame, upgradeSamples);
-               float adc2fC = samples[0];
+               float adc2fC = upgradeSamples[0];
 
                if (isMasked)
                   upgradeLUT_[lutId][adc] = 0;
@@ -359,6 +359,11 @@ void HcaluLUTTPGCoder::adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics
 }
 
 void HcaluLUTTPGCoder::adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const {
+  int lutId = getLUTId(HcalDetId(df.id()));
+  const Lut& lut = inputLUT_.at(lutId);
+  for (int i=0; i<df.samples(); i++){
+    ics[i] = (lut.at(df[i].adc()) & 0x3FF);
+  }
 }
 
 void HcaluLUTTPGCoder::adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const {

--- a/CalibFormats/HcalObjects/interface/HcalTPGCoder.h
+++ b/CalibFormats/HcalObjects/interface/HcalTPGCoder.h
@@ -5,6 +5,8 @@
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HcalTriggerPrimitiveDigi.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 
 // forward declaration of EventSetup is all that is needed here
 namespace edm {
@@ -25,6 +27,8 @@ class HcalTPGCoder {
 public:
   virtual void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const = 0;
   virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const = 0;
+  virtual void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const = 0;
+  virtual void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const = 0;
   virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const = 0;
   unsigned short adc2Linear(unsigned char adc, HcalDetId id) const { return adc2Linear(HcalQIESample(adc,0,0,0),id); }
   virtual void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const = 0;

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -140,6 +140,10 @@ def customise_HcalPhase1(process):
         process=customise_harvesting(process)
     if hasattr(process,'validation_step'):
         process=customise_Validation(process)
+    if hasattr(process,'simHcalTriggerPrimitiveDigis'):
+        process.simHcalTriggerPrimitiveDigis.upgradeHF = cms.bool(True)
+        process.simHcalTriggerPrimitiveDigis.upgradeHE = cms.bool(True)
+        process.simHcalTriggerPrimitiveDigis.upgradeHB = cms.bool(True)
     process=customise_condOverRides(process)
     return process
 

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -91,6 +91,8 @@ def customise_Hcal2017(process):
         process.globalReplace("hfreco", hfreco)
     if hasattr(process,'datamixing_step'):
         process=customise_mixing(process)
+    if hasattr(process,'simHcalTriggerPrimitiveDigis'):
+        process.simHcalTriggerPrimitiveDigis.upgradeHF = cms.bool(True)
     
     return process
     
@@ -108,6 +110,9 @@ def customise_Hcal2017Full(process):
         process.hbheprereco.saveInfos = cms.bool(True)
         process.hbheprereco.digiLabelQIE8 = cms.InputTag("simHcalDigis")
         process.hbheprereco.digiLabelQIE11 = cms.InputTag("simHcalDigis", "HBHEQIE11DigiCollection")
+
+    if hasattr(process,'simHcalTriggerPrimitiveDigis'):
+        process.simHcalTriggerPrimitiveDigis.upgradeHE = cms.bool(True)
 
     return process
     

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -20,6 +20,16 @@ class IntegerCaloSamples;
 
 class HcalTriggerPrimitiveAlgo {
 public:
+   struct DatabaseParameters {
+      // TEMPORARY
+      // This parameters should be in the conditions, this struct is
+      // temporary container to hardcode them.
+
+      uint64_t hf_tdc_mask = 0x200000FFFFFFFFFF;
+      // uint64_t hf_tdc_mask = 0x2FFFFFFFFFFFFFFF;
+      uint16_t hf_adc_thresh = 0;
+   };
+
   HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, 
                            int latency,
                            bool FG_MinimumBias, uint32_t FG_threshold, uint32_t ZS_threshold,
@@ -116,6 +126,8 @@ public:
   uint32_t PMT_NoiseThreshold_; 
   int NCTScaleShift;
   int RCTScaleShift;  
+
+  DatabaseParameters params_;
 
   // Algo1: isPeak = TS[i-1] < TS[i] && TS[i] >= TS[i+1]
   // Algo2: isPeak = TSS[i-1] < TSS[i] && TSS[i] >= TSS[i+1],

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -20,23 +20,17 @@ class IntegerCaloSamples;
 
 class HcalTriggerPrimitiveAlgo {
 public:
-   struct DatabaseParameters {
-      // TEMPORARY
-      // This parameters should be in the conditions, this struct is
-      // temporary container to hardcode them.
-
-      uint64_t hf_tdc_mask = 0x200000FFFFFFFFFF;
-      // uint64_t hf_tdc_mask = 0x2FFFFFFFFFFFFFFF;
-      uint16_t hf_adc_thresh = 0;
+   struct TPParameters {
+      uint64_t hf_tdc_mask;
+      uint32_t hf_adc_threshold;
+      uint32_t hf_fg_threshold;
    };
 
-  HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, 
-                           int latency,
-                           bool FG_MinimumBias, uint32_t FG_threshold, uint32_t ZS_threshold,
+  HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, int latency,
+                           uint32_t FG_threshold, uint32_t ZS_threshold,
                            int numberOfSamples,   int numberOfPresamples,
                            int numberOfSamplesHF, int numberOfPresamplesHF,
-                           uint32_t minSignalThreshold=0, uint32_t PMT_NoiseThreshold=0,
-                           bool upgrade_hb=false, bool upgrade_he=false, bool upgrade_hf=false);
+                           uint32_t minSignalThreshold=0, uint32_t PMT_NoiseThreshold=0);
   ~HcalTriggerPrimitiveAlgo();
 
   template<typename... Digis>
@@ -76,6 +70,11 @@ public:
   void setNCTScaleShift(int);
   void setRCTScaleShift(int);
 
+  void setUpgradeFlags(bool hb, bool he, bool hf);
+  void overrideParameters(unsigned int hf_tdc_mask,
+                          unsigned int hf_adc_threshold,
+                          unsigned int hf_fg_threshold);
+
  private:
 
   /// adds the signal to the map
@@ -114,7 +113,6 @@ public:
   bool peakfind_;
   std::vector<double> weights_;
   int latency_;
-  bool FG_MinimumBias_;
   uint32_t FG_threshold_;
   uint32_t ZS_threshold_;
   int ZS_threshold_I_;
@@ -126,8 +124,6 @@ public:
   uint32_t PMT_NoiseThreshold_; 
   int NCTScaleShift;
   int RCTScaleShift;  
-
-  DatabaseParameters params_;
 
   // Algo1: isPeak = TS[i-1] < TS[i] && TS[i] >= TS[i+1]
   // Algo2: isPeak = TSS[i-1] < TSS[i] && TSS[i] >= TSS[i+1],
@@ -179,9 +175,11 @@ public:
   typedef std::map<HcalTrigTowerDetId, std::vector<bool> > FGbitMap;
   FGbitMap fgMap_;
 
-  bool upgrade_hb_;
-  bool upgrade_he_;
-  bool upgrade_hf_;
+  bool upgrade_hb_ = false;
+  bool upgrade_he_ = false;
+  bool upgrade_hf_ = false;
+
+  std::unique_ptr<const TPParameters> override_parameters_;
 
   static const int first_he_tower = 16;
 };

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -78,6 +78,8 @@ public:
 
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);
+  // Phase1: QIE11
+  void analyzePhase1(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
   // Version 0: RCT
   void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, const int hf_lumi_shift);
   // Version 1: 1x1
@@ -88,7 +90,7 @@ public:
           const HcalFeatureBit* HCALFEM
           );
   // With dual anode readout
-  void analyzeHF2017(
+  void analyzeHFPhase1(
           const IntegerCaloSamples& SAMPLES,
           HcalTriggerPrimitiveDigi& result,
           const int HF_LUMI_SHIFT,
@@ -169,6 +171,7 @@ public:
   bool upgrade_he_;
   bool upgrade_hf_;
 
+  static const int first_he_tower = 16;
 };
 
 template<typename... Digis>
@@ -203,15 +206,21 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
             analyzeHF(mapItr->second, result.back(), RCTScaleShift);
          } else if (detId.version() == 1) {
             if (upgrade_hf_)
-               analyzeHF2017(mapItr->second, result.back(), NCTScaleShift, LongvrsShortCut);
+               analyzeHFPhase1(mapItr->second, result.back(), NCTScaleShift, LongvrsShortCut);
             else
                analyzeHF2016(mapItr->second, result.back(), NCTScaleShift, LongvrsShortCut);
          } else {
             // Things are going to go poorly
          }
       }
-      else { 
-         analyze(mapItr->second, result.back());
+      else {
+         if (upgrade_he_ and abs(detId.ieta()) >= first_he_tower) {
+            analyzePhase1(mapItr->second, result.back());
+         } else if (upgrade_hb_ and detId.subdet() < first_he_tower) {
+            analyzePhase1(mapItr->second, result.back());
+         } else {
+            analyze(mapItr->second, result.back());
+         }
       }
    }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -33,7 +33,7 @@ public:
            const HBHEDigiCollection& hbheDigis,
            const HFDigiCollection& hfDigis,
            HcalTrigPrimDigiCollection& result,
-	   const HcalTrigTowerGeometry* trigTowerGeometry,
+           const HcalTrigTowerGeometry* trigTowerGeometry,
            float rctlsb, const HcalFeatureBit* LongvrsShortCut=0);
 
   void runZS(HcalTrigPrimDigiCollection& tp);

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -24,6 +24,10 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
     LSConfig=LSParameter,
+
+    upgradeHF = cms.bool(False),
+    upgradeHB = cms.bool(False),
+    upgradeHE = cms.bool(False),
     
     
 #
@@ -31,6 +35,9 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     # Input digi label (_must_ be without zero-suppression!)
     inputLabel = cms.VInputTag(cms.InputTag('simHcalUnsuppressedDigis'),
                                cms.InputTag('simHcalUnsuppressedDigis')),
+    inputUpgradeLabel = cms.VInputTag(
+        cms.InputTag('simHcalUnsuppressedDigis:HBHEQIE11DigiCollection'),
+        cms.InputTag('simHcalUnsuppressedDigis:HFQIE10DigiCollection')),
     InputTagFEDRaw = cms.InputTag("rawDataCollector"),
     RunZS = cms.bool(False),
     FrontEndFormatError = cms.bool(False), # Front End Format Error, for real data only

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -28,6 +28,12 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     upgradeHF = cms.bool(False),
     upgradeHB = cms.bool(False),
     upgradeHE = cms.bool(False),
+
+    parameters = cms.untracked.PSet(
+        TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
+        ADCThreshold=cms.uint32(0),
+        FGThreshold=cms.uint32(12)
+    ),
     
     
 #

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -25,7 +25,11 @@ private:
 
   /// input tags for HCAL digis
   std::vector<edm::InputTag> inputLabel_;
+  std::vector<edm::InputTag> inputUpgradeLabel_;
   // this seems a strange way of doing things
+  edm::EDGetTokenT<QIE11DigiCollection> tok_hbhe_up_;
+  edm::EDGetTokenT<QIE10DigiCollection> tok_hf_up_;
+
   edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HFDigiCollection> tok_hf_;
 
@@ -37,6 +41,9 @@ private:
   bool runZS_;
 
   bool runFrontEndFormatError_;
+
+  bool upgrade_;
+  bool legacy_;
 
   bool HFEMB_;
   edm::ParameterSet LongShortCut_;


### PR DESCRIPTION
Rough implementation of 2017 HCAL Trigger Primitives using QIE10/11.

Adding:
- Linearization LUTs for QIE10/11
- HF TP with QIE10 dual-anode read-out and energy recovery
- HE TP with QIE11

Finegrain bits will come with a later pull request.
