### PR TITLE
Puppi MET and MET significance fixes in the MET tool

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -54,7 +54,7 @@ namespace pat {
       MET(const edm::Ptr<reco::MET> & aMETRef);
       /// copy constructor
       MET( MET const&);
-      /// cosntructor for corrected METs (keeping specific informations from src MET)
+      /// constructor for corrected METs (keeping specific informations from src MET)
       MET(const reco::MET & corMET, const MET& srcMET );
       /// destructor
       virtual ~MET();

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -80,6 +80,8 @@ pfMET_(srcMET.pfMET_),
 metSig_(srcMET.metSig_),
 caloPackedMet_(srcMET.caloPackedMet_) {
 
+  setSignificanceMatrix(srcMET.getSignificanceMatrix());
+
   initCorMap();
 }
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -50,7 +50,7 @@ patMETs = cms.EDProducer("PATMETProducer",
     # significance computation parameters, not used
     # if the significance is not computed
     srcJets = cms.InputTag("selectedPatJets"),
-    srcPFCands =  cms.InputTag("packedPFCandidates"),
+    srcPFCands =  cms.InputTag("particleFlow"),
     srcLeptons = cms.VInputTag("selectedPatElectrons", "selectedPatMuons", "selectedPatPhotons"),
     srcJetSF = cms.string('AK4PFchs'),
     srcJetResPt = cms.string('AK4PFchs_pt'),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -46,7 +46,7 @@ patMETs = cms.EDProducer("PATMETProducer",
     resolutions     = cms.PSet(),
 
     # significance
-    computeMETSignificance  = cms.bool(True),
+    computeMETSignificance  = cms.bool(False),
     # significance computation parameters, not used
     # if the significance is not computed
     srcJets = cms.InputTag("selectedPatJets"),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -46,7 +46,7 @@ patMETs = cms.EDProducer("PATMETProducer",
     resolutions     = cms.PSet(),
 
     # significance
-    computeMETSignificance  = cms.bool(False),
+    computeMETSignificance  = cms.bool(True),
     # significance computation parameters, not used
     # if the significance is not computed
     srcJets = cms.InputTag("selectedPatJets"),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -275,7 +275,7 @@ def miniAOD_customizeCommon(process):
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies
     makePuppies( process );
 
-    runMetCorAndUncForMiniAODProduction(process, metType="PF",
+    runMetCorAndUncForMiniAODProduction(process, metType="Puppi",
                                         pfCandColl=cms.InputTag("puppiForMET"),
                                         jetCollUnskimmed="slimmedJetsPuppi",
                                         recoMetFromPFCs=True,

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -22,14 +22,14 @@ process.options = cms.untracked.PSet(
 
 # How many events to process
 process.maxEvents = cms.untracked.PSet( 
-   input = cms.untracked.int32(10)
+   input = cms.untracked.int32(100)
 )
 
 #configurable options =======================================================================
 runOnData=False #data/MC switch
 usePrivateSQlite=False #use external JECs (sqlite file)
 useHFCandidates=True #create an additionnal NoHF slimmed MET collection if the option is set to false
-redoPuppi=False # rebuild puppiMET
+redoPuppi=True # rebuild puppiMET
 #===================================================================
 
 
@@ -75,9 +75,9 @@ if usePrivateSQlite:
 ### =====================================================================================================
 # Define the input source
 if runOnData:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_0_0_pre4/SinglePhoton/MINIAOD/80X_dataRun2_v0_RelVal_sigPh2015D-v1/00000/600919D1-51AA-E511-8E4C-0025905B855C.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre9/DoubleEG/MINIAOD/81X_dataRun2_relval_v2_RelVal_doubEG2015D-v1/10000/029C887F-2D53-E611-92EE-0CC47A74525A.root'
 else:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_0_3/RelValTTbar_13/MINIAODSIM/PU25ns_80X_mcRun2_asymptotic_2016_v3_gs7120p2NewGTv3-v1/00000/36E82F31-D6EF-E511-A22B-0025905B8574.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre9/RelValTTbar_13/MINIAODSIM/PU25ns_81X_mcRun2_asymptotic_v2-v1/10000/8C46B127-3253-E611-BEBF-0025905A605E.root'
 
 # Define the input source
 process.source = cms.Source("PoolSource", 
@@ -120,6 +120,7 @@ if redoPuppi:
 
   runMetCorAndUncFromMiniAOD(process,
                              isData=runOnData,
+                             metType="Puppi",
                              pfCandColl=cms.InputTag("puppiForMET"),
                              recoMetFromPFCs=True,
                              reclusterJets=True,
@@ -141,8 +142,6 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
                                             "keep *_patPFMetT1Smear_*_*",
                                             "keep *_patPFMetT1SmearJetResDown_*_*",
                                             "keep *_patPFMetT1SmearJetResUp_*_*",
-                                            "keep *_puppiForMET_*_*",
-                                            "keep *_puppi_*_*",
                                             "keep *_patPFMetT1Puppi_*_*",
                                             "keep *_slimmedMETsPuppi_*_*",
                                             ),

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -75,9 +75,9 @@ if usePrivateSQlite:
 ### =====================================================================================================
 # Define the input source
 if runOnData:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre9/DoubleEG/MINIAOD/81X_dataRun2_relval_v2_RelVal_doubEG2015D-v1/10000/029C887F-2D53-E611-92EE-0CC47A74525A.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre10/DoubleEG/MINIAOD/81X_dataRun2_relval_v4_RelVal_doubEG2015D-v1/00000/88859857-6168-E611-9E79-0025905A60AA.root'
 else:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre9/RelValTTbar_13/MINIAODSIM/PU25ns_81X_mcRun2_asymptotic_v2-v1/10000/8C46B127-3253-E611-BEBF-0025905A605E.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbar_13/MINIAODSIM/81X_mcRun2_asymptotic_v5_recycle-v1/00000/B49E8325-6E67-E611-BFE7-0025905A60D0.root'
 
 # Define the input source
 process.source = cms.Source("PoolSource", 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -536,6 +536,18 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
+            if self._parameters["runOnData"].value:
+                getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
+            if "Puppi" in postfix:
+                getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')
+                getattr(process, "pat"+metType+"Met"+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
+                getattr(process, "pat"+metType+"Met"+postfix).srcJetSF = cms.string('AK4PFPuppi')
+                getattr(process, "pat"+metType+"Met"+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
+                getattr(process, "pat"+metType+"Met"+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
+
+        #MET significance bypass for the patMETs from AOD
+        if not self._parameters["onMiniAOD"].value:
+            getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
 
         #T1 parameter tuning when CHS jets are not used
         if "T1" in correctionLevel and not self._parameters["CHS"].value:  
@@ -1238,6 +1250,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
                 setattr(process, 'patMETs'+postfix, getattr(process,'patMETs' ).clone() )
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
+                getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
+                if "Puppi" in postfix:
+                    getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
+                    getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
+                    getattr(process, 'patMETs'+postfix).srcJetSF = cms.string('AK4PFPuppi')
+                    getattr(process, 'patMETs'+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
+                    getattr(process, 'patMETs'+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
 
 
     def extractMET(self, process, correctionLevel, patMetModuleSequence, postfix):

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -57,7 +57,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 # the file is used only for local running
         self.addParameter(self._defaultParameters, 'jecUncertaintyFile', '',
                           "Extra JES uncertainty file", Type=str)
-        self.addParameter(self._defaultParameters, 'jecUncertaintyTag', 'Uncertainty',
+        self.addParameter(self._defaultParameters, 'jecUncertaintyTag', None,
                           "JES uncertainty Tag", Type=str)
         
         self.addParameter(self._defaultParameters, 'mvaMetLeptons',["Electrons","Muons"],
@@ -271,8 +271,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #prepare jet configuration
         jetUncInfos = { "jCorrPayload":jetFlavor, "jCorLabelUpToL3":jetCorLabelUpToL3,
                         "jCorLabelL3Res":jetCorLabelL3Res, "jecUncFile":jecUncertaintyFile,
-                        "jecUncTag":jecUncertaintyTag }        
+                        "jecUncTag":"Uncertainty" }     
 
+        if (jecUncertaintyFile!="" and jecUncertaintyTag==None):
+            jetUncInfos[ "jecUncTag" ] = ""
+        else:
+            jetUncInfos[ "jecUncTag" ] = jecUncertaintyTag
+            
         patMetModuleSequence = cms.Sequence()
 
         # recompute the MET (and thus the jets as well for correction) from scratch

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -562,6 +562,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #MET significance bypass for the patMETs from AOD
         if not self._parameters["onMiniAOD"].value:
             getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
+            getattr(process, "patMETs"+postfix).srcPFCands=self._parameters["pfCandCollection"].value
 
         #T1 parameter tuning when CHS jets are not used
         if "T1" in correctionLevel and not self._parameters["CHS"].value:  

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -23,7 +23,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
     def __init__(self):
         ConfigToolBase.__init__(self)
         self.addParameter(self._defaultParameters, 'metType', "PF",
-                          "Type of considered MET (only PF supported so far)", Type=str)
+                          "Type of considered MET (only PF and Puppi supported so far)", Type=str)
         self.addParameter(self._defaultParameters, 'correctionLevel', [""],
                           "level of correction : available corrections for pfMet are T0, T1, T2, Txy and Smear; irrelevant entry for MVAMet)",
                           allowedValues=["T0","T1","T2","Txy","Smear",""])
@@ -83,6 +83,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Switch on miniAOD configuration", Type=bool)
         self.addParameter(self._defaultParameters, 'postfix', '',
                           "Technical parameter to identify the resulting sequence and its modules (allows multiple calls in a job)", Type=str)
+
+
+        #private parameters
+        self.addParameter(self._defaultParameters, 'Puppi', False,
+                          "Puppi algorithm (private)", Type=bool)
+
+
+
         self._parameters = copy.deepcopy(self._defaultParameters)
         self._comment = ""
 
@@ -212,9 +220,15 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('postfix',postfix),
 
         #if mva/puppi MET, autoswitch to std jets
-        if metType == "MVA" or 'Puppi' in postfix:
+        if metType == "MVA" or metType == "Puppi":
             self.setParameter('CHS',False),
 
+        #enabling puppi flag
+        self.setParameter('Puppi',self._defaultParameters['Puppi'].value) 
+        if metType == "Puppi":
+            self.setParameter('metType',"PF") 
+            self.setParameter('Puppi',True) 
+            
         #jet energy scale uncertainty needs
         if manualJetConfig:
             self.setParameter('CHS',CHS)
@@ -231,7 +245,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         
         #ZD: puppi jet reclustering breaks the puppi jets
         #overwriting of jet reclustering parameter for puppi
-        if 'Puppi' in postfix and not onMiniAOD:
+        if self._parameters["Puppi"].value and not onMiniAOD:
             self.setParameter('reclusterJets',False)
 
         #jet collection overloading for automatic jet reclustering or JEC application
@@ -337,12 +351,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"patPFMetT1T2Corr"+postfix).src = jetCollection
             getattr(process,"patPFMetT2Corr"+postfix).src = jetCollection
             #ZD:puppi currently doesn't have the L1 corrections in the GT
-            if 'Puppi' in postfix:
+            if self._parameters["Puppi"].value:
                 getattr(process,"patPFMetT1T2Corr"+postfix).offsetCorrLabel = cms.InputTag("")
                 getattr(process,"patPFMetT2Corr"+postfix).offsetCorrLabel = cms.InputTag("")
         if "Smear" in metModName:
             getattr(process,"patSmearedJets"+postfix).src = jetCollection
-            if 'Puppi' in postfix:
+            if self._parameters["Puppi"].value:
                 getattr(process,"patPFMetT1T2SmearCorr"+postfix).offsetCorrLabel = cms.InputTag("")
 
  
@@ -418,7 +432,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
             
         if postfix != "" and metType == "PF" and not hasattr(process, 'pat'+metType+'Met'+postfix):
-            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if "Puppi" not in postfix else []
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if not self._parameters["Puppi"].value else []
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp)
             setattr(process, 'pat'+metType+'Met'+postfix, getattr(process,'patPFMet' ).clone() )
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
@@ -477,7 +491,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             }
 
         if postfix != "":
-            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if "Puppi" not in postfix else []
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if not self._parameters["Puppi"].value else []
             if not hasattr(process, "patPFMetT0CorrSequence"+postfix):
                 configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT0CorrSequence"), postfix, noClones = noClonesTmp)
             if not hasattr(process, "patPFMetT1T2CorrSequence"+postfix):
@@ -538,7 +552,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
             if self._parameters["runOnData"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
-            if "Puppi" in postfix:
+            if self._parameters["Puppi"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')
                 getattr(process, "pat"+metType+"Met"+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
                 getattr(process, "pat"+metType+"Met"+postfix).srcJetSF = cms.string('AK4PFPuppi')
@@ -558,7 +572,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "corrPfMetType1"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
             getattr(process, "basicJetsForMet"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
         
-        if "T1" in correctionLevel and 'Puppi' in postfix:  
+        if "T1" in correctionLevel and self._parameters["Puppi"].value:  
             setattr(process, "corrPfMetType1"+postfix, getattr(process, "corrPfMetType1" ).clone() )
             getattr(process, "corrPfMetType1"+postfix).src =  cms.InputTag("ak4PFJets"+postfix)
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabel = cms.InputTag("ak4PFPuppiL1FastL2L3Corrector")
@@ -1243,7 +1257,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"patMETCorrections"), postfix)
                   
             #T1 pfMet for AOD to mAOD only
-            if not onMiniAOD or "Puppi" in postfix:
+            if not onMiniAOD or self._parameters["Puppi"].value:
                 #correction duplication needed
                 getattr(process, "pfMetT1"+postfix).src = cms.InputTag("pfMet"+postfix)
                 patMetModuleSequence += getattr(process, "pfMetT1"+postfix)
@@ -1251,7 +1265,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 setattr(process, 'patMETs'+postfix, getattr(process,'patMETs' ).clone() )
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
-                if "Puppi" in postfix:
+                if self._parameters["Puppi"].value:
                     getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
                     getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
                     getattr(process, 'patMETs'+postfix).srcJetSF = cms.string('AK4PFPuppi')
@@ -1287,7 +1301,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
-            payload = 'AK4PFchs' if "Puppi" not in postfix else 'AK4PFPuppi' ) # always CHS from miniAODs, except for puppi
+            payload = 'AK4PFchs' if not self._parameters["Puppi"].value else 'AK4PFPuppi' ) # always CHS from miniAODs, except for puppi
         
         if self._parameters["runOnData"].value:
             patJetCorrFactorsReapplyJEC.levels.append("L2L3Residual")
@@ -1399,7 +1413,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             
             getattr(process,"patJetCorrFactors"+postfix).src=cms.InputTag(jetColName)
             getattr(process,"patJetCorrFactors"+postfix).primaryVertices= cms.InputTag("offlineSlimmedPrimaryVertices")
-            if "Puppi" in postfix:
+            if self._parameters["Puppi"].value:
                 getattr(process,"patJetCorrFactors"+postfix).payload=cms.string('AK4PFPuppi')
 
         return cms.InputTag("patJets"+postfix)
@@ -1595,7 +1609,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
     
     #MET flavors
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T0","T1","T2","Smear","Txy"],
                                       computeUncertainties=False,
                                       produceIntermediateCorrections=True,
@@ -1615,7 +1629,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       )
     
     #MET T1 uncertainties
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1"],
                                       computeUncertainties=True,
                                       produceIntermediateCorrections=False,
@@ -1635,7 +1649,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       )
     
     #MET T1 Smeared JER uncertainties
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1","Smear"],
                                       computeUncertainties=True,
                                       produceIntermediateCorrections=False,
@@ -1682,7 +1696,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
 
     #MET T1 uncertainties
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1"],
                                       computeUncertainties=True,
                                       produceIntermediateCorrections=False,
@@ -1709,7 +1723,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       )
     
     #MET T1+Txy / Smear
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1","Txy"],
                                       computeUncertainties=False,
                                       produceIntermediateCorrections=True,
@@ -1735,7 +1749,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       postfix=postfix,
                                       )
     #MET T1+Smear + uncertainties
-    runMETCorrectionsAndUncertainties(process, metType="PF",
+    runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1","Smear"],
                                       computeUncertainties=True,
                                       produceIntermediateCorrections=False,

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -550,6 +550,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
+            getattr(process, "pat"+metType+"Met"+postfix).srcPFCands =  cms.InputTag("packedPFCandidates")
             if self._parameters["runOnData"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
             if self._parameters["Puppi"].value:

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -432,7 +432,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
             
         if postfix != "" and metType == "PF" and not hasattr(process, 'pat'+metType+'Met'+postfix):
-            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if not self._parameters["Puppi"].value else []
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp)
             setattr(process, 'pat'+metType+'Met'+postfix, getattr(process,'patPFMet' ).clone() )
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
@@ -491,7 +491,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             }
 
         if postfix != "":
-            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ] if not self._parameters["Puppi"].value else []
+            noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
             if not hasattr(process, "patPFMetT0CorrSequence"+postfix):
                 configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT0CorrSequence"), postfix, noClones = noClonesTmp)
             if not hasattr(process, "patPFMetT1T2CorrSequence"+postfix):

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -551,6 +551,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
             getattr(process, "pat"+metType+"Met"+postfix).srcPFCands =  cms.InputTag("packedPFCandidates")
+            if postfix=="NoHF":
+                getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
             if self._parameters["runOnData"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
             if self._parameters["Puppi"].value:
@@ -561,7 +563,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, "pat"+metType+"Met"+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
 
         #MET significance bypass for the patMETs from AOD
-        if not self._parameters["onMiniAOD"].value:
+        if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
             getattr(process, "patMETs"+postfix).srcPFCands=self._parameters["pfCandCollection"].value
 
@@ -1271,6 +1273,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 setattr(process, 'patMETs'+postfix, getattr(process,'patMETs' ).clone() )
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
+                if postfix=="NoHF":
+                    getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(False)
+                getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
                 if self._parameters["Puppi"].value:
                     getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
                     getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
@@ -1490,7 +1495,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                              metSource = "metrawCalo"+postfix
                              )
             getattr(process,"patCaloMet").addGenMET = False
-            
 
             #smearing and type0 variations not yet supported in reprocessing
             #del getattr(process,"slimmedMETs"+postfix).t1SmearedVarsAndUncs

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1195,7 +1195,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 enabled = cms.bool(smear),
                 variation = cms.int32( int(varyByNsigmas) ),
                 )    
-           
+
+        if self._parameters["Puppi"].value:
+            smearedJetModule.algo = cms.string('AK4PFPuppi')
+            smearedJetModule.algopt = cms.string('AK4PFPuppi_pt')
+
         #MM: FIXME MVA
         #if "MVA" == self._parameters["metType"].value:
         #    from RecoMET.METProducers.METSigParams_cfi import *
@@ -1403,13 +1407,17 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                 jetCorrections = ('AK4PF'+CHSname, corLevels , ''),
                                 postfix=postfix
                                 )
-
+            
             getattr(process,"patJets"+postfix).addGenJetMatch = False 
             getattr(process,"patJets"+postfix).addGenPartonMatch = False 
             getattr(process,"patJets"+postfix).addPartonJetMatch = False 
+            getattr(process,"patJets"+postfix).embedGenPartonMatch = False 
+            getattr(process,"patJets"+postfix).embedGenJetMatch = False 
             if self._parameters['onMiniAOD'].value:
                 del getattr(process,"patJets"+postfix).JetFlavourInfoSource
                 del getattr(process,"patJets"+postfix).JetPartonMapSource
+                del getattr(process,"patJets"+postfix).genPartonMatch
+                del getattr(process,"patJets"+postfix).genJetMatch
             getattr(process,"patJets"+postfix).getJetMCFlavour = False
             
             getattr(process,"patJetCorrFactors"+postfix).src=cms.InputTag(jetColName)
@@ -1507,6 +1515,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             jetCorLabelL3ResName += "CHS"
         elif "Puppi" in jetFlavor:
             self.setParameter("CHS",False)
+            jetCorLabelUpToL3Name += "Puppi"
+            jetCorLabelL3ResName += "Puppi"
             
         else:
             self.setParameter("CHS",False)

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -12,7 +12,32 @@ METSignificanceParams = cms.PSet(
       jeta = cms.vdouble(0.8, 1.3, 1.9, 2.5),
 
       # tuning parameters
-      jpar = cms.vdouble(1.20,1.13,1.03,0.96,1.08),
-      pjpar = cms.vdouble(-1.9,0.6383)
+      #Run I, based on 53X / JME-13-003
+      #jpar = cms.vdouble(1.20,1.13,1.03,0.96,1.08),
+      #pjpar = cms.vdouble(-1.9,0.6383)
+      #Run II MC, based on 76X
+      #https://indico.cern.ch/event/527789/contributions/2160488/attachments/1271716/1884792/nmirman_20160511.pdf
+      jpar = cms.vdouble(1.29,1.19,1.07,1.13,1.12),
+      pjpar = cms.vdouble(-0.04,0.6504),
+      )
 
+METSignificanceParams_Data=cms.PSet(
+
+      # jet resolutions
+      jetThreshold = cms.double(15),
+      
+      #jet-lepton matching dR
+      dRMatch = cms.double(0.4),
+
+      # eta bins for jet resolution tuning
+      jeta = cms.vdouble(0.8, 1.3, 1.9, 2.5),
+
+      # tuning parameters
+      #Run I, based on 53X / JME-13-003
+      #jpar = cms.vdouble(1.20,1.13,1.03,0.96,1.08),
+      #pjpar = cms.vdouble(-1.9,0.6383)
+      #Run II data, based on 76X
+      #https://indico.cern.ch/event/527789/contributions/2160488/attachments/1271716/1884792/nmirman_20160511.pdf
+      jpar = cms.vdouble(1.26,1.14,1.13,1.13,1.06),
+      pjpar = cms.vdouble(-3.3,0.5961),
       )


### PR DESCRIPTION
This PR fixes several bugs and inconsistencies in the PAT MET tool :
- use of proper JECs for the Puppi MET
- fix the MET significance storage when miniAOD are produced
- update the MET significance tune
- modify some MET constructors (RECO and PAT) to keep the met significance matrix when met objects is copied.

Changes expected : 
- Puppi MET and its uncertainties
- MET significance

The puppi MET results will have sense when #15562 will be integrated.

Packages impacted:
- DataFormats/METReco
- DataFormats/PatCandidates
- PhysicsTools/PatAlgos
- PhysicsTools/PatUtils
- RecoMET/METProducers

Local tests and matrix tests seems successfull.

I will be out of office from August 27th to September 17th. If comments comes during that period, please contact @mariadalfonso and @zdemirag .
