### PR TITLE
remove unused variable to avoid gcc493 build errors

### DIFF
--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -438,7 +438,6 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
        NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("Mean number of vertices",2);
 
-       int GoodPVtxBin      = conf_.getParameter<int>("GoodPVtxBin");
        double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
        double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
        


### PR DESCRIPTION
this should fix the build error of gcc493 IBs 

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc493/CMSSW_8_1_X_2016-08-22-1100/DQM/TrackingMonitor
