### PR TITLE
80X: miscellaneous fixes to new FSQ vtx smearing parameters

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -44,8 +44,8 @@ VtxSmeared = {
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
     'Nominal5TeVpp2015Collision':    'IOMC.EventVertexGenerators.VtxSmearedNominal5TeVpp2015Collision_cfi',
     'Realistic25ns13TeV2016Collision':    'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeV2016Collision_cfi',
-    'Realistic25ns13TeVCollisionBetaStar90m' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVCollisionBetaStar90m',
-    'Realistic25ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVCollisionBetaStar90mLowBunches'
+    'Realistic100ns13TeVCollisionBetaStar90m' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi',
+    'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi'
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='NominalHICollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -475,7 +475,7 @@ Realistic50ns13TeVCollisionVtxSmearingParameters = cms.PSet(
 #
 # Emittance has been calculated to match a BeamWidht of O(10um) with: https://lpc.web.cern.ch/lumi2.html
 #
-Realistic25ns13TeVCollisionBetaStar90mVtxSmearingParameters = cms.PSet(
+Realistic100ns13TeVCollisionBetaStar90mVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(9121.0),
     Emittance = cms.double(0.12e-7),
@@ -500,7 +500,7 @@ Realistic25ns13TeVCollisionBetaStar90mVtxSmearingParameters = cms.PSet(
 #
 # Emittance has been calculated to match a BeamWidht of O(10um) with: https://lpc.web.cern.ch/lumi2.html
 #
-Realistic25ns13TeVCollisionBetaStar90mLowBunchesVtxSmearingParameters = cms.PSet(
+Realistic100ns13TeVCollisionBetaStar90mLowBunchesVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(9121.0),
     Emittance = cms.double(0.12e-7),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
-    Realistic25ns13TeVCollisionBetaStar90mVtxSmearingParameters,
+    Realistic100ns13TeVCollisionBetaStar90mLowBunchesVtxSmearingParameters,
     VtxSmearedCommon
 )

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
-    Realistic25ns13TeVCollisionBetaStar90mLowBunchesVtxSmearingParameters,
+    Realistic100ns13TeVCollisionBetaStar90mVtxSmearingParameters,
     VtxSmearedCommon
 )


### PR DESCRIPTION
Two fixes:   
- correcting the names of the scenarios to contain correct bunch spacing
- fixing `Configuration/StandardSequences/python/VtxSmeared.py` adding `_cfi` at the end of configuration fragment 
