### PR TITLE
Modifications of bend corrections to improve tau reconstruction performance

### DIFF
--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
@@ -60,9 +60,9 @@ decayMode_2Prong0Pi0 = cms.PSet(
     maxMass = cms.string("1.2"),
     # for XProng0Pi0 decay modes bending corrections are transparent
     applyBendCorrection = cms.PSet(
-        eta = cms.bool(True),
-        phi = cms.bool(True),
-        mass = cms.bool(True)
+        eta = cms.bool(False),
+        phi = cms.bool(False),
+        mass = cms.bool(False)
     )
 )
 decayMode_2Prong1Pi0 = cms.PSet(
@@ -73,9 +73,9 @@ decayMode_2Prong1Pi0 = cms.PSet(
     minMass = cms.double(0.),
     maxMass = cms.string("max(1.2, min(1.2*sqrt(pt/100.), 4.0))"),
     applyBendCorrection = cms.PSet(
-        eta = cms.bool(True),
-        phi = cms.bool(True),
-        mass = cms.bool(True)
+        eta = cms.bool(False),
+        phi = cms.bool(False),
+        mass = cms.bool(False)
     )
 )
 decayMode_3Prong0Pi0 = cms.PSet(
@@ -86,9 +86,9 @@ decayMode_3Prong0Pi0 = cms.PSet(
     minMass = cms.double(0.8),
     maxMass = cms.string("1.5"),
     applyBendCorrection = cms.PSet(
-        eta = cms.bool(True),
-        phi = cms.bool(True),
-        mass = cms.bool(True)
+        eta = cms.bool(False),
+        phi = cms.bool(False),
+        mass = cms.bool(False)
     )
 )
 decayMode_3Prong1Pi0 = cms.PSet( #suggestions made by CV
@@ -100,9 +100,9 @@ decayMode_3Prong1Pi0 = cms.PSet( #suggestions made by CV
     maxMass = cms.string("1.6"),
     # for XProng0Pi0 decay modes bending corrections are transparent
     applyBendCorrection = cms.PSet(
-        eta = cms.bool(True),
-        phi = cms.bool(True),
-        mass = cms.bool(True)
+        eta = cms.bool(False),
+        phi = cms.bool(False),
+        mass = cms.bool(False)
     )
 )
 


### PR DESCRIPTION
Dear colleagues,

this is a modification on the configuration level only. It has been anticipated on the last pull request related to this topic that retuning might be applied later, which is being done now. Corresponding studies have shown that the bend corrections, which had been switched on for all decay modes lead to a performance deterioration of the 2prong+1pi0 and 3prong+1pi0 decay modes (*). Therefore these corrections are switched off consistently for all 2prong and 3prong decay modes. For the nprong-0pi0 decay modes the switch is actually transparent. It is done consistently nevertheless. For the 1prong decay modes the bend corrections are kept by TauPOG decisions. 

We aim to integrate this change to 81X before the release closes. 

Cheers,
Roger

(*)
https://hypernews.cern.ch/HyperNews/CMS/get/tauid/670.html
