### PR TITLE
Fixed static analyzer warnings7

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h
@@ -2,7 +2,7 @@
 #define CastorSim_CastorDigiAnalyzer_h
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -18,7 +18,7 @@
 */
 
 
-class CastorDigiAnalyzer : public edm::EDAnalyzer
+class CastorDigiAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 

--- a/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h
@@ -2,7 +2,7 @@
 #define CastorSim_CastorHitAnalyzer_h
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -16,7 +16,7 @@
   \Author P. Katsas, Univ. of Athens
 */
 
-class CastorHitAnalyzer : public edm::EDAnalyzer
+class CastorHitAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
@@ -14,7 +14,7 @@
 #include<iostream>
 
 CastorAmplifier::CastorAmplifier(const CastorSimParameterMap * parameters, bool addNoise) :
-  theDbService(0),
+  theDbService(nullptr),
   theParameterMap(parameters),
   theStartingCapId(0),
   addNoise_(addNoise)
@@ -23,29 +23,34 @@ CastorAmplifier::CastorAmplifier(const CastorSimParameterMap * parameters, bool 
 
 void CastorAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engine) const {
   const CastorSimParameters & parameters = theParameterMap->castorParameters();
-  assert(theDbService != 0);
+  assert(theDbService != nullptr);
   HcalGenericDetId hcalGenDetId(frame.id());
   const CastorPedestal* peds = theDbService->getPedestal(hcalGenDetId);
   const CastorPedestalWidth* pwidths = theDbService->getPedestalWidth(hcalGenDetId);
   if (!peds || !pwidths )
   {
-    edm::LogError("CastorAmplifier") << "Could not fetch HCAL/CASTOR conditions for channel " << hcalGenDetId;
+    edm::LogError("CastorAmplifier") 
+      << "Could not fetch HCAL/CASTOR conditions for channel " << hcalGenDetId;
   }
+  else 
+  {
+    double gauss [32]; //big enough
+    double noise [32]; //big enough
+    double fCperPE = parameters.photoelectronsToAnalog(frame.id());
 
-  double gauss [32]; //big enough
-  double noise [32]; //big enough
-  double fCperPE = parameters.photoelectronsToAnalog(frame.id());
-
-  for (int i = 0; i < frame.size(); i++) gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.);
-  pwidths->makeNoise (frame.size(), gauss, noise);
-  for(int tbin = 0; tbin < frame.size(); ++tbin) {
-    int capId = (theStartingCapId + tbin)%4;
-    double pedestal = peds->getValue (capId);
+    for (int i = 0; i < frame.size(); i++) { gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.); }
     if(addNoise_) {
-      pedestal += noise [tbin];
+      pwidths->makeNoise (frame.size(), gauss, noise);
     }
-    frame[tbin] *= fCperPE;
-    frame[tbin] += pedestal;
+    for(int tbin = 0; tbin < frame.size(); ++tbin) {
+      int capId = (theStartingCapId + tbin)%4;
+      double pedestal = peds->getValue (capId);
+      if(addNoise_) {
+	pedestal += noise [tbin];
+      }
+      frame[tbin] *= fCperPE;
+      frame[tbin] += pedestal;
+    }
   }
   LogDebug("CastorAmplifier") << frame;
 }

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.h
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.h
@@ -18,7 +18,7 @@ public:
   /// the Producer will probably update this every event
   void setDbService(const CastorDbService * service) {
     theDbService = service;
-   }
+  }
 
   virtual void amplify(CaloSamples & linearFrame, CLHEP::HepRandomEngine*) const;
 

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
@@ -53,17 +53,20 @@ double CastorSimParameters::fCtoGeV(const DetId & detId) const
   HcalGenericDetId hcalGenDetId(detId);
   const CastorGain* gains = theDbService->getGain(hcalGenDetId);
   const CastorGainWidth* gwidths = theDbService->getGainWidth(hcalGenDetId);
+  double result = 0.0;
   if (!gains || !gwidths )
   {
     edm::LogError("CastorAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
   }
-  // only one gain will be recorded per channel, so just use capID 0 for now
-  
-  double result = gains->getValue(0);
-//  if(doNoise_)
-///  {
-//    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
-//  }
+  else 
+  {
+    // only one gain will be recorded per channel, so just use capID 0 for now
+    result = gains->getValue(0);
+    //  if(doNoise_)
+    ///  {
+    //    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
+    //  }
+  }
   return result;
 }
 /*

--- a/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.h
+++ b/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.h
@@ -1,14 +1,14 @@
 #ifndef CastorTechTrigProducer_CastorTTRecord_h
 #define CastorTechTrigProducer_CastorTTRecord_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
-class CastorTTRecord : public edm::EDProducer
+class CastorTTRecord : public edm::one::EDProducer<>
 {
 public:
 

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
@@ -9,7 +9,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -31,9 +31,9 @@
 
 struct TCCinput; 
 typedef std::vector<TCCinput> TCCInputData;
-const int N_SM = 36; //number of ecal barrel supermodules
+static const int N_SM = 36; //number of ecal barrel supermodules
 
-class EcalFEtoDigi : public edm::EDProducer {
+class EcalFEtoDigi : public edm::one::EDProducer<> {
 
 public:
 

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -38,7 +38,7 @@
  *    <LI>untracked string outputBaseName: basename for output files</LI>
  *    </UL>
  */
-class EcalSimRawData: public edm::EDAnalyzer{
+class EcalSimRawData: public edm::one::EDAnalyzer<> {
   public:
   /** Constructor
    * @param pset CMSSW configuration
@@ -55,6 +55,9 @@ class EcalSimRawData: public edm::EDAnalyzer{
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
+
+  int iEvent;
+
   /** Number of crystals in ECAL barrel along eta
    */
   static const int nEbEta = 170;

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimCalorimetry_EcalElectronicsEmulationEcalSimpleProducer_h
 #define SimCalorimetry_EcalElectronicsEmulationEcalSimpleProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include <memory>
 #include <TFormula.h>
 #include <string>
@@ -35,7 +35,7 @@
  * TFormula</A>
  *
  */
-class EcalSimpleProducer: public edm::EDProducer {
+class EcalSimpleProducer: public edm::one::EDProducer<> {
 
   //constructor(s) and destructor(s)
 public:

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
@@ -67,6 +67,7 @@ EcalSimRawData::EcalSimRawData(const edm::ParameterSet& params){
   tccInDefaultVal_ = params.getUntrackedParameter<int>("tccInDefaultVal", 0xffff);
   basename_ = params.getUntrackedParameter<std::string>("outputBaseName");
 
+  iEvent = 0;
 
   string writeMode = params.getParameter<string>("writeMode");
 
@@ -83,7 +84,6 @@ void
 EcalSimRawData::analyze(const edm::Event& event,
 			const edm::EventSetup& es){
   //Event counter:
-  static int iEvent = 0;
   ++iEvent; 
     
   if(xtalVerbose_ | tpVerbose_){

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSRCondTools.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSRCondTools.h
@@ -5,13 +5,13 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
 
 /**
  */
-class EcalSRCondTools : public edm::EDAnalyzer {
+class EcalSRCondTools : public edm::one::EDAnalyzer<> {
   //methods
 public:
   /** Constructor
@@ -70,6 +70,9 @@ private:
 private:
 
   edm::ParameterSet ps_;
+
+  bool done_;
+
 };
 
 #endif //SRCONDACCESS_H not defined

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
@@ -2,11 +2,7 @@
 #define ECALZEROSUPPRESSIONPRODUCER_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-//#include "FWCore/Framework/interface/Event.h"
-//#include "DataFormats/Common/interface/Handle.h"
-//#include "FWCore/ParameterSet/interface/ParameterSet.h"
-//#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadoutSuppressor.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
@@ -15,7 +11,7 @@
 #include <memory>
 #include <vector>
 
-class EcalSelectiveReadoutProducer : public edm::EDProducer
+class EcalSelectiveReadoutProducer : public edm::one::EDProducer<>
 {
 public:
 
@@ -71,10 +67,10 @@ private:
 	      int& binOfMax) const;
 
   const EBDigiCollection*
-  getEBDigis(edm::Event& event) const;
+  getEBDigis(edm::Event& event);
 
   const EEDigiCollection*
-  getEEDigis(edm::Event& event) const;
+  getEEDigis(edm::Event& event);
 
   const EcalTrigPrimDigiCollection*
   getTrigPrims(edm::Event& event) const;
@@ -145,11 +141,16 @@ private:
    */
   bool useCondDb_;
 
-
   /**  Special switch to turn off SR entirely using special DB entries 
    */
 
   bool useFullReadout_;
+
+  /** keys
+   */
+  bool firstCallEB_;
+  bool firstCallEE_;
+  int  iEvent_;
 
   /** Used when settings_ is imported from configuration file. Just used
    * for memory management. Used settings_ to access to the object

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
@@ -17,7 +17,7 @@
 
 // system include files
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -52,15 +52,15 @@ class CaloSubdetectorGeometry ;
 // class declaration
 //
 
-class EcalTPCondAnalyzer : public edm::EDAnalyzer {
+class EcalTPCondAnalyzer : public edm::one::EDAnalyzer<> {
  public:
   explicit EcalTPCondAnalyzer(const edm::ParameterSet&);
   ~EcalTPCondAnalyzer();
 
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void beginJob();
-  void beginRun(const edm::Run & run, const edm::EventSetup& es) override;
+  void beginRun(const edm::Run & run, const edm::EventSetup& es);
   virtual void endJob();
 
  private:

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.h
@@ -17,7 +17,7 @@
 // system include files
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,7 +35,7 @@
 // class declaration
 //
 
-class EcalTrigPrimAnalyzer : public edm::EDAnalyzer {
+class EcalTrigPrimAnalyzer : public edm::one::EDAnalyzer<> {
    public:
       explicit EcalTrigPrimAnalyzer(const edm::ParameterSet&);
       ~EcalTrigPrimAnalyzer();

--- a/SimCalorimetry/EcalZeroSuppressionProducers/interface/EcalZeroSuppressionProducer.h
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/interface/EcalZeroSuppressionProducer.h
@@ -2,7 +2,7 @@
 #define ECALZEROSUPPRESSIONPRODUCER_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,7 +21,7 @@
 #include "SimCalorimetry/EcalZeroSuppressionAlgos/interface/EcalZeroSuppressor.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloDigiCollectionSorter.h"
 
-class EcalZeroSuppressionProducer : public edm::EDProducer
+class EcalZeroSuppressionProducer : public edm::stream::EDProducer<>
 {
 public:
 

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -37,17 +37,20 @@ double HFSimParameters::fCtoGeV(const DetId & detId) const
   HcalGenericDetId hcalGenDetId(detId);
   const HcalGain* gains = theDbService->getGain(hcalGenDetId);
   const HcalGainWidth* gwidths = theDbService->getGainWidth(hcalGenDetId);
+  double result = 0.0;
   if (!gains || !gwidths )
   {
     edm::LogError("HcalAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
   }
-  // only one gain will be recorded per channel, so just use capID 0 for now
-  
-  double result = gains->getValue(0);
-//  if(doNoise_)
-///  {
-//    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
-//  }
+  else 
+  {
+    // only one gain will be recorded per channel, so just use capID 0 for now
+    result = gains->getValue(0);
+    //  if(doNoise_)
+    ///  {
+    //    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
+    //  }
+  }
   return result;
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HPDIonFeedbackSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HPDIonFeedbackSim.cc
@@ -27,7 +27,7 @@ using namespace edm;
 using namespace std;
 
 // constants for simulation/parameterization
-const double pe2Charge = 0.333333;    // fC/p.e.
+static const double pe2Charge = 0.333333;    // fC/p.e.
 
 HPDIonFeedbackSim::HPDIonFeedbackSim(const edm::ParameterSet & iConfig, const CaloShapes * shapes)
 : theDbService(0), theShapes(shapes)
@@ -134,11 +134,15 @@ double HPDIonFeedbackSim::fCtoGeV(const DetId & detId) const
   HcalGenericDetId hcalGenDetId(detId);
   const HcalGain* gains = theDbService->getGain(hcalGenDetId);
   const HcalGainWidth* gwidths = theDbService->getGainWidth(hcalGenDetId);
+  double result = 0.0;
   if (!gains || !gwidths )
   {
     edm::LogError("HcalAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
+  } 
+  else 
+  {
+    // only one gain will be recorded per channel, so just use capID 0 for now
+    result = gains->getValue(0);
   }
-  // only one gain will be recorded per channel, so just use capID 0 for now
-  double result = gains->getValue(0);
   return result;
 }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
@@ -87,16 +87,20 @@ double HcalSimParameters::fCtoGeV(const DetId & detId) const
   HcalGenericDetId hcalGenDetId(detId);
   const HcalGain* gains = theDbService->getGain(hcalGenDetId);
   const HcalGainWidth* gwidths = theDbService->getGainWidth(hcalGenDetId);
+  double result = 0.0;
   if (!gains || !gwidths )
   {
     edm::LogError("HcalAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
-  }
-  // only one gain will be recorded per channel, so just use capID 0 for now
-  double result = gains->getValue(0);
+  } 
+  else 
+  {
+    // only one gain will be recorded per channel, so just use capID 0 for now
+    result = gains->getValue(0);
 //  if(doNoise_)
 ///  {
 //    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
 //  }
+  }
   return result;
 }
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiAnalyzer.h
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiAnalyzer.h
@@ -2,7 +2,7 @@
 #define HcalSimProducers_HcalDigiAnalyzer_h
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,7 +20,7 @@
 */
 
 
-class HcalDigiAnalyzer : public edm::EDAnalyzer
+class HcalDigiAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalHitAnalyzer.h
+++ b/SimCalorimetry/HcalSimProducers/src/HcalHitAnalyzer.h
@@ -2,7 +2,7 @@
 #define HcalSimProducers_HcalHitAnalyzer_h
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -18,7 +18,7 @@
 */
 
 
-class HcalHitAnalyzer : public edm::EDAnalyzer
+class HcalHitAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPTriggerRecord.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPTriggerRecord.h
@@ -1,13 +1,13 @@
 #ifndef HcalTrigPrimProducers_HcalTTPTriggerRecord_h
 #define HcalTrigPrimProducers_HcalTTPTriggerRecord_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
-class HcalTTPTriggerRecord : public edm::EDProducer
+class HcalTTPTriggerRecord : public edm::stream::EDProducer<>
 {
 public:
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef HcalTrigPrimDigiProducer_h
 #define HcalTrigPrimDigiProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -9,7 +9,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include <vector>
 
-class HcalTrigPrimDigiProducer : public edm::EDProducer
+class HcalTrigPrimDigiProducer : public edm::stream::EDProducer<>
 {
 public:
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.h
@@ -1,7 +1,7 @@
 #ifndef HCALSIMPLEAMPLITUDEZS_H
 #define HCALSIMPLEAMPLITUDEZS_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -17,7 +17,7 @@
 	
 \author J. Mans - Minnesota
 */
-class HcalSimpleAmplitudeZS : public edm::EDProducer {
+class HcalSimpleAmplitudeZS : public edm::stream::EDProducer<> {
 public:
   explicit HcalSimpleAmplitudeZS(const edm::ParameterSet& ps);
   virtual ~HcalSimpleAmplitudeZS();


### PR DESCRIPTION
This PR provide fixes for static analyzer warnings. Most are obvious. This complete the campaign for Simulation related sub-packages. Remaining warnings in Sim sub-packages are false positive except few cases which needs special attention. Production results should not be affected. 
