### PR TITLE
Avoid unnecessary creation of temporary InputTag

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTTrigTools.h
+++ b/DQMOffline/Trigger/interface/EgHLTTrigTools.h
@@ -109,7 +109,7 @@ namespace egHLT {
   std::vector<TrigCodes::TrigBitSet> partTrigBits(1);
   const double maxDeltaR=0.1;
   for(size_t filterNrInVec=0;filterNrInVec<filters.size();filterNrInVec++){
-    size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec],"",hltTag).encode());
+    size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec],"",hltTag));
     //const TrigCodes::TrigBitSet filterCode = trigCodes.getCode(filters[filterNrInVec].c_str()); 
     if(filterNrInEvt<trigEvt->sizeFilters()){ //filter found in event, something passes it
       const trigger::Keys& trigKeys = trigEvt->filterKeys(filterNrInEvt);  //trigger::Keys is actually a vector<uint16_t> holding the position of trigger objects in the trigger collection passing the filter

--- a/DQMOffline/Trigger/src/EgHLTTrigTools.cc
+++ b/DQMOffline/Trigger/src/EgHLTTrigTools.cc
@@ -15,7 +15,7 @@ TrigCodes::TrigBitSet trigTools::getFiltersPassed(
 {
   TrigCodes::TrigBitSet evtTrigs;
   for(size_t filterNrInVec=0;filterNrInVec<filters.size();filterNrInVec++){
-    size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec].first,"",hltTag).encode());
+    size_t filterNrInEvt = trigEvt->filterIndex(edm::InputTag(filters[filterNrInVec].first,"",hltTag));
     const TrigCodes::TrigBitSet filterCode = trigCodes.getCode(filters[filterNrInVec].first.c_str());
     if(filterNrInEvt<trigEvt->sizeFilters()){ //filter found in event, however this only means that something passed the previous filter
       const trigger::Keys& trigKeys = trigEvt->filterKeys(filterNrInEvt);


### PR DESCRIPTION
These functions were creating a temporary InputTag, calling encode
to create a string but then passing that string to a function that
takes an InputTag as an argument. This meant the compiler inserted
a call to edm::InputTag(const std::string&) into the code.
