### PR TITLE
Have InputProductResolver use DelayedReader

### DIFF
--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -29,8 +29,6 @@ namespace edm {
     virtual ~DelayedReader();
     std::unique_ptr<WrapperBase> getProduct(BranchKey const& k,
                                             EDProductGetter const* ep,
-                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preReadFromSourceSignal = nullptr,
-                                            signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postReadFromSourceSignal = nullptr,
                                             ModuleCallingContext const* mcc = nullptr);
 
     void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
@@ -40,13 +38,16 @@ namespace edm {
       return sharedResources_();
     }
     
-    
+
     
   private:
     virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
     virtual SharedResourcesAcquirer* sharedResources_() const;
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const = 0;
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const = 0;
+
   };
 }
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -180,8 +180,6 @@ namespace edm {
 
     edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID) const;
 
-    virtual void readFromSource_(ProductResolverBase const& phb, ModuleCallingContext const* mcc) const override;
-
     virtual unsigned int transitionIndex_() const override;
     
     std::shared_ptr<ProductProvenanceRetriever const> provRetrieverPtr() const {return get_underlying_safe(provRetrieverPtr_);}

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -174,9 +174,6 @@ namespace edm {
 
     using Base::getProvenance;
 
-    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preReadFromSourceSignal_;
-    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postReadFromSourceSignal_;
-
   private:
 
     BranchID pidToBid(ProductID const& pid) const;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -174,9 +174,6 @@ namespace edm {
 
     using Base::getProvenance;
 
-    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preModuleDelayedGetSignal_;
-    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postModuleDelayedGetSignal_;
-
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preReadFromSourceSignal_;
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postReadFromSourceSignal_;
 

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -68,6 +68,7 @@ namespace edm {
   class ProcessHistoryRegistry;
   class ProductRegistry;
   class StreamContext;
+  class ModuleCallingContext;
   class SharedResourcesAcquirer;
   class ThinnedAssociationsHelper;
   namespace multicore {
@@ -340,6 +341,10 @@ namespace edm {
       std::string const& lfn_;
       bool usedFallback_;
     };
+
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preEventReadFromSourceSignal_;
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postEventReadFromSourceSignal_;
+    
 
   protected:
     virtual void skip(int offset);

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -248,8 +248,6 @@ namespace edm {
                                           SharedResourcesAcquirer* sra,
                                           ModuleCallingContext const* mcc) const;
 
-    void resolveProductImmediately(ProductResolverBase& phb);
-    
     virtual bool isComplete_() const {return true;}
     
     void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* productResolver) const;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -212,17 +212,6 @@ namespace edm {
     
   private:
 
-    // Make my DelayedReader get the EDProduct for a ProductResolver.
-    // The ProductResolver is a cache, and so can be modified through the const
-    // reference.
-    // We do not change the *number* of products through this call, and so
-    // *this is const.
-    // This function is only meant to be called by InputProductResolver
-    friend class InputProductResolver;
-    void readFromSource(ProductResolverBase const& phb, ModuleCallingContext const* mcc) const {
-      readFromSource_(phb, mcc);
-    }
-
     void addScheduledProduct(std::shared_ptr<BranchDescription const> bd);
     void addSourceProduct(std::shared_ptr<BranchDescription const> bd);
     void addInputProduct(std::shared_ptr<BranchDescription const> bd);
@@ -259,8 +248,6 @@ namespace edm {
                                           SharedResourcesAcquirer* sra,
                                           ModuleCallingContext const* mcc) const;
 
-    virtual void readFromSource_(ProductResolverBase const& /* phb */, ModuleCallingContext const* /* mcc */) const {}
-    
     void resolveProductImmediately(ProductResolverBase& phb);
     
     virtual bool isComplete_() const {return true;}

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -71,6 +71,9 @@ namespace edm {
       return prefetchAsync_(waitTask, principal, skipCurrentProcess, sra, mcc);
     }
 
+    void retrieveAndMerge(Principal const& principal) const {
+      retrieveAndMerge_(principal);
+    }
     void resetProductData() { resetProductData_(false); }
 
     void unsafe_deleteProduct() const {
@@ -167,6 +170,9 @@ namespace edm {
                                 bool skipCurrentProcess,
                                 SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const = 0;
+    
+    virtual void retrieveAndMerge_(Principal const& principal) const;
+
 
     virtual bool unscheduledWasNotRun_() const = 0;
     virtual bool productUnavailable_() const = 0;

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -20,12 +20,6 @@ namespace edm {
                             EDProductGetter const* ep,
                             ModuleCallingContext const* mcc) {
 
-    auto sr = sharedResources_();
-    std::unique_lock<SharedResourcesAcquirer> guard;
-    if(sr) {
-      guard =std::unique_lock<SharedResourcesAcquirer>(*sr);
-    }
-
     auto preSignal = preEventReadFromSourceSignal();
     if(mcc and preSignal) {
       preSignal->emit(*(mcc->getStreamContext()),*mcc);

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -188,14 +188,6 @@ namespace edm {
     // must attempt to load from persistent store
     BranchKey const bk = BranchKey(phb.branchDescription());
     {
-      if(mcc) {
-        preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
-      }
-      std::shared_ptr<void> guard(nullptr,[this,mcc](const void*){
-        if(mcc) {
-          postModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
-        }
-      });
       
       std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, &preReadFromSourceSignal_, &postReadFromSourceSignal_, mcc));
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -189,7 +189,7 @@ namespace edm {
     BranchKey const bk = BranchKey(phb.branchDescription());
     {
       
-      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, &preReadFromSourceSignal_, &postReadFromSourceSignal_, mcc));
+      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, mcc));
 
       // Now fix up the ProductResolver
       phb.putProduct(std::move(edp));

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -181,21 +181,6 @@ namespace edm {
     phb->putProduct(std::move(edp));
   }
 
-   void
-  EventPrincipal::readFromSource_(ProductResolverBase const& phb, ModuleCallingContext const* mcc) const {
-    if(!reader()) return; // nothing to do.
-    
-    // must attempt to load from persistent store
-    BranchKey const bk = BranchKey(phb.branchDescription());
-    {
-      
-      std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this, mcc));
-
-      // Now fix up the ProductResolver
-      phb.putProduct(std::move(edp));
-    }
-  }
-
   BranchID
   EventPrincipal::pidToBid(ProductID const& pid) const {
     if(!pid.isValid()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -174,6 +174,8 @@ namespace edm {
       std::shared_ptr<int> sentry(nullptr,[areg,&md](void*){areg->postSourceConstructionSignal_(md);});
       convertException::wrap([&]() {
         input = std::unique_ptr<InputSource>(InputSourceFactory::get()->makeInputSource(*main_input, isdesc).release());
+        input->preEventReadFromSourceSignal_.connect(std::cref(areg->preEventReadFromSourceSignal_));
+        input->postEventReadFromSourceSignal_.connect(std::cref(areg->postEventReadFromSourceSignal_));
       });
     }
     catch (cms::Exception& iException) {
@@ -544,8 +546,6 @@ namespace edm {
       // Reusable event principal
       auto ep = std::make_shared<EventPrincipal>(preg(), branchIDListHelper(),
            thinnedAssociationsHelper(), *processConfiguration_, historyAppender_.get(), index);
-      ep->preReadFromSourceSignal_.connect(std::cref(actReg_->preEventReadFromSourceSignal_));
-      ep->postReadFromSourceSignal_.connect(std::cref(actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);
     }
     // initialize the subprocesses, if there are any

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -544,8 +544,6 @@ namespace edm {
       // Reusable event principal
       auto ep = std::make_shared<EventPrincipal>(preg(), branchIDListHelper(),
            thinnedAssociationsHelper(), *processConfiguration_, historyAppender_.get(), index);
-      ep->preModuleDelayedGetSignal_.connect(std::cref(actReg_->preModuleEventDelayedGetSignal_));
-      ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
       ep->preReadFromSourceSignal_.connect(std::cref(actReg_->preEventReadFromSourceSignal_));
       ep->postReadFromSourceSignal_.connect(std::cref(actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -829,28 +829,10 @@ namespace edm {
   
   void
   Principal::readAllFromSourceAndMergeImmediately() {
+    if(not reader()) {return;}
+    
     for(auto & prod : *this) {
-      ProductResolverBase & phb = *prod;
-      if(phb.singleProduct() && !phb.branchDescription().produced()) {
-        if(!phb.productUnavailable()) {
-          resolveProductImmediately(phb);
-        }
-      }
+      prod->retrieveAndMerge(*this);
     }
   }
-  void
-  Principal::resolveProductImmediately(ProductResolverBase& phb)  {
-    if(phb.branchDescription().produced()) return; // nothing to do.
-    if(!reader()) return; // nothing to do.
-    
-    // must attempt to load from persistent store
-    BranchKey const bk = BranchKey(phb.branchDescription());
-    std::unique_ptr<WrapperBase> edp(reader()->getProduct(bk, this));
-    
-    // Now fix up the ProductResolver
-    if(edp.get() != nullptr) {
-      putOrMerge(std::move(edp), &phb);
-    }
-  }
-
 }

--- a/FWCore/Framework/src/ProductResolverBase.cc
+++ b/FWCore/Framework/src/ProductResolverBase.cc
@@ -38,6 +38,11 @@ namespace edm {
   }
 
   void
+  ProductResolverBase::retrieveAndMerge_(Principal const& principal) const {
+  }
+
+  
+  void
   ProductResolverBase::write(std::ostream& os) const {
     // This is grossly inadequate. It is also not critical for the
     // first pass.

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -121,13 +121,13 @@ namespace edm {
         // The file may already be closed so the reader is invalid
         return;
       }
-      if(mcc and (branchType == InEvent)) {
+      if(mcc and (branchType == InEvent) and aux_) {
         aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
       }
 
       auto sentry( make_sentry(mcc,
                                [this, branchType](ModuleCallingContext const* iContext){
-                                 if(branchType == InEvent) {
+                                 if(branchType == InEvent and aux_) {
                                    aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext); }
                                }));
 

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -143,6 +143,22 @@ namespace edm {
                               
   }
   
+  void
+  InputProductResolver::retrieveAndMerge_(Principal const& principal) const {
+    
+    //Can't use resolveProductImpl since it first checks to see
+    // if the product was already retrieved and then returns if it is
+    BranchKey const bk = BranchKey(branchDescription());
+    std::unique_ptr<WrapperBase> edp(principal.reader()->getProduct(bk, &principal));
+    
+    if(edp.get() != nullptr) {
+      putOrMergeProduct(std::move(edp));
+    } else if( status()== defaultStatus()) {
+      setFailedStatus();
+    }
+  }
+
+  
   template<typename F>
   class FunctorTask : public tbb::task {
   public:

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -13,6 +13,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
 #include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/make_sentry.h"
 
 #include <cassert>
 #include <utility>
@@ -20,11 +21,6 @@
 static constexpr unsigned int kUnsetOffset = 0;
 static constexpr unsigned int kAmbiguousOffset = 1;
 static constexpr unsigned int kMissingOffset = 2;
-namespace {
-  template<typename T, typename F> std::unique_ptr<T, F> make_sentry(T* iObject, F iFunc) {
-    return std::unique_ptr<T, F>(iObject, iFunc);
-  }
-}
 
 namespace edm {
 

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -116,6 +116,9 @@ namespace edm {
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    
+      virtual void retrieveAndMerge_(Principal const& principal) const override;
+
       virtual bool unscheduledWasNotRun_() const override final {return false;}
     
       virtual void resetProductData_(bool deleteEarly) override;

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -97,7 +97,10 @@ namespace edm {
     public:
     explicit InputProductResolver(std::shared_ptr<BranchDescription const> bd) :
       DataManagingProductResolver(bd, ProductStatus::ResolveNotRun),
-      m_prefetchRequested{ false } {}
+      m_prefetchRequested{ false },
+      aux_{nullptr} {}
+
+    virtual void setupUnscheduled(UnscheduledConfigurator const&) override final;
 
     private:
       virtual bool isFromCurrentProcess() const override final;
@@ -119,6 +122,8 @@ namespace edm {
 
       mutable std::atomic<bool> m_prefetchRequested;
       mutable WaitingTaskList m_waitingTasks;
+      UnscheduledAuxiliary const* aux_; //provides access to the delayedGet signals
+
 
   };
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -170,8 +170,6 @@ namespace edm {
                                                  &(historyAppenders_[index]),
                                                  index,
                                                  false /*not primary process*/);
-      ep->preModuleDelayedGetSignal_.connect(std::cref(items.actReg_->preModuleEventDelayedGetSignal_));
-      ep->postModuleDelayedGetSignal_.connect(std::cref(items.actReg_->postModuleEventDelayedGetSignal_));
       ep->preReadFromSourceSignal_.connect(std::cref(items.actReg_->preEventReadFromSourceSignal_));
       ep->postReadFromSourceSignal_.connect(std::cref(items.actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -170,8 +170,6 @@ namespace edm {
                                                  &(historyAppenders_[index]),
                                                  index,
                                                  false /*not primary process*/);
-      ep->preReadFromSourceSignal_.connect(std::cref(items.actReg_->preEventReadFromSourceSignal_));
-      ep->postReadFromSourceSignal_.connect(std::cref(items.actReg_->postEventReadFromSourceSignal_));
       principalCache_.insert(ep);
     }
     if(hasSubProcesses) {

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -349,30 +349,18 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -503,30 +491,18 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -657,30 +633,18 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: delayed processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -74,6 +74,14 @@ namespace edm {
       }
       virtual void mergeReaders_(DelayedReader*) override {}
       virtual void reset_() override {}
+      
+      virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const override {
+        return nullptr;
+      }
+      virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const override {
+        return nullptr;
+      };
+
       Long64_t entry_;
       TTree* eventTree_;
       std::shared_ptr<ProductRegistry const>(reg_);

--- a/FWCore/Utilities/interface/make_sentry.h
+++ b/FWCore/Utilities/interface/make_sentry.h
@@ -1,0 +1,34 @@
+#ifndef Framework_Utilities_make_sentry_h
+#define Framework_Utilities_make_sentry_h
+// -*- C++ -*-
+//
+// Package:     Framework/Utilities
+// Class  :     make_sentry
+// 
+/**\function make_sentry make_sentry.h "FWCore/Utilities/interface/make_sentry.h"
+
+ Description: Creates a std::unique_ptr from a lambda to be used as a sentry
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  root
+//         Created:  Fri, 19 Aug 2016 20:02:12 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  ///NOTE: if iObject is null, then iFunc will not be called
+  template<typename T, typename F> std::unique_ptr<T, F> make_sentry(T* iObject, F iFunc) {
+    return std::unique_ptr<T, F>(iObject, iFunc);
+  }
+}
+
+#endif

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -45,6 +45,19 @@ namespace edm {
     RootDelayedReader(RootDelayedReader const&) = delete; // Disallow copying and moving
     RootDelayedReader& operator=(RootDelayedReader const&) = delete; // Disallow copying and moving
 
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const override final {
+      return preEventReadFromSourceSignal_;
+    }
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const override final {
+      return postEventReadFromSourceSignal_;
+    }
+
+    void setSignals(signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+                    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource) {
+      preEventReadFromSourceSignal_ =preEventReadSource;
+      postEventReadFromSourceSignal_ = postEventReadSource;
+    }
+
   private:
     virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
     virtual void mergeReaders_(DelayedReader* other) override {nextReader_ = other;}
@@ -63,6 +76,10 @@ namespace edm {
     std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
     InputType inputType_;
     edm::propagate_const<TClass*> wrapperBaseTClass_;
+    
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal_ = nullptr;
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal_ = nullptr;
+
     //If a fatal exception happens we need to make a copy so we can
     // rethrow that exception on other threads. This avoids TTree
     // non-exception safety problems on later calls to TTree.

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1776,6 +1776,13 @@ namespace edm {
       }
     }
   }
+  
+  void 
+  RootFile::setSignals(signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+                      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource) {
+    eventTree_.setSignals(preEventReadSource,postEventReadSource);
+  }
+
 
   std::unique_ptr<MakeProvenanceReader>
   RootFile::makeProvenanceReaderMaker(InputType inputType) {

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -212,6 +212,8 @@ namespace edm {
     void setPosition(IndexIntoFile::IndexIntoFileItr const& position);
     void initAssociationsFromSecondary(std::vector<BranchID> const&);
 
+    void setSignals(signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+                    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource);
   private:
     RootTreePtrArray& treePointers() {return treePointers_;}
     bool skipThisEntry();

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -290,6 +290,9 @@ namespace edm {
     if(filePtr) {
       size_t currentIndexIntoFile = fileIter_ - fileIterBegin_;
       rootFile_ = makeRootFile(filePtr);
+      if(input) {
+        rootFile_->setSignals(&(input->preEventReadFromSourceSignal_), &(input->postEventReadFromSourceSignal_));
+      }
       assert(rootFile_);
       fileIterLastOpened_ = fileIter_;
       setIndexIntoFile(currentIndexIntoFile);

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -474,6 +474,14 @@ namespace edm {
     } 
  
   }
+  
+  void
+  RootTree::setSignals(signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+                       signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource) {
+    rootDelayedReader_->setSignals(preEventReadSource,
+                                   postEventReadSource);
+  }
+
 
   namespace roottree {
     Int_t

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -29,9 +29,17 @@ class TTreeCache;
 
 namespace edm {
   class BranchKey;
-  class DelayedReader;
+  class RootDelayedReader;
   class InputFile;
   class RootTree;
+
+  class StreamContext;
+  class ModuleCallingContext;
+  
+  namespace signalslot {
+    template <typename T> class Signal;
+  }
+
 
   namespace roottree {
     unsigned int const defaultCacheSize = 20U * 1024 * 1024;
@@ -152,6 +160,10 @@ namespace edm {
     void resetTraining() {trainNow_ = true;}
 
     BranchType branchType() const {return branchType_;}
+    
+    void setSignals(signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+                    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource);
+
   private:
     void setCacheSize(unsigned int cacheSize);
     void setTreeMaxVirtualSize(int treeMaxVirtualSize);
@@ -191,7 +203,7 @@ namespace edm {
 // effect on the primary treeCache_; all other caches have this explicitly disabled.
     bool enablePrefetching_;
     bool enableTriggerCache_;
-    std::unique_ptr<DelayedReader> rootDelayedReader_;
+    std::unique_ptr<RootDelayedReader> rootDelayedReader_;
 
     TBranch* branchEntryInfoBranch_; //backwards compatibility
     // below for backward compatibility


### PR DESCRIPTION
Moved communicating with the DelayedReader from the Principal into the InputProductResolver. This   allows a more maintainable system as well as better application of the shared resource handling.
