### PR TITLE
Use unique_ptr, not auto_ptr in RecoLocalTracker

### DIFF
--- a/RecoLocalTracker/Phase2ITPixelClusterizer/plugins/Phase2ITPixelClusterProducer.cc
+++ b/RecoLocalTracker/Phase2ITPixelClusterizer/plugins/Phase2ITPixelClusterProducer.cc
@@ -100,7 +100,7 @@
     es.get<TrackerDigiGeometryRecord>().get( geom );
 
     // Step B: create the final output collection
-    std::auto_ptr<Phase2ITPixelClusterCollectionNew> output( new Phase2ITPixelClusterCollectionNew() );
+    auto output = std::make_unique<Phase2ITPixelClusterCollectionNew>();
     //FIXME: put a reserve() here
 
     // Step C: Iterate over DetIds and invoke the pixel clusterizer algorithm
@@ -109,7 +109,7 @@
 
     // Step D: write output to file
     output->shrink_to_fit();
-    e.put( output );
+    e.put(std::move(output));
 
   }
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -64,7 +64,7 @@ void Phase2TrackerRecHits::produce(edm::StreamID sid, edm::Event& event, const e
   const TrackerGeometry* tkGeom(&(*geomHandle));
 
   // Global container for the RecHits of each module
-  std::auto_ptr< Phase2TrackerRecHit1DCollectionNew > outputRecHits(new Phase2TrackerRecHit1DCollectionNew());
+  auto outputRecHits = std::make_unique<Phase2TrackerRecHit1DCollectionNew>();
 
   // Loop over clusters
   for (auto DSViter : *clusters) { 
@@ -91,7 +91,7 @@ void Phase2TrackerRecHits::produce(edm::StreamID sid, edm::Event& event, const e
   }
 
   outputRecHits->shrink_to_fit();
-  event.put(outputRecHits);
+  event.put(std::move(outputRecHits));
 
 }
 

--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
@@ -66,7 +66,7 @@ class Phase2TrackerClusterizer : public edm::stream::EDProducer<> {
         const TrackerGeometry* tkGeom(&(*geomHandle)); 
 
         // Global container for the clusters of each modules
-        std::auto_ptr< Phase2TrackerCluster1DCollectionNew > outputClusters(new Phase2TrackerCluster1DCollectionNew());
+        auto outputClusters = std::make_unique<Phase2TrackerCluster1DCollectionNew>();
 
         // Go over all the modules
         for (auto DSViter : *digis) {
@@ -92,7 +92,7 @@ class Phase2TrackerClusterizer : public edm::stream::EDProducer<> {
 
         // Add the data to the output
         outputClusters->shrink_to_fit();
-        event.put(outputClusters);
+        event.put(std::move(outputClusters));
     }
 
 DEFINE_FWK_MODULE(Phase2TrackerClusterizer);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -101,7 +101,7 @@
     es.get<TrackerDigiGeometryRecord>().get( geom );
 
     // Step B: create the final output collection
-    std::auto_ptr<SiPixelClusterCollectionNew> output( new SiPixelClusterCollectionNew() );
+    auto output = std::make_unique< SiPixelClusterCollectionNew>();
     //FIXME: put a reserve() here
 
     // Step C: Iterate over DetIds and invoke the pixel clusterizer algorithm
@@ -110,7 +110,7 @@
 
     // Step D: write output to file
     output->shrink_to_fit();
-    e.put( output );
+    e.put(std::move(output));
 
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -69,7 +69,7 @@ namespace cms
     es.get<TrackerDigiGeometryRecord>().get( geom );
 
     // Step B: create empty output collection
-    std::auto_ptr<SiPixelRecHitCollectionNew> output(new SiPixelRecHitCollectionNew);
+    auto output = std::make_unique<SiPixelRecHitCollectionNew>();
     
     // Step B*: create CPE
     edm::ESHandle<PixelClusterParameterEstimator> hCPE;
@@ -83,7 +83,7 @@ namespace cms
     run( input, *output, geom );
 
     output->shrink_to_fit();
-    e.put(output);
+    e.put(std::move(output));
 
   }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -215,7 +215,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     ev.getByToken( productToken_, rawData); 
     
     
-    std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > 
+    std::unique_ptr< edmNew::DetSetVector<SiStripCluster> > 
       output( onDemand ?
 	      new edmNew::DetSetVector<SiStripCluster>(std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(std::make_shared<ClusterFiller>(*rawData, *clusterizer_, 
 																	 *rawAlgos_, doAPVEmulatorCheck_)
@@ -236,7 +236,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
 	   << std::endl;
     }
    
-    ev.put(output);
+    ev.put(std::move(output));
 
   }
 
@@ -255,8 +255,8 @@ private:
   
   SiStripDetCabling const * cabling_;
   
-  std::auto_ptr<StripClusterizerAlgorithm> clusterizer_;
-  std::auto_ptr<SiStripRawProcessingAlgorithms> rawAlgos_;
+  std::unique_ptr<StripClusterizerAlgorithm> clusterizer_;
+  std::unique_ptr<SiStripRawProcessingAlgorithms> rawAlgos_;
   
   
   // March 2012: add flag for disabling APVe check in configuration

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
@@ -76,15 +76,15 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
     process(*input, output_base);
 
 
-  std::auto_ptr< DigiCollection > outputZS(new DigiCollection(output_base) );
-  std::auto_ptr< DigiCollection > outputVR(new DigiCollection() );
-  std::auto_ptr< DigiCollection > outputPR(new DigiCollection() );
-  std::auto_ptr< DigiCollection > outputSM(new DigiCollection() );
+  auto outputZS = std::make_unique<DigiCollection>(output_base);
+  auto outputVR = std::make_unique<DigiCollection>();
+  auto outputPR = std::make_unique<DigiCollection>();
+  auto outputSM = std::make_unique<DigiCollection>();
 
-  event.put( outputZS, "ZeroSuppressed");
-  event.put( outputVR, "VirginRaw"     );
-  event.put( outputPR, "ProcessedRaw"  );
-  event.put( outputSM, "ScopeMode"     );
+  event.put(std::move(outputZS), "ZeroSuppressed");
+  event.put(std::move(outputVR), "VirginRaw"     );
+  event.put(std::move(outputPR), "ProcessedRaw"  );
+  event.put(std::move(outputSM), "ScopeMode"     );
 }
 
 void SiStripClusterToDigiProducer::

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -17,7 +17,7 @@ SiStripClusterizer(const edm::ParameterSet& conf)
 void SiStripClusterizer::
 produce(edm::Event& event, const edm::EventSetup& es)  {
 
-  std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > output(new edmNew::DetSetVector<SiStripCluster>());
+  auto output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
   output->reserve(10000,4*10000);
 
   edm::Handle< edm::DetSetVector<SiStripDigi> >     inputOld;  
@@ -34,7 +34,7 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
   LogDebug("Output") << output->dataSize() << " clusters from " 
 		     << output->size()     << " modules";
   output->shrink_to_fit();
-  event.put(output);
+  event.put(std::move(output));
 }
 
 template<class T>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -21,7 +21,7 @@ private:
 
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
-  std::auto_ptr<StripClusterizerAlgorithm> algorithm;
+  std::unique_ptr<StripClusterizerAlgorithm> algorithm;
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.cc
@@ -15,28 +15,28 @@ ClusterRefinerTagMCmerged(const edm::ParameterSet& conf)
 void ClusterRefinerTagMCmerged::
 produce(edm::Event& event, const edm::EventSetup& es)  {
 
-  std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > output(new edmNew::DetSetVector<SiStripCluster>());
+  auto output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
   output->reserve(10000,4*10000);
 
   associator_.reset(new TrackerHitAssociator(event, trackerHitAssociatorConfig_));
   edm::Handle< edmNew::DetSetVector<SiStripCluster> >     input;  
 
-  if ( findInput(inputToken, input, event) ) refineCluster(input, output);
+  if ( findInput(inputToken, input, event) ) refineCluster(input, *output);
   else edm::LogError("Input Not Found") << "[ClusterRefinerTagMCmerged::produce] ";// << inputTag;
 
   LogDebug("Output") << output->dataSize() << " clusters from " 
 		     << output->size()     << " modules";
   output->shrink_to_fit();
-  event.put(output);
+  event.put(std::move(output));
 }
 
 void  ClusterRefinerTagMCmerged::
 refineCluster(const edm::Handle< edmNew::DetSetVector<SiStripCluster> >& input,
-	      std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {
+	      edmNew::DetSetVector<SiStripCluster>& output) {
 
   for (edmNew::DetSetVector<SiStripCluster>::const_iterator det=input->begin(); det!=input->end(); det++) {
     // DetSetVector filler to receive the clusters we produce
-    edmNew::DetSetVector<SiStripCluster>::TSFastFiller outFill(*output, det->id());
+    edmNew::DetSetVector<SiStripCluster>::TSFastFiller outFill(output, det->id());
     uint32_t detId = det->id();
     int ntk = 0;
     int NtkAll = 0;

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.h
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.h
@@ -27,7 +27,7 @@ private:
 
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   virtual void refineCluster(const edm::Handle< edmNew::DetSetVector<SiStripCluster> >& input,
-			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output);
+			     edmNew::DetSetVector<SiStripCluster>& output);
 
   const edm::InputTag inputTag;
   typedef edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > token_t;

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTester.h
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTester.h
@@ -42,7 +42,7 @@ class ClusterizerUnitTester : public edm::EDAnalyzer {
   static std::string printCluster(const SiStripCluster&);
   
   VPSet testGroups;
-  std::auto_ptr<StripClusterizerAlgorithm> clusterizer;
+  std::unique_ptr<StripClusterizerAlgorithm> clusterizer;
   uint32_t detId;
 };
 

--- a/RecoLocalTracker/SiStripClusterizer/test/StripByStripTestDriver.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/StripByStripTestDriver.cc
@@ -23,7 +23,7 @@ StripByStripTestDriver::
 void StripByStripTestDriver::
 produce(edm::Event& event, const edm::EventSetup& es) {
 
-  std::auto_ptr<output_t> output(new output_t());
+  auto output = std::make_unique<output_t>();
   output->reserve(10000,4*10000);
 
   edm::Handle< edm::DetSetVector<SiStripDigi> >  input;  
@@ -44,5 +44,5 @@ produce(edm::Event& event, const edm::EventSetup& es) {
 
   edm::LogInfo("Output") << output->dataSize() << " clusters from " 
 			 << output->size()     << " modules";
-  event.put(output);
+  event.put(std::move(output));
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -23,8 +23,8 @@ class SiStripRecHitConverterAlgorithm
  public:
   
   struct products {
-    std::auto_ptr<SiStripMatchedRecHit2DCollection> matched;
-    std::auto_ptr<SiStripRecHit2DCollection> rphi, stereo, rphiUnmatched, stereoUnmatched;
+    std::unique_ptr<SiStripMatchedRecHit2DCollection> matched;
+    std::unique_ptr<SiStripRecHit2DCollection> rphi, stereo, rphiUnmatched, stereoUnmatched;
     products() 
       :  matched(new SiStripMatchedRecHit2DCollection),
 	 rphi(new SiStripRecHit2DCollection),

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
@@ -30,10 +30,10 @@ produce(edm::Event& e, const edm::EventSetup& es)
 				     << output.rphi->dataSize()   << "  clusters in mono detectors\n"                            
 				     << output.stereo->dataSize() << "  clusters in partners stereo detectors\n";
 
-  e.put( output.matched,         matchedRecHitsTag );
-  e.put( output.rphi,            rphiRecHitsTag    );
-  e.put( output.stereo,          stereoRecHitsTag  );
-  e.put( output.rphiUnmatched,   rphiRecHitsTag   + "Unmatched" );
-  e.put( output.stereoUnmatched, stereoRecHitsTag + "Unmatched" );  
+  e.put(std::move(output.matched),         matchedRecHitsTag);
+  e.put(std::move(output.rphi),            rphiRecHitsTag   );
+  e.put(std::move(output.stereo),          stereoRecHitsTag );
+  e.put(std::move(output.rphiUnmatched),   rphiRecHitsTag   + "Unmatched");
+  e.put(std::move(output.stereoUnmatched), stereoRecHitsTag + "Unmatched");  
 
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -369,7 +369,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   //if it is inside the gluedet bonds
   //Change NSigmaInside in the configuration file to accept more hits
   if(force || (gluedDet->surface()).bounds().inside(position,error,scale_)) 
-    return std::unique_ptr<SiStripMatchedRecHit2D> (new SiStripMatchedRecHit2D(LocalPoint(position), error, *gluedDet, monoRH,stereoRH));
+    return std::make_unique<SiStripMatchedRecHit2D>(LocalPoint(position), error, *gluedDet, monoRH,stereoRH);
   return std::unique_ptr<SiStripMatchedRecHit2D>(nullptr);
 }
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
@@ -136,8 +136,7 @@ SiStripMeanCMExtractor::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     
 	
 	
-	std::auto_ptr< edm::DetSetVector<SiStripProcessedRawDigi> > outputMeanCM(new edm::DetSetVector<SiStripProcessedRawDigi>(meancm) );
-    iEvent.put( outputMeanCM,"MEANAPVCM");
+    iEvent.put(std::make_unique<edm::DetSetVector<SiStripProcessedRawDigi>>(meancm),"MEANAPVCM");
    
 }
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
@@ -71,27 +71,22 @@ inline void SiStripZeroSuppression::StandardZeroSuppression(edm::Event& e){
       if (input->size())
         processRaw(*inputTag, *input);
     
-      std::auto_ptr< edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(output_base) );
-      e.put( output, inputTag->instance() );
+      e.put(std::make_unique<edm::DetSetVector<SiStripDigi>>(output_base), inputTag->instance());
     	
       if(produceRawDigis){
-	std::auto_ptr< edm::DetSetVector<SiStripRawDigi> > outputraw(new edm::DetSetVector<SiStripRawDigi>(output_base_raw) );
-	e.put(outputraw, inputTag->instance() );
+        e.put(std::make_unique<edm::DetSetVector<SiStripRawDigi>>(output_base_raw), inputTag->instance());
       }
     
       if(produceCalculatedBaseline){
-	std::auto_ptr< edm::DetSetVector<SiStripProcessedRawDigi> > outputbaseline(new edm::DetSetVector<SiStripProcessedRawDigi>(output_baseline) );
-	e.put(outputbaseline, "BADAPVBASELINE"+inputTag->instance() );
+        e.put(std::make_unique<edm::DetSetVector<SiStripProcessedRawDigi>>(output_baseline), "BADAPVBASELINE"+inputTag->instance());
       }
   
       if(produceBaselinePoints){
-	std::auto_ptr< edm::DetSetVector<SiStripDigi> > outputbaselinepoints(new edm::DetSetVector<SiStripDigi>(output_baseline_points) );
-	e.put(outputbaselinepoints, "BADAPVBASELINEPOINTS"+inputTag->instance() );
+        e.put(std::make_unique<edm::DetSetVector<SiStripDigi>>(output_baseline_points), "BADAPVBASELINEPOINTS"+inputTag->instance());
       }
   
       if(storeCM){
-	std::auto_ptr< edm::DetSetVector<SiStripProcessedRawDigi> > outputAPVCM(new edm::DetSetVector<SiStripProcessedRawDigi>(output_apvcm) );
-	e.put( outputAPVCM,"APVCM"+inputTag->instance());
+	e.put(std::make_unique<edm::DetSetVector<SiStripProcessedRawDigi>>(output_apvcm), "APVCM"+inputTag->instance());
       }
     
   }
@@ -402,8 +397,7 @@ inline void SiStripZeroSuppression::MergeCollectionsZeroSuppression(edm::Event& 
 		
 		
 		std::cout << "write the output vector" << std::endl;
-		std::auto_ptr< edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(outputdigi) );
-		e.put( output, "ZeroSuppressed" );  
+		e.put(std::make_unique<edm::DetSetVector<SiStripDigi>>(outputdigi), "ZeroSuppressed" );  
 		
 		
     }//if inputraw.size
@@ -433,8 +427,7 @@ inline void SiStripZeroSuppression::CollectionMergedZeroSuppression(edm::Event& 
       output_base.push_back(*itinputdigi);	
     }
 	
-    std::auto_ptr< edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(output_base) );
-    e.put( output, inputTag->instance() );
+    e.put(std::make_unique<edm::DetSetVector<SiStripDigi>>(output_base), inputTag->instance());
   	
   }
 

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
@@ -110,17 +110,13 @@ namespace {
 
     }
 
-    std::auto_ptr<StripMaskContainer> removedStripClusterMask(
-         new StripMaskContainer(edm::RefProd<edmNew::DetSetVector<SiStripCluster> >(stripClusters),collectedStrips));
       LogDebug("ClusterChargeMasker")<<"total strip to skip: "<<std::count(collectedStrips.begin(),collectedStrips.end(),true);
       // std::cout << "ClusterChargeMasker " <<"total strip to skip: "<<std::count(collectedStrips.begin(),collectedStrips.end(),true) 
       //          << " for CCC " << minGoodStripCharge_ <<std::endl;
-       iEvent.put( removedStripClusterMask );
+       iEvent.put(std::make_unique<StripMaskContainer>(edm::RefProd<edmNew::DetSetVector<SiStripCluster> >(stripClusters),collectedStrips));
 
-      std::auto_ptr<PixelMaskContainer> removedPixelClusterMask(
-         new PixelMaskContainer(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels));      
       LogDebug("ClusterChargeMasker")<<"total pxl to skip: "<<std::count(collectedPixels.begin(),collectedPixels.end(),true);
-      iEvent.put( removedPixelClusterMask );
+      iEvent.put(std::make_unique<PixelMaskContainer>(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels));
  
 
 

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
@@ -112,10 +112,10 @@ ClusterSummaryProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
    }
 
    //Put the filled class into the producer
-   std::auto_ptr<ClusterSummary> result(new ClusterSummary (0) );
+   auto result = std::make_unique<ClusterSummary>();
    //Cleanup empty selections
    result->copyNonEmpty(cCluster);
-   iEvent.put( result );
+   iEvent.put(std::move(result));
 }
 
 

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -85,7 +85,7 @@ class HLTTrackClusterRemoverNew final : public edm::stream::EDProducer<> {
 	inline void process(const OmniClusterRef & cluRef, uint32_t subdet);
 
         template<typename T> 
-        std::auto_ptr<edmNew::DetSetVector<T> >
+        std::unique_ptr<edmNew::DetSetVector<T> >
         cleanup(const edmNew::DetSetVector<T> &oldClusters, const std::vector<uint8_t> &isGood, 
                     reco::ClusterRemovalInfo::Indices &refs, const reco::ClusterRemovalInfo::Indices *oldRefs) ;
 
@@ -203,13 +203,13 @@ void HLTTrackClusterRemoverNew::mergeOld(ClusterRemovalInfo::Indices &refs,
 
  
 template<typename T> 
-auto_ptr<edmNew::DetSetVector<T> >
+std::unique_ptr<edmNew::DetSetVector<T> >
 HLTTrackClusterRemoverNew::cleanup(const edmNew::DetSetVector<T> &oldClusters, const std::vector<uint8_t> &isGood, 
 			     reco::ClusterRemovalInfo::Indices &refs, const reco::ClusterRemovalInfo::Indices *oldRefs){
     typedef typename edmNew::DetSetVector<T>             DSV;
     typedef typename edmNew::DetSetVector<T>::FastFiller DSF;
     typedef typename edmNew::DetSet<T>                   DS;
-    auto_ptr<DSV> output(new DSV());
+    auto output = std::make_unique<DSV>();
     output->reserve(oldClusters.size(), oldClusters.dataSize());
 
     unsigned int countOld=0;
@@ -432,16 +432,12 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
     
     //    std::cout << " => collectedRegStrips_: " << collectedRegStrips_.size() << std::endl;
     //    std::cout << " total strip to skip: "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true) << std::endl;
-    std::auto_ptr<StripMaskContainer> removedStripClusterMask(
-							      new StripMaskContainer(edm::RefProd<edmNew::DetSetVector<SiStripCluster> >(stripClusters),collectedRegStrips_));
     LogDebug("TrackClusterRemover")<<"total strip to skip: "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true);
     // std::cout << "TrackClusterRemover" <<" total strip to skip: "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true)<<std::endl;
-    iEvent.put( removedStripClusterMask );
+    iEvent.put(std::make_unique<StripMaskContainer>(edm::RefProd<edmNew::DetSetVector<SiStripCluster> >(stripClusters),collectedRegStrips_));
     
-    std::auto_ptr<PixelMaskContainer> removedPixelClusterMask(
-							      new PixelMaskContainer(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels_));      
     LogDebug("TrackClusterRemover")<<"total pxl to skip: "<<std::count(collectedPixels_.begin(),collectedPixels_.end(),true);
-    iEvent.put( removedPixelClusterMask );
+    iEvent.put(std::make_unique<PixelMaskContainer>(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels_));
 
     collectedRegStrips_.clear();
     collectedPixels_.clear();

--- a/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
@@ -110,8 +110,7 @@ void JetCoreClusterSplitter::produce(edm::Event& iEvent,
   iSetup.get<TkPixelCPERecord>().get(pixelCPE_, pe);
   pp = pe.product();
 
-  std::auto_ptr<edmNew::DetSetVector<SiPixelCluster> > output(
-      new edmNew::DetSetVector<SiPixelCluster>());
+  auto output = std::make_unique<edmNew::DetSetVector<SiPixelCluster>>();
 
   edmNew::DetSetVector<SiPixelCluster>::const_iterator detIt =
       inputPixelClusters->begin();
@@ -191,7 +190,7 @@ void JetCoreClusterSplitter::produce(edm::Event& iEvent,
       }
     }
   }
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 bool JetCoreClusterSplitter::split(

--- a/RecoLocalTracker/SubCollectionProducers/src/PixelClusterSelectorTopBottom.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/PixelClusterSelectorTopBottom.cc
@@ -10,7 +10,7 @@ void PixelClusterSelectorTopBottom::produce( edm::StreamID, edm::Event& event, c
   setup.get<TrackerDigiGeometryRecord>().get( geom );
   const TrackerGeometry& theTracker( *geom );
   
-  std::auto_ptr<SiPixelClusterCollectionNew> output( new SiPixelClusterCollectionNew() );
+  auto output = std::make_unique<SiPixelClusterCollectionNew>();
 
   for (SiPixelClusterCollectionNew::const_iterator clustSet = input->begin(); clustSet!=input->end(); ++clustSet) {
     edmNew::DetSet<SiPixelCluster>::const_iterator clustIt = clustSet->begin();
@@ -30,7 +30,7 @@ void PixelClusterSelectorTopBottom::produce( edm::StreamID, edm::Event& event, c
       }
     }
   }
-  event.put( output );  
+  event.put(std::move(output));  
 }
 
 DEFINE_FWK_MODULE( PixelClusterSelectorTopBottom );

--- a/RecoLocalTracker/SubCollectionProducers/src/StripClusterSelectorTopBottom.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/StripClusterSelectorTopBottom.cc
@@ -10,7 +10,7 @@ void StripClusterSelectorTopBottom::produce( edm::StreamID, edm::Event& event, c
   setup.get<TrackerDigiGeometryRecord>().get( geom );
   const TrackerGeometry& theTracker( *geom );
   
-  std::auto_ptr<edmNew::DetSetVector<SiStripCluster> > output( new edmNew::DetSetVector<SiStripCluster>() );
+  auto output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
 
   for (edmNew::DetSetVector<SiStripCluster>::const_iterator clustSet = input->begin(); clustSet!=input->end(); ++clustSet) {
     edmNew::DetSet<SiStripCluster>::const_iterator clustIt = clustSet->begin();
@@ -30,7 +30,7 @@ void StripClusterSelectorTopBottom::produce( edm::StreamID, edm::Event& event, c
       }
     }
   }
-  event.put( output );  
+  event.put(std::move(output));  
 }
 
 DEFINE_FWK_MODULE( StripClusterSelectorTopBottom );

--- a/RecoLocalTracker/SubCollectionProducers/src/TopBottomClusterInfoProducer.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TopBottomClusterInfoProducer.cc
@@ -75,7 +75,7 @@ TopBottomClusterInfoProducer::produce(edm::StreamID, Event& iEvent, const EventS
     Handle<edmNew::DetSetVector<SiStripCluster> > stripClustersNew;
     iEvent.getByToken(stripClustersNew_, stripClustersNew);
 
-    auto_ptr<ClusterRemovalInfo> cri(new ClusterRemovalInfo(pixelClustersOld, stripClustersOld));
+    auto cri = std::make_unique<ClusterRemovalInfo>(pixelClustersOld, stripClustersOld);
     ClusterRemovalInfo::Indices& pixelInd = cri->pixelIndices();
     ClusterRemovalInfo::Indices& stripInd = cri->stripIndices();
     stripInd.reserve(stripClustersNew->size()); 
@@ -150,7 +150,7 @@ TopBottomClusterInfoProducer::produce(edm::StreamID, Event& iEvent, const EventS
     cri->setNewPixelClusters(edm::OrphanHandle<SiPixelClusterCollectionNew>(pixelClustersNew.product(),pixelClustersNew.id()));
     cri->setNewStripClusters(edm::OrphanHandle<edmNew::DetSetVector<SiStripCluster> >(stripClustersNew.product(),stripClustersNew.id()));
 
-    iEvent.put(cri);
+    iEvent.put(std::move(cri));
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
@@ -191,7 +191,7 @@ private:
 		    const TrajectoryStateOnSurface& tsos) const ;
   
   template<typename Cluster>
-  std::auto_ptr<edmNew::DetSetVector<Cluster> > 
+  std::unique_ptr<edmNew::DetSetVector<Cluster> > 
   splitClusters(const std::map<uint32_t, 
 		boost::sub_range<std::vector<ClusterWithTracks<Cluster> > > > &input, 
 		const reco::Vertex &vtx) const ;
@@ -516,11 +516,11 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iEvent.getByToken(stripdigisimlinkToken, stripdigisimlink);
 
   // gavril : to do: choose the best vertex here instead of just choosing the first one ? 
-  std::auto_ptr<edmNew::DetSetVector<SiPixelCluster> > newPixelClusters( splitClusters( siPixelDetsWithClusters, vertices->front() ) );
-  std::auto_ptr<edmNew::DetSetVector<SiStripCluster> > newStripClusters( splitClusters( siStripDetsWithClusters, vertices->front() ) );
+  std::unique_ptr<edmNew::DetSetVector<SiPixelCluster> > newPixelClusters( splitClusters( siPixelDetsWithClusters, vertices->front() ) );
+  std::unique_ptr<edmNew::DetSetVector<SiStripCluster> > newStripClusters( splitClusters( siStripDetsWithClusters, vertices->front() ) );
   
-  iEvent.put(newPixelClusters);
-  iEvent.put(newStripClusters);
+  iEvent.put(std::move(newPixelClusters));
+  iEvent.put(std::move(newStripClusters));
     
   allSiPixelClusters.clear(); siPixelDetsWithClusters.clear();
   allSiStripClusters.clear(); siStripDetsWithClusters.clear();
@@ -550,11 +550,11 @@ void TrackClusterSplitter::markClusters( std::map<uint32_t, boost::sub_range<std
 }
 
 template<typename Cluster>
-std::auto_ptr<edmNew::DetSetVector<Cluster> > 
+std::unique_ptr<edmNew::DetSetVector<Cluster> > 
 TrackClusterSplitter::splitClusters(const std::map<uint32_t, boost::sub_range<std::vector<ClusterWithTracks<Cluster> > > > &input, 
 				    const reco::Vertex &vtx) const 
 {
-  std::auto_ptr<edmNew::DetSetVector<Cluster> > output(new edmNew::DetSetVector<Cluster>());
+  auto output = std::make_unique<edmNew::DetSetVector<Cluster>>();
   typedef std::pair<uint32_t, boost::sub_range<std::vector<ClusterWithTracks<Cluster> > > > pair;
   
   foreach(const pair &p, input) 


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoLocalTracker packages. Also, std::make_unique is used when appropriate. Also, there were a few cases where a reference to an auto_ptr was an input argument to a function, which is a bad practice because it obscures the possible transfer of ownership. In the cases here, ownership was not transferred, so the object itself was passed by reference.
