### PR TITLE
Modifications to include HLT_DoubleMu0 path in the HeavyFlavor DQM package in CMSSW_8_1_X

### DIFF
--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -104,6 +104,11 @@ hfvTau3mu = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu3_Trk_tau3mu_v')
 )
 
+### DoubleMu0
+hfvDoubleMu0 = heavyFlavorValidationHarvesting.clone(
+  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu0')
+)
+
 combiner = cms.EDAnalyzer('PlotCombiner',
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),
   Plots = cms.untracked.VPSet(
@@ -154,6 +159,7 @@ heavyFlavorValidationHarvestingSequence = cms.Sequence(
   +hfv6+hfv7+hfv8+hfv9
   +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
   +hfvTau3mu
+  +hfvDoubleMu0
 	+combiner+combiner2
 )
 

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
@@ -110,6 +110,10 @@ hfvTau3mu = hfv1.clone(
     TriggerPathName = cms.untracked.string("HLT_DoubleMu3_Trk_tau3mu_v")
 )
 
+### DoubleMu0
+hfvDoubleMu0 = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_DoubleMu0")
+)
 
 heavyFlavorValidationSequence = cms.Sequence(
   hfv1+hfv2+hfv3+hfv4+hfv5 
@@ -117,5 +121,6 @@ heavyFlavorValidationSequence = cms.Sequence(
   +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8+hfvTnP9+hfvTnP10+hfvTnP11
   +hfv6+hfv7+hfv8+hfv9
   +hfvTau3mu
+  +hfvDoubleMu0
   +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
 )


### PR DESCRIPTION
Dear Experts,

Please incorporate the following modifications to include HLT_DoubleMu0 path in the HeavyFlavor DQM package in CMSSW_8_1_X:

https://github.com/cms-sw/cmssw/commit/dc186ebc95ba021e807dbbd6b5f37db8a87a3572

We have not made any changes in the c++ code.

Regards,
Nairit
