### PR TITLE
Remove generator related PAT collections when running on data

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -42,14 +42,6 @@ class RunOnData(ConfigToolBase):
 
         print '******************* RunOnData *******************'
         removeMCMatching(process, names=names, postfix=postfix, outputModules=outputModules)
-        modStringsToRemove = [
-            'patJetGenJet', 
-            'GenParticle', 
-            'slimmedGenJets', 
-            'tauGenJet', 
-            'patJetFlavourAssociation', 
-            'patJetParton',
-        ]
         for mod in process.producerNames().split():
             if mod.startswith('patJetCorrFactors'):
                 prefix = getattr(process, mod).payload.pythonValue().replace("'","")
@@ -63,8 +55,6 @@ class RunOnData(ConfigToolBase):
                             idx = getattr(process,prefix+'CombinedCorrector'+postfix).correctors.index(prefix+'L3Absolute')+1
                             getattr(process,prefix+'CombinedCorrector'+postfix).correctors.insert(idx, prefix+'L2L3Residual')
                             print 'adding L2L3Residual for TypeI MET correction:', getattr(process,prefix+'CombinedCorrector'+postfix).label_()
-            if any(x in mod for x in modStringsToRemove):
-                delattr(process,mod)
 
 runOnData=RunOnData()
 
@@ -108,6 +98,7 @@ class RemoveMCMatching(ConfigToolBase):
         outputModules=self._parameters['outputModules'].value
 
         print "************** MC dependence removal ************"
+        attrsToDelete = []
         for obj in range(len(names)):
             if( names[obj] == 'Photons'   or names[obj] == 'All' ):
                 print "removing MC dependencies for photons"
@@ -125,7 +116,10 @@ class RemoveMCMatching(ConfigToolBase):
                 tauProducer = getattr(process,'patTaus'+postfix)
                 tauProducer.addGenJetMatch   = False
                 tauProducer.embedGenJetMatch = False
+                attrsToDelete += [tauProducer.genJetMatch.getModuleLabel()]
                 tauProducer.genJetMatch      = ''
+                attrsToDelete += ['tauGenJets'+postfix]
+                attrsToDelete += ['tauGenJetsSelectorAllHadrons'+postfix]
             #Boosted Taus
             if( names[obj] == 'TausBoosted'      or names[obj] == 'All' ):
                 print "removing MC dependencies for taus boosted %s" %postfix
@@ -135,7 +129,10 @@ class RemoveMCMatching(ConfigToolBase):
                     tauProducer = getattr(process,'patTausBoosted'+postfix)
                     tauProducer.addGenJetMatch   = False
                     tauProducer.embedGenJetMatch = False
+                    attrsToDelete += [tauProducer.genJetMatch.getModuleLabel()]
                     tauProducer.genJetMatch      = ''
+                    attrsToDelete += ['tauGenJetsBoosted'+postfix]
+                    attrsToDelete += ['tauGenJetsSelectorAllHadronsBoosted'+postfix]
                 else :
                     print "...skipped since taus boosted %s" %postfix, "are not part of process."  
             if( names[obj] == 'Jets'      or names[obj] == 'All' ):
@@ -149,14 +146,19 @@ class RemoveMCMatching(ConfigToolBase):
                     jetProducer = getattr(process, jetCollectionString()+pfix)
                     jetProducer.addGenPartonMatch   = False
                     jetProducer.embedGenPartonMatch = False
+                    attrsToDelete += [jetProducer.genPartonMatch.getModuleLabel()]
                     jetProducer.genPartonMatch      = ''
                     jetProducer.addGenJetMatch      = False
+                    attrsToDelete += [jetProducer.genJetMatch.getModuleLabel()]
                     jetProducer.genJetMatch         = ''
                     jetProducer.getJetMCFlavour     = False
                     jetProducer.useLegacyJetMCFlavour = False
                     jetProducer.addJetFlavourInfo   = False
+                    attrsToDelete += [jetProducer.JetPartonMapSource.getModuleLabel()]
                     jetProducer.JetPartonMapSource  = ''
+                    attrsToDelete += [jetProducer.JetFlavourInfoSource.getModuleLabel()]
                     jetProducer.JetFlavourInfoSource = ''
+                    attrsToDelete += ['slimmedGenJets'+pfix]
                 ## adjust output
                 for outMod in outputModules:
                     if hasattr(process,outMod):
@@ -171,7 +173,15 @@ class RemoveMCMatching(ConfigToolBase):
                         ## remove mc extra configs for MET
                         metProducer = getattr(process, mod)
                         metProducer.addGenMET           = False
+                        attrsToDelete += [metProducer.genMETSource.getModuleLabel()]
                         metProducer.genMETSource        = ''
+        attrsToDelete += [
+            'prunedGenParticles',
+            'prunedGenParticlesWithStatusOne',
+            'packedGenParticles',
+        ]
+        for attr in attrsToDelete:
+            if hasattr(process,attr): delattr(process,attr)
 
 removeMCMatching=RemoveMCMatching()
 
@@ -180,4 +190,6 @@ def _removeMCMatchingForPATObject(process, matcherName, producerName, postfix=""
     objectProducer = getattr(process, producerName+postfix)
     objectProducer.addGenMatch      = False
     objectProducer.embedGenMatch    = False
+    attr = objectProducer.genParticleMatch.getModuleLabel()
+    if hasattr(process,attr): delattr(process,attr)
     objectProducer.genParticleMatch = ''

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -55,6 +55,8 @@ class RunOnData(ConfigToolBase):
                             idx = getattr(process,prefix+'CombinedCorrector'+postfix).correctors.index(prefix+'L3Absolute')+1
                             getattr(process,prefix+'CombinedCorrector'+postfix).correctors.insert(idx, prefix+'L2L3Residual')
                             print 'adding L2L3Residual for TypeI MET correction:', getattr(process,prefix+'CombinedCorrector'+postfix).label_()
+            if 'patJetGenJet' in mod or 'GenParticle' in mod or 'slimmedGenJets' in mod or 'tauGenJet' in mod:
+                delattr(process,mod)
 
 runOnData=RunOnData()
 

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -42,6 +42,14 @@ class RunOnData(ConfigToolBase):
 
         print '******************* RunOnData *******************'
         removeMCMatching(process, names=names, postfix=postfix, outputModules=outputModules)
+        modStringsToRemove = [
+            'patJetGenJet', 
+            'GenParticle', 
+            'slimmedGenJets', 
+            'tauGenJet', 
+            'patJetFlavourAssociation', 
+            'patJetParton',
+        ]
         for mod in process.producerNames().split():
             if mod.startswith('patJetCorrFactors'):
                 prefix = getattr(process, mod).payload.pythonValue().replace("'","")
@@ -55,7 +63,7 @@ class RunOnData(ConfigToolBase):
                             idx = getattr(process,prefix+'CombinedCorrector'+postfix).correctors.index(prefix+'L3Absolute')+1
                             getattr(process,prefix+'CombinedCorrector'+postfix).correctors.insert(idx, prefix+'L2L3Residual')
                             print 'adding L2L3Residual for TypeI MET correction:', getattr(process,prefix+'CombinedCorrector'+postfix).label_()
-            if 'patJetGenJet' in mod or 'GenParticle' in mod or 'slimmedGenJets' in mod or 'tauGenJet' in mod:
+            if any(x in mod for x in modStringsToRemove):
                 delattr(process,mod)
 
 runOnData=RunOnData()


### PR DESCRIPTION
As part of a cleanup of constructed but not run modules, I am updating the runOnData portion of PAT to remove these modules. Its a simple loop over producers in the process and delattr if they are found to match the naming condition.

The full list of modules are:

packedGenParticles
patJetFlavourAssociation
patJetFlavourAssociationAK8
patJetFlavourAssociationAK8PFCHSSoftDropSubjets
patJetFlavourAssociationAK8PFPuppiSoftDropSubjets
patJetFlavourAssociationAK8Puppi
patJetFlavourAssociationLegacy
patJetFlavourAssociationLegacyAK8
patJetFlavourAssociationLegacyAK8PFCHSSoftDropSubjets
patJetFlavourAssociationLegacyAK8PFPuppiSoftDropSubjets
patJetFlavourAssociationLegacyAK8Puppi
patJetFlavourAssociationLegacyNoHF
patJetFlavourAssociationLegacyPuppi
patJetFlavourAssociationNoHF
patJetFlavourAssociationPuppi
patJetGenJetMatch
patJetGenJetMatchAK8
patJetGenJetMatchAK8PFCHSSoftDrop
patJetGenJetMatchAK8PFCHSSoftDropSubjets
patJetGenJetMatchAK8PFPuppiSoftDrop
patJetGenJetMatchAK8PFPuppiSoftDropSubjets
patJetGenJetMatchAK8Puppi
patJetGenJetMatchNoHF
patJetGenJetMatchPuppi
patJetPartonAssociationLegacy
patJetPartonAssociationLegacyAK8
patJetPartonAssociationLegacyAK8PFCHSSoftDropSubjets
patJetPartonAssociationLegacyAK8PFPuppiSoftDropSubjets
patJetPartonAssociationLegacyAK8Puppi
patJetPartonAssociationLegacyNoHF
patJetPartonAssociationLegacyPuppi
patJetPartonMatch
patJetPartonMatchAK8
patJetPartonMatchAK8PFCHSSoftDrop
patJetPartonMatchAK8PFCHSSoftDropSubjets
patJetPartonMatchAK8PFPuppiSoftDrop
patJetPartonMatchAK8PFPuppiSoftDropSubjets
patJetPartonMatchAK8Puppi
patJetPartonMatchNoHF
patJetPartonMatchPuppi
patJetPartons
patJetPartonsLegacy
patJetPartonsLegacyNoHF
patJetPartonsNoHF
prunedGenParticles
prunedGenParticlesWithStatusOne
slimmedGenJets
slimmedGenJetsAK8
tauGenJetMatch
tauGenJetMatchBoosted
tauGenJets
tauGenJetsBoosted
tauGenJetsSelectorAllHadrons
tauGenJetsSelectorAllHadronsBoosted
