### PR TITLE
MiniAOD in phase2

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1692,12 +1692,12 @@ for k in upgradeKeys:
         upgradeStepDict['RecoFull_trackingOnlyPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFull_trackingOnly'][k]])
 
 
-    upgradeStepDict['RecoFullGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION:@phase2Validation,DQM:@phase2',
+    upgradeStepDict['RecoFullGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
                                       '--conditions':gt,
-                                      '--datatier':'GEN-SIM-RECO,DQMIO',
+                                      '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',
                                       '-n':'10',
                                       '--runUnscheduled':'',
-                                      '--eventcontent':'FEVTDEBUGHLT,DQM',
+                                      '--eventcontent':'FEVTDEBUGHLT,MINIAODSIM,DQM',
                                       '--geometry' : geom
                                       }
     if cust!=None : upgradeStepDict['RecoFullGlobal'][k]['--customise']=cust
@@ -1734,7 +1734,7 @@ for k in upgradeKeys:
         upgradeStepDict['HARVESTFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFull'][k]])
 
     upgradeStepDict['HARVESTFull_trackingOnly'][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, upgradeStepDict['HARVESTFull'][k]])
-    upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2'}, upgradeStepDict['HARVESTFull'][k]])
+    upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVESTFull'][k]])
 
     if k2 in PUDataSets:
         upgradeStepDict['HARVESTFull_trackingOnlyPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFull_trackingOnly'][k]])

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -156,3 +156,7 @@ DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD)
 PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD)
 PostDQMOffline = cms.Sequence()
 
+eras.phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndExclude([
+    pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise yet
+]))
+

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -49,3 +49,9 @@ def miniAOD_customizeMETFiltersFastSim(process):
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))
     return process
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_hgcal.toReplaceWith( Flag_HBHENoiseFilter, cms.Path() )
+eras.phase2_hgcal.toReplaceWith( Flag_HBHENoiseIsoFilter, cms.Path() )
+eras.phase2_hgcal.toReplaceWith( Flag_eeBadScFilter, cms.Path() )
+

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -63,6 +63,7 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
  
  const edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHits_;
  const edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
+ const bool                                   doPreshowerEcalHits_;
  const edm::EDGetTokenT<EcalRecHitCollection> preshowerEcalHits_;
  
  const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMapT_;

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 reducedEgamma = cms.EDProducer("ReducedEGProducer",
   keepPhotons = cms.string("hadTowOverEm()<0.15 && pt>10 && (pt>14 || chargedHadronIso()<10)"), #keep in output
@@ -56,4 +57,8 @@ reducedEgamma = cms.EDProducer("ReducedEGProducer",
         "eleEcalPFClusIso",
         "eleHcalPFClusIso",
   ),
+)
+
+eras.phase2_common.toModify(reducedEgamma, 
+        preshowerEcalHits = cms.InputTag(""),
 )

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -99,6 +99,9 @@ class PhotonIDValueMapProducer : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<edm::View<reco::Candidate> > pfCandidatesTokenMiniAOD_;
   edm::EDGetToken srcMiniAOD_;
 
+  // check whether a non-null preshower is there
+  bool usesES_;
+
   // Cluster shapes
   constexpr static char phoFull5x5SigmaIEtaIEta_[] = "phoFull5x5SigmaIEtaIEta";
   constexpr static char phoFull5x5SigmaIEtaIPhi_[] = "phoFull5x5SigmaIEtaIPhi";
@@ -144,10 +147,17 @@ PhotonIDValueMapProducer::PhotonIDValueMapProducer(const edm::ParameterSet& iCon
   eeReducedRecHitCollectionMiniAOD_ = mayConsume<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>
 								       ("eeReducedRecHitCollectionMiniAOD"));
 
-  esReducedRecHitCollection_        = mayConsume<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>
-								       ("esReducedRecHitCollection"));
-  esReducedRecHitCollectionMiniAOD_ = mayConsume<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>
-								       ("esReducedRecHitCollectionMiniAOD"));
+  if (!iConfig.getParameter<edm::InputTag>("esReducedRecHitCollection").label().empty() ||
+      !iConfig.getParameter<edm::InputTag>("esReducedRecHitCollectionMiniAOD").label().empty()) {
+      usesES_ = true;
+      esReducedRecHitCollection_        = mayConsume<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>
+                                                                           ("esReducedRecHitCollection"));
+      esReducedRecHitCollectionMiniAOD_ = mayConsume<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>
+                                                                           ("esReducedRecHitCollectionMiniAOD"));
+      
+  } else {
+      usesES_ = false;
+  }
 
   vtxToken_        = mayConsume<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
   vtxTokenMiniAOD_ = mayConsume<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("verticesMiniAOD"));
@@ -212,16 +222,28 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
   }
 
   // Configure Lazy Tools
-  if( isAOD )
-    lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
-						  ebReducedRecHitCollection_,
-						  eeReducedRecHitCollection_,
-						  esReducedRecHitCollection_));
-  else
-    lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
-						  ebReducedRecHitCollectionMiniAOD_,
-              eeReducedRecHitCollectionMiniAOD_,
-              esReducedRecHitCollectionMiniAOD_)); 
+  if (usesES_) {
+      if( isAOD )
+        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+                                                      ebReducedRecHitCollection_,
+                                                      eeReducedRecHitCollection_,
+                                                      esReducedRecHitCollection_));
+      else
+        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+                                                      ebReducedRecHitCollectionMiniAOD_,
+                                                      eeReducedRecHitCollectionMiniAOD_,
+                                                      esReducedRecHitCollectionMiniAOD_)); 
+  } else {
+      if( isAOD )
+        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+                                                      ebReducedRecHitCollection_,
+                                                      eeReducedRecHitCollection_));
+      else
+        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+                                                      ebReducedRecHitCollectionMiniAOD_,
+                                                      eeReducedRecHitCollectionMiniAOD_)); 
+
+  }
   
   // Get PV
   edm::Handle<reco::VertexCollection> vertices;

--- a/RecoEgamma/PhotonIdentification/python/PhotonIDValueMapProducer_cfi.py
+++ b/RecoEgamma/PhotonIdentification/python/PhotonIDValueMapProducer_cfi.py
@@ -23,3 +23,9 @@ photonIDValueMapProducer = cms.EDProducer('PhotonIDValueMapProducer',
                                           # there is no need for the isolation map here, for miniAOD it is inside packedPFCandidates
                                           srcMiniAOD = cms.InputTag('slimmedPhotons',processName=cms.InputTag.skipCurrentProcess()),
                                           )
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_common.toModify(photonIDValueMapProducer, 
+    esReducedRecHitCollection = cms.InputTag(""),
+    esReducedRecHitCollectionMiniAOD = cms.InputTag(""),
+)

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -672,32 +672,34 @@ int EcalDeadCellTriggerPrimitiveFilter::getChannelStatusMaps(){
   } // end loop ieta
 
 // Loop over EE detid
-  for( int ix=0; ix<=100; ix++ ){
-     for( int iy=0; iy<=100; iy++ ){
-        for( int iz=-1; iz<=1; iz++ ){
-           if(iz==0)  continue;
-           if(! EEDetId::validDetId( ix, iy, iz ) )  continue;
+  if (doEEfilter_) {
+      for( int ix=0; ix<=100; ix++ ){
+         for( int iy=0; iy<=100; iy++ ){
+            for( int iz=-1; iz<=1; iz++ ){
+               if(iz==0)  continue;
+               if(! EEDetId::validDetId( ix, iy, iz ) )  continue;
 
-           const EEDetId detid = EEDetId( ix, iy, iz, EEDetId::XYMODE );
-           EcalChannelStatus::const_iterator chit = ecalStatus->find( detid );
-           int status = ( chit != ecalStatus->end() ) ? chit->getStatusCode() & 0x1F : -1;
+               const EEDetId detid = EEDetId( ix, iy, iz, EEDetId::XYMODE );
+               EcalChannelStatus::const_iterator chit = ecalStatus->find( detid );
+               int status = ( chit != ecalStatus->end() ) ? chit->getStatusCode() & 0x1F : -1;
 
-           const CaloSubdetectorGeometry*  subGeom = geometry->getSubdetectorGeometry (detid);
-           const CaloCellGeometry*        cellGeom = subGeom->getGeometry (detid);
-           double eta = cellGeom->getPosition ().eta () ;
-           double phi = cellGeom->getPosition ().phi () ;
-           double theta = cellGeom->getPosition().theta();
+               const CaloSubdetectorGeometry*  subGeom = geometry->getSubdetectorGeometry (detid);
+               const CaloCellGeometry*        cellGeom = subGeom->getGeometry (detid);
+               double eta = cellGeom->getPosition ().eta () ;
+               double phi = cellGeom->getPosition ().phi () ;
+               double theta = cellGeom->getPosition().theta();
 
-           if(status >= maskedEcalChannelStatusThreshold_){
-              std::vector<double> valVec; std::vector<int> bitVec;
-              valVec.push_back(eta); valVec.push_back(phi); valVec.push_back(theta);
-              bitVec.push_back(2); bitVec.push_back(ix); bitVec.push_back(iy); bitVec.push_back(iz); bitVec.push_back(status);
-              EcalAllDeadChannelsValMap.insert( std::make_pair(detid, valVec) );
-              EcalAllDeadChannelsBitMap.insert( std::make_pair(detid, bitVec) );
-           }
-        } // end loop iz
-     } // end loop iy
-  } // end loop ix
+               if(status >= maskedEcalChannelStatusThreshold_){
+                  std::vector<double> valVec; std::vector<int> bitVec;
+                  valVec.push_back(eta); valVec.push_back(phi); valVec.push_back(theta);
+                  bitVec.push_back(2); bitVec.push_back(ix); bitVec.push_back(iy); bitVec.push_back(iz); bitVec.push_back(status);
+                  EcalAllDeadChannelsValMap.insert( std::make_pair(detid, valVec) );
+                  EcalAllDeadChannelsBitMap.insert( std::make_pair(detid, bitVec) );
+               }
+            } // end loop iz
+         } // end loop iy
+      } // end loop ix
+  }
 
   EcalAllDeadChannelsTTMap.clear();
   std::map<DetId, std::vector<int> >::iterator bitItor;

--- a/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
+++ b/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
@@ -27,3 +27,8 @@ EcalDeadCellTriggerPrimitiveFilter = cms.EDFilter(
     useTTsum = cms.bool ( True ),
     usekTPSaturated = cms.bool ( False)
 )
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_hgcal.toModify( EcalDeadCellTriggerPrimitiveFilter, 
+    doEEfilter = cms.untracked.bool(False)
+)

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -96,3 +96,10 @@ metFilters = cms.Sequence(
    chargedHadronTrackResolutionFilter *
    muonBadTrackFilter
 )
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_hgcal.toReplaceWith(metFilters, metFilters.copyAndExclude([
+    HBHENoiseFilterResultProducer, HBHENoiseFilter, # No hcalnoise for hgcal
+    eeBadScFilter                                   # No EE
+]))
+


### PR DESCRIPTION
Minimal set of changes to get miniAOD production running in the Phase2 era.

Mainly it requires to reconfigure reducedEgamma to ignore ES RecHits, and to switch off the extra electron and photon id stuff, which otherwise is also crashing due to ES RecHits.

Tested in the Phase2C1 scenario (wf 10424.0) in `CMSSW_8_1_X_2016-08-24-1100`, and enabled in the `RecoFullGlobal` chain (though this last change can be backed off easily)

For making the miniAOD_tools customizers era-aware I used the cff + `makeProcessModifier` approach, I can change it when we settle on the best one.

There's some random complaints from tau id, which probably doesn't cope with the updated tracker coverage.

@arizzi @kpedro88 @bendavid @lgray  
