### PR TITLE
Refined hltDiff output for automatisation [8_1_X]

### DIFF
--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <iomanip>
 #include <memory>
+#include <algorithm>
 
 #include <cstring>
 #include <unistd.h>
@@ -1252,10 +1253,11 @@ public:
 
     // loop over the reference events
     const unsigned int nEvents = std::min((int)old_events->size(), (int)max_events);
+    const unsigned int counter_denominator = std::max(1, int(nEvents/10));
     for (old_events->toBegin(); not old_events->atEnd(); ++(*old_events)) {
       // printing progress on every 10%
-      if (counter%(nEvents/10) == 0) {
-        printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, 10*counter/(nEvents/10));
+      if (counter%(counter_denominator) == 0) {
+        printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, 10*counter/(counter_denominator));
       }
 
       // seek the same event in the "new" files

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -18,8 +18,8 @@
 #include <cstring>
 #include <unistd.h>
 #include <getopt.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
@@ -828,9 +828,9 @@ public:
     }
 
     if (filesCreated.size() > 0) {
-      printf("Created the following JSON files:\n");
+      std::cout << "Created the following JSON files:" << std::endl;
       for (const std::string& filename : filesCreated)
-        printf(" %s\n", filename.c_str());
+        std::cout << " " << filename << std::endl;
     }
   }
 };
@@ -1197,9 +1197,9 @@ public:
     }
 
     if (filesCreated.size() > 0) {
-      printf("Created the following summary files:\n");
+      std::cout << "Created the following summary files:" << std::endl;
       for (const std::string& filename : filesCreated)
-        printf(" %s\n", filename.c_str());
+        std::cout << " " << filename << std::endl;
     }
   }
 
@@ -1305,7 +1305,8 @@ public:
     for (old_events->toBegin(); not old_events->atEnd(); ++(*old_events)) {
       // printing progress on every 10%
       if (counter%(counter_denominator) == 0) {
-        printf("Processed events: %d out of %d (%d%%)\n", (int)counter, (int)nEvents, 10*counter/(counter_denominator));
+        std::cout << "Processed events: " << counter << " out of " << nEvents
+          << " (" << 10*counter/(counter_denominator) << "%)" << std::endl;
       }
 
       // seek the same event in the "new" files

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -776,6 +776,7 @@ public:
   }
 
   void write() {
+    if (!writeJson) return;
     std::set<std::string> filesCreated;
     for (const auto& runEvents : m_run_events) {
       const int run = runEvents.first;
@@ -1184,6 +1185,7 @@ public:
   std::string               new_process;
   unsigned int              max_events;
   bool                      ignore_prescales;
+  bool                      csv_out;
   bool                      json_out;
   bool                      root_out;
   std::string               output_file;
@@ -1198,6 +1200,7 @@ public:
     new_process(""),
     max_events(1e9),
     ignore_prescales(true),
+    csv_out(false),
     json_out(false),
     root_out(false),
     output_file(""),
@@ -1450,12 +1453,12 @@ public:
       std::cout << "Found " << counter << " matching events, out of which " << affected << " have different HLT results";
       if (skipped)
         std::cout << ", " << skipped << " events were skipped";
-      std::cout << "\nSee more in the files listed below...\n" << std::endl;
+      std::cout << "\n" << std::endl;
     }
 
     // writing all the required output
     json.write();   // to JSON file for interactive visualisation
-    SummaryOutputProducer summary(json, this->root_out, true);
+    SummaryOutputProducer summary(json, this->root_out, this->csv_out);
     summary.write();   // to ROOT file for fast validation with static plots
   }
 
@@ -1488,6 +1491,9 @@ usage: hltDiff -o|--old-files FILE1.ROOT [FILE2.ROOT ...] [-O|--old-process LABE
 \n\
   -p|--prescales\n\
       do not ignore differences caused by HLTPrescaler modules\n\
+\n\
+  -c|--csv-output\n\
+      produce comparison results in a CSV format\n\
 \n\
   -j|--json-output\n\
       produce comparison results in a JSON format\n\
@@ -1522,7 +1528,7 @@ usage: hltDiff -o|--old-files FILE1.ROOT [FILE2.ROOT ...] [-O|--old-process LABE
 
 int main(int argc, char ** argv) {
   // options
-  const char optstring[] = "dfo:O:n:N:m:pjrF:v::h";
+  const char optstring[] = "dfo:O:n:N:m:pcjrF:v::h";
   const option longopts[] = {
     option{ "debug",        no_argument,        nullptr, 'd' },
     option{ "file-check",   no_argument,        nullptr, 'f' },
@@ -1532,6 +1538,7 @@ int main(int argc, char ** argv) {
     option{ "new-process",  required_argument,  nullptr, 'N' },
     option{ "max-events",   required_argument,  nullptr, 'm' },
     option{ "prescales",    no_argument,        nullptr, 'p' },
+    option{ "csv-output",   optional_argument,  nullptr, 'c' },
     option{ "json-output",  optional_argument,  nullptr, 'j' },
     option{ "root-output",  optional_argument,  nullptr, 'r' },
     option{ "output-file",  optional_argument,  nullptr, 'F' },
@@ -1588,6 +1595,10 @@ int main(int argc, char ** argv) {
 
       case 'p':
         hlt->ignore_prescales = false;
+        break;
+
+      case 'c':
+        hlt->csv_out = true;
         break;
 
       case 'j':

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -1466,8 +1466,9 @@ public:
     out << "\
 usage: hltDiff -o|--old-files FILE1.ROOT [FILE2.ROOT ...] [-O|--old-process LABEL[:INSTANCE[:PROCESS]]]\n\
                -n|--new-files FILE1.ROOT [FILE2.ROOT ...] [-N|--new-process LABEL[:INSTANCE[:PROCESS]]]\n\
-               [-m|--max-events MAXEVENTS] [-p|--prescales] [-j|--json-output] OUTPUT_FILE.JSON\n\
-               [-r|--root-output] OUTPUT_FILE.ROOT [-f|--file-check] [-d|--debug] [-v|--verbose] [-h|--help]\n\
+               [-m|--max-events MAXEVENTS] [-p|--prescales] [-c|--csv-output] [-j|--json-output]\n\
+               [-r|--root-output] [-f|--file-check] [-d|--debug] [-v|--verbose] [-h|--help]\n\
+               [-F|--output-file] FILE_NAME\n\
 \n\
   -o|--old-files FILE1.ROOT [FILE2.ROOT ...]\n\
       input file(s) with the old (reference) trigger results\n\


### PR DESCRIPTION
Implemented several improvements of the hltDiff output:
- recovered missing summary printout with the list of affected triggers
- always creating all requested output files, even if no affected events were found
- minor bug fixes
