### PR TITLE
adding latest 25ns JER to 50ns simulation GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,7 +12,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '81X_mcRun2_design_v5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v5',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '81X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Startup scenario** : [81X_mcRun2_startup_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v7) as [81X_mcRun2_startup_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v7/81X_mcRun2_startup_v5): 
  - added JER and JER SF tags with latest values for 25ns simulation (needed by #15565)
