### PR TITLE
Use unique_ptr, not auto_ptr, in PDMV package

### DIFF
--- a/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
+++ b/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
@@ -74,8 +74,8 @@ void MatchedProbeMaker<T>::produce(edm::Event& iEvent, const edm::EventSetup& iS
   using namespace edm;
   using namespace reco;
 
-  std::auto_ptr< edm::RefVector< collection > > outputCollection_matched( new edm::RefVector< collection > );
-  std::auto_ptr< edm::RefVector< collection > > outputCollection_unmatched(new edm::RefVector< collection > );
+  std::unique_ptr<edm::RefVector< collection> > outputCollection_matched(new edm::RefVector<collection>);
+  std::unique_ptr<edm::RefVector< collection> > outputCollection_unmatched(new edm::RefVector<collection>);
   
   // Get the candidates from the event
   edm::Handle< edm::RefVector< collection > > Cands;
@@ -127,8 +127,8 @@ void MatchedProbeMaker<T>::produce(edm::Event& iEvent, const edm::EventSetup& iS
     }  
   }
   
-  if( matched_ ) iEvent.put( outputCollection_matched );
-  else           iEvent.put( outputCollection_unmatched );
+  if(matched_) iEvent.put(std::move(outputCollection_matched));
+  else         iEvent.put(std::move(outputCollection_unmatched));
   
 }
 

--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -79,9 +79,8 @@ class LogErrorEventFilter : public edm::one::EDFilter<edm::one::WatchRuns,
         template<typename Collection> static void increment(ErrorSet &scoreboard, Collection &list);
         template<typename Collection> static void print(const Collection &errors) ;
 
-        static std::auto_ptr<ErrorList > serialize(const ErrorSet &set) {
-            std::auto_ptr<ErrorList> ret(new ErrorList(set.begin(), set.end()));
-            return ret;
+        static std::unique_ptr<ErrorList > serialize(const ErrorSet &set) {
+            return std::make_unique<ErrorList>(set.begin(), set.end());
         }
 };
 
@@ -170,8 +169,8 @@ LogErrorEventFilter::endLuminosityBlock(edm::LuminosityBlock const &lumi, const 
 void
 LogErrorEventFilter::endLuminosityBlockProduce(edm::LuminosityBlock &lumi, const edm::EventSetup &iSetup) {
     lumi.put(serialize(errorCollectionThisLumi_));
-    std::auto_ptr<int> outpass(new int(npassLumi_)); lumi.put(outpass, "pass");
-    std::auto_ptr<int> outfail(new int(nfailLumi_)); lumi.put(outfail, "fail");
+    lumi.put(std::make_unique<int>(npassLumi_), "pass");
+    lumi.put(std::make_unique<int>(nfailLumi_), "fail");
 }
 
 
@@ -232,7 +231,7 @@ LogErrorEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
    
     if (errors->empty()) { 
         npassRun_++; npassLumi_++;
-	iEvent.put( std::auto_ptr<bool>(new bool(false)) );
+	iEvent.put(std::make_unique<bool>(false));
 
 	if(taggedMode_) return forcedValue_;
         return false;
@@ -262,7 +261,7 @@ LogErrorEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 
 
     if (fail) { nfailLumi_++; nfailRun_++; } else { npassRun_++; npassLumi_++; }
-    iEvent.put( std::auto_ptr<bool>(new bool(fail)) );  // fail is the unbiased boolean 
+    iEvent.put(std::make_unique<bool>(fail));  // fail is the unbiased boolean 
 
     if(taggedMode_) return forcedValue_;
     return save;

--- a/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
+++ b/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
@@ -67,7 +67,7 @@ TagProbeMassProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
    // We need the output Muon association collection to fill
-   std::auto_ptr<std::vector<float> > TPmass( new std::vector<float>);
+   std::unique_ptr<std::vector<float> > TPmass( new std::vector<float>);
 
    if ( !iEvent.getByLabel( tagCollection_, tags ) ) {
       edm::LogWarning("TagProbe") << "Could not extract tag muons with input tag "
@@ -126,7 +126,7 @@ TagProbeMassProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
 
    // Finally put the tag probe collection in the event
-   iEvent.put( TPmass,"TPmass" );
+   iEvent.put(std::move(TPmass),"TPmass");
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
+++ b/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
@@ -71,9 +71,9 @@ void TriggerMatchProducer<object>::produce(edm::Event &event, const edm::EventSe
   HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
 
    // Create the output collection
-  std::auto_ptr< edm::RefToBaseVector<object> > 
+  std::unique_ptr< edm::RefToBaseVector<object> > 
     outColRef( new edm::RefToBaseVector<object> );
-  std::auto_ptr< edm::PtrVector<object> > 
+  std::unique_ptr< edm::PtrVector<object> > 
     outColPtr( new edm::PtrVector<object> );
 
 
@@ -126,8 +126,8 @@ void TriggerMatchProducer<object>::produce(edm::Event &event, const edm::EventSe
      edm::LogInfo("info")<< "******** Following Trigger Summary Object Not Found: " << 
        triggerEventTag_;
 
-     event.put(outColRef, "R");
-     event.put(outColPtr);
+     event.put(std::move(outColRef), "R");
+     event.put(std::move(outColPtr));
      return;
    }
 
@@ -223,8 +223,8 @@ void TriggerMatchProducer<object>::produce(edm::Event &event, const edm::EventSe
 	       outColPtr->push_back( ptrVect[counter] );
 	 }
      }   
-   event.put(outColRef, "R");
-   event.put(outColPtr);
+   event.put(std::move(outColRef), "R");
+   event.put(std::move(outColPtr));
 }
 
 


### PR DESCRIPTION
In preparation for removing framework support for auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in the DPGAnalysis/Skims package, which is under the pdmv L2. Also, std::make_unique is used when appropriate. 
