### PR TITLE
Update tracking MC validation scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -14,8 +14,10 @@ _sampleName = {
     "RelValWjet_Pt_3000_3500": "Wjet Pt 3000 to 3500",
     "RelValH125GGgluonfusion": "Higgs to gamma gamma",
     "RelValSingleElectronPt35": "Single Electron Pt 35",
+    "RelValSingleElectronPt35Extended": "Single Electron Pt 35 (extended eta)",
     "RelValSingleElectronPt10": "Single Electron Pt 10",
     "RelValSingleMuPt10": "Single Muon Pt 10",
+    "RelValSingleMuPt10Extended": "Single Muon Pt 10 (extended eta)",
     "RelValSingleMuPt100": "Single Muon Pt 100",
     "RelValTenMuE_0_200": "Ten muon Pt 0-200",
 }
@@ -30,8 +32,10 @@ _sampleFileName = {
     "RelValWjet_Pt_3000_3500": "wjet3000",
     "RelValH125GGgluonfusion": "hgg",
     "RelValSingleElectronPt35": "ele35",
+    "RelValSingleElectronPt35Extended": "ele35ext",
     "RelValSingleElectronPt10": "ele10",
     "RelValSingleMuPt10": "mu10",
+    "RelValSingleMuPt10Extended": "mu10ext",
     "RelValSingleMuPt100": "mu100",
     "RelValTenMuE_0_200": "tenmu200",
 }
@@ -594,7 +598,11 @@ class IndexSection:
                 pileup = "with %s pileup" % sample.pileupType()
         if hasattr(sample, "customPileupLabel"):
             pileup = sample.customPileupLabel()
-        self._sampleName += "%s sample %s" % (_sampleName.get(sample.name(), sample.name()), pileup)
+
+        scenario = ""
+        if hasattr(sample, "hasScenario") and sample.hasScenario():
+            scenario = " (\"%s\")" % sample.scenario()
+        self._sampleName += "%s sample%s %s" % (_sampleName.get(sample.name(), sample.name()), scenario, pileup)
 
         params = [title, self._sampleName, sample, fastVsFull]
         self._summaryPage = PageSet(*params)

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -17,6 +17,7 @@ _sampleName = {
     "RelValSingleElectronPt10": "Single Electron Pt 10",
     "RelValSingleMuPt10": "Single Muon Pt 10",
     "RelValSingleMuPt100": "Single Muon Pt 100",
+    "RelValTenMuE_0_200": "Ten muon Pt 0-200",
 }
 
 _sampleFileName = {
@@ -32,6 +33,7 @@ _sampleFileName = {
     "RelValSingleElectronPt10": "ele10",
     "RelValSingleMuPt10": "mu10",
     "RelValSingleMuPt100": "mu100",
+    "RelValTenMuE_0_200": "tenmu200",
 }
 
 _allTPEfficName = "All tracks (all TPs)"

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -134,6 +134,8 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("building", "Built tracks"),
     ("", "All tracks"),
     ("highPurity", "High purity tracks"),
+    ("btvLike", "BTV-like"),
+    ("ak4PFJets", "AK4 PF jets"),
     ("allTPEffic", _allTPEfficName),
     ("allTPEffic_highPurity", _allTPEfficName.replace("All", "High purity")),
     ("fromPV", _fromPVName),

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -143,8 +143,15 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("conversion", _conversionName),
     ("gsf", _gsfName),
     # These are for vertices
+    ("genvertex", "Gen vertices"),
+    ("pixelVertices", "Pixel vertices"),
+    ("selectedPixelVertices", "Selected pixel vertices"),
+    ("firstStepPrimaryVerticesPreSplitting", "firstStepPrimaryVerticesPreSplitting"),
+    ("firstStepPrimaryVertices", "firstStepPrimaryVertices"),
     ("offlinePrimaryVertices", "All vertices (offlinePrimaryVertices)"),
     ("selectedOfflinePrimaryVertices", "Selected vertices (selectedOfflinePrimaryVertices)"),
+    ("offlinePrimaryVerticesWithBS", "All vertices with BS constraint"),
+    ("selectedOfflinePrimaryVerticesWithBS", "Selected vertices with BS constraint"),
     # These are for V0
     ("k0", "K0"),
     ("lambda", "Lambda"),

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -588,6 +588,8 @@ class IndexSection:
             pileup = "with no pileup"
             if sample.hasPileup():
                 pileup = "with %s pileup" % sample.pileupType()
+        if hasattr(sample, "customPileupLabel"):
+            pileup = sample.customPileupLabel()
         self._sampleName += "%s sample %s" % (_sampleName.get(sample.name(), sample.name()), pileup)
 
         params = [title, self._sampleName, sample, fastVsFull]

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -12,6 +12,7 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 import html
 
 verbose=False
+ratioYTitle = "Ratio"
 
 def _setStyle():
     _absoluteSize = True
@@ -1058,7 +1059,7 @@ class FrameRatio:
 
         self._frameRatio.GetYaxis().SetNdivisions(4, 5, 0)
 
-        self._frameRatio.GetYaxis().SetTitle("Ratio")
+        self._frameRatio.GetYaxis().SetTitle(ratioYTitle)
 
     def setLogx(self, log):
         self._pad.SetLogx(log)

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -993,7 +993,7 @@ class FrameRatio:
     def setXTitleSize(self, size):
         self._frameRatio.GetXaxis().SetTitleSize(size)
 
-    def setYTitleOffset(self, offset):
+    def setXTitleOffset(self, offset):
         self._frameRatio.GetXaxis().SetTitleOffset(offset)
 
     def setXLabelSize(self, size):

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -316,7 +316,8 @@ def _getXmin(obj, limitToNonZeroContent=False):
         else:
             return xaxis.GetBinLowEdge(xaxis.GetFirst())
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        return min([obj.GetX()[i] for i in xrange(0, obj.GetN())])*0.9
+        m = min([obj.GetX()[i] for i in xrange(0, obj.GetN())])
+        return m*0.9 if m > 0 else m*1.1
     raise Exception("Unsupported type %s" % str(obj))
 
 def _getXmax(obj, limitToNonZeroContent=False):
@@ -331,21 +332,30 @@ def _getXmax(obj, limitToNonZeroContent=False):
         else:
             return xaxis.GetBinUpEdge(xaxis.GetLast())
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        return max([obj.GetX()[i] for i in xrange(0, obj.GetN())])*1.02
+        m = max([obj.GetX()[i] for i in xrange(0, obj.GetN())])
+        return m*1.1 if m > 0 else m*0.9
     raise Exception("Unsupported type %s" % str(obj))
 
 def _getYmin(obj):
-    if isinstance(obj, ROOT.TH1):
+    if isinstance(obj, ROOT.TH2):
+        yaxis = obj.GetYaxis()
+        return yaxis.GetBinLowEdge(yaxis.GetFirst())
+    elif isinstance(obj, ROOT.TH1):
         return obj.GetMinimum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        return min([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        m = min([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        return m*0.9 if m > 0 else m*1.1
     raise Exception("Unsupported type %s" % str(obj))
 
 def _getYmax(obj):
-    if isinstance(obj, ROOT.TH1):
+    if isinstance(obj, ROOT.TH2):
+        yaxis = obj.GetYaxis()
+        return yaxis.GetBinUpEdge(yaxis.GetLast())
+    elif isinstance(obj, ROOT.TH1):
         return obj.GetMaximum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        return max([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        m = max([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        return m*1.1 if m > 0 else m*0.9
     raise Exception("Unsupported type %s" % str(obj))
 
 def _getYmaxWithError(th1):

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2425,6 +2425,9 @@ class PlotterItem:
             subFolders = []
         possibleDirFound = False
         for fname in files:
+            if fname is None:
+                continue
+
             isOpenFile = isinstance(fname, ROOT.TFile)
             if isOpenFile:
                 tfile = fname

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -13,6 +13,34 @@ import html
 
 verbose=False
 
+def _setStyle():
+    _absoluteSize = True
+    if _absoluteSize:
+        font = 43
+        titleSize = 22
+        labelSize = 22
+        statSize = 14
+    else:
+        font = 42
+        titleSize = 0.05
+        labelSize = 0.05
+        statSize = 0.025
+
+    ROOT.gROOT.SetStyle("Plain")
+    ROOT.gStyle.SetPadRightMargin(0.07)
+    ROOT.gStyle.SetPadLeftMargin(0.13)
+    ROOT.gStyle.SetTitleFont(font, "XYZ")
+    ROOT.gStyle.SetTitleSize(titleSize, "XYZ")
+    ROOT.gStyle.SetTitleOffset(1.2, "Y")
+    #ROOT.gStyle.SetTitleFontSize(0.05)
+    ROOT.gStyle.SetLabelFont(font, "XYZ")
+    ROOT.gStyle.SetLabelSize(labelSize, "XYZ")
+    ROOT.gStyle.SetTextSize(labelSize)
+    ROOT.gStyle.SetStatFont(font)
+    ROOT.gStyle.SetStatFontSize(statSize)
+
+    ROOT.TGaxis.SetMaxDigits(4)
+
 def _getObject(tdirectory, name):
     obj = tdirectory.Get(name)
     if not obj:
@@ -2457,34 +2485,8 @@ class Plotter:
     """Contains PlotFolders, i.e. the information what plots to do, and creates a helper object to actually produce the plots."""
     def __init__(self):
         self._plots = []
-
-        _absoluteSize = True
-        if _absoluteSize:
-            font = 43
-            titleSize = 22
-            labelSize = 22
-            statSize = 14
-        else:
-            font = 42
-            titleSize = 0.05
-            labelSize = 0.05
-            statSize = 0.025
-
-        ROOT.gROOT.SetStyle("Plain")
-        ROOT.gStyle.SetPadRightMargin(0.07)
-        ROOT.gStyle.SetPadLeftMargin(0.13)
-        ROOT.gStyle.SetTitleFont(font, "XYZ")
-        ROOT.gStyle.SetTitleSize(titleSize, "XYZ")
-        ROOT.gStyle.SetTitleOffset(1.2, "Y")
-        #ROOT.gStyle.SetTitleFontSize(0.05)
-        ROOT.gStyle.SetLabelFont(font, "XYZ")
-        ROOT.gStyle.SetLabelSize(labelSize, "XYZ")
-        ROOT.gStyle.SetTextSize(labelSize)
-        ROOT.gStyle.SetStatFont(font)
-        ROOT.gStyle.SetStatFontSize(statSize)
-
+        _setStyle()
         ROOT.TH1.AddDirectory(False)
-        ROOT.TGaxis.SetMaxDigits(4)
 
     def append(self, *args, **kwargs):
         """Append a plot folder to the plotter.

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2076,7 +2076,7 @@ class PlotGroup:
         for plot in self._plots:
             plot.create(tdirectories, requireAllHistograms)
 
-    def draw(self, legendLabels, prefix=None, separate=False, saveFormat=".pdf", ratio=False):
+    def draw(self, legendLabels, prefix=None, separate=False, saveFormat=".pdf", ratio=True):
         """Draw the histograms using values for a given algorithm.
 
         Arguments:
@@ -2084,7 +2084,7 @@ class PlotGroup:
         prefix        -- Optional string for file name prefix (default None)
         separate      -- Save the plots of a group to separate files instead of a file per group (default False)
         saveFormat   -- String specifying the plot format (default '.pdf')
-        ratio        -- Add ratio to the plot (default False)
+        ratio        -- Add ratio to the plot (default True)
         """
 
         if self._overrideLegendLabels is not None:
@@ -2344,14 +2344,14 @@ class PlotFolder:
                 continue
             pg.create(dirs, requireAllHistograms)
 
-    def draw(self, prefix=None, separate=False, saveFormat=".pdf", ratio=False):
+    def draw(self, prefix=None, separate=False, saveFormat=".pdf", ratio=True):
         """Draw and save all plots using settings of a given algorithm.
 
         Arguments:
         prefix   -- Optional string for file name prefix (default None)
         separate -- Save the plots of a group to separate files instead of a file per group (default False)
         saveFormat   -- String specifying the plot format (default '.pdf')
-        ratio    -- Add ratio to the plot (default False)
+        ratio    -- Add ratio to the plot (default True)
         """
         ret = []
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -366,7 +366,7 @@ _possibleTrackingCollsOld = {
     "Tenth" : "iter10",
 }
 
-def _trackingSubFoldersFallbackSLHC(subfolder):
+def _trackingSubFoldersFallbackSLHC_Phase1PU70_OldMapping(subfolder):
     ret = subfolder.replace("trackingParticleRecoAsssociation", "AssociatorByHitsRecoDenom")
     for (old, new) in [("InitialStep",         "Zero"),
                        ("LowPtTripletStep",    "First"),
@@ -374,11 +374,12 @@ def _trackingSubFoldersFallbackSLHC(subfolder):
                        ("MixedTripletStep",    "Fourth"),
                        ("MuonSeededStepInOut", "Ninth"),
                        ("MuonSeededStepOutIn", "Tenth")]:
+
         ret = ret.replace(old, new)
     if ret == subfolder:
         return None
     return ret
-def _trackingRefFileFallbackSLHC(path):
+def _trackingRefFileFallbackSLHC_Phase1PU70_OldMapping(path):
     for (old, new) in [("initialStep",         "iter0"),
                        ("lowPtTripletStep",    "iter1"),
                        ("pixelPairStep",       "iter2"),
@@ -387,6 +388,33 @@ def _trackingRefFileFallbackSLHC(path):
                        ("muonSeededStepOutIn", "iter10")]:
         path = path.replace(old, new)
     return path
+
+def _trackingSubFoldersFallbackSLHC_Phase1PU140(subfolder):
+    ret = subfolder.replace("trackingParticleRecoAsssociation", "AssociatorByHitsRecoDenom")
+    for (old, new) in [("InitialStep",         "Zero"),
+                       ("HighPtTripletStep",   "First"),
+                       ("LowPtQuadStep",       "Second"),
+                       ("LowPtTripletStep",    "Third"),
+                       ("DetachedQuadStep",    "Fourth"),
+                       ("PixelPairStep",       "Fifth"),
+                       ("MuonSeededStepInOut", "Ninth"),
+                       ("MuonSeededStepOutIn", "Tenth")]:
+        ret = ret.replace(old, new)
+    if ret == subfolder:
+        return None
+    return ret
+def _trackingRefFileFallbackSLHC_Phase1PU140(path):
+    for (old, new) in [("initialStep",         "iter0"),
+                       ("highPtTripletStep",   "iter1"),
+                       ("lowPtQuadStep",       "iter2"),
+                       ("lowPtTripletStep",    "iter3"),
+                       ("detachedQuadStep",    "iter4"),
+                       ("pixelPairStep",       "iter5"),
+                       ("muonSeededStepInOut", "iter9"),
+                       ("muonSeededStepOutIn", "iter10")]:
+        path = path.replace(old, new)
+    return path
+
 def _trackingSubFoldersFallbackFromPV(subfolder):
     return subfolder.replace("trackingParticleRecoAsssociation", "trackingParticleRecoAsssociationSignal")
 def _trackingSubFoldersFallbackConversion(subfolder):
@@ -894,8 +922,14 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
     folders = _trackingFolders(lastDirName)
     # to keep backward compatibility, this set of plots has empty name
     limiters = dict(onlyForPileup=onlyForPileup, onlyForElectron=onlyForElectron, onlyForConversion=onlyForConversion)
-    commonForTPF = dict(purpose=PlotPurpose.TrackingIteration, fallbackRefFiles=[_trackingRefFileFallbackSLHC], **limiters)
-    common = dict(fallbackDqmSubFolders=[_trackingSubFoldersFallbackSLHC, _trackingSubFoldersFallbackFromPV, _trackingSubFoldersFallbackConversion])
+    commonForTPF = dict(purpose=PlotPurpose.TrackingIteration, fallbackRefFiles=[
+        #_trackingRefFileFallbackSLHC_Phase1PU70_OldMapping
+        _trackingRefFileFallbackSLHC_Phase1PU140
+    ], **limiters)
+    common = dict(fallbackDqmSubFolders=[
+        #_trackingSubFoldersFallbackSLHC_Phase1PU70_OldMapping,
+        _trackingSubFoldersFallbackSLHC_Phase1PU140,
+        _trackingSubFoldersFallbackFromPV, _trackingSubFoldersFallbackConversion])
     plotter.append(name, folders, TrackingPlotFolder(*algoPlots, **commonForTPF), **common)
     plotterExt.append(name, folders, TrackingPlotFolder(*_extendedPlots, **commonForTPF), **common)
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -768,8 +768,12 @@ class TrackingSummaryTable:
         n_duplicate = _formatOrNone(_getN("num_duplicate_coll"), int)
 
         eff = _formatOrNone(_getN("effic_vs_coll"), lambda n: "%.4f" % n)
+        eff_nopt = _formatOrNone(_getN("effic_vs_coll_allPt"), lambda n: "%.4f" % n)
+        fake = _formatOrNone(_getN("fakerate_vs_coll"), lambda n: "%.4f" % n)
 
-        ret = [eff, n_tps, n_m_tps, n_tracks, n_true, n_fake, n_pileup, n_duplicate]
+        ret = [eff, n_tps, n_m_tps,
+               eff_nopt, fake,
+               n_tracks, n_true, n_fake, n_pileup, n_duplicate]
         if ret.count(None) == len(ret):
             return None
         return ret
@@ -779,6 +783,8 @@ class TrackingSummaryTable:
             "Efficiency",
             "Number of TrackingParticles (after cuts)",
             "Number of matched TrackingParticles",
+            "Efficiency (w/o pT cut)",
+            "Fake rate",
             "Number of tracks",
             "Number of true tracks",
             "Number of fake tracks",

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -503,10 +503,11 @@ def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAl
     _common = {"drawStyle": "EP", "xbinlabelsize": 10, "xbinlabeloption": "d"}
     _commonN = {"ylog": True, "ymin": _minMaxN, "ymax": _minMaxN}
     _commonN.update(_common)
-    _commonAB = {"mapping": mapping,
-                 "renameBin": lambda bl: _summaryBinRename(bl, highPurity, byOriginalAlgo, byAlgoMask, seeds),
-                 "ignoreMissingBins": True,
-    }
+    _commonAB = dict(mapping=mapping,
+                     renameBin=lambda bl: _summaryBinRename(bl, highPurity, byOriginalAlgo, byAlgoMask, seeds),
+                     ignoreMissingBins=True,
+                     originalOrder=True,
+    )
     if byOriginalAlgo or byAlgoMask:
         _commonAB["minExistingBins"] = 2
     prefix = "summary"+midfix
@@ -1205,11 +1206,11 @@ _common = {
     "xbinlabelsize": 10,
     "xbinlabeloption": "d"
 }
-_time_per_iter = AggregateBins("iteration", "reconstruction_step_module_average", _iterModuleMap(), ignoreMissingBins=True)
+_time_per_iter = AggregateBins("iteration", "reconstruction_step_module_average", _iterModuleMap(), ignoreMissingBins=True, originalOrder=True)
 _timing_summary = PlotGroup("summary", [
     Plot(_time_per_iter,
          ytitle="Average processing time (ms)", title="Average processing time / event", legendDx=-0.4, **_common),
-    Plot(AggregateBins("iteration_fraction", "reconstruction_step_module_average", _iterModuleMap(), ignoreMissingBins=True),
+    Plot(AggregateBins("iteration_fraction", "reconstruction_step_module_average", _iterModuleMap(), ignoreMissingBins=True, originalOrder=True),
          ytitle="Fraction", title="", normalizeToUnitArea=True, **_common),
     #
     Plot(AggregateBins("step", "reconstruction_step_module_average", _stepModuleMap(), ignoreMissingBins=True),

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -38,6 +38,8 @@ _legendDy_2rows = -0.025
 _legendDy_2rows_3cols = -0.17
 _legendDy_4rows = 0.09
 
+_trackingNumberOfEventsHistogram = "DQMData/Run 1/Tracking/Run summary/Track/general_trackingParticleRecoAsssociation/tracks"
+
 def _makeEffFakeDupPlots(postfix, quantity, unit="", common={}, effopts={}, fakeopts={}):
     p = postfix
     q = quantity
@@ -501,7 +503,9 @@ def _summaryBinRename(binLabel, highPurity, byOriginalAlgo, byAlgoMask, seeds):
 
 def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAlgoMask=False, seeds=False, midfix=""):
     _common = {"drawStyle": "EP", "xbinlabelsize": 10, "xbinlabeloption": "d"}
-    _commonN = {"ylog": True, "ymin": _minMaxN, "ymax": _minMaxN}
+    _commonN = dict(ylog=True, ymin=_minMaxN, ymax=_minMaxN,
+                    normalizeToNumberOfEvents=True,
+    )
     _commonN.update(_common)
     _commonAB = dict(mapping=mapping,
                      renameBin=lambda bl: _summaryBinRename(bl, highPurity, byOriginalAlgo, byAlgoMask, seeds),
@@ -545,11 +549,11 @@ def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAl
         Plot(h_pileuprate, title="Pileup rate vs collection", ytitle="Pileup rate", ymax=_maxFake, **_common),
     ])
     summaryN = PlotGroup(prefix+"_ntracks", [
-        Plot(h_reco, ytitle="Tracks", title="Number of tracks vs collection", **_commonN),
-        Plot(h_true, ytitle="True tracks", title="Number of true tracks vs collection", **_commonN),
-        Plot(h_fake, ytitle="Fake tracks", title="Number of fake tracks vs collection", **_commonN),
-        Plot(h_duplicate, ytitle="Duplicate tracks", title="Number of duplicate tracks vs collection", **_commonN),
-        Plot(h_pileup, ytitle="Pileup tracks", title="Number of pileup tracks vs collection", **_commonN),
+        Plot(h_reco, ytitle="Tracks/event", title="Number of tracks/event vs collection", **_commonN),
+        Plot(h_true, ytitle="True tracks/event", title="Number of true tracks/event vs collection", **_commonN),
+        Plot(h_fake, ytitle="Fake tracks/event", title="Number of fake tracks/event vs collection", **_commonN),
+        Plot(h_duplicate, ytitle="Duplicate tracks/event", title="Number of duplicate tracks/event vs collection", **_commonN),
+        Plot(h_pileup, ytitle="Pileup tracks/event", title="Number of pileup tracks/event vs collection", **_commonN),
     ])
 
     return (summary, summaryN)
@@ -904,7 +908,7 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
         summaryPlots.extend([_summaryRaw, _summaryRawN])
     summaryPlots.extend(_summaryPlots)
 
-    common = dict(loopSubFolders=False, purpose=PlotPurpose.TrackingSummary, page="summary", **limiters)
+    common = dict(loopSubFolders=False, purpose=PlotPurpose.TrackingSummary, page="summary", numberOfEventsHistogram=_trackingNumberOfEventsHistogram, **limiters)
     plotter.append(summaryName, folders,
                    PlotFolder(*summaryPlots, section=name, **common))
     plotter.append(summaryName+"_highPurity", folders,

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -398,13 +398,13 @@ def _mapCollectionToAlgoQuality(collName):
     hasPtCut = False
     if "Pt" in collName:
         if "Step" in collName:
-            hasPtCut = collName.index("Pt") > collName.index("Step")
+            hasPtCut = collName.rindex("Pt") > collName.index("Step")
         else:
             hasPtCut = True
     collNameNoQuality = collName.replace("Hp", "")
     if hasPtCut:
         quality += "Pt"
-        collNameNoQuality = collNameNoQuality.replace("Pt", "")
+        collNameNoQuality = "".join(collNameNoQuality.rsplit("Pt", 1)) # rreplace
     if "ByOriginalAlgo" in collName:
         quality += "ByOriginalAlgo"
         collNameNoQuality = collNameNoQuality.replace("ByOriginalAlgo", "")

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -116,8 +116,8 @@ _effandfake3 = PlotGroup("effandfake3",
 )
 _common = {"ymin": 0, "ymax": _maxEff}
 _effandfake4 = PlotGroup("effandfake4",
-                         _makeEffFakeDupPlots("vertpos", "vert xy", "cm", fakeopts=dict(xtitle="track ref. point xy (cm)", ytitle="fake+duplicates vs. xy")) +
-                         _makeEffFakeDupPlots("zpos"   , "vert z" , "cm", fakeopts=dict(xtitle="track ref. point z (cm)" , ytitle="fake+duplicates vs. z")) +
+                         _makeEffFakeDupPlots("vertpos", "vert r", "cm", fakeopts=dict(xtitle="track ref. point r (cm)", ytitle="fake+duplicates vs. r")) +
+                         _makeEffFakeDupPlots("zpos"   , "vert z", "cm", fakeopts=dict(xtitle="track ref. point z (cm)", ytitle="fake+duplicates vs. z")) +
                          _makeEffFakeDupPlots("dr"     , "#DeltaR", effopts=dict(xtitle="TP min #DeltaR"), fakeopts=dict(xtitle="track min #DeltaR"), common=dict(xlog=True)) +
                          _makeEffFakeDupPlots("pu"     , "PU"     , common=dict(xtitle="Pileup", xmin=_minPU, xmax=_maxPU)),
                          legendDy=_legendDy_4rows
@@ -134,10 +134,10 @@ _dupandfake1 = PlotGroup("dupandfake1", [
                          ncols=3
 )
 _dupandfake2 = PlotGroup("dupandfake2",
-                         _makeFakeDupPileupPlots("dxy"  , "dxy"  , "cm") +
-                         _makeFakeDupPileupPlots("dxypv", "dxypv", "cm") +
-                         _makeFakeDupPileupPlots("dz"   , "dz"   , "cm") +
-                         _makeFakeDupPileupPlots("dzpv" , "dzpv" , "cm"),
+                         _makeFakeDupPileupPlots("dxy"  , "dxy"    , "cm") +
+                         _makeFakeDupPileupPlots("dxypv", "dxy(PV)", "cm") +
+                         _makeFakeDupPileupPlots("dz"   , "dz"     , "cm") +
+                         _makeFakeDupPileupPlots("dzpv" , "dz(PV)" , "cm"),
                          ncols=3, legendDy=_legendDy_4rows
 )
 _dupandfake3 = PlotGroup("dupandfake3",
@@ -148,10 +148,10 @@ _dupandfake3 = PlotGroup("dupandfake3",
                          ncols=3, legendDy=_legendDy_4rows
 )
 _dupandfake4 = PlotGroup("dupandfake4",
-                         _makeFakeDupPileupPlots("vertpos", "xy", "cm", xquantity="ref. point xy (cm)") +
-                         _makeFakeDupPileupPlots("zpos"   , "z" , "cm", xquantity="ref. point z (cm)") +
-                         _makeFakeDupPileupPlots("dr"     , "#DeltaR" , xquantity="min #DeltaR", common=dict(xlog=True)) +
-                         _makeFakeDupPileupPlots("pu"     , "PU"      , xquantity="Pileup", common=dict(xmin=_minPU, xmax=_maxPU)),
+                         _makeFakeDupPileupPlots("vertpos", "r", "cm", xquantity="ref. point r (cm)") +
+                         _makeFakeDupPileupPlots("zpos"   , "z", "cm", xquantity="ref. point z (cm)") +
+                         _makeFakeDupPileupPlots("dr"     , "#DeltaR", xquantity="min #DeltaR", common=dict(xlog=True)) +
+                         _makeFakeDupPileupPlots("pu"     , "PU"     , xtitle="Pileup", common=dict(xmin=_minPU, xmax=_maxPU)),
                          ncols=3, legendDy=_legendDy_4rows
 )
 _seedingLayerSet_common = dict(removeEmptyBins=True, xbinlabelsize=8, xinlabeloption="d", adjustMarginRight=0.1)
@@ -248,7 +248,7 @@ _common = {"stat": True, "normalizeToUnitArea": True, "ylog": True, "ymin": 1e-6
 _hitsAndPt = PlotGroup("hitsAndPt", [
     Plot("missing_inner_layers", xmin=_minLayers, xmax=_maxLayers, ymax=1, **_common),
     Plot("missing_outer_layers", xmin=_minLayers, xmax=_maxLayers, ymax=1, **_common),
-    Plot("hits_eta", stat=True, statx=0.38, xtitle="track #eta", ytitle="<hits> vs #eta", ymin=_minHits, ymax=_maxHits, statyadjust=[0,0,-0.15],
+    Plot("hits_eta", xtitle="track #eta", ytitle="<hits> vs #eta", ymin=_minHits, ymax=_maxHits, statyadjust=[0,0,-0.15],
          fallback={"name": "nhits_vs_eta", "profileX": True}),
     Plot("hits", stat=True, xtitle="track hits", xmin=_minHits, xmax=_maxHits, ylog=True, ymin=[5e-1, 5, 5e1, 5e2, 5e3], drawStyle="hist"),
     Plot("num_simul_pT", xtitle="TP p_{T}", xlog=True, ymax=[1e-1, 2e-1, 5e-1, 1], **_common),
@@ -257,9 +257,9 @@ _hitsAndPt = PlotGroup("hitsAndPt", [
 _tuning = PlotGroup("tuning", [
     Plot("chi2", stat=True, normalizeToUnitArea=True, ylog=True, ymin=1e-6, ymax=[0.1, 0.2, 0.5, 1.0001], drawStyle="hist", xtitle="#chi^{2}", ratioUncertainty=False),
     Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})"),
-    Plot("chi2mean", stat=True, title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymax=2.5,
+    Plot("chi2mean", title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymin=[0, 0.5], ymax=[2, 2.5, 3, 5],
          fallback={"name": "chi2_vs_eta", "profileX": True}),
-    Plot("ptres_vs_eta_Mean", stat=True, scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > [%]", ymin=-1.5, ymax=1.5)
+    Plot("ptres_vs_eta_Mean", scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > [%]", ymin=-1.5, ymax=1.5)
 ])
 _common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025], "ratioUncertainty": False}
 _pulls = PlotGroup("pulls", [

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -379,7 +379,6 @@ class Sample:
         pileup = ""
         fastsim = ""
         midfix = ""
-        scenario = ""
         sample = self._sample
         if self._append is not None:
             midfix += self._append
@@ -397,14 +396,12 @@ class Sample:
                 pileup = "PU"+self.pileupType(newRelease)+"_"
         if self._fastsim:
             fastsim = "_FastSim"
-        if self._scenario is not None:
-            scenario = "_"+self._scenario
             
         globalTag = _getGlobalTag(self, newRelease)
 
-        fname = 'DQM_V{dqmVersion}_R000000001__{sample}{midfix}__{newrelease}-{pileup}{globaltag}{appendGlobalTag}{scenario}{fastsim}-{version}__DQMIO.root'.format(
+        fname = 'DQM_V{dqmVersion}_R000000001__{sample}{midfix}__{newrelease}-{pileup}{globaltag}{appendGlobalTag}{fastsim}-{version}__DQMIO.root'.format(
             sample=sample, midfix=midfix, newrelease=_stripRelease(newRelease),
-            pileup=pileup, globaltag=globalTag, appendGlobalTag=self._appendGlobalTag, scenario=scenario, fastsim=fastsim,
+            pileup=pileup, globaltag=globalTag, appendGlobalTag=self._appendGlobalTag, fastsim=fastsim,
             version=self.version(newRelease), dqmVersion=self._dqmVersion
         )
 
@@ -640,10 +637,7 @@ class Validation:
         newGlobalTag = _getGlobalTag(sample, self._newRelease)
 
         # Construct selection string
-        selectionNameBase = ""
-        if sample.hasScenario():
-            selectionNameBase += "_"+sample.scenario()
-        selectionNameBase += "_"+sample.pileup()
+        selectionNameBase = "_"+sample.pileup()
         newSelection = newGlobalTag+selectionNameBase+plotterFolder.getSelectionName(dqmSubFolder)
         if sample.pileupEnabled():
             newPu = sample.pileupType(self._newRelease)

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -141,15 +141,40 @@ _globalTags = {
     "CMSSW_8_0_3_71XGENSIM_tec": {"default": "80X_mcRun2_asymptotic_SiStripBad_TEC_CL62_for2016_v1_mc_gs7120p2TrkCoolLoop"},
     "CMSSW_8_0_5": {"default": "80X_mcRun2_asymptotic_v12_gs7120p2", "fastsim": "80X_mcRun2_asymptotic_v12"},
     "CMSSW_8_0_5_pmx": {"default": "80X_mcRun2_asymptotic_v12_gs7120p2_resub", "fastsim": "80X_mcRun2_asymptotic_v12"},
+    "CMSSW_8_0_10": {"default": "80X_mcRun2_asymptotic_v14"},
+    "CMSSW_8_0_10_patch1_BS": {"default": "80X_mcRun2_asymptotic_RealisticBS_25ns_13TeV2016_v1_mc_realisticBS2016"},
+    "CMSSW_8_0_11": {"default": "80X_mcRun2_asymptotic_v14"},
+    "CMSSW_8_0_15": {"default": "80X_mcRun2_asymptotic_v16_gs7120p2", "fastsim": "80X_mcRun2_asymptotic_v16"},
+    "CMSSW_8_0_16": {"default": "80X_mcRun2_asymptotic_v16_gs7120p2", "fastsim": "80X_mcRun2_asymptotic_v16"},
+    "CMSSW_8_0_16_Tranche4GT": {"default": "80X_mcRun2_asymptotic_2016_TrancheIV_v0_gs7120p2_Tranch4GT", "fastsim": "80X_mcRun2_asymptotic_2016_TrancheIV_v0_Tranch4GT"},
     "CMSSW_8_1_0_pre1": {"default": "80X_mcRun2_asymptotic_v6"},
     "CMSSW_8_1_0_pre1_phase1": {"default": "80X_upgrade2017_design_v4_UPG17", "fullsim_25ns": "80X_upgrade2017_design_v4_UPG17PU35"},
     "CMSSW_8_1_0_pre2": {"default": "80X_mcRun2_asymptotic_v10_gs810pre2", "fastsim": "80X_mcRun2_asymptotic_v10"},
     "CMSSW_8_1_0_pre2_phase1": {"default": "80X_upgrade2017_design_v9_UPG17designGT", "fullsim_25ns": "80X_upgrade2017_design_v9_UPG17PU35designGT"},
     "CMSSW_8_1_0_pre2_phase1_realGT": {"default": "80X_upgrade2017_realistic_v1_UPG17realGT", "fullsim_25ns": "80X_upgrade2017_realistic_v1_UPG17PU35realGT"},
+    "CMSSW_8_1_0_pre3": {"default": "80X_mcRun2_asymptotic_v12"},
+    "CMSSW_8_1_0_pre3_phase1": {"default": "80X_upgrade2017_realistic_v3_UPG17", "fullsim_25ns": "80X_upgrade2017_realistic_v3_UPG17PU35"},
+    "CMSSW_8_1_0_pre4": {"default": "80X_mcRun2_asymptotic_v13"},
+    "CMSSW_8_1_0_pre4_phase1": {"default": "80X_upgrade2017_realistic_v4_UPG17", "fullsim_25ns": "80X_upgrade2017_realistic_v4_UPG17PU35"},
+    "CMSSW_8_1_0_pre5": {"default": "80X_mcRun2_asymptotic_v13"},
+    "CMSSW_8_1_0_pre5_phase1": {"default": "80X_upgrade2017_realistic_v4_resubUPG17", "fullsim_25ns": "80X_upgrade2017_realistic_v4_resubUPG17PU35"},
+    "CMSSW_8_1_0_pre6": {"default": "80X_mcRun2_asymptotic_v14"},
+    "CMSSW_8_1_0_pre6_phase1": {"default": "81X_upgrade2017_realistic_v0_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v0_UPG17PU35"},
+    "CMSSW_8_1_0_pre7": {"default": "81X_mcRun2_asymptotic_v0"},
+    "CMSSW_8_1_0_pre7_phase1": {"default": "81X_upgrade2017_realistic_v2_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v2_UPG17PU35"},
+    "CMSSW_8_1_0_pre7_phase1_newGT": {"default": "81X_upgrade2017_realistic_v3_UPG17newGT", "fullsim_25ns": "81X_upgrade2017_realistic_v3_UPG17PU35newGTresub"},
+    "CMSSW_8_1_0_pre8": {"default": "81X_mcRun2_asymptotic_v1"},
+    "CMSSW_8_1_0_pre8_phase1": {"default": "81X_upgrade2017_realistic_v3_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v3_UPG17PU35"},
+    "CMSSW_8_1_0_pre8_phase1_newGT": {"default": "81X_upgrade2017_realistic_v4_UPG17newGT", "fullsim_25ns": "81X_upgrade2017_realistic_v4_UPG17PU35newGT"},
+    "CMSSW_8_1_0_pre8_phase1_newGT2": {"default": "81X_upgrade2017_realistic_v5_UPG17newGTset2", "fullsim_25ns": "81X_upgrade2017_realistic_v5_UPG17PU35newGTset2"},
+    "CMSSW_8_1_0_pre9": {"default": "81X_mcRun2_asymptotic_v2"},
+    "CMSSW_8_1_0_pre9_Geant4102": {"default": "81X_mcRun2_asymptotic_v2"},
+    "CMSSW_8_1_0_pre9_phase1": {"default": "81X_upgrade2017_realistic_v5_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v5_UPG17PU35"},
+    "CMSSW_8_1_0_pre9_phase1_newGT": {"default": "81X_upgrade2017_realistic_v6_UPG17newGT", "fullsim_25ns": "81X_upgrade2017_realistic_v6_UPG17PU35newGT"},
 }
 
 _releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_71XGENSIM_pmx", "_gcc530_pmx", "_pmx_v2", "_pmx_v3", "_pmx", "_Fall14DR", "_71XGENSIM_FIXGT", "_71XGENSIM_PU", "_71XGENSIM_PXbest", "_71XGENSIM_PXworst", "_71XGENSIM_hcal", "_71XGENSIM_tec", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113", "_extended",
-                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1_13TeV", "_phase1_realGT", "_phase1", "_ecal15fb", "_ecal30fb", "_pixDynIneff", "_gcc530"]
+                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1_13TeV", "_phase1_realGT", "_phase1_newGT2", "_phase1_newGT", "_phase1", "_ecal15fb", "_ecal30fb", "_pixDynIneff", "_gcc530", "_Tranche4GT"]
 def _stripRelease(release):
     for pf in _releasePostfixes:
         if pf in release:

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -491,6 +491,7 @@ class Validation:
             print "Private key file {keyfile} does not exist, unable to download RelVal files from {url}".format(keyfile=keyfile, url=relvalUrl)
             sys.exit(1)
         
+        # curl --cert-type PEM --cert $HOME/.globus/usercert.pem --key $HOME/.globus/userkye.pem -k -O <url> -O <url>
         cmd = ["curl", "--cert-type", "PEM", "--cert", certfile, "--key", keyfile, "-k"]
         for u in urls:
             cmd.extend(["-O", u])
@@ -897,11 +898,12 @@ def _findDuplicates(lst):
     return list(found2)
 
 class SimpleSample:
-    def __init__(self, label, name, fileLegends, pileup=True):
+    def __init__(self, label, name, fileLegends, pileup=True, customPileupLabel=""):
         self._label = label
         self._name = name
         self._fileLegends = fileLegends
         self._pileup = pileup
+        self._customPileupLabel = customPileupLabel
 
     def digest(self):
         # Label should be unique among the plotting run, so it serves also as the digest
@@ -925,6 +927,9 @@ class SimpleSample:
 
     def pileupEnabled(self):
         return self._pileup
+
+    def customPileupLabel(self):
+        return self._customPileupLabel
 
     def doElectron(self):
         return True

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -962,16 +962,18 @@ class SimpleValidation:
 
             self._openFiles = []
             for f in sample.files():
-                if not os.path.exists(f):
-                    print "File %s not found (from sample %s)" % (f, sample.name)
-                    sys.exit(1)
-                self._openFiles.append(ROOT.TFile.Open(f))
+                if os.path.exists(f):
+                    self._openFiles.append(ROOT.TFile.Open(f))
+                else:
+                    print "File %s not found (from sample %s), ignoring it" % (f, sample.name())
+                    self._openFiles.append(None)
 
             for plotter in plotters:
                 self._doPlotsForPlotter(plotter, sample, **kwargs)
 
             for tf in self._openFiles:
-                tf.Close()
+                if tf is not None:
+                    tf.Close()
             self._openFiles = []
 
     def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -16,7 +16,15 @@ _globalTags = {
     "CMSSW_6_2_0": {"default": "PRE_ST62_V8"},
     "CMSSW_6_2_0_SLHC15": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
     "CMSSW_6_2_0_SLHC17": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
-    "CMSSW_6_2_0_SLHC20": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
+    "CMSSW_6_2_0_SLHC20": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1_UPG2023SHNoTaper"},
+    "CMSSW_6_2_0_SLHC22": {"UPG2023SHNoTaper": "PH2_1K_FB_V6_UPG23SHNoTaper",
+                           # map 81X GReco and tilted to SHNoTaper
+                           "2023GReco": "PH2_1K_FB_V6_UPG23SHNoTaper", "2023GRecoPU35": "", "2023GRecoPU140": "", "2023GRecoPU200": "",
+                           "2023tilted": "PH2_1K_FB_V6_UPG23SHNoTaper", "2023tiltedPU35": "", "2023tiltedPU140": "", "2023tiltedPU200": ""},
+    "CMSSW_6_2_0_SLHC26": {"LHCCRefPU140": "DES23_62_V1_LHCCRefPU140", "LHCCRefPU200": "DES23_62_V1_LHCCRefPU200",
+                           # map 81X GReco and tilted to LHCCRef
+                           "2023GReco": "", "2023GRecoPU35": "", "2023GRecoPU140": "DES23_62_V1_LHCCRefPU140", "2023GRecoPU200": "DES23_62_V1_LHCCRefPU200",
+                           "2023tilted": "", "2023tiltedPU35": "", "2023tiltedPU140": "DES23_62_V1_LHCCRefPU140", "2023tiltedPU200": "DES23_62_V1_LHCCRefPU200"},
     "CMSSW_6_2_0_SLHC27_phase1": {"default": "DES17_62_V8_UPG17"},
     "CMSSW_7_0_0": {"default": "POSTLS170_V3", "fullsim_50ns": "POSTLS170_V4"},
     "CMSSW_7_0_0_AlcaCSA14": {"default": "POSTLS170_V5_AlcaCSA14", "fullsim_50ns": "POSTLS170_V6_AlcaCSA14"},
@@ -163,10 +171,14 @@ _globalTags = {
     "CMSSW_8_1_0_pre7": {"default": "81X_mcRun2_asymptotic_v0"},
     "CMSSW_8_1_0_pre7_phase1": {"default": "81X_upgrade2017_realistic_v2_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v2_UPG17PU35"},
     "CMSSW_8_1_0_pre7_phase1_newGT": {"default": "81X_upgrade2017_realistic_v3_UPG17newGT", "fullsim_25ns": "81X_upgrade2017_realistic_v3_UPG17PU35newGTresub"},
+    "CMSSW_8_1_0_pre7_phase2": {"2023GReco": "81X_mcRun2_asymptotic_v0_2023GReco", "2023GRecoPU35": "", "2023GRecoPU140": "81X_mcRun2_asymptotic_v0_2023GRecoPU140resubmit2", "2023GRecoPU200": "81X_mcRun2_asymptotic_v0_2023GRecoPU200resubmit2",
+                                "2023tilted": "81X_mcRun2_asymptotic_v0_2023tilted", "2023tiltedPU35": "", "2023tiltedPU140": "81X_mcRun2_asymptotic_v0_2023tiltedPU140resubmit2", "2023tiltedPU200": "81X_mcRun2_asymptotic_v0_2023tiltedPU200resubmit2"},
     "CMSSW_8_1_0_pre8": {"default": "81X_mcRun2_asymptotic_v1"},
     "CMSSW_8_1_0_pre8_phase1": {"default": "81X_upgrade2017_realistic_v3_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v3_UPG17PU35"},
     "CMSSW_8_1_0_pre8_phase1_newGT": {"default": "81X_upgrade2017_realistic_v4_UPG17newGT", "fullsim_25ns": "81X_upgrade2017_realistic_v4_UPG17PU35newGT"},
     "CMSSW_8_1_0_pre8_phase1_newGT2": {"default": "81X_upgrade2017_realistic_v5_UPG17newGTset2", "fullsim_25ns": "81X_upgrade2017_realistic_v5_UPG17PU35newGTset2"},
+    "CMSSW_8_1_0_pre8_phase2": {"2023GReco": "81X_mcRun2_asymptotic_v1_resub2023GReco", "2023GRecoPU35": "81X_mcRun2_asymptotic_v1_resub2023GRecoPU35", "2023GRecoPU140": "81X_mcRun2_asymptotic_v1_resub2023GRecoPU140", "2023GRecoPU200": "81X_mcRun2_asymptotic_v1_resub2023GRecoPU200",
+                                "2023tilted": "81X_mcRun2_asymptotic_v1_2023tilted", "2023tiltedPU35": "81X_mcRun2_asymptotic_v1_2023tiltedPU", "2023tiltedPU140": "81X_mcRun2_asymptotic_v1_2023tiltedPU140", "2023tiltedPU200": "81X_mcRun2_asymptotic_v1_2023tiltedPU200"},
     "CMSSW_8_1_0_pre9": {"default": "81X_mcRun2_asymptotic_v2"},
     "CMSSW_8_1_0_pre9_Geant4102": {"default": "81X_mcRun2_asymptotic_v2"},
     "CMSSW_8_1_0_pre9_phase1": {"default": "81X_upgrade2017_realistic_v5_UPG17", "fullsim_25ns": "81X_upgrade2017_realistic_v5_UPG17PU35"},
@@ -174,7 +186,7 @@ _globalTags = {
 }
 
 _releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_71XGENSIM_pmx", "_gcc530_pmx", "_pmx_v2", "_pmx_v3", "_pmx", "_Fall14DR", "_71XGENSIM_FIXGT", "_71XGENSIM_PU", "_71XGENSIM_PXbest", "_71XGENSIM_PXworst", "_71XGENSIM_hcal", "_71XGENSIM_tec", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113", "_extended",
-                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1_13TeV", "_phase1_realGT", "_phase1_newGT2", "_phase1_newGT", "_phase1", "_ecal15fb", "_ecal30fb", "_pixDynIneff", "_gcc530", "_Tranche4GT"]
+                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch", "_noCCC_v3", "_noCCC", "_MT", "_phase1_rereco", "_phase1_pythia8", "_phase1_13TeV", "_phase1_realGT", "_phase1_newGT2", "_phase1_newGT", "_phase1", "_phase2", "_ecal15fb", "_ecal30fb", "_pixDynIneff", "_gcc530", "_Tranche4GT"]
 def _stripRelease(release):
     for pf in _releasePostfixes:
         if pf in release:

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -32,10 +32,11 @@ def main(opts):
         plotting.verbose = True
 
     val = SimpleValidation(files, labels, opts.outputDir)
+    sample = SimpleSample(opts.subdirprefix, opts.html_sample)
     kwargs = {}
     if opts.html:
         htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
-        htmlReport.beginSample(SimpleSample(opts.html_prefix, opts.html_sample))
+        htmlReport.beginSample(sample)
         kwargs["htmlReport"] = htmlReport
 
     kwargs_tracking = {}
@@ -61,13 +62,13 @@ def main(opts):
             "building": ignore,
         }
 
-    val.doPlots(trackingPlots.plotter, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs_tracking)
+    trk = [trackingPlots.plotter]
+    other = [trackingPlots.timePlotter, vertexPlots.plotter]
     if opts.extended:
-        val.doPlots(trackingPlots.plotterExt, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs_tracking)
-    val.doPlots(trackingPlots.timePlotter, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
-    val.doPlots(vertexPlots.plotter, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
-    if opts.extended:
-        val.doPlots(vertexPlots.plotterExt, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
+        trk.append(trackingPlots.plotterExt)
+        other.append(vertexPlots.plotterExt)
+    val.doPlots(trk, sample, plotterDrawArgs=drawArgs, **kwargs_tracking)
+    val.doPlots(other, sample, plotterDrawArgs=drawArgs, **kwargs)
     print
     if opts.html:
         htmlReport.write()
@@ -99,8 +100,6 @@ if __name__ == "__main__":
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
     parser.add_argument("--html", action="store_true",
                         help="Generate HTML pages")
-    parser.add_argument("--html-prefix", default="plots",
-                        help="Prefix for HTML page generation (default 'plots')")
     parser.add_argument("--html-sample", default="Sample",
                         help="Sample name for HTML page generation (default 'Sample')")
     parser.add_argument("--html-validation-name", default="",

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -34,8 +34,6 @@ def main(opts):
     kwargs = {}
     if opts.html:
         htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
-        htmlReport.beginSample(sample)
-        kwargs["htmlReport"] = htmlReport
 
     kwargs_tracking = {}
     kwargs_tracking.update(kwargs)

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -21,8 +21,8 @@ def main(opts):
     sample = SimpleSample(opts.subdirprefix, opts.html_sample, [(f, f.replace(".root", "")) for f in opts.files])
 
     drawArgs={}
-    if opts.ratio:
-        drawArgs["ratio"] = True
+    if opts.no_ratio:
+        drawArgs["ratio"] = False
     if opts.separate:
         drawArgs["separate"] = True
     if opts.png:
@@ -83,7 +83,9 @@ if __name__ == "__main__":
     parser.add_argument("--ignoreMissing", action="store_true",
                         help="Ignore missing histograms and directories")
     parser.add_argument("--ratio", action="store_true",
-                        help="Create ratio pads")
+                        help="Create ratio pads (deprecated, as it is already the default")
+    parser.add_argument("--no-ratio", action="store_true",
+                        help="Disable ratio pads")
     parser.add_argument("--separate", action="store_true",
                         help="Save all plots separately instead of grouping them")
     parser.add_argument("--png", action="store_true",
@@ -110,6 +112,9 @@ if __name__ == "__main__":
 
     if opts.ignoreMissing:
         print "--ignoreMissing is now the only operation mode, so you can stop using this parameter"
+
+    if opts.ratio:
+        print "--ratio is now the default, so you can stop using this parameter"
 
     if opts.limit_tracking_algo is not None:
         if opts.limit_relval:

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -32,8 +32,7 @@ def main(opts):
 
     val = SimpleValidation([sample], opts.outputDir)
     kwargs = {}
-    if opts.html:
-        htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
+    htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
 
     kwargs_tracking = {}
     kwargs_tracking.update(kwargs)
@@ -66,11 +65,11 @@ def main(opts):
     val.doPlots(trk, plotterDrawArgs=drawArgs, **kwargs_tracking)
     val.doPlots(other, plotterDrawArgs=drawArgs, **kwargs)
     print
-    if opts.html:
+    if opts.no_html:
+        print "Plots created into directory '%s'." % opts.outputDir
+    else:
         htmlReport.write()
         print "Plots and HTML report created into directory '%s'. You can just move it to some www area and access the pages via web browser" % opts.outputDir
-    else:
-        print "Plots created into directory '%s'." % opts.outputDir
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files.")
@@ -80,10 +79,6 @@ if __name__ == "__main__":
                         help="Plot output directory (default: 'plots')")
     parser.add_argument("--subdirprefix", type=str, default="plots",
                         help="Prefix for subdirectories inside outputDir (default: 'plots')")
-    parser.add_argument("--ignoreMissing", action="store_true",
-                        help="Ignore missing histograms and directories")
-    parser.add_argument("--ratio", action="store_true",
-                        help="Create ratio pads (deprecated, as it is already the default")
     parser.add_argument("--no-ratio", action="store_true",
                         help="Disable ratio pads")
     parser.add_argument("--separate", action="store_true",
@@ -96,14 +91,22 @@ if __name__ == "__main__":
                         help="Limit set of plots to those in release validation (almost). (default: all plots in the DQM files; conflicts with --limit-tracking-algo)")
     parser.add_argument("--extended", action="store_true",
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
-    parser.add_argument("--html", action="store_true",
-                        help="Generate HTML pages")
+    parser.add_argument("--no-html", action="store_true",
+                        help="Disable HTML page genration")
     parser.add_argument("--html-sample", default="Sample",
                         help="Sample name for HTML page generation (default 'Sample')")
     parser.add_argument("--html-validation-name", default="",
                         help="Validation name for HTML page generation (enters to <title> element) (default '')")
     parser.add_argument("--verbose", action="store_true",
                         help="Be verbose")
+
+    group = parser.add_argument_group("deprecated arguments (they have no effect and will be removed in the future):")
+    group.add_argument("--ignoreMissing", action="store_true",
+                       help="Ignore missing histograms and directories (deprecated, is this is already the default mode)")
+    group.add_argument("--ratio", action="store_true",
+                       help="Create ratio pads (deprecated, as it is already the default")
+    group.add_argument("--html", action="store_true",
+                       help="Generate HTML pages (deprecated, as it is already the default")
 
     opts = parser.parse_args()
     for f in opts.files:
@@ -115,6 +118,9 @@ if __name__ == "__main__":
 
     if opts.ratio:
         print "--ratio is now the default, so you can stop using this parameter"
+
+    if opts.html:
+        print "--html is now the default, so you can stop using this parameter"
 
     if opts.limit_tracking_algo is not None:
         if opts.limit_relval:

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -66,6 +66,8 @@ def main(opts):
         val.doPlots(trackingPlots.plotterExt, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs_tracking)
     val.doPlots(trackingPlots.timePlotter, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
     val.doPlots(vertexPlots.plotter, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
+    if opts.extended:
+        val.doPlots(vertexPlots.plotterExt, subdirprefix=opts.subdirprefix, plotterDrawArgs=drawArgs, **kwargs)
     print
     if opts.html:
         htmlReport.write()

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -18,8 +18,7 @@ def limitRelVal(algo, quality):
     return quality in ["", "highPurity"]
 
 def main(opts):
-    files = opts.files
-    labels = [f.replace(".root", "") for f in files]
+    sample = SimpleSample(opts.subdirprefix, opts.html_sample, [(f, f.replace(".root", "")) for f in opts.files])
 
     drawArgs={}
     if opts.ratio:
@@ -31,8 +30,7 @@ def main(opts):
     if opts.verbose:
         plotting.verbose = True
 
-    val = SimpleValidation(files, labels, opts.outputDir)
-    sample = SimpleSample(opts.subdirprefix, opts.html_sample)
+    val = SimpleValidation([sample], opts.outputDir)
     kwargs = {}
     if opts.html:
         htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
@@ -67,8 +65,8 @@ def main(opts):
     if opts.extended:
         trk.append(trackingPlots.plotterExt)
         other.append(vertexPlots.plotterExt)
-    val.doPlots(trk, sample, plotterDrawArgs=drawArgs, **kwargs_tracking)
-    val.doPlots(other, sample, plotterDrawArgs=drawArgs, **kwargs)
+    val.doPlots(trk, plotterDrawArgs=drawArgs, **kwargs_tracking)
+    val.doPlots(other, plotterDrawArgs=drawArgs, **kwargs)
     print
     if opts.html:
         htmlReport.write()

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -21,12 +21,11 @@ val = SimpleValidation([x[0] for x in filesLabels], [x[1] for x in filesLabels],
 sample = SimpleSample("sample_prefix", "Sample name")
 #report = val.createHtmlReport(validationName="Short description of your comparison")
 #report.beginSample(sample)
-val.doPlots(trackingPlots.plotter, sample=sample, plotterDrawArgs={"ratio": True},
+val.doPlots([trackingPlots.plotter,
+#             vertexPlots.plotter # Uncomment this to include also vertex plots
+            ],
+            sample, plotterDrawArgs={"ratio": True},
 #            htmlReport=report
 )
-## Uncomment this to include also vertex plots
-##val.doPlots(vertexPlots.plotter, sample=sample, plotterDrawArgs={"ratio": True},
-##            htmlReport=report
-##)
 #report.write()
 

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -20,12 +20,10 @@ outputDir = "plots"
 sample = SimpleSample("sample_prefix", "Sample name", filesLabels)
 val = SimpleValidation([sample], outputDir)
 #report = val.createHtmlReport(validationName="Short description of your comparison")
-#report.beginSample(sample)
 val.doPlots([trackingPlots.plotter,
 #             vertexPlots.plotter # Uncomment this to include also vertex plots
             ],
             plotterDrawArgs={"ratio": True},
-#            htmlReport=report
 )
 #report.write()
 

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -12,7 +12,7 @@ description = "Short description of your comparison"
 
 plotterDrawArgs = dict(
     separate=False, # Set to true if you want each plot in it's own canvas
-    ratio=True,     # Enables ratio pad
+#    ratio=False,   # Uncomment to disable ratio pad
 )
 
 # Pairs of file names and legend labels

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -7,23 +7,98 @@ from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSam
 import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
 
+outputDir = "plots" # Plot output directory
+description = "Short description of your comparison"
 
-# Example of file - label pairs
+plotterDrawArgs = dict(
+    separate=False, # Set to true if you want each plot in it's own canvas
+    ratio=True,     # Enables ratio pad
+)
+
+# Pairs of file names and legend labels
 filesLabels = [
     ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
     ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
 ]
+# Files are grouped together as a "sample" (the files don't
+# necessarily have to come from the same sample, like ttbar, but this
+# is the abstraction here)
+sample = SimpleSample("sample_prefix", # Prefix for subdirectory names
+                      "Sample name",   # The name appears in the HTML pages
+                      filesLabels)     # Files and legend labels
 
-outputDir = "plots"
+# You can produce plots for multiple samples on one. Just construct
+# multiple SimpleSample objects like above and add them to the list
+# below.
+samples = [
+    sample
+]
 
-# To auto-generate HTML pages, uncomment the commented lines below
-sample = SimpleSample("sample_prefix", "Sample name", filesLabels)
-val = SimpleValidation([sample], outputDir)
-#report = val.createHtmlReport(validationName="Short description of your comparison")
-val.doPlots([trackingPlots.plotter,
-#             vertexPlots.plotter # Uncomment this to include also vertex plots
-            ],
-            plotterDrawArgs={"ratio": True},
+# Example of how to limit tracking plots to specific iterations
+kwargs_tracking = {}
+class LimitTrackAlgo: # helper class to limit to iterations
+    def __init__(self, algos):
+        self._algos = algos
+    def __call__(self, algo, quality):
+        return algo in self._algos
+limit = LimitTrackAlgo(["ootb", "initialStep"]) # limit to generalTracks (ootb) and initialStep
+ignore = lambda algo, quality: False # ignore everything
+
+# This specifies how different sets of plots are treated. If some
+# "plot set" is not in the dictionary, full set of plots will be
+# produced for it
+limitSubFolders = {
+    "":            limit,  # The default set (signal TrackingParticles for efficiency, all TrackingParticles for fakes)
+    "allTPEffic":  ignore, # Efficiency with all TrackingParticles
+    "fromPV":      limit,  # Tracks from PV, signal TrackingParticles for efficiency and fakes
+    "fromPVAllTP": limit,  # Tracks from PV, all TrackingParticles for fakes
+    "building":    ignore, # Built tracks (as opposed to selected tracks in above)
+    "seeding":     ignore, # Seeds
+}
+# arguments to be passed to tracking val.doPlots() below
+kwargs_tracking["limitSubFoldersOnlyTo"]=limitSubFolders
+
+# Example of how to customize the plots, here applied only if each
+# plot is drawn separately
+if plotterDrawArgs["separate"]:
+    common = dict(
+        title=""
+    )
+
+    for plotFolderName in ["", "building"]: # these refer to the various cases added with _appendTrackingPlots in trackingPlots.py
+        # Get the PlotFolder object
+        plotFolder = trackingPlots.plotter.getPlotFolder(plotFolderName)
+
+        # These are the PlotGroup objects defined in trackingPlots.py,
+        # name is the same as the first parameter to PlotGroup constructor
+        plotGroup = plotFolder.getPlotGroup("effandfake1")
+        # From PlotGroup one can ask an individual Plot, again name is
+        # the same as used for Plot constructor. The setProperties()
+        # accepts the same parameters as the constructor, see
+        # plotting.Plot for more information.
+        plotGroup.getPlot("efficPt").setProperties(legendDx=-0, legendDy=-0, **common)
+
+    # Example of customization of vertex plots
+    common["lineWidth"] = 4
+    plotFolder = vertexPlots.plotterExt.getPlotFolder("gen")
+    plotGroup = plotFolder.getPlotGroup("genpos")
+    plotGroup.getPlot("GenAllV_Z").setProperties(xtitle="Simulated vertex z (cm)", legendDy=-0.1, legendDx=-0.45, ratioYmax=2.5, **common)
+
+
+val = SimpleValidation(samples, outputDir)
+report = val.createHtmlReport(validationName=description)
+val.doPlots([
+    trackingPlots.plotter,     # standard tracking plots
+    #trackingPlots.plotterExt, # extended tracking plots (e.g. distributions)
+],
+            plotterDrawArgs=plotterDrawArgs,
+            **kwargs_tracking
 )
-#report.write()
-
+val.doPlots([
+    #trackingPlots.timePlotter, # tracking timing plots
+    vertexPlots.plotter,        # standard vertex plots
+    #vertexPlots.plotterExt,    # extended vertex plots (e.g. distributions)
+],
+            plotterDrawArgs=plotterDrawArgs,
+)
+report.write() # comment this if you don't want HTML page generation

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -17,14 +17,14 @@ filesLabels = [
 outputDir = "plots"
 
 # To auto-generate HTML pages, uncomment the commented lines below
-val = SimpleValidation([x[0] for x in filesLabels], [x[1] for x in filesLabels], outputDir)
-sample = SimpleSample("sample_prefix", "Sample name")
+sample = SimpleSample("sample_prefix", "Sample name", filesLabels)
+val = SimpleValidation([sample], outputDir)
 #report = val.createHtmlReport(validationName="Short description of your comparison")
 #report.beginSample(sample)
 val.doPlots([trackingPlots.plotter,
 #             vertexPlots.plotter # Uncomment this to include also vertex plots
             ],
-            sample, plotterDrawArgs={"ratio": True},
+            plotterDrawArgs={"ratio": True},
 #            htmlReport=report
 )
 #report.write()

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -32,6 +32,8 @@ startupsamples= [
 
 def putype(t):
     if "_pmx" in NewRelease:
+        if "_pmx" in RefRelease:
+            return {"default": "pmx"+t}
         return {"default": t, NewRelease: "pmx"+t}
     return t
 
@@ -96,6 +98,9 @@ if "_pmx" in NewRelease:
     doFastVsFull = False
     if not NewRelease in validation._globalTags:
         validation._globalTags[NewRelease] = validation._globalTags[NewRelease.replace("_pmx", "")]
+if RefRelease is not None and "_pmx" in RefRelease:
+    if not RefRelease in validation._globalTags:
+        validation._globalTags[RefRelease] = validation._globalTags[RefRelease.replace("_pmx", "")]
 if "_extended" in NewRelease:
     startupsamples = [
         Sample('RelValTTbar', midfix="13_HS"),

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -36,10 +36,10 @@ def putype(t):
     return t
 
 pileupstartupsamples = [
-    Sample('RelValTTbar', putype=putype("25ns"), midfix="13"),
-#    Sample('RelValTTbar', putype=putype("50ns"), midfix="13"),
-    Sample('RelValZMM', putype=putype("25ns"), midfix="13"),
-#    Sample('RelValZMM', putype=putype("50ns"), midfix="13")
+    Sample('RelValTTbar', putype=putype("25ns"), punum=35, midfix="13"),
+#    Sample('RelValTTbar', putype=putype("50ns"), punum=35, midfix="13"),
+    Sample('RelValZMM', putype=putype("25ns"), punum=35, midfix="13"),
+#    Sample('RelValZMM', putype=putype("50ns"), punum=35, midfix="13")
 ]
 
 phase1samples = [
@@ -48,27 +48,27 @@ phase1samples = [
     Sample('RelValZMM', midfix="13"),
     Sample('RelValQCD_Pt_600_800', midfix="13"),
     Sample('RelValTenMuE_0_200'),
-    Sample("RelValTTbar", midfix="13", putype=putype("25ns")),
-    Sample("RelValZMM", midfix="13", putype=putype("25ns")),
+    Sample("RelValTTbar", midfix="13", putype=putype("25ns"), punum=35),
+    Sample("RelValZMM", midfix="13", putype=putype("25ns"), punum=35),
 ]
 
 phase2samples = [
     Sample("RelValMinBias", midfix="TuneZ2star_14TeV", scenario="2023GReco"),
     Sample("RelValMinBias", midfix="TuneZ2star_14TeV", scenario="2023tilted"),
     Sample("RelValTTbar", midfix="14TeV", scenario="2023GReco"),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU35", putype=putype("25ns")),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU140", putype=putype("25ns")),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU200", putype=putype("25ns")),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU35", putype=putype("25ns"), punum=35),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU140", putype=putype("25ns"), punum=140),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023GRecoPU200", putype=putype("25ns"), punum=200),
     Sample("RelValTTbar", midfix="14TeV", scenario="2023tilted"),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU35", putype=putype("25ns")),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU140", putype=putype("25ns")),
-    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU200", putype=putype("25ns")),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU35", putype=putype("25ns"), punum=35),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU140", putype=putype("25ns"), punum=140),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2023tiltedPU200", putype=putype("25ns"), punum=200),
     Sample("RelValZMM", midfix="13", scenario="2023GReco"),
-    Sample("RelValZMM", midfix="13", scenario="2023GRecoPU140", putype=putype("25ns")),
-    Sample("RelValZMM", midfix="13", scenario="2023GRecoPU200", putype=putype("25ns")),
+    Sample("RelValZMM", midfix="13", scenario="2023GRecoPU140", putype=putype("25ns"), punum=140),
+    Sample("RelValZMM", midfix="13", scenario="2023GRecoPU200", putype=putype("25ns"), punum=200),
     Sample("RelValZMM", midfix="13", scenario="2023tilted"),
-    Sample("RelValZMM", midfix="13", scenario="2023tiltedPU140", putype=putype("25ns")),
-    Sample("RelValZMM", midfix="13", scenario="2023tiltedPU200", putype=putype("25ns")),
+    Sample("RelValZMM", midfix="13", scenario="2023tiltedPU140", putype=putype("25ns"), punum=140),
+    Sample("RelValZMM", midfix="13", scenario="2023tiltedPU200", putype=putype("25ns"), punum=200),
     Sample("RelValSingleElectronPt35Extended", scenario="2023GReco"),
     Sample("RelValSingleElectronPt35Extended", scenario="2023tilted"),
     Sample("RelValSingleMuPt10Extended", scenario="2023GReco"),
@@ -85,10 +85,11 @@ fastsimstartupsamples = [
 ]
 
 pileupfastsimstartupsamples = [
-    Sample('RelValTTbar', putype=putype("25ns"), midfix="13", fastsim=True)
+    Sample('RelValTTbar', putype=putype("25ns"), punum=35, midfix="13", fastsim=True)
 ]
 
 doFastVsFull = True
+doPhase2PU = False
 if "_pmx" in NewRelease:
     startupsamples = []
     fastsimstartupsamples = []
@@ -121,6 +122,7 @@ if "_phase2" in NewRelease:
     fastsimstartupsamples = []
     pileupfastsimstartupsamples = []
     doFastVsFull = False
+    doPhase2PU = True
 
 ### Track algorithm name and quality. Can be a list.
 Algos= ['ootb', 'initialStep', 'lowPtTripletStep','pixelPairStep','detachedTripletStep','mixedTripletStep','pixelLessStep','tobTecStep','jetCoreRegionalStep','muonSeededStepInOut','muonSeededStepOutIn',
@@ -166,14 +168,14 @@ htmlReport = val.createHtmlReport()
 val.download()
 val.doPlots(plotter=trackingPlots.plotter,
 #            limitSubFoldersOnlyTo={"": limitProcessing, "allTPEffic": limitProcessing, "fromPV": limitProcessing, "fromPVAllTP": limitProcessing},
-            htmlReport=htmlReport, doFastVsFull=doFastVsFull
+            htmlReport=htmlReport, doFastVsFull=doFastVsFull, doPhase2PU=doPhase2PU,
             **kwargs_tracking
 )
 
 val.download()
 val.doPlots(plotter=vertexPlots.plotter,
             limitSubFoldersOnlyTo={"": VertexCollections},
-            htmlReport=htmlReport, doFastVsFull=doFastVsFull
+            htmlReport=htmlReport, doFastVsFull=doFastVsFull, doPhase2PU=doPhase2PU,
 )
 htmlReport.write()
 

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -9,10 +9,10 @@ import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
 ########### User Defined Variables (BEGIN) ##############
 
 ### Reference release
-RefRelease='CMSSW_8_1_0_pre1'
+RefRelease='CMSSW_8_1_0_pre8'
 
 ### Relval release (set if different from $CMSSW_VERSION)
-NewRelease='CMSSW_8_1_0_pre2'
+NewRelease='CMSSW_8_1_0_pre9'
 
 ### This is the list of IDEAL-conditions relvals 
 startupsamples= [
@@ -43,6 +43,7 @@ pileupstartupsamples = [
 ]
 
 phase1samples = [
+    Sample('RelValMinBias', midfix="13"),
     Sample("RelValTTbar", midfix="13"),
     Sample('RelValZMM', midfix="13"),
     Sample('RelValQCD_Pt_600_800', midfix="13"),

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -132,13 +132,13 @@ val = Validation(
 )
 htmlReport = val.createHtmlReport()
 val.download()
-val.doPlots(plotter=trackingPlots.plotter, plotterDrawArgs={"ratio": True},
+val.doPlots(plotter=trackingPlots.plotter,
 #            limitSubFoldersOnlyTo={"": limitProcessing, "allTPEffic": limitProcessing, "fromPV": limitProcessing, "fromPVAllTP": limitProcessing},
             htmlReport=htmlReport, doFastVsFull=doFastVsFull
 )
 
 val.download()
-val.doPlots(plotter=vertexPlots.plotter, plotterDrawArgs={"ratio": True},
+val.doPlots(plotter=vertexPlots.plotter,
             limitSubFoldersOnlyTo={"": VertexCollections},
             htmlReport=htmlReport, doFastVsFull=doFastVsFull
 )

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -12,6 +12,8 @@ _maxFake = [0.05, 0.1, 0.2, 0.5, 0.7, 1.025]
 _minMaxRes = [5, 10, 50, 100, 200, 500, 1000, 2000, 5000]
 _minMaxPt = [5e-1, 1, 5, 1e1, 5e1, 1e2, 5e2, 1e3, 5e3, 1e4]
 
+_vertexNumberOfEventsHistogram = "DQMData/Run 1/Vertexing/Run summary/PrimaryVertexV/GenPV_Z"
+
 _common = {"xtitle": "Simulated interactions", "xmin": _minPU, "xmax": _maxPU, "ymin": _minVtx, "ymax": _maxVtx}
 _recovsgen = PlotGroup("recovsgen", [
     Plot("RecoVtx_vs_GenVtx", ytitle="Reco vertices", **_common),
@@ -162,7 +164,7 @@ _extDist = PlotGroup("dist", [
     Plot("RecoAllAssoc2Gen_Y", xtitle="Reco vertex pos y (cm)", ytitle="N", **_commonXY),
     Plot("RecoAllAssoc2Gen_R", xtitle="Reco vertex pos r (cm)", ytitle="N", **_commonXY),
     Plot("RecoAllAssoc2Gen_Z", xtitle="Reco vertex pos z (cm)", ytitle="N", **_commonZ),
-    Plot("RecoAllAssoc2Gen_NumVertices", xtitle="Number of reco vertices", ytitle="Events", stat=True, drawStyle="hist", min=_minVtx, xmax=_maxVtx),
+    Plot("RecoAllAssoc2Gen_NumVertices", xtitle="Number of reco vertices", ytitle="A.u.", normalizeToUnitArea=True, stat=True, drawStyle="hist", min=_minVtx, xmax=_maxVtx),
     Plot("RecoAllAssoc2Gen_NumTracks", xtitle="Number of tracks in vertex fit", ytitle="N", stat=True, drawStyle="hist"),
 ])
 _common = dict(title="", xtitle="Vertex z (cm)", scale=1e4, ylog=True, ymin=_minMaxRes , ymax=_minMaxRes, xmin=range(-60,-10,10), xmax=range(20,70,10))
@@ -292,7 +294,8 @@ plotterExt.append("", _vertexFolders, PlotFolder(
     _extResolutionZ,
     purpose=PlotPurpose.Vertexing,
     page="vertex",
-    onlyForPileup=True
+    onlyForPileup=True,
+    numberOfEventsHistogram=_vertexNumberOfEventsHistogram
 ))
 plotterExt.append("dqm", _vertexDqmFolders, PlotFolder(
     _extDqm,

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -108,7 +108,7 @@ _k0_effandfakeTk = PlotGroup("effandfakeTk", [
 ],
                              legendDy=-0.025
 )
-_common = {"normalizeToUnitArea": True, "drawStyle": "HIST"}
+_common = dict(normalizeToUnitArea=True, drawStyle="HIST", stat=True)
 _k0_mass = PlotGroup("mass", [
     Plot("ksMassAll", xtitle="mass of all (GeV)", **_common),
     Plot("ksMassGood", xtitle="mass of good (GeV)", **_common),

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -9,6 +9,8 @@ _minVtx = [0, 80, 120]
 _maxVtx = [60, 100, 150, 200, 250]
 _maxEff = 1.025
 _maxFake = [0.05, 0.1, 0.2, 0.5, 0.7, 1.025]
+_minMaxRes = [5, 10, 50, 100, 200, 500, 1000, 2000, 5000]
+_minMaxPt = [5e-1, 1, 5, 1e1, 5e1, 1e2, 5e2, 1e3, 5e3, 1e4]
 
 _common = {"xtitle": "Simulated interactions", "xmin": _minPU, "xmax": _maxPU, "ymin": _minVtx, "ymax": _maxVtx}
 _recovsgen = PlotGroup("recovsgen", [
@@ -44,7 +46,7 @@ _resolution = PlotGroup("resolution", [
     Plot("RecoAllAssoc2GenMatched_ResolZ", xtitle="Resolution in z (#mum)", **_common),
     Plot("RecoAllAssoc2GenMatchedMerged_ResolZ", xtitle="Resolution in z for merged vertices (#mum)", **_common),
 ])
-_common = {"title": "", "xtitle": "Number of tracks", "scale": 1e4, "ylog": True, "ymin": 5, "ymax": 500}
+_common = dict(title="", xtitle="Number of tracks", scale=1e4, ylog=True, ymin=_minMaxRes , ymax=_minMaxRes)
 _resolutionNumTracks = PlotGroup("resolutionNumTracks", [
     Plot("RecoAllAssoc2GenMatched_ResolX_vs_NumTracks_Sigma", ytitle="Resolution in x (#mum)", **_common),
     Plot("RecoAllAssoc2GenMatchedMerged_ResolX_vs_NumTracks_Sigma", ytitle="Resolution in x for merged vertices (#mum)", **_common),
@@ -52,6 +54,15 @@ _resolutionNumTracks = PlotGroup("resolutionNumTracks", [
     Plot("RecoAllAssoc2GenMatchedMerged_ResolY_vs_NumTracks_Sigma", ytitle="Resolution in y for merged vertices (#mum)", **_common),
     Plot("RecoAllAssoc2GenMatched_ResolZ_vs_NumTracks_Sigma", ytitle="Resolution in z (#mum)", **_common),
     Plot("RecoAllAssoc2GenMatchedMerged_ResolZ_vs_NumTracks_Sigma", ytitle="Resolution in z for merged vertices (#mum)", **_common),
+])
+_common.update(dict(xtitle= "Sum of track p_{T} (GeV)", xlog=True, xmin=_minMaxPt, xmax=_minMaxPt))
+_resolutionPt = PlotGroup("resolutionPt", [
+    Plot("RecoAllAssoc2GenMatched_ResolX_vs_Pt_Sigma", ytitle="Resolution in x (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolX_vs_Pt_Sigma", ytitle="Resolution in x for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolY_vs_Pt_Sigma", ytitle="Resolution in y (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolY_vs_Pt_Sigma", ytitle="Resolution in y for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolZ_vs_Pt_Sigma", ytitle="Resolution in z (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolZ_vs_Pt_Sigma", ytitle="Resolution in z for merged vertices (#mum)", **_common),
 ])
 _common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -6, "xmax": 6, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]}
 _pull = PlotGroup("pull", [
@@ -220,6 +231,7 @@ plotter.append("", _vertexFolders, PlotFolder(
     _effandfake,
     _resolution,
     _resolutionNumTracks,
+    _resolutionPt,
     _pull,
     _puritymissing,
     _sumpt2,

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -91,16 +91,6 @@ _sumpt2 = PlotGroup("sumpt2", [
                     legendDy=-0.025
 )
 
-_common = {"drawStyle": "HIST"}
-_genpos = PlotGroup("genpos", [
-    Plot("GenAllV_X", xtitle="Gen AllV pos x", ytitle="N", **_common),
-    Plot("GenPV_X", xtitle="Gen PV pos x", ytitle="N", **_common),
-    Plot("GenAllV_Y", xtitle="Gen AllV pos y", ytitle="N", **_common),
-    Plot("GenPV_Y", xtitle="Gen PV pos y", ytitle="N", **_common),
-    Plot("GenAllV_Z", xtitle="Gen AllV pos z", ytitle="N", **_common),
-    Plot("GenPV_Z", xtitle="Gen PV pos z", ytitle="N", **_common),
-])
-
 _k0_effandfake = PlotGroup("effandfake", [
     Plot("K0sEffVsPt", xtitle="p_{T} (GeV)", ytitle="Efficiency vs. p_{T}"),
     Plot("K0sFakeVsPt", xtitle="p_{T} (GeV)", ytitle="Fake rate vs. p_{T}"),
@@ -153,6 +143,42 @@ _lambda_mass = PlotGroup("mass", [
                          legendDy=-0.025
 )
 
+## Extended set of plots
+_common = dict(drawStyle = "HIST", stat=True)
+_commonXY = dict(xmin=[x*0.1 for x in xrange(-6, 6, 1)], xmax=[x*0.1 for x in xrange(-5, 7, 1)])
+_commonZ = dict(xmin=[-60,-30], xmax=[30,60])
+_commonXY.update(_common)
+_commonZ.update(_common)
+_extGenpos = PlotGroup("genpos", [
+    Plot("GenAllV_X", xtitle="Gen AllV pos x (cm)", ytitle="N", **_commonXY),
+    Plot("GenPV_X",   xtitle="Gen PV pos x (cm)",   ytitle="N", **_commonXY),
+    Plot("GenAllV_Y", xtitle="Gen AllV pos y (cm)", ytitle="N", **_commonXY),
+    Plot("GenPV_Y",   xtitle="Gen PV pos y (cm)",   ytitle="N", **_commonXY),
+    Plot("GenAllV_Z", xtitle="Gen AllV pos z (cm)", ytitle="N", **_commonZ),
+    Plot("GenPV_Z",   xtitle="Gen PV pos z (cm)",   ytitle="N", **_commonZ),
+])
+_extDist = PlotGroup("dist", [
+    Plot("RecoAllAssoc2Gen_X", xtitle="Reco vertex pos x (cm)", ytitle="N", **_commonXY),
+    Plot("RecoAllAssoc2Gen_Y", xtitle="Reco vertex pos y (cm)", ytitle="N", **_commonXY),
+    Plot("RecoAllAssoc2Gen_R", xtitle="Reco vertex pos r (cm)", ytitle="N", **_commonXY),
+    Plot("RecoAllAssoc2Gen_Z", xtitle="Reco vertex pos z (cm)", ytitle="N", **_commonZ),
+    Plot("RecoAllAssoc2Gen_NumVertices", xtitle="Number of reco vertices", ytitle="Events", stat=True, drawStyle="hist", min=_minVtx, xmax=_maxVtx),
+    Plot("RecoAllAssoc2Gen_NumTracks", xtitle="Number of tracks in vertex fit", ytitle="N", stat=True, drawStyle="hist"),
+])
+_common = dict(title="", xtitle="Vertex z (cm)", scale=1e4, ylog=True, ymin=_minMaxRes , ymax=_minMaxRes, xmin=range(-60,-10,10), xmax=range(20,70,10))
+_extResolutionZ = PlotGroup("resolutionZ", [
+    Plot("RecoAllAssoc2GenMatched_ResolX_vs_Z_Sigma", ytitle="Resolution in x (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolX_vs_Z_Sigma", ytitle="Resolution in x for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolY_vs_Z_Sigma", ytitle="Resolution in y (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolY_vs_Z_Sigma", ytitle="Resolution in y for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolZ_vs_Z_Sigma", ytitle="Resolution in z (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolZ_vs_Z_Sigma", ytitle="Resolution in z for merged vertices (#mum)", **_common),
+])
+_extDqm = PlotGroup("dqm", [
+    Plot("tagVtxTrksVsZ", xtitle="z_{vertex} - z_{beamspot} (cm)", ytitle="Tracks / selected PV"),
+    Plot("otherVtxTrksVsZ", xtitle="z_{vertex} - z_{beamspot} (cm)", ytitle="Tracks / pileup vertex"),
+    Plot("vtxNbr", xtitle="Reconstructed vertices", ytitle="Events", stat=True, drawStyle="hist", xmin=_minVtx, xmax=_maxVtx),
+])
 
 class VertexSummaryTable:
     def __init__(self, page="vertex"):
@@ -218,6 +244,10 @@ _vertexFolders = [
     "DQMData/Run 1/Vertexing/Run summary/PrimaryVertexV",
     "DQMData/Vertexing/PrimaryVertexV",
 ]
+_vertexDqmFolders = [
+    "DQMData/Run 1/OfflinePV/Run summary/offlinePrimaryVertices",
+    "DQMData/OffinePV/offlinePrimaryVertices",
+]
 _v0Folders = [
     "DQMData/Run 1/Vertexing/Run summary/V0",
     "DQMData/Vertexing/V0",
@@ -225,6 +255,7 @@ _v0Folders = [
     "DQMData/Vertexing/V0V",
 ]
 plotter = Plotter()
+plotterExt = Plotter()
 plotter.append("", _vertexFolders, PlotFolder(
     _recovsgen,
     _pvtagging,
@@ -256,7 +287,29 @@ plotter.append("Lambda", [x+"/Lambda" for x in _v0Folders], PlotFolder(
     purpose=PlotPurpose.Vertexing,
     page="v0", section="lambda"
 ))
-#plotter.append("gen", _vertexFolders, PlotFolder(_genpos, loopSubFolders=False, purpose=PlotPurpose.Vertexing, page="vertex", section="Gen vertex"))
+plotterExt.append("", _vertexFolders, PlotFolder(
+    _extDist,
+    _extResolutionZ,
+    purpose=PlotPurpose.Vertexing,
+    page="vertex",
+    onlyForPileup=True
+))
+plotterExt.append("dqm", _vertexDqmFolders, PlotFolder(
+    _extDqm,
+    loopSubFolders=False,
+    purpose=PlotPurpose.Vertexing,
+    page="vertex",
+    section="offlinePrimaryVertices",
+    onlyForPileup=True
+))
+plotterExt.append("gen", _vertexFolders, PlotFolder(
+    _extGenpos,
+    loopSubFolders=False,
+    purpose=PlotPurpose.Vertexing,
+    page="vertex",
+    section="Gen vertex",
+    onlyForPileup=True
+))
 
 class VertexValidation(validation.Validation):
     def _init__(self, *args, **kwargs):

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -307,7 +307,7 @@ plotterExt.append("gen", _vertexFolders, PlotFolder(
     loopSubFolders=False,
     purpose=PlotPurpose.Vertexing,
     page="vertex",
-    section="Gen vertex",
+    section="genvertex",
     onlyForPileup=True
 ))
 

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -22,7 +22,7 @@ _recovsgen = PlotGroup("recovsgen", [
                        legendDy=-0.025
 )
 _pvtagging = PlotGroup("pvtagging", [
-    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=15, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3),
+    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=15, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3, ratioCoverageXrange=[-0.5, 0.5]),
     Plot("TruePVLocationIndex", xtitle="Index of signal PV in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, ylog=True, ymin=1e-5),
     Plot("MisTagRate_vs_PU", xtitle="PU", ytitle="Mistag rate vs. PU", title="", xmax=_maxPU, ymax=_maxFake),
     Plot("MisTagRate_vs_sum-pt2", xtitle="#Sigmap_{T}^{2}", ytitle="Mistag rate vs. #Sigmap_{T}^{2}", title="", xlog=True, ymax=_maxFake),


### PR DESCRIPTION
Notable updates:
- Add proper support for 81X phase2 validation
- Make `--ratio --html` options of `makeTrackValidationPlots.py` the default
  - Either can be turned off with command-line options
- Improved `trackingCompare.py` example to show (some) plot customization possibilities
- Extend the set of internal functions that can be used outside of `plotting.py`
- Semi-automatic y axis bounds for ratio pad
- Option to fit straight line to ratio
- Possibility to normalize histograms by number of events
  - Applied to summary "number of tracks per iteration" plots
- New plots
  - Vertex resolution vs. sum pT
- More numbers in summary tables
- Add "extended set of plots" also for vertices
  - Distributions of simulated and reconstructed vertices, resolutions vs. z, tracks / PV, and number of vertices

Tested in CMSSW_8_1_0_pre5, should not affect standard workflows.

@rovere @VinInn 
