### PR TITLE
Fix posftix and scheduled mode issue in the runMETUncertainty tool (Copy of the original #14606)

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -636,7 +636,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 continue
 
             corName='pat'+metType+'Met' + corName + postfix
-            if configtools.contains(getattr(process,"patMetCorrectionSequence"+postfix), corName ):
+            if configtools.contains(getattr(process,"patMetCorrectionSequence"+postfix), corName ) and hasattr(process, corName):
                 continue
             
             interMets[corName] =  cms.EDProducer("CorrectedPATMETProducer",

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -388,8 +388,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         fullPatMetSequence += getattr(process, "patShiftedModuleSequence"+postfix)
         
         #adding the slimmed MET
-        fullPatMetSequence +=getattr(process, "patCaloMet")
-        fullPatMetSequence +=getattr(process, "slimmedMETs"+postfix)
+        if hasattr(process, "patCaloMet"):
+            fullPatMetSequence +=getattr(process, "patCaloMet")
+        if hasattr(process, "slimmedMETs"+postfix):
+            fullPatMetSequence +=getattr(process, "slimmedMETs"+postfix)
 
         setattr(process,"fullPatMetSequence"+postfix,fullPatMetSequence)
 


### PR DESCRIPTION
Identical to the original #14606 PR that was messed up when solving conflicts appeared during the holding time.
