### PR TITLE
re-adding fixes overwritten by git migration

### DIFF
--- a/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
@@ -121,6 +121,13 @@ MixBoostEvtVtxGenerator::MixBoostEvtVtxGenerator(const edm::ParameterSet & pset 
   mixLabel(consumes<CrossingFrame<HepMCProduct> >(pset.getParameter<edm::InputTag>("mixLabel"))),
   useRecVertex(pset.exists("useRecVertex")?pset.getParameter<bool>("useRecVertex"):false)
 { 
+  beta_  =  pset.getParameter<double>("Beta");
+  alpha_ = 0;
+  phi_ = 0;
+  if(pset.exists("Alpha")){
+     alpha_ =  pset.getParameter<double>("Alpha")*radian;
+     phi_   =  pset.getParameter<double>("Phi")*radian;
+  }
 
   vtxOffset.resize(3);
   if(pset.exists("vtxOffset")) vtxOffset=pset.getParameter< std::vector<double> >("vtxOffset"); 
@@ -131,9 +138,8 @@ MixBoostEvtVtxGenerator::MixBoostEvtVtxGenerator(const edm::ParameterSet & pset 
 
 MixBoostEvtVtxGenerator::~MixBoostEvtVtxGenerator() 
 {
-  delete fVertex ;
+  if (fVertex != 0) delete fVertex ;
   if (boost_ != 0 ) delete boost_;
-  delete fRandom; 
 }
 
 
@@ -237,10 +243,10 @@ TMatrixD* MixBoostEvtVtxGenerator::GetInvLorentzBoost() {
        tmpboostZ(3,2)=0.;
        tmpboostZ(3,3) = 1.;
 
-       tmpboostXYZ=tmpboost*tmpboostZ;
-       tmpboost.Invert();
+       tmpboostXYZ=tmpboostZ*tmpboost;
+       tmpboostXYZ.Invert();
 
-
+       cout<<"Boosting with beta : "<<beta_<<endl;
 
        boost_ = new TMatrixD(tmpboostXYZ);
        boost_->Print();
@@ -320,10 +326,11 @@ void MixBoostEvtVtxGenerator::produce( Event& evt, const EventSetup& )
   std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
   // generate new vertex & apply the shift 
   //
-  HepMCEvt->applyVtxGen( useRecVertex ? getRecVertex(evt) : getVertex(evt) ) ;
  
-  //   HepMCEvt->boostToLab( GetInvLorentzBoost(), "vertex" );
-  //   HepMCEvt->boostToLab( GetInvLorentzBoost(), "momentum" );
+  HepMCEvt->boostToLab( GetInvLorentzBoost(), "vertex" );
+  HepMCEvt->boostToLab( GetInvLorentzBoost(), "momentum" );
+
+  HepMCEvt->applyVtxGen( useRecVertex ? getRecVertex(evt) : getVertex(evt) ) ;
   
   evt.put(std::move(HepMCEvt));
   return ;


### PR DESCRIPTION
Fixing segmentation fault caused by double deallocating the fRandom object and readding simple fixes done for release 5_3_X overwritten by git migration.  Needed for lorentz-boosted 8 TeV pPb production.

Also tagging @yetkinyilmaz @dgulhan @mandrenguyen 
