### PR TITLE
Importing Phase2StripCPE from external package

### DIFF
--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
@@ -13,14 +13,13 @@ from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi impo
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from RecoLocalTracker.SubCollectionProducers.clustersummaryproducer_cfi import *
 
-from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi import *
-
 pixeltrackerlocalreco = cms.Sequence(siPixelClustersPreSplitting*siPixelRecHitsPreSplitting)
 striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
 trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducer)
 
 from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import *
 from RecoLocalTracker.Phase2ITPixelClusterizer.Phase2ITPixelClusterizer_cfi import *
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi import *
 
 from Configuration.StandardSequences.Eras import eras
 eras.phase2_tracker.toReplaceWith(pixeltrackerlocalreco,

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
@@ -13,6 +13,8 @@ from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi impo
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from RecoLocalTracker.SubCollectionProducers.clustersummaryproducer_cfi import *
 
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi import *
+
 pixeltrackerlocalreco = cms.Sequence(siPixelClustersPreSplitting*siPixelRecHitsPreSplitting)
 striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
 trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducer)

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPETrivial_H
-#define RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPETrivial_H
+#ifndef RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPE_H
+#define RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPE_H
 
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-class Phase2StripCPETrivial : public ClusterParameterEstimator<Phase2TrackerCluster1D> {
+class Phase2StripCPE : public ClusterParameterEstimator<Phase2TrackerCluster1D> {
 
   public:
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -8,7 +8,7 @@
 
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h"
 
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
@@ -38,7 +38,7 @@ class Phase2StripCPEESProducer: public edm::ESProducer {
 Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet & p) {
   std::string name = p.getParameter<std::string>("ComponentType");
 
-  enumMap_[std::string("Phase2StripCPETrivial")]   = TRIVIAL;
+  enumMap_[std::string("Phase2StripCPE")]   = TRIVIAL;
   enumMap_[std::string("Phase2StripCPEGeometric")] = GEOMETRIC;
   if (enumMap_.find(name) == enumMap_.end())
     throw cms::Exception("Unknown StripCPE type") << name;
@@ -53,7 +53,7 @@ std::shared_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripC
 
   switch(cpeNum_) {
     case TRIVIAL:
-      cpe_ = std::make_shared<Phase2StripCPETrivial>();
+      cpe_ = std::make_shared<Phase2StripCPE>();
       break;
     case GEOMETRIC:
       cpe_ = std::make_shared<Phase2StripCPEGeometric>(pset_);

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -22,7 +22,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 
 #include <vector>
 #include <string>

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 phase2StripCPEESProducer = cms.ESProducer("Phase2StripCPEESProducer",
-  ComponentType = cms.string('Phase2StripCPETrivial'),
+  ComponentType = cms.string('Phase2StripCPE'),
   parameters    = cms.PSet()
 )

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
@@ -1,8 +1,7 @@
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 
-
-Phase2StripCPETrivial::LocalValues Phase2StripCPETrivial::localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const {
+Phase2StripCPE::LocalValues Phase2StripCPE::localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const {
   float strippitch  = 0.0090; // hardcoded dummy, a la 2S
   float striplength = 5.;     // hardcoded dummy, a la 2S
   std::pair<float, float> barycenter = cluster.barycenter();

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/module.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/module.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Utilities/interface/typelookup.h"
+
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h"
+
+TYPELOOKUP_DATA_REG(Phase2StripCPEGeometric);

--- a/RecoTracker/MeasurementDet/plugins/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="RecoTracker/MeasurementDet"/>
+<use   name="RecoLocalTracker/Phase2TrackerRecHits"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
 <use   name="CondFormats/DataRecord"/>

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -9,6 +9,7 @@
 
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
@@ -48,6 +49,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
   std::string pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
   std::string stripCPEName = pset_.getParameter<std::string>("StripCPE");
+  edm::ESInputTag phase2TrackerCPEName = pset_.getParameter<edm::ESInputTag>("Phase2StripCPE");
   std::string matcherName  = pset_.getParameter<std::string>("HitMatcher");
 
   // ========= SiPixelQuality related tasks =============
@@ -118,14 +120,15 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   edm::ESHandle<SiStripRecHitMatcher>           hitMatcher;
   edm::ESHandle<TrackerGeometry>                trackerGeom;
   edm::ESHandle<GeometricSearchTracker>         geometricSearchTracker;
-
+  edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > phase2TrackerCPE;
   
   iRecord.getRecord<TkPixelCPERecord>().get(pixelCPEName,pixelCPE);
   iRecord.getRecord<TkStripCPERecord>().get(stripCPEName,stripCPE);
+  iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
   iRecord.getRecord<TkStripCPERecord>().get(matcherName,hitMatcher);
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
-  
+
   _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),
 							          stripCPE.product(),

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -49,7 +49,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
   std::string pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
   std::string stripCPEName = pset_.getParameter<std::string>("StripCPE");
-  edm::ESInputTag phase2TrackerCPEName = pset_.getParameter<edm::ESInputTag>("Phase2StripCPE");
+  std::string phase2TrackerCPEName = pset_.getParameter<std::string>("Phase2StripCPE");
   std::string matcherName  = pset_.getParameter<std::string>("HitMatcher");
 
   // ========= SiPixelQuality related tasks =============

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -38,7 +38,16 @@ using namespace edm;
 MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterSet & p) 
 {  
   std::string myname = p.getParameter<std::string>("ComponentName");
+  pixelCPEName = p.getParameter<std::string>("PixelCPE");
+  stripCPEName = p.getParameter<std::string>("StripCPE");
+  matcherName  = p.getParameter<std::string>("HitMatcher");
+
+  //FIXME:: just temporary solution for phase2!
   phase2TrackerCPEName = "";
+  if (p.existsAs<std::string>("Phase2StripCPE")) {
+    phase2TrackerCPEName = p.getParameter<std::string>("Phase2StripCPE");
+  }
+
   pset_ = p;
   setWhatProduced(this,myname);
 }
@@ -48,14 +57,7 @@ MeasurementTrackerESProducer::~MeasurementTrackerESProducer() {}
 std::shared_ptr<MeasurementTracker> 
 MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
-  pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
-  stripCPEName = pset_.getParameter<std::string>("StripCPE");
-  matcherName  = pset_.getParameter<std::string>("HitMatcher");
 
-  //FIXME:: just temporary solution for phase2!
-  if (pset_.existsAs<std::string>("Phase2StripCPE")) {
-    phase2TrackerCPEName = pset_.getParameter<std::string>("Phase2StripCPE");
-  }
 
   // ========= SiPixelQuality related tasks =============
   const SiPixelQuality    *ptr_pixelQuality = 0;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -38,6 +38,7 @@ using namespace edm;
 MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterSet & p) 
 {  
   std::string myname = p.getParameter<std::string>("ComponentName");
+  phase2TrackerCPEName = "";
   pset_ = p;
   setWhatProduced(this,myname);
 }
@@ -47,12 +48,11 @@ MeasurementTrackerESProducer::~MeasurementTrackerESProducer() {}
 std::shared_ptr<MeasurementTracker> 
 MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
-  std::string pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
-  std::string stripCPEName = pset_.getParameter<std::string>("StripCPE");
-  std::string matcherName  = pset_.getParameter<std::string>("HitMatcher");
+  pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
+  stripCPEName = pset_.getParameter<std::string>("StripCPE");
+  matcherName  = pset_.getParameter<std::string>("HitMatcher");
 
   //FIXME:: just temporary solution for phase2!
-  std::string phase2TrackerCPEName = "";
   if (pset_.existsAs<std::string>("Phase2StripCPE")) {
     phase2TrackerCPEName = pset_.getParameter<std::string>("Phase2StripCPE");
   }

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -49,8 +49,13 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
   std::string pixelCPEName = pset_.getParameter<std::string>("PixelCPE");
   std::string stripCPEName = pset_.getParameter<std::string>("StripCPE");
-  std::string phase2TrackerCPEName = pset_.getParameter<std::string>("Phase2StripCPE");
   std::string matcherName  = pset_.getParameter<std::string>("HitMatcher");
+
+  //FIXME:: just temporary solution for phase2!
+  std::string phase2TrackerCPEName = "";
+  if (pset_.existsAs<std::string>("Phase2StripCPE")) {
+    phase2TrackerCPEName = pset_.getParameter<std::string>("Phase2StripCPE");
+  }
 
   // ========= SiPixelQuality related tasks =============
   const SiPixelQuality    *ptr_pixelQuality = 0;
@@ -124,15 +129,15 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   
   iRecord.getRecord<TkPixelCPERecord>().get(pixelCPEName,pixelCPE);
   iRecord.getRecord<TkStripCPERecord>().get(stripCPEName,stripCPE);
-  iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
   iRecord.getRecord<TkStripCPERecord>().get(matcherName,hitMatcher);
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
 
-  _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
+  if(phase2TrackerCPEName != ""){
+      iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
+      _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),
 							          stripCPE.product(),
-							          phase2TrackerCPE.product(),
 							          hitMatcher.product(),
 							          trackerGeom.product(),
 							          geometricSearchTracker.product(),
@@ -142,7 +147,23 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 							          ptr_pixelQuality,
 							          ptr_pixelCabling,
                                                                   pixelQualityFlags,
-                                                                  pixelQualityDebugFlags); 
+                                                                  pixelQualityDebugFlags,
+							          phase2TrackerCPE.product());
+  } else {
+      _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
+							          pixelCPE.product(),
+							          stripCPE.product(),
+							          hitMatcher.product(),
+							          trackerGeom.product(),
+							          geometricSearchTracker.product(),
+							          ptr_stripQuality,
+                                                                  stripQualityFlags,
+                                                                  stripQualityDebugFlags,
+							          ptr_pixelQuality,
+                                                                  ptr_pixelCabling,
+                                                                  pixelQualityFlags,
+                                                                  pixelQualityDebugFlags);
+  }
   return _measurementTracker;
 }
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -9,7 +9,7 @@
 
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -132,6 +132,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),
 							          stripCPE.product(),
+							          phase2TrackerCPE.product(),
 							          hitMatcher.product(),
 							          trackerGeom.product(),
 							          geometricSearchTracker.product(),

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
@@ -15,6 +15,10 @@ class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
  private:
   std::shared_ptr<MeasurementTracker> _measurementTracker;
   edm::ParameterSet pset_;
+  std::string pixelCPEName;
+  std::string stripCPEName;
+  std::string matcherName;
+  std::string phase2TrackerCPEName;
 };
 
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -80,6 +80,7 @@ namespace {
 MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&              conf,
 				       const PixelClusterParameterEstimator* pixelCPE,
 				       const StripClusterParameterEstimator* stripCPE,
+		                       const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE,
 				       const SiStripRecHitMatcher*  hitMatcher,
 				       const TrackerGeometry*  trackerGeom,
 				       const GeometricSearchTracker* geometricSearchTracker,
@@ -95,7 +96,7 @@ MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&         
   name_(conf.getParameter<std::string>("ComponentName")),
   theStDetConditions(hitMatcher,stripCPE),
   thePxDetConditions(pixelCPE),
-  thePhase2DetConditions(pixelCPE)
+  thePhase2DetConditions(phase2OTCPE)
 {
   this->initialize();
   this->initializeStripStatus(stripQuality, stripQualityFlags, stripQualityDebugFlags);

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -80,7 +80,6 @@ namespace {
 MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&              conf,
 				       const PixelClusterParameterEstimator* pixelCPE,
 				       const StripClusterParameterEstimator* stripCPE,
-		                       const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE,
 				       const SiStripRecHitMatcher*  hitMatcher,
 				       const TrackerGeometry*  trackerGeom,
 				       const GeometricSearchTracker* geometricSearchTracker,
@@ -90,7 +89,8 @@ MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&         
                                        const SiPixelQuality *pixelQuality,
                                        const SiPixelFedCabling *pixelCabling,
                                        int   pixelQualityFlags,
-                                       int   pixelQualityDebugFlags) :
+                                       int   pixelQualityDebugFlags,
+		                       const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE):
   MeasurementTracker(trackerGeom,geometricSearchTracker),
   pset_(conf),
   name_(conf.getParameter<std::string>("ComponentName")),

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -8,6 +8,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
@@ -50,6 +51,7 @@ public:
   MeasurementTrackerImpl(const edm::ParameterSet&              conf,
 		     const PixelClusterParameterEstimator* pixelCPE,
 		     const StripClusterParameterEstimator* stripCPE,
+		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE,
 		     const SiStripRecHitMatcher*  hitMatcher,
 		     const TrackerGeometry*  trackerGeom,
 		     const GeometricSearchTracker* geometricSearchTracker,

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -51,7 +51,6 @@ public:
   MeasurementTrackerImpl(const edm::ParameterSet&              conf,
 		     const PixelClusterParameterEstimator* pixelCPE,
 		     const StripClusterParameterEstimator* stripCPE,
-		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE,
 		     const SiStripRecHitMatcher*  hitMatcher,
 		     const TrackerGeometry*  trackerGeom,
 		     const GeometricSearchTracker* geometricSearchTracker,
@@ -61,7 +60,8 @@ public:
                      const SiPixelQuality *pixelQuality,
                      const SiPixelFedCabling *pixelCabling,
                      int   pixelQualityFlags,
-                     int   pixelQualityDebugFlags);
+                     int   pixelQualityDebugFlags,
+		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE = 0);
 
   virtual ~MeasurementTrackerImpl();
  

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -8,7 +8,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
@@ -56,25 +56,9 @@ TrackingRecHit::RecHitPointer
 TkPhase2OTMeasurementDet::buildRecHit( const Phase2TrackerCluster1DRef & cluster,
 				    const LocalTrajectoryParameters & ltp) const
 {
-/*
-  //FIXME:just temporary solution for phase2!
-  const PixelGeomDetUnit& gdu( specificGeomDet() );
-  const PixelTopology * topo = &gdu.specificTopology();
 
-  float pitch_x = topo->pitch().first;
-  float pitch_y = topo->pitch().second;
-  float ix = cluster->center();
-  float iy = cluster->column()+0.5; // halfway the column
-
-  LocalPoint lp( topo->localX(ix), topo->localY(iy), 0 );          // x, y, z
-  LocalError le( pow(pitch_x, 2) / 12, 0, pow(pitch_y, 2) / 12);   // e2_xx, e2_xy, e2_yy
-*/
   const PixelGeomDetUnit& gdu( specificGeomDet() );
   auto && params = cpe()->localParameters( *cluster, gdu );
-//std::cout << "LocalPoint     >> " << lp << std::endl;
-//std::cout << "LocalPointCPE >> " << params.first << std::endl;
-//std::cout << "LocalError     >> " << le << std::endl;
-//std::cout << "LocalErrorCPE >> " << params.second << std::endl;
 
   return std::make_shared<Phase2TrackerRecHit1D>( params.first, params.second, fastGeomDet(), cluster);
 

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
@@ -56,6 +56,7 @@ TrackingRecHit::RecHitPointer
 TkPhase2OTMeasurementDet::buildRecHit( const Phase2TrackerCluster1DRef & cluster,
 				    const LocalTrajectoryParameters & ltp) const
 {
+/*
   //FIXME:just temporary solution for phase2!
   const PixelGeomDetUnit& gdu( specificGeomDet() );
   const PixelTopology * topo = &gdu.specificTopology();
@@ -67,10 +68,16 @@ TkPhase2OTMeasurementDet::buildRecHit( const Phase2TrackerCluster1DRef & cluster
 
   LocalPoint lp( topo->localX(ix), topo->localY(iy), 0 );          // x, y, z
   LocalError le( pow(pitch_x, 2) / 12, 0, pow(pitch_y, 2) / 12);   // e2_xx, e2_xy, e2_yy
-  return std::make_shared<Phase2TrackerRecHit1D>( lp, le, fastGeomDet(), cluster);
+*/
+  const PixelGeomDetUnit& gdu( specificGeomDet() );
+  auto && params = cpe()->localParameters( *cluster, gdu );
+//std::cout << "LocalPoint     >> " << lp << std::endl;
+//std::cout << "LocalPointCPE >> " << params.first << std::endl;
+//std::cout << "LocalError     >> " << le << std::endl;
+//std::cout << "LocalErrorCPE >> " << params.second << std::endl;
 
-//  auto && params = cpe()->getParameters( * cluster, gdu, ltp );
-//  return std::make_shared<SiPixelRecHit>( std::get<0>(params), std::get<1>(params), std::get<2>(params), fastGeomDet(), cluster);
+  return std::make_shared<Phase2TrackerRecHit1D>( params.first, params.second, fastGeomDet(), cluster);
+
 }
 
 TkPhase2OTMeasurementDet::RecHitContainer 

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -2,7 +2,7 @@
 #define TkPhase2OTMeasurementDet_H
 
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
-#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 //#include "DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -21,10 +21,10 @@ public:
   
   typedef edmNew::DetSet<Phase2TrackerCluster1D> detset;
   typedef detset::const_iterator const_iterator;
-  typedef PixelClusterParameterEstimator::LocalValues    LocalValues;
+  typedef ClusterParameterEstimator<Phase2TrackerCluster1D>::LocalValues    LocalValues;
 
   TkPhase2OTMeasurementDet( const GeomDet* gdet,
-			 Phase2OTMeasurementConditionSet & conditionSet );
+    			    Phase2OTMeasurementConditionSet & conditionSet );
 
   void update(Phase2OTMeasurementDetSet &data, const detset & detSet ) { 
     data.update(index(), detSet);
@@ -85,7 +85,7 @@ private:
   Phase2OTMeasurementConditionSet & conditionSet() { return *theDetConditions; }
   const Phase2OTMeasurementConditionSet & conditionSet() const { return *theDetConditions; }
 
-  const PixelClusterParameterEstimator * cpe() const { return conditionSet().pixelCPE(); }
+  const ClusterParameterEstimator<Phase2TrackerCluster1D>* cpe() const { return conditionSet().cpe(); }
 
 };
 

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -2,7 +2,7 @@
 #define TkPhase2OTMeasurementDet_H
 
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -3,7 +3,6 @@
 
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
-//#include "DataFormats/SiPixelCluster/interface/SiPixelClusterFwd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -5,7 +5,6 @@ MeasurementTracker = cms.ESProducer("MeasurementTrackerESProducer",
 
     PixelCPE = cms.string('PixelCPEGeneric'),
     StripCPE = cms.string('StripCPEfromTrackAngle'),
-    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
     HitMatcher = cms.string('StandardMatcher'),
 
     SiStripQualityLabel         = cms.string(''),  ## unlabelled default SiStripQuality
@@ -30,4 +29,5 @@ MeasurementTracker = cms.ESProducer("MeasurementTrackerESProducer",
     DebugPixelROCQualityDB    = cms.untracked.bool(False), ## dump out info om module status
 )
 
-
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase2PU140.toModify(MeasurementTracker, Phase2StripCPE = cms.string('Phase2StripCPEGeometric'))

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -5,7 +5,7 @@ MeasurementTracker = cms.ESProducer("MeasurementTrackerESProducer",
 
     PixelCPE = cms.string('PixelCPEGeneric'),
     StripCPE = cms.string('StripCPEfromTrackAngle'),
-    Phase2StripCPE = cms.ESInputTag("phase2StripCPEGeometricESProducer", "Phase2StripCPEGeometric"),
+    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
     HitMatcher = cms.string('StandardMatcher'),
 
     SiStripQualityLabel         = cms.string(''),  ## unlabelled default SiStripQuality

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -5,6 +5,7 @@ MeasurementTracker = cms.ESProducer("MeasurementTrackerESProducer",
 
     PixelCPE = cms.string('PixelCPEGeneric'),
     StripCPE = cms.string('StripCPEfromTrackAngle'),
+    Phase2StripCPE = cms.ESInputTag("phase2StripCPEGeometricESProducer", "Phase2StripCPEGeometric"),
     HitMatcher = cms.string('StandardMatcher'),
 
     SiStripQualityLabel         = cms.string(''),  ## unlabelled default SiStripQuality

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -8,11 +8,13 @@ class TkPixelMeasurementDet;
 class SiStripRecHitMatcher;
 class StripClusterParameterEstimator;
 class PixelClusterParameterEstimator;
+class Phase2StripCPETrivial;
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
@@ -392,7 +394,7 @@ private:
 //FIXME:just temporary solution for phase2 OT that works!
 class Phase2OTMeasurementConditionSet {
 public:
-  Phase2OTMeasurementConditionSet(const PixelClusterParameterEstimator *cpe) :
+  Phase2OTMeasurementConditionSet(const ClusterParameterEstimator<Phase2TrackerCluster1D> *cpe) :
     theCPE(cpe) {}
 
   void init(int size);
@@ -403,7 +405,7 @@ public:
     return std::lower_bound(id_.begin()+i,id_.end(),jd)-id_.begin();
   }
 
-  const PixelClusterParameterEstimator*  pixelCPE() const { return theCPE;}
+  const ClusterParameterEstimator<Phase2TrackerCluster1D>*  cpe() const { return theCPE;}
   bool isActiveThisPeriod(int i) const { return activeThisPeriod_[i]; }
 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually).
@@ -415,7 +417,7 @@ private:
   friend class MeasurementTrackerImpl;
 
   // Globals (not-per-event)
-  const PixelClusterParameterEstimator* theCPE;
+  const ClusterParameterEstimator<Phase2TrackerCluster1D>* theCPE;
   
   // Locals, per-event
   std::vector<unsigned int> id_;

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -8,13 +8,13 @@ class TkPixelMeasurementDet;
 class SiStripRecHitMatcher;
 class StripClusterParameterEstimator;
 class PixelClusterParameterEstimator;
-class Phase2StripCPETrivial;
+class Phase2StripCPE;
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"

--- a/RecoTracker/TransientTrackingRecHit/BuildFile.xml
+++ b/RecoTracker/TransientTrackingRecHit/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="RecoLocalTracker/ClusterParameterEstimator"/>
 <use   name="RecoLocalTracker/SiPixelRecHits"/>
 <use   name="RecoLocalTracker/SiStripRecHitConverter"/>
+<use   name="RecoLocalTracker/Phase2TrackerRecHits"/>
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/Common"/>
 <use   name="clhep"/>

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include "DataFormats/TrackerRecHit2D/interface/TkCloner.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
@@ -15,7 +16,10 @@ public:
   TkClonerImpl(const PixelClusterParameterEstimator * ipixelCPE,
 	       const StripClusterParameterEstimator * istripCPE,
 	       const SiStripRecHitMatcher           * iMatcher
-	       ): pixelCPE(ipixelCPE), stripCPE(istripCPE), theMatcher(iMatcher){}
+	       ): pixelCPE(ipixelCPE), stripCPE(istripCPE), theMatcher(iMatcher), phase2TrackerCPE(0){}
+  TkClonerImpl(const PixelClusterParameterEstimator * ipixelCPE,
+	       const ClusterParameterEstimator<Phase2TrackerCluster1D> * iPhase2OTCPE
+	       ): pixelCPE(ipixelCPE), stripCPE(0), theMatcher(0), phase2TrackerCPE(iPhase2OTCPE){}
 
   using TkCloner::operator();
   virtual std::unique_ptr<SiPixelRecHit> operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const override;
@@ -42,6 +46,7 @@ private:
   const PixelClusterParameterEstimator * pixelCPE;
   const StripClusterParameterEstimator * stripCPE;
   const SiStripRecHitMatcher           * theMatcher;
+  const ClusterParameterEstimator<Phase2TrackerCluster1D> * phase2TrackerCPE;
 
 
 };

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include "DataFormats/TrackerRecHit2D/interface/TkCloner.h"
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;

--- a/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
@@ -37,7 +37,12 @@ class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBui
   const TrackingGeometry               * geometry() const  { return tGeometry_;}
 
   // for the time being here...
-  TkClonerImpl cloner() const { return TkClonerImpl(pixelCPE,stripCPE,theMatcher);}
+  TkClonerImpl cloner() const { 
+    if(phase2OTCPE == 0)
+      return TkClonerImpl(pixelCPE,stripCPE,theMatcher);
+    else
+      return TkClonerImpl(pixelCPE,phase2OTCPE);
+  }
 
 private:
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
@@ -1,7 +1,7 @@
 #ifndef RECOTRACKER_TRANSIENTRECHITBUILDER_H
 #define RECOTRACKER_TRANSIENTRECHITBUILDER_H
 
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
@@ -12,7 +12,7 @@
 class SiStripRecHitMatcher;
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
-class Phase2StripCPETrivial;
+class Phase2StripCPE;
 
 
 class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBuilder {

--- a/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
@@ -1,6 +1,7 @@
 #ifndef RECOTRACKER_TRANSIENTRECHITBUILDER_H
 #define RECOTRACKER_TRANSIENTRECHITBUILDER_H
 
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
@@ -11,6 +12,8 @@
 class SiStripRecHitMatcher;
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
+class Phase2StripCPETrivial;
+
 
 class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBuilder {
   
@@ -20,12 +23,16 @@ class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBui
 				    const StripClusterParameterEstimator * ,
                                     const SiStripRecHitMatcher           *,
 				    bool computeCoarseLocalPositionFromDisk);
+  TkTransientTrackingRecHitBuilder (const TrackingGeometry* trackingGeometry, 
+				    const PixelClusterParameterEstimator * ,
+				    const ClusterParameterEstimator<Phase2TrackerCluster1D> * );
 
   TransientTrackingRecHit::RecHitPointer build (const TrackingRecHit * p) const ;
 
 
   const PixelClusterParameterEstimator * pixelClusterParameterEstimator() const {return pixelCPE;}
   const StripClusterParameterEstimator * stripClusterParameterEstimator() const {return stripCPE;}
+  const ClusterParameterEstimator<Phase2TrackerCluster1D> * phase2TrackerClusterParameterEstimator() const {return phase2OTCPE;}
   const SiStripRecHitMatcher           * siStripRecHitMatcher() const {return theMatcher;}
   const TrackingGeometry               * geometry() const  { return tGeometry_;}
 
@@ -41,6 +48,7 @@ private:
   const StripClusterParameterEstimator * stripCPE;
   const SiStripRecHitMatcher           * theMatcher;
   bool theComputeCoarseLocalPosition;
+  const ClusterParameterEstimator<Phase2TrackerCluster1D> * phase2OTCPE;
 };
 
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -79,21 +79,20 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );     
   
   //For Phase2 upgrade
-  std::string p2OTname = pset_.getParameter<std::string>("Phase2StripCPE");
+  std::string p2OTname = "";
+  if(pset_.existsAs<std::string>("Phase2StripCPE")){
+    p2OTname = pset_.getParameter<std::string>("Phase2StripCPE");
+  }
   edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > p2OTe;
   const ClusterParameterEstimator<Phase2TrackerCluster1D> * p2OTp;
 
-  if (p2OTname == "Fake") {
-    p2OTp = 0;
-  }else{
+  if (p2OTname != "") {
     iRecord.getRecord<TkStripCPERecord>().get( p2OTname, p2OTe );
     p2OTp = p2OTe.product();
-  }
-
-  if(p2OTp == 0)
-    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
-  else
     _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, p2OTp);
+  } else {
+    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
+  }
 
   return _builder;
 }

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -3,7 +3,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
-#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -3,6 +3,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
+#include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPETrivial.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -24,7 +25,22 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
 }
 
 TkTransientTrackingRecHitBuilderESProducer::~TkTransientTrackingRecHitBuilderESProducer() {}
+/*
+void TkTransientTrackingRecHitBuilderESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("StripCPE","StripCPEfromTrackAngle");
+    desc.add<std::string>("PixelCPE","PixelCPEGeneric");
+    desc.add<std::string>("ComponentName","WithTrackAngle");
+    desc.add<std::string>("Matcher","StandardMatcher");
+    desc.add<bool>("ComputeCoarseLocalPositionFromDisk",false);
+
+    desc.add<std::string>("Phase2StripCPE","Phase2StripCPEGeometric");
+
+    descriptions.add("ttrhbwr", desc);
+
+}
+*/
 std::shared_ptr<TransientTrackingRecHitBuilder> 
 TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord & iRecord){ 
 //   if (_propagator){
@@ -35,10 +51,11 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   std::string sname = pset_.getParameter<std::string>("StripCPE");
   std::string pname = pset_.getParameter<std::string>("PixelCPE");
   std::string mname = pset_.getParameter<std::string>("Matcher");
+
   
   edm::ESHandle<StripClusterParameterEstimator> se; 
   edm::ESHandle<PixelClusterParameterEstimator> pe; 
-  edm::ESHandle<SiStripRecHitMatcher>           me; 
+  edm::ESHandle<SiStripRecHitMatcher>           me;
   const StripClusterParameterEstimator * sp ;
   const PixelClusterParameterEstimator * pp ;
   const SiStripRecHitMatcher           * mp ;
@@ -76,7 +93,23 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   edm::ESHandle<TrackerGeometry> pDD;
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );     
   
-  _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
+  //For Phase2 upgrade
+  std::string p2OTname = pset_.getParameter<std::string>("Phase2StripCPE");
+  edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > p2OTe;
+  const ClusterParameterEstimator<Phase2TrackerCluster1D> * p2OTp;
+
+  if (p2OTname == "Fake") {
+    p2OTp = 0;
+  }else{
+    iRecord.getRecord<TkStripCPERecord>().get( p2OTname, p2OTe );
+    p2OTp = p2OTe.product();
+  }
+
+  if(p2OTp == 0)
+    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
+  else
+    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, p2OTp);
+
   return _builder;
 }
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -25,22 +25,7 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
 }
 
 TkTransientTrackingRecHitBuilderESProducer::~TkTransientTrackingRecHitBuilderESProducer() {}
-/*
-void TkTransientTrackingRecHitBuilderESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
-    edm::ParameterSetDescription desc;
-    desc.add<std::string>("StripCPE","StripCPEfromTrackAngle");
-    desc.add<std::string>("PixelCPE","PixelCPEGeneric");
-    desc.add<std::string>("ComponentName","WithTrackAngle");
-    desc.add<std::string>("Matcher","StandardMatcher");
-    desc.add<bool>("ComputeCoarseLocalPositionFromDisk",false);
-
-    desc.add<std::string>("Phase2StripCPE","Phase2StripCPEGeometric");
-
-    descriptions.add("ttrhbwr", desc);
-
-}
-*/
 std::shared_ptr<TransientTrackingRecHitBuilder> 
 TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord & iRecord){ 
 //   if (_propagator){

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -16,6 +16,7 @@ class  TkTransientTrackingRecHitBuilderESProducer: public edm::ESProducer{
   TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet & p);
   virtual ~TkTransientTrackingRecHitBuilderESProducer(); 
   std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
+  //void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  private:
   std::shared_ptr<TransientTrackingRecHitBuilder> _builder;
   edm::ParameterSet pset_;

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -16,7 +16,6 @@ class  TkTransientTrackingRecHitBuilderESProducer: public edm::ESProducer{
   TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet & p);
   virtual ~TkTransientTrackingRecHitBuilderESProducer(); 
   std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
-  //void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  private:
   std::shared_ptr<TransientTrackingRecHitBuilder> _builder;
   edm::ParameterSet pset_;

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -5,7 +5,8 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
     ComponentName = cms.string('WithAngleAndTemplate'),
     PixelCPE = cms.string('PixelCPETemplateReco'),
     Matcher = cms.string('StandardMatcher'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False)                                             
+    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -6,7 +6,8 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
     PixelCPE = cms.string('PixelCPETemplateReco'),
     Matcher = cms.string('StandardMatcher'),
     ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPEGeometric'))
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
@@ -6,7 +6,8 @@ ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     PixelCPE = cms.string('Fake'),
     Matcher = cms.string('Fake'),
     ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase2PU140.toModify(ttrhbwor, Phase2StripCPE = cms.string('Phase2StripCPEGeometric'))
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
@@ -5,7 +5,8 @@ ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     ComponentName = cms.string('WithoutRefit'),
     PixelCPE = cms.string('Fake'),
     Matcher = cms.string('Fake'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False)                          
+    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -5,7 +5,8 @@ ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     ComponentName = cms.string('WithTrackAngle'),
     PixelCPE = cms.string('PixelCPEGeneric'),
     Matcher = cms.string('StandardMatcher'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False)
+    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -6,7 +6,8 @@ ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     PixelCPE = cms.string('PixelCPEGeneric'),
     Matcher = cms.string('StandardMatcher'),
     ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-    Phase2StripCPE = cms.string('Phase2StripCPEGeometric'),
 )
 
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase2PU140.toModify(ttrhbwr, Phase2StripCPE = cms.string('Phase2StripCPEGeometric'))
 

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -50,18 +50,8 @@ std::unique_ptr<SiStripRecHit1D> TkClonerImpl::operator()(SiStripRecHit1D const 
 std::unique_ptr<Phase2TrackerRecHit1D> TkClonerImpl::operator()(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const {
   const Phase2TrackerCluster1D&  clust = hit.phase2OTCluster();
   const PixelGeomDetUnit & gdu = (const PixelGeomDetUnit &) *(hit.detUnit()) ;
-  const PixelTopology * topo = &gdu.specificTopology();
-
-  //FIXME:just temporary solution for phase2!
-  float pitch_x = topo->pitch().first;
-  float pitch_y = topo->pitch().second;
-  float ix = clust.center();
-  float iy = clust.column()+0.5; // halfway the column
-
-  LocalPoint lp( topo->localX(ix), topo->localY(iy), 0 );          // x, y, z
-  LocalError le( pow(pitch_x, 2) / 12, 0, pow(pitch_y, 2) / 12);   // e2_xx, e2_xy, e2_yy
-
-  return std::unique_ptr<Phase2TrackerRecHit1D>{new Phase2TrackerRecHit1D(lp, le, *hit.det(), hit.cluster())};
+  auto && params = phase2TrackerCPE->localParameters( clust, gdu );
+  return std::unique_ptr<Phase2TrackerRecHit1D>{new Phase2TrackerRecHit1D(params.first, params.second, *hit.det(), hit.cluster())};
 }
 
 TrackingRecHit::ConstRecHitPointer TkClonerImpl::makeShared(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const {
@@ -93,18 +83,8 @@ TrackingRecHit::ConstRecHitPointer TkClonerImpl::makeShared(SiStripRecHit1D cons
 TrackingRecHit::ConstRecHitPointer TkClonerImpl::makeShared(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const {
   const Phase2TrackerCluster1D&  clust = hit.phase2OTCluster();
   const PixelGeomDetUnit & gdu = (const PixelGeomDetUnit &) *(hit.detUnit()) ;
-  const PixelTopology * topo = &gdu.specificTopology();
-
-  //FIXME:just temporary solution for phase2!
-  float pitch_x = topo->pitch().first;
-  float pitch_y = topo->pitch().second;
-  float ix = clust.center();
-  float iy = clust.column()+0.5; // halfway the column
-
-  LocalPoint lp( topo->localX(ix), topo->localY(iy), 0 );          // x, y, z
-  LocalError le( pow(pitch_x, 2) / 12, 0, pow(pitch_y, 2) / 12);   // e2_xx, e2_xy, e2_yy
-
-  return std::make_shared<Phase2TrackerRecHit1D>( lp, le, *hit.det(), hit.cluster());
+  auto && params = phase2TrackerCPE->localParameters( clust, gdu );
+  return std::unique_ptr<Phase2TrackerRecHit1D>{new Phase2TrackerRecHit1D(params.first, params.second, *hit.det(), hit.cluster())};
 }
 
 

--- a/RecoTracker/TransientTrackingRecHit/src/TkTransientTrackingRecHitBuilder.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkTransientTrackingRecHitBuilder.cc
@@ -23,7 +23,18 @@ TkTransientTrackingRecHitBuilder::TkTransientTrackingRecHitBuilder( const Tracki
   pixelCPE(pCPE),
   stripCPE(sCPE),
   theMatcher(matcher),
-  theComputeCoarseLocalPosition(computeCoarseLocalPositionFromDisk){}
+  theComputeCoarseLocalPosition(computeCoarseLocalPositionFromDisk),
+  phase2OTCPE(0){}
+
+TkTransientTrackingRecHitBuilder::TkTransientTrackingRecHitBuilder (const TrackingGeometry* trackingGeometry, 
+				                                    const PixelClusterParameterEstimator * pCPE,
+				                                    const ClusterParameterEstimator<Phase2TrackerCluster1D> * ph2StripCPE):
+  tGeometry_(trackingGeometry),
+  pixelCPE(pCPE),
+  stripCPE(0),
+  theMatcher(0),
+  theComputeCoarseLocalPosition(false),
+  phase2OTCPE(ph2StripCPE){}
 
 TransientTrackingRecHit::RecHitPointer 
 TkTransientTrackingRecHitBuilder::build (const TrackingRecHit * p) const 


### PR DESCRIPTION
As reported in the [last meeting](https://indico.cern.ch/event/562813/contributions/2274095/attachments/1326310/1991167/EricaBrondolin_20160824_RecoMeeting_PRs.pdf), this PR fix the phase2 CPE for the outer tracker used in the track reconstruction. Now the CPE is imported from external package as all the other CPEs. This PR is purely technical, no changes are expected for phase2 (comparison for 100 ttbar events in tilted geom can be found [here](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/CPE/MTV_TTbar_14TeV_tilt_CPE_3/plots_summary/summary.pdf)). For this last reason, I do NOT consider this PR a candidate for pre11.

No changes expected also for phase0/1.

@VinInn @rovere @boudoul @delaere @kpedro88 for your information.
