### PR TITLE
fixes needed for next root update

### DIFF
--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -267,7 +267,7 @@ AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup& iS
    XercesDOMParser *parser = new XercesDOMParser();
    parser->setValidationScheme(XercesDOMParser::Val_Always);
 
-   ErrorHandler *errHandler = (ErrorHandler*)(new HandlerBase());
+   xercesc_3_1::ErrorHandler *errHandler = (xercesc_3_1::ErrorHandler*)(new HandlerBase());
    parser->setErrorHandler(errHandler);
 
    try {

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -267,7 +267,7 @@ AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup& iS
    XercesDOMParser *parser = new XercesDOMParser();
    parser->setValidationScheme(XercesDOMParser::Val_Always);
 
-   xercesc_3_1::ErrorHandler *errHandler = (xercesc_3_1::ErrorHandler*)(new HandlerBase());
+   XERCES_CPP_NAMESPACE::ErrorHandler *errHandler = (XERCES_CPP_NAMESPACE::ErrorHandler*)(new HandlerBase());
    parser->setErrorHandler(errHandler);
 
    try {

--- a/DataFormats/L1Trigger/src/L1ParticleMap.cc
+++ b/DataFormats/L1Trigger/src/L1ParticleMap.cc
@@ -184,7 +184,7 @@ L1ParticleMap::L1ParticleMap(
    const L1IndexComboVector& indexCombos )
    : triggerType_( triggerType ),
      triggerDecision_( triggerDecision ),
-     indexCombosState_{static_cast<char>(indexCombos.size()>0? kSet:kUnset)},
+     indexCombosState_{static_cast<char>(indexCombos.size()>0? kSet:IndexComboStates::kUnset)},
      objectTypes_( objectTypes ),
      emParticles_( emParticles ),
      jetParticles_( jetParticles ),
@@ -197,7 +197,7 @@ L1ParticleMap::L1ParticleMap(
 L1ParticleMap::L1ParticleMap(const L1ParticleMap& rhs):
   triggerType_(rhs.triggerType_),
   triggerDecision_(rhs.triggerDecision_),
-  indexCombosState_(kUnset),
+  indexCombosState_(IndexComboStates::kUnset),
   objectTypes_(rhs.objectTypes_),
   emParticles_(rhs.emParticles_),
   jetParticles_(rhs.jetParticles_),
@@ -324,7 +324,7 @@ L1ParticleMap::setIndexCombos() const {
       tempIndexCombos.push_back( tmpCombo ) ;
     }
   }
-  char expected = kUnset;
+  char expected = IndexComboStates::kUnset;
   if(indexCombosState_.compare_exchange_strong(expected,kSetting,std::memory_order_acq_rel)) {
     //If this was read from an old file, it is possible that indexCombos_ is already set.
     // This is the only safe place to check since we know no other thread can be attempting 


### PR DESCRIPTION
Next root update which includes

https://github.com/cms-sw/root/commit/ab679afd0e558bb60443d28a172fa83840c02ae8

causes compilation errors due to  ambiguous kUnset and ErrorHandler (defined in TError and xercesc).
