### PR TITLE
bsunanda:Run2-hcx89 Add DB objects for HCAL TP 

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -40,6 +40,10 @@ Text file formats for different data types is as following:
  eta phi depth det fcByPE darkCurrent auxi1 auxi2
 - HcalSiPMCharacteristics:
  type pixels non-linearityParameters(3) auxi1 auxi2 
+- HcalTPParameters
+ HBHE-FGAlgorithm HF-ADCThreshold HF-TDCMask HF-SelfTriggerBits auxi1 auxi2
+- HcalTPChannelParameters
+ eta(int)  phi(int) depth(int) det(HB,HE,HF) Mask FGBitInfo auxi1 auxi2
 */
 namespace HcalDbASCIIIO {
   bool getObject (std::istream& fInput, HcalPedestals* fObject);
@@ -101,10 +105,16 @@ namespace HcalDbASCIIIO {
   // Getting/Dumping Hcal Flag information
   bool getObject (std::istream& fInput, HcalFlagHFDigiTimeParams* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalFlagHFDigiTimeParams& fObject);
+
   bool getObject (std::istream& fInput, HcalSiPMParameters* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalSiPMParameters& fObject);
   bool getObject (std::istream& fInput, HcalSiPMCharacteristics* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalSiPMCharacteristics& fObject);
+
+  bool getObject (std::istream& fInput, HcalTPParameters* fObject);
+  bool dumpObject (std::ostream& fOutput, const HcalTPParameters& fObject);
+  bool getObject (std::istream& fInput, HcalTPChannelParameters* fObject);
+  bool dumpObject (std::ostream& fOutput, const HcalTPChannelParameters& fObject);
 
   DetId getId (const std::vector <std::string> & items);
   void dumpId (std::ostream& fOutput, DetId id);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -24,6 +24,8 @@
 #include "CondFormats/HcalObjects/interface/HcalMCParam.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMParameter.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h"
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalHardcodeParameters.h"
 
 /**
@@ -77,6 +79,8 @@ class HcalDbHardcode {
 				 const std::vector<HcalGenericDetId>& cells);
     HcalSiPMParameter makeHardcodeSiPMParameter (HcalGenericDetId fId);
     void makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm);
+    HcalTPChannelParameter makeHardcodeTPChannelParameter (HcalGenericDetId fId);
+    void makeHardcodeTPParameters (HcalTPParameters& tppar);
     
   private:
     //member variables

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbXml.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbXml.h
@@ -54,5 +54,11 @@ namespace HcalDbXml {
   bool dumpObject (std::ostream& fOutput, 
 		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
 		   const HcalSiPMCharacteristics& fObject);
+  bool dumpObject (std::ostream& fOutput, 
+		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
+		   const HcalTPParameters& fObject);
+  bool dumpObject (std::ostream& fOutput, 
+		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
+		   const HcalTPChannelParameters& fObject);
 } 
 #endif

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -594,8 +594,8 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalLongRecoParams* fObject
       continue;
     }
     if (items.size() > 7) {
-      edm::LogWarning("Format Problem ?") << "Check line: " << buffer << "\n line must contain 6 items: eta, phi, depth, subdet, signalTSs, noiseTSs. "
-					  << "\n ! signalTS and noiseTS must be of format <ts1,ts2,ts3,...> withOUT spaces. Ignoring line for safety" << std::endl;
+      edm::LogWarning("Format Error") << "Check line: " << buffer << "\n line must contain 6 items: eta, phi, depth, subdet, signalTSs, noiseTSs. "
+				      << "\n ! signalTS and noiseTS must be of format <ts1,ts2,ts3,...> withOUT spaces. Ignoring line for safety" << std::endl;
       continue;
     }
     DetId id = HcalDbASCIIIO::getId (items);
@@ -749,6 +749,7 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalMCParams* fObject)
   }
   return true;
 }
+
 bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalMCParams& fObject)
 {
   char buffer [1024];
@@ -1843,7 +1844,7 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalFrontEndMap* fObject) {
     if (buffer [0] == '#') continue; //ignore comment
     std::vector <std::string> items = splitString (std::string (buffer));
     if (items.size () != 6) {
-      edm::LogError("MapFormat") << "HcalFrontEndMap-> line ignored: " << buffer;
+      edm::LogError("Format Error") << "HcalFrontEndMap-> line ignored: " << buffer;
       continue;
     }
     ++good;
@@ -1886,7 +1887,7 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalSiPMParameters* fObject
     std::vector <std::string> items = splitString (std::string (buffer));
     if (items.size()==0) continue; // blank line
     if (items.size () < 9) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 8 items: eta, phi, depth, subdet, 5x values" << std::endl;
+      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 9 items: eta, phi, depth, subdet, 5x values" << std::endl;
       continue;
     }
     DetId id = HcalDbASCIIIO::getId (items);
@@ -1980,5 +1981,101 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalSiPMCharacteris
 	     type, pixels, par0, par1, par2, cTalk, auxi1, auxi2);
     fOutput << buffer;
   }
+  return true;
+}
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalTPChannelParameters* fObject) {
+  if (!fObject) return false; 
+  char buffer [1024];
+  while (fInput.getline(buffer, 1024)) {
+    if (buffer [0] == '#') continue; //ignore comment
+    std::vector <std::string> items = splitString (std::string (buffer));
+    if (items.size()==0) continue; // blank line
+    if (items.size () < 8) {
+      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 8 items: eta, phi, depth, subdet, 4x values" << std::endl;
+      continue;
+    }
+    DetId id = HcalDbASCIIIO::getId (items);
+    
+    HcalTPChannelParameter* obj = new HcalTPChannelParameter(id.rawId(), 
+							     atoi(items[4].c_str()),
+							     atoi(items[5].c_str()),
+							     atoi(items[6].c_str()),
+							     atoi(items[7].c_str()));
+    fObject->addValues(*obj);
+    delete obj;
+  }
+  return true;
+}
+
+bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalTPChannelParameters& fObject) {
+
+  char buffer [1024];
+  sprintf (buffer, "# %15s %15s %15s %15s %15s %15s %15s %15s\n", 
+	   "eta", "phi", "dep", "det", "Mask", "FGBitInfo", "auxi1", "auxi2");
+  fOutput << buffer;
+  std::vector<DetId> channels = fObject.getAllChannels ();
+  std::sort (channels.begin(), channels.end(), DetIdLess ());
+  for (std::vector<DetId>::iterator channel = channels.begin ();
+       channel !=  channels.end ();
+       ++channel) {
+    const uint32_t mask      = fObject.getValues(*channel)->getMask();
+    const uint32_t fgBitInfo = fObject.getValues(*channel)->getFGBitInfo();
+    const int      auxi1     = fObject.getValues(*channel)->getauxi1();
+    const int      auxi2     = fObject.getValues(*channel)->getauxi2();
+    HcalDbASCIIIO::dumpId (fOutput, *channel);
+    sprintf (buffer, " %15d %15d %15d %15d \n", mask, fgBitInfo, auxi1, auxi2);
+    fOutput << buffer;
+  }
+  return true;
+}
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalTPParameters* fObject) {
+  char buffer [1024];
+  unsigned int all(0), good(0);
+  while (fInput.getline(buffer, 1024)) {
+    ++all;
+    if (buffer [0] == '#') continue; //ignore comment
+    std::vector <std::string> items = splitString (std::string (buffer));
+    if (items.size () != 6) {
+      edm::LogError("Format Error") << "HcalTPParameters-> line ignored: " << buffer;
+      continue;
+    }
+    ++good;
+    //    std::cout << "HcalTPParameters-> processing line: " << buffer << std::endl;
+    int version = atoi (items [0].c_str());
+    int adcCut  = atoi (items [1].c_str());
+    int tdcMask = atoi (items [2].c_str());
+    int tbits   = atoi (items [3].c_str());
+    int auxi1   = atoi (items [4].c_str());
+    int auxi2   = atof (items [5].c_str());
+    fObject->loadObject (version, adcCut, tdcMask, tbits, auxi1, auxi2);
+    break;
+  }
+  edm::LogInfo("MapFormat") << "HcalTPParameters:: processed " << good << " records in " << all << " record" << std::endl;
+  return true;
+}
+
+bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalTPParameters& fObject) {
+
+  char buffer [1024];
+  sprintf (buffer, "# %15s %15s %15s %15s %15s %15s\n", "FGAlgo_HBHE", 
+	   "ADCThrHF", "TDCMaskHF", "STBitsHF", "auxi1", "auxi2");
+  fOutput << buffer;
+
+  const int      version  = fObject.getFGVersionHBHE();
+  const int      adcCut   = fObject.getADCThresholdHF();
+  const uint32_t tdcMask  = fObject.getTDCMaskHF();
+  const uint32_t tbits    = fObject.getHFTriggerInfo();
+  const int      auxi1    = fObject.getAuxi1();
+  const int      auxi2   = fObject.getAuxi2();
+  sprintf (buffer, " %15d %15d %15d %15d %15d %15d\n", version, adcCut,
+	   tdcMask, tbits, auxi1, auxi2);
+  fOutput << buffer;
+
   return true;
 }

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -783,10 +783,18 @@ void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::v
   emap.sort();
 }
 
-
 HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fId) {
   return HcalSiPMParameter(fId.rawId(), 0, 0, 0, 0, 0);
 }
 
 void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm) {
+  sipm.loadObject(0,0,0,0,0,0,0,0);
+}
+
+HcalTPChannelParameter HcalDbHardcode::makeHardcodeTPChannelParameter (HcalGenericDetId fId) {
+  return HcalTPChannelParameter(fId.rawId(), 0, 0, 0, 0);
+}
+
+void HcalDbHardcode::makeHardcodeTPParameters (HcalTPParameters& tppar) {
+  tppar.loadObject(0,0,0,0,0,0);
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -63,6 +63,8 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 			  &HcalDbProducer::frontEndMapCallback &
 //			  &HcalDbProducer::SiPMParametersCallback &
 //			  &HcalDbProducer::SiPMCharacteristicsCallback &
+//			  &HcalDbProducer::TPChannelParametersCallback &
+//			  &HcalDbProducer::TPParameterisCallback &
 			  &HcalDbProducer::lutMetadataCallback 
 			  )
 		   );
@@ -403,7 +405,36 @@ void HcalDbProducer::SiPMCharacteristicsCallback (const HcalSiPMCharacteristicsR
   fRecord.get (item);
   mService->setData (item.product ());
   if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("SiPMCharacteristics")) != mDumpRequest.end()) {
-    *mDumpStream << "New HCAL FrontEnd Map set" << std::endl;
+    *mDumpStream << "New HCAL SiPMCharacteristics set" << std::endl;
+    HcalDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+  }
+}
+
+void HcalDbProducer::TPChannelParametersCallback (const HcalTPChannelParametersRcd& fRecord) {
+  edm::ESTransientHandle <HcalTPChannelParameters> item;
+  fRecord.get (item);
+
+  mTPChannelParameters.reset( new HcalTPChannelParameters(*item) );
+
+  edm::ESHandle<HcalTopology> htopo;
+  fRecord.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+  mTPChannelParameters->setTopo(topo);
+
+  mService->setData (mTPChannelParameters.get());
+  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TPChannelParameters")) != mDumpRequest.end()) {
+    *mDumpStream << "New HCAL TPChannelParameters set" << std::endl;
+    HcalDbASCIIIO::dumpObject (*mDumpStream, *(mTPChannelParameters));
+  }
+}
+
+void HcalDbProducer::TPParametersCallback (const HcalTPParametersRcd& fRecord){
+
+  edm::ESHandle <HcalTPParameters> item;
+  fRecord.get (item);
+  mService->setData (item.product ());
+  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TPParameters")) != mDumpRequest.end()) {
+    *mDumpStream << "New HCAL TPParameters set" << std::endl;
     HcalDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
   }
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -59,8 +59,10 @@ class HcalDbProducer : public edm::ESProducer {
   void lutMetadataCallback (const HcalLutMetadataRcd& fRecord);
   void SiPMParametersCallback (const HcalSiPMParametersRcd& fRecord);
   void SiPMCharacteristicsCallback (const HcalSiPMCharacteristicsRcd& fRecord);
+  void TPChannelParametersCallback (const HcalTPChannelParametersRcd& fRecord);
+  void TPParametersCallback (const HcalTPParametersRcd& fRecord);
 
-   private:
+private:
       // ----------member data ---------------------------
   std::shared_ptr<HcalDbService> mService;
   std::vector<std::string> mDumpRequest;
@@ -81,5 +83,7 @@ class HcalDbProducer : public edm::ESProducer {
   std::unique_ptr<HcalLutMetadata> mLutMetadata;
   std::unique_ptr<HcalSiPMParameters> mSiPMParameters;
   std::unique_ptr<HcalSiPMCharacteristics> mSiPMCharacteristics;
+  std::unique_ptr<HcalTPChannelParameters> mTPChannelParameters;
+  std::unique_ptr<HcalTPParameters> mTPParameters;
 
 };

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -259,9 +259,17 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
       setWhatProduced (this, &HcalHardcodeCalibrations::produceSiPMParameters);
       findingRecord <HcalSiPMParametersRcd> ();
     }
-    if ((*objectName == "SiPMCharacteristics") || (*objectName == "frontEndMap") || all) {
+    if ((*objectName == "SiPMCharacteristics") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceSiPMCharacteristics);
       findingRecord <HcalSiPMCharacteristicsRcd> ();
+    }
+    if ((*objectName == "TPChannelParameters") || all) {
+      setWhatProduced (this, &HcalHardcodeCalibrations::produceTPChannelParameters);
+      findingRecord <HcalTPChannelParametersRcd> ();
+    }
+    if ((*objectName == "TPParameters") || all) {
+      setWhatProduced (this, &HcalHardcodeCalibrations::produceTPParameters);
+      findingRecord <HcalTPParametersRcd> ();
     }
   }
 }
@@ -768,6 +776,30 @@ std::unique_ptr<HcalSiPMCharacteristics> HcalHardcodeCalibrations::produceSiPMCh
 
   auto result = std::make_unique<HcalSiPMCharacteristics>();
   dbHardcode.makeHardcodeSiPMCharacteristics(*result);
+  return result;
+}
+
+
+std::unique_ptr<HcalTPChannelParameters> HcalHardcodeCalibrations::produceTPChannelParameters (const HcalTPChannelParametersRcd& rec) {
+  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceTPChannelParameters-> ...";
+  edm::ESHandle<HcalTopology> htopo;
+  rec.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+
+  auto result = std::make_unique<HcalTPChannelParameters>(topo);
+  std::vector <HcalGenericDetId> cells = allCells(*htopo);
+  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
+    HcalTPChannelParameter item = dbHardcode.makeHardcodeTPChannelParameter (*cell);
+    result->addValues(item);
+  }
+  return result;
+}
+
+std::unique_ptr<HcalTPParameters> HcalHardcodeCalibrations::produceTPParameters (const HcalTPParametersRcd& rcd) {
+  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceTPParameters-> ...";
+
+  auto result = std::make_unique<HcalTPParameters>();
+  dbHardcode.makeHardcodeTPParameters(*result);
   return result;
 }
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -46,6 +46,8 @@ class HcalTimingParamsRcd;
 class HcalFrontEndMapRcd;
 class HcalSiPMParametersRcd;
 class HcalSiPMCharacteristicsRcd;
+class HcalTPChannelParametersRcd;
+class HcalTPParaamersRcd;
 
 class HcalHardcodeCalibrations : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 
@@ -94,6 +96,9 @@ protected:
 
   std::unique_ptr<HcalSiPMParameters> produceSiPMParameters (const HcalSiPMParametersRcd& rcd);
   std::unique_ptr<HcalSiPMCharacteristics> produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd);
+  std::unique_ptr<HcalTPChannelParameters> produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd);
+  std::unique_ptr<HcalTPParameters> produceTPParameters (const HcalTPParametersRcd& rcd);
+
 private:
   HcalDbHardcode dbHardcode;
   double iLumi;

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -144,6 +144,14 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
       setWhatProduced (this, &HcalTextCalibrations::produceSiPMCharacteristics);
       findingRecord <HcalSiPMCharacteristicsRcd> ();
     }
+    else if (objectName == "TPChannelParameters") {
+      setWhatProduced (this, &HcalTextCalibrations::produceTPChannelParameters);
+      findingRecord <HcalTPChannelParametersRcd> ();
+    }
+    else if (objectName == "TPParameters") {
+      setWhatProduced (this, &HcalTextCalibrations::produceTPParameters);
+      findingRecord <HcalTPParametersRcd> ();
+    }
     else {
       std::cerr << "HcalTextCalibrations-> Unknown object name '" << objectName 
 		<< "', known names are: "
@@ -378,4 +386,15 @@ std::unique_ptr<HcalSiPMParameters> HcalTextCalibrations::produceSiPMParameters 
 
 std::unique_ptr<HcalSiPMCharacteristics> HcalTextCalibrations::produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd) {
   return produce_impl<HcalSiPMCharacteristics> (mInputs ["SiPMCharacteristics"]);
+}
+
+std::unique_ptr<HcalTPChannelParameters> HcalTextCalibrations::produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd) {
+  edm::ESHandle<HcalTopology> htopo;
+  rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+  return produce_impl<HcalTPChannelParameters> (topo,mInputs ["TPChannelParameters"]);
+}
+
+std::unique_ptr<HcalTPParameters> HcalTextCalibrations::produceTPParameters (const HcalTPParametersRcd& rcd) {
+  return produce_impl<HcalTPParameters> (mInputs ["TPParameters"]);
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -39,6 +39,8 @@ class HcalFlagHFDigiTimeParamsRcd;
 class HcalTimingParamsRcd;
 class HcalSiPMParametersRcd;
 class HcalSiPMCharacteristicsRcd;
+class HcalTPChannelParametersRcd;
+class HcalTPParaamersRcd;
 
 class HcalTextCalibrations : public edm::ESProducer,
   public edm::EventSetupRecordIntervalFinder
@@ -85,7 +87,10 @@ protected:
   std::unique_ptr<HcalTimingParams> produceTimingParams (const HcalTimingParamsRcd& rcd);
   std::unique_ptr<HcalSiPMParameters> produceSiPMParameters (const HcalSiPMParametersRcd& rcd);
   std::unique_ptr<HcalSiPMCharacteristics> produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd);
- private:
+  std::unique_ptr<HcalTPChannelParameters> produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd);
+  std::unique_ptr<HcalTPParameters> produceTPParameters (const HcalTPParametersRcd& rcd);
+
+private:
   std::map <std::string, std::string> mInputs;
 };
 

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -28,12 +28,12 @@
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
-  boost::mpl::vector<HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
+  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
   HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
   HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, 
-//  HcalRecNumberingRecord, IdealGeometryRecord, 
-  HcalTPParametersRcd, HcalTPChannelParametersRcd, HcalLutMetadataRcd > > {}; 
+//  HcalTPParametersRcd, HcalTPChannelParametersRcd,
+  HcalLutMetadataRcd > > {}; 
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */
 

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -28,10 +28,12 @@
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
-  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
+  boost::mpl::vector<HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
   HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
-  HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalLutMetadataRcd > > {}; 
+  HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, 
+//  HcalRecNumberingRecord, IdealGeometryRecord, 
+  HcalTPParametersRcd, HcalTPChannelParametersRcd, HcalLutMetadataRcd > > {}; 
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */
 

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -17,7 +17,7 @@
 // Author:      
 // Created:     Tue Aug  9 19:10:36 CDT 2005
 //
-#include "boost/mpl/vector.hpp"
+#include "boost/mpl/vector/vector30.hpp"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
@@ -28,12 +28,10 @@
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
-  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
+  boost::mpl::vector22<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
   HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
-  HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, 
-//  HcalTPParametersRcd, HcalTPChannelParametersRcd,
+  HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalTPParametersRcd, HcalTPChannelParametersRcd,
   HcalLutMetadataRcd > > {}; 
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */
-

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -53,6 +53,8 @@ class HcalDbService {
   const HcalQIEType* getHcalQIEType (const HcalGenericDetId& fId) const;
   const HcalSiPMParameter* getHcalSiPMParameter (const HcalGenericDetId& fId) const;
   const HcalSiPMCharacteristics* getHcalSiPMCharacteristics () const;
+  const HcalTPChannelParameter* getHcalTPChannelParameter (const HcalGenericDetId& fId) const;
+  const HcalTPParameters* getHcalTPParameters () const;
 
   void setData (const HcalPedestals* fItem) {mPedestals = fItem; mCalibSet = nullptr;}
   void setData (const HcalPedestalWidths* fItem) {mPedestalWidths = fItem; mCalibWidthSet = nullptr;}
@@ -72,6 +74,8 @@ class HcalDbService {
   void setData (const HcalLutMetadata* fItem) {mLutMetadata = fItem;}
   void setData (const HcalSiPMParameters* fItem) {mSiPMParameters = fItem; mCalibSet = nullptr;}
   void setData (const HcalSiPMCharacteristics* fItem) {mSiPMCharacteristics = fItem;}
+  void setData (const HcalTPChannelParameters* fItem) {mTPChannelParameters = fItem; mCalibSet = nullptr;}
+  void setData (const HcalTPParameters* fItem) {mTPParameters = fItem;}
 
  private:
   bool makeHcalCalibration (const HcalGenericDetId& fId, HcalCalibrations* fObject, 
@@ -98,6 +102,8 @@ class HcalDbService {
   const HcalLutMetadata* mLutMetadata;
   const HcalSiPMParameters* mSiPMParameters;
   const HcalSiPMCharacteristics* mSiPMCharacteristics;
+  const HcalTPChannelParameters* mTPChannelParameters;
+  const HcalTPParameters* mTPParameters;
   //  bool mPedestalInADC;
   mutable std::atomic<HcalCalibrationsSet const *> mCalibSet;
   mutable std::atomic<HcalCalibrationWidthsSet const *> mCalibWidthSet;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -26,14 +26,15 @@ HcalDbService::HcalDbService (const edm::ParameterSet& cfg):
   mPFCorrs(0),
   mLutMetadata(0),
   mSiPMParameters(0), mSiPMCharacteristics(0),
+  mTPChannelParameters(0), mTPParameters(0),
   mCalibSet(nullptr), mCalibWidthSet(nullptr)
  {}
 
 const HcalTopology* HcalDbService::getTopologyUsed() const {
   if (mPedestals && mPedestals->topo()) return mPedestals->topo();
-  if (mGains && mGains->topo()) return mGains->topo();
+  if (mGains && mGains->topo())         return mGains->topo();
   if (mRespCorrs && mRespCorrs->topo()) return mRespCorrs->topo();
-  if (mQIETypes && mQIETypes->topo()) return mQIETypes->topo();
+  if (mQIETypes && mQIETypes->topo())   return mQIETypes->topo();
   if (mL1TriggerObjects && mL1TriggerObjects->topo()) return mL1TriggerObjects->topo();
   if (mLutMetadata && mLutMetadata->topo()) return mLutMetadata->topo();
   return 0;
@@ -302,6 +303,17 @@ const HcalSiPMParameter* HcalDbService::getHcalSiPMParameter (const HcalGenericD
 
 const HcalSiPMCharacteristics* HcalDbService::getHcalSiPMCharacteristics () const {
   return mSiPMCharacteristics;
+}
+
+const HcalTPChannelParameter* HcalDbService::getHcalTPChannelParameter (const HcalGenericDetId& fId) const {
+  if (mTPChannelParameters) {
+    return mTPChannelParameters->getValues (fId);
+  }
+  return 0;
+}
+
+const HcalTPParameters* HcalDbService::getHcalTPParameters () const {
+  return mTPParameters;
 }
 
 TYPELOOKUP_DATA_REG(HcalDbService);

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -72,3 +72,5 @@ REGISTER_PLUGIN(HcalInterpolatedPulseCollRcd,HcalInterpolatedPulseColl);
 REGISTER_PLUGIN(HBHENegativeEFilterRcd,HBHENegativeEFilter);
 REGISTER_PLUGIN(HcalSiPMParametersRcd,HcalSiPMParameters);
 REGISTER_PLUGIN(HcalSiPMCharacteristicsRcd,HcalSiPMCharacteristics);
+REGISTER_PLUGIN(HcalTPParametersRcd,HcalTPParameters);
+REGISTER_PLUGIN(HcalTPChannelParametersRcd,HcalTPChannelParameters);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -160,6 +160,8 @@ namespace cond {
       FETCH_PAYLOAD_CASE( HcalRecoParams )
       FETCH_PAYLOAD_CASE( HcalRespCorrs )
       FETCH_PAYLOAD_CASE( HcalTimeCorrs )
+      FETCH_PAYLOAD_CASE( HcalTPChannelParameters )
+      FETCH_PAYLOAD_CASE( HcalTPParameters )
       FETCH_PAYLOAD_CASE( HcalZSThresholds )
       FETCH_PAYLOAD_CASE( HcalInterpolatedPulseColl )
       FETCH_PAYLOAD_CASE( OOTPileupCorrectionBuffer )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -174,6 +174,8 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( HcalSiPMCharacteristics )
       IMPORT_PAYLOAD_CASE( HcalSiPMParameters )
       IMPORT_PAYLOAD_CASE( HcalTimeCorrs )
+      IMPORT_PAYLOAD_CASE( HcalTPChannelParameters )
+      IMPORT_PAYLOAD_CASE( HcalTPParameters )
       IMPORT_PAYLOAD_CASE( HcalZSThresholds )
       IMPORT_PAYLOAD_CASE( HcalInterpolatedPulseColl )
       IMPORT_PAYLOAD_CASE( JetCorrectorParametersCollection )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -199,6 +199,8 @@
 #include "CondFormats/HcalObjects/interface/HcalSiPMParameters.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h"
 #include "CondFormats/HcalObjects/interface/HcalTimeCorrs.h"
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
 #include "CondFormats/HcalObjects/interface/HcalZSThresholds.h"
 #include "CondFormats/L1TObjects/interface/L1CaloGeometry.h"
 #include "CondFormats/L1TObjects/interface/L1GctJetFinderParams.h"

--- a/CondFormats/DataRecord/interface/HcalAllRcds.h
+++ b/CondFormats/DataRecord/interface/HcalAllRcds.h
@@ -21,6 +21,8 @@
 #include "CondFormats/DataRecord/interface/HcalZSThresholdsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalValidationCorrsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalLutMetadataRcd.h"
+#include "CondFormats/DataRecord/interface/HcalTPParametersRcd.h"
+#include "CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h"
 #include "CondFormats/DataRecord/interface/HcalDcsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalDcsMapRcd.h"
 #include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"

--- a/CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h
+++ b/CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h
@@ -1,0 +1,8 @@
+#ifndef CondFormatsDataRecordHcalTPChannelParametersRcd_H
+#define CondFormatsDataRecordHcalTPChannelParametersRcd_H
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+class HcalTPChannelParametersRcd : public edm::eventsetup::DependentRecordImplementation<HcalTPChannelParametersRcd, boost::mpl::vector<HcalRecNumberingRecord,IdealGeometryRecord> > {};
+#endif

--- a/CondFormats/DataRecord/interface/HcalTPParametersRcd.h
+++ b/CondFormats/DataRecord/interface/HcalTPParametersRcd.h
@@ -1,0 +1,5 @@
+#ifndef CondFormatsDataRecordHcalTPParametersRcd_H
+#define CondFormatsDataRecordHcalTPParametersRcd_H
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class HcalTPParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<HcalTPParametersRcd> {};
+#endif

--- a/CondFormats/DataRecord/src/HcalTPChannelParametersRcd.cc
+++ b/CondFormats/DataRecord/src/HcalTPChannelParametersRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HcalTPChannelParametersRcd);

--- a/CondFormats/DataRecord/src/HcalTPParametersRcd.cc
+++ b/CondFormats/DataRecord/src/HcalTPParametersRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/DataRecord/interface/HcalTPParametersRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HcalTPParametersRcd);

--- a/CondFormats/HcalObjects/interface/AllObjects.h
+++ b/CondFormats/HcalObjects/interface/AllObjects.h
@@ -35,4 +35,6 @@
 #include "CondFormats/HcalObjects/interface/HcalFrontEndMap.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMParameters.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h"
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
 #endif

--- a/CondFormats/HcalObjects/interface/HcalRecoParams.h
+++ b/CondFormats/HcalObjects/interface/HcalRecoParams.h
@@ -1,5 +1,5 @@
-#ifndef HcalRecoParams_h
-#define HcalRecoParams_h
+#ifndef CondFormatsHcalObjectsHcalRecoParams_h
+#define CondFormatsHcalObjectsHcalRecoParams_h
 
 
 #include "CondFormats/Serialization/interface/Serializable.h"

--- a/CondFormats/HcalObjects/interface/HcalTPChannelParameter.h
+++ b/CondFormats/HcalObjects/interface/HcalTPChannelParameter.h
@@ -1,0 +1,39 @@
+#ifndef CondFormatsHcalObjectsHcalTPChannelParameter_h
+#define CondFormatsHcalObjectsHcalTPChannelParameter_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include <boost/cstdint.hpp>
+
+class HcalTPChannelParameter {
+
+public:
+  /// get mask for channel validity and self trigger information
+  uint32_t     getMask()      const {return mask_;}
+  /// get FG bit information
+  uint32_t     getFGBitInfo() const {return fgBitInfo_;}
+  /// get Detector ID
+  uint32_t     rawId()        const {return id_;}
+  int          getauxi1()     const {return auxi1_;}
+  int          getauxi2()     const {return auxi2_;}
+
+  // functions below are not supposed to be used by consumer applications
+
+  HcalTPChannelParameter () : id_(0), mask_(0), fgBitInfo_(0), auxi1_ (0), 
+    auxi2_(0) {}
+  
+  HcalTPChannelParameter (uint32_t fId, uint32_t mask, uint32_t bitInfo, 
+			  int auxi1=0, int auxi2=0) : id_(fId), mask_(mask),
+    fgBitInfo_(bitInfo), auxi1_(auxi1), auxi2_(auxi2) {}
+
+
+private:
+  uint32_t id_;
+  uint32_t mask_;
+  uint32_t fgBitInfo_;
+  int      auxi1_;
+  int      auxi2_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HcalObjects/interface/HcalTPChannelParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalTPChannelParameters.h
@@ -1,0 +1,22 @@
+#ifndef CondFormatsHcalObjectsHcalTPChannelParameters_h
+#define CondFormatsHcalObjectsHcalTPChannelParameters_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameter.h"
+#include "CondFormats/HcalObjects/interface/HcalCondObjectContainer.h"
+
+class HcalTPChannelParameters: public HcalCondObjectContainer<HcalTPChannelParameter> {
+
+public:
+  //constructor definition: has to contain 
+#ifndef HCAL_COND_SUPPRESS_DEFAULT
+  HcalTPChannelParameters():HcalCondObjectContainer<HcalTPChannelParameter>(0) {}
+#endif
+  HcalTPChannelParameters(const HcalTopology* topo):HcalCondObjectContainer<HcalTPChannelParameter>(topo) {}
+
+  std::string myname() const {return (std::string)"HcalTPChannelParameters";}
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HcalObjects/interface/HcalTPParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalTPParameters.h
@@ -1,0 +1,44 @@
+#ifndef CondFormatsHcalObjectsHcalTPParameters_h
+#define CondFormatsHcalObjectsHcalTPParameters_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <vector>
+#include <algorithm>
+#include <boost/cstdint.hpp>
+
+class HcalTPParameters {
+
+public:
+  HcalTPParameters();
+  ~HcalTPParameters();
+
+  // Load a new entry
+  void         loadObject(int version, int adcCut, uint32_t tdcMask,
+			  uint32_t tbits, int auxi1,  int auxi2);
+
+  /// get FineGrain Algorithm Version for HBHE
+  int          getFGVersionHBHE()          const {return version_;}
+  /// get ADC thresho;d fof TDC mask of HF
+  int          getADCThresholdHF()         const {return adcCut_;}
+  /// get TDC mask for HF
+  uint32_t getTDCMaskHF()                  const {return tdcMask_;}
+  /// get Self Trigger bits
+  uint32_t getHFTriggerInfo()              const {return tbits_;}
+  /// get Axiliary words
+  int          getAuxi1()                  const {return auxi1_;}
+  int          getAuxi2()                  const {return auxi2_;}
+
+private:
+
+  int          version_;
+  int          adcCut_;
+  uint32_t     tdcMask_;
+  uint32_t     tbits_;
+  int          auxi1_;
+  int          auxi2_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HcalObjects/src/HcalTPChannelParameter.cc
+++ b/CondFormats/HcalObjects/src/HcalTPChannelParameter.cc
@@ -1,0 +1,1 @@
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameter.h"

--- a/CondFormats/HcalObjects/src/HcalTPChannelParameters.cc
+++ b/CondFormats/HcalObjects/src/HcalTPChannelParameters.cc
@@ -1,0 +1,1 @@
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"

--- a/CondFormats/HcalObjects/src/HcalTPParameters.cc
+++ b/CondFormats/HcalObjects/src/HcalTPParameters.cc
@@ -1,0 +1,22 @@
+#include <algorithm>
+#include <iostream>
+#include <set>
+
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+HcalTPParameters::HcalTPParameters() : version_(0), adcCut_(0), tdcMask_(0),
+				     tbits_(0), auxi1_(0), auxi2_(0) { }
+
+
+HcalTPParameters::~HcalTPParameters() { }
+
+void HcalTPParameters::loadObject(int version, int adcCut, uint32_t tdcMask, 
+				  uint32_t tbits, int auxi1,  int auxi2) {
+  version_ = version;
+  adcCut_  = adcCut;
+  tdcMask_ = tdcMask;
+  tbits_   = tbits;
+  auxi1_   = auxi1;
+  auxi2_   = auxi2;
+}

--- a/CondFormats/HcalObjects/src/T_EventSetup_HcalTPChannelParameters.cc
+++ b/CondFormats/HcalObjects/src/T_EventSetup_HcalTPChannelParameters.cc
@@ -1,0 +1,5 @@
+// user include files
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HcalTPChannelParameters);

--- a/CondFormats/HcalObjects/src/T_EventSetup_HcalTPParameters.cc
+++ b/CondFormats/HcalObjects/src/T_EventSetup_HcalTPParameters.cc
@@ -1,0 +1,5 @@
+// user include files
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HcalTPParameters);

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -91,6 +91,11 @@ namespace CondFormats_HcalObjects {
  
     HcalSiPMCharacteristics mySiPMCharacteristics;
     std::vector<HcalSiPMCharacteristics::PrecisionItem> mySiPMCharacteristicvec;
+ 
+    HcalTPParameters myTPParameters;
+
+    HcalTPChannelParameters myTPChannelParameters();
+    std::vector<HcalTPChannelParameter> myTPChannelParametervec;
 
     // OOT pileup correction objects
     std::map<std::string, AbsOOTPileupCorrection*> myInnerMap;

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -404,6 +404,23 @@
  </class>
  <class name="HcalMCParams" class_version="0"/>
 
+ <class name="std::vector<HcalTPChannelParameter>"/>
+ <class name="std::pair<std::string, std::vector<HcalTPChannelParameter> >"/>
+ <class name="std::vector<std::pair<std::string, std::vector<HcalTPChannelParameter> > >"/>
+ <class name="HcalCondObjectContainer<HcalTPChannelParameter>">
+  <field name="HBcontainer" mapping="blob" />
+  <field name="HEcontainer" mapping="blob" />
+  <field name="HFcontainer" mapping="blob" />
+  <field name="HOcontainer" mapping="blob" />
+  <field name="HTcontainer" mapping="blob" />
+  <field name="ZDCcontainer" mapping="blob" />
+  <field name="CALIBcontainer" mapping="blob" />
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="HcalTPChannelParameters"/>
+
+ <class name="HcalTPParameters"/>
+
  <class name="HcalFlagHFDigiTimeParam"/>
  <class name="std::vector<HcalFlagHFDigiTimeParam>"/>
  <class name="std::pair<std::string, std::vector<HcalFlagHFDigiTimeParam> >"/>

--- a/CondTools/Hcal/interface/HcalTPChannelParametersHandler.h
+++ b/CondTools/Hcal/interface/HcalTPChannelParametersHandler.h
@@ -1,0 +1,39 @@
+#ifndef CondToolsHcalHcalTPChannelParametersHandler_h
+#define CondToolsHcalHcalTPChannelParametersHandler_h
+
+#include <string>
+#include <iostream>
+#include <typeinfo>
+#include <fstream>
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+ 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+// user include files
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
+#include "CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
+
+
+class HcalTPChannelParametersHandler : public popcon::PopConSourceHandler<HcalTPChannelParameters> {
+
+public:
+  void getNewObjects();
+  std::string id() const {return m_name;}
+  ~HcalTPChannelParametersHandler();
+  HcalTPChannelParametersHandler(edm::ParameterSet const &);
+
+  void initObject(HcalTPChannelParameters*);
+  
+private:
+  unsigned int             sinceTime;
+  edm::FileInPath          fFile;
+  HcalTPChannelParameters* myDBObject;
+  std::string              m_name;
+
+};
+#endif

--- a/CondTools/Hcal/interface/HcalTPParametersHandler.h
+++ b/CondTools/Hcal/interface/HcalTPParametersHandler.h
@@ -1,0 +1,39 @@
+#ifndef CondToolsHcalHcalHcalTPParametersHandler_h
+#define CondToolsHcalHcalHcalTPParametersHandler_h
+
+#include <string>
+#include <iostream>
+#include <typeinfo>
+#include <fstream>
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+ 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+// user include files
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/DataRecord/interface/HcalTPParametersRcd.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
+
+
+class HcalTPParametersHandler : public popcon::PopConSourceHandler<HcalTPParameters> {
+
+public:
+  void getNewObjects();
+  std::string id() const {return m_name;}
+  ~HcalTPParametersHandler();
+  HcalTPParametersHandler(edm::ParameterSet const &);
+
+  void initObject(HcalTPParameters*);
+
+private:
+  unsigned int      sinceTime;
+  edm::FileInPath   fFile;
+  HcalTPParameters* myDBObject;
+  std::string       m_name;
+
+};
+#endif

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -163,13 +163,14 @@ namespace edmtest
       dumpIt(new HcalMCParams(&(*topology)), new HcalMCParamsRcd, e,context,"MCParams", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("FlagHFDigiTimeParams")) != mDumpRequest.end())
       dumpIt(new HcalFlagHFDigiTimeParams(&(*topology)), new HcalFlagHFDigiTimeParamsRcd, e,context,"FlagHFDigiTimeParams", topo);
-    /*
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("SiPMParameters")) != mDumpRequest.end())
       dumpIt(new HcalSiPMParameters(&(*topology)), new HcalSiPMParametersRcd, e,context,"SiPMParameters", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("SiPMCharacteristics")) != mDumpRequest.end())
       dumpIt(new HcalSiPMCharacteristics, new HcalSiPMCharacteristicsRcd, e,context,"SiPMCharacteristics");
-    */
-    
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TPChannelParameters")) != mDumpRequest.end())
+      dumpIt(new HcalTPChannelParameters(&(*topology)), new HcalTPChannelParametersRcd, e,context,"TPChannelParameters", topo);
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TPParameters")) != mDumpRequest.end())
+      dumpIt(new HcalTPParameters, new HcalTPParametersRcd, e,context,"TPParameters");
   }
   DEFINE_FWK_MODULE(HcalDumpConditions);
 }

--- a/CondTools/Hcal/plugins/HcalTPChannelParametersPopConAnalyzer.cc
+++ b/CondTools/Hcal/plugins/HcalTPChannelParametersPopConAnalyzer.cc
@@ -1,0 +1,37 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Hcal/interface/HcalTPChannelParametersHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+class HcalTPChannelParametersPopConAnalyzer: public popcon::PopConAnalyzer<HcalTPChannelParametersHandler> {
+public:
+  typedef HcalTPChannelParametersHandler SourceHandler;
+
+  HcalTPChannelParametersPopConAnalyzer(const edm::ParameterSet& pset): 
+    popcon::PopConAnalyzer<HcalTPChannelParametersHandler>(pset),
+    m_populator(pset),
+    m_source(pset.getParameter<edm::ParameterSet>("Source")) {}
+
+private:
+  virtual void endJob() override {
+    m_source.initObject(myDBObject);
+    write();
+  }
+
+  virtual void analyze(const edm::Event& ev, const edm::EventSetup& esetup) override {
+    //Using ES to get the data:
+    
+    edm::ESHandle<HcalTPChannelParameters> objecthandle;
+    esetup.get<HcalTPChannelParametersRcd>().get(objecthandle);
+    myDBObject = new HcalTPChannelParameters(*objecthandle.product() );
+  }
+
+  void write() { m_populator.write(m_source); }
+  
+private:
+  popcon::PopCon m_populator;
+  SourceHandler m_source;
+
+  HcalTPChannelParameters* myDBObject;
+};
+
+DEFINE_FWK_MODULE(HcalTPChannelParametersPopConAnalyzer);

--- a/CondTools/Hcal/plugins/HcalTPParametersPopConAnalyzer.cc
+++ b/CondTools/Hcal/plugins/HcalTPParametersPopConAnalyzer.cc
@@ -1,0 +1,38 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Hcal/interface/HcalTPParametersHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+class HcalTPParametersPopConAnalyzer: public popcon::PopConAnalyzer<HcalTPParametersHandler> {
+public:
+  typedef HcalTPParametersHandler SourceHandler;
+
+  HcalTPParametersPopConAnalyzer(const edm::ParameterSet& pset): 
+    popcon::PopConAnalyzer<HcalTPParametersHandler>(pset),
+    m_populator(pset),
+    m_source(pset.getParameter<edm::ParameterSet>("Source")) {}
+
+private:
+  virtual void endJob() override {
+    m_source.initObject(myDBObject);
+    write();
+  }
+
+  virtual void analyze(const edm::Event& ev, const edm::EventSetup& esetup) override {
+    //Using ES to get the data:
+
+    edm::ESHandle<HcalTPParameters> objecthandle;
+    esetup.get<HcalTPParametersRcd>().get(objecthandle);
+    myDBObject = new HcalTPParameters(*objecthandle.product() );
+  }
+
+  void write() { m_populator.write(m_source); }
+
+private:
+  popcon::PopCon m_populator;
+  SourceHandler m_source;
+
+  HcalTPParameters* myDBObject;
+};
+
+DEFINE_FWK_MODULE(HcalTPParametersPopConAnalyzer);

--- a/CondTools/Hcal/src/HcalTPChannelsParametersHandler.cc
+++ b/CondTools/Hcal/src/HcalTPChannelsParametersHandler.cc
@@ -1,0 +1,41 @@
+#include "CondTools/Hcal/interface/HcalTPChannelParametersHandler.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include <memory>
+
+HcalTPChannelParametersHandler::HcalTPChannelParametersHandler(edm::ParameterSet const & ps){
+  m_name = ps.getUntrackedParameter<std::string>("name","HcalTPChannelParametersHandler");
+  sinceTime = ps.getUntrackedParameter<unsigned>("IOVRun",0);
+}
+
+HcalTPChannelParametersHandler::~HcalTPChannelParametersHandler() { }
+
+void HcalTPChannelParametersHandler::getNewObjects() {
+  edm::LogInfo ("HcalCondTools") << "------- " << m_name 
+				 << " - > getNewObjects\n" << "got offlineInfo"
+				 << tagInfo().name << ", size " 
+				 << tagInfo().size 
+				 << ", last object valid since " 
+				 << tagInfo().lastInterval.first << std::endl;
+
+  if (!myDBObject) 
+    throw cms::Exception("Empty DB object") << m_name 
+					    << " has received empty object - nothing to write to DB" 
+					    << std::endl;
+
+  //  IOV information
+  cond::Time_t myTime = sinceTime;
+
+  edm::LogInfo ("HcalCondTools") << "Using IOV run " << sinceTime << std::endl;
+
+  // prepare for transfer:
+  m_to_transfer.push_back(std::make_pair(myDBObject,myTime));
+
+  edm::LogInfo ("HcalCondTools") << "------- " << m_name 
+				 << " - > getNewObjects" << std::endl;
+
+}
+
+void HcalTPChannelParametersHandler::initObject(HcalTPChannelParameters* fObject) {
+  myDBObject = fObject;
+}

--- a/CondTools/Hcal/src/HcalTPParametersHandler.cc
+++ b/CondTools/Hcal/src/HcalTPParametersHandler.cc
@@ -1,0 +1,41 @@
+#include "CondTools/Hcal/interface/HcalTPParametersHandler.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include <memory>
+
+HcalTPParametersHandler::HcalTPParametersHandler(edm::ParameterSet const & ps){
+  m_name = ps.getUntrackedParameter<std::string>("name","HcalTPParametersHandler");
+  sinceTime = ps.getUntrackedParameter<unsigned>("IOVRun",0);
+}
+
+HcalTPParametersHandler::~HcalTPParametersHandler() { }
+
+void HcalTPParametersHandler::getNewObjects() {
+  edm::LogInfo ("HcalCondTools") << "------- " << m_name 
+				 << " - > getNewObjects\n" << "got offlineInfo"
+				 << tagInfo().name << ", size " 
+				 << tagInfo().size 
+				 << ", last object valid since " 
+				 << tagInfo().lastInterval.first << std::endl;
+
+  if (!myDBObject) 
+    throw cms::Exception("Empty DB object") << m_name 
+					    << " has received empty object - nothing to write to DB" 
+					    << std::endl;
+
+  //  IOV information
+  cond::Time_t myTime = sinceTime;
+
+  edm::LogInfo ("HcalCondTools") << "Using IOV run " << sinceTime << std::endl;
+
+  // prepare for transfer:
+  m_to_transfer.push_back(std::make_pair(myDBObject,myTime));
+
+  edm::LogInfo ("HcalCondTools") << "------- " << m_name 
+				 << " - > getNewObjects" << std::endl;
+
+}
+
+void HcalTPParametersHandler::initObject(HcalTPParameters* fObject) {
+  myDBObject = fObject;
+}


### PR DESCRIPTION
This adds 2 data base objects: HcalTPParameters which summarizes the TP implementation and HcalTPChannelParameters which contains parameters for each channel
