### PR TITLE
Update cache InputProductResolver only if this is the first thread

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -351,7 +351,10 @@ namespace edm {
 
   void
   InputProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
-    setProduct(std::move(edp));
+    if ( not productResolved()) {
+      //Another thread could have set this
+      setProduct(std::move(edp));
+    }
   }
   
   bool


### PR DESCRIPTION
If multiple edm::Refs are requesting the same data product, they all
get serialized by the DelayedReader. However, they would also all
update the cached wrapper held by the InputProductResolver. This
could cause some edm::Refs to get a pointer to a deleted data
product.
This fix now only updates the cache if it has not yet been set.
