### PR TITLE
GT for pA 2016

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v6',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun1_pA_v0',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '81X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v0) as [81X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v0/81X_mcRun2_pA_v0):
  - fix GT name
