### PR TITLE
Save pixel and strip layers in miniAOD

### DIFF
--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -491,6 +491,8 @@ class PackedCandidateTrackValidator: public DQMEDAnalyzer{
   MonitorElement *h_diffEtaError;
 
 
+  MonitorElement *h_diffNumberOfPixelLayers;
+  MonitorElement *h_diffNumberOfStripLayers;
   MonitorElement *h_diffNumberOfPixelHits;
   MonitorElement *h_diffNumberOfHits;
   MonitorElement *h_diffLostInnerHits;
@@ -500,6 +502,9 @@ class PackedCandidateTrackValidator: public DQMEDAnalyzer{
   MonitorElement *h_diffHitPatternNumberOfLostInnerHits;
   MonitorElement *h_diffHitPatternHasValidHitInFirstPixelBarrel;
 
+  MonitorElement *h_numberPixelLayersOverMax;
+  MonitorElement *h_numberStripLayersOverMax;
+  MonitorElement *h_numberLayersOverMax;
   MonitorElement *h_numberPixelHitsOverMax;
   MonitorElement *h_numberStripHitsOverMax;
   MonitorElement *h_numberHitsOverMax;
@@ -611,6 +616,8 @@ void PackedCandidateTrackValidator::bookHistograms(DQMStore::IBooker& iBooker, e
   h_diffEtaError    = iBooker.book1D("diffEtaError",    "(PackedCandidate::bestTrack() - reco::Track)/reco::Track in etaError()",    60, -0.15, 0.15); // not equal
 
 
+  h_diffNumberOfPixelLayers = iBooker.book1D("diffNumberOfPixelLayers", "PackedCandidate::pixelLayersWithMeasurement() - reco::Track::hitPattern::pixelLayersWithMeasurement()", 5, -2.5, 2.5); // expect equality 
+  h_diffNumberOfStripLayers = iBooker.book1D("diffNumberOfStripLayers", "PackedCandidate::stripLayersWithMeasurement() - reco::Track::hitPattern::stripLayersWithMeasurement()",             5, -2.5, 2.5); // expect equality
   h_diffNumberOfPixelHits = iBooker.book1D("diffNumberOfPixelHits", "PackedCandidate::numberOfPixelHits() - reco::Track::hitPattern::numberOfValidPixelHits()", 5, -2.5, 2.5); // expect equality 
   h_diffNumberOfHits      = iBooker.book1D("diffNumberOfHits",      "PackedCandidate::numberHits() - reco::Track::hitPattern::numberOfValidHits()",             5, -2.5, 2.5); // expect equality
   h_diffLostInnerHits     = iBooker.book1D("diffLostInnerHits",     "PackedCandidate::lostInnerHits() - reco::Track::hitPattern::numberOfLostHits(MISSING_INNER_HITS)",      5, -2.5, 2.5); // expect equality
@@ -620,6 +627,9 @@ void PackedCandidateTrackValidator::bookHistograms(DQMStore::IBooker& iBooker, e
   h_diffHitPatternNumberOfLostInnerHits  = iBooker.book1D("diffHitPatternNumberOfLostPixelHits",  "PackedCandidate::bestTrack() - reco::Track in hitPattern::numberOfLostHits(MISSING_INNER_HITS)", 13, -10.5, 2.5); // not equal
   h_diffHitPatternHasValidHitInFirstPixelBarrel = iBooker.book1D("diffHitPatternHasValidHitInFirstPixelBarrel", "PackedCandidate::bestTrack() - reco::Track in hitPattern::hasValidHitInFirstPixelBarrel", 3, -1.5, 1.5); // expect equality
 
+  h_numberPixelLayersOverMax = iBooker.book1D("numberPixelLayersOverMax", "Number of pixel layers over the maximum of PackedCandidate", 10, 0, 10);
+  h_numberStripLayersOverMax = iBooker.book1D("numberStripLayersOverMax", "Number of strip layers over the maximum of PackedCandidate", 10, 0, 10);
+  h_numberLayersOverMax = iBooker.book1D("numberLayersOverMax", "Number of layers over the maximum of PackedCandidate", 20, 0, 20);
   h_numberPixelHitsOverMax = iBooker.book1D("numberPixelHitsOverMax", "Number of pixel hits over the maximum of PackedCandidate", 10, 0, 10);
   h_numberStripHitsOverMax = iBooker.book1D("numberStripHitsOverMax", "Number of strip hits over the maximum of PackedCandidate", 10, 0, 10);
   h_numberHitsOverMax = iBooker.book1D("numberHitsOverMax", "Number of hits over the maximum of PackedCandidate", 20, 0, 20);
@@ -759,23 +769,52 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     const auto pcNumberOfHits = pcRef->numberOfHits();
     const auto pcNumberOfPixelHits = pcRef->numberOfPixelHits();
     const auto pcNumberOfStripHits = pcNumberOfHits - pcNumberOfPixelHits;
+    const auto trackNumberOfLayers = track.hitPattern().trackerLayersWithMeasurement();
+    const auto trackNumberOfPixelLayers = track.hitPattern().pixelLayersWithMeasurement();
+    const auto trackNumberOfStripLayers = track.hitPattern().stripLayersWithMeasurement();
+    const auto pcNumberOfLayers = pcRef->trackerLayersWithMeasurement();
+    const auto pcNumberOfPixelLayers = pcRef->pixelLayersWithMeasurement();
+    const auto pcNumberOfStripLayers = pcRef->stripLayersWithMeasurement();
 
-    const int pixelOverflow = trackNumberOfPixelHits > pat::PackedCandidate::trackPixelHitsMask ? trackNumberOfPixelHits - pat::PackedCandidate::trackPixelHitsMask : 0;
-    const int stripOverflow = trackNumberOfStripHits > pat::PackedCandidate::trackStripHitsMask ? trackNumberOfStripHits - pat::PackedCandidate::trackStripHitsMask : 0;
-    const int hitsOverflow = trackNumberOfHits > (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) ? trackNumberOfHits - (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) : 0;
+    // layer number overflow (should be zero)
+    const int pixelLayerOverflow = trackNumberOfPixelLayers > pat::PackedCandidate::trackPixelHitsMask ? trackNumberOfPixelLayers - pat::PackedCandidate::trackPixelHitsMask : 0;
+    const int stripLayerOverflow = trackNumberOfStripLayers > pat::PackedCandidate::trackStripHitsMask ? trackNumberOfStripLayers - pat::PackedCandidate::trackStripHitsMask : 0;
+    const int layerOverflow = trackNumberOfLayers > (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) ? trackNumberOfLayers - (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) : 0;
+
+    // hit overflow (should also be zero)
+    const int pixelOverflow = trackNumberOfPixelHits - pcNumberOfPixelLayers > pat::PackedCandidate::trackPixelHitsMask ? trackNumberOfPixelHits - pcNumberOfPixelLayers - pat::PackedCandidate::trackPixelHitsMask : 0;
+    const int stripOverflow = trackNumberOfStripHits - pcNumberOfStripLayers > pat::PackedCandidate::trackStripHitsMask ? trackNumberOfStripHits - pcNumberOfStripLayers - pat::PackedCandidate::trackStripHitsMask : 0;
+    const int hitsOverflow = trackNumberOfHits - pcNumberOfLayers > (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) ? trackNumberOfHits - pcNumberOfLayers - (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) : 0;
     // PackedCandidate counts overflow pixel hits as strip
-    const int pixelInducedStripOverflow = (trackNumberOfStripHits+pixelOverflow) > pat::PackedCandidate::trackStripHitsMask ? (trackNumberOfStripHits+pixelOverflow-stripOverflow) - pat::PackedCandidate::trackStripHitsMask : 0;
+    const int pixelInducedStripOverflow = (trackNumberOfStripHits+pixelOverflow) > pat::PackedCandidate::trackStripHitsMask ? (trackNumberOfStripHits+pixelOverflow-stripOverflow) - pat::PackedCandidate::trackStripHitsMask : 0; // FIXME
+    h_numberPixelLayersOverMax->Fill(pixelLayerOverflow);
+    h_numberStripLayersOverMax->Fill(stripLayerOverflow);
+    h_numberLayersOverMax->Fill(layerOverflow);
     h_numberPixelHitsOverMax->Fill(pixelOverflow);
     h_numberStripHitsOverMax->Fill(stripOverflow);
     h_numberHitsOverMax->Fill(hitsOverflow);
 
     int diffNumberOfPixelHits = 0;
     int diffNumberOfHits = 0;
+    int diffNumberOfPixelLayers = 0;
+    int diffNumberOfStripLayers = 0;
+    if(pixelLayerOverflow) {
+      diffNumberOfPixelLayers = pcNumberOfPixelLayers - pat::PackedCandidate::trackPixelHitsMask;
+    }
+    else {
+      diffNumberOfPixelLayers = pcNumberOfPixelLayers - trackNumberOfPixelLayers;
+    }
     if(pixelOverflow) {
-      diffNumberOfPixelHits = pcNumberOfPixelHits - pat::PackedCandidate::trackPixelHitsMask;
+      diffNumberOfPixelHits = pcNumberOfPixelHits - pcNumberOfPixelLayers - pat::PackedCandidate::trackPixelHitsMask;
     }
     else {
       diffNumberOfPixelHits = pcNumberOfPixelHits - trackNumberOfPixelHits;
+    }
+    if(stripLayerOverflow) {
+       diffNumberOfStripLayers = pcNumberOfStripLayers - pat::PackedCandidate::trackStripHitsMask;
+    }
+    else {
+      diffNumberOfStripLayers = pcNumberOfStripLayers - trackNumberOfStripLayers;
     }
     if(stripOverflow || pixelInducedStripOverflow || pixelOverflow) {
       int diffNumberOfStripHits = 0;
@@ -792,8 +831,12 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
       diffNumberOfHits = pcNumberOfHits - trackNumberOfHits;
     }
 
+
+
     fillNoFlow(h_diffNumberOfPixelHits, diffNumberOfPixelHits);
     fillNoFlow(h_diffNumberOfHits, diffNumberOfHits);
+    fillNoFlow(h_diffNumberOfPixelLayers, diffNumberOfPixelLayers);
+    fillNoFlow(h_diffNumberOfStripLayers, diffNumberOfStripLayers);
 
     int diffLostInnerHits = 0;
     const auto trackLostInnerHits = track.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);

--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -497,6 +497,9 @@ class PackedCandidateTrackValidator: public DQMEDAnalyzer{
   MonitorElement *h_diffNumberOfHits;
   MonitorElement *h_diffLostInnerHits;
 
+  MonitorElement *h_diffHitPatternPixelLayersWithMeasurement;
+  MonitorElement *h_diffHitPatternTrackerLayersWithMeasurement;
+  MonitorElement *h_diffHitPatternStripLayersWithMeasurement;
   MonitorElement *h_diffHitPatternNumberOfValidPixelHits;
   MonitorElement *h_diffHitPatternNumberOfValidHits;
   MonitorElement *h_diffHitPatternNumberOfLostInnerHits;
@@ -622,6 +625,9 @@ void PackedCandidateTrackValidator::bookHistograms(DQMStore::IBooker& iBooker, e
   h_diffNumberOfHits      = iBooker.book1D("diffNumberOfHits",      "PackedCandidate::numberHits() - reco::Track::hitPattern::numberOfValidHits()",             5, -2.5, 2.5); // expect equality
   h_diffLostInnerHits     = iBooker.book1D("diffLostInnerHits",     "PackedCandidate::lostInnerHits() - reco::Track::hitPattern::numberOfLostHits(MISSING_INNER_HITS)",      5, -2.5, 2.5); // expect equality
 
+  h_diffHitPatternPixelLayersWithMeasurement = iBooker.book1D("diffHitPatternPixelLayersWithMeasurement", "PackedCandidate::bestTrack() - reco::Track in hitPattern::pixelLayersWithMeasurement()",   13, -10.5, 2.5); // not equal
+  h_diffHitPatternStripLayersWithMeasurement = iBooker.book1D("diffHitPatternStripLayersWithMeasurement", "PackedCandidate::bestTrack() - reco::Track in hitPattern::stripLayersWithMeasurement()",   13, -10.5, 2.5); // not equal
+  h_diffHitPatternTrackerLayersWithMeasurement = iBooker.book1D("diffHitPatternTrackerLayersWithMeasurement", "PackedCandidate::bestTrack() - reco::Track in hitPattern::trackerLayersWithMeasurement()",   13, -10.5, 2.5); // not equal
   h_diffHitPatternNumberOfValidPixelHits = iBooker.book1D("diffHitPatternNumberOfValidPixelHits", "PackedCandidate::bestTrack() - reco::Track in hitPattern::numberOfValidPixelHits()",   13, -10.5, 2.5); // not equal
   h_diffHitPatternNumberOfValidHits      = iBooker.book1D("diffHitPatternNumberOfValidHits",      "PackedCandidate::bestTrack() - reco::Track in hitPattern::numberOfValidHits()",      13, -10.5, 2.5); // not equal
   h_diffHitPatternNumberOfLostInnerHits  = iBooker.book1D("diffHitPatternNumberOfLostPixelHits",  "PackedCandidate::bestTrack() - reco::Track in hitPattern::numberOfLostHits(MISSING_INNER_HITS)", 13, -10.5, 2.5); // not equal
@@ -786,7 +792,7 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     const int stripOverflow = trackNumberOfStripHits - pcNumberOfStripLayers > pat::PackedCandidate::trackStripHitsMask ? trackNumberOfStripHits - pcNumberOfStripLayers - pat::PackedCandidate::trackStripHitsMask : 0;
     const int hitsOverflow = trackNumberOfHits - pcNumberOfLayers > (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) ? trackNumberOfHits - pcNumberOfLayers - (pat::PackedCandidate::trackPixelHitsMask+pat::PackedCandidate::trackStripHitsMask) : 0;
     // PackedCandidate counts overflow pixel hits as strip
-    const int pixelInducedStripOverflow = (trackNumberOfStripHits+pixelOverflow) > pat::PackedCandidate::trackStripHitsMask ? (trackNumberOfStripHits+pixelOverflow-stripOverflow) - pat::PackedCandidate::trackStripHitsMask : 0; // FIXME
+    const int pixelInducedStripOverflow = (trackNumberOfStripHits+pixelOverflow-pcNumberOfStripLayers) > pat::PackedCandidate::trackStripHitsMask ? (trackNumberOfStripHits+pixelOverflow-stripOverflow-pcNumberOfStripLayers) - pat::PackedCandidate::trackStripHitsMask : 0; 
     h_numberPixelLayersOverMax->Fill(pixelLayerOverflow);
     h_numberStripLayersOverMax->Fill(stripLayerOverflow);
     h_numberLayersOverMax->Fill(layerOverflow);
@@ -855,6 +861,12 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
     fillNoFlow(h_diffLostInnerHits, diffLostInnerHits);
 
     // For HitPattern ones, calculate the full diff (i.e. some differences are expected)
+    auto diffHitPatternPixelLayersWithMeasurement = trackPc.hitPattern().pixelLayersWithMeasurement() - trackNumberOfPixelLayers;
+    fillNoFlow(h_diffHitPatternPixelLayersWithMeasurement, diffHitPatternPixelLayersWithMeasurement);
+    auto diffHitPatternStripLayersWithMeasurement = trackPc.hitPattern().stripLayersWithMeasurement() - trackNumberOfStripLayers;
+    fillNoFlow(h_diffHitPatternStripLayersWithMeasurement, diffHitPatternStripLayersWithMeasurement);
+    auto diffHitPatternTrackerLayersWithMeasurement = trackPc.hitPattern().trackerLayersWithMeasurement() - trackNumberOfLayers;
+    fillNoFlow(h_diffHitPatternTrackerLayersWithMeasurement, diffHitPatternTrackerLayersWithMeasurement);
     auto diffHitPatternNumberOfValidPixelHits = trackPc.hitPattern().numberOfValidPixelHits() - trackNumberOfPixelHits;
     fillNoFlow(h_diffHitPatternNumberOfValidPixelHits, diffHitPatternNumberOfValidPixelHits);
     auto diffHitPatternNumberOfValidHits = trackPc.hitPattern().numberOfValidHits() - trackNumberOfHits;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -478,7 +478,7 @@ namespace pat {
 
     /// return a pointer to the track if present. otherwise, return a null pointer
     virtual const reco::Track * bestTrack() const {
-      if (packedHits_!=0) {
+      if (packedHits_!=0 || packedLayers_ !=0) {
         if (!track_) unpackTrk();
         return track_.load();
       }

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -52,7 +52,7 @@ namespace pat {
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
       dxydxy_(0),
       dzdz_(0),dxydz_(0),dlambdadz_(0), dphidxy_(0),dptdpt_(0),detadeta_(0),
-      dphidphi_(0), packedHits_(0), normalizedChi2_(0) { }
+      dphidphi_(0), packedHits_(0), packedLayers_(0), normalizedChi2_(0) { }
 
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
@@ -62,7 +62,7 @@ namespace pat {
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), dphi_(0), 
       track_(nullptr), pdgId_(c.pdgId()), qualityFlags_(0), pvRefProd_(pvRefProd),
       pvRefKey_(pvRefKey),dxydxy_(0),dzdz_(0),dxydz_(0), dlambdadz_(0),
-      dphidxy_(0),dptdpt_(0), detadeta_(0),dphidphi_(0), packedHits_(0),
+      dphidxy_(0),dptdpt_(0), detadeta_(0),dphidphi_(0), packedHits_(0), packedLayers_(0),
       normalizedChi2_(0) {
       packBoth();
     }
@@ -77,7 +77,7 @@ namespace pat {
       track_(nullptr), pdgId_(pdgId),
       qualityFlags_(0), pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
             dxydxy_(0),dzdz_(0),dxydz_(0),dlambdadz_(0),dphidxy_(0),dptdpt_(0),
-      detadeta_(0),dphidphi_(0),packedHits_(0),normalizedChi2_(0) {
+      detadeta_(0),dphidphi_(0),packedHits_(0),packedLayers_(0),normalizedChi2_(0) {
       packBoth();
     }
 
@@ -93,7 +93,7 @@ namespace pat {
       pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
       dxydxy_(0),dzdz_(0),dxydz_(0),
       dlambdadz_(0),dphidxy_(0),dptdpt_(0), detadeta_(0),dphidphi_(0),
-      packedHits_(0),normalizedChi2_(0) {
+      packedHits_(0),packedLayers_(0),normalizedChi2_(0) {
       packBoth();
     }
 
@@ -120,7 +120,7 @@ namespace pat {
       pvRefProd_(iOther.pvRefProd_),pvRefKey_(iOther.pvRefKey_),
       dxydxy_(iOther.dxydxy_),dzdz_(iOther.dzdz_),dxydz_(iOther.dxydz_), dlambdadz_(iOther.dlambdadz_),
       dphidxy_(iOther.dphidxy_),dptdpt_(iOther.dptdpt_), detadeta_(iOther.detadeta_),
-      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), normalizedChi2_(iOther.normalizedChi2_) {
+      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), packedLayers_(iOther.packedLayers_), normalizedChi2_(iOther.normalizedChi2_) {
       }
 
     PackedCandidate( PackedCandidate&& iOther) :
@@ -145,7 +145,7 @@ namespace pat {
       pvRefProd_(std::move(iOther.pvRefProd_)),pvRefKey_(iOther.pvRefKey_),
       dxydxy_(iOther.dxydxy_),dzdz_(iOther.dzdz_),dxydz_(iOther.dxydz_), dlambdadz_(iOther.dlambdadz_),
       dphidxy_(iOther.dphidxy_),dptdpt_(iOther.dptdpt_), detadeta_(iOther.detadeta_),
-      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), normalizedChi2_(iOther.normalizedChi2_) {
+      dphidphi_(iOther.dphidphi_), packedHits_(iOther.packedHits_), packedLayers_(iOther.packedLayers_), normalizedChi2_(iOther.normalizedChi2_) {
       }
 
 
@@ -214,6 +214,7 @@ namespace pat {
       detadeta_=iOther.detadeta_;
       dphidphi_=iOther.dphidphi_; 
       packedHits_=iOther.packedHits_; 
+      packedLayers_=iOther.packedLayers_; 
       normalizedChi2_=iOther.normalizedChi2_;
       return *this;
     }
@@ -260,6 +261,7 @@ namespace pat {
       detadeta_=iOther.detadeta_;
       dphidphi_=iOther.dphidphi_; 
       packedHits_=iOther.packedHits_; 
+      packedLayers_=iOther.packedLayers_; 
       normalizedChi2_=iOther.normalizedChi2_;
       return *this;
     }
@@ -400,11 +402,17 @@ namespace pat {
       dphidphi_ = covariance(2,2)*pt()*pt();
 
       normalizedChi2_ = tk.normalizedChi2();
-      int numberOfPixelHits_ = tk.hitPattern().numberOfValidPixelHits();
+      int numberOfPixelLayers_ = tk.hitPattern().pixelLayersWithMeasurement();
+      if (numberOfPixelLayers_ > trackPixelHitsMask) numberOfPixelLayers_ = trackPixelHitsMask;
+      int numberOfStripLayers_ = tk.hitPattern().stripLayersWithMeasurement();
+      if (numberOfStripLayers_ > trackStripHitsMask) numberOfStripLayers_ = trackStripHitsMask;
+      packedLayers_ = (numberOfPixelLayers_&trackPixelHitsMask) | (numberOfStripLayers_ << trackStripHitsShift);
+      int numberOfPixelHits_ = tk.hitPattern().numberOfValidPixelHits() - numberOfPixelLayers_;
       if (numberOfPixelHits_ > trackPixelHitsMask) numberOfPixelHits_ = trackPixelHitsMask;
-      int numberOfStripHits_ = tk.hitPattern().numberOfValidHits() - numberOfPixelHits_;
+      int numberOfStripHits_ = tk.hitPattern().numberOfValidHits() - numberOfPixelHits_ - numberOfPixelLayers_ - numberOfStripLayers_;
       if (numberOfStripHits_ > trackStripHitsMask) numberOfStripHits_ = trackStripHitsMask;
       packedHits_ = (numberOfPixelHits_&trackPixelHitsMask) | (numberOfStripHits_ << trackStripHitsShift);
+ 
       packBoth();
     }
 
@@ -412,8 +420,11 @@ namespace pat {
 	setTrackProperties(tk,tk.covariance());
     }	
  
-    int numberOfPixelHits() const { return packedHits_ & trackPixelHitsMask; }
-    int numberOfHits() const { return (packedHits_ >> trackStripHitsShift) + numberOfPixelHits(); }
+    int numberOfPixelHits() const { return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement(); }
+    int numberOfHits() const { return (packedHits_ >> trackStripHitsShift) + stripLayersWithMeasurement() + numberOfPixelHits(); }
+    int pixelLayersWithMeasurement() const { return packedLayers_ & trackPixelHitsMask; }
+    int stripLayersWithMeasurement() const { return (packedLayers_ >> trackStripHitsShift); }
+    int trackerLayersWithMeasurement() const { return stripLayersWithMeasurement() + pixelLayersWithMeasurement(); }
 	
     /// vertex position
     virtual const Point & vertex() const { maybeUnpackBoth(); return *vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
@@ -619,7 +630,7 @@ namespace pat {
 
     /// IP covariance	
     CMS_THREAD_GUARD(vertex_) mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
-    uint8_t packedHits_;
+    uint8_t packedHits_, packedLayers_;
     /// track quality information
     uint8_t normalizedChi2_; 
 //    uint8_t numberOfPixelHits_;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -402,11 +402,13 @@ namespace pat {
       dphidphi_ = covariance(2,2)*pt()*pt();
 
       normalizedChi2_ = tk.normalizedChi2();
+      // first we count the number of layers with hits
       int numberOfPixelLayers_ = tk.hitPattern().pixelLayersWithMeasurement();
       if (numberOfPixelLayers_ > trackPixelHitsMask) numberOfPixelLayers_ = trackPixelHitsMask;
       int numberOfStripLayers_ = tk.hitPattern().stripLayersWithMeasurement();
       if (numberOfStripLayers_ > trackStripHitsMask) numberOfStripLayers_ = trackStripHitsMask;
       packedLayers_ = (numberOfPixelLayers_&trackPixelHitsMask) | (numberOfStripLayers_ << trackStripHitsShift);
+      // now we count number of additional hits, beyond the one-per-layer implied by packedLayers_
       int numberOfPixelHits_ = tk.hitPattern().numberOfValidPixelHits() - numberOfPixelLayers_;
       if (numberOfPixelHits_ > trackPixelHitsMask) numberOfPixelHits_ = trackPixelHitsMask;
       int numberOfStripHits_ = tk.hitPattern().numberOfValidHits() - numberOfPixelHits_ - numberOfPixelLayers_ - numberOfStripLayers_;
@@ -630,7 +632,7 @@ namespace pat {
 
     /// IP covariance	
     CMS_THREAD_GUARD(vertex_) mutable float dxydxy_, dzdz_, dxydz_,dlambdadz_,dphidxy_,dptdpt_,detadeta_,dphidphi_;
-    uint8_t packedHits_, packedLayers_;
+    uint8_t packedHits_, packedLayers_; // packedLayers_ -> layers with valid hits; packedHits_ -> extra hits beyond the one-per-layer implied by packedLayers_
     /// track quality information
     uint8_t normalizedChi2_; 
 //    uint8_t numberOfPixelHits_;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -184,7 +184,9 @@ void pat::PackedCandidate::unpackTrk() const {
     
     // add hits to match the number of laters and validHitInFirstPixelBarrelLayer
     if(innerLost == validHitInFirstPixelBarrelLayer){
+        // first we add one hit on the first barrel layer
         track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::valid); 
+        // then to encode the number of layers, we add more hits on distinct layers (B2, B3, B4, F1, ...)
         for(i++; i<numberOfPixelLayers; i++) {
             if (i <= 3) { 
                 track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i+1, 0, TrackingRecHit::valid); 
@@ -193,6 +195,7 @@ void pat::PackedCandidate::unpackTrk() const {
             }
         }
     } else {
+        // to encode the information on the layers, we add one valid hits per layer but skipping PXB1
         for(;i<numberOfPixelLayers; i++) {
             if (i <= 2 ) { 
                 track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i+2, 0, TrackingRecHit::valid); 
@@ -201,11 +204,13 @@ void pat::PackedCandidate::unpackTrk() const {
             }
         }
     }
-    // add extra hits (overlaps, etc)
+    // add extra hits (overlaps, etc), all on the first layer with a hit - to avoid increasing the layer count
     for(;i<numberOfPixelHits; i++) { 
        track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, (innerLost == validHitInFirstPixelBarrelLayer ? 1 : 2), 0, TrackingRecHit::valid); 
     }
-    // now start adding tracker layers
+    // now start adding strip layers, putting one hit on each layer so that the hitPattern.stripLayersWithMeasurement works.
+    // we don't know what the layers where, so we just start with TIB (4 layers), then TOB (6 layers), then TEC (9)
+    // and then TID(3), so that we can get a number of valid strip layers up to 4+6+9+3
     for(int sl = 0; sl < numberOfStripLayers; ++sl, ++i) {
         if      (sl < 4)    track->appendTrackerHitPattern(StripSubdetector::TIB,   sl   +1, 1, TrackingRecHit::valid);
         else if (sl < 4+6)  track->appendTrackerHitPattern(StripSubdetector::TOB, (sl- 4)+1, 1, TrackingRecHit::valid);
@@ -213,6 +218,8 @@ void pat::PackedCandidate::unpackTrk() const {
         else if (sl < 19+3) track->appendTrackerHitPattern(StripSubdetector::TID, (sl-13)+1, 1, TrackingRecHit::valid);
         else break; // wtf?
     }
+    // finally we account for extra strip hits beyond the one-per-layer added above. we put them all on TIB1,
+    // to avoid incrementing the number of layersWithMeasurement.
     for(;i<numberOfHits;i++) {
           track->appendTrackerHitPattern(StripSubdetector::TIB, 1, 1, TrackingRecHit::valid);
     }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -279,7 +279,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="26">
+  <class name="pat::PackedCandidate" ClassVersion="27">
+    <version ClassVersion="27" checksum="2418936168"/>
     <version ClassVersion="26" checksum="2986327792"/>
     <version ClassVersion="25" checksum="3654469025"/>
     <version ClassVersion="24" checksum="663492232"/>


### PR DESCRIPTION
Save also the strip and pixel layers for packed candidates.
For compactness, instead of saving then also the number of hits we save the number of extra hits (hits - layers). 

Disk size cost seems to be ~100 bytes/event, on 8.5k TTbar (PUpmx25ns).

Validation module updated as well, and used to check that there is perfect agreement between the reported number of hits and layers in the strip and pixel detector between the AOD track, the PackedCandidate methods and the PackedCandidate pseudoTrack, on ~1k TTbar events, both for 2016 and 2017 scenarios.

When reading old MiniAODs, the number of layers will be reported as zero, and but the number of hits should still be correct (I didn't put any iorule magic to try to fudge a number of layers). 

@arizzi @makortel @ferencek 
