### PR TITLE
Set Global Quality to show RED when FE is disabled

### DIFF
--- a/DQM/EcalMonitorClient/src/RawDataClient.cc
+++ b/DQM/EcalMonitorClient/src/RawDataClient.cc
@@ -64,7 +64,7 @@ namespace ecaldqm {
         float entries(sFEStatus.getBinContent(id, iS + 1));
         towerEntries += entries;
         if(entries > 0. &&
-           iS != Enabled && iS != Disabled && iS != Suppressed &&
+           iS != Enabled && iS != Suppressed &&
            iS != FIFOFull && iS != FIFOFullL1ADesync && iS != ForcedZS)
           towerStatus = doMask ? kMBad : kBad;
       }

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -115,7 +115,7 @@ namespace ecaldqm
       // Initialize individual Quality Summaries
       // NOTE: These represent quality over *cumulative* statistics
       int integrity(sIntegrity ? sIntegrity->getBinContent(id) : kUnknown);
-      if(integrity == kUnknown || integrity == kMUnknown){
+      if(integrity == kMUnknown){
         qItr->setBinContent(integrity);
         if ( onlineMode_ ) continue;
       }


### PR DESCRIPTION
**Set Global and Raw Data Quality Summaries to correctly show RED when an FE is in DISABLED state:**
(1) Include channels with integrity=kUnknown in global quality summary analysis.
(2) Set RawData Quality Summary to show RED when FE is in DISABLED state.

**Background:**
(1) At the moment, if integrity=kUnknown or kMUnknown, the channel is not analyzed.
- The fix ensures status from other quality inputs are still propagated to Global Quality even if Integrity=kUnknown for that channel as occurs when there is low/zero digi occupancy
- In collisions run 278821, the entire EE+04 was RED in Trigger Primitives but because Integrity showed YELLOW, the Bad status from TPs was not propagated to Global Quality. The nature of the problem caused digis to not be produced for this FED.
- Moreover, a patch implemented by Pierre some time ago prevents DCC desync errors--which normally trigger the Integrity Summary to show RED--to no longer be propagated to the DQM, so DQM thinks there are no errors and that the occupancy is just harmlessly low/zero

(2) At the moment, an FE in DISABLED state is not a trigger for Raw Data Quality to show RED.
- Also in collisions run 278821, the entire EE+04 was in RawData=DISABLED, with no raw data (and so digis and rechits) being produced for the entire FED. The whole run had to be flagged as BAD as a result.
- As approved by PFG, the severity of the problem warrants RawData=DISABLED to be included in the list of states that should be set to show RED, as implemented in this fix

In conjunction with 81X PR https://github.com/cms-sw/cmssw/pull/15553
