### PR TITLE
Set siPixelClusters.MissCalibrate=True for phase1

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -28,5 +28,4 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
 from Configuration.StandardSequences.Eras import eras
 eras.phase1Pixel.toModify(siPixelClusters, # FIXME
     src = 'simSiPixelDigis',
-    MissCalibrate = False
 )


### PR DESCRIPTION
The (sim) pixel digitizer `MissCalibrate` parameter was set to `True` in #13357, so the `siPixelClusters.MissCalibrate` needs to be set to `True` as well.

Tested in 8_1_0_pre10, small changes (numerical-level on tracking) expected in phase1 workflows (no changes expected for phase0/2). Here are MTV plots for 1000 TTbar noPU events https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre10_phase1MissCalibrate/.

Another PR switching the 2017 workflow to "digi->raw->digi" chain for pixels will follow once this gets merged.

@rovere @VinInn @dkotlins @veszpv
