### PR TITLE
fix nan Calo-towers, when HO is deactivated, but has energy deposit (and ECAL/HCAL do not have any energy deposits)

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -999,8 +999,8 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
     
     
     // insert in collection (remove and return if below threshold)
-    if unlikely ( (towerP4[3]==0) & (E_outer>0)  ) {
-      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(0,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
+    if unlikely ( (towerP4[3]==0) & (E_outer>0) & (!theHOIsUsed) ) {
+      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(1e-9,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
     } else {
       collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
     }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -999,8 +999,9 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
     
     
     // insert in collection (remove and return if below threshold)
-    if unlikely ( (towerP4[3]==0) & (E_outer>0) & (!theHOIsUsed) ) {
-      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(1e-9,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
+    if unlikely ( (towerP4[3]==0) & (E_outer>0)  ) {
+        float val = theHOIsUsed ? 0 : 1E-9; // to keep backwards compatibility for theHOIsUsed == true
+        collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(val,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint); 
     } else {
       collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
     }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -932,7 +932,7 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
 	    // double emPf = 1.0/cosh(emPoint.eta());
 	    // towerP4 += CaloTower::PolarLorentzVector(E_em*emPf, emPoint.eta(), emPoint.phi(), 0); 
 	  }
-	  if ( (E_had + E_outer) >0) {
+	  if ( E_had_tot >0) {
             massless = (E_em<=0);
 	    hadPoint  = hadShwrPos(id, momHadDepth);
 	    auto lP4 = hadPoint.basicVector().unit();
@@ -953,6 +953,13 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
 	    //  towerP4 += CaloTower::PolarLorentzVector(E_had_tot*hadPf, hadPoint.eta(), hadPoint.phi(), 0); 
 	    // }
 	  }
+          if (E_had_tot==0 && E_em==0 && !theHOIsUsed && E_outer>0) { //extra-fallback for deactivated HO and zero E_em and E_had deposits to avoid nan towers
+	    auto lP4 = hadPoint.basicVector().unit();
+	    lP4[3] = 1.f;  // energy
+	    lP4 *=1e-9; // set to tiny pt to avoid nan
+	    towerP4 +=lP4;
+          }
+          
 	}
 	else {  // forward detector: use the CaloTower position 
 	  GlobalPoint p=theTowerGeometry->getGeometry(id)->getPosition();

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -932,7 +932,7 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
 	    // double emPf = 1.0/cosh(emPoint.eta());
 	    // towerP4 += CaloTower::PolarLorentzVector(E_em*emPf, emPoint.eta(), emPoint.phi(), 0); 
 	  }
-	  if ( E_had_tot >0) {
+	  if ( (E_had + E_outer) >0) {
             massless = (E_em<=0);
 	    hadPoint  = hadShwrPos(id, momHadDepth);
 	    auto lP4 = hadPoint.basicVector().unit();
@@ -953,13 +953,6 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
 	    //  towerP4 += CaloTower::PolarLorentzVector(E_had_tot*hadPf, hadPoint.eta(), hadPoint.phi(), 0); 
 	    // }
 	  }
-          if (E_had_tot==0 && E_em==0 && !theHOIsUsed && E_outer>0) { //extra-fallback for deactivated HO and zero E_em and E_had deposits to avoid nan towers
-	    auto lP4 = hadPoint.basicVector().unit();
-	    lP4[3] = 1.f;  // energy
-	    lP4 *=1e-9; // set to tiny pt to avoid nan
-	    towerP4 +=lP4;
-          }
-          
 	}
 	else {  // forward detector: use the CaloTower position 
 	  GlobalPoint p=theTowerGeometry->getGeometry(id)->getPosition();


### PR DESCRIPTION
add precaution for deactivated HO (theHOIsUsed==false): set tower energy to tiny value to avoid nan-eta for HO-only towers (when HO is'deactivated', i.e. energy set to zero)
