### PR TITLE
split out era definitions into separate python files,

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C1_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C1_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Phase2C1 = cms.ModifierChain(run2_common, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_muon, run3_GEM)
+

--- a/Configuration/Eras/python/Era_Phase2C2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C2_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Phase2C2 = cms.ModifierChain(run2_common, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_hcal, phase2_hgcal, phase2_muon, run3_GEM)
+

--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+
+Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, ctpps_2016)
+

--- a/Configuration/Eras/python/Era_Run2_2016_trackingLowPU_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_trackingLowPU_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
+
+Run2_2016_trackingLowPU = cms.ModifierChain(Run2_2016, trackingLowPU)
+

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+
+Run2_2017 = cms.ModifierChain(Run2_2016, phase1Pixel, trackingPhase1, run2_HE_2017)
+

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
+
+Run2_2017_trackingPhase1PU70 = cms.ModifierChain(Run2_2016, phase1Pixel, trackingPhase1PU70)
+

--- a/Configuration/Eras/python/Era_Run2_2017_trackingRun2_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingRun2_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+Run2_2017_trackingRun2 = cms.ModifierChain(Run2_2016, phase1Pixel)
+

--- a/Configuration/Eras/python/Era_Run2_25ns_cff.py
+++ b/Configuration/Eras/python/Era_Run2_25ns_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+
+Run2_25ns = cms.ModifierChain(run2_common, run2_25ns_specific, stage1L1Trigger)
+

--- a/Configuration/Eras/python/Era_Run2_50ns_cff.py
+++ b/Configuration/Eras/python/Era_Run2_50ns_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_run2_50ns_specific_cff import run2_50ns_specific
+
+Run2_50ns = cms.ModifierChain(run2_common, run2_50ns_specific)
+

--- a/Configuration/Eras/python/Era_Run2_HI_cff.py
+++ b/Configuration/Eras/python/Era_Run2_HI_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+
+Run2_HI = cms.ModifierChain(run2_common, run2_HI_specific, stage1L1Trigger)
+

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Run3 = cms.ModifierChain(Run2_2017, run3_GEM)
+

--- a/Configuration/Eras/python/Modifier_Run1_cff.py
+++ b/Configuration/Eras/python/Modifier_Run1_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+Run1 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_ctpps_2016_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_2016_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps_2016 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_fastSim_cff.py
+++ b/Configuration/Eras/python/Modifier_fastSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+fastSim =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase1Pixel_cff.py
+++ b/Configuration/Eras/python/Modifier_phase1Pixel_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase1Pixel =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase2_common_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_common_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_common =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase2_hcal_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_hcal_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_hcal =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase2_hgcal_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_hgcal_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_hgcal =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase2_muon_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_muon_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_muon =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_phase2_tracker_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_tracker_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_tracker =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run2_25ns_specific_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_25ns_specific_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_25ns_specific =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run2_50ns_specific_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_50ns_specific_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_50ns_specific =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run2_HE_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_HE_2017_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_HE_2017 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run2_HI_specific_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_HI_specific_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_HI_specific =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run2_common_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_common_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_common =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_run3_GEM_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_GEM_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_GEM =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_stage1L1Trigger_cff.py
+++ b/Configuration/Eras/python/Modifier_stage1L1Trigger_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+stage1L1Trigger =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_trackingLowPU_cff.py
+++ b/Configuration/Eras/python/Modifier_trackingLowPU_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+trackingLowPU =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_trackingPhase1PU70_cff.py
+++ b/Configuration/Eras/python/Modifier_trackingPhase1PU70_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+trackingPhase1PU70 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_trackingPhase1_cff.py
+++ b/Configuration/Eras/python/Modifier_trackingPhase1_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+trackingPhase1 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_trackingPhase2PU140_cff.py
+++ b/Configuration/Eras/python/Modifier_trackingPhase2PU140_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+trackingPhase2PU140 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -1,90 +1,64 @@
 import FWCore.ParameterSet.Config as cms
+from  FWCore.ParameterSet.Config import ModifierChain,Modifier
 
 class Eras (object):
     """
     Dummy container for all the cms.Modifier instances that config fragments
     can use to selectively configure depending on what scenario is active.
     """
-    def __init__(self):
-        # These eras should not be set directly by the user.
-        self.run2_common = cms.Modifier()
-        self.run2_25ns_specific = cms.Modifier()
-        self.run2_50ns_specific = cms.Modifier()
-        self.run2_HI_specific = cms.Modifier()
-        self.run2_HE_2017 = cms.Modifier()
-        self.ctpps_2016 = cms.Modifier()
-        self.stage1L1Trigger = cms.Modifier()
-        self.stage2L1Trigger = cms.Modifier()
-        self.phase1Pixel = cms.Modifier()
-        # Implementation note: When this was first started, stage1L1Trigger wasn't in all
-        # of the eras. Now that it is, it could in theory be dropped if all changes are
-        # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
-        # "run2_common" over the whole python tree). In practice, I don't think it's worth
-        # it, and this also gives the flexibilty to take it out easily.
-        self.run3_GEM = cms.Modifier()
+    def addEra(self,name,obj):
+        setattr(self,name,obj)
 
-        # Phase 2 sub-eras for stable features
-        self.phase2_common = cms.Modifier()
-        self.phase2_hcal = cms.Modifier()
-        self.phase2_tracker = cms.Modifier()
-        self.phase2_hgcal = cms.Modifier()
-        self.phase2_muon = cms.Modifier()
+    def inspectModifier(self,m,details):
+        print '      ',m.__dict__ ['_Modifier__processModifiers']
 
-        # These eras are used to specify the tracking configuration
-        # when it should differ from the default (which is Run2). This
-        # way the tracking configuration is decoupled from the
-        # detector geometry to allow e.g. running Run2 tracking on
-        # phase1Pixel detector.
-        self.trackingPhase1 = cms.Modifier()
-        self.trackingPhase1PU70 = cms.Modifier()
-        self.trackingLowPU = cms.Modifier()
-        self.trackingPhase2PU140 = cms.Modifier()
-        
-        # This era should not be set by the user with the "--era" command, it's
-        # activated automatically if the "--fast" command is used.
-        self.fastSim = cms.Modifier()
-        
-        #
-        # These are the eras that the user should specify
-        #
-        # Run1 currently does nothing. It's useful to use as a no-operation era commands when scripting,
-        # but also retains the flexibility to add Run1 specific commands at a later date.
-        self.Run1 = cms.Modifier()
-        # The various Run2 scenarios for 2015 startup.
-        self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
-        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
-        self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
-        # Future Run 2 scenarios.
-        self.Run2_2016 = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage2L1Trigger, self.ctpps_2016 )
-        self.Run2_2017 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1, self.run2_HE_2017 )
-        # Scenarios further afield.
-        # Run3 includes the GE1/1 upgrade
-        self.Run3 = cms.ModifierChain( self.Run2_2017,self.run3_GEM )
-        # Phase2 is everything for the 2023 (2026?) detector that works so far in this release.
-        self.Phase2C1 = cms.ModifierChain( self.run2_common, self.phase2_common, self.phase2_tracker, self.trackingPhase2PU140, self.phase2_muon, self.run3_GEM )
-        self.Phase2C2 = cms.ModifierChain( self.run2_common, self.phase2_common, self.phase2_tracker, self.trackingPhase2PU140, self.phase2_hcal, self.phase2_hgcal, self.phase2_muon, self.run3_GEM )
+    def inspectEra(self,e,details):
+        print '\nEra:',e
+        print '   isChosen:',getattr(self,e).isChosen()
+        if details: print '   Modifiers:'
+        nmod=0
+        for value in getattr(self,e).__dict__['_ModifierChain__chain']:
+            if type(value)==Modifier:
+                nmod=nmod+1
+                if details: self.inspectModifier(value,details)
+        print '   ',nmod,'modifiers defined' 
 
-        # Scenarios with low-PU tracking (for B=0T reconstruction)
-        self.Run2_2016_trackingLowPU = cms.ModifierChain(self.Run2_2016, self.trackingLowPU)
+    def inspect(self,name=None,onlyChosen=False,details=True):
+        if name==None:
+            print 'Inspecting the known eras',
+            if onlyChosen: print ' (all active)'
+            else: print '(all eras defined)'
+        else:
+            print 'Inspecting the '+name+' era',
 
-        # 2017 scenarios with customized tracking for expert use
-        # Will be used as reference points for 2017 tracking development
-        self.Run2_2017_trackingPhase1PU70 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel, self.trackingPhase1PU70 )
-        self.Run2_2017_trackingRun2 = cms.ModifierChain( self.Run2_2016, self.phase1Pixel ) # no tracking-era = Run2 tracking
-        
-        # The only thing this collection is used for is for cmsDriver to
-        # warn the user if they specify an era that is discouraged from being
-        # set directly. It also stops these eras being printed in the error
-        # message of available values when an invalid era is specified.
-        self.internalUseEras = [self.run2_common, self.run2_25ns_specific,
-                                self.run2_50ns_specific, self.run2_HI_specific,
-                                self.stage1L1Trigger, self.fastSim,
-                                self.run2_HE_2017, self.stage2L1Trigger,
-                                self.phase1Pixel, self.run3_GEM,
-                                self.phase2_common, self.phase2_tracker,
-                                self.phase2_hgcal, self.phase2_muon,
-                                self.phase2_hcal,
-                                self.trackingLowPU, self.trackingPhase1, self.trackingPhase1PU70,
-                               ]
+        allEras=[]
+        for key, value in self.__dict__.items():
+            if type(value)==ModifierChain: allEras.append(key)
+
+        for e in allEras:
+            if name is not None and name==e:
+                self.inspectEra(e,details)
+            if name is None:
+                if not onlyChosen or getattr(self,e).isChosen(): 
+                    self.inspectEra(e,details)
+
 
 eras=Eras()
+
+allEras=['Run2_50ns',
+         'Run2_25ns',
+         'Run2_HI',
+         'Run2_2016',
+         'Run2_2016_trackingLowPU',
+         'Run2_2017',
+         'Run2_2017_trackingRun2',
+         'Run2_2017_trackingPhase1PU70',
+         'Run3',
+         'Phase2C1',
+         'Phase2C2']
+
+for e in allEras:
+    eObj=getattr(__import__('Configuration.Eras.Era_'+e+'_cff',globals(),locals(),[e],0),e)
+    eras.addEra(e,eObj)
+
+#eras.inspect()


### PR DESCRIPTION
split out era definitions into separate python files, and start an era inspection tool (lots of work needed there)

Eras.py still survives. Hopefully in a way that does not require 100+ files to be recompiled aside from when a new era is defined. This can be further improved by removing the central Eras.py file - this means changing all of the users os Eras.py to import the Modifier(s) that they will use instead of the central Eras.py. I think we can start enforcing this and at the same time go back and modify the packages using this Eras.py - but not for today. (once done, the cmsDriver change needed is ~trivial)
