### PR TITLE
added missing DataFormats/TrajectorySeed dependency in BuildFile

### DIFF
--- a/DataFormats/TrackCandidate/BuildFile.xml
+++ b/DataFormats/TrackCandidate/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackingRecHit"/>
-
+<use   name="DataFormats/TrajectorySeed"/>
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
DataFormats/TrackCandidate uses DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h without any explicit dependency in BuildFile. this PR explicitly adds the missing dependency
