### PR TITLE
use unique_ptr, not auto_ptr, in PhysicsTools packages

### DIFF
--- a/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.cc
+++ b/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.cc
@@ -22,8 +22,7 @@ EventShapeVarsProducer::EventShapeVarsProducer(const edm::ParameterSet& cfg)
 
 void put(edm::Event& evt, double value, const char* instanceName)
 {
-  std::auto_ptr<double> eventShapeVarPtr(new double(value));
-  evt.put(eventShapeVarPtr, instanceName);
+  evt.put(std::make_unique<double>(value), instanceName);
 }
 
 void EventShapeVarsProducer::produce(edm::Event& evt, const edm::EventSetup&)

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthCompositeMatcher.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthCompositeMatcher.h
@@ -52,7 +52,7 @@ void MCTruthCompositeMatcher<C1, C2>::produce( edm::Event & evt , const edm::Eve
     maps.push_back( & * matchMap );
   }
   MCCandMatcher<C1, C2> match( maps );
-  auto_ptr<map_type> matchMap( new map_type );
+  auto matchMap = std::make_unique<map_type>();
   for( size_t i = 0; i != cands->size(); ++ i ) {
     const typename C1::value_type & cand = ( * cands )[ i ];
     reference_type mc(match( cand ));
@@ -61,7 +61,7 @@ void MCTruthCompositeMatcher<C1, C2>::produce( edm::Event & evt , const edm::Eve
     }
   }
 
-  evt.put( matchMap );
+  evt.put(std::move(matchMap) );
 }
 
 #endif

--- a/PhysicsTools/HepMCCandAlgos/plugins/FlavorHistoryFilter.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/FlavorHistoryFilter.cc
@@ -184,7 +184,7 @@ FlavorHistoryFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   Handle<FlavorHistoryEvent > cFlavorHistoryEvent;
   iEvent.getByToken(csrcToken_,cFlavorHistoryEvent);
 
-  std::auto_ptr<unsigned int> selection ( new unsigned int() );
+  auto selection = std::make_unique<unsigned int>(0);
 
   // Get the number of matched b-jets in the event
   unsigned int nb = bFlavorHistoryEvent->nb();
@@ -238,7 +238,7 @@ FlavorHistoryFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
     pass = true;
   }
 
-  iEvent.put( selection );
+  iEvent.put(std::move(selection) );
 
   return pass;
 

--- a/PhysicsTools/HepMCCandAlgos/plugins/FlavorHistoryProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/FlavorHistoryProducer.cc
@@ -80,7 +80,7 @@ void FlavorHistoryProducer::produce( Event& evt, const EventSetup& )
   vector<FlavorHistory::FLAVOR_T> flavorSources;
 
   // Make a new flavor history vector
-  auto_ptr<FlavorHistoryEvent > flavorHistoryEvent ( new FlavorHistoryEvent () ) ;
+  auto flavorHistoryEvent = std::make_unique<FlavorHistoryEvent>();
 
   // ------------------------------------------------------------
   // Loop over partons
@@ -321,7 +321,7 @@ void FlavorHistoryProducer::produce( Event& evt, const EventSetup& )
   }
 
   // Now add the flavor history to the event record
-  evt.put( flavorHistoryEvent, flavorHistoryName_ );
+  evt.put(std::move(flavorHistoryEvent), flavorHistoryName_ );
 }
 
 

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleDecaySelector.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleDecaySelector.cc
@@ -52,13 +52,13 @@ void GenParticleDecaySelector::produce(edm::Event& evt, const edm::EventSetup& e
 
   Handle<GenParticleCollection> genParticles;
   evt.getByToken(srcToken_, genParticles);
-  auto_ptr<GenParticleCollection> decay(new GenParticleCollection);
+  auto decay = std::make_unique<GenParticleCollection>();
   const GenParticleRefProd ref = evt.getRefBeforePut<GenParticleCollection>();
   for(GenParticleCollection::const_iterator g = genParticles->begin();
       g != genParticles->end(); ++g)
     if(g->pdgId() == particle_.pdgId() && g->status() == status_)
       add(*decay, *g, ref);
-  evt.put(decay);
+  evt.put(std::move(decay));
 }
 
 pair<GenParticleRef, GenParticle*> GenParticleDecaySelector::add(GenParticleCollection & decay, const GenParticle & p,

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -176,8 +176,8 @@ void GenParticleProducer::produce( Event& evt, const EventSetup& es ) {
    // initialise containers
    const size_t size = totalSize;
   vector<const HepMC::GenParticle *> particles( size );
-  auto_ptr<GenParticleCollection> candsPtr( new GenParticleCollection( size ) );
-  auto_ptr<vector<int> > barCodeVector( new vector<int>( size ) );
+  auto candsPtr = std::make_unique<GenParticleCollection>(size);
+  auto barCodeVector = std::make_unique<vector<int>>(size);
   ref_ = evt.getRefBeforePut<GenParticleCollection>();
   GenParticleCollection & cands = * candsPtr;
   size_t offset = 0;
@@ -257,8 +257,8 @@ void GenParticleProducer::produce( Event& evt, const EventSetup& es ) {
      }
   }
   
-  evt.put( candsPtr );
-  if(saveBarCodes_) evt.put( barCodeVector );
+  evt.put(std::move(candsPtr));
+  if(saveBarCodes_) evt.put(std::move(barCodeVector));
   if(cfhepmcprod) delete cfhepmcprod;
 
 }

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
@@ -231,7 +231,7 @@ void GenParticlePruner::produce(Event& evt, const EventSetup& es) {
     }
   }
 
-  auto_ptr<GenParticleCollection> out(new GenParticleCollection);
+  auto out = std::make_unique<GenParticleCollection>();
   GenParticleRefProd outRef = evt.getRefBeforePut<GenParticleCollection>();
   out->reserve(counter);
   
@@ -261,12 +261,12 @@ void GenParticlePruner::produce(Event& evt, const EventSetup& es) {
   }
 
 
-    edm::OrphanHandle<reco::GenParticleCollection> oh = evt.put(out);
-    std::auto_ptr<edm::Association<reco::GenParticleCollection> > orig2new(new edm::Association<reco::GenParticleCollection>(oh   ));
+    edm::OrphanHandle<reco::GenParticleCollection> oh = evt.put(std::move(out));
+    auto orig2new = std::make_unique<edm::Association<reco::GenParticleCollection>>(oh);
     edm::Association<reco::GenParticleCollection>::Filler orig2newFiller(*orig2new);
     orig2newFiller.insert(src, flags_.begin(), flags_.end());
     orig2newFiller.fill();
-    evt.put(orig2new);
+    evt.put(std::move(orig2new));
    
 
 }

--- a/PhysicsTools/HepMCCandAlgos/plugins/MCTruthCompositeMatcherNew.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/MCTruthCompositeMatcherNew.cc
@@ -53,7 +53,7 @@ namespace reco {
 	maps.push_back(& * matchMap);
       }
       utilsNew::CandMatcher<GenParticleCollection> match(maps);
-      auto_ptr<GenParticleMatch> matchMap(new GenParticleMatch(match.ref()));
+      auto matchMap = std::make_unique<GenParticleMatch>(match.ref());
       int size = cands->size();
       vector<int>::const_iterator begin = pdgId_.begin(), end = pdgId_.end();
       if(size != 0) {
@@ -74,7 +74,7 @@ namespace reco {
 	filler.insert(ref, indices.begin(), indices.end());
 	filler.fill();
       }
-      evt.put(matchMap);
+      evt.put(std::move(matchMap));
     }
 
   }

--- a/PhysicsTools/IsolationAlgos/interface/EventDependentAbsVetos.h
+++ b/PhysicsTools/IsolationAlgos/interface/EventDependentAbsVetos.h
@@ -58,7 +58,7 @@ namespace reco {
       private:
           edm::EDGetTokenT<edm::View<reco::Candidate> > src_;
           std::vector<Direction> items_;
-          std::auto_ptr<AbsVeto> veto_;
+          std::unique_ptr<AbsVeto> veto_;
     };
 
     class OtherJetConstituentsDeltaRVeto : public EventDependentAbsVeto {

--- a/PhysicsTools/IsolationAlgos/interface/IsolationProducer.h
+++ b/PhysicsTools/IsolationAlgos/interface/IsolationProducer.h
@@ -70,14 +70,14 @@ void IsolationProducer<C1, C2, Alg, OutputCollection, Setup>::produce( edm::Even
   Setup::init( alg_, es );
 
   typename OutputCollection::refprod_type ref( src );
-  auto_ptr<OutputCollection> isolations( new OutputCollection( ref )  );
+  auto isolations = std::make_unique<OutputCollection>( ref );
 
   size_t i = 0;
   for( typename C1::const_iterator lep = src->begin(); lep != src->end(); ++ lep ) {
     typename Alg::value_type iso= alg_(*lep,*elements);
     isolations->setValue( i++, iso );
   }
-  evt.put( isolations );
+  evt.put(std::move(isolations) );
 }
 
 #endif

--- a/PhysicsTools/IsolationAlgos/interface/IsolationProducerNew.h
+++ b/PhysicsTools/IsolationAlgos/interface/IsolationProducerNew.h
@@ -73,7 +73,7 @@ namespace reco {
       Setup::init(alg_, es);
 
       ::helper::MasterCollection<C1> master(src, evt);
-      auto_ptr<OutputCollection> isolations(new OutputCollection);
+      auto isolations = std::make_unique<OutputCollection>();
       if(src->size()!= 0) {
 	typename OutputCollection::Filler filler(*isolations);
 	vector<double> iso(master.size(),-1);
@@ -83,7 +83,7 @@ namespace reco {
 	filler.insert(master.get(), iso.begin(), iso.end());
 	filler.fill();
       }
-      evt.put( isolations );
+      evt.put(std::move(isolations) );
     }
 
   }

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -114,7 +114,7 @@ namespace citk {
 
   void  PFIsolationSumProducer::
   produce(edm::Event& ev, const edm::EventSetup& es) {
-    typedef std::auto_ptr<edm::ValueMap<float> >  product_type;
+    typedef std::unique_ptr<edm::ValueMap<float> >  product_type;
     typedef std::vector<float> product_values;
     edm::Handle<CandView> to_isolate;
     edm::Handle<CandView> isolate_with;
@@ -167,7 +167,7 @@ namespace citk {
 			  the_values[i][j].begin(),
 			  the_values[i][j].end());
 	fillerprod.fill();
-	ev.put(the_product,_product_names[i][j]);
+	ev.put(std::move(the_product),_product_names[i][j]);
       }
     }
   }

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -116,7 +116,7 @@ namespace citk {
 
   void  PFIsolationSumProducerForPUPPI::
   produce(edm::Event& ev, const edm::EventSetup& es) {
-    typedef std::auto_ptr<edm::ValueMap<float> >  product_type;
+    typedef std::unique_ptr<edm::ValueMap<float> >  product_type;
     typedef std::vector<float> product_values;
     edm::Handle<CandView> to_isolate;
     edm::Handle<CandView> isolate_with;
@@ -175,7 +175,7 @@ namespace citk {
 			  the_values[i][j].begin(),
 			  the_values[i][j].end());
 	fillerprod.fill();
-	ev.put(the_product,_product_names[i][j]);
+	ev.put(std::move(the_product),_product_names[i][j]);
       }
     }
   }

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
@@ -149,7 +149,7 @@ void CandIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup)
     }
     
     //! fill the maps here
-    std::unique_ptr<reco::IsoDepositMap> depMap(new reco::IsoDepositMap());    
+    auto depMap = std::make_unique<reco::IsoDepositMap>();    
     reco::IsoDepositMap::Filler filler(*depMap);
     filler.insert(hCands, deps2D[iDep].begin(), deps2D[iDep].end());
     deps2D[iDep].clear();

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
@@ -140,10 +140,10 @@ void CandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSetu
   const IsoDepositMap & map = begin->map();
 
   if (map.size()==0) { // !!???
-        event.put(std::auto_ptr<CandDoubleMap>(new CandDoubleMap()));
+        event.put(std::make_unique<CandDoubleMap>());
         return;
   }
-  std::auto_ptr<CandDoubleMap> ret(new CandDoubleMap());
+  auto ret = std::make_unique<CandDoubleMap>();
   CandDoubleMap::Filler filler(*ret);
 
   typedef reco::IsoDepositMap::const_iterator iterator_i;
@@ -167,7 +167,7 @@ void CandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSetu
     filler.insert(candH, retV.begin(), retV.end());
   }
   filler.fill();
-  event.put(ret);
+  event.put(std::move(ret));
 }
 
 DEFINE_FWK_MODULE( CandIsolatorFromDeposits );

--- a/PhysicsTools/IsolationAlgos/plugins/IsolationProducerForTracks.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/IsolationProducerForTracks.cc
@@ -47,7 +47,7 @@ IsolationProducerForTracks::IsolationProducerForTracks(const ParameterSet & pset
  }
 
 void IsolationProducerForTracks::produce(Event & event, const EventSetup & setup) {
-  std::auto_ptr<TkIsoMap> caloIsolations(new TkIsoMap);
+  auto caloIsolations = std::make_unique<TkIsoMap>();
   TkIsoMap::Filler filler(*caloIsolations);
   {
     Handle<CandidateView> tracks;
@@ -86,7 +86,7 @@ void IsolationProducerForTracks::produce(Event & event, const EventSetup & setup
 
   // really fill the association map
   filler.fill();
-  event.put(caloIsolations);
+  event.put(std::move(caloIsolations));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
+++ b/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
@@ -19,7 +19,7 @@ namespace reco { namespace isodeposit {
 	      veto_->centerOn(eta,phi);
 	    }
         private:
-            std::auto_ptr<AbsVeto> veto_;
+            std::unique_ptr<AbsVeto> veto_;
             bool barrel_;
     };
 
@@ -72,7 +72,7 @@ namespace reco { namespace isodeposit {
 reco::isodeposit::AbsVeto *
 IsoDepositVetoFactory::make(const char *string, edm::ConsumesCollector& iC) {
     reco::isodeposit::EventDependentAbsVeto * evdep = 0;
-    std::auto_ptr<reco::isodeposit::AbsVeto> ret(make(string,evdep, iC));
+    std::unique_ptr<reco::isodeposit::AbsVeto> ret(make(string,evdep, iC));
     if (evdep != 0) {
         throw cms::Exception("Configuration") << "The resulting AbsVeto depends on the edm::Event.\n"
                                               << "Please use the two-arguments IsoDepositVetoFactory::make.\n";

--- a/PhysicsTools/JetCharge/plugins/JetChargeProducer.cc
+++ b/PhysicsTools/JetCharge/plugins/JetChargeProducer.cc
@@ -14,11 +14,10 @@ void JetChargeProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::Ev
 
     if (hJTAs->keyProduct().isNull()) {
         // need to work around this bug someway, altough it's not stricly my fault
-        std::auto_ptr<JetChargeCollection> ret(new JetChargeCollection());
-        iEvent.put(ret);
+        iEvent.put(std::make_unique<JetChargeCollection>());
         return;
     }
-    std::auto_ptr<JetChargeCollection> ret(new JetChargeCollection(hJTAs->keyProduct()));
+    auto ret = std::make_unique<JetChargeCollection>(hJTAs->keyProduct());
     for (IT it = hJTAs->begin(), ed = hJTAs->end(); it != ed; ++it) {
         const JetRef &jet = it->first;
         const reco::TrackRefVector &tracks = it->second;
@@ -26,5 +25,5 @@ void JetChargeProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::Ev
         reco::JetFloatAssociation::setValue(*ret, jet, val);
     }
 
-    iEvent.put(ret);
+    iEvent.put(std::move(ret));
 }

--- a/PhysicsTools/JetMCAlgos/interface/BasePartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/BasePartonSelector.h
@@ -17,7 +17,7 @@ class BasePartonSelector
     ~BasePartonSelector();
 
     virtual void run(const edm::Handle<reco::GenParticleCollection> & particles,
-                     std::auto_ptr<reco::GenParticleRefVector> & partons);
+                     std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/interface/Herwig6PartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/Herwig6PartonSelector.h
@@ -15,7 +15,7 @@ class Herwig6PartonSelector : public BasePartonSelector
     virtual ~Herwig6PartonSelector();
 
     void run(const edm::Handle<reco::GenParticleCollection> & particles,
-             std::auto_ptr<reco::GenParticleRefVector> & partons);
+             std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/interface/HerwigppPartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/HerwigppPartonSelector.h
@@ -15,7 +15,7 @@ class HerwigppPartonSelector : public BasePartonSelector
     virtual ~HerwigppPartonSelector();
 
     void run(const edm::Handle<reco::GenParticleCollection> & particles,
-             std::auto_ptr<reco::GenParticleRefVector> & partons);
+             std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/interface/Pythia6PartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/Pythia6PartonSelector.h
@@ -15,7 +15,7 @@ class Pythia6PartonSelector : public BasePartonSelector
     virtual ~Pythia6PartonSelector();
 
     void run(const edm::Handle<reco::GenParticleCollection> & particles,
-             std::auto_ptr<reco::GenParticleRefVector> & partons);
+             std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/interface/Pythia8PartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/Pythia8PartonSelector.h
@@ -15,7 +15,7 @@ class Pythia8PartonSelector : public BasePartonSelector
     virtual ~Pythia8PartonSelector();
 
     void run(const edm::Handle<reco::GenParticleCollection> & particles,
-             std::auto_ptr<reco::GenParticleRefVector> & partons);
+             std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/interface/SherpaPartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/SherpaPartonSelector.h
@@ -15,7 +15,7 @@ class SherpaPartonSelector : public BasePartonSelector
     virtual ~SherpaPartonSelector();
 
     void run(const edm::Handle<reco::GenParticleCollection> & particles,
-             std::auto_ptr<reco::GenParticleRefVector> & partons);
+             std::unique_ptr<reco::GenParticleRefVector> & partons);
 };
 
 #endif

--- a/PhysicsTools/JetMCAlgos/plugins/CandOneToManyDeltaRMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/CandOneToManyDeltaRMatcher.cc
@@ -90,9 +90,9 @@ void CandOneToManyDeltaRMatcher::produce( Event& evt, const EventSetup& es ) {
   }
 
 
-  auto_ptr<CandMatchMapMany> matchMap( new CandMatchMapMany( CandMatchMapMany::ref_type( CandidateRefProd( source  ),
-                                                                                         CandidateRefProd( matched )
-											 ) ) );
+  auto matchMap = std::make_unique<CandMatchMapMany>( CandMatchMapMany::ref_type( CandidateRefProd( source  ),
+                                                                                  CandidateRefProd( matched )
+										  ) );
   for( size_t c = 0; c != source->size(); ++ c ) {
     const Candidate & src = (*source)[ c ];
     if (printdebug_) cout << "[CandOneToManyDeltaRMatcher] source (Et,Eta,Phi) =(" << src.et() << "," <<
@@ -116,7 +116,7 @@ void CandOneToManyDeltaRMatcher::produce( Event& evt, const EventSetup& es ) {
     }
   }
 
-  evt.put( matchMap );
+  evt.put(std::move(matchMap) );
 
 }
 

--- a/PhysicsTools/JetMCAlgos/plugins/CandOneToOneDeltaRMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/CandOneToOneDeltaRMatcher.cc
@@ -161,14 +161,14 @@ void CandOneToOneDeltaRMatcher::produce( Event& evt, const EventSetup& es ) {
   for(int i1=0; i1<nMin; i1++) edm::LogVerbatim("CandOneToOneDeltaRMatcher") << "min: " << i1 << " " << bestCB[i1] << " " << AllDist[i1][bestCB[i1]];
 
 /*
-  auto_ptr<CandViewMatchMap> matchMapSrMt( new CandViewMatchMap( CandViewMatchMap::ref_type( CandidateRefProd( source  ),
-                                                                                             CandidateRefProd( matched )  ) ) );
-  auto_ptr<CandViewMatchMap> matchMapMtSr( new CandViewMatchMap( CandViewMatchMap::ref_type( CandidateRefProd( matched ),
-                                                                                             CandidateRefProd( source  )  ) ) );
+  auto matchMapSrMt = std::make_unique<CandViewMatchMap>(CandViewMatchMap::ref_type( CandidateRefProd( source  ),
+                                                                                             CandidateRefProd( matched ) ) );
+  auto matchMapMtSr = std::make_unique<CandViewMatchMap>(CandViewMatchMap::ref_type( CandidateRefProd( matched ),
+                                                                                             CandidateRefProd( source ) ) );
 */
 
-  auto_ptr<CandViewMatchMap> matchMapSrMt( new CandViewMatchMap() );
-  auto_ptr<CandViewMatchMap> matchMapMtSr( new CandViewMatchMap() );
+  auto matchMapSrMt = std::make_unique<CandViewMatchMap>();
+  auto matchMapMtSr = std::make_unique<CandViewMatchMap>();
 
   for( int c = 0; c != nMin; c ++ ) {
     if( source->size() <= matched->size() ) {
@@ -191,8 +191,8 @@ void CandOneToOneDeltaRMatcher::produce( Event& evt, const EventSetup& es ) {
     }
   }
 */
-  evt.put( matchMapSrMt, "src2mtc" );
-  evt.put( matchMapMtSr, "mtc2src" );
+  evt.put(std::move(matchMapSrMt), "src2mtc" );
+  evt.put(std::move(matchMapMtSr), "mtc2src" );
 
   AllDist.clear();
 }

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -207,30 +207,30 @@ void GenHFHadronMatcher::produce ( edm::Event& evt, const edm::EventSetup& setup
     evt.getByToken(jetFlavourInfosToken_, jetFlavourInfos);
     
     // Defining adron matching variables
-    std::auto_ptr<std::vector<reco::GenParticle> > hadMothers ( new std::vector<reco::GenParticle> );
-    std::auto_ptr<std::vector<std::vector<int> > > hadMothersIndices ( new std::vector<std::vector<int> > );
-    std::auto_ptr<std::vector<int> > hadIndex ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadFlavour ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadJetIndex ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadLeptonIndex ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadLeptonHadIndex ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadLeptonViaTau( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadFromTopWeakDecay ( new std::vector<int> );
-    std::auto_ptr<std::vector<int> > hadBHadronId ( new std::vector<int> );
+    auto hadMothers = std::make_unique<std::vector<reco::GenParticle> >();
+    auto hadMothersIndices = std::make_unique<std::vector<std::vector<int> > >();
+    auto hadIndex = std::make_unique<std::vector<int> >();
+    auto hadFlavour = std::make_unique<std::vector<int> >();
+    auto hadJetIndex = std::make_unique<std::vector<int> >();
+    auto hadLeptonIndex = std::make_unique<std::vector<int> >();
+    auto hadLeptonHadIndex = std::make_unique<std::vector<int> >();
+    auto hadLeptonViaTau = std::make_unique<std::vector<int> >();
+    auto hadFromTopWeakDecay = std::make_unique<std::vector<int> >();
+    auto hadBHadronId = std::make_unique<std::vector<int> >();
     
     *hadJetIndex = findHadronJets (genParticles.product(), jetFlavourInfos.product(), *hadIndex, *hadMothers, *hadMothersIndices, *hadLeptonIndex, *hadLeptonHadIndex, *hadLeptonViaTau, *hadFlavour, *hadFromTopWeakDecay, *hadBHadronId );
 
     // Putting products to the event
-    evt.put ( hadMothers,         "gen"+flavourStr_+"HadPlusMothers" );
-    evt.put ( hadMothersIndices,  "gen"+flavourStr_+"HadPlusMothersIndices" );
-    evt.put ( hadIndex,           "gen"+flavourStr_+"HadIndex" );
-    evt.put ( hadFlavour,         "gen"+flavourStr_+"HadFlavour" );
-    evt.put ( hadJetIndex,        "gen"+flavourStr_+"HadJetIndex" );
-    evt.put ( hadLeptonIndex,     "gen"+flavourStr_+"HadLeptonIndex" );
-    evt.put ( hadLeptonHadIndex,  "gen"+flavourStr_+"HadLeptonHadronIndex" );
-    evt.put ( hadLeptonViaTau,    "gen"+flavourStr_+"HadLeptonViaTau" );
-    evt.put ( hadFromTopWeakDecay,"gen"+flavourStr_+"HadFromTopWeakDecay" );
-    evt.put ( hadBHadronId,       "gen"+flavourStr_+"HadBHadronId" );
+    evt.put(std::move(hadMothers),         "gen"+flavourStr_+"HadPlusMothers" );
+    evt.put(std::move(hadMothersIndices),  "gen"+flavourStr_+"HadPlusMothersIndices" );
+    evt.put(std::move(hadIndex),           "gen"+flavourStr_+"HadIndex" );
+    evt.put(std::move(hadFlavour),         "gen"+flavourStr_+"HadFlavour" );
+    evt.put(std::move(hadJetIndex),        "gen"+flavourStr_+"HadJetIndex" );
+    evt.put(std::move(hadLeptonIndex),     "gen"+flavourStr_+"HadLeptonIndex" );
+    evt.put(std::move(hadLeptonHadIndex),  "gen"+flavourStr_+"HadLeptonHadronIndex" );
+    evt.put(std::move(hadLeptonViaTau),    "gen"+flavourStr_+"HadLeptonViaTau" );
+    evt.put(std::move(hadFromTopWeakDecay),"gen"+flavourStr_+"HadFromTopWeakDecay" );
+    evt.put(std::move(hadBHadronId),       "gen"+flavourStr_+"HadBHadronId" );
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/PhysicsTools/JetMCAlgos/plugins/GenJetBCEnergyRatio.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenJetBCEnergyRatio.cc
@@ -98,8 +98,8 @@ void GenJetBCEnergyRatio::produce( Event& iEvent, const EventSetup& iEs )
     jtc2 = new JetBCEnergyRatioCollection();
   }
 
-  std::auto_ptr<JetBCEnergyRatioCollection> bRatioColl(jtc1);
-  std::auto_ptr<JetBCEnergyRatioCollection> cRatioColl(jtc2);
+  std::unique_ptr<JetBCEnergyRatioCollection> bRatioColl(jtc1);
+  std::unique_ptr<JetBCEnergyRatioCollection> cRatioColl(jtc2);
 
   for( size_t j = 0; j != genjets->size(); ++j ) {
 
@@ -114,8 +114,8 @@ void GenJetBCEnergyRatio::produce( Event& iEvent, const EventSetup& iEs )
   }
 
 
-  iEvent.put(bRatioColl, "bRatioCollection");
-  iEvent.put(cRatioColl, "cRatioCollection");
+  iEvent.put(std::move(bRatioColl), "bRatioCollection");
+  iEvent.put(std::move(cRatioColl), "cRatioCollection");
 
 }
 

--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -203,11 +203,11 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    edm::Handle<reco::GenParticleCollection> particles;
    iEvent.getByToken(particlesToken_, particles);
 
-   std::auto_ptr<reco::GenParticleRefVector> bHadrons ( new reco::GenParticleRefVector );
-   std::auto_ptr<reco::GenParticleRefVector> cHadrons ( new reco::GenParticleRefVector );
-   std::auto_ptr<reco::GenParticleRefVector> partons  ( new reco::GenParticleRefVector );
-   std::auto_ptr<reco::GenParticleRefVector> physicsPartons  ( new reco::GenParticleRefVector );
-   std::auto_ptr<reco::GenParticleRefVector> leptons  ( new reco::GenParticleRefVector );
+   auto bHadrons = std::make_unique<reco::GenParticleRefVector>();
+   auto cHadrons = std::make_unique<reco::GenParticleRefVector>();
+   auto partons  = std::make_unique<reco::GenParticleRefVector>();
+   auto physicsPartons  = std::make_unique<reco::GenParticleRefVector>();
+   auto leptons  = std::make_unique<reco::GenParticleRefVector>();
 
    // loop over particles and select b and c hadrons and leptons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
@@ -260,11 +260,11 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
      }
    }
 
-   iEvent.put( bHadrons, "bHadrons" );
-   iEvent.put( cHadrons, "cHadrons" );
-   iEvent.put( partons,  "algorithmicPartons" );
-   iEvent.put( physicsPartons,  "physicsPartons" );
-   iEvent.put( leptons,  "leptons" );
+   iEvent.put(std::move(bHadrons), "bHadrons" );
+   iEvent.put(std::move(cHadrons), "cHadrons" );
+   iEvent.put(std::move(partons),  "algorithmicPartons" );
+   iEvent.put(std::move(physicsPartons),  "physicsPartons" );
+   iEvent.put(std::move(leptons),  "leptons" );
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -287,10 +287,10 @@ JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    if( useLeptons_ )
      iEvent.getByToken(leptonsToken_, leptons);
 
-   std::auto_ptr<reco::JetFlavourInfoMatchingCollection> jetFlavourInfos( new reco::JetFlavourInfoMatchingCollection(reco::JetRefBaseProd(jets)) );
-   std::auto_ptr<reco::JetFlavourInfoMatchingCollection> subjetFlavourInfos;
+   auto jetFlavourInfos = std::make_unique<reco::JetFlavourInfoMatchingCollection>(reco::JetRefBaseProd(jets));
+   std::unique_ptr<reco::JetFlavourInfoMatchingCollection> subjetFlavourInfos;
    if( useSubjets_ )
-     subjetFlavourInfos = std::auto_ptr<reco::JetFlavourInfoMatchingCollection>( new reco::JetFlavourInfoMatchingCollection(reco::JetRefBaseProd(subjets)) );
+     subjetFlavourInfos = std::make_unique<reco::JetFlavourInfoMatchingCollection>(reco::JetRefBaseProd(subjets));
 
    // vector of constituents for reclustering jets and "ghosts"
    std::vector<fastjet::PseudoJet> fjInputs;
@@ -474,10 +474,10 @@ JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
 
    // put jet flavour infos in the event
-   iEvent.put( jetFlavourInfos );
+   iEvent.put(std::move(jetFlavourInfos));
    // put subjet flavour infos in the event
    if( useSubjets_ )
-     iEvent.put( subjetFlavourInfos, "SubJets" );
+     iEvent.put(std::move(subjetFlavourInfos), "SubJets" );
 }
 
 // ------------ method that inserts "ghost" particles in the vector of jet constituents ------------

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourIdentifier.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourIdentifier.cc
@@ -152,7 +152,7 @@ void JetFlavourIdentifier::produce( Event& iEvent, const EventSetup& iEs )
   } else {
     jfmc = new JetFlavourMatchingCollection();
   }
-  auto_ptr<reco::JetFlavourMatchingCollection> jetFlavMatching(jfmc);
+  std::unique_ptr<reco::JetFlavourMatchingCollection> jetFlavMatching(jfmc);
 
   // Loop over the matched partons and see which match.
   for ( JetMatchedPartonsCollection::const_iterator j  = theTagByRef->begin();
@@ -278,7 +278,7 @@ void JetFlavourIdentifier::produce( Event& iEvent, const EventSetup& iEs )
 
 
   // Put the object into the event.
-  iEvent.put(  jetFlavMatching );
+  iEvent.put(std::move(jetFlavMatching));
 
 }
 

--- a/PhysicsTools/JetMCAlgos/plugins/JetPartonMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetPartonMatcher.cc
@@ -164,7 +164,7 @@ void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
                                              aParton.phi()    << endl;
   }
 
-  auto_ptr<reco::JetMatchedPartonsCollection> jetMatchedPartons( new JetMatchedPartonsCollection(reco::JetRefBaseProd(jets_h)));
+  auto jetMatchedPartons = std::make_unique<JetMatchedPartonsCollection>(reco::JetRefBaseProd(jets_h));
 
   for (size_t j = 0; j < jets_h->size(); j++) {
 
@@ -186,7 +186,7 @@ void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
     (*jetMatchedPartons)[jets_h->refAt(j)]=MatchedPartons(pHV,pN2,pN3,pPH,pAL);
   }
 
-  iEvent.put(  jetMatchedPartons );
+  iEvent.put(std::move(jetMatchedPartons));
 
 }
 

--- a/PhysicsTools/JetMCAlgos/plugins/PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/PartonSelector.cc
@@ -89,7 +89,7 @@ void PartonSelector::produce( Event& iEvent, const EventSetup& iEs )
   edm::LogVerbatim("PartonSelector") << "=== GenParticle size:" << particles->size();
   int nPart=0;
 
-  auto_ptr<GenParticleRefVector> thePartons ( new GenParticleRefVector);
+  auto thePartons = std::make_unique<GenParticleRefVector>();
 
   for (size_t m = 0; m < particles->size(); m++) {
 
@@ -152,7 +152,7 @@ void PartonSelector::produce( Event& iEvent, const EventSetup& iEs )
   }
 
   edm::LogVerbatim("PartonSelector") << "=== GenParticle selected:" << nPart;
-  iEvent.put( thePartons );
+  iEvent.put(std::move(thePartons) );
 
 }
 

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -44,8 +44,7 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent,
     throw cms::Exception( "MissingProduct", err.str());
   }
 
-  std::auto_ptr<GenJetCollection>
-    pOutVisTaus(new GenJetCollection());
+  auto pOutVisTaus = std::make_unique<GenJetCollection>();
 
   using namespace GenParticlesHelper;
 
@@ -109,7 +108,7 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent,
     pOutVisTaus->push_back( jet );
 
   }
-  iEvent.put( pOutVisTaus );
+  iEvent.put(std::move(pOutVisTaus) );
 }
 
 

--- a/PhysicsTools/JetMCAlgos/src/BasePartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/BasePartonSelector.cc
@@ -10,6 +10,6 @@ BasePartonSelector::~BasePartonSelector()
 
 void
 BasePartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                        std::auto_ptr<reco::GenParticleRefVector> & partons)
+                        std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
 }

--- a/PhysicsTools/JetMCAlgos/src/Herwig6PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Herwig6PartonSelector.cc
@@ -18,7 +18,7 @@ Herwig6PartonSelector::~Herwig6PartonSelector()
 
 void
 Herwig6PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                          std::auto_ptr<reco::GenParticleRefVector> & partons)
+                          std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
    // loop over particles and select partons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)

--- a/PhysicsTools/JetMCAlgos/src/HerwigppPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/HerwigppPartonSelector.cc
@@ -19,7 +19,7 @@ HerwigppPartonSelector::~HerwigppPartonSelector()
 
 void
 HerwigppPartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                          std::auto_ptr<reco::GenParticleRefVector> & partons)
+                          std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
    // loop over particles and select partons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)

--- a/PhysicsTools/JetMCAlgos/src/Pythia6PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Pythia6PartonSelector.cc
@@ -18,7 +18,7 @@ Pythia6PartonSelector::~Pythia6PartonSelector()
 
 void
 Pythia6PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                          std::auto_ptr<reco::GenParticleRefVector> & partons)
+                          std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
    // loop over particles and select partons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)

--- a/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
@@ -19,7 +19,7 @@ Pythia8PartonSelector::~Pythia8PartonSelector()
 
 void
 Pythia8PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                          std::auto_ptr<reco::GenParticleRefVector> & partons)
+                          std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
    // loop over particles and select partons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)

--- a/PhysicsTools/JetMCAlgos/src/SherpaPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/SherpaPartonSelector.cc
@@ -17,7 +17,7 @@ SherpaPartonSelector::~SherpaPartonSelector()
 
 void
 SherpaPartonSelector::run(const edm::Handle<reco::GenParticleCollection> & particles,
-                          std::auto_ptr<reco::GenParticleRefVector> & partons)
+                          std::unique_ptr<reco::GenParticleRefVector> & partons)
 {
    // loop over particles and select partons
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)

--- a/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
+++ b/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
@@ -79,7 +79,7 @@ namespace pat {
     ~CandidateSummaryTable();
     
     static std::unique_ptr<pathelpers::RecordCache> initializeGlobalCache(edm::ParameterSet const& conf) {
-      return std::unique_ptr<pathelpers::RecordCache>(new pathelpers::RecordCache(conf));
+      return std::make_unique<pathelpers::RecordCache>(conf);
     }
 
     virtual void analyze(const edm::Event & iEvent, const edm::EventSetup& iSetup) override;

--- a/PhysicsTools/PatAlgos/plugins/DuplicatedElectronCleaner.cc
+++ b/PhysicsTools/PatAlgos/plugins/DuplicatedElectronCleaner.cc
@@ -66,10 +66,10 @@ pat::DuplicatedElectronCleaner::produce(edm::StreamID, edm::Event & iEvent, cons
   iEvent.getByToken(electronSrcToken_, electrons);
   try_ += electrons->size();
 
-  //std::auto_ptr<RefVector<reco::GsfElectronCollection> > result(new RefVector<reco::GsfElectronCollection>());
-  std::auto_ptr<RefToBaseVector<reco::GsfElectron> > result(new RefToBaseVector<reco::GsfElectron>());
-  //std::auto_ptr<PtrVector<reco::GsfElectron> > result(new PtrVector<reco::GsfElectron>());
-  std::auto_ptr< std::vector<size_t> > duplicates = duplicateRemover_.duplicatesToRemove(*electrons);
+  //auto result = std::make_unique<RefVector<reco::GsfElectronCollection>>();
+  auto result = std::make_unique<RefToBaseVector<reco::GsfElectron>>();
+  //auto result = std::make_unique<PtrVector<reco::GsfElectron>>();
+  std::unique_ptr< std::vector<size_t> > duplicates = duplicateRemover_.duplicatesToRemove(*electrons);
 
   std::vector<size_t>::const_iterator itdup = duplicates->begin(), enddup = duplicates->end();
   for (size_t i = 0, n = electrons->size(); i < n; ++i) {
@@ -80,7 +80,7 @@ pat::DuplicatedElectronCleaner::produce(edm::StreamID, edm::Event & iEvent, cons
     //result->push_back(electrons->ptrAt(i));
   }
   pass_ += result->size();
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/GenMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenMETExtractor.cc
@@ -34,8 +34,8 @@ void GenMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
   std::vector<reco::GenMET> *genMetCol = new std::vector<reco::GenMET>();
   genMetCol->push_back( (*genMet) );
 
-  std::auto_ptr<std::vector<reco::GenMET> > genMETs(genMetCol);
-  iEvent.put(genMETs);
+  std::unique_ptr<std::vector<reco::GenMET> > genMETs(genMetCol);
+  iEvent.put(std::move(genMETs));
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -284,13 +284,13 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     jcfs.push_back(corrFactors);
   }
   // build the value map
-  std::auto_ptr<JetCorrFactorsMap> jetCorrsMap(new JetCorrFactorsMap());
+  auto jetCorrsMap = std::make_unique<JetCorrFactorsMap>();
   JetCorrFactorsMap::Filler filler(*jetCorrsMap);
   // jets and jetCorrs have their indices aligned by construction
   filler.insert(jets, jcfs.begin(), jcfs.end());
   filler.fill(); // do the actual filling
   // put our produced stuff in the event
-  event.put(jetCorrsMap);
+  event.put(std::move(jetCorrsMap));
 }
 
 void

--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
@@ -39,7 +39,7 @@ namespace pat {
     
     virtual void produce(edm::Event& evt,const edm::EventSetup& evs) override final {
       edm::Handle<edm::View<T> > input;
-      std::auto_ptr<Collection> output(new Collection);
+      auto output = std::make_unique<Collection>();
 
       evt.getByToken(src_,input);
       output->reserve(input->size());
@@ -52,7 +52,7 @@ namespace pat {
         modifier_->modify(obj);
       }
 
-      evt.put(output);
+      evt.put(std::move(output));
     }
 
   private:

--- a/PhysicsTools/PatAlgos/plugins/PATCleaner.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCleaner.h
@@ -101,7 +101,7 @@ pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup 
   iEvent.getByToken(srcToken_, candidates);
 
   // Prepare a collection for the output
-  std::auto_ptr< std::vector<PATObjType> > output(new std::vector<PATObjType>());
+  auto output = std::make_unique<std::vector<PATObjType>>();
 
   // initialize the overlap tests
   for (auto& itov : overlapTests_) {
@@ -134,7 +134,7 @@ pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup 
       if (!finalCut_(obj)) output->pop_back();
   }
 
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
@@ -107,8 +107,8 @@ void PATConversionProducer::produce(edm::StreamID, edm::Event & iEvent, const ed
   }
 
   // add the electrons to the event output
-  std::auto_ptr<std::vector<Conversion> > ptr(patConversions);
-  iEvent.put(ptr);
+  std::unique_ptr<std::vector<Conversion> > ptr(patConversions);
+  iEvent.put(std::move(ptr));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -688,8 +688,8 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   std::sort(patElectrons->begin(), patElectrons->end(), pTComparator_);
 
   // add the electrons to the event output
-  std::auto_ptr<std::vector<Electron> > ptr(patElectrons);
-  iEvent.put(ptr);
+  std::unique_ptr<std::vector<Electron> > ptr(patElectrons);
+  iEvent.put(std::move(ptr));
 
   // clean up
   if (isolator_.enabled()) isolator_.endEvent();

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -108,7 +108,7 @@ pat::PATElectronSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iS
     }
     noZS::EcalClusterLazyTools lazyToolsNoZS(iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
 
-    auto_ptr<vector<pat::Electron> >  out(new vector<pat::Electron>());
+    auto out = std::make_unique<std::vector<pat::Electron>>();
     out->reserve(src->size());
 
     if( modifyElectron_ ) { electronModifier_->setEvent(iEvent); }
@@ -158,7 +158,7 @@ pat::PATElectronSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iS
         }
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
@@ -246,7 +246,7 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
   event.getByToken(simTracksToken_, simtracks);
 
   // Need to check that SimTrackContainer is sorted; otherwise, copy and sort :-(
-  std::auto_ptr<SimTrackContainer> simtracksTmp;
+  std::unique_ptr<SimTrackContainer> simtracksTmp;
   const SimTrackContainer * simtracksSorted = &* simtracks;
   if (makeMotherLink_ || writeAncestors_) {
       if (!__gnu_cxx::is_sorted(simtracks->begin(), simtracks->end(), LessById())) {
@@ -273,7 +273,7 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
 
 
   // make the output collection
-  auto_ptr<GenParticleCollection> cands(new GenParticleCollection);
+  auto cands = std::make_unique<GenParticleCollection>();
   edm::RefProd<GenParticleCollection> refprod = event.getRefBeforePut<GenParticleCollection>();
 
   GlobalContext globals(*simtracksSorted, *simvertices, gens, genBarcodes, barcodesAreSorted, *cands, refprod);
@@ -312,7 +312,7 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
   }
 
   // Write to the Event, and get back a handle (which can be useful for debugging)
-  edm::OrphanHandle<reco::GenParticleCollection> orphans = event.put(cands);
+  edm::OrphanHandle<reco::GenParticleCollection> orphans = event.put(std::move(cands));
 
 #ifdef DEBUG_PATGenCandsFromSimTracksProducer
   std::cout << "Produced a list of " << orphans->size() << " genParticles." << std::endl;

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -61,7 +61,7 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     Handle<View<reco::GenJet> >      src;
     iEvent.getByToken(src_, src);
 
-    auto_ptr<vector<reco::GenJet> >  out(new vector<reco::GenJet>());
+    auto out = std::make_unique<vector<reco::GenJet>>();
     out->reserve(src->size());
 
     Handle<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp;
@@ -102,7 +102,7 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
         }
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
@@ -187,8 +187,8 @@ void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSe
   std::sort(PATGenericParticles->begin(), PATGenericParticles->end(), eTComparator_);
 
   // put genEvt object in Event
-  std::auto_ptr<std::vector<GenericParticle> > myGenericParticles(PATGenericParticles);
-  iEvent.put(myGenericParticles);
+  std::unique_ptr<std::vector<GenericParticle> > myGenericParticles(PATGenericParticles);
+  iEvent.put(std::move(myGenericParticles));
   if (isolator_.enabled()) isolator_.endEvent();
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
@@ -159,7 +159,7 @@ PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
   }
   
   // create product
-  std::auto_ptr< std::vector<Hemisphere> > hemispheres(new std::vector<Hemisphere>);;
+  auto hemispheres = std::make_unique<std::vector<Hemisphere>>();
   hemispheres->reserve(2);
   
   //calls HemiAlgorithm for seed method 3 (transv. inv. Mass) and association method 3 (Lund algo)
@@ -188,7 +188,7 @@ PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
   }
   
   
-  iEvent.put(hemispheres);  
+  iEvent.put(std::move(hemispheres));  
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -208,12 +208,12 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   if ( addJetID_ ) iEvent.getByToken( jetIDMapToken_, hJetIDMap );
 
   // loop over jets
-  std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() );
+  auto patJets = std::make_unique<std::vector<Jet>>();
 
-  std::auto_ptr<reco::GenJetCollection > genJetsOut ( new reco::GenJetCollection() );
-  std::auto_ptr<std::vector<CaloTower>  >  caloTowersOut( new std::vector<CaloTower> () );
-  std::auto_ptr<reco::PFCandidateCollection > pfCandidatesOut( new reco::PFCandidateCollection() );
-  std::auto_ptr<edm::OwnVector<reco::BaseTagInfo> > tagInfosOut ( new edm::OwnVector<reco::BaseTagInfo>() );
+  auto genJetsOut = std::make_unique<reco::GenJetCollection>();
+  auto caloTowersOut = std::make_unique<std::vector<CaloTower>>();
+  auto pfCandidatesOut = std::make_unique<reco::PFCandidateCollection>();
+  auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
 
   edm::RefProd<reco::GenJetCollection > h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection >( "genJets" );
@@ -408,12 +408,12 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   std::sort(patJets->begin(), patJets->end(), pTComparator_);
 
   // put genEvt  in Event
-  iEvent.put(patJets);
+  iEvent.put(std::move(patJets));
 
-  iEvent.put( genJetsOut, "genJets" );
-  iEvent.put( caloTowersOut, "caloTowers" );
-  iEvent.put( pfCandidatesOut, "pfCandidates" );
-  iEvent.put( tagInfosOut, "tagInfos" );
+  iEvent.put(std::move(genJetsOut), "genJets" );
+  iEvent.put(std::move(caloTowersOut), "caloTowers" );
+  iEvent.put(std::move(pfCandidatesOut), "pfCandidates" );
+  iEvent.put(std::move(tagInfosOut), "tagInfos" );
 
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -45,12 +45,12 @@ namespace pat {
 
     virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
 
-      std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() );
+      auto patJets = std::make_unique<std::vector<Jet>>();
 
-      std::auto_ptr<reco::GenJetCollection > genJetsOut ( new reco::GenJetCollection() );
-      std::auto_ptr<std::vector<CaloTower>  >  caloTowersOut( new std::vector<CaloTower> () );
-      std::auto_ptr<reco::PFCandidateCollection > pfCandidatesOut( new reco::PFCandidateCollection() );
-      std::auto_ptr<edm::OwnVector<reco::BaseTagInfo> > tagInfosOut ( new edm::OwnVector<reco::BaseTagInfo>() );
+      auto genJetsOut = std::make_unique<reco::GenJetCollection>();
+      auto caloTowersOut = std::make_unique<std::vector<CaloTower> >();
+      auto pfCandidatesOut = std::make_unique<reco::PFCandidateCollection>();
+      auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
 
       edm::RefProd<reco::GenJetCollection > h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection >( "genJets" );
@@ -103,10 +103,10 @@ namespace pat {
 
 
       // Output the secondary collections.
-      edm::OrphanHandle<reco::GenJetCollection>  oh_genJetsOut = iEvent.put( genJetsOut, "genJets" );
-      edm::OrphanHandle<std::vector<CaloTower> > oh_caloTowersOut = iEvent.put( caloTowersOut, "caloTowers" );
-      edm::OrphanHandle<reco::PFCandidateCollection> oh_pfCandidatesOut = iEvent.put( pfCandidatesOut, "pfCandidates" );
-      edm::OrphanHandle<edm::OwnVector<reco::BaseTagInfo> > oh_tagInfosOut = iEvent.put( tagInfosOut, "tagInfos" );
+      edm::OrphanHandle<reco::GenJetCollection>  oh_genJetsOut = iEvent.put(std::move(genJetsOut), "genJets" );
+      edm::OrphanHandle<std::vector<CaloTower> > oh_caloTowersOut = iEvent.put(std::move(caloTowersOut), "caloTowers" );
+      edm::OrphanHandle<reco::PFCandidateCollection> oh_pfCandidatesOut = iEvent.put(std::move(pfCandidatesOut), "pfCandidates" );
+      edm::OrphanHandle<edm::OwnVector<reco::BaseTagInfo> > oh_tagInfosOut = iEvent.put(std::move(tagInfosOut), "tagInfos" );
 
 
 
@@ -182,7 +182,7 @@ namespace pat {
 
       // put genEvt  in Event
       bool pass = patJets->size() > 0;
-      iEvent.put(patJets);
+      iEvent.put(std::move(patJets));
 
       if ( filter_ )
 	return pass;

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -79,7 +79,7 @@ pat::PATJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
     iEvent.getByToken(pf2pc_,pf2pc);
 	
-    auto_ptr<vector<pat::Jet> >  out(new vector<pat::Jet>());
+    auto out = std::make_unique<std::vector<pat::Jet>>();
     out->reserve(src->size());
 
     if( modifyJet_ ) { jetModifier_->setEvent(iEvent); }
@@ -136,7 +136,7 @@ pat::PATJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	    //         }
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
@@ -115,9 +115,9 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
   }
 
   // loop over jets
-  std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() );
+  auto patJets = std::make_unique<std::vector<Jet>>();
 
-  std::auto_ptr<edm::OwnVector<reco::BaseTagInfo> > tagInfosOut ( new edm::OwnVector<reco::BaseTagInfo>() );
+  auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
   edm::RefProd<edm::OwnVector<reco::BaseTagInfo> > h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo> > ( "tagInfos" );
 
@@ -209,9 +209,9 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
   std::sort(patJets->begin(), patJets->end(), pTComparator_);
 
   // put genEvt  in Event
-  iEvent.put(patJets);
+  iEvent.put(std::move(patJets));
 
-  iEvent.put( tagInfosOut, "tagInfos" );
+  iEvent.put(std::move(tagInfosOut), "tagInfos" );
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -90,10 +90,10 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     iEvent.getByToken( PVOrigs_, PVOrigs );
     const reco::Vertex & PVOrig = (*PVOrigs)[0];
 
-    std::auto_ptr< std::vector<reco::Track> > outPtrP( new std::vector<reco::Track> );
+    auto outPtrP = std::make_unique<std::vector<reco::Track>>();
     std::vector<int> used(tracks->size(),0);
 
-    std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrC( new std::vector<pat::PackedCandidate> );
+    auto outPtrC = std::make_unique<std::vector<pat::PackedCandidate>>();
 
     //Mark all tracks used in candidates	
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
@@ -136,13 +136,13 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 			j++;
 		}
     } 
-    iEvent.put(outPtrP);
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh =   iEvent.put(outPtrC);
-    std::auto_ptr<edm::Association<pat::PackedCandidateCollection> > tk2pc(new edm::Association<pat::PackedCandidateCollection>(oh   ));
+    iEvent.put(std::move(outPtrP));
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh =   iEvent.put(std::move(outPtrC));
+    auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
     edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
     tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
     tk2pcFiller.fill() ; 
-    iEvent.put(tk2pc);
+    iEvent.put(std::move(tk2pc));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -126,8 +126,8 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   //  std::sort(patMETs->begin(), patMETs->end(), eTComparator_);
 
   // put genEvt object in Event
-  std::auto_ptr<std::vector<MET> > myMETs(patMETs);
-  iEvent.put(myMETs);
+  std::unique_ptr<std::vector<MET> > myMETs(patMETs);
+  iEvent.put(std::move(myMETs));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -144,14 +144,14 @@ pat::PATMETSlimmer::produce(edm::StreamID, edm::Event & iEvent, const edm::Event
     iEvent.getByToken(src_, src);
     if (src->size() != 1) throw cms::Exception("CorruptData", "More than one MET in the collection");
 
-    auto_ptr<vector<pat::MET> >  out(new vector<pat::MET>(1, src->front()));
+    auto out = std::make_unique<std::vector<pat::MET>>(1, src->front());
     pat::MET & met = out->back();
 
     for (const OneMETShift &shift : shifts_) {
         shift.readAndSet(iEvent, met);
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
@@ -85,7 +85,7 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   double met_set=0;
 
 
-  std::auto_ptr<pat::MHTCollection>  themetsigcoll (new pat::MHTCollection);
+  auto themetsigcoll = std::make_unique<pat::MHTCollection>();
 
   if(physobjvector_.size() >= 1) { // Only when the vector is not empty
 
@@ -115,7 +115,7 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   } // If the vector is empty, just put empty product.
 
 
-  iEvent.put( themetsigcoll);
+  iEvent.put(std::move(themetsigcoll));
 
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -360,8 +360,8 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   std::sort(patMuons->begin(), patMuons->end(), pTComparator_);
 
   // put genEvt object in Event
-  std::auto_ptr<std::vector<Muon> > ptr(patMuons);
-  iEvent.put(ptr);
+  std::unique_ptr<std::vector<Muon> > ptr(patMuons);
+  iEvent.put(std::move(ptr));
 
   if (isolator_.enabled()) isolator_.endEvent();
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -74,7 +74,7 @@ pat::PATMuonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     Handle<pat::MuonCollection>      src;
     iEvent.getByToken(src_, src);
 
-    auto_ptr<vector<pat::Muon> >  out(new vector<pat::Muon>());
+    auto out = std::make_unique<std::vector<pat::Muon>>();
     out->reserve(src->size());
 
     if( modifyMuon_ ) { muonModifier_->setEvent(iEvent); }
@@ -103,7 +103,7 @@ pat::PATMuonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         }
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
@@ -128,8 +128,8 @@ void PATPFParticleProducer::produce(edm::Event & iEvent,
   std::sort(patPFParticles->begin(), patPFParticles->end(), pTComparator_);
 
   // put genEvt object in Event
-  std::auto_ptr<std::vector<PFParticle> > ptr(patPFParticles);
-  iEvent.put(ptr);
+  std::unique_ptr<std::vector<PFParticle> > ptr(patPFParticles);
+  iEvent.put(std::move(ptr));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -178,7 +178,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
     edm::Handle<reco::TrackCollection> TKOrigs;
     iEvent.getByToken( TKOrigs_, TKOrigs );
-    std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrP( new std::vector<pat::PackedCandidate> );
+    auto outPtrP = std::make_unique<std::vector<pat::PackedCandidate>>();
     std::vector<int> mapping(cands->size());
     std::vector<int> mappingReverse(cands->size());
     std::vector<int> mappingTk(TKOrigs->size(), -1);
@@ -296,7 +296,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
     }
 
-    std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrPSorted( new std::vector<pat::PackedCandidate> );
+    auto outPtrPSorted = std::make_unique<std::vector<pat::PackedCandidate>>();
     std::vector<size_t> order=sort_indexes(*outPtrP);
     std::vector<size_t> reverseOrder(order.size());
     for(size_t i=0,nc=cands->size();i<nc;i++) {
@@ -315,11 +315,11 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
         mappingPuppi[i]=reverseOrder[mappingPuppi[i]];
     }
 
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put( outPtrPSorted );
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrPSorted));
 
     // now build the two maps
-    std::auto_ptr<edm::Association<pat::PackedCandidateCollection> > pf2pc(new edm::Association<pat::PackedCandidateCollection>(oh   ));
-    std::auto_ptr<edm::Association<reco::PFCandidateCollection   > > pc2pf(new edm::Association<reco::PFCandidateCollection   >(cands));
+    auto pf2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+    auto pc2pf = std::make_unique<edm::Association<reco::PFCandidateCollection>>(cands);
     edm::Association<pat::PackedCandidateCollection>::Filler pf2pcFiller(*pf2pc);
     edm::Association<reco::PFCandidateCollection   >::Filler pc2pfFiller(*pc2pf);
     pf2pcFiller.insert(cands, mappingReverse.begin(), mappingReverse.end());
@@ -330,8 +330,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
     pf2pcFiller.fill();
     pc2pfFiller.fill();
-    iEvent.put(pf2pc);
-    iEvent.put(pc2pf);
+    iEvent.put(std::move(pf2pc));
+    iEvent.put(std::move(pc2pf));
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -104,7 +104,7 @@ void pat::PATPackedGenParticleProducer::produce(edm::StreamID, edm::Event& iEven
 	reverseMap.insert(std::pair<edm::Ref<reco::GenParticleCollection>,edm::Ref<reco::GenParticleCollection>>(newRef,originalRef));
     }
 
-    std::auto_ptr< std::vector<pat::PackedGenParticle> > outPtrP( new std::vector<pat::PackedGenParticle> );
+    auto outPtrP = std::make_unique<std::vector<pat::PackedGenParticle>>();
 
     unsigned int packed=0;
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
@@ -128,13 +128,13 @@ void pat::PATPackedGenParticleProducer::produce(edm::StreamID, edm::Event& iEven
     }
 
 
-    edm::OrphanHandle<std::vector<pat::PackedGenParticle> > oh= iEvent.put( outPtrP );
+    edm::OrphanHandle<std::vector<pat::PackedGenParticle> > oh= iEvent.put(std::move(outPtrP));
 
-    std::auto_ptr<edm::Association< std::vector<pat::PackedGenParticle> > > gp2pgp(new edm::Association< std::vector<pat::PackedGenParticle> > (oh   ));
+    auto gp2pgp = std::make_unique<edm::Association<std::vector<pat::PackedGenParticle>>>(oh);
     edm::Association< std::vector<pat::PackedGenParticle> >::Filler gp2pgpFiller(*gp2pgp);
     gp2pgpFiller.insert(genOrigs, mapping.begin(), mapping.end());
     gp2pgpFiller.fill();
-    iEvent.put(gp2pgp);
+    iEvent.put(std::move(gp2pgp));
  
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -373,8 +373,8 @@ void PATPhotonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSe
   std::sort(PATPhotons->begin(), PATPhotons->end(), eTComparator_);
 
   // put genEvt object in Event
-  std::auto_ptr<std::vector<Photon> > myPhotons(PATPhotons);
-  iEvent.put(myPhotons);
+  std::unique_ptr<std::vector<Photon> > myPhotons(PATPhotons);
+  iEvent.put(std::move(myPhotons));
   if (isolator_.enabled()) isolator_.endEvent();
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -108,7 +108,7 @@ pat::PATPhotonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     }
     noZS::EcalClusterLazyTools lazyToolsNoZS(iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
 
-    auto_ptr<vector<pat::Photon> >  out(new vector<pat::Photon>());
+    auto out = std::make_unique<std::vector<pat::Photon>>();
     out->reserve(src->size());
 
     if( modifyPhoton_ ) { photonModifier_->setEvent(iEvent); }
@@ -172,7 +172,7 @@ pat::PATPhotonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
 
      }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
@@ -42,7 +42,7 @@ pat::PATSecondaryVertexSlimmer::~PATSecondaryVertexSlimmer() {}
 
 void pat::PATSecondaryVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
-    std::auto_ptr<reco::VertexCompositePtrCandidateCollection> outPtr(new reco::VertexCompositePtrCandidateCollection);
+    auto outPtr = std::make_unique<reco::VertexCompositePtrCandidateCollection>();
  
     edm::Handle<reco::VertexCompositePtrCandidateCollection> candVertices;
     iEvent.getByToken(src_, candVertices);
@@ -100,7 +100,7 @@ void pat::PATSecondaryVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, 
         }
     }
 
-    iEvent.put(outPtr);
+    iEvent.put(std::move(outPtr));
 }
 
 using pat::PATSecondaryVertexSlimmer;

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.cc
@@ -97,7 +97,7 @@ PATSingleVertexSelector::filter(edm::Event & iEvent, const edm::EventSetup & iSe
   }
   
   bool passes = false;
-  auto_ptr<vector<reco::Vertex> > result;
+  std::unique_ptr<vector<reco::Vertex> > result;
   // Run main mode + possible fallback modes
   for (std::vector<Mode>::const_iterator itm = modes_.begin(), endm = modes_.end(); itm != endm; ++itm) {
     result = filter_(*itm, iEvent, iSetup);
@@ -107,18 +107,18 @@ PATSingleVertexSelector::filter(edm::Event & iEvent, const edm::EventSetup & iSe
       break;
     }
   }
-  iEvent.put(result);
+  iEvent.put(std::move(result));
   // Check if we want to apply the EDFilter
   if (doFilterEvents_)
     return passes;
   else return true;
 }
 
-std::auto_ptr<std::vector<reco::Vertex> >
+std::unique_ptr<std::vector<reco::Vertex> >
 PATSingleVertexSelector::filter_(Mode mode, const edm::Event &iEvent, const edm::EventSetup & iSetup) {
   using namespace edm;
   using namespace std;
-  std::auto_ptr<std::vector<reco::Vertex> > result(new std::vector<reco::Vertex>());
+  auto result = std::make_unique<std::vector<reco::Vertex>>();
   switch(mode) {
   case First: {
     if (selVtxs_.empty()) return result;

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
@@ -41,7 +41,7 @@ namespace pat {
 
       Mode parseMode(const std::string &name) const;
       
-      std::auto_ptr<std::vector<reco::Vertex> >
+      std::unique_ptr<std::vector<reco::Vertex> >
         filter_(Mode mode, const edm::Event & iEvent, const edm::EventSetup & iSetup);
       bool hasMode_(Mode mode) const ;
       // configurables

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -160,8 +160,8 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     iEvent.getByToken(baseTauToken_, anyTaus);
   } catch (const edm::Exception &e) {
     edm::LogWarning("DataSource") << "WARNING! No Tau collection found. This missing input will not block the job. Instead, an empty tau collection is being be produced.";
-    std::auto_ptr<std::vector<Tau> > patTaus(new std::vector<Tau>());
-    iEvent.put(patTaus);
+    auto patTaus = std::make_unique<std::vector<Tau>>();
+    iEvent.put(std::move(patTaus));
     return;
   }
 
@@ -196,7 +196,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     }
   }
 
-  std::auto_ptr<std::vector<Tau> > patTaus(new std::vector<Tau>());
+  auto patTaus = std::make_unique<std::vector<Tau>>();
 
   bool first=true; // this is introduced to issue warnings only for the first tau-jet
   for (size_t idx = 0, ntaus = anyTaus->size(); idx < ntaus; ++idx) {
@@ -421,7 +421,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   std::sort(patTaus->begin(), patTaus->end(), pTTauComparator_);
 
   // put genEvt object in Event
-  iEvent.put(patTaus);
+  iEvent.put(std::move(patTaus));
 
   // clean up
   if (isolator_.enabled()) isolator_.endEvent();

--- a/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
@@ -74,7 +74,7 @@ pat::PATTauSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
     Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
     if (linkToPackedPF_) iEvent.getByToken(pf2pc_, pf2pc);
 
-    auto_ptr<vector<pat::Tau> >  out(new vector<pat::Tau>());
+    auto out = std::make_unique<std::vector<pat::Tau>>();
     out->reserve(src->size());
 
     if( modifyTau_ ) { tauModifier_->setEvent(iEvent); }
@@ -136,7 +136,7 @@ pat::PATTauSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -212,7 +212,7 @@ void PATTriggerEventProducer::produce( Event& iEvent, const EventSetup& iSetup )
 
   // produce trigger event
 
-  std::auto_ptr< TriggerEvent > triggerEvent( new TriggerEvent( handleL1GtTriggerMenu->gtTriggerMenuName(), std::string( hltConfig_.tableName() ), handleTriggerResults->wasrun(), handleTriggerResults->accept(), handleTriggerResults->error(), physDecl ) );
+  auto triggerEvent = std::make_unique<TriggerEvent>( handleL1GtTriggerMenu->gtTriggerMenuName(), std::string( hltConfig_.tableName() ), handleTriggerResults->wasrun(), handleTriggerResults->accept(), handleTriggerResults->error(), physDecl );
   // set product references to trigger collections
   if ( handleTriggerAlgorithms.isValid() ) {
     triggerEvent->setAlgorithms( handleTriggerAlgorithms );
@@ -282,13 +282,13 @@ void PATTriggerEventProducer::produce( Event& iEvent, const EventSetup& iSetup )
         indices.push_back( it->second.key() );
         ++it;
       }
-      std::auto_ptr< TriggerObjectMatch > triggerObjectMatch( new TriggerObjectMatch( handleTriggerObjects ) );
+      auto triggerObjectMatch = std::make_unique<TriggerObjectMatch>(handleTriggerObjects);
       TriggerObjectMatch::Filler matchFiller( *triggerObjectMatch );
       if ( handleCands.isValid() ) {
         matchFiller.insert( handleCands, indices.begin(), indices.end() );
       }
       matchFiller.fill();
-      OrphanHandle< TriggerObjectMatch > handleTriggerObjectMatch( iEvent.put( triggerObjectMatch, labelTriggerObjectMatcher ) );
+      OrphanHandle< TriggerObjectMatch > handleTriggerObjectMatch( iEvent.put(std::move(triggerObjectMatch), labelTriggerObjectMatcher ) );
       // set product reference to trigger match association
       if ( ! handleTriggerObjectMatch.isValid() ) {
         LogError( "triggerMatchValid" ) << "pat::TriggerObjectMatch product with InputTag '" << labelTriggerObjectMatcher << "' not in event";
@@ -300,7 +300,7 @@ void PATTriggerEventProducer::produce( Event& iEvent, const EventSetup& iSetup )
     }
   }
 
-  iEvent.put( triggerEvent );
+  iEvent.put(std::move(triggerEvent) );
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
@@ -83,7 +83,7 @@ PATTriggerMatchEmbedder< PATObjectType >::PATTriggerMatchEmbedder( const edm::Pa
 template< class PATObjectType >
 void PATTriggerMatchEmbedder< PATObjectType >::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
 {
-  std::auto_ptr< std::vector< PATObjectType > > output( new std::vector< PATObjectType >() );
+  auto output = std::make_unique<std::vector<PATObjectType>>();
 
   edm::Handle< edm::View< PATObjectType > > candidates;
   iEvent.getByToken( srcToken_, candidates );
@@ -113,7 +113,7 @@ void PATTriggerMatchEmbedder< PATObjectType >::produce( edm::StreamID, edm::Even
     output->push_back( cand );
   }
 
-  iEvent.put( output );
+  iEvent.put(std::move(output) );
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
@@ -61,7 +61,7 @@ void PATTriggerObjectStandAloneUnpacker::produce( edm::StreamID, edm::Event & iE
   edm::Handle< edm::TriggerResults > triggerResults;
   iEvent.getByToken( triggerResultsToken_, triggerResults );
 
-  std::auto_ptr< TriggerObjectStandAloneCollection > patTriggerObjectsStandAloneUnpacked( new TriggerObjectStandAloneCollection );
+  auto patTriggerObjectsStandAloneUnpacked = std::make_unique<TriggerObjectStandAloneCollection>();
 
   for ( size_t iTrigObj = 0; iTrigObj < patTriggerObjectsStandAlone->size(); ++iTrigObj ) {
     TriggerObjectStandAlone patTriggerObjectStandAloneUnpacked( patTriggerObjectsStandAlone->at( iTrigObj ) );
@@ -70,7 +70,7 @@ void PATTriggerObjectStandAloneUnpacker::produce( edm::StreamID, edm::Event & iE
     patTriggerObjectsStandAloneUnpacked->push_back( patTriggerObjectStandAloneUnpacked );
   }
 
-  iEvent.put( patTriggerObjectsStandAloneUnpacked );
+  iEvent.put(std::move(patTriggerObjectsStandAloneUnpacked) );
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -317,9 +317,9 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   // Terminate, if auto process name determination failed
   if ( nameProcess_ == "*" ) return;
 
-  std::auto_ptr< TriggerObjectCollection > triggerObjects( new TriggerObjectCollection() );
-  std::auto_ptr< TriggerObjectStandAloneCollection > triggerObjectsStandAlone( new TriggerObjectStandAloneCollection() );
-  std::auto_ptr< PackedTriggerPrescales > packedPrescales, packedPrescalesL1min, packedPrescalesL1max;
+  auto triggerObjects = std::make_unique<TriggerObjectCollection>();
+  auto triggerObjectsStandAlone = std::make_unique<TriggerObjectStandAloneCollection>();
+  std::unique_ptr<PackedTriggerPrescales> packedPrescales, packedPrescalesL1min, packedPrescalesL1max;
 
   // HLT
   HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
@@ -402,7 +402,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     std::map< std::string, int > moduleStates;
 
     if ( ! onlyStandAlone_ ) {
-      std::auto_ptr< TriggerPathCollection > triggerPaths( new TriggerPathCollection() );
+      auto triggerPaths = std::make_unique<TriggerPathCollection>();
       triggerPaths->reserve( sizePaths );
       const std::vector<std::string> & pathNames = hltConfig.triggerNames();
       for ( size_t indexPath = 0; indexPath < sizePaths; ++indexPath ) {
@@ -454,7 +454,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
         }
       }
       // Put HLT paths to event
-      iEvent.put( triggerPaths );
+      iEvent.put(std::move(triggerPaths));
     }
 
     // Store used trigger objects and their types for HLT filters
@@ -525,7 +525,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
 
     // Re-iterate HLT filters and finally produce them in order to account for optionally skipped objects
     if ( ! onlyStandAlone_ ) {
-      std::auto_ptr< TriggerFilterCollection > triggerFilters( new TriggerFilterCollection() );
+      auto triggerFilters = std::make_unique<TriggerFilterCollection>();
       triggerFilters->reserve( sizeFilters );
       for ( size_t iF = 0; iF < sizeFilters; ++iF ) {
         const std::string nameFilter( handleTriggerEvent->filterTag( iF ).label() );
@@ -561,7 +561,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
         triggerFilters->push_back( triggerFilter );
       }
       // put HLT filters to event
-      iEvent.put( triggerFilters );
+      iEvent.put(std::move(triggerFilters));
     }
 
     if (packPrescales_) {
@@ -589,9 +589,9 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
             packedPrescales->addPrescaledTrigger(i, pvdet.second);
             //assert( hltprescale == pvdet.second );
         }
-        iEvent.put( packedPrescales );
-        iEvent.put( packedPrescalesL1max, "l1max" );
-        iEvent.put( packedPrescalesL1min, "l1min" );
+        iEvent.put(std::move(packedPrescales));
+        iEvent.put(std::move(packedPrescalesL1max), "l1max");
+        iEvent.put(std::move(packedPrescalesL1min), "l1min");
     }
 
   } // if ( goodHlt )
@@ -803,12 +803,12 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   }
 
   // Put trigger objects to event
-  if ( ! onlyStandAlone_ ) iEvent.put( triggerObjects );
+  if ( ! onlyStandAlone_ ) iEvent.put(std::move(triggerObjects));
 
   // L1 algorithms
   if ( ! onlyStandAlone_ ) {
-    std::auto_ptr< TriggerAlgorithmCollection > triggerAlgos( new TriggerAlgorithmCollection() );
-    std::auto_ptr< TriggerConditionCollection > triggerConditions( new TriggerConditionCollection() );
+    auto triggerAlgos = std::make_unique<TriggerAlgorithmCollection>();
+    auto triggerConditions = std::make_unique<TriggerConditionCollection>();
     if ( addL1Algos_ ) {
       // create trigger object types transalation map (yes, it's ugly!)
       std::map< L1GtObject, trigger::TriggerObjectType > mapObjectTypes;
@@ -1013,8 +1013,8 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     }
 
     // Put L1 algorithms and conditions to event
-    iEvent.put( triggerAlgos );
-    iEvent.put( triggerConditions );
+    iEvent.put(std::move(triggerAlgos));
+    iEvent.put(std::move(triggerConditions));
   }
 
 
@@ -1025,7 +1025,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     }
   }
   // Put (finally) stand-alone trigger objects to event
-  iEvent.put( triggerObjectsStandAlone );
+  iEvent.put(std::move(triggerObjectsStandAlone));
 
   firstInRun_ = false;
 

--- a/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
@@ -41,7 +41,7 @@ pat::PATVertexSlimmer::~PATVertexSlimmer() {}
 void pat::PATVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
     edm::Handle<std::vector<reco::Vertex> > vertices;
     iEvent.getByToken(src_, vertices);
-    std::auto_ptr<std::vector<reco::Vertex> > outPtr(new std::vector<reco::Vertex>());
+    auto outPtr = std::make_unique<std::vector<reco::Vertex>>();
 
     outPtr->reserve(vertices->size());
     for (unsigned int i = 0, n = vertices->size(); i < n; ++i) {
@@ -57,11 +57,11 @@ void pat::PATVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm
         outPtr->push_back(reco::Vertex(v.position(), co, v.chi2(), v.ndof(), 0));
     }
 
-    auto oh = iEvent.put(outPtr);
+    auto oh = iEvent.put(std::move(outPtr));
     if(rekeyScores_) {
       edm::Handle<edm::ValueMap<float> > scores;
       iEvent.getByToken(score_, scores);
-      std::auto_ptr<edm::ValueMap<float> >  vertexScoreOutput( new edm::ValueMap<float> );
+      auto vertexScoreOutput = std::make_unique<edm::ValueMap<float>>();
       edm::ValueMap<float>::const_iterator idIt=scores->begin();
       for(;idIt!=scores->end();idIt++) {
           if(idIt.id() ==  vertices.id()) break;
@@ -70,7 +70,7 @@ void pat::PATVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm
       edm::ValueMap<float>::Filler vertexScoreFiller(*vertexScoreOutput);
       vertexScoreFiller.insert(oh,idIt.begin(),idIt.end());
       vertexScoreFiller.fill();
-      iEvent.put( vertexScoreOutput );
+      iEvent.put(std::move(vertexScoreOutput));
     }
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
@@ -26,7 +26,7 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
                                        edm::Event& evt,
                                        const edm::EventSetup& es ) const {
   edm::Handle<std::vector<PileupSummaryInfo> > input;
-  std::auto_ptr<std::vector<PileupSummaryInfo> > output( new std::vector<PileupSummaryInfo> );
+  auto output = std::make_unique<std::vector<PileupSummaryInfo>>();
 
   evt.getByToken(src_,input);
   
@@ -69,7 +69,7 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
                          bunchSpacing);
   }
 
-  evt.put(output);
+  evt.put(std::move(output));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
@@ -53,8 +53,8 @@ void RecoMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
   reco::MET met(src->front().corP4(corLevel_), src->front().vertex() );
   metCol->push_back( met );
   
-  std::auto_ptr<std::vector<reco::MET> > recoMETs(metCol);
-  iEvent.put(recoMETs);
+  std::unique_ptr<std::vector<reco::MET> > recoMETs(metCol);
+  iEvent.put(std::move(recoMETs));
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
@@ -135,14 +135,14 @@ TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   }
 
   // build the valuemap
-  std::auto_ptr<TauJetCorrFactorsMap> jecMapping(new TauJetCorrFactorsMap());
+  auto jecMapping = std::make_unique<TauJetCorrFactorsMap>();
   TauJetCorrFactorsMap::Filler filler(*jecMapping);
   // tauJets and tauJetCorrections vectors have their indices aligned by construction
   filler.insert(tauJets, tauJetCorrections.begin(), tauJetCorrections.end());
   filler.fill(); // do the actual filling
 
   // add valuemap to the event
-  evt.put(jecMapping);
+  evt.put(std::move(jecMapping));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
@@ -77,7 +77,7 @@ void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, cons
 	Handle<std::vector<pat::PackedCandidate> > addTracks;
 	iEvent.getByToken(AdditionalTracks_, addTracks);
 
-	std::auto_ptr< std::vector<reco::Track> > outTks( new std::vector<reco::Track> );
+	auto outTks = std::make_unique<std::vector<reco::Track>>();
 	std::map<unsigned int, std::vector<unsigned int> > asso;
 	std::map<unsigned int, unsigned int> trackKeys;
 	unsigned int j=0;
@@ -104,9 +104,9 @@ void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, cons
 		j++;
 	}
 	
-	edm::OrphanHandle< std::vector<reco::Track>  > oh = iEvent.put( outTks );
+	edm::OrphanHandle< std::vector<reco::Track>  > oh = iEvent.put(std::move(outTks));
 	
-	std::auto_ptr< std::vector<reco::Vertex> > outPv( new std::vector<reco::Vertex> );
+	auto outPv = std::make_unique<std::vector<reco::Vertex>>();
 	
 	for(size_t ipv=0;ipv< pvs->size(); ++ipv) {
 		reco::Vertex  pv = (*pvs)[ipv];
@@ -118,9 +118,9 @@ void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, cons
 		}
 		outPv->push_back(pv);
 	}
-	iEvent.put(outPv);
+	iEvent.put(std::move(outPv));
 
-        std::auto_ptr< std::vector<reco::Vertex> > outSv( new std::vector<reco::Vertex> );
+        auto outSv = std::make_unique<std::vector<reco::Vertex>>();
 	for(size_t i=0;i< svs->size(); i++) {
 		const reco::VertexCompositePtrCandidate &sv = (*svs)[i];	
 		outSv->push_back(reco::Vertex(sv.vertex(),sv.vertexCovariance(),sv.vertexChi2(),sv.vertexNdof(),0));
@@ -138,7 +138,7 @@ void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, cons
 		}	
 	}   
 
-       iEvent.put(outSv,"secondary");
+       iEvent.put(std::move(outSv),"secondary");
 
 }
 

--- a/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
@@ -73,7 +73,7 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   vertexing_.newEvent(iEvent, iSetup);
 
   // prepare room and tools for output
-  auto_ptr<VertexAssociationMap> result(new VertexAssociationMap());
+  auto result = std::make_unique<VertexAssociationMap>();
   VertexAssociationMap::Filler filler(*result);
   vector<pat::VertexAssociation> assos;
 
@@ -95,7 +95,7 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   filler.fill();
 
   // put our produced stuff in the event
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 

--- a/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
+++ b/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
@@ -171,26 +171,26 @@ PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
        std::cout << "Got " << recoMuons->size() << " muons" << std::endl;
 
        vector<int> ints(recoMuons->size(), 42);
-       auto_ptr<ValueMap<int> > answers(new ValueMap<int>());
+       auto answers = std::make_unique<ValueMap<int>>();
        ValueMap<int>::Filler intfiller(*answers);
        intfiller.insert(recoMuons, ints.begin(), ints.end());
        intfiller.fill();
-       iEvent.put(answers, label_);
+       iEvent.put(std::move(answers), label_);
        std::cout << "Filled in the answer" << std::endl;
 
        vector<float> floats(recoMuons->size(), 3.14);
-       auto_ptr<ValueMap<float> > pis(new ValueMap<float>());
+       auto pis = std::make_unique<ValueMap<float>>();
        ValueMap<float>::Filler floatfiller(*pis);
        floatfiller.insert(recoMuons, floats.begin(), floats.end());
        floatfiller.fill();
-       iEvent.put(pis);
+       iEvent.put(std::move(pis));
        std::cout << "Wrote useless floats into the event" << std::endl;
 
-       auto_ptr<OwnVector<pat::UserData> > halfp4s(new OwnVector<pat::UserData>());
+       auto halfp4s = std::make_unique<OwnVector<pat::UserData>>();
        for (size_t i = 0; i < recoMuons->size(); ++i) {
             halfp4s->push_back( pat::UserData::make( 0.5 * (*recoMuons)[i].p4() ) );
        }
-       OrphanHandle<OwnVector<pat::UserData> > handle = iEvent.put(halfp4s);
+       OrphanHandle<OwnVector<pat::UserData> > handle = iEvent.put(std::move(halfp4s));
        std::cout << "Wrote OwnVector of useless objects into the event" << std::endl;
        vector<Ptr<pat::UserData> > halfp4sPtr;
        for (size_t i = 0; i < recoMuons->size(); ++i) {
@@ -198,12 +198,12 @@ PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
             halfp4sPtr.push_back(Ptr<pat::UserData>(handle, i));
        }
        std::cout << "   Made edm::Ptr<> to those useless objects" << std::endl;
-       auto_ptr<ValueMap<Ptr<pat::UserData> > > vmhalfp4s(new ValueMap<Ptr<pat::UserData> >());
+       auto vmhalfp4s = std::make_unique<ValueMap<Ptr<pat::UserData>>>();
        ValueMap<Ptr<pat::UserData> >::Filler filler(*vmhalfp4s);
        filler.insert(recoMuons, halfp4sPtr.begin(), halfp4sPtr.end());
        filler.fill();
        std::cout << "   Filled the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
-       iEvent.put(vmhalfp4s);
+       iEvent.put(std::move(vmhalfp4s));
        std::cout << "   Wrote the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
 
        std::cout << "So long, and thanks for all the muons.\n" << std::endl;

--- a/PhysicsTools/PatAlgos/test/private/TestEventHypothesisWriter.cc
+++ b/PhysicsTools/PatAlgos/test/private/TestEventHypothesisWriter.cc
@@ -78,7 +78,7 @@ TestEventHypothesisWriter::produce(edm::Event &iEvent, const edm::EventSetup &iS
     using reco::Candidate;
     using reco::CandidatePtr;
 
-    auto_ptr<vector<pat::EventHypothesis> > hyps(new vector<pat::EventHypothesis>());;
+    auto hyps = std::make_unique<std::vector<pat::EventHypothesis>>();;
     vector<double>  deltaRs;
 
     Handle<View<Candidate> > hMu;
@@ -124,14 +124,14 @@ TestEventHypothesisWriter::produce(edm::Event &iEvent, const edm::EventSetup &iS
     std::cout << "Found " << deltaRs.size() << " possible options" << std::endl;
 
     // work done, save results
-    OrphanHandle<vector<pat::EventHypothesis> > handle = iEvent.put(hyps);
-    auto_ptr<ValueMap<double> > deltaRMap(new ValueMap<double>());
+    OrphanHandle<vector<pat::EventHypothesis> > handle = iEvent.put(std::move(hyps));
+    auto deltaRMap = std::make_unique<ValueMap<double>>();
     //if (deltaRs.size() > 0) {
         ValueMap<double>::Filler filler(*deltaRMap);
         filler.insert(handle, deltaRs.begin(), deltaRs.end());
         filler.fill();
     //}
-    iEvent.put(deltaRMap, "deltaR");
+    iEvent.put(std::move(deltaRMap), "deltaR");
 }
 
 DEFINE_FWK_MODULE(TestEventHypothesisWriter);

--- a/PhysicsTools/PatExamples/plugins/JetEnergyShift.cc
+++ b/PhysicsTools/PatExamples/plugins/JetEnergyShift.cc
@@ -85,8 +85,8 @@ JetEnergyShift::produce(edm::Event& event, const edm::EventSetup& setup)
   edm::Handle<std::vector<pat::MET> > mets;
   event.getByToken(inputMETsToken_, mets);
 
-  std::auto_ptr<std::vector<pat::Jet> > pJets(new std::vector<pat::Jet>);
-  std::auto_ptr<std::vector<pat::MET> > pMETs(new std::vector<pat::MET>);
+  auto pJets = std::make_unique<std::vector<pat::Jet>>();
+  auto pMETs = std::make_unique<std::vector<pat::MET>>();
 
   double dPx    = 0.;
   double dPy    = 0.;
@@ -112,8 +112,8 @@ JetEnergyShift::produce(edm::Event& event, const edm::EventSetup& setup)
   double scaledMETPy = met.py() - dPy;
   pat::MET scaledMET(reco::MET(met.sumEt()+dSumEt, reco::MET::LorentzVector(scaledMETPx, scaledMETPy, 0, sqrt(scaledMETPx*scaledMETPx+scaledMETPy*scaledMETPy)), reco::MET::Point(0,0,0)));
   pMETs->push_back( scaledMET );
-  event.put(pJets, outputJets_);
-  event.put(pMETs, outputMETs_);
+  event.put(std::move(pJets), outputJets_);
+  event.put(std::move(pMETs), outputMETs_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatExamples/plugins/PatJPsiProducer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatJPsiProducer.cc
@@ -97,7 +97,7 @@ void
 PatJPsiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  std::auto_ptr<std::vector<pat::CompositeCandidate> > jpsiCands( new std::vector<pat::CompositeCandidate> );
+  auto jpsiCands = std::make_unique<std::vector<pat::CompositeCandidate>>();
   edm::Handle<edm::View<pat::Muon> > h_muons;
   iEvent.getByToken( muonSrcToken_, h_muons );
 
@@ -137,7 +137,7 @@ PatJPsiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
   }
 
-  iEvent.put( jpsiCands );
+  iEvent.put(std::move(jpsiCands));
 
 }
 

--- a/PhysicsTools/PatUtils/interface/DuplicatedElectronRemover.h
+++ b/PhysicsTools/PatUtils/interface/DuplicatedElectronRemover.h
@@ -40,15 +40,15 @@ namespace pat {
 
             // List of duplicate electrons to remove 
             // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
-            std::auto_ptr< std::vector<size_t> > duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const ;
 
             // List of duplicate electrons to remove 
             // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
-            std::auto_ptr< std::vector<size_t> > duplicatesToRemove(const edm::View<reco::GsfElectron>   &electrons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const edm::View<reco::GsfElectron>   &electrons) const ;
 
             // Generic method. Collection can be vector, view or whatever you like
             template<typename Collection>
-            std::auto_ptr< std::vector<size_t> > duplicatesToRemove(const Collection &electrons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const Collection &electrons) const ;
             
         private:
     }; // class
@@ -56,7 +56,7 @@ namespace pat {
 
 // implemented here because is templated
 template<typename Collection>
-std::auto_ptr< std::vector<size_t> >
+std::unique_ptr< std::vector<size_t> >
 pat::DuplicatedElectronRemover::duplicatesToRemove(const Collection &electrons) const {
     pat::GenericDuplicateRemover<SameSuperclusterOrTrack,BestEoverP> dups;
     return dups.duplicates(electrons);

--- a/PhysicsTools/PatUtils/interface/DuplicatedPhotonRemover.h
+++ b/PhysicsTools/PatUtils/interface/DuplicatedPhotonRemover.h
@@ -38,50 +38,50 @@ namespace pat {
             /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
             /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
             template <typename PhotonCollection> 
-            std::auto_ptr< std::vector<size_t> > duplicatesBySuperCluster(const PhotonCollection &photons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const PhotonCollection &photons) const ;
             
             /// Indices of duplicated photons (same supercluster) to remove. It keeps the photons with highest energy.
             /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
             /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
             template <typename PhotonCollection> 
-            std::auto_ptr< std::vector<size_t> > duplicatesBySeed(const PhotonCollection &photons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const PhotonCollection &photons) const ;
 
             /// Indices of photons which happen to be also electrons (that is, they share the same SC seed)
             template <typename PhotonCollection, typename ElectronCollection> 
-            std::auto_ptr< pat::OverlapList > 
+            std::unique_ptr< pat::OverlapList > 
             electronsBySeed(const PhotonCollection &photons, const ElectronCollection &electrons) const ;
 
             /// Indices of photons which happen to be also electrons (that is, they share the same SC)
             template <typename PhotonCollection, typename ElectronCollection> 
-            std::auto_ptr< pat::OverlapList > 
+            std::unique_ptr< pat::OverlapList > 
             electronsBySuperCluster(const PhotonCollection &photons, const ElectronCollection &electrons) const ;
 
             // ===== Concrete versions for users (and to get it compiled, so I can see if there are errors) ===
-            std::auto_ptr< std::vector<size_t> > duplicatesBySeed(const reco::PhotonCollection &photons) const ;
-            std::auto_ptr< std::vector<size_t> > duplicatesBySeed(const edm::View<reco::Photon> &photons) const ;
-            std::auto_ptr< std::vector<size_t> > duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const ;
-            std::auto_ptr< std::vector<size_t> > duplicatesBySuperCluster(const reco::PhotonCollection &photons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
+            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const reco::PhotonCollection &photons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const edm::View<reco::Photon> &photons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const ;
+            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const reco::PhotonCollection &photons) const ;
+            std::unique_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
                     const reco::GsfElectronCollection& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
                     const reco::GsfElectronCollection& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
                     const reco::GsfElectronCollection& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
                     const reco::GsfElectronCollection& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
                     const edm::View<reco::GsfElectron>& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
                     const edm::View<reco::GsfElectron>& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
                     const edm::View<reco::GsfElectron>& electrons) const ;
-            std::auto_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
+            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
                     const edm::View<reco::GsfElectron>& electrons) const ;
     };
 }
 
 template<typename PhotonCollection>
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const PhotonCollection &photons) const {
     typedef typename PhotonCollection::value_type PhotonType;
     pat::GenericDuplicateRemover<EqualBySuperCluster, GreaterByEt<PhotonType> > dups;
@@ -89,7 +89,7 @@ pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const PhotonCollection &p
 }
 
 template<typename PhotonCollection>
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySeed(const PhotonCollection &photons) const {
     typedef typename PhotonCollection::value_type PhotonType;
     pat::GenericDuplicateRemover<EqualBySuperClusterSeed, GreaterByEt<PhotonType> > dups;
@@ -98,7 +98,7 @@ pat::DuplicatedPhotonRemover::duplicatesBySeed(const PhotonCollection &photons) 
 
 /// Indices of photons which happen to be also electrons (that is, they share the same SC)
 template <typename PhotonCollection, typename ElectronCollection> 
-std::auto_ptr< pat::OverlapList > 
+std::unique_ptr< pat::OverlapList > 
 pat::DuplicatedPhotonRemover::electronsBySuperCluster(const PhotonCollection &photons, const ElectronCollection &electrons) const {
     pat::GenericOverlapFinder< pat::OverlapDistance<EqualBySuperCluster> > ovl;
     return ovl.find(photons, electrons);
@@ -106,7 +106,7 @@ pat::DuplicatedPhotonRemover::electronsBySuperCluster(const PhotonCollection &ph
 
 /// Indices of photons which happen to be also electrons (that is, they share the same SC)
 template <typename PhotonCollection, typename ElectronCollection> 
-std::auto_ptr< pat::OverlapList > 
+std::unique_ptr< pat::OverlapList > 
 pat::DuplicatedPhotonRemover::electronsBySeed(const PhotonCollection &photons, const ElectronCollection &electrons) const {
     pat::GenericOverlapFinder< pat::OverlapDistance<EqualBySuperClusterSeed> > ovl;
     return ovl.find(photons, electrons);

--- a/PhysicsTools/PatUtils/interface/GenericDuplicateRemover.h
+++ b/PhysicsTools/PatUtils/interface/GenericDuplicateRemover.h
@@ -24,7 +24,7 @@ namespace pat {
             ///      arbitrator(x1, x2) should return true if x1 is better, that is we want to keep x1 and delete x2
             /// Collection can be vector, View, or anything with the same interface
             template <typename Collection>
-            std::auto_ptr< std::vector<size_t> >
+            std::unique_ptr< std::vector<size_t> >
             duplicates(const Collection &items) const ;
 
         private:
@@ -36,7 +36,7 @@ namespace pat {
 
 template<typename Comparator, typename Arbitrator>
 template<typename Collection>
-std::auto_ptr< std::vector<size_t> >
+std::unique_ptr< std::vector<size_t> >
 pat::GenericDuplicateRemover<Comparator,Arbitrator>::duplicates(const Collection &items) const 
 {
     size_t size = items.size();
@@ -57,7 +57,7 @@ pat::GenericDuplicateRemover<Comparator,Arbitrator>::duplicates(const Collection
         }
     }
 
-    std::auto_ptr< std::vector<size_t> > ret(new std::vector<size_t>());
+    auto ret = std::make_unique<std::vector<size_t>>();
 
     for (size_t i = 0; i < size; ++i) {
         if (bad[i]) ret->push_back(i);

--- a/PhysicsTools/PatUtils/interface/GenericOverlapFinder.h
+++ b/PhysicsTools/PatUtils/interface/GenericOverlapFinder.h
@@ -59,7 +59,7 @@ namespace pat {
             /// Items are considered to overlap if distance(x1,x2) < 1
             /// both Collections can be vectors, Views, or anything with the same interface
             template <typename Collection, typename OtherCollection>
-            std::auto_ptr< OverlapList >
+            std::unique_ptr< OverlapList >
             find(const Collection &items, const OtherCollection &other) const ;
 
         private:
@@ -70,12 +70,12 @@ namespace pat {
 
 template<typename Distance>
 template<typename Collection, typename OtherCollection>
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::GenericOverlapFinder<Distance>::find(const Collection &items, const OtherCollection &other) const 
 {
     size_t size = items.size(), size2 = other.size();
 
-    std::auto_ptr< OverlapList > ret(new OverlapList());
+    auto ret = std::make_unique<OverlapList>();
     
     for (size_t ie = 0; ie < size; ++ie) {
         double dmin   = 1.0;

--- a/PhysicsTools/PatUtils/interface/JetSelector.h
+++ b/PhysicsTools/PatUtils/interface/JetSelector.h
@@ -57,8 +57,8 @@ namespace pat {
 
     JetSelection config_;
 
-    std::auto_ptr<CaloJetSelector> CaloJetSelector_;///Selects CaloJets
-    //std::auto_ptr<CaloJetSelector> PFSelector_;///Selects PFJets
+    std::unique_ptr<CaloJetSelector> CaloJetSelector_;///Selects CaloJets
+    //std::unique_ptr<CaloJetSelector> PFSelector_;///Selects PFJets
 
   }; // class
 

--- a/PhysicsTools/PatUtils/interface/JetSelector.icc
+++ b/PhysicsTools/PatUtils/interface/JetSelector.icc
@@ -10,10 +10,8 @@ pat::JetSelector<JetType>::JetSelector( const pat::JetSelection& config ) :
 {
 
   if (config_.selectionType=="custom") {
-    CaloJetSelector_ = std::auto_ptr<CaloJetSelector>( 
-                                new CaloJetSelector(config) );
-    //PFJetSelector_ = std::auto_ptr<PFJetSelector>( 
-    //                          new PFJetSelector(config) );
+    CaloJetSelector_ = std::make_unique<CaloJetSelector>(config);
+    //PFJetSelector_ = std::make_unique<PFJetSelector>(config);
   }
 
 }

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -107,7 +107,7 @@ template <typename T, typename Textractor>
     if ( evt.isRealData() && addResidualJES_ ) {
       evt.getByToken(jetCorrTokenUpToL3Res_, jetCorrUpToL3Res);
     }
-    std::auto_ptr<JetCollection> shiftedJets(new JetCollection);
+    auto shiftedJets = std::make_unique<JetCollection>();
 
     if ( jetCorrPayloadName_ != "" ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
@@ -170,7 +170,7 @@ template <typename T, typename Textractor>
       shiftedJets->push_back(shiftedJet);
     }
 
-    evt.put(shiftedJets);
+    evt.put(std::move(shiftedJets));
   }
 
   std::string moduleLabel_;

--- a/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
@@ -70,7 +70,7 @@ class ShiftedParticleProducerT : public edm::stream::EDProducer<>
     edm::Handle<ParticleCollection> originalParticles;
     evt.getByToken(srcToken_, originalParticles);
 
-    std::auto_ptr<ParticleCollection> shiftedParticles(new ParticleCollection);
+    auto shiftedParticles = std::make_unique<ParticleCollection>();
 
     for ( typename ParticleCollection::const_iterator originalParticle = originalParticles->begin();
 	  originalParticle != originalParticles->end(); ++originalParticle ) {
@@ -96,7 +96,7 @@ class ShiftedParticleProducerT : public edm::stream::EDProducer<>
       shiftedParticles->push_back(shiftedParticle);
     }
 
-    evt.put(shiftedParticles);
+    evt.put(std::move(shiftedParticles));
   }
 
   std::string moduleLabel_;

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -198,7 +198,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
             if (m_genJetMatcher)
                 m_genJetMatcher->getTokens(event);
 
-            std::unique_ptr<JetCollection> smearedJets(new JetCollection());
+            auto smearedJets = std::make_unique<JetCollection>();
 
             for (const auto& jet: jets) {
 

--- a/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
+++ b/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
@@ -21,8 +21,8 @@ void
 BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup&)
 {  
 
-  std::auto_ptr< std::vector<pat::Jet> > outputs( new std::vector<pat::Jet> );
-  std::auto_ptr< std::vector<pat::Jet> > outputSubjets( new std::vector<pat::Jet> );
+  auto outputs = std::make_unique<std::vector<pat::Jet>>();
+  auto outputSubjets = std::make_unique<std::vector<pat::Jet>>();
 
   edm::RefProd< std::vector<pat::Jet> > h_subJetsOut = iEvent.getRefBeforePut< std::vector<pat::Jet> >( "SubJets" );
  
@@ -62,8 +62,8 @@ BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup&)
   }
 
   
-  iEvent.put(outputs);
-  iEvent.put(outputSubjets, "SubJets");
+  iEvent.put(std::move(outputs));
+  iEvent.put(std::move(outputSubjets), "SubJets");
 
 }
 

--- a/PhysicsTools/PatUtils/plugins/CorrectedPATMETProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/CorrectedPATMETProducer.cc
@@ -61,9 +61,9 @@ private:
     reco::MET corrMET = corrector.getCorrectedMET(srcMET, evt, es);
     pat::MET outMET(corrMET, srcMET);
   
-    std::auto_ptr<METCollection> product(new METCollection);
+    auto product = std::make_unique<METCollection>();
     product->push_back(outMET);
-    evt.put(product);
+    evt.put(std::move(product));
   }
 
 };

--- a/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
+++ b/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
@@ -29,7 +29,7 @@ void
 JetSubstructurePacker::produce(edm::Event& iEvent, const edm::EventSetup&)
 {  
 
-  std::auto_ptr< std::vector<pat::Jet> > outputs( new std::vector<pat::Jet> );
+  auto outputs = std::make_unique<std::vector<pat::Jet>>();
  
   edm::Handle< edm::View<pat::Jet> > jetHandle;
   std::vector< edm::Handle< edm::View<pat::Jet> > > algoHandles;
@@ -121,7 +121,7 @@ JetSubstructurePacker::produce(edm::Event& iEvent, const edm::EventSetup&)
     }
   }
 
-  iEvent.put(outputs);
+  iEvent.put(std::move(outputs));
 
 }
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.cc
@@ -80,7 +80,7 @@ void ShiftedJetProducerByMatchedObjectT<T>::produce(edm::Event& evt, const edm::
   
   match.assign(objects_.size(), false);
 
-  std::auto_ptr<JetCollection> shiftedJets(new JetCollection);
+  auto shiftedJets = std::make_unique<JetCollection>();
     
   for ( typename JetCollection::const_iterator originalJet = originalJets->begin();
 	originalJet != originalJets->end(); ++originalJet ) {
@@ -121,7 +121,7 @@ void ShiftedJetProducerByMatchedObjectT<T>::produce(edm::Event& evt, const edm::
     shiftedJets->push_back(shiftedJet);
   }
   
-  evt.put(shiftedJets);
+  evt.put(std::move(shiftedJets));
 }
 
 #include "DataFormats/JetReco/interface/CaloJet.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.cc
@@ -63,14 +63,14 @@ void ShiftedMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup
 
       double shift = shiftBy_*(*binningEntry)->binUncertainty_;
 
-      std::auto_ptr<CorrMETData> shiftedObject(new CorrMETData(*originalObject));
+      auto shiftedObject = std::make_unique<CorrMETData>(*originalObject);
 //--- MET balances momentum of reconstructed particles,
 //    hence variations of "unclustered energy" and MET are opposite in sign
       shiftedObject->mex   = -shift*originalObject->mex;
       shiftedObject->mey   = -shift*originalObject->mey;
       shiftedObject->sumet = shift*originalObject->sumet;
 
-      evt.put(shiftedObject, (*binningEntry)->getInstanceLabel_full(src_i->instance()));
+      evt.put(std::move(shiftedObject), (*binningEntry)->getInstanceLabel_full(src_i->instance()));
     }
   }
 }

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.cc
@@ -58,7 +58,7 @@ void ShiftedPFCandidateProducerByMatchedObject::produce(edm::Event& evt, const e
     }
   }
  
-  std::auto_ptr<reco::PFCandidateCollection> shiftedPFCandidates(new reco::PFCandidateCollection);
+  auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
     
   for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
 	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
@@ -93,7 +93,7 @@ void ShiftedPFCandidateProducerByMatchedObject::produce(edm::Event& evt, const e
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
   
-  evt.put(shiftedPFCandidates);
+  evt.put(std::move(shiftedPFCandidates));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
@@ -57,8 +57,7 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
       jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
     }
 
-  std::auto_ptr<reco::PFCandidateCollection> shiftedPFCandidates(new reco::PFCandidateCollection);
-
+  auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
   for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
 	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
 
@@ -93,7 +92,7 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
 
-  evt.put(shiftedPFCandidates);
+  evt.put(std::move(shiftedPFCandidates));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.cc
@@ -72,7 +72,7 @@ void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::
 
   match.assign(objects_.size(), false);
 
-  std::auto_ptr<reco::PFCandidateCollection> shiftedPFCandidates(new reco::PFCandidateCollection);
+  auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
 
   for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
 	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
@@ -113,7 +113,7 @@ void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
 
-  evt.put(shiftedPFCandidates);
+  evt.put(std::move(shiftedPFCandidates));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
@@ -71,7 +71,7 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
       jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
     }
 
-  std::auto_ptr<reco::PFCandidateCollection> shiftedPFCandidates(new reco::PFCandidateCollection);
+  auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
 
   for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
 	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
@@ -106,7 +106,7 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
 
-  evt.put(shiftedPFCandidates);
+  evt.put(std::move(shiftedPFCandidates));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
@@ -20,7 +20,7 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt
   edm::Handle<CandidateView> shiftedParticles;
   evt.getByToken(srcShiftedToken_, shiftedParticles);
 
-  std::auto_ptr<CorrMETData> metCorrection(new CorrMETData());
+  auto metCorrection = std::make_unique<CorrMETData>();
 
   for ( CandidateView::const_iterator originalParticle = originalParticles->begin();
 	originalParticle != originalParticles->end(); ++originalParticle ) {
@@ -36,7 +36,7 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt
     metCorrection->sumet -= shiftedParticle->et();
   }
 
-  evt.put(metCorrection);
+  evt.put(std::move(metCorrection));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
@@ -36,7 +36,7 @@ ShiftedParticleProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   edm::Handle<CandidateView> originalParticles;
   evt.getByToken(srcToken_, originalParticles);
 
-  std::auto_ptr<reco::CandidateCollection> shiftedParticles(new reco::CandidateCollection);
+  auto shiftedParticles = std::make_unique<reco::CandidateCollection>();
 
   for(CandidateView::const_iterator originalParticle = originalParticles->begin();
       originalParticle != originalParticles->end(); ++originalParticle ) {
@@ -48,13 +48,13 @@ ShiftedParticleProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     //leave 0*nan = 0
     if (! (edm::isNotFinite(shift) && shiftedParticleP4.mag2()==0)) shiftedParticleP4 *= (1. + shift);
 
-    std::auto_ptr<reco::Candidate> shiftedParticle( new reco::LeafCandidate( *originalParticle ) );
+    std::unique_ptr<reco::Candidate> shiftedParticle = std::make_unique<reco::LeafCandidate>(*originalParticle);
     shiftedParticle->setP4(shiftedParticleP4);
     
     shiftedParticles->push_back( shiftedParticle.release() );
   }
 
-  evt.put(shiftedParticles);
+  evt.put(std::move(shiftedParticles));
 }
 
 double 

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
@@ -56,14 +56,14 @@ class ShiftedParticleProducer : public edm::stream::EDProducer<>
       binUncertainty_(uncertainty),
       energyDep_(false)
     {
-      binUncFormula_ = std::unique_ptr<TF2>(new TF2(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() ) );
+      binUncFormula_ = std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() );
     }
   binningEntryType(const edm::ParameterSet& cfg, std::string moduleLabel)
   : binSelection_(new StringCutObjectSelector<reco::Candidate>(cfg.getParameter<std::string>("binSelection"))),
       binUncertainty_(cfg.getParameter<std::string>("binUncertainty")),
       energyDep_(false)
     {
-      binUncFormula_ = std::unique_ptr<TF2>(new TF2(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() ) );
+      binUncFormula_ = std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() );
       if(cfg.exists("energyDependency") ) {energyDep_=cfg.getParameter<bool>("energyDependency");
       }
     }

--- a/PhysicsTools/PatUtils/src/DuplicatedElectronRemover.cc
+++ b/PhysicsTools/PatUtils/src/DuplicatedElectronRemover.cc
@@ -3,12 +3,12 @@
 #include <algorithm>
 
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedElectronRemover::duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const {
     return duplicatesToRemove< std::vector<reco::GsfElectron> >(electrons);
 }
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedElectronRemover::duplicatesToRemove(const edm::View<reco::GsfElectron>   &electrons) const {
     return duplicatesToRemove< edm::View<reco::GsfElectron> >(electrons);
 }
@@ -17,7 +17,7 @@ pat::DuplicatedElectronRemover::duplicatesToRemove(const edm::View<reco::GsfElec
 
 
 /*
-std::auto_ptr< std::vector<size_t> >
+std::unique_ptr< std::vector<size_t> >
 pat::DuplicatedElectronRemover::duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) 
 {
     using namespace std;
@@ -51,7 +51,7 @@ pat::DuplicatedElectronRemover::duplicatesToRemove(const std::vector<reco::GsfEl
         }
     }
 
-    auto_ptr< vector<size_t> > ret(new vector<size_t>());
+    auto ret = std::make_unique<std::vector<size_t>>();
 
     for (size_t i = 0; i < size; ++i) {
         if (bad[i]) ret->push_back(i);

--- a/PhysicsTools/PatUtils/src/DuplicatedPhotonRemover.cc
+++ b/PhysicsTools/PatUtils/src/DuplicatedPhotonRemover.cc
@@ -2,72 +2,72 @@
 
 #include <algorithm>
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySeed(const reco::PhotonCollection &photons) const {
     return duplicatesBySeed<reco::PhotonCollection>(photons);
 }
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySeed(const edm::View<reco::Photon> &photons) const {
     return duplicatesBySeed< edm::View<reco::Photon> >(photons);
 }
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const reco::PhotonCollection &photons) const {
     return duplicatesBySuperCluster<reco::PhotonCollection>(photons);
 }
 
-std::auto_ptr< std::vector<size_t> > 
+std::unique_ptr< std::vector<size_t> > 
 pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const {
     return duplicatesBySuperCluster< edm::View<reco::Photon> >(photons);
 }
 
 // ================ ELECTRONS  =============================
 // ---------------- against EleCollection  -----------------------------
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySeed(const reco::PhotonCollection &photons, 
         const reco::GsfElectronCollection& electrons) const {
     return electronsBySeed<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySeed(const edm::View<reco::Photon> &photons, 
         const reco::GsfElectronCollection& electrons) const {
     return electronsBySeed<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
         const reco::GsfElectronCollection& electrons) const {
     return electronsBySuperCluster<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySuperCluster(const reco::PhotonCollection &photons, 
         const reco::GsfElectronCollection&  electrons) const {
     return electronsBySuperCluster<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
 }
 
 // ---------------- against EleView  -----------------------------
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySeed(const reco::PhotonCollection &photons, 
         const edm::View<reco::GsfElectron>&  electrons) const {
     return electronsBySeed<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySeed(const edm::View<reco::Photon> &photons, 
         const edm::View<reco::GsfElectron>&  electrons) const {
     return electronsBySeed<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
         const edm::View<reco::GsfElectron>&  electrons) const {
     return electronsBySuperCluster<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::auto_ptr< pat::OverlapList >
+std::unique_ptr< pat::OverlapList >
 pat::DuplicatedPhotonRemover::electronsBySuperCluster(const reco::PhotonCollection &photons, 
         const edm::View<reco::GsfElectron>&  electrons) const {
     return electronsBySuperCluster<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);

--- a/PhysicsTools/RecoAlgos/interface/MassKinFitterCandProducer.h
+++ b/PhysicsTools/RecoAlgos/interface/MassKinFitterCandProducer.h
@@ -16,7 +16,7 @@ public:
   explicit MassKinFitterCandProducer(const edm::ParameterSet&, CandMassKinFitter * = 0);
 private:
   edm::EDGetTokenT<reco::CandidateCollection> srcToken_;
-  std::auto_ptr<CandMassKinFitter> fitter_;
+  std::unique_ptr<CandMassKinFitter> fitter_;
   void produce( edm::Event &, const edm::EventSetup & );
 };
 

--- a/PhysicsTools/RecoAlgos/src/MassKinFitterCandProducer.cc
+++ b/PhysicsTools/RecoAlgos/src/MassKinFitterCandProducer.cc
@@ -16,12 +16,12 @@ void MassKinFitterCandProducer::produce( edm::Event & evt, const edm::EventSetup
   using namespace reco;
   Handle<CandidateCollection> cands;
   evt.getByToken(srcToken_, cands);
-  std::auto_ptr<CandidateCollection> refitted( new CandidateCollection );
+  auto refitted = std::make_unique<CandidateCollection>();
   for( CandidateCollection::const_iterator c = cands->begin(); c != cands->end(); ++ c ) {
     Candidate * clone = c->clone();
     fitter_->set( * clone );
     refitted->push_back( clone );
   }
-  evt.put( refitted );
+  evt.put(std::move(refitted));
 }
 

--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -139,12 +139,12 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const Collection& physicsobjects = *physicsObjectsHandle;
 
   for( const auto& id : ids_ ) {
-    std::auto_ptr<edm::ValueMap<bool> > outPass(new edm::ValueMap<bool>() );
-    std::auto_ptr<edm::ValueMap<float> > outPassf(new edm::ValueMap<float>() );
-    std::auto_ptr<edm::ValueMap<unsigned> > outHowFar(new edm::ValueMap<unsigned>() );
-    std::auto_ptr<edm::ValueMap<unsigned> > outBitmap(new edm::ValueMap<unsigned>() );
-    std::auto_ptr<edm::ValueMap<vid::CutFlowResult> > out_cfrs(new edm::ValueMap<vid::CutFlowResult>() );
-    std::auto_ptr<pat::UserDataCollection> out_usrd(new pat::UserDataCollection);
+    auto outPass = std::make_unique<edm::ValueMap<bool>>();
+    auto outPassf = std::make_unique<edm::ValueMap<float>>();
+    auto outHowFar = std::make_unique<edm::ValueMap<unsigned>>();
+    auto outBitmap = std::make_unique<edm::ValueMap<unsigned>>();
+    auto out_cfrs = std::make_unique<edm::ValueMap<vid::CutFlowResult>>();
+    auto out_usrd = std::make_unique<pat::UserDataCollection>();
         
     std::vector<bool> passfail;
     std::vector<float> passfailf;
@@ -182,16 +182,16 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     fillercfr.insert(physicsObjectsHandle, cfrs.begin(), cfrs.end() );
     fillercfr.fill(); 
 
-    iEvent.put(outPass,id->name());
-    iEvent.put(outPassf,id->name());
-    iEvent.put(outHowFar,id->name());
-    iEvent.put(outBitmap,id->name()+std::string(bitmap_label));
-    iEvent.put(out_cfrs,id->name());
-    iEvent.put(std::auto_ptr<std::string>(new std::string(id->md5String())),
+    iEvent.put(std::move(outPass),id->name());
+    iEvent.put(std::move(outPassf),id->name());
+    iEvent.put(std::move(outHowFar),id->name());
+    iEvent.put(std::move(outBitmap),id->name()+std::string(bitmap_label));
+    iEvent.put(std::move(out_cfrs),id->name());
+    iEvent.put(std::make_unique<std::string>(id->md5String()),
 	       id->name());
-    auto usrd_handle = iEvent.put(out_usrd,id->name());
+    auto usrd_handle = iEvent.put(std::move(out_usrd),id->name());
     //now add the value map of ptrs to user datas
-    std::auto_ptr<edm::ValueMap<edm::Ptr<pat::UserData> > > out_usrdptrs(new edm::ValueMap<edm::Ptr<pat::UserData> >);
+    auto out_usrdptrs = std::make_unique<edm::ValueMap<edm::Ptr<pat::UserData>>>();
     std::vector<edm::Ptr<pat::UserData> > usrdptrs;
     for( unsigned i = 0; i < usrd_handle->size(); ++i ){
       usrdptrs.push_back(edm::Ptr<pat::UserData>(usrd_handle,i));
@@ -201,7 +201,7 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     fillerusrdptrs.insert(physicsObjectsHandle, usrdptrs.begin(), usrdptrs.end());
     fillerusrdptrs.fill();
 
-    iEvent.put(out_usrdptrs,id->name());        
+    iEvent.put(std::move(out_usrdptrs),id->name());        
   }   
 }
 

--- a/PhysicsTools/TagAndProbe/plugins/AnythingToValueMap.h
+++ b/PhysicsTools/TagAndProbe/plugins/AnythingToValueMap.h
@@ -47,11 +47,11 @@ void AnythingToValueMap<Adaptor,Collection,value_type>::produce(edm::Event & iEv
 
     adaptor_.run(*handle, ret);
 
-    std::auto_ptr<Map> map(new Map());
+    auto map = std::make_unique<Map>();
     MapFiller filler(*map);
     filler.insert(handle, ret.begin(), ret.end());
     filler.fill();
-    iEvent.put(map, adaptor_.label());
+    iEvent.put(std::move(map), adaptor_.label());
 }
 
   template<class Adaptor, class Collection = typename Adaptor::Collection, typename value_type = typename Adaptor::value_type> 
@@ -92,11 +92,11 @@ void ManyThingsToValueMaps<Adaptor,Collection,value_type>::produce(edm::Event & 
     for (typename std::vector<Adaptor>::iterator it = adaptors_.begin(), ed = adaptors_.end(); it != ed; ++it) {
         ret.clear();
         if (it->run(iEvent, *handle, ret)) {
-            std::auto_ptr<Map> map(new Map());
+            auto map = std::make_unique<Map>();
             MapFiller filler(*map);
             filler.insert(handle, ret.begin(), ret.end());
             filler.fill();
-            iEvent.put(map, it->label());
+            iEvent.put(std::move(map), it->label());
         } else {
             if (!failSilently_) throw cms::Exception("ManyThingsToValueMaps") << "Error in adapter " << it->label() << "\n";
         }

--- a/PhysicsTools/TagAndProbe/plugins/ColinsSoperVariablesComputer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ColinsSoperVariablesComputer.cc
@@ -111,26 +111,26 @@ ColinsSoperVariablesComputer::produce(edm::Event & iEvent, const edm::EventSetup
 
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(bosons, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap, "costheta");
+    iEvent.put(std::move(valMap), "costheta");
 
 
     // ---> same for sin2theta
-    std::auto_ptr<ValueMap<float> > valMap2(new ValueMap<float>());
+    auto valMap2 = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler2(*valMap2);
     filler2.insert(bosons, values2.begin(), values2.end());
     filler2.fill();
-    iEvent.put(valMap2, "sin2theta");
+    iEvent.put(std::move(valMap2), "sin2theta");
 
     // ---> same for tanphi
-    std::auto_ptr<ValueMap<float> > valMap3(new ValueMap<float>());
+    auto valMap3 = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler3(*valMap3);
     filler3.insert(bosons, values3.begin(), values3.end());
     filler3.fill();
-    iEvent.put(valMap3, "tanphi");
+    iEvent.put(std::move(valMap3), "tanphi");
 
 }
 

--- a/PhysicsTools/TagAndProbe/plugins/DeltaRNearestObjectComputer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/DeltaRNearestObjectComputer.cc
@@ -98,11 +98,11 @@ DeltaRNearestObjectComputer<T>::produce(edm::Event & iEvent, const edm::EventSet
     }
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(probes, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap);
+    iEvent.put(std::move(valMap));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
@@ -113,34 +113,34 @@ ElectronConversionRejectionVars::produce(edm::Event & iEvent, const edm::EventSe
 
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(probes, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap, "dist");
+    iEvent.put(std::move(valMap), "dist");
 
 
     // ---> same for dcot
-    std::auto_ptr<ValueMap<float> > valMap2(new ValueMap<float>());
+    auto valMap2 = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler2(*valMap2);
     filler2.insert(probes, values2.begin(), values2.end());
     filler2.fill();
-    iEvent.put(valMap2, "dcot");
+    iEvent.put(std::move(valMap2), "dcot");
 
     // ---> same for convradius
-    std::auto_ptr<ValueMap<float> > valMap3(new ValueMap<float>());
+    auto valMap3 = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler3(*valMap3);
     filler3.insert(probes, values3.begin(), values3.end());
     filler3.fill();
-    iEvent.put(valMap3, "convradius");
+    iEvent.put(std::move(valMap3), "convradius");
 
 
     // ---> same for passConvRej
-    std::auto_ptr<ValueMap<float> > valMap4(new ValueMap<float>());
+    auto valMap4 = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler4(*valMap4);
     filler4.insert(probes, values4.begin(), values4.end());
     filler4.fill();
-    iEvent.put(valMap4, "passConvRej");
+    iEvent.put(std::move(valMap4), "passConvRej");
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ElectronMatchedCandidateProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ElectronMatchedCandidateProducer.cc
@@ -42,10 +42,8 @@ void ElectronMatchedCandidateProducer::produce(edm::Event &event,
 			      const edm::EventSetup &eventSetup)
 {
    // Create the output collection
-  std::auto_ptr< edm::RefToBaseVector<reco::Candidate> >
-    outColRef( new edm::RefToBaseVector<reco::Candidate> );
-  std::auto_ptr< edm::PtrVector<reco::Candidate> >
-    outColPtr( new edm::PtrVector<reco::Candidate> );
+  auto outColRef = std::make_unique<edm::RefToBaseVector<reco::Candidate>>();
+  auto outColPtr = std::make_unique<edm::PtrVector<reco::Candidate>>();
 
 
   // Read electrons
@@ -82,8 +80,8 @@ void ElectronMatchedCandidateProducer::produce(edm::Event &event,
 
   } // end candidate loop
 
-  event.put(outColRef);
-  event.put(outColPtr);
+  event.put(std::move(outColRef));
+  event.put(std::move(outColPtr));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/NearbyCandCountComputer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/NearbyCandCountComputer.cc
@@ -85,11 +85,11 @@ NearbyCandCountComputer::produce(edm::Event & iEvent, const edm::EventSetup & iS
     }
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(probes, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap);
+    iEvent.put(std::move(valMap));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ObjectMultiplicityCounter.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ObjectMultiplicityCounter.cc
@@ -75,11 +75,11 @@ ObjectMultiplicityCounter<T>::produce(edm::Event & iEvent, const edm::EventSetup
     std::vector<float> values(probes->size(), count);
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(probes, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap);
+    iEvent.put(std::move(valMap));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ObjectViewCleaner.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ObjectViewCleaner.cc
@@ -117,8 +117,7 @@ ObjectViewCleaner<T>::~ObjectViewCleaner()
 template<typename T>
 void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
-  auto_ptr<edm::RefToBaseVector<T> >
-    cleanObjects(new edm::RefToBaseVector<T >());
+  auto cleanObjects = std::make_unique<edm::RefToBaseVector<T>>();
 
   edm::Handle<edm::View<T> > candidates;
   iEvent.getByToken(srcCandsToken_,candidates);
@@ -151,7 +150,7 @@ void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSe
   nObjectsClean_+=cleanObjects->size();
 
   delete [] isClean;
-  iEvent.put(cleanObjects);
+  iEvent.put(std::move(cleanObjects));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ObjectViewMatcher.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ObjectViewMatcher.cc
@@ -111,7 +111,7 @@ ObjectViewMatcher<T1, T2>::~ObjectViewMatcher(){}
 template<typename T1, typename T2>
 void ObjectViewMatcher<T1, T2>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
-  std::auto_ptr<std::vector<T1> > cleanObjects(new std::vector<T1 >);
+  auto cleanObjects = std::make_unique<std::vector<T1>>();
 
   edm::Handle<edm::View<T1> > candidates;
   iEvent.getByToken(srcCandsToken_,candidates);
@@ -151,7 +151,7 @@ void ObjectViewMatcher<T1, T2>::produce(edm::Event& iEvent,const edm::EventSetup
   nObjectsMatch_+=cleanObjects->size();
 
   delete [] isMatch;
-  iEvent.put(cleanObjects);
+  iEvent.put(std::move(cleanObjects));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/OtherObjectVariableComputer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/OtherObjectVariableComputer.cc
@@ -87,11 +87,11 @@ OtherObjectVariableComputer<T>::produce(edm::Event & iEvent, const edm::EventSet
     std::vector<float> values(probes->size(), (selected.empty() ? default_ : selected.back().second));
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(probes, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap);
+    iEvent.put(std::move(valMap));
 }
 
 

--- a/PhysicsTools/TagAndProbe/plugins/ProbeMulteplicityProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ProbeMulteplicityProducer.cc
@@ -80,11 +80,11 @@ ProbeMulteplicityProducer::produce(edm::Event & iEvent, const edm::EventSetup & 
     }
 
     // convert into ValueMap and store
-    std::auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+    auto valMap = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler filler(*valMap);
     filler.insert(pairs, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap);
+    iEvent.put(std::move(valMap));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
@@ -53,7 +53,7 @@ class ProbeTreeProducer : public edm::EDFilter {
     int32_t maxProbes_;
 
     /// The object that actually computes variables and fills the tree for the probe
-    std::auto_ptr<tnp::BaseTreeFiller> probeFiller_;
+    std::unique_ptr<tnp::BaseTreeFiller> probeFiller_;
 };
 
 ProbeTreeProducer::ProbeTreeProducer(const edm::ParameterSet& iConfig) :

--- a/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeProducer.cc
@@ -76,13 +76,13 @@ class TagProbeFitTreeProducer : public edm::EDAnalyzer {
       /// The object that produces pairs of tags and probes, making any arbitration needed
       tnp::TagProbePairMaker tagProbePairMaker_;
       /// The object that actually computes variables and fills the tree for T&P
-      std::auto_ptr<tnp::TPTreeFiller> treeFiller_;
+      std::unique_ptr<tnp::TPTreeFiller> treeFiller_;
       /// The object that actually computes variables and fills the tree for unbiased MC
-      std::auto_ptr<tnp::BaseTreeFiller> mcUnbiasFiller_;
-      std::auto_ptr<tnp::BaseTreeFiller> oldTagFiller_;
-      std::auto_ptr<tnp::BaseTreeFiller> tagFiller_;
-      std::auto_ptr<tnp::BaseTreeFiller> pairFiller_;
-      std::auto_ptr<tnp::BaseTreeFiller> mcFiller_;
+      std::unique_ptr<tnp::BaseTreeFiller> mcUnbiasFiller_;
+      std::unique_ptr<tnp::BaseTreeFiller> oldTagFiller_;
+      std::unique_ptr<tnp::BaseTreeFiller> tagFiller_;
+      std::unique_ptr<tnp::BaseTreeFiller> pairFiller_;
+      std::unique_ptr<tnp::BaseTreeFiller> mcFiller_;
 };
 
 //

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -381,10 +381,10 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
   createPdf(w, pdfs[pdfName]);
   //set the initial values for the yields of signal and background
   setInitialValues(w);  
-  std::auto_ptr<RooFitResult> res(0);
+  std::unique_ptr<RooFitResult> res;
   
   RooAbsData *data = w->data("data");
-  std::auto_ptr<RooDataHist> bdata;
+  std::unique_ptr<RooDataHist> bdata;
   if (binnedFit) { 
     // get variables from data, which contain also other binning or expression variables
     const RooArgSet *dataObs = data->get(0); 
@@ -617,7 +617,7 @@ void TagProbeFitter::saveFitPlot(RooWorkspace* w){
   RooAbsData* dataPass = dataAll->reduce(Cut("_efficiencyCategory_==_efficiencyCategory_::Passed")); 
   RooAbsData* dataFail = dataAll->reduce(Cut("_efficiencyCategory_==_efficiencyCategory_::Failed")); 
   RooAbsPdf& pdf = *w->pdf("simPdf");
-  std::auto_ptr<RooArgSet> obs(pdf.getObservables(*dataAll));
+  std::unique_ptr<RooArgSet> obs(pdf.getObservables(*dataAll));
   RooRealVar* mass = 0;
   RooLinkedListIter it = obs->iterator();
   for(RooAbsArg* v = (RooAbsArg*)it.Next(); v!=0; v = (RooAbsArg*)it.Next() ){
@@ -742,7 +742,7 @@ void TagProbeFitter::saveEfficiencyPlots(RooDataSet& eff, const TString& effName
       }else{
         RooDataSet myEff(eff);
         myEff.addColumn(allCats2D);
-        std::auto_ptr<TIterator> catIt(allCats2D.typeIterator());
+        std::unique_ptr<TIterator> catIt(allCats2D.typeIterator());
         for(RooCatType* t = (RooCatType*)catIt->Next(); t!=0; t = (RooCatType*)catIt->Next() ){
           TString catName = t->GetName();
           if(catName.Contains("NotMapped")) continue;
@@ -757,7 +757,7 @@ void TagProbeFitter::saveEfficiencyPlots(RooDataSet& eff, const TString& effName
     }else{
       RooDataSet myEff(eff);
       myEff.addColumn(allCats1D);
-      std::auto_ptr<TIterator> catIt(allCats1D.typeIterator());
+      std::unique_ptr<TIterator> catIt(allCats1D.typeIterator());
       for(RooCatType* t = (RooCatType*)catIt->Next(); t!=0; t = (RooCatType*)catIt->Next() ){
         TString catName = t->GetName();
         if(catName.Contains("NotMapped")) continue;

--- a/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
+++ b/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
@@ -76,15 +76,13 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
   HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
 
    // Create the output collection
-  std::auto_ptr< edm::RefToBaseVector<object> >
-    outColRef( new edm::RefToBaseVector<object> );
-  //std::auto_ptr< edm::PtrVector<object> >
-  // outColPtr( new edm::PtrVector<object> );
+  auto outColRef = std::make_unique<edm::RefToBaseVector<object>>();
+  //auto outColPtr = std::make_unique<edm::PtrVector<object>>();
 
   //skip event if HLT paths do not have identical process names
   if (skipEvent_) {
-    event.put(outColRef);
-    //event.put(outColPtr);
+    event.put(std::move(outColRef));
+    //event.put(std::move(outColPtr));
     return;
   }
 
@@ -198,8 +196,8 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
      edm::LogInfo("info")<< "******** Following Trigger Summary Object Not Found: " <<
        triggerEventTag_;
 
-     event.put(outColRef);
-     // event.put(outColPtr);
+     event.put(std::move(outColRef));
+     // event.put(std::move(outColPtr));
      return;
    }
 
@@ -293,7 +291,7 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
            if (isTriggerOR_) continue;
         //    edm::LogInfo("info")<< "******** Following TRIGGER Name Not in Dataset: " <<
        //     theRightHLTTag_.label();
-       //     event.put(outColRef);
+       //     event.put(std::move(outColRef));
        //     return;
            } else
            {
@@ -344,12 +342,12 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
    if(!foundPath) {
      edm::LogInfo("info")<< "******** Following TRIGGER Name Not in Dataset: " <<
        theRightHLTTag_.label();
-     event.put(outColRef);
+     event.put(std::move(outColRef));
      return;
    }
 
-   event.put(outColRef);
-   // event.put(outColPtr);
+   event.put(std::move(outColRef));
+   // event.put(std::move(outColPtr));
 }
 
 

--- a/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
@@ -69,7 +69,7 @@ namespace edm {
     /// everything which has to be done during the event loop. NOTE: We can't use the eventSetup in FWLite so ignore it
     virtual bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override {
       // create a collection of the objects to put into the event
-      std::auto_ptr<C> objsToPut( new C() );
+      auto objsToPut = std::make_unique<C>();
       // get the handle to the objects in the event.
       edm::Handle<C> h_c;
       event.getByToken( src_, h_c );
@@ -81,7 +81,7 @@ namespace edm {
       }
       // put objs in the event
       bool pass = objsToPut->size() > 0;
-      event.put(objsToPut);
+      event.put(std::move(objsToPut));
       if ( doFilter_ )
 	return pass;
       else

--- a/PhysicsTools/UtilAlgos/interface/NtpProducer.h
+++ b/PhysicsTools/UtilAlgos/interface/NtpProducer.h
@@ -62,12 +62,12 @@ void NtpProducer<C>::produce( edm::Event& iEvent, const edm::EventSetup& ) {
    typename std::vector<std::pair<std::string, StringObjectFunction<typename C::value_type> > >::const_iterator
      q = tags_.begin(), end = tags_.end();
    for(;q!=end; ++q) {
-     std::auto_ptr<std::vector<float> > x(new std::vector<float>);
+     auto x = std::make_unique<std::vector<float>>();
      x->reserve(coll->size());
      for (typename C::const_iterator elem=coll->begin(); elem!=coll->end(); ++elem ) {
        x->push_back(q->second(*elem));
      }
-     iEvent.put(x, q->first);
+     iEvent.put(std::move(x), q->first);
    }
 }
 

--- a/PhysicsTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/PhysicsTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -28,7 +28,7 @@ namespace helper {
   
   template<typename T>
   struct IteratorToObjectConverter<edm::OwnVector<T> > {
-    typedef std::auto_ptr<T> value_type;
+    typedef std::unique_ptr<T> value_type;
     template<typename I>
     static value_type convert( const I & i ) {
       return value_type( (*i)->clone() );
@@ -66,15 +66,15 @@ namespace helper {
   /*
   template<typename OutputCollection, typename InputCollection>
   struct OutputCollectionCreator {
-    static std::auto_ptr<OutputCollection> createNewCollection( const edm::Handle<InputCollection> & ) {
-      return std::auto_ptr<OutputCollection>( new OutputCollection );
+    static std::unique_ptr<OutputCollection> createNewCollection( const edm::Handle<InputCollection> & ) {
+      return std::make_unique<OutputCollection>();
     }
   };
 
   template<typename T, typename InputCollection>
   struct OutputCollectionCreator<edm::RefToBaseVector<T>, InputCollection> {
-    static std::auto_ptr<edm::RefToBaseVector<T> > createNewCollection( const edm::Handle<InputCollection> & h ) {
-      return std::auto_ptr<edm::RefToBaseVector<T> >( new edm::RefToBaseVector<T>(h) );
+    static std::unique_ptr<edm::RefToBaseVector<T> > createNewCollection( const edm::Handle<InputCollection> & h ) {
+      return std::make_unique<edm::RefToBaseVector<T> >(h);
     }
   };
   */
@@ -105,12 +105,12 @@ namespace helper {
         selected_->push_back( v );
       }
     }
-    edm::OrphanHandle<collection> put( edm::Event & evt ) {
-      return evt.put( selected_ );
+    edm::OrphanHandle<collection> put(edm::Event & evt) {
+      return evt.put(selected_);
     }
     size_t size() const { return selected_->size(); }
   private:
-    std::auto_ptr<collection> selected_;
+    std::unique_ptr<collection> selected_;
   };
 
   template<typename OutputCollection>

--- a/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
@@ -116,10 +116,10 @@ class VariableNTupler : public NTupler{
       iterator i=leaves_.begin();
       iterator i_end=leaves_.end();
       for(;i!=i_end;++i){
-	std::auto_ptr<double> leafValue(new double((*i->second)(iEvent)));
+	auto leafValue = std::make_unique<double>((*i->second)(iEvent));
 	std::string lName(i->first); 
 	std::replace(lName.begin(), lName.end(),'_','0');
-	iEvent.put(leafValue, lName.c_str());
+	iEvent.put(std::move(leafValue), lName.c_str());
       }
     }
   }

--- a/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
@@ -130,7 +130,7 @@ bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSe
   //will the filter pass or not.
   bool majorGlobalAccept=false;
 
-  std::auto_ptr<std::vector<bool> > passedProduct(new std::vector<bool>(flows_.size(),false));
+  auto passedProduct = std::make_unique<std::vector<bool>>(flows_.size(),false);
   bool filledOnce=false;
 
   // loop the requested selections
@@ -205,7 +205,7 @@ bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
   }//loop the different filter order/number: loop the Selections
 
-  iEvent.put(passedProduct);
+  iEvent.put(std::move(passedProduct));
   if (workAsASelector_)
     return majorGlobalAccept;
   else

--- a/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
@@ -82,8 +82,7 @@ void
 NTuplingDevice::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   ntupler_->fill(iEvent);
-  std::auto_ptr<double> v(new double(0));
-  iEvent.put(v,"dummy");
+  iEvent.put(std::make_unique<double>(0.),"dummy");
 }
 
 // ------------ method called once each job just before starting event loop  ------------


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in PhysicsTools packages. Also, std::make_unique is used when appropriate.
