### PR TITLE
Change HCAL TP compression to account for multiple FG bits.

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -124,7 +124,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
     }
 }
 
-HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
+HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, int fineGrain) const {
   unsigned int itower = getOutputLUTId(id);
 
   if (sample >= OUTPUT_LUT_SIZE) {
@@ -136,7 +136,7 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
     throw cms::Exception("Out of Range") << "No decompression LUT found for " << id;
   }
 
-  return HcalTriggerPrimitiveSample(outputLUT_[itower][sample],fineGrain,0,0);
+  return HcalTriggerPrimitiveSample(outputLUT_[itower][sample], fineGrain);
 }
 
 double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compET) const {

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -20,7 +20,7 @@ public:
   CaloTPGTranscoderULUT(const std::string& compressionFile="",
                         const std::string& decompressionFile="");
   virtual ~CaloTPGTranscoderULUT();
-  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
+  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, int fineGrain) const override;
   virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
 
   virtual void rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -28,7 +28,7 @@ public:
 
   enum Mode { All=0, RCT=1, HcalTPG=2, EcalTPG=3 };
   /** \brief Compression from linear samples+fine grain in the HTR */
-  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const = 0;
+  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, int fineGrain) const = 0;
   /** \brief Compression from linear samples+fine grain in the ECAL */
   virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const = 0;
   /** \brief Uncompression for the Electron/Photon path in the RCT */


### PR DESCRIPTION
HCAL TP in 2017 have up to 4 fine-grain bits.  The
HcalTriggerPrimitiveSample already supports setting multiple fine-grain
bits, this adds support to the various compression classes.

In preparation for the 4 HE feature bits of 2017.
