### PR TITLE
80X: updating SiStrip DQM TriggerBits for HIP monitoring (PR #15449)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,11 +20,11 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v10',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v17',
+    'run1_data'         :   '80X_dataRun2_v18',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v17',
+    'run2_data'         :   '80X_dataRun2_v18',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v15',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v16',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
Backporting in 80X the same changes as in  #15460 + #15508
# Summary of changes in Global Tags
## RunII data
- **RunII Offline processing** : [80X_dataRun2_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v18) as [80X_dataRun2_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v18/80X_dataRun2_v17): 
  - updated SiStripDQM TriggerBits for HIP monitoring 
- **RunII Offline relval processing** : [80X_dataRun2_relval_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v16) as [80X_dataRun2_relval_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v16/80X_dataRun2_relval_v15): 
  - updated SiStripDQM TriggerBits for HIP monitoring 
# 
# Updated content
- RunI+ RunII-2015 IOV:

```
---+++++ *IOV*: 1-264291
| *TriggerBits list key* | *HLT paths* |
| 'SiStrip_HLT' | 'HLT_ZeroBias_v*', 'HLT_HIZeroBias_v*', 'HLT_BptxAnd_*' |
| 'SiStrip_L1' | 'L1_ZeroBias' |
| 'Tracking_HLT' | 'HLT_ZeroBias_v*', 'HLT_BptxAnd_*' |
| 'Tracking_HLT_HIP_OOT' | 'HLT_ZeroBias_FirstBXAfterTrain_v*' |
| 'Tracking_HLT_HIP_noOOT' | 'HLT_ZeroBias_FirstCollisionInTrain_v*' |
| 'Tracking_HLT_noHIP_noOOT' | 'HLT_ZeroBias_FirstCollisionAfterAbortGap_v*' |
```
- RunII-2016 IOV:

```
---+++++ *IOV*: 264292-inf
| *TriggerBits list key* | *HLT paths* |
| 'SiStrip_HLT' | 'HLT_ZeroBias_v*', 'HLT_HIZeroBias_v*', 'HLT_BptxAnd_*' |
| 'SiStrip_L1' | 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias', 'L1_ExtCond_032' |
| 'Tracking_HLT' | 'HLT_ZeroBias_v*', 'HLT_BptxAnd_*' |
| 'Tracking_HLT_HIP_OOT' | 'HLT_ZeroBias_FirstBXAfterTrain_v*' |
| 'Tracking_HLT_HIP_noOOT' | 'HLT_ZeroBias_FirstCollisionInTrain_v*' |
| 'Tracking_HLT_noHIP_noOOT' | 'HLT_ZeroBias_FirstCollisionAfterAbortGap_v*' |
```

attn: @mtosi @fioriNTU @arunhep
