### PR TITLE
Add run2_HE2017 to 2017 special tracking eras

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 
-Run2_2017_trackingPhase1PU70 = cms.ModifierChain(Run2_2016, phase1Pixel, trackingPhase1PU70)
+Run2_2017_trackingPhase1PU70 = cms.ModifierChain(Run2_2016, phase1Pixel, trackingPhase1PU70, run2_HE_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2017_trackingRun2_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingRun2_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 
-Run2_2017_trackingRun2 = cms.ModifierChain(Run2_2016, phase1Pixel)
+Run2_2017_trackingRun2 = cms.ModifierChain(Run2_2016, phase1Pixel, run2_HE_2017)
 


### PR DESCRIPTION
This PR adds the `run2_HE_2017` sub-era to `Run2_2017_trackingPhase1PU70` and `Run2_2017_trackingRun2` eras following its existence in `Run2_2017` era (which I noticed in https://github.com/cms-sw/cmssw/pull/15469#issuecomment-239787517).

Tested in CMSSW_8_1_X_2016-08-16-2300. There should be no effect in standard phase0/1/2 workflows. I guess in principle the special workflows `10024.[23]` (employing `Run2_2017_trackingRun2` era) could be affected via jetCore iteration, but with 10 events in runTheMatrix I saw no differences.

@rovere @VinInn 
