### PR TITLE
bsunanda:Run2-sim01 Checking neutrino tracking and saving info

### DIFF
--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -260,7 +260,8 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track * aTra
 	  ((pdg == 2112) && (ke < kmaxNeutron))) { classification = fKill; }
     }
     if (!trackNeutrino  && classification != fKill) {
-      if (pdg == 12 || pdg == 14 || pdg == 16 || pdg == 18) 
+      if (pdg == 12 || pdg == 14 || pdg == 16 || pdg == 18 ||
+	  pdg ==-12 || pdg ==-14 || pdg ==-16 || pdg ==-18 ) 
 	classification = fKill;
     }
     if (classification != fKill && isItLongLived(aTrack)) 

--- a/SimG4Core/SaveSimTrackAction/README
+++ b/SimG4Core/SaveSimTrackAction/README
@@ -1,11 +1,11 @@
-To save SimTracks with particle code (PDG code) within a range, need
-to activate the watcher SaveSimTrack specifying the range in .cfg file:
+To save SimTracks with particle code (PDG code) from a list, need
+to activate the watcher SaveSimTrack specifying the codes in .cfg file:
  
-	replace g4SimHits.Watchers = {
-                    {string type              = "SaveSimTrack"
-                     untracked int32  MinimumPDGCode  = 2212
-                     untracked int32  MaximumPDGCode  = 2212
-		    }
-                }
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    SaveSimTrack = cms.PSet(
+         PDGCodes  = cms.untracked.vint32([2212])
+    ),
+    type  = cms.string('SaveSimTrack')
+) )               
 
 will save all particles of code 2212.

--- a/SimG4Core/SaveSimTrackAction/interface/SaveSimTrack.h
+++ b/SimG4Core/SaveSimTrackAction/interface/SaveSimTrack.h
@@ -6,6 +6,8 @@
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <vector>
+
 class SaveSimTrack : public SimWatcher,
                      public Observer<const BeginOfTrack *> {
 
@@ -15,7 +17,7 @@ public:
   void update(const BeginOfTrack * trk);
 
 private:
-  int    pdgMin, pdgMax;
+  std::vector<int> pdgs_;
 };
 
 #endif

--- a/SimG4Core/SaveSimTrackAction/src/SaveSimTrack.cc
+++ b/SimG4Core/SaveSimTrackAction/src/SaveSimTrack.cc
@@ -8,15 +8,18 @@
 #include "G4Track.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
+#include <algorithm>
 
 SaveSimTrack::SaveSimTrack(edm::ParameterSet const & p) {
 
-  pdgMin     = p.getUntrackedParameter<int>("MinimumPDGCode", 1000000);
-  pdgMax     = p.getUntrackedParameter<int>("MaximumPDGCode", 2000000);
+  edm::ParameterSet ps = p.getParameter<edm::ParameterSet>("SaveSimTrack");
+  pdgs_ = ps.getUntrackedParameter<std::vector<int>>("PDGCodes");
 
   edm::LogInfo("SaveSimTrack") << "SaveSimTrack:: Save Sim Track if PDG code "
-			       << "lies between "  << pdgMin << " and " 
-			       << pdgMax;
+			       << "is one from the list of "  << pdgs_.size()
+			       << " items";
+  for (unsigned int k=0; k<pdgs_.size(); ++k)
+    edm::LogInfo("SaveSimTrack") << "[" << k << "] " << pdgs_[k];
 }
 
 SaveSimTrack::~SaveSimTrack() {}
@@ -26,8 +29,8 @@ void SaveSimTrack::update(const BeginOfTrack * trk) {
   G4Track* theTrack = (G4Track*)((*trk)());
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
   if (trkInfo) {
-    int pdg = std::abs(theTrack->GetDefinition()->GetPDGEncoding());
-    if (pdg >= pdgMin && pdg <= pdgMax) {
+    int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+    if (std::find(pdgs_.begin(),pdgs_.end(),pdg) != pdgs_.end()) {
       trkInfo->storeTrack(true);
       LogDebug("SaveSimTrack") << "Save SimTrack the Track " 
 			       << theTrack->GetTrackID() << " Type " 


### PR DESCRIPTION
Use a vector of integers rather than a range to save sim tracks. Also remove anti-neutrinos from tracking
