### PR TITLE
bsunanda:Run2-alca60 Have some non-trivial parameters for SiPM hardcoded conditions

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -798,7 +798,7 @@ HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fI
 }
 
 void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm) {
-  sipm.loadObject(HcalHOZercotek,36000,1,0,0,0.32,0,0);
+  sipm.loadObject(HcalHOZecotek,36000,1,0,0,0.32,0,0);
   sipm.loadObject(HcalHOHamamatsu,2500,1,0,0,0.32,0,0);
   sipm.loadObject(HcalHEHamamatsu1,27370,1.000669,1.34646E-5,1.57918E-10,0.32,0,0);
   sipm.loadObject(HcalHEHamamatsu2,38018,1.000669,1.34646E-5,1.57918E-10,0.32,0,0);

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -9,6 +9,7 @@
 
 #include "CLHEP/Random/RandGauss.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h"
+#include "CalibFormats/HcalObjects/interface/HcalSiPMType.h"
 #include "DataFormats/HcalDigi/interface/HcalQIENum.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
  
@@ -784,11 +785,24 @@ void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::v
 }
 
 HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fId) {
+  if (fId.isHcalDetId()) {
+    if (fId.subdetId() == HcalBarrel) {
+      return HcalSiPMParameter(fId.rawId(), HcalHBHamamatsu1, 57.5, 0.055, 0, 0);
+    } else if (fId.subdetId() == HcalEndcap) {
+      return HcalSiPMParameter(fId.rawId(), HcalHEHamamatsu1, 57.5, 0.055, 0, 0);
+    } else if (fId.subdetId() == HcalOuter) {
+      return HcalSiPMParameter(fId.rawId(), HcalHOHamamatsu, 4.0, 0.055, 0, 0);
+    }
+  } 
   return HcalSiPMParameter(fId.rawId(), 0, 0, 0, 0, 0);
 }
 
 void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm) {
-  sipm.loadObject(0,0,0,0,0,0,0,0);
+  sipm.loadObject(HcalHOZercotek,36000,1,0,0,0.32,0,0);
+  sipm.loadObject(HcalHOHamamatsu,2500,1,0,0,0.32,0,0);
+  sipm.loadObject(HcalHEHamamatsu1,27370,1.000669,1.34646E-5,1.57918E-10,0.32,0,0);
+  sipm.loadObject(HcalHEHamamatsu2,38018,1.000669,1.34646E-5,1.57918E-10,0.32,0,0);
+  sipm.loadObject(HcalHBHamamatsu1,27370,1.000669,1.34646E-5,1.57918E-10,0.32,0,0);
 }
 
 HcalTPChannelParameter HcalDbHardcode::makeHardcodeTPChannelParameter (HcalGenericDetId fId) {

--- a/CalibFormats/HcalObjects/interface/HcalSiPMType.h
+++ b/CalibFormats/HcalObjects/interface/HcalSiPMType.h
@@ -1,7 +1,7 @@
 #ifndef CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H
 #define CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H 1
 
-enum HcalSiPMType {HcalHOZercotek=0, HcalHOHamamatsu=1, HcalHEHamamatsu1=2, 
+enum HcalSiPMType {HcalHOZecotek=0, HcalHOHamamatsu=1, HcalHEHamamatsu1=2, 
 		   HcalHEHamamatsu2=3, HcalHBHamamatsu1=4, HcalHBHamamatsu2=5};
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalSiPMType.h
+++ b/CalibFormats/HcalObjects/interface/HcalSiPMType.h
@@ -1,0 +1,7 @@
+#ifndef CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H
+#define CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H 1
+
+enum HcalSiPMType {HcalHOZercotek=0, HcalHOHamamatsu=1, HcalHEHamamatsu1=2, 
+		   HcalHEHamamatsu2=3, HcalHBHamamatsu1=4, HcalHBHamamatsu2=5};
+
+#endif

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -57,7 +57,7 @@ public:
     PrecisionItem (int type, int pixels, float parLin1, float parLin2, 
 		   float parLin3, float crossTalk, int auxi1,  float auxi2) :
     type_(type), pixels_(pixels), parLin1_(parLin1), parLin2_(parLin2),
-      parLin3_(parLin3), auxi1_(auxi1), auxi2_(auxi2) {}
+      parLin3_(parLin3), crossTalk_(crossTalk), auxi1_(auxi1), auxi2_(auxi2) {}
 
     int      type_;
     int      pixels_;

--- a/CondFormats/HcalObjects/interface/HcalTPParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalTPParameters.h
@@ -19,7 +19,7 @@ public:
 
   /// get FineGrain Algorithm Version for HBHE
   int          getFGVersionHBHE()          const {return version_;}
-  /// get ADC thresho;d fof TDC mask of HF
+  /// get ADC threshold fof TDC mask of HF
   int          getADCThresholdHF()         const {return adcCut_;}
   /// get TDC mask for HF
   uint32_t getTDCMaskHF()                  const {return tdcMask_;}


### PR DESCRIPTION
Change default hardcoded conditions for SiPM parameters
SiPMCharacteristics contain for each type of SiPM, # of pixels, parameters for non-linearity correction function (at the moment a second order polynomial), cross talk parameter and two auxiliary words. These numbers are taken from data sheets and some measurements.
SiPMParameter contains for each DetID, SiPM type, PE to FC factor, dark current - again coming from some measurements
