### PR TITLE
Flip the soft lepton sIP in case the Negative CTagger is used

### DIFF
--- a/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
+++ b/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
@@ -15,6 +15,7 @@ charmTagsNegativeComputerCvsL = charmTagsComputerCvsL.clone()
 
 charmTagsNegativeComputerCvsL.slComputerCfg.vertexFlip = cms.bool(True)
 charmTagsNegativeComputerCvsL.slComputerCfg.trackFlip = cms.bool(True)
+charmTagsNegativeComputerCvsL.slComputerCfg.SoftLeptonFlip = cms.bool(True)
 charmTagsNegativeComputerCvsL.slComputerCfg.trackSelection.sip3dSigMax = 0
 charmTagsNegativeComputerCvsL.slComputerCfg.trackPseudoSelection.sip3dSigMax = 0
 charmTagsNegativeComputerCvsL.slComputerCfg.trackPseudoSelection.sip2dSigMin = -99999.9
@@ -24,6 +25,7 @@ charmTagsNegativeComputerCvsB = charmTagsComputerCvsB.clone()
 
 charmTagsNegativeComputerCvsB.slComputerCfg.vertexFlip = cms.bool(True)
 charmTagsNegativeComputerCvsB.slComputerCfg.trackFlip = cms.bool(True)
+charmTagsNegativeComputerCvsB.slComputerCfg.SoftLeptonFlip = cms.bool(True)
 charmTagsNegativeComputerCvsB.slComputerCfg.trackSelection.sip3dSigMax = 0
 charmTagsNegativeComputerCvsB.slComputerCfg.trackPseudoSelection.sip3dSigMax = 0
 charmTagsNegativeComputerCvsB.slComputerCfg.trackPseudoSelection.sip2dSigMin = -99999.9

--- a/RecoBTag/CTagging/python/pfNegativeCombinedCvsLJetTags_cfi.py
+++ b/RecoBTag/CTagging/python/pfNegativeCombinedCvsLJetTags_cfi.py
@@ -5,7 +5,7 @@ pfNegativeCombinedCvsLJetTags = cms.EDProducer(
    jetTagComputer = cms.string('charmTagsNegativeComputerCvsL'),
    tagInfos = cms.VInputTag(
       cms.InputTag("pfImpactParameterTagInfos"),
-      cms.InputTag("pfInclusiveSecondaryVertexFinderCvsLNegativeTagInfos"),
+      cms.InputTag("pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos"),
       cms.InputTag("softPFMuonsTagInfos"),
       cms.InputTag("softPFElectronsTagInfos")
       )

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
@@ -15,12 +15,22 @@ class CombinedSVSoftLeptonComputer : public CombinedSVComputer {
     public:
 	explicit CombinedSVSoftLeptonComputer(const edm::ParameterSet &params);
 	
+	double flipSoftLeptonValue(double value) const;
+	
 	template <class IPTI,class SVTI>
 	reco::TaggingVariableList
 	operator () (const IPTI &ipInfo, const SVTI &svInfo,
 		     const reco::CandSoftLeptonTagInfo &muonInfo,
 		     const reco::CandSoftLeptonTagInfo &elecInfo ) const;
+	
+	private:
+	bool					SoftLeptonFlip;
 };
+
+double CombinedSVSoftLeptonComputer::flipSoftLeptonValue(double value) const
+{
+	return SoftLeptonFlip ? -value : value;
+}
 
 template <class IPTI,class SVTI>
 reco::TaggingVariableList CombinedSVSoftLeptonComputer::operator () (const IPTI &ipInfo, const SVTI &svInfo,
@@ -46,7 +56,7 @@ reco::TaggingVariableList CombinedSVSoftLeptonComputer::operator () (const IPTI 
 		leptonCategory = 1; // muon category
 		const SoftLeptonProperties & propertiesMuon = muonInfo.properties(i);
 		vars.insert(btau::leptonPtRel,propertiesMuon.ptRel , true);
-		vars.insert(btau::leptonSip3d,propertiesMuon.sip3d , true);
+		vars.insert(btau::leptonSip3d,flipSoftLeptonValue(propertiesMuon.sip3d) , true);
 		vars.insert(btau::leptonDeltaR,propertiesMuon.deltaR , true);
 		vars.insert(btau::leptonRatioRel,propertiesMuon.ratioRel , true);
 		vars.insert(btau::leptonEtaRel,propertiesMuon.etaRel , true);
@@ -60,7 +70,7 @@ reco::TaggingVariableList CombinedSVSoftLeptonComputer::operator () (const IPTI 
 			leptonCategory = 2; // electron category
 			const SoftLeptonProperties & propertiesElec = elecInfo.properties(i);
 			vars.insert(btau::leptonPtRel,propertiesElec.ptRel , true);
-			vars.insert(btau::leptonSip3d,propertiesElec.sip3d , true);
+			vars.insert(btau::leptonSip3d,flipSoftLeptonValue(propertiesElec.sip3d) , true);
 			vars.insert(btau::leptonDeltaR,propertiesElec.deltaR , true);
 			vars.insert(btau::leptonRatioRel,propertiesElec.ratioRel , true);
 			vars.insert(btau::leptonEtaRel,propertiesElec.etaRel , true);

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexCommon_cff.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexCommon_cff.py
@@ -8,6 +8,7 @@ combinedSecondaryVertexCommon = cms.PSet(
 	trackSelectionBlock,
 	trackFlip = cms.bool(False),
 	vertexFlip = cms.bool(False),
+	SoftLeptonFlip = cms.bool(False),
 	useTrackWeights = cms.bool(True),
 	pseudoMultiplicityMin = cms.uint32(2),
 	correctVertexMass = cms.bool(True),

--- a/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
@@ -5,6 +5,7 @@ using namespace std;
 
 
 CombinedSVSoftLeptonComputer::CombinedSVSoftLeptonComputer(const edm::ParameterSet &params) :
-	CombinedSVComputer(params)
+	CombinedSVComputer(params),
+	SoftLeptonFlip(params.getParameter<bool>("SoftLeptonFlip"))
 {
 }


### PR DESCRIPTION
This PR introduces the possibility to also flip the softElectron and softMuon impact parameter sign in case the negative c-tagger is used. The boolian is by default set to false (no other b-taggers are affected by this), but it is set to true in case the negative c-tagger is used.

@mverzett and @kovitang are interested in following this PR
