### PR TITLE
Use unique_ptr, not auto_ptr in EventFilter

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -192,21 +192,21 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
   e.getByToken( i_token, rawdata);
 
   /// create the collections of CSC digis
-  std::auto_ptr<CSCWireDigiCollection> wireProduct(new CSCWireDigiCollection);
-  std::auto_ptr<CSCStripDigiCollection> stripProduct(new CSCStripDigiCollection);
-  std::auto_ptr<CSCALCTDigiCollection> alctProduct(new CSCALCTDigiCollection);
-  std::auto_ptr<CSCCLCTDigiCollection> clctProduct(new CSCCLCTDigiCollection);
-  std::auto_ptr<CSCComparatorDigiCollection> comparatorProduct(new CSCComparatorDigiCollection);
-  std::auto_ptr<CSCRPCDigiCollection> rpcProduct(new CSCRPCDigiCollection);
-  std::auto_ptr<CSCCorrelatedLCTDigiCollection> corrlctProduct(new CSCCorrelatedLCTDigiCollection);
-  std::auto_ptr<CSCCFEBStatusDigiCollection> cfebStatusProduct(new CSCCFEBStatusDigiCollection);
-  std::auto_ptr<CSCDMBStatusDigiCollection> dmbStatusProduct(new CSCDMBStatusDigiCollection);
-  std::auto_ptr<CSCTMBStatusDigiCollection> tmbStatusProduct(new CSCTMBStatusDigiCollection);
-  std::auto_ptr<CSCDDUStatusDigiCollection> dduStatusProduct(new CSCDDUStatusDigiCollection);
-  std::auto_ptr<CSCDCCStatusDigiCollection> dccStatusProduct(new CSCDCCStatusDigiCollection);
-  std::auto_ptr<CSCALCTStatusDigiCollection> alctStatusProduct(new CSCALCTStatusDigiCollection);
+  auto wireProduct = std::make_unique<CSCWireDigiCollection>();
+  auto stripProduct = std::make_unique<CSCStripDigiCollection>();
+  auto alctProduct = std::make_unique<CSCALCTDigiCollection>();
+  auto clctProduct = std::make_unique<CSCCLCTDigiCollection>();
+  auto comparatorProduct = std::make_unique<CSCComparatorDigiCollection>();
+  auto rpcProduct = std::make_unique<CSCRPCDigiCollection>();
+  auto corrlctProduct = std::make_unique<CSCCorrelatedLCTDigiCollection>();
+  auto cfebStatusProduct = std::make_unique<CSCCFEBStatusDigiCollection>();
+  auto dmbStatusProduct = std::make_unique<CSCDMBStatusDigiCollection>();
+  auto tmbStatusProduct = std::make_unique<CSCTMBStatusDigiCollection>();
+  auto dduStatusProduct = std::make_unique<CSCDDUStatusDigiCollection>();
+  auto dccStatusProduct = std::make_unique<CSCDCCStatusDigiCollection>();
+  auto alctStatusProduct = std::make_unique<CSCALCTStatusDigiCollection>();
 
-  std::auto_ptr<CSCDCCFormatStatusDigiCollection> formatStatusProduct(new CSCDCCFormatStatusDigiCollection);
+  auto formatStatusProduct = std::make_unique<CSCDCCFormatStatusDigiCollection>();
 
 
   // If set selective unpacking mode
@@ -659,24 +659,24 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
         } // end of if fed has data
     } // end of loop over DCCs
   // put into the event
-  e.put(wireProduct,          "MuonCSCWireDigi");
-  e.put(stripProduct,         "MuonCSCStripDigi");
-  e.put(alctProduct,          "MuonCSCALCTDigi");
-  e.put(clctProduct,          "MuonCSCCLCTDigi");
-  e.put(comparatorProduct,    "MuonCSCComparatorDigi");
-  e.put(rpcProduct,           "MuonCSCRPCDigi");
-  e.put(corrlctProduct,       "MuonCSCCorrelatedLCTDigi");
+  e.put(std::move(wireProduct),          "MuonCSCWireDigi");
+  e.put(std::move(stripProduct),         "MuonCSCStripDigi");
+  e.put(std::move(alctProduct),          "MuonCSCALCTDigi");
+  e.put(std::move(clctProduct),          "MuonCSCCLCTDigi");
+  e.put(std::move(comparatorProduct),    "MuonCSCComparatorDigi");
+  e.put(std::move(rpcProduct),           "MuonCSCRPCDigi");
+  e.put(std::move(corrlctProduct),       "MuonCSCCorrelatedLCTDigi");
 
-  if (useFormatStatus)  e.put(formatStatusProduct,    "MuonCSCDCCFormatStatusDigi");
+  if (useFormatStatus)  e.put(std::move(formatStatusProduct),    "MuonCSCDCCFormatStatusDigi");
 
   if (unpackStatusDigis)
     {
-      e.put(cfebStatusProduct,    "MuonCSCCFEBStatusDigi");
-      e.put(dmbStatusProduct,     "MuonCSCDMBStatusDigi");
-      e.put(tmbStatusProduct,     "MuonCSCTMBStatusDigi");
-      e.put(dduStatusProduct,     "MuonCSCDDUStatusDigi");
-      e.put(dccStatusProduct,     "MuonCSCDCCStatusDigi");
-      e.put(alctStatusProduct,    "MuonCSCALCTStatusDigi");
+      e.put(std::move(cfebStatusProduct),    "MuonCSCCFEBStatusDigi");
+      e.put(std::move(dmbStatusProduct),     "MuonCSCDMBStatusDigi");
+      e.put(std::move(tmbStatusProduct),     "MuonCSCTMBStatusDigi");
+      e.put(std::move(dduStatusProduct),     "MuonCSCDDUStatusDigi");
+      e.put(std::move(dccStatusProduct),     "MuonCSCDCCStatusDigi");
+      e.put(std::move(alctStatusProduct),    "MuonCSCALCTStatusDigi");
     }
   if (printEventNumber) LogTrace("CSCDCCUnpacker|CSCRawToDigi")
     <<"[CSCDCCUnpacker]: " << numOfEvents << " events processed ";

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
@@ -96,7 +96,7 @@ void CSCDigiToRawModule::produce( edm::Event & e, const edm::EventSetup& c ){
   c.get<CSCChamberMapRcd>().get(hcham); 
   const CSCChamberMap* theMapping = hcham.product();
 
-  std::auto_ptr<FEDRawDataCollection> fed_buffers(new FEDRawDataCollection);
+  auto fed_buffers = std::make_unique<FEDRawDataCollection>();
 
   // Take digis from the event
   edm::Handle<CSCWireDigiCollection> wireDigis;
@@ -123,7 +123,7 @@ void CSCDigiToRawModule::produce( edm::Event & e, const edm::EventSetup& c ){
 			   packEverything_);
   
   // put the raw data to the event
-  e.put(fed_buffers, "CSCRawData");
+  e.put(std::move(fed_buffers), "CSCRawData");
 }
 
 

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
@@ -333,7 +333,7 @@ void CSCTFPacker::produce(edm::Event& e, const edm::EventSetup& c){
 	*pos++ = 0x0000; *pos++ = 0x0000; *pos++ = 0x0000; *pos++ = 0x0000;
 
 	if( putBufferToEvent ){
-		std::auto_ptr<FEDRawDataCollection> data(new FEDRawDataCollection);
+		auto data = std::make_unique<FEDRawDataCollection>();
 		FEDRawData& fedRawData = data->FEDData((unsigned int)FEDNumbering::MINCSCTFFEDID);
 		fedRawData.resize((pos-spDDUrecord)*sizeof(unsigned short));
 		std::copy((unsigned char*)spDDUrecord,(unsigned char*)pos,fedRawData.data());
@@ -341,7 +341,7 @@ void CSCTFPacker::produce(edm::Event& e, const edm::EventSetup& c){
 		csctfFEDHeader.set(fedRawData.data(), 0, e.id().event(), 0, FEDNumbering::MINCSCTFFEDID);
 		FEDTrailer csctfFEDTrailer(fedRawData.data()+(fedRawData.size()-8));
 		csctfFEDTrailer.set(fedRawData.data()+(fedRawData.size()-8), fedRawData.size()/8, evf::compute_crc(fedRawData.data(),fedRawData.size()), 0, 0);
-		e.put(data,"CSCTFRawData");
+		e.put(std::move(data),"CSCTFRawData");
 	}
 
 	if(file) fwrite(spDDUrecord,2,pos-spDDUrecord,file);

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
@@ -92,10 +92,10 @@ void CSCTFUnpacker::produce(edm::Event& e, const edm::EventSetup& c){
 	e.getByToken(Raw_token,rawdata);
 
 	// create the collection of CSC wire and strip digis as well as of DT stubs, which we receive from DTTF
-	std::auto_ptr<CSCCorrelatedLCTDigiCollection> LCTProduct(new CSCCorrelatedLCTDigiCollection);
-	std::auto_ptr<L1CSCTrackCollection>           trackProduct(new L1CSCTrackCollection);
-	std::auto_ptr<L1CSCStatusDigiCollection>      statusProduct(new L1CSCStatusDigiCollection);
-	std::auto_ptr<CSCTriggerContainer<csctf::TrackStub> > dtProduct(new CSCTriggerContainer<csctf::TrackStub>);
+	auto LCTProduct = std::make_unique<CSCCorrelatedLCTDigiCollection>();
+	auto trackProduct = std::make_unique<L1CSCTrackCollection>();
+	auto statusProduct = std::make_unique<L1CSCStatusDigiCollection>();
+	auto dtProduct = std::make_unique<CSCTriggerContainer<csctf::TrackStub>>();
 
 	for(int fedid=FEDNumbering::MINCSCTFFEDID; fedid<=FEDNumbering::MAXCSCTFFEDID; fedid++){
 		const FEDRawData& fedData = rawdata->FEDData(fedid);
@@ -272,8 +272,8 @@ void CSCTFUnpacker::produce(edm::Event& e, const edm::EventSetup& c){
 		statusProduct->first  = unpacking_status;
 
 	} //end of fed cycle
-	e.put(dtProduct,"DT");
-	e.put(LCTProduct); // put processed lcts into the event.
-	e.put(trackProduct);
-	e.put(statusProduct);
+	e.put(std::move(dtProduct),"DT");
+	e.put(std::move(LCTProduct)); // put processed lcts into the event.
+	e.put(std::move(trackProduct));
+	e.put(std::move(statusProduct));
 }

--- a/EventFilter/CSCTFRawToDigi/test/CSCTFSingleGen.cc
+++ b/EventFilter/CSCTFRawToDigi/test/CSCTFSingleGen.cc
@@ -70,8 +70,8 @@ CSCTFSingleGen::~CSCTFSingleGen(){
 void CSCTFSingleGen::produce(edm::Event& e, const edm::EventSetup& c){
 
   // create the collection of CSC wire and strip digis as well as of DT stubs, which we receive from DTTF
-  std::auto_ptr<CSCCorrelatedLCTDigiCollection> LCTProduct(new CSCCorrelatedLCTDigiCollection);
-  //  std::auto_ptr<CSCTriggerContainer<csctf::TrackStub> > dtProduct(new CSCTriggerContainer<csctf::TrackStub>);
+  auto LCTProduct = std::make_unique<CSCCorrelatedLCTDigiCollection>();
+  //  auto dtProduct = std::make_unique<CSCTriggerContainer<csctf::TrackStub>>();
 
 
   for(unsigned int tbin=6; tbin<7; tbin++){
@@ -129,8 +129,8 @@ void CSCTFSingleGen::produce(edm::Event& e, const edm::EventSetup& c){
   strip++;
 
 
-  //e.put(dtProduct,"DT");
-  e.put(LCTProduct); // put processed lcts into the event.
+  //e.put(std::move(dtProduct),"DT");
+  e.put(std::move(LCTProduct)); // put processed lcts into the event.
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(CSCTFSingleGen);

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
@@ -40,7 +40,7 @@ void CastorDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   es.get<CastorDbRecord>().get( pSetup );
   const CastorElectronicsMap* readoutMap=pSetup->getCastorMapping();
   // Step B: Create empty output
-  std::auto_ptr<FEDRawDataCollection> raw=std::auto_ptr<FEDRawDataCollection>(new FEDRawDataCollection());
+  auto raw = std::make_unique<FEDRawDataCollection>();
 
   const int ifed_first=FEDNumbering::MINCASTORFEDID;  //690
   const int ifed_last=FEDNumbering::MAXCASTORFEDID;   //693
@@ -65,7 +65,7 @@ void CastorDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
     }
   }
 
-  e.put(raw);
+  e.put(std::move(raw));
 }
 
 

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -78,7 +78,7 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   std::vector<HcalTTPDigi> ttp;
   std::vector<CastorTriggerPrimitiveDigi> htp;
 
-  std::auto_ptr<HcalUnpackerReport> report(new HcalUnpackerReport);
+  auto report = std::make_unique<HcalUnpackerReport>();
 
   CastorRawCollections colls;
   colls.castorCont=&castor;
@@ -177,8 +177,8 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   }//end of loop over feds
 
   // Step B: encapsulate vectors in actual collections
-  std::auto_ptr<CastorDigiCollection> castor_prod(new CastorDigiCollection()); 
-  std::auto_ptr<CastorTrigPrimDigiCollection> htp_prod(new CastorTrigPrimDigiCollection());  
+  auto castor_prod = std::make_unique<CastorDigiCollection>();
+  auto htp_prod = std::make_unique<CastorTrigPrimDigiCollection>();
 
   castor_prod->swap_contents(castor);
   htp_prod->swap_contents(htp);
@@ -197,24 +197,24 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
    
    if(unpackZDC_)
      {
-       std::auto_ptr<ZDCDigiCollection> zdc_prod(new ZDCDigiCollection());
+       auto zdc_prod = std::make_unique<ZDCDigiCollection>();
        zdc_prod->swap_contents(zdc);
        
        zdc_prod->sort();
-       e.put(zdc_prod);
+       e.put(std::move(zdc_prod));
      }
    
-   e.put(castor_prod);
-   e.put(htp_prod);
+   e.put(std::move(castor_prod));
+   e.put(std::move(htp_prod));
    
   if (unpackTTP_) {
-    std::auto_ptr<HcalTTPDigiCollection> prod(new HcalTTPDigiCollection());
+    auto prod = std::make_unique<HcalTTPDigiCollection>();
     prod->swap_contents(ttp);
     
     prod->sort();
-    e.put(prod);
+    e.put(std::move(prod));
   }
-  e.put(report);
+  e.put(std::move(report));
 }
 void CastorRawToDigi::beginRun(edm::Run const& irun, edm::EventSetup const& es){
 	if ( usenominalOrbitMessageTime_ ) {

--- a/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.cc
@@ -34,8 +34,8 @@ DTDDUUnpacker::~DTDDUUnpacker() {
 void DTDDUUnpacker::interpretRawData(const unsigned int* index32, int datasize,
 				     int dduID,
 				     edm::ESHandle<DTReadOutMapping>& mapping,
-				     std::auto_ptr<DTDigiCollection>& detectorProduct,
-				     std::auto_ptr<DTLocalTriggerCollection>& triggerProduct,
+				     std::unique_ptr<DTDigiCollection>& detectorProduct,
+				     std::unique_ptr<DTLocalTriggerCollection>& triggerProduct,
 				     uint16_t rosList) {
 
   // Definitions

--- a/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.h
@@ -28,8 +28,8 @@ class DTDDUUnpacker : public DTUnpacker {
   virtual void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
-				std::auto_ptr<DTDigiCollection>& product,
-				std::auto_ptr<DTLocalTriggerCollection>& product2,
+				std::unique_ptr<DTDigiCollection>& product,
+				std::unique_ptr<DTLocalTriggerCollection>& product2,
 				uint16_t rosList=0);
   
   inline const std::vector<DTROS25Data> & getROSsControlData() const {

--- a/EventFilter/DTRawToDigi/plugins/DTDigiToRawModule.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTDigiToRawModule.cc
@@ -40,7 +40,7 @@ DTDigiToRawModule::~DTDigiToRawModule(){
 
 void DTDigiToRawModule::produce(Event & e, const EventSetup& iSetup) {
 
-  auto_ptr<FEDRawDataCollection> fed_buffers(new FEDRawDataCollection);
+  auto fed_buffers = std::make_unique<FEDRawDataCollection>();
   
   // Take digis from the event
   Handle<DTDigiCollection> digis;
@@ -78,7 +78,7 @@ void DTDigiToRawModule::produce(Event & e, const EventSetup& iSetup) {
 
   }
   // Put the raw data to the event
-  e.put(fed_buffers);
+  e.put(std::move(fed_buffers));
   
 }
 

--- a/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.cc
@@ -49,8 +49,8 @@ DTROS25Unpacker::~DTROS25Unpacker() {}
 void DTROS25Unpacker::interpretRawData(const unsigned int* index, int datasize,
 				       int dduIDfromDDU,
 				       edm::ESHandle<DTReadOutMapping>& mapping,
-				       std::auto_ptr<DTDigiCollection>& detectorProduct,
-				       std::auto_ptr<DTLocalTriggerCollection>& triggerProduct,
+				       std::unique_ptr<DTDigiCollection>& detectorProduct,
+				       std::unique_ptr<DTLocalTriggerCollection>& triggerProduct,
 				       uint16_t rosList) {
 
   int dduID;

--- a/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.h
@@ -29,8 +29,8 @@ public:
   virtual void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
-				std::auto_ptr<DTDigiCollection>& product,
-				std::auto_ptr<DTLocalTriggerCollection>& product2,
+				std::unique_ptr<DTDigiCollection>& product,
+				std::unique_ptr<DTLocalTriggerCollection>& product2,
 				uint16_t rosList = 0);
 
   inline const std::vector<DTROS25Data> & getROSsControlData() const {

--- a/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.cc
@@ -20,8 +20,8 @@ using namespace cms;
 void DTROS8Unpacker::interpretRawData(const unsigned int* index, int datasize,
 				      int dduID,
 				      edm::ESHandle<DTReadOutMapping>& mapping, 
-				      std::auto_ptr<DTDigiCollection>& product,
-                                      std::auto_ptr<DTLocalTriggerCollection>& product2,
+				      std::unique_ptr<DTDigiCollection>& product,
+                                      std::unique_ptr<DTLocalTriggerCollection>& product2,
 				      uint16_t rosList) {
  
 

--- a/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.h
@@ -29,8 +29,8 @@ public:
   virtual void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
-				std::auto_ptr<DTDigiCollection>& product,
-                                std::auto_ptr<DTLocalTriggerCollection>& product2,
+				std::unique_ptr<DTDigiCollection>& product,
+                                std::unique_ptr<DTLocalTriggerCollection>& product2,
 				uint16_t rosList = 0);
 
 private:

--- a/EventFilter/DTRawToDigi/plugins/DTUnpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTUnpacker.h
@@ -33,8 +33,8 @@ class DTUnpacker {
   virtual void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
-				std::auto_ptr<DTDigiCollection>& product, 
-				std::auto_ptr<DTLocalTriggerCollection>& product2, 
+				std::unique_ptr<DTDigiCollection>& product, 
+				std::unique_ptr<DTLocalTriggerCollection>& product2, 
                                 uint16_t rosList=0) = 0;
 
  protected:

--- a/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.cc
@@ -122,11 +122,11 @@ void DTUnpackingModule::produce(Event & e, const EventSetup& context){
   context.get<DTReadOutMappingRcd>().get(mapping);
   
   // Create the result i.e. the collections of MB Digis and SC local triggers
-  auto_ptr<DTDigiCollection> detectorProduct(new DTDigiCollection);
-  auto_ptr<DTLocalTriggerCollection> triggerProduct(new DTLocalTriggerCollection);
+  auto detectorProduct = std::make_unique<DTDigiCollection>();
+  auto triggerProduct = std::make_unique<DTLocalTriggerCollection>();
 
-  auto_ptr<std::vector<DTDDUData> > dduProduct(new std::vector<DTDDUData>);
-  auto_ptr<DTROS25Collection> ros25Product(new DTROS25Collection);
+  auto dduProduct = std::make_unique<std::vector<DTDDUData>>();
+  auto ros25Product = std::make_unique<DTROS25Collection>();
   
   // Loop over the DT FEDs
   int FEDIDmin = 0, FEDIDMax = 0;
@@ -160,12 +160,12 @@ void DTUnpackingModule::produce(Event & e, const EventSetup& context){
 
   // commit to the event  
   if(!dqmOnly) {
-    e.put(detectorProduct);
-    e.put(triggerProduct);
+    e.put(std::move(detectorProduct));
+    e.put(std::move(triggerProduct));
   }
   if(performDataIntegrityMonitor) {
-    e.put(dduProduct);
-    e.put(ros25Product);
+    e.put(std::move(dduProduct));
+    e.put(std::move(ros25Product));
   }
 }
 

--- a/EventFilter/ESDigiToRaw/src/ESDigiToRaw.cc
+++ b/EventFilter/ESDigiToRaw/src/ESDigiToRaw.cc
@@ -102,7 +102,7 @@ void ESDigiToRaw::produce(edm::Event& ev, const edm::EventSetup& es) {
     Digis[ifed].push_back(df);
   }
 
-  auto_ptr<FEDRawDataCollection> productRawData( new FEDRawDataCollection );
+  auto productRawData = std::make_unique<FEDRawDataCollection>();
 
   ESDataFormatter::Digis::const_iterator itfed; 
   for (itfed = Digis.begin(); itfed != Digis.end(); ++itfed) {   
@@ -114,7 +114,7 @@ void ESDigiToRaw::produce(edm::Event& ev, const edm::EventSetup& es) {
     if (debug_) cout<<"FED : "<<fId<<" Data size : "<<fedRawData.size()<<" (Bytes)"<<endl;
   } 
 
-  ev.put(productRawData);
+  ev.put(std::move(productRawData));
 
   return;
 }

--- a/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
+++ b/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
@@ -66,9 +66,9 @@ void ESRawToDigi::produce(edm::Event& e, const edm::EventSetup& es) {
   }
 
   // Output
-  std::auto_ptr<ESRawDataCollection> productDCC(new ESRawDataCollection);
-  std::auto_ptr<ESLocalRawDataCollection> productKCHIP(new ESLocalRawDataCollection);
-  std::auto_ptr<ESDigiCollection> productDigis(new ESDigiCollection);  
+  auto productDCC = std::make_unique<ESRawDataCollection>();
+  auto productKCHIP = std::make_unique<ESLocalRawDataCollection>();
+  auto productDigis = std::make_unique<ESDigiCollection>();  
   
   ESDigiCollection digis;
 
@@ -90,8 +90,8 @@ void ESRawToDigi::produce(edm::Event& e, const edm::EventSetup& es) {
     }   
   }
 
-  e.put(productDCC);
-  e.put(productKCHIP);
-  e.put(productDigis, ESdigiCollection_);
+  e.put(std::move(productDCC));
+  e.put(std::move(productKCHIP));
+  e.put(std::move(productDigis), ESdigiCollection_);
 }
 

--- a/EventFilter/EcalDigiToRaw/src/EcalDigiToRaw.cc
+++ b/EventFilter/EcalDigiToRaw/src/EcalDigiToRaw.cc
@@ -129,7 +129,7 @@ EcalDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   lv1_ = counter_ % (0x1<<24);
 
-  auto_ptr<FEDRawDataCollection> productRawData(new FEDRawDataCollection);
+  auto productRawData = std::make_unique<FEDRawDataCollection>();
 
 
   Headerblockformatter_ -> DigiToRaw(productRawData.get());
@@ -281,7 +281,7 @@ EcalDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
  Towerblockformatter_ -> EndEvent(productRawData.get());
 
- iEvent.put(productRawData);
+ iEvent.put(std::move(productRawData));
 
 
  return;

--- a/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
@@ -63,69 +63,69 @@ public :
     Set the collection pointers
   */
 
-  void setEBDigisCollection( std::auto_ptr<EBDigiCollection>                         * x )
+  void setEBDigisCollection( std::unique_ptr<EBDigiCollection>                         * x )
   { ebDigis_                = x; } 
  
-  void setEEDigisCollection( std::auto_ptr<EEDigiCollection>                         * x )
+  void setEEDigisCollection( std::unique_ptr<EEDigiCollection>                         * x )
   { eeDigis_                = x; } 
  
-  void setDccHeadersCollection( std::auto_ptr<EcalRawDataCollection>                 * x )
+  void setDccHeadersCollection( std::unique_ptr<EcalRawDataCollection>                 * x )
   { dccHeaders_             = x; }
  
-  void setEBSrFlagsCollection( std::auto_ptr<EBSrFlagCollection>                     * x )
+  void setEBSrFlagsCollection( std::unique_ptr<EBSrFlagCollection>                     * x )
   { ebSrFlags_              = x; } 
   
-  void setEESrFlagsCollection( std::auto_ptr<EESrFlagCollection>                     * x )
+  void setEESrFlagsCollection( std::unique_ptr<EESrFlagCollection>                     * x )
   { eeSrFlags_              = x; }
 
-  void setEcalTpsCollection( std::auto_ptr<EcalTrigPrimDigiCollection>                  * x )
+  void setEcalTpsCollection( std::unique_ptr<EcalTrigPrimDigiCollection>                  * x )
   { ecalTps_                  = x; }
 
-  void  setEcalPSsCollection( std::auto_ptr<EcalPSInputDigiCollection>                  * x )
+  void  setEcalPSsCollection( std::unique_ptr<EcalPSInputDigiCollection>                  * x )
   { ecalPSs_                  = x; }
 
-  void setInvalidGainsCollection( std::auto_ptr<EBDetIdCollection>                    * x )
+  void setInvalidGainsCollection( std::unique_ptr<EBDetIdCollection>                    * x )
   { invalidGains_           = x; }
  
-  void setInvalidGainsSwitchCollection( std::auto_ptr<EBDetIdCollection>              * x )
+  void setInvalidGainsSwitchCollection( std::unique_ptr<EBDetIdCollection>              * x )
   { invalidGainsSwitch_     = x; }
  
-  void setInvalidChIdsCollection( std::auto_ptr<EBDetIdCollection>                    * x )
+  void setInvalidChIdsCollection( std::unique_ptr<EBDetIdCollection>                    * x )
   { invalidChIds_           = x; }
 
   // EE 
-  void setInvalidEEGainsCollection( std::auto_ptr<EEDetIdCollection>                    * x )
+  void setInvalidEEGainsCollection( std::unique_ptr<EEDetIdCollection>                    * x )
   { invalidEEGains_           = x; }
   
-  void setInvalidEEGainsSwitchCollection( std::auto_ptr<EEDetIdCollection>              * x )
+  void setInvalidEEGainsSwitchCollection( std::unique_ptr<EEDetIdCollection>              * x )
   { invalidEEGainsSwitch_     = x; }
  
-  void setInvalidEEChIdsCollection( std::auto_ptr<EEDetIdCollection>                    * x )
+  void setInvalidEEChIdsCollection( std::unique_ptr<EEDetIdCollection>                    * x )
   { invalidEEChIds_           = x; }
   // EE 
  
-  void setInvalidTTIdsCollection( std::auto_ptr<EcalElectronicsIdCollection>         * x )
+  void setInvalidTTIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>         * x )
   { invalidTTIds_           = x; }
 
-  void setInvalidZSXtalIdsCollection( std::auto_ptr<EcalElectronicsIdCollection>     * x )
+  void setInvalidZSXtalIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>     * x )
   { invalidZSXtalIds_           = x; }
 
-  void setInvalidBlockLengthsCollection( std::auto_ptr<EcalElectronicsIdCollection>  * x )
+  void setInvalidBlockLengthsCollection( std::unique_ptr<EcalElectronicsIdCollection>  * x )
   { invalidBlockLengths_    = x; }
  
-  void setPnDiodeDigisCollection( std::auto_ptr<EcalPnDiodeDigiCollection>            * x )
+  void setPnDiodeDigisCollection( std::unique_ptr<EcalPnDiodeDigiCollection>            * x )
   { pnDiodeDigis_           = x; }
  
-  void setInvalidMemTtIdsCollection( std::auto_ptr<EcalElectronicsIdCollection>      * x )
+  void setInvalidMemTtIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
   { invalidMemTtIds_        = x; }
  
-  void setInvalidMemBlockSizesCollection( std::auto_ptr<EcalElectronicsIdCollection> * x )
+  void setInvalidMemBlockSizesCollection( std::unique_ptr<EcalElectronicsIdCollection> * x )
   { invalidMemBlockSizes_   = x; }
  
-  void setInvalidMemChIdsCollection( std::auto_ptr<EcalElectronicsIdCollection>      * x )
+  void setInvalidMemChIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
   { invalidMemChIds_        = x; }
  
-  void setInvalidMemGainsCollection( std::auto_ptr<EcalElectronicsIdCollection>      * x )
+  void setInvalidMemGainsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
   { invalidMemGains_        = x; }
   
  
@@ -133,69 +133,69 @@ public :
    Get the collection pointers
   */
   
-  std::auto_ptr<EBDigiCollection>             * ebDigisCollection()
+  std::unique_ptr<EBDigiCollection>             * ebDigisCollection()
   { return ebDigis_;               }
   
-  std::auto_ptr<EEDigiCollection>             * eeDigisCollection()
+  std::unique_ptr<EEDigiCollection>             * eeDigisCollection()
   { return eeDigis_;               }
   
-  std::auto_ptr<EcalTrigPrimDigiCollection>   * ecalTpsCollection()
+  std::unique_ptr<EcalTrigPrimDigiCollection>   * ecalTpsCollection()
   { return ecalTps_;                 } 
   
-  std::auto_ptr<EcalPSInputDigiCollection>    * ecalPSsCollection()
+  std::unique_ptr<EcalPSInputDigiCollection>    * ecalPSsCollection()
   { return ecalPSs_;                 } 
 
-  std::auto_ptr<EBSrFlagCollection>           * ebSrFlagsCollection()
+  std::unique_ptr<EBSrFlagCollection>           * ebSrFlagsCollection()
   { return ebSrFlags_;             }  
   
-  std::auto_ptr<EESrFlagCollection>           * eeSrFlagsCollection()
+  std::unique_ptr<EESrFlagCollection>           * eeSrFlagsCollection()
   { return eeSrFlags_;             } 
   
-  std::auto_ptr<EcalRawDataCollection>        * dccHeadersCollection()
+  std::unique_ptr<EcalRawDataCollection>        * dccHeadersCollection()
   { return dccHeaders_;            }
   
-  std::auto_ptr<EBDetIdCollection>            * invalidGainsCollection()
+  std::unique_ptr<EBDetIdCollection>            * invalidGainsCollection()
   { return invalidGains_;          }
   
-  std::auto_ptr<EBDetIdCollection>            * invalidGainsSwitchCollection()
+  std::unique_ptr<EBDetIdCollection>            * invalidGainsSwitchCollection()
   { return invalidGainsSwitch_;    }
   
-  std::auto_ptr<EBDetIdCollection>            * invalidChIdsCollection()
+  std::unique_ptr<EBDetIdCollection>            * invalidChIdsCollection()
   { return invalidChIds_;          }
 
   //EE
-  std::auto_ptr<EEDetIdCollection>            * invalidEEGainsCollection()
+  std::unique_ptr<EEDetIdCollection>            * invalidEEGainsCollection()
   { return invalidEEGains_;          }
   
-  std::auto_ptr<EEDetIdCollection>            * invalidEEGainsSwitchCollection()
+  std::unique_ptr<EEDetIdCollection>            * invalidEEGainsSwitchCollection()
   { return invalidEEGainsSwitch_;    }
   
-  std::auto_ptr<EEDetIdCollection>            * invalidEEChIdsCollection()
+  std::unique_ptr<EEDetIdCollection>            * invalidEEChIdsCollection()
   { return invalidEEChIds_;          }
   //EE
 
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidTTIdsCollection()
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIdsCollection()
   { return invalidTTIds_;          }
 
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidZSXtalIdsCollection()
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIdsCollection()
   { return invalidZSXtalIds_;          }  
   
-  std::auto_ptr< EcalElectronicsIdCollection> * invalidBlockLengthsCollection()
+  std::unique_ptr< EcalElectronicsIdCollection> * invalidBlockLengthsCollection()
   { return invalidBlockLengths_;   }
      
-  std::auto_ptr<EcalElectronicsIdCollection>  * invalidMemTtIdsCollection()
+  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemTtIdsCollection()
   { return invalidMemTtIds_;       }
  
-  std::auto_ptr<EcalElectronicsIdCollection>  * invalidMemBlockSizesCollection()
+  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemBlockSizesCollection()
   { return invalidMemBlockSizes_;  }
   
-  std::auto_ptr<EcalElectronicsIdCollection>  * invalidMemChIdsCollection()
+  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemChIdsCollection()
   { return invalidMemChIds_;       }
   
-  std::auto_ptr<EcalElectronicsIdCollection>  * invalidMemGainsCollection()
+  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemGainsCollection()
   { return invalidMemGains_;       }
 
-  std::auto_ptr<EcalPnDiodeDigiCollection>    * pnDiodeDigisCollection()
+  std::unique_ptr<EcalPnDiodeDigiCollection>    * pnDiodeDigisCollection()
   { return pnDiodeDigis_;          }
   
 
@@ -229,30 +229,30 @@ public :
 protected :
 
   // Data collections pointers
-  std::auto_ptr<EBDigiCollection>            * ebDigis_;
-  std::auto_ptr<EEDigiCollection>            * eeDigis_;
-  std::auto_ptr<EcalTrigPrimDigiCollection>  * ecalTps_;
-  std::auto_ptr<EcalPSInputDigiCollection>   * ecalPSs_;
-  std::auto_ptr<EcalRawDataCollection>       * dccHeaders_;
-  std::auto_ptr<EBDetIdCollection>           * invalidGains_;
-  std::auto_ptr<EBDetIdCollection>           * invalidGainsSwitch_;
-  std::auto_ptr<EBDetIdCollection>           * invalidChIds_;
+  std::unique_ptr<EBDigiCollection>            * ebDigis_;
+  std::unique_ptr<EEDigiCollection>            * eeDigis_;
+  std::unique_ptr<EcalTrigPrimDigiCollection>  * ecalTps_;
+  std::unique_ptr<EcalPSInputDigiCollection>   * ecalPSs_;
+  std::unique_ptr<EcalRawDataCollection>       * dccHeaders_;
+  std::unique_ptr<EBDetIdCollection>           * invalidGains_;
+  std::unique_ptr<EBDetIdCollection>           * invalidGainsSwitch_;
+  std::unique_ptr<EBDetIdCollection>           * invalidChIds_;
   //EE
-  std::auto_ptr<EEDetIdCollection>           * invalidEEGains_;
-  std::auto_ptr<EEDetIdCollection>           * invalidEEGainsSwitch_;
-  std::auto_ptr<EEDetIdCollection>           * invalidEEChIds_;
+  std::unique_ptr<EEDetIdCollection>           * invalidEEGains_;
+  std::unique_ptr<EEDetIdCollection>           * invalidEEGainsSwitch_;
+  std::unique_ptr<EEDetIdCollection>           * invalidEEChIds_;
   //EE
-  std::auto_ptr<EBSrFlagCollection>          * ebSrFlags_;
-  std::auto_ptr<EESrFlagCollection>          * eeSrFlags_;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_; 
+  std::unique_ptr<EBSrFlagCollection>          * ebSrFlags_;
+  std::unique_ptr<EESrFlagCollection>          * eeSrFlags_;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_; 
   
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidMemTtIds_ ;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidMemBlockSizes_ ;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidMemChIds_ ;
-  std::auto_ptr<EcalElectronicsIdCollection> * invalidMemGains_ ;
-  std::auto_ptr<EcalPnDiodeDigiCollection>   * pnDiodeDigis_;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemTtIds_ ;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemBlockSizes_ ;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemChIds_ ;
+  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemGains_ ;
+  std::unique_ptr<EcalPnDiodeDigiCollection>   * pnDiodeDigis_;
 
   EcalElectronicsMapper  * electronicsMapper_;
   const EcalChannelStatusMap* chdb_;

--- a/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
@@ -45,7 +45,7 @@ class DCCEBSRPBlock : public DCCSRPBlock{
 	 
     bool checkSrpIdAndNumbSRFlags();
     
-    std::auto_ptr<EBSrFlagCollection>  * ebSrFlagsDigis_;
+    std::unique_ptr<EBSrFlagCollection>  * ebSrFlagsDigis_;
     
     EcalTrigTowerDetId * pTTDetId_;
 		

--- a/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
@@ -44,7 +44,7 @@ class DCCEESRPBlock : public DCCSRPBlock{
     
     bool checkSrpIdAndNumbSRFlags();
 	 
-    std::auto_ptr<EESrFlagCollection>  * eeSrFlagsDigis_;
+    std::unique_ptr<EESrFlagCollection>  * eeSrFlagsDigis_;
 	 
     EcalScDetId * pSCDetId_;
     

--- a/EventFilter/EcalRawToDigi/interface/DCCEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEventBlock.h
@@ -117,7 +117,7 @@ class DCCEventBlock {
     bool memUnpacking_;
     bool forceToKeepFRdata_;
 
-    std::auto_ptr<EcalRawDataCollection> *  dccHeaders_;
+    std::unique_ptr<EcalRawDataCollection> *  dccHeaders_;
 	 
 
 };

--- a/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
@@ -42,7 +42,7 @@ class DCCFEBlock : public DCCDataBlockPrototype {
   protected :
 	 
     virtual int unpackXtalData(unsigned int stripID, unsigned int xtalID){      return BLOCK_UNPACKED;};
-    virtual void fillEcalElectronicsError( std::auto_ptr<EcalElectronicsIdCollection> * ){};
+    virtual void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ){};
     
     
     bool zs_;
@@ -64,9 +64,9 @@ class DCCFEBlock : public DCCDataBlockPrototype {
     unsigned int l1_;
     
     short * xtalGains_;
-    std::auto_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
-    std::auto_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
-    std::auto_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_;
+    std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
+    std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
+    std::unique_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_;
 
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
@@ -69,11 +69,11 @@ class DCCMemBlock : public DCCDataBlockPrototype {
     unsigned int bx_;
     unsigned int l1_;
 	 
-    std::auto_ptr<EcalElectronicsIdCollection>   * invalidMemChIds_;  
-    std::auto_ptr<EcalElectronicsIdCollection>   * invalidMemBlockSizes_; 
-    std::auto_ptr<EcalElectronicsIdCollection>   * invalidMemTtIds_; 
-    std::auto_ptr<EcalElectronicsIdCollection>   * invalidMemGains_;
-    std::auto_ptr<EcalPnDiodeDigiCollection>     * pnDiodeDigis_;
+    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemChIds_;  
+    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemBlockSizes_; 
+    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemTtIds_; 
+    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemGains_;
+    std::unique_ptr<EcalPnDiodeDigiCollection>     * pnDiodeDigis_;
 	
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
@@ -33,17 +33,17 @@ class DCCSCBlock : public DCCFEBlock {
   protected :
 
    int unpackXtalData(unsigned int stripID, unsigned int xtalID);
-   void fillEcalElectronicsError( std::auto_ptr<EcalElectronicsIdCollection> * );
+   void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * );
 	 
    EEDetId                                * pDetId_;
    EEDataFrame                            * pDFId_;
 	 
-   std::auto_ptr<EEDigiCollection>        * digis_;
+   std::unique_ptr<EEDigiCollection>        * digis_;
 
    // to restructure as common collections to DCCTowerBlock, to inherit from DCCFEBlock
-   std::auto_ptr<EEDetIdCollection>       * invalidGains_;
-   std::auto_ptr<EEDetIdCollection>       * invalidGainsSwitch_ ;
-   std::auto_ptr<EEDetIdCollection>       * invalidChIds_;
+   std::unique_ptr<EEDetIdCollection>       * invalidGains_;
+   std::unique_ptr<EEDetIdCollection>       * invalidGainsSwitch_ ;
+   std::unique_ptr<EEDetIdCollection>       * invalidChIds_;
     
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
@@ -65,8 +65,8 @@ class DCCTCCBlock : public DCCDataBlockPrototype {
     EcalTrigTowerDetId * pTTDetId_;   
     EcalTriggerPrimitiveDigi * pTP_;
     EcalPseudoStripInputDigi * pPS_;
-    std::auto_ptr<EcalTrigPrimDigiCollection> * tps_;  
-    std::auto_ptr<EcalPSInputDigiCollection> * pss_;  
+    std::unique_ptr<EcalTrigPrimDigiCollection> * tps_;  
+    std::unique_ptr<EcalPSInputDigiCollection> * pss_;  
 
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
@@ -32,16 +32,16 @@ class DCCTowerBlock : public DCCFEBlock {
   protected:
 	 
     int unpackXtalData(unsigned int stripID, unsigned int xtalID);
-    void fillEcalElectronicsError( std::auto_ptr<EcalElectronicsIdCollection> * );
+    void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * );
 
-    std::auto_ptr<EBDigiCollection>     * digis_;
+    std::unique_ptr<EBDigiCollection>     * digis_;
     
     EBDetId                             * pDetId_;
 
     // to restructure as common collections to DCCSCBlock, to inherit from DCCFEBlock
-    std::auto_ptr<EBDetIdCollection>    * invalidGains_;  
-    std::auto_ptr<EBDetIdCollection>    * invalidGainsSwitch_ ;
-    std::auto_ptr<EBDetIdCollection>    * invalidChIds_;
+    std::unique_ptr<EBDetIdCollection>    * invalidGains_;  
+    std::unique_ptr<EBDetIdCollection>    * invalidGainsSwitch_ ;
+    std::unique_ptr<EBDetIdCollection>    * invalidChIds_;
 	 
 };
 

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
@@ -343,97 +343,97 @@ void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // Step B: encapsulate vectors in actual collections and set unpacker pointers
 
   // create the collection of Ecal Digis
-  std::auto_ptr<EBDigiCollection> productDigisEB(new EBDigiCollection);
+  auto productDigisEB = std::make_unique<EBDigiCollection>();
   productDigisEB->reserve(1700);
   theUnpacker_->setEBDigisCollection(&productDigisEB);
   
   // create the collection of Ecal Digis
-  std::auto_ptr<EEDigiCollection> productDigisEE(new EEDigiCollection);
+  auto productDigisEE = std::make_unique<EEDigiCollection>();
   theUnpacker_->setEEDigisCollection(&productDigisEE);
   
   // create the collection for headers
-  std::auto_ptr<EcalRawDataCollection> productDccHeaders(new EcalRawDataCollection);
+  auto productDccHeaders = std::make_unique<EcalRawDataCollection>();
   theUnpacker_->setDccHeadersCollection(&productDccHeaders); 
 
   // create the collection for invalid gains
-  std::auto_ptr< EBDetIdCollection> productInvalidGains(new EBDetIdCollection);
+  auto productInvalidGains = std::make_unique<EBDetIdCollection>();
   theUnpacker_->setInvalidGainsCollection(&productInvalidGains); 
 
   // create the collection for invalid gain Switch
-  std::auto_ptr< EBDetIdCollection> productInvalidGainsSwitch(new EBDetIdCollection);
+  auto productInvalidGainsSwitch = std::make_unique<EBDetIdCollection>();
   theUnpacker_->setInvalidGainsSwitchCollection(&productInvalidGainsSwitch);
    
   // create the collection for invalid chids
-  std::auto_ptr< EBDetIdCollection> productInvalidChIds(new EBDetIdCollection);
+  auto productInvalidChIds = std::make_unique<EBDetIdCollection>();
   theUnpacker_->setInvalidChIdsCollection(&productInvalidChIds);
   
   ///////////////// make EEDetIdCollections for these ones
     
   // create the collection for invalid gains
-  std::auto_ptr<EEDetIdCollection> productInvalidEEGains(new EEDetIdCollection);
+  auto productInvalidEEGains = std::make_unique<EEDetIdCollection>();
   theUnpacker_->setInvalidEEGainsCollection(&productInvalidEEGains); 
     
   // create the collection for invalid gain Switch
-  std::auto_ptr<EEDetIdCollection> productInvalidEEGainsSwitch(new EEDetIdCollection);
+  auto productInvalidEEGainsSwitch = std::make_unique<EEDetIdCollection>();
   theUnpacker_->setInvalidEEGainsSwitchCollection(&productInvalidEEGainsSwitch);
     
   // create the collection for invalid chids
-  std::auto_ptr<EEDetIdCollection> productInvalidEEChIds(new EEDetIdCollection);
+  auto productInvalidEEChIds = std::make_unique<EEDetIdCollection>();
   theUnpacker_->setInvalidEEChIdsCollection(&productInvalidEEChIds);
 
   ///////////////// make EEDetIdCollections for these ones    
 
   // create the collection for EB srflags       
-  std::auto_ptr<EBSrFlagCollection> productEBSrFlags(new EBSrFlagCollection);
+  auto productEBSrFlags = std::make_unique<EBSrFlagCollection>();
   theUnpacker_->setEBSrFlagsCollection(&productEBSrFlags);
   
   // create the collection for EB srflags       
-  std::auto_ptr<EESrFlagCollection> productEESrFlags(new EESrFlagCollection);
+  auto productEESrFlags = std::make_unique<EESrFlagCollection>();
   theUnpacker_->setEESrFlagsCollection(&productEESrFlags);
 
   // create the collection for ecal trigger primitives
-  std::auto_ptr<EcalTrigPrimDigiCollection> productEcalTps(new EcalTrigPrimDigiCollection);
+  auto productEcalTps = std::make_unique<EcalTrigPrimDigiCollection>();
   theUnpacker_->setEcalTpsCollection(&productEcalTps);
   /////////////////////// collections for problems pertaining towers are already EE+EB communal
 
   // create the collection for ecal trigger primitives
-  std::auto_ptr<EcalPSInputDigiCollection> productEcalPSs(new EcalPSInputDigiCollection);
+  auto productEcalPSs = std::make_unique<EcalPSInputDigiCollection>();
   theUnpacker_->setEcalPSsCollection(&productEcalPSs);
   /////////////////////// collections for problems pertaining towers are already EE+EB communal
 
   // create the collection for invalid TTIds
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidTTIds(new EcalElectronicsIdCollection);
+  auto productInvalidTTIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidTTIdsCollection(&productInvalidTTIds);
  
    // create the collection for invalid TTIds
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidZSXtalIds(new EcalElectronicsIdCollection);
+  auto productInvalidZSXtalIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidZSXtalIdsCollection(&productInvalidZSXtalIds);
 
 
  
   // create the collection for invalid BlockLengths
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidBlockLengths(new EcalElectronicsIdCollection);
+  auto productInvalidBlockLengths = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidBlockLengthsCollection(&productInvalidBlockLengths);
 
   // MEMs Collections
   // create the collection for the Pn Diode Digis
-  std::auto_ptr<EcalPnDiodeDigiCollection> productPnDiodeDigis(new EcalPnDiodeDigiCollection);
+  auto productPnDiodeDigis = std::make_unique<EcalPnDiodeDigiCollection>();
   theUnpacker_->setPnDiodeDigisCollection(&productPnDiodeDigis);
 
   // create the collection for invalid Mem Tt id 
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidMemTtIds(new EcalElectronicsIdCollection);
+  auto productInvalidMemTtIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidMemTtIdsCollection(& productInvalidMemTtIds);
   
   // create the collection for invalid Mem Block Size 
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidMemBlockSizes(new EcalElectronicsIdCollection);
+  auto productInvalidMemBlockSizes = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidMemBlockSizesCollection(& productInvalidMemBlockSizes);
   
   // create the collection for invalid Mem Block Size 
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidMemChIds(new EcalElectronicsIdCollection);
+  auto productInvalidMemChIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidMemChIdsCollection(& productInvalidMemChIds);
  
   // create the collection for invalid Mem Gain Errors 
-  std::auto_ptr<EcalElectronicsIdCollection> productInvalidMemGains(new EcalElectronicsIdCollection);
+  auto productInvalidMemGains = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidMemGainsCollection(& productInvalidMemGains); 
   //  double TIME_START = clock(); 
   
@@ -481,40 +481,40 @@ void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   if(put_){
     
     if( headerUnpacking_){ 
-      e.put(productDccHeaders); 
+      e.put(std::move(productDccHeaders));
     }
     
     if(feUnpacking_){
       productDigisEB->sort();
-      e.put(productDigisEB,"ebDigis");
+      e.put(std::move(productDigisEB),"ebDigis");
       productDigisEE->sort();
-      e.put(productDigisEE,"eeDigis");
-      e.put(productInvalidGains,"EcalIntegrityGainErrors");
-      e.put(productInvalidGainsSwitch, "EcalIntegrityGainSwitchErrors");
-      e.put(productInvalidChIds, "EcalIntegrityChIdErrors");
+      e.put(std::move(productDigisEE),"eeDigis");
+      e.put(std::move(productInvalidGains),"EcalIntegrityGainErrors");
+      e.put(std::move(productInvalidGainsSwitch), "EcalIntegrityGainSwitchErrors");
+      e.put(std::move(productInvalidChIds), "EcalIntegrityChIdErrors");
       // EE (leaving for now the same names as in EB)
-      e.put(productInvalidEEGains,"EcalIntegrityGainErrors");
-      e.put(productInvalidEEGainsSwitch, "EcalIntegrityGainSwitchErrors");
-      e.put(productInvalidEEChIds, "EcalIntegrityChIdErrors");
+      e.put(std::move(productInvalidEEGains),"EcalIntegrityGainErrors");
+      e.put(std::move(productInvalidEEGainsSwitch), "EcalIntegrityGainSwitchErrors");
+      e.put(std::move(productInvalidEEChIds), "EcalIntegrityChIdErrors");
       // EE
-      e.put(productInvalidTTIds,"EcalIntegrityTTIdErrors");
-      e.put(productInvalidZSXtalIds,"EcalIntegrityZSXtalIdErrors");
-      e.put(productInvalidBlockLengths,"EcalIntegrityBlockSizeErrors");
-      e.put(productPnDiodeDigis);
+      e.put(std::move(productInvalidTTIds),"EcalIntegrityTTIdErrors");
+      e.put(std::move(productInvalidZSXtalIds),"EcalIntegrityZSXtalIdErrors");
+      e.put(std::move(productInvalidBlockLengths),"EcalIntegrityBlockSizeErrors");
+      e.put(std::move(productPnDiodeDigis));
     }
     if(memUnpacking_){
-      e.put(productInvalidMemTtIds,"EcalIntegrityMemTtIdErrors");
-      e.put(productInvalidMemBlockSizes,"EcalIntegrityMemBlockSizeErrors");
-      e.put(productInvalidMemChIds,"EcalIntegrityMemChIdErrors");
-      e.put(productInvalidMemGains,"EcalIntegrityMemGainErrors");
+      e.put(std::move(productInvalidMemTtIds),"EcalIntegrityMemTtIdErrors");
+      e.put(std::move(productInvalidMemBlockSizes),"EcalIntegrityMemBlockSizeErrors");
+      e.put(std::move(productInvalidMemChIds),"EcalIntegrityMemChIdErrors");
+      e.put(std::move(productInvalidMemGains),"EcalIntegrityMemGainErrors");
     }
     if(srpUnpacking_){
-      e.put(productEBSrFlags);
-      e.put(productEESrFlags);
+      e.put(std::move(productEBSrFlags));
+      e.put(std::move(productEESrFlags));
     }
     if(tccUnpacking_){
-      e.put(productEcalTps,"EcalTriggerPrimitives");
-      e.put(productEcalPSs,"EcalPseudoStripInputs");
+      e.put(std::move(productEcalTps),"EcalTriggerPrimitives");
+      e.put(std::move(productEcalPSs),"EcalPseudoStripInputs");
     }
   }
   

--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -181,17 +181,16 @@ MatacqProducer::addMatacqData(edm::Event& event){
   edm::Handle<FEDRawDataCollection> sourceColl;
   event.getByToken(inputRawCollectionToken_, sourceColl);
 
-  std::auto_ptr<FEDRawDataCollection> rawColl;
+  std::unique_ptr<FEDRawDataCollection> rawColl;
   if(produceRaw_){
     if(mergeRaw_){
-      rawColl = auto_ptr<FEDRawDataCollection>(new FEDRawDataCollection(*sourceColl));
+      rawColl = std::make_unique<FEDRawDataCollection>(*sourceColl);
     } else{
-      rawColl = auto_ptr<FEDRawDataCollection>(new FEDRawDataCollection());
+      rawColl = std::make_unique<FEDRawDataCollection>();
     }
   }
   
-  std::auto_ptr<EcalMatacqDigiCollection>
-    digiColl(new EcalMatacqDigiCollection());
+  auto digiColl = std::make_unique<EcalMatacqDigiCollection>();
   
   if(eventSkipCounter_==0){
     if(sourceColl->FEDData(matacqFedId_).size()>4 && !produceRaw_){
@@ -282,14 +281,14 @@ MatacqProducer::addMatacqData(edm::Event& event){
     if(verbosity_>1) cout << "[Matacq " << now() << "] "
                           << "Adding FEDRawDataCollection collection "
                           << " to event.\n";
-    event.put(rawColl, rawInstanceName_);
+    event.put(std::move(rawColl), rawInstanceName_);
   }
 
   if(produceDigis_){
     if(verbosity_>1) cout << "[Matacq " << now() << "] "
                           << "Adding EcalMatacqDigiCollection collection "
                           << " to event.\n";
-    event.put(digiColl, digiInstanceName_);
+    event.put(std::move(digiColl), digiInstanceName_);
   }
 }
 

--- a/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
@@ -273,7 +273,7 @@ int DCCSCBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalID){
 }
 
 
-void DCCSCBlock::fillEcalElectronicsError( std::auto_ptr<EcalElectronicsIdCollection> * errorColection){
+void DCCSCBlock::fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * errorColection){
 
   const int activeDCC = mapper_->getActiveSM();
 

--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -254,7 +254,7 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
 
 
 
-void DCCTowerBlock::fillEcalElectronicsError( std::auto_ptr<EcalElectronicsIdCollection> * errorColection ){
+void DCCTowerBlock::fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * errorColection ){
 
    const int activeDCC = mapper_->getActiveSM();
 

--- a/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
@@ -179,57 +179,57 @@ void EcalDCCTB07UnpackingModule::produce(edm::Event & e, const edm::EventSetup& 
   
 
   // create the collection of Ecal Digis
-  std::auto_ptr<EBDigiCollection> productEb(new EBDigiCollection);
+  auto productEb = std::make_unique<EBDigiCollection>();
 
   // YM create the collection of Ecal Endcap Digis
-  std::auto_ptr<EEDigiCollection> productEe(new EEDigiCollection);
+  auto productEe = std::make_unique<EEDigiCollection>();
 
   // create the collection of Matacq Digi
-  std::auto_ptr<EcalMatacqDigiCollection> productMatacq(new EcalMatacqDigiCollection());
+  auto productMatacq = std::make_unique<EcalMatacqDigiCollection>();
 
   // create the collection of Ecal PN's
-  std::auto_ptr<EcalPnDiodeDigiCollection> productPN(new EcalPnDiodeDigiCollection);
+  auto productPN = std::make_unique<EcalPnDiodeDigiCollection>();
   
   //create the collection of Ecal DCC Header
-  std::auto_ptr<EcalRawDataCollection> productDCCHeader(new EcalRawDataCollection);
+  auto productDCCHeader = std::make_unique<EcalRawDataCollection>();
 
   // create the collection with trigger primitives, bits and flags
-  std::auto_ptr<EcalTrigPrimDigiCollection> productTriggerPrimitives(new EcalTrigPrimDigiCollection);
+  auto productTriggerPrimitives = std::make_unique<EcalTrigPrimDigiCollection>();
 
   // create the collection of Ecal Integrity DCC Size
-  std::auto_ptr<EBDetIdCollection> productDCCSize(new EBDetIdCollection);
+  auto productDCCSize = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity TT Id
-  std::auto_ptr<EcalElectronicsIdCollection> productTTId(new EcalElectronicsIdCollection);
+  auto productTTId = std::make_unique<EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity TT Block Size
-  std::auto_ptr<EcalElectronicsIdCollection> productBlockSize(new EcalElectronicsIdCollection);
+  auto productBlockSize = std::make_unique<EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity Ch Id
-  std::auto_ptr<EBDetIdCollection> productChId(new EBDetIdCollection);
+  auto productChId = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Gain
-  std::auto_ptr<EBDetIdCollection> productGain(new EBDetIdCollection);
+  auto productGain = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Gain Switch
-  std::auto_ptr<EBDetIdCollection> productGainSwitch(new EBDetIdCollection);
+  auto productGainSwitch = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Mem towerBlock_id errors
-  std::auto_ptr<EcalElectronicsIdCollection> productMemTtId(new EcalElectronicsIdCollection);
+  auto productMemTtId = std::make_unique<EcalElectronicsIdCollection>();
   
   // create the collection of Ecal Integrity Mem gain errors
-  std::auto_ptr< EcalElectronicsIdCollection> productMemBlockSize(new EcalElectronicsIdCollection);
+  auto productMemBlockSize = std::make_unique< EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity Mem gain errors
-  std::auto_ptr< EcalElectronicsIdCollection> productMemGain(new EcalElectronicsIdCollection);
+  auto productMemGain = std::make_unique< EcalElectronicsIdCollection>();
   
   // create the collection of Ecal Integrity Mem ch_id errors
-  std::auto_ptr<EcalElectronicsIdCollection> productMemChIdErrors(new EcalElectronicsIdCollection);
+  auto productMemChIdErrors = std::make_unique<EcalElectronicsIdCollection>();
   
   // create the collection of TB specifics data
-  std::auto_ptr<EcalTBHodoscopeRawInfo> productHodo(new EcalTBHodoscopeRawInfo());         
-  std::auto_ptr<EcalTBTDCRawInfo> productTdc(new EcalTBTDCRawInfo());                      
-  std::auto_ptr<EcalTBEventHeader> productHeader(new EcalTBEventHeader());                      
+  auto productHodo = std::make_unique<EcalTBHodoscopeRawInfo>();         
+  auto productTdc = std::make_unique<EcalTBTDCRawInfo>();                      
+  auto productHeader = std::make_unique<EcalTBEventHeader>();                      
 
 
   try {
@@ -291,28 +291,28 @@ void EcalDCCTB07UnpackingModule::produce(edm::Event & e, const edm::EventSetup& 
   
 
   // commit to the event  
-  e.put(productPN);
-  if (ProduceEBDigis_)  e.put(productEb,"ebDigis");
-  if (ProduceEEDigis_)  e.put(productEe,"eeDigis");
-  e.put(productMatacq);
-  e.put(productDCCHeader);
-  e.put(productTriggerPrimitives, "EBTT");
+  e.put(std::move(productPN));
+  if (ProduceEBDigis_)  e.put(std::move(productEb),"ebDigis");
+  if (ProduceEEDigis_)  e.put(std::move(productEe),"eeDigis");
+  e.put(std::move(productMatacq));
+  e.put(std::move(productDCCHeader));
+  e.put(std::move(productTriggerPrimitives), "EBTT");
   
-  if (ProduceEBDigis_)  e.put(productDCCSize,"EcalIntegrityDCCSizeErrors");
-  if (ProduceEBDigis_)  e.put(productTTId,"EcalIntegrityTTIdErrors");
-  if (ProduceEBDigis_)  e.put(productBlockSize,"EcalIntegrityBlockSizeErrors");
-  if (ProduceEBDigis_)  e.put(productChId,"EcalIntegrityChIdErrors");
-  if (ProduceEBDigis_)  e.put(productGain,"EcalIntegrityGainErrors");
-  if (ProduceEBDigis_)  e.put(productGainSwitch,"EcalIntegrityGainSwitchErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productDCCSize),"EcalIntegrityDCCSizeErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productTTId),"EcalIntegrityTTIdErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productBlockSize),"EcalIntegrityBlockSizeErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productChId),"EcalIntegrityChIdErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productGain),"EcalIntegrityGainErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productGainSwitch),"EcalIntegrityGainSwitchErrors");
   
-  if (ProduceEBDigis_)  e.put(productMemTtId,"EcalIntegrityMemTtIdErrors");
-  if (ProduceEBDigis_)  e.put(productMemBlockSize,"EcalIntegrityMemBlockSize");
-  if (ProduceEBDigis_)  e.put(productMemChIdErrors,"EcalIntegrityMemChIdErrors");
-  if (ProduceEBDigis_)  e.put(productMemGain,"EcalIntegrityMemGainErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productMemTtId),"EcalIntegrityMemTtIdErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productMemBlockSize),"EcalIntegrityMemBlockSize");
+  if (ProduceEBDigis_)  e.put(std::move(productMemChIdErrors),"EcalIntegrityMemChIdErrors");
+  if (ProduceEBDigis_)  e.put(std::move(productMemGain),"EcalIntegrityMemGainErrors");
 
-  e.put(productHodo);
-  e.put(productTdc);
-  e.put(productHeader);
+  e.put(std::move(productHodo));
+  e.put(std::move(productTdc));
+  e.put(std::move(productHeader));
 
   } catch (ECALTBParserException &e) {
     std::cout << "[EcalDCCTB07UnpackingModule] " << e.what() << std::endl;

--- a/EventFilter/EcalTBRawToDigi/src/EcalDCCUnpackingModule.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalDCCUnpackingModule.cc
@@ -97,54 +97,54 @@ void EcalDCCTBUnpackingModule::produce(edm::Event & e, const edm::EventSetup& c)
   
 
   // create the collection of Ecal Digis
-  std::auto_ptr<EBDigiCollection> productEb(new EBDigiCollection);
+  auto productEb = std::make_unique<EBDigiCollection>();
 
   // create the collection of Matacq Digi
-  std::auto_ptr<EcalMatacqDigiCollection> productMatacq(new EcalMatacqDigiCollection());
+  auto productMatacq = std::make_unique<EcalMatacqDigiCollection>();
 
   // create the collection of Ecal PN's
-  std::auto_ptr<EcalPnDiodeDigiCollection> productPN(new EcalPnDiodeDigiCollection);
+  auto productPN = std::make_unique<EcalPnDiodeDigiCollection>();
   
   //create the collection of Ecal DCC Header
-  std::auto_ptr<EcalRawDataCollection> productDCCHeader(new EcalRawDataCollection);
+  auto productDCCHeader = std::make_unique<EcalRawDataCollection>();
 
   // create the collection with trigger primitives, bits and flags
-  std::auto_ptr<EcalTrigPrimDigiCollection> productTriggerPrimitives(new EcalTrigPrimDigiCollection);
+  auto productTriggerPrimitives = std::make_unique<EcalTrigPrimDigiCollection>();
 
   // create the collection of Ecal Integrity DCC Size
-  std::auto_ptr<EBDetIdCollection> productDCCSize(new EBDetIdCollection);
+  auto productDCCSize = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity TT Id
-  std::auto_ptr<EcalElectronicsIdCollection> productTTId(new EcalElectronicsIdCollection);
+  auto productTTId = std::make_unique<EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity TT Block Size
-  std::auto_ptr<EcalElectronicsIdCollection> productBlockSize(new EcalElectronicsIdCollection);
+  auto productBlockSize = std::make_unique<EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity Ch Id
-  std::auto_ptr<EBDetIdCollection> productChId(new EBDetIdCollection);
+  auto productChId = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Gain
-  std::auto_ptr<EBDetIdCollection> productGain(new EBDetIdCollection);
+  auto productGain = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Gain Switch
-  std::auto_ptr<EBDetIdCollection> productGainSwitch(new EBDetIdCollection);
+  auto productGainSwitch = std::make_unique<EBDetIdCollection>();
 
   // create the collection of Ecal Integrity Mem towerBlock_id errors
-  std::auto_ptr<EcalElectronicsIdCollection> productMemTtId(new EcalElectronicsIdCollection);
+  auto productMemTtId = std::make_unique<EcalElectronicsIdCollection>();
   
   // create the collection of Ecal Integrity Mem gain errors
-  std::auto_ptr< EcalElectronicsIdCollection> productMemBlockSize(new EcalElectronicsIdCollection);
+  auto productMemBlockSize = std::make_unique<EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity Mem gain errors
-  std::auto_ptr< EcalElectronicsIdCollection> productMemGain(new EcalElectronicsIdCollection);
+  auto productMemGain = std::make_unique<EcalElectronicsIdCollection>();
   
   // create the collection of Ecal Integrity Mem ch_id errors
-  std::auto_ptr<EcalElectronicsIdCollection> productMemChIdErrors(new EcalElectronicsIdCollection);
+  auto productMemChIdErrors = std::make_unique<EcalElectronicsIdCollection>();
   
   // create the collection of TB specifics data
-  std::auto_ptr<EcalTBHodoscopeRawInfo> productHodo(new EcalTBHodoscopeRawInfo());         
-  std::auto_ptr<EcalTBTDCRawInfo> productTdc(new EcalTBTDCRawInfo());                      
-  std::auto_ptr<EcalTBEventHeader> productHeader(new EcalTBEventHeader());                      
+  auto productHodo = std::make_unique<EcalTBHodoscopeRawInfo>();
+  auto productTdc = std::make_unique<EcalTBTDCRawInfo>();
+  auto productHeader = std::make_unique<EcalTBEventHeader>();
 
 
   try {
@@ -205,27 +205,27 @@ void EcalDCCTBUnpackingModule::produce(edm::Event & e, const edm::EventSetup& c)
   
 
   // commit to the event  
-  e.put(productPN);
-  e.put(productEb,"ebDigis");
-  e.put(productMatacq);
-  e.put(productDCCHeader);
-  e.put(productTriggerPrimitives,"EBTT");
+  e.put(std::move(productPN));
+  e.put(std::move(productEb),"ebDigis");
+  e.put(std::move(productMatacq));
+  e.put(std::move(productDCCHeader));
+  e.put(std::move(productTriggerPrimitives),"EBTT");
 
-  e.put(productDCCSize,"EcalIntegrityDCCSizeErrors");
-  e.put(productTTId,"EcalIntegrityTTIdErrors");
-  e.put(productBlockSize,"EcalIntegrityBlockSizeErrors");
-  e.put(productChId,"EcalIntegrityChIdErrors");
-  e.put(productGain,"EcalIntegrityGainErrors");
-  e.put(productGainSwitch,"EcalIntegrityGainSwitchErrors");
+  e.put(std::move(productDCCSize),"EcalIntegrityDCCSizeErrors");
+  e.put(std::move(productTTId),"EcalIntegrityTTIdErrors");
+  e.put(std::move(productBlockSize),"EcalIntegrityBlockSizeErrors");
+  e.put(std::move(productChId),"EcalIntegrityChIdErrors");
+  e.put(std::move(productGain),"EcalIntegrityGainErrors");
+  e.put(std::move(productGainSwitch),"EcalIntegrityGainSwitchErrors");
 
-  e.put(productMemTtId,"EcalIntegrityMemTtIdErrors");
-  e.put(productMemBlockSize,"EcalIntegrityMemBlockSize");
-  e.put(productMemChIdErrors,"EcalIntegrityMemChIdErrors");
-  e.put(productMemGain,"EcalIntegrityMemGainErrors");
+  e.put(std::move(productMemTtId),"EcalIntegrityMemTtIdErrors");
+  e.put(std::move(productMemBlockSize),"EcalIntegrityMemBlockSize");
+  e.put(std::move(productMemChIdErrors),"EcalIntegrityMemChIdErrors");
+  e.put(std::move(productMemGain),"EcalIntegrityMemGainErrors");
 
-  e.put(productHodo);
-  e.put(productTdc);
-  e.put(productHeader);
+  e.put(std::move(productHodo));
+  e.put(std::move(productTdc));
+  e.put(std::move(productHeader));
 
   } catch (ECALTBParserException &e) {
     std::cout << "[EcalDCCTBUnpackingModule] " << e.what() << std::endl;

--- a/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
@@ -49,7 +49,7 @@ void
 HcalCalibFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  std::auto_ptr<FEDRawDataCollection> producedData(new FEDRawDataCollection);
+  auto producedData = std::make_unique<FEDRawDataCollection>();
 
   edm::Handle<FEDRawDataCollection> rawIn;
   iEvent.getByToken(tok_fed_,rawIn);
@@ -118,7 +118,7 @@ HcalCalibFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
        }
    }
 
- iEvent.put(producedData);
+ iEvent.put(std::move(producedData));
 }
 
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.cc
@@ -76,7 +76,7 @@ void HcalDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   es.get<HcalDbRecord>().get( pSetup );
   const HcalElectronicsMap* readoutMap=pSetup->getHcalMapping();
   // Step B: Create empty output
-  std::auto_ptr<FEDRawDataCollection> raw=std::auto_ptr<FEDRawDataCollection>(new FEDRawDataCollection());
+  auto raw = std::make_unique<FEDRawDataCollection>();
 
   const int ifed_first=FEDNumbering::MINHCALFEDID;
   const int ifed_last=FEDNumbering::MAXHCALFEDID;
@@ -98,7 +98,7 @@ void HcalDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   }
 
 
-  e.put(raw);
+  e.put(std::move(raw));
 }
 
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.cc
@@ -40,7 +40,7 @@ void HcalHistogramRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   const HcalElectronicsMap* readoutMap=pSetup->getHcalMapping();
 
   // Step B: Create empty output
-  std::auto_ptr<HcalHistogramDigiCollection> prod(new HcalHistogramDigiCollection());
+  auto prod = std::make_unique<HcalHistogramDigiCollection>();
   std::vector<HcalHistogramDigi> digis;
 
   // Step C: unpack all requested FEDs
@@ -55,7 +55,7 @@ void HcalHistogramRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 
   // Step D: Put outputs into event
   prod->sort();
-  e.put(prod);
+  e.put(std::move(prod));
 }
 
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.cc
@@ -15,8 +15,7 @@ void HcalLaserEventFiltProducer2012::endJob() {
 }
 
 void HcalLaserEventFiltProducer2012::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  std::auto_ptr<bool> output(new bool(hcalLaserEventFilter2012->filter(iEvent, iSetup)));
-  iEvent.put(output);
+  iEvent.put(std::make_unique<bool>(hcalLaserEventFilter2012->filter(iEvent, iSetup)));
 }
 
 DEFINE_FWK_MODULE(HcalLaserEventFiltProducer2012);

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -117,7 +117,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   std::vector<HcalTTPDigi> ttp;
   std::vector<HOTriggerPrimitiveDigi> hotp;
   HcalUMNioDigi umnio;
-  std::auto_ptr<HcalUnpackerReport> report(new HcalUnpackerReport);
+  auto report = std::make_unique<HcalUnpackerReport>();
 
   // Heuristics: use ave+(max-ave)/8
   if (stats_.max_hbhe>0) hbhe.reserve(stats_.ave_hbhe+(stats_.max_hbhe-stats_.ave_hbhe)/8);
@@ -193,19 +193,19 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   if( cntHFdup ) edm::LogError("HcalRawToDigi") << "Duplicated HF digis found for "<<cntHFdup<<" times"<<std::endl;
 
   // Step B: encapsulate vectors in actual collections
-  std::auto_ptr<HBHEDigiCollection> hbhe_prod(new HBHEDigiCollection()); 
-  std::auto_ptr<HFDigiCollection> hf_prod(new HFDigiCollection());
-  std::auto_ptr<HODigiCollection> ho_prod(new HODigiCollection());
-  std::auto_ptr<HcalTrigPrimDigiCollection> htp_prod(new HcalTrigPrimDigiCollection());  
-  std::auto_ptr<HOTrigPrimDigiCollection> hotp_prod(new HOTrigPrimDigiCollection());  
+  auto hbhe_prod = std::make_unique<HBHEDigiCollection>();
+  auto hf_prod = std::make_unique<HFDigiCollection>();
+  auto ho_prod = std::make_unique<HODigiCollection>();
+  auto htp_prod = std::make_unique<HcalTrigPrimDigiCollection>();
+  auto hotp_prod = std::make_unique<HOTrigPrimDigiCollection>();
   if (colls.qie10 == 0) {
     colls.qie10 = new QIE10DigiCollection(); 
   }
-  std::auto_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
+  std::unique_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
   if (colls.qie11 == 0) {
     colls.qie11 = new QIE11DigiCollection(); 
   }
-  std::auto_ptr<QIE11DigiCollection> qie11_prod(colls.qie11);
+  std::unique_ptr<QIE11DigiCollection> qie11_prod(colls.qie11);
 
   hbhe_prod->swap_contents(hbhe);
   if( !cntHFdup ) hf_prod->swap_contents(hf);
@@ -235,17 +235,17 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   qie10_prod->sort();
   qie11_prod->sort();
 
-  e.put(hbhe_prod);
-  e.put(ho_prod);
-  e.put(hf_prod);
-  e.put(htp_prod);
-  e.put(hotp_prod);
-  e.put(qie10_prod);
-  e.put(qie11_prod);
+  e.put(std::move(hbhe_prod));
+  e.put(std::move(ho_prod));
+  e.put(std::move(hf_prod));
+  e.put(std::move(htp_prod));
+  e.put(std::move(hotp_prod));
+  e.put(std::move(qie10_prod));
+  e.put(std::move(qie11_prod));
 
   /// calib
   if (unpackCalib_) {
-    std::auto_ptr<HcalCalibDigiCollection> hc_prod(new HcalCalibDigiCollection());
+    auto hc_prod = std::make_unique<HcalCalibDigiCollection>();
     hc_prod->swap_contents(hc);
 
     if (filter_.active()) {
@@ -254,12 +254,12 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     }
 
     hc_prod->sort();
-    e.put(hc_prod);
+    e.put(std::move(hc_prod));
   }
 
   /// zdc
   if (unpackZDC_) {
-    std::auto_ptr<ZDCDigiCollection> prod(new ZDCDigiCollection());
+    auto prod = std::make_unique<ZDCDigiCollection>();
     prod->swap_contents(zdc);
     
     if (filter_.active()) {
@@ -268,22 +268,21 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     }
 
     prod->sort();
-    e.put(prod);
+    e.put(std::move(prod));
   }
 
   if (unpackTTP_) {
-    std::auto_ptr<HcalTTPDigiCollection> prod(new HcalTTPDigiCollection());
+    auto prod = std::make_unique<HcalTTPDigiCollection>();
     prod->swap_contents(ttp);
     
     prod->sort();
-    e.put(prod);
+    e.put(std::move(prod));
   }
-  e.put(report);
+  e.put(std::move(report));
   /// umnio
   if (unpackUMNio_) {
     if(colls.umnio != 0) {
-      std::auto_ptr<HcalUMNioDigi> prod(new HcalUMNioDigi(umnio));
-      e.put(prod);
+      e.put(std::make_unique<HcalUMNioDigi>(umnio));
     }
 
   }

--- a/EventFilter/LTCRawToDigi/src/LTCRawToDigi.cc
+++ b/EventFilter/LTCRawToDigi/src/LTCRawToDigi.cc
@@ -94,7 +94,7 @@ LTCRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByLabel("source" , rawdata);
 
   // create collection we'll save in the event record
-  std::auto_ptr<LTCDigiCollection> pOut(new LTCDigiCollection());
+  auto pOut = std::make_unique<LTCDigiCollection>();
 
   // Loop over all possible FED's with the appropriate FED ID
   for ( int id = LTCFedIDLo; id <= LTCFedIDHi; ++id ) {
@@ -106,7 +106,7 @@ LTCRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     LTCDigi ltcDigi(fedData.data());
     pOut->push_back(ltcDigi);
   }
-  iEvent.put(pOut);
+  iEvent.put(std::move(pOut));
 }
 
 //define this as a plug-in

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
@@ -59,8 +59,8 @@ void Phase2Tracker::Phase2TrackerCommissioningDigiProducer::produce( edm::Event&
       {
         cond_data_digi->push_back(Phase2TrackerCommissioningDigi(it->first,it->second));
       }
-      std::auto_ptr< edm::DetSet<Phase2TrackerCommissioningDigi> > cdd(cond_data_digi);
-      event.put( cdd, "ConditionData" );
+      std::unique_ptr<edm::DetSet<Phase2TrackerCommissioningDigi>> cdd(cond_data_digi);
+      event.put(std::move(cdd), "ConditionData");
     }
   }
 }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -213,8 +213,7 @@ namespace Phase2Tracker {
 
         edm::DetSetVector<Phase2TrackerDigi> proc_raw_dsv( sorted_and_merged, true );
         pr->swap( proc_raw_dsv );
-        std::auto_ptr< edm::DetSetVector<Phase2TrackerDigi> > pr_dsv(pr);
-        event.put( pr_dsv, "ProcessedRaw" );
+        event.put(std::unique_ptr<edm::DetSetVector<Phase2TrackerDigi>>(pr), "ProcessedRaw");
         delete buffer;
         }
      }   

--- a/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.cc
@@ -88,10 +88,10 @@ void RPCUnpackingModule::produce(Event & ev, const EventSetup& es)
   ev.getByToken(fedToken_,allFEDRawData); 
 
 
-  std::auto_ptr<RPCDigiCollection> producedRPCDigis(new RPCDigiCollection);
-  std::auto_ptr<RPCRawDataCounts> producedRawDataCounts(new RPCRawDataCounts);
-  std::auto_ptr<RPCRawSynchro::ProdItem> producedRawSynchoCounts;
-  if (doSynchro_) producedRawSynchoCounts.reset(new RPCRawSynchro::ProdItem);
+  auto producedRPCDigis = std::make_unique<RPCDigiCollection>();
+  auto producedRawDataCounts = std::make_unique<RPCRawDataCounts>();
+  std::unique_ptr<RPCRawSynchro::ProdItem> producedRawSynchoCounts;
+  if (doSynchro_) producedRawSynchoCounts = std::make_unique<RPCRawSynchro::ProdItem>();
 
   int status = 0;
   for (int fedId= FEDNumbering::MINRPCFEDID; fedId<=FEDNumbering::MAXRPCFEDID; ++fedId){  
@@ -209,8 +209,8 @@ void RPCUnpackingModule::produce(Event & ev, const EventSetup& es)
   }
   if (status && debug) LogTrace("")<<" RPCUnpackingModule - There was unpacking PROBLEM in this event"<<endl;
   if (debug) LogTrace("") << DebugDigisPrintout()(producedRPCDigis.get()) << endl;
-  ev.put(producedRPCDigis);  
-  ev.put(producedRawDataCounts);
-  if (doSynchro_) ev.put(producedRawSynchoCounts);
+  ev.put(std::move(producedRPCDigis));  
+  ev.put(std::move(producedRawDataCounts));
+  if (doSynchro_) ev.put(std::move(producedRawSynchoCounts));
 
 }

--- a/EventFilter/RPCRawToDigi/src/RPCPackingModule.cc
+++ b/EventFilter/RPCRawToDigi/src/RPCPackingModule.cc
@@ -69,7 +69,7 @@ void RPCPackingModule::produce( edm::Event& ev,
     LogTrace("") <<" READOUT MAP VERSION: " << theCabling->version() << endl; 
   }
 
-  auto_ptr<FEDRawDataCollection> buffers( new FEDRawDataCollection );
+  auto buffers = std::make_unique<FEDRawDataCollection>();
 
 //  pair<int,int> rpcFEDS=FEDNumbering::getRPCFEDIds();
   pair<int,int> rpcFEDS(790,792);
@@ -83,7 +83,7 @@ void RPCPackingModule::produce( edm::Event& ev,
     fedRawData = *rawData;
     delete rawData;
   }
-  ev.put( buffers );  
+  ev.put(std::move(buffers));  
 }
 
 

--- a/EventFilter/RawDataCollector/interface/RawDataFEDSelector.h
+++ b/EventFilter/RawDataCollector/interface/RawDataFEDSelector.h
@@ -28,9 +28,9 @@ public:
   inline void setRange(const std::pair<int,int> & range) {fedRange = range;};
   inline void setRange(const std::vector<int> & list) {fedList = list;};
 
-  std::auto_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData);
-  std::auto_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData, const std::pair<int,int> & range);
-  std::auto_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData, const std::vector<int> & list);
+  std::unique_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData);
+  std::unique_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData, const std::pair<int,int> & range);
+  std::unique_ptr<FEDRawDataCollection> select(const edm::Handle<FEDRawDataCollection> & rawData, const std::vector<int> & list);
 
 
 private:

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
@@ -50,7 +50,7 @@ void RawDataCollectorByLabel::produce(Event & e, const EventSetup& c){
    //else{     //skipping the inputtag requested. but this is a normal operation to bare data & MC. silent warning   }
  }
 
- std::auto_ptr<FEDRawDataCollection> producedData(new FEDRawDataCollection);
+ auto producedData = std::make_unique<FEDRawDataCollection>();
 
  for (unsigned int i=0; i< rawData.size(); ++i ) { 
 
@@ -88,7 +88,7 @@ void RawDataCollectorByLabel::produce(Event & e, const EventSetup& c){
  }
 
  // Insert the new product in the event  
- e.put(producedData);  
+ e.put(std::move(producedData));
 
 }
 

--- a/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
@@ -15,9 +15,9 @@
 using namespace std;
 using namespace edm;
 
-auto_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData) {
+std::unique_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData) {
 
-  auto_ptr<FEDRawDataCollection> selectedRawData(new FEDRawDataCollection);
+  auto selectedRawData = std::make_unique<FEDRawDataCollection>();
 
   // if vector of FED indexes is defined, loop over it
   if (fedList.size()) {
@@ -57,13 +57,13 @@ auto_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDat
 } 
 
 
-auto_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData, 
+std::unique_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData, 
 						       const pair<int,int> & range) {
   setRange(range);
   return select(rawData);
 }
 
-auto_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData, 
+std::unique_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FEDRawDataCollection> & rawData, 
 						       const vector<int> & list) {
   setRange(list);
   return select(rawData);

--- a/EventFilter/RawDataCollector/src/RawDataSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataSelector.cc
@@ -69,10 +69,10 @@ void RawDataSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
   // the filtered raw data collections
-  auto_ptr<FEDRawDataCollection> selectedRawData = selector->select(rawData, fedRange);
+  std::unique_ptr<FEDRawDataCollection> selectedRawData = selector->select(rawData, fedRange);
 
 
-  iEvent.put(selectedRawData);
+  iEvent.put(std::move(selectedRawData));
   
 }
 

--- a/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
+++ b/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
@@ -89,19 +89,16 @@ void ScalersRawToDigi::produce(edm::Event& iEvent,
   edm::Handle<FEDRawDataCollection> rawdata;
   iEvent.getByToken(fedToken_, rawdata);
 
-  std::auto_ptr<LumiScalersCollection> pLumi(new LumiScalersCollection());
+  auto pLumi = std::make_unique<LumiScalersCollection>();
 
-  std::auto_ptr<L1TriggerScalersCollection> 
-    pOldTrigger(new L1TriggerScalersCollection());
+  auto pOldTrigger = std::make_unique<L1TriggerScalersCollection>();
 
-  std::auto_ptr<Level1TriggerScalersCollection> 
-    pTrigger(new Level1TriggerScalersCollection());
+  auto pTrigger = std::make_unique<Level1TriggerScalersCollection>();
 
-  std::auto_ptr<L1AcceptBunchCrossingCollection> 
-    pBunch(new L1AcceptBunchCrossingCollection());
+  auto pBunch = std::make_unique<L1AcceptBunchCrossingCollection>();
 
-  std::auto_ptr<BeamSpotOnlineCollection> pBeamSpotOnline(new BeamSpotOnlineCollection());
-  std::auto_ptr<DcsStatusCollection> pDcsStatus(new DcsStatusCollection());
+  auto pBeamSpotOnline = std::make_unique<BeamSpotOnlineCollection>();
+  auto pDcsStatus = std::make_unique<DcsStatusCollection>();
 
   /// Take a reference to this FED's data
   const FEDRawData & fedData = rawdata->FEDData(ScalersRaw::SCALERS_FED_ID);
@@ -159,12 +156,12 @@ void ScalersRawToDigi::produce(edm::Event& iEvent,
       pDcsStatus->push_back(dcsStatus);
     }
   }
-  iEvent.put(pOldTrigger); 
-  iEvent.put(pTrigger); 
-  iEvent.put(pLumi); 
-  iEvent.put(pBunch);
-  iEvent.put(pBeamSpotOnline);
-  iEvent.put(pDcsStatus);
+  iEvent.put(std::move(pOldTrigger));
+  iEvent.put(std::move(pTrigger));
+  iEvent.put(std::move(pLumi));
+  iEvent.put(std::move(pBunch));
+  iEvent.put(std::move(pBeamSpotOnline));
+  iEvent.put(std::move(pDcsStatus));
 }
 
 // Define this as a plug-in

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -111,7 +111,7 @@ void SiPixelDigiToRaw::produce( edm::Event& ev,
   if (theTimer) theTimer->start();
 
   // create product (raw data)
-  std::auto_ptr<FEDRawDataCollection> buffers( new FEDRawDataCollection );
+  auto buffers = std::make_unique<FEDRawDataCollection>();
 
   const vector<const PixelFEDCabling *>  fedList = cablingTree_->fedList();
 
@@ -143,7 +143,7 @@ void SiPixelDigiToRaw::produce( edm::Event& ev,
     hDigi->Fill(formatter.nDigis());
   }
   
-  ev.put( buffers );
+  ev.put(std::move(buffers));
   
 }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -186,11 +186,11 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
   ev.getByToken(tFEDRawDataCollection, buffers);
 
 // create product (digis & errors)
-  std::auto_ptr< edm::DetSetVector<PixelDigi> > collection( new edm::DetSetVector<PixelDigi> );
+  auto collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
   // collection->reserve(8*1024);
-  std::auto_ptr< edm::DetSetVector<SiPixelRawDataError> > errorcollection( new edm::DetSetVector<SiPixelRawDataError> );
-  std::auto_ptr< DetIdCollection > tkerror_detidcollection(new DetIdCollection());
-  std::auto_ptr< DetIdCollection > usererror_detidcollection(new DetIdCollection());
+  auto errorcollection = std::make_unique<edm::DetSetVector<SiPixelRawDataError>>();
+  auto tkerror_detidcollection = std::make_unique<DetIdCollection>();
+  auto usererror_detidcollection = std::make_unique<DetIdCollection>();
 
   //PixelDataFormatter formatter(cabling_.get()); // phase 0 only
   PixelDataFormatter formatter(cabling_.get(), usePhase1); // for phase 1 & 0
@@ -284,10 +284,10 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
   }
 
   //send digis and errors back to framework 
-  ev.put( collection );
+  ev.put(std::move(collection));
   if(includeErrors){
-    ev.put( errorcollection );
-    ev.put( tkerror_detidcollection );
-    ev.put( usererror_detidcollection, "UserErrorModules" );
+    ev.put(std::move(errorcollection));
+    ev.put(std::move(tkerror_detidcollection));
+    ev.put(std::move(usererror_detidcollection), "UserErrorModules");
   }
 }

--- a/EventFilter/SiStripChannelChargeFilter/src/ClusterMTCCFilter.cc
+++ b/EventFilter/SiStripChannelChargeFilter/src/ClusterMTCCFilter.cc
@@ -122,14 +122,11 @@ bool ClusterMTCCFilter::filter(edm::Event & e, edm::EventSetup const& c) {
       decision = true; // accept event
   }
 
-  std::auto_ptr< int > output_decision( new int(decision) );
-  e.put(output_decision);
+  e.put(std::make_unique<int>(decision));
 
-  std::auto_ptr< unsigned int > output_sumofcharges( new unsigned int(sum_of_cluster_charges) );
-  e.put(output_sumofcharges);
+  e.put(std::make_unique<unsigned int>(sum_of_cluster_charges));
 
-  std::auto_ptr< map<unsigned int,vector<SiStripCluster> > > output_clusters(new map<unsigned int,vector<SiStripCluster> > (clusters_in_subcomponents));
-  e.put(output_clusters);
+  e.put(std::make_unique<std::map<unsigned int,std::vector<SiStripCluster>>>(clusters_in_subcomponents));
 
   return decision;
 }

--- a/EventFilter/SiStripChannelChargeFilter/src/MTCCHLTrigger.cc
+++ b/EventFilter/SiStripChannelChargeFilter/src/MTCCHLTrigger.cc
@@ -43,10 +43,8 @@ bool MTCCHLTrigger::filter(edm::Event & e, edm::EventSetup const& c) {
       }
     }
     bool decision= (amplclus>ChargeThreshold) ? true : false;
-    std::auto_ptr< unsigned int > output( new unsigned int(amplclus) );
-    std::auto_ptr< int > output_dec( new int(decision) );
-    e.put(output);
-    e.put(output_dec);
+    e.put(std::make_unique<unsigned int>(amplclus));
+    e.put(std::make_unique<int>(decision));
     return decision;
   }
  }

--- a/EventFilter/SiStripChannelChargeFilter/src/TECClusterFilter.cc
+++ b/EventFilter/SiStripChannelChargeFilter/src/TECClusterFilter.cc
@@ -63,8 +63,7 @@ namespace cms
 	  }
       }
     if(nr_clusters_above_threshold>=minNrOfTECClusters) decision=true;
-    std::auto_ptr< int > output_decision( new int(decision) );
-    e.put(output_decision);
+    e.put(std::make_unique<int>(decision));
     return decision;
   }
 }

--- a/EventFilter/SiStripChannelChargeFilter/src/TrackMTCCFilter.cc
+++ b/EventFilter/SiStripChannelChargeFilter/src/TrackMTCCFilter.cc
@@ -36,8 +36,7 @@ bool TrackMTCCFilter::filter(edm::Event & e, edm::EventSetup const& c) {
 //  edm::LogInfo("TrackMTCCFilter")<<"trackCollection->size()="<<nroftracks;
   if(nroftracks>=MinNrOfTracks) decision = true;
 
-  std::auto_ptr< int > output_decision( new int(decision) );
-  e.put(output_decision);
+  e.put(std::make_unique<int>(decision));
   return decision;
 }
 

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -93,12 +93,10 @@ namespace sistrip {
       }
     }
 
-    std::auto_ptr< DetIdCollection > detids( new DetIdCollection(detids_) );
-
     // for( unsigned int it = 0; it < detids->size(); ++it ) {
     //   std::cout << "detId = " << (*detids)[it]() << std::endl;
     // }
 
-    event.put(detids);
+    event.put(std::make_unique<DetIdCollection>(detids_));
   }
 }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -55,14 +55,14 @@ namespace sistrip {
   void DigiToRaw::createFedBuffers( edm::Event& event,
 				    edm::ESHandle<SiStripFedCabling>& cabling,
 				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
-				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, collection, buffers, true);
   }
   
   void DigiToRaw::createFedBuffers( edm::Event& event,
 				    edm::ESHandle<SiStripFedCabling>& cabling,
 				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
-				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, collection, buffers, false);
   }
 
@@ -71,7 +71,7 @@ namespace sistrip {
 				    edm::ESHandle<SiStripFedCabling>& cabling,
 				    edm::Handle<FEDRawDataCollection> & rawbuffers,
 				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
-				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, rawbuffers, collection, buffers, true);
   }
   
@@ -79,7 +79,7 @@ namespace sistrip {
 				    edm::ESHandle<SiStripFedCabling>& cabling,
 				    edm::Handle<FEDRawDataCollection> & rawbuffers,
 				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
-				    std::auto_ptr<FEDRawDataCollection>& buffers ) { 
+				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
     createFedBuffers_(event, cabling, rawbuffers, collection, buffers, false);
   }
 
@@ -90,7 +90,7 @@ namespace sistrip {
   void DigiToRaw::createFedBuffers_( edm::Event& event,
 				     edm::ESHandle<SiStripFedCabling>& cabling,
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
-				     std::auto_ptr<FEDRawDataCollection>& buffers,
+				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
 
     edm::Handle<FEDRawDataCollection> rawbuffers;
@@ -104,7 +104,7 @@ namespace sistrip {
 				     edm::ESHandle<SiStripFedCabling>& cabling,
 				     edm::Handle<FEDRawDataCollection> & rawbuffers,
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
-				     std::auto_ptr<FEDRawDataCollection>& buffers,
+				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
     try {
       
@@ -134,8 +134,8 @@ namespace sistrip {
 	  }
 	  
 	  //need to construct full object to copy full header
-	  std::auto_ptr<const sistrip::FEDBuffer> fedbuffer;
-	  //std::auto_ptr<const sistrip::FEDBufferBase> bufferBase;
+	  std::unique_ptr<const sistrip::FEDBuffer> fedbuffer;
+	  //std::unique_ptr<const sistrip::FEDBufferBase> bufferBase;
 	  try {
 	    fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
 	    //bufferBase.reset(new sistrip::FEDBufferBase(rawfedData.data(),rawfedData.size()));
@@ -178,7 +178,7 @@ namespace sistrip {
 	      << " SpecialHeader: " << debugStream.str();
 	  }
 
-	  std::auto_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
+	  std::unique_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
 	  FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
 	  if ( edm::isDebugEnabled() ) {
 	    std::ostringstream debugStream;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
@@ -36,23 +36,23 @@ namespace sistrip {
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
-			   std::auto_ptr<FEDRawDataCollection>& buffers );
+			   std::unique_ptr<FEDRawDataCollection>& buffers );
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
-			   std::auto_ptr<FEDRawDataCollection>& buffers);
+			   std::unique_ptr<FEDRawDataCollection>& buffers);
 
     //with input raw data for copying header   
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle<FEDRawDataCollection> & rawbuffers,
 			   edm::Handle< edm::DetSetVector<SiStripDigi> >& digis,
-			   std::auto_ptr<FEDRawDataCollection>& buffers );
+			   std::unique_ptr<FEDRawDataCollection>& buffers );
     void createFedBuffers( edm::Event&, 
 			   edm::ESHandle<SiStripFedCabling>& cabling,
 			   edm::Handle<FEDRawDataCollection> & rawbuffers,
 			   edm::Handle< edm::DetSetVector<SiStripRawDigi> >& digis,
-			   std::auto_ptr<FEDRawDataCollection>& buffers);
+			   std::unique_ptr<FEDRawDataCollection>& buffers);
     
     inline void fedReadoutMode( FEDReadoutMode mode ) { mode_ = mode; }
 
@@ -62,7 +62,7 @@ namespace sistrip {
     void createFedBuffers_( edm::Event&, 
 			    edm::ESHandle<SiStripFedCabling>& cabling,
 			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
-			    std::auto_ptr<FEDRawDataCollection>& buffers,
+			    std::unique_ptr<FEDRawDataCollection>& buffers,
 			    bool zeroSuppressed);
 
     template<class Digi_t>
@@ -70,7 +70,7 @@ namespace sistrip {
 			    edm::ESHandle<SiStripFedCabling>& cabling,
 			    edm::Handle<FEDRawDataCollection> & rawbuffers,
 			    edm::Handle< edm::DetSetVector<Digi_t> >& digis,
-			    std::auto_ptr<FEDRawDataCollection>& buffers,
+			    std::unique_ptr<FEDRawDataCollection>& buffers,
 			    bool zeroSuppressed);
 
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -133,7 +133,7 @@ namespace sistrip {
 
     eventCounter_++; 
   
-    std::auto_ptr<FEDRawDataCollection> buffers( new FEDRawDataCollection );
+    auto buffers = std::make_unique<FEDRawDataCollection>();
 
     edm::ESHandle<SiStripFedCabling> cabling;
     iSetup.get<SiStripFedCablingRcd>().get( cabling );
@@ -170,7 +170,7 @@ namespace sistrip {
     }
 
 
-    iEvent.put( buffers );
+    iEvent.put(std::move(buffers));
   
   }
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
@@ -96,7 +96,7 @@ namespace sistrip {
     event.getByToken( token_, buffers ); 
 
     // Populate SiStripEventSummary object with "trigger FED" info
-    std::auto_ptr<SiStripEventSummary> summary( new SiStripEventSummary() );
+    auto summary = std::make_unique<SiStripEventSummary>();
     rawToDigi_->triggerFed( *buffers, *summary, event.id().event() ); 
 
     // Create containers for digis
@@ -110,22 +110,22 @@ namespace sistrip {
     // Create digis
     if ( rawToDigi_ ) { rawToDigi_->createDigis( *cabling_,*buffers,*summary,*sm,*vr,*pr,*zs,*ids,*cm ); }
   
-    // Create auto_ptr's of digi products
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > sm_dsv(sm);
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > vr_dsv(vr);
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > pr_dsv(pr);
-    std::auto_ptr< edm::DetSetVector<SiStripDigi> > zs_dsv(zs);
-    std::auto_ptr< DetIdCollection > det_ids(ids);
-    std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > cm_dsv(cm);
+    // Create unique_ptr's of digi products
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > sm_dsv(sm);
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > vr_dsv(vr);
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > pr_dsv(pr);
+    std::unique_ptr< edm::DetSetVector<SiStripDigi> > zs_dsv(zs);
+    std::unique_ptr< DetIdCollection > det_ids(ids);
+    std::unique_ptr< edm::DetSetVector<SiStripRawDigi> > cm_dsv(cm);
   
     // Add to event
-    event.put( summary );
-    event.put( sm_dsv, "ScopeMode" );
-    event.put( vr_dsv, "VirginRaw" );
-    event.put( pr_dsv, "ProcessedRaw" );
-    event.put( zs_dsv, "ZeroSuppressed" );
-    event.put( det_ids );
-    if ( extractCm_ ) event.put( cm_dsv, "CommonMode" );
+    event.put(std::move(summary));
+    event.put(std::move(sm_dsv), "ScopeMode");
+    event.put(std::move(vr_dsv), "VirginRaw");
+    event.put(std::move(pr_dsv), "ProcessedRaw");
+    event.put(std::move(zs_dsv), "ZeroSuppressed");
+    event.put(std::move(det_ids));
+    if ( extractCm_ ) event.put(std::move(cm_dsv), "CommonMode");
   
   }
 

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
@@ -31,7 +31,7 @@ void SiStripTrivialClusterSource::endJob() {}
 
 void SiStripTrivialClusterSource::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
   
-  std::auto_ptr< edm::DetSetVector<SiStripDigi> > clusters(new edm::DetSetVector<SiStripDigi>());
+  auto clusters = std::make_unique<edm::DetSetVector<SiStripDigi>>();
   
   double occupancy = random_.Uniform(minocc_,maxocc_);
   double indexdigis = nstrips_ * occupancy;
@@ -66,7 +66,7 @@ void SiStripTrivialClusterSource::produce(edm::Event& iEvent,const edm::EventSet
   }
   }
   
-  iEvent.put(clusters);
+  iEvent.put(std::move(clusters));
 }
 
 bool SiStripTrivialClusterSource::available(const edm::DetSet<SiStripDigi>& detset, const uint16_t firststrip, const uint32_t size) {

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.cc
@@ -142,7 +142,7 @@ void SiStripTrivialDigiSource::produce( edm::Event& event,
   }
 
   // Create final DetSetVector container
-  std::auto_ptr< edm::DetSetVector<SiStripDigi> > collection( new edm::DetSetVector<SiStripDigi> );
+  auto collection = std::make_unique<edm::DetSetVector<SiStripDigi>>();
   
   // Populate final DetSetVector container with ZS data 
   if ( !zero_suppr_vector.empty() ) {
@@ -173,7 +173,7 @@ void SiStripTrivialDigiSource::produce( edm::Event& event,
   } 
 
   // Put collection in event
-  event.put( collection );
+  event.put(std::move(collection));
   
   // Some debug
   if ( edm::isDebugEnabled() && nchans ) { 

--- a/EventFilter/Utilities/plugins/DaqFakeReader.cc
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.cc
@@ -106,8 +106,8 @@ void DaqFakeReader::produce(Event&e, EventSetup const&es){
   edm::Handle<FEDRawDataCollection> rawdata;
   FEDRawDataCollection *fedcoll = 0;
   fillRawData(e,fedcoll);
-  std::auto_ptr<FEDRawDataCollection> bare_product(fedcoll);
-  e.put(bare_product);
+  std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
+  e.put(std::move(bare_product));
 }
 
 

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -96,7 +96,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
     }
   }
 
-  rawData_.reset(new FEDRawDataCollection());
+  rawData_ = std::make_unique<FEDRawDataCollection>();
 
   uint32_t eventSize = frdEventMsg->eventSize();
   char* event = (char*)frdEventMsg->payload();
@@ -163,7 +163,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
 
 
 void FRDStreamSource::produce(edm::Event& e) {
-  e.put(rawData_);
+  e.put(std::move(rawData_));
 }
 
 

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -43,7 +43,7 @@ private:
   // member data
   std::vector<std::string>::const_iterator itFileName_;
   std::ifstream fin_;
-  std::auto_ptr<FEDRawDataCollection> rawData_;
+  std::unique_ptr<FEDRawDataCollection> rawData_;
   std::vector<char> buffer_;
   const bool verifyAdler32_;
   const bool verifyChecksum_;

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -100,8 +100,7 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
     //std::cout<<"nibble is "<<nibble<<std::endl;
 
-    std::unique_ptr<int> pOut(new int(nibble));
-    iEvent.put( std::move(pOut), "nibble" );
+    iEvent.put(std::make_unique<int>(nibble), "nibble");
 }
 
  


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in EventFilter packages. Also, std::make_unique is used when appropriate.
