### PR TITLE
Adding key for Run2 pA simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -19,6 +19,8 @@ autoCond = {
     'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v15',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v10',
+    # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
+    'run2_mc_pa'        :   '80X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v17',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
Adding key for Run2 pA simulation
# Summary of changes in Global Tags
## RunII simulation
- **RunII proton-Lead scenario** : [80X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v0) as [80X_mcRun2_asymptotic_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_pA_v0/80X_mcRun2_asymptotic_v17): 
  - change L1 menu for pA 2016 run (`L1Menu_HeavyIons2016_v0_xml`)

attn: @kkotov @mandrenguyen @jrcastle 
