### PR TITLE
yet another update of triggerbits

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,11 +20,11 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v6',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v4',
+    'run1_data'         :   '81X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v4',
+    'run2_data'         :   '81X_dataRun2_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v5) as [81X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v5/81X_dataRun2_v4): 
  - updated SiStripDQM TriggerBits for HIP monitoring in Run-I IOV
- **RunII Offline relval processing** : [81X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v6) as [81X_dataRun2_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v6/81X_dataRun2_relval_v5): 
  - updated SiStripDQM TriggerBits for HIP monitoring in Run-I IOV
# 
# Updated content
- RunI+ RunII-2015 IOV:

```
---+++++ *IOV*: 1-264291
| *TriggerBits list key* | *HLT paths* |
| 'SiStrip_HLT' | 'HLT_ZeroBias_v*', 'HLT_HIZeroBias_v*', 'HLT_BptxAnd_*' |
| 'SiStrip_L1' | 'L1_ZeroBias' |
| 'Tracking_HLT' | 'HLT_ZeroBias_v*', 'HLT_BptxAnd_*' |
| 'Tracking_HLT_HIP_OOT' | 'HLT_ZeroBias_FirstBXAfterTrain_v*' |
| 'Tracking_HLT_HIP_noOOT' | 'HLT_ZeroBias_FirstCollisionInTrain_v*' |
| 'Tracking_HLT_noHIP_noOOT' | 'HLT_ZeroBias_FirstCollisionAfterAbortGap_v*' |
```

side note: this is needed beacuse wf 1000.0 probing Tier-0 Prompt Reco is not yet updated to consume Run2 data. 
