### PR TITLE
For HTTP tests use files from opendata.cern.ch

### DIFF
--- a/Utilities/DavixAdaptor/test/davixcheck.cpp
+++ b/Utilities/DavixAdaptor/test/davixcheck.cpp
@@ -5,9 +5,9 @@ int main(int, char ** /*argv*/) try {
   initTest();
 
   IOOffset size = -1;
-  bool exists = StorageFactory::get()->check("http://transfer-8.ultralight.org:1094/store/mc/HC/"
-                                             "GenericTTbar/GEN-SIM-RECO/CMSSW_7_0_4_START70_V7-v1/"
-                                             "00000///127938CD-F8CC-E311-9250-02163E00E8E6.root",
+  bool exists = StorageFactory::get()->check("http://opendata.cern.ch/eos/opendata"
+                                             "/cms/Run2011A/PhotonHad/AOD/12Oct2013-v1"
+                                             "/00000/024938EB-3445-E311-A72B-002590593920.root",
                                              &size);
 
   std::cout << "exists = " << exists << ", size = " << size << "\n";

--- a/Utilities/DavixAdaptor/test/davixread.cpp
+++ b/Utilities/DavixAdaptor/test/davixread.cpp
@@ -10,8 +10,8 @@ int main(int, char ** /*argv*/) try {
   IOSize size = 1024;
   char buf[size];
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://transfer-8.ultralight.org:1094/store/mc/HC/GenericTTbar/GEN-SIM-RECO/"
-      "CMSSW_7_0_4_START70_V7-v1/00000///10FB32C7-0BCD-E311-B035-02163E00E79D.root");
+      "http://opendata.cern.ch/eos/opendata/cms/Run2011A/PhotonHad/AOD"
+      "/12Oct2013-v1/00000/024938EB-3445-E311-A72B-002590593920.root");
   assert(s);
 
   if ((n = s->read(buf, sizeof(buf)) != size)) {

--- a/Utilities/DavixAdaptor/test/davixreadfilenotfound.cpp
+++ b/Utilities/DavixAdaptor/test/davixreadfilenotfound.cpp
@@ -8,7 +8,7 @@ int main(int, char ** /*argv*/) try {
 
   char buf[1024];
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://transfer-8.ultralight.org:1094/store/mc/this/file/does/not/exist.root");
+      "http://opendata.cern.ch/eos/opendata/cms/mc/this/file/does/not/exist.root");
   assert(s);
 
   s->read(buf, sizeof(buf));

--- a/Utilities/DavixAdaptor/test/davixreadv.cpp
+++ b/Utilities/DavixAdaptor/test/davixreadv.cpp
@@ -7,8 +7,8 @@ int main(int, char ** /*argv*/) try {
   initTest();
 
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://transfer-8.ultralight.org:1094/store/mc/HC/GenericTTbar/GEN-SIM-RECO/"
-      "CMSSW_7_0_4_START70_V7-v1/00000///127938CD-F8CC-E311-9250-02163E00E8E6.root");
+      "http://opendata.cern.ch/eos/opendata/cms/Run2011A/PhotonHad/AOD"
+      "/12Oct2013-v1/00000/024938EB-3445-E311-A72B-002590593920.root");
   assert(s);
 
   IOSize totalVecs = 6;


### PR DESCRIPTION
It is better/more stable to use files from opendata.cern.ch for HTTP tests
