### PR TITLE
Fix ordering in Phase2OTEndcapRing

### DIFF
--- a/RecoTracker/TkDetLayers/src/Phase2OTEndcapRing.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTEndcapRing.cc
@@ -22,6 +22,14 @@ using namespace std;
 
 typedef GeometricSearchDet::DetWithState DetWithState;
 
+class DetGroupElementZLess {
+public:
+  bool operator()(DetGroup a,DetGroup b)
+  {
+    return (fabs(a.front().det()->position().z()) < fabs(b.front().det()->position().z()));
+  }
+};
+
 Phase2OTEndcapRing::Phase2OTEndcapRing(vector<const GeomDet*>& innerDets,
 			       vector<const GeomDet*>& outerDets,
 			       vector<const GeomDet*>& innerDetBrothers,
@@ -131,6 +139,21 @@ Phase2OTEndcapRing::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos
 
   DetGroupMerger::orderAndMergeTwoLevels( std::move(closestCompleteResult), std::move(nextCompleteResult), result,
 					  crossings.closestIndex(), crossingSide);
+
+  //due to propagator problems, when we add single pt sub modules, we should order them in z (endcap)
+  sort(result.begin(),result.end(),DetGroupElementZLess());
+
+#ifdef EDM_ML_DEBUG
+  for (auto&  grp : result) {
+    if ( grp.empty() )  continue;
+      LogTrace("TkDetLayers") <<"New group in Phase2OTEndcapRing made by : " << std::endl;
+      for (auto const & det : grp) {
+          LogTrace("TkDetLayers") <<" geom det at r: " << det.det()->position().perp() <<" id:" << det.det()->geographicalId().rawId()
+                    <<" tsos at:" << det.trajectoryState().globalPosition() << std::endl;
+      }
+    }
+#endif
+
 }
 
 


### PR DESCRIPTION
Back-porting from SLHC release a fix in the order of the sub-modules in the endcap rings for phase2. 
It has been developed on top of the CMSSW_8_1_X_2016-08-23-2300 release. 
This change fixes partly the distribution of the number of hits in the tracks ([comparison](http://ebrondol.web.cern.ch/ebrondol/Migration81X/MTV_TTbar_fixPhase2OTEndcapRing_tilt/plots_ootb/hitsAndPt.pdf)) and keep the eff/fakerate almost unchanged ([comparison](http://ebrondol.web.cern.ch/ebrondol/Migration81X/MTV_TTbar_fixPhase2OTEndcapRing_tilt/plots_ootb/effandfake1.pdf)). For the comparison, 100 events of 14TeV ttbar production have been reconstructed in the tilted geometry.

No changes expected for phase0/1.

@VinInn @rovere @boudoul @delaere @kpedro88 for your information.
