### PR TITLE
Keep lumi from scalers

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -63,7 +63,9 @@ MicroEventContent = cms.PSet(
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
         'keep recoCSCHaloData_CSCHaloData_*_*',
-        'keep recoBeamHaloSummary_BeamHaloSummary_*_*'
+        'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
+        # Lumi
+        'keep LumiScalerss_scalersRawToDigi_*_*',
     )
 )
 MicroEventContentMC = cms.PSet(


### PR DESCRIPTION
80X backport of #15585, for a future re-reco or update of prompt reco or re-miniAOD.
