### PR TITLE
Fix throwing CapacityExausted

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -299,7 +299,7 @@ namespace edmNew {
         bool expected=false;
         while (!m_v.m_filling.compare_exchange_weak(expected,true))  { expected=false; nanosleep(0,0);}
         int offset = m_v.m_data.size();
-        if (m_v.onDemand() && m_v.m_data.capacity()<offset+m_lv.size()) {
+        if (m_v.onDemand() && full()) {
           m_v.m_filling = false;
           dstvdetails::throwCapacityExausted();
         }
@@ -313,6 +313,11 @@ namespace edmNew {
       
 #endif
       
+     bool full() const {
+        int offset = m_v.m_data.size();
+        return m_v.m_data.capacity()<offset+m_lv.size();
+     }
+
       void abort() {
         m_lv.clear();
       }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -141,7 +141,7 @@ namespace {
     
 #ifdef VIDEBUG
     struct Stat {
-      Stat() : totDet(0), detReady(0),detSet(0),detAct(0),detNoZ(0),totClus(0){}
+      Stat() : totDet(0), detReady(0),detSet(0),detAct(0),detNoZ(0),detAbrt(0),totClus(0){}
       std::atomic<int> totDet; // all dets
       std::atomic<int> detReady; // dets "updated"
       std::atomic<int> detSet;  // det actually set not empty

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -464,6 +464,7 @@ try { // edmNew::CapacityExaustedException
   incAct();
  
   if (record.full()) {
+    edm::LogError(sistrip::mlRawToCluster_) << "too many Sistrip Clusters to fit space allocated for OnDemand for " << record.id() << ' ' << record.size();
     record.abort();
     incAbrt();
   }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -147,6 +147,7 @@ namespace {
       std::atomic<int> detSet;  // det actually set not empty
       std::atomic<int> detAct;  // det actually set with content
       std::atomic<int> detNoZ;  // det actually set with content
+      std::atomic<int> detAbrt;  // det aborted
       std::atomic<int> totClus; // total number of clusters
     };
     
@@ -157,9 +158,10 @@ namespace {
     void incSet() const { stat.detSet++;}
     void incAct() const { stat.detAct++;}
     void incNoZ() const { stat.detNoZ++;}
+    void incAbrt() const { stat.detAbrt++;}
     void incClus(int n) const { stat.totClus+=n;}
     void printStat() const {
-      COUT << "VI clusters " << stat.totDet <<','<< stat.detReady <<','<< stat.detSet <<','<< stat.detAct<<','<< stat.detNoZ <<','<< stat.totClus << std::endl;
+      COUT << "VI clusters " << stat.totDet <<','<< stat.detReady <<','<< stat.detSet <<','<< stat.detAct<<','<< stat.detNoZ <<','<<stat.detAbrt <<','<<stat.totClus << std::endl;
     }
     
 #else
@@ -169,6 +171,7 @@ namespace {
     static void incSet() {}
     static void incAct() {}
     static void incNoZ() {}
+    static void incAbrt(){}
     static void incClus(int){}
     static void printStat(){}
 #endif
@@ -459,6 +462,12 @@ try { // edmNew::CapacityExaustedException
   clusterizer.stripByStripEnd(state,record);
   
   incAct();
+ 
+  if (record.full()) {
+    record.abort();
+    incAbrt();
+  }
+  
   if(!record.empty()) incNoZ();
 
   COUT << "filled " << record.size() << std::endl;


### PR DESCRIPTION
catch "buffer full" before insertion (as in pre-threadSafe version).
print LogError (as in pre-threadSafe version).
tested with runTheMatrix and addOnTests.py -t hlt_data_GRun reducing the capacity to 10K...

will recompile the universe
