### PR TITLE
81X: realistic BS for PbPb 2015 simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -18,7 +18,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v6',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '81X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -567,7 +567,7 @@ hiAlca = {'--conditions':'auto:run2_mc_hi', '--era':'Run2_2016,Run2_HI'}
 hiAlca2011 = {'--conditions':'auto:run1_mc_hi'}
 
 hiDefaults2011=merge([hiAlca2011,{'--scenario':'HeavyIons','-n':2,'--beamspot':'RealisticHI2011Collision'}])
-hiDefaults=merge([hiAlca,{'--scenario':'HeavyIons','-n':2,'--beamspot':'NominalHICollision2015'}])
+hiDefaults=merge([hiAlca,{'--scenario':'HeavyIons','-n':2,'--beamspot':'RealisticHICollision2015'}])
 
 steps['HydjetQ_MinBias_5020GeV']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_5020GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_5020GeVINPUT']={'INPUT':InputInfo(dataSet='/RelValHydjetQ_MinBias_5020GeV/%s/GEN-SIM'%(baseDataSetRelease[9],),location='STD',split=5)}

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -50,4 +50,4 @@ VtxSmeared = {
     'Realistic25ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVCollisionBetaStar90mLowBunches'
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
-VtxSmearedHIDefaultKey='NominalHICollision2015'
+VtxSmearedHIDefaultKey='RealisticHICollision2015'


### PR DESCRIPTION
_Realistic vertex smearing for 2015 PbPb MC (81X)_ 
- Updated the vertex smearing based on final beamspot fits to the data (taking into account the shift of the pixel detector) has been introduced in #15224. 
- The corresponding reco beamspot has been placed in the GT key `run2_mc_hi`, following request: [HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2538.html)
- Since the reco beamspot tag is in place, the HI reco relval workflow has been updated to use this vertex smearing.
# Summary of changes in Global Tags
## RunII simulation
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v6) as [81X_mcRun2_HeavIon_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavIon_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v6/81X_mcRun2_HeavIon_v5): 
  - updated retune of the RECO BS for 2015 PbPb MC
