### PR TITLE
HLT Calibration Event Type Filter for HCAL

### DIFF
--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -106,6 +106,8 @@ class HcalUHTRData {
   inline uint32_t bunchNumber() const { return uint32_t(m_raw64[0]>>20)&0xFFF; }
   /** \brief Get the HTR orbit number */
   inline uint32_t orbitNumber() const { return uint32_t(m_raw64[1]>>16)&0xFFFF; }
+  /** \brief Get the event type */
+  int getEventType() const { return uint32_t(m_raw64[1]>>40)&0xF; }
   /** \brief Get the raw board id */
   inline uint32_t boardId() const { return uint32_t(m_raw64[1])&0xFFFF; }
   /** \brief Get the board crate */

--- a/HLTrigger/special/src/HLTHcalCalibTypeFilter.cc
+++ b/HLTrigger/special/src/HLTHcalCalibTypeFilter.cc
@@ -36,7 +36,8 @@ Implementation:
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/HcalDigi/interface/HcalCalibrationEventTypes.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
-
+#include "EventFilter/HcalRawToDigi/interface/HcalUHTRData.h"
+#include "EventFilter/HcalRawToDigi/interface/AMC13Header.h"
 #include "HLTrigger/special/interface/HLTHcalCalibTypeFilter.h"
 
 //
@@ -82,35 +83,57 @@ HLTHcalCalibTypeFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Eve
   
   edm::Handle<FEDRawDataCollection> rawdata;  
   iEvent.getByToken(DataInputToken_,rawdata);
-  
-  // checking FEDs for calibration information
-  int calibType = -1 ; int numEmptyFEDs = 0 ; 
-  std::vector<int> calibTypeCounter(8,0) ;
-  for (int i=FEDNumbering::MINHCALFEDID;
-       i<=FEDNumbering::MAXHCALFEDID; i++) {
-      const FEDRawData& fedData = rawdata->FEDData(i) ; 
-      if ( fedData.size() < 24 ) numEmptyFEDs++ ; 
-      if ( fedData.size() < 24 ) continue ; 
-      int value = ((const HcalDCCHeader*)(fedData.data()))->getCalibType() ; 
-      calibTypeCounter.at(value)++ ; // increment the counter for this calib type
-  }
-  int maxCount = 0 ;
-  int numberOfFEDIds = FEDNumbering::MAXHCALFEDID - FEDNumbering::MINHCALFEDID + 1 ; 
-  for (unsigned int i=0; i<calibTypeCounter.size(); i++) {
-      if ( calibTypeCounter.at(i) > maxCount ) { calibType = i ; maxCount = calibTypeCounter.at(i) ; } 
-      if ( maxCount == numberOfFEDIds ) break ;
-  }
-  if ( calibType < 0 ) return false ; // No HCAL FEDs, thus no calibration type
-  if ( maxCount != (numberOfFEDIds-numEmptyFEDs) )
-      edm::LogWarning("HLTHcalCalibTypeFilter") << "Conflicting calibration types found.  Assigning type " 
-                                             << calibType ; 
-  LogDebug("HLTHcalCalibTypeFilter") << "Calibration type is: " << calibType ;
-  if (Summary_)
-    ++eventsByType_.at(calibType);
 
-  for (unsigned int i=0; i<CalibTypes_.size(); i++) 
-      if ( calibType == CalibTypes_.at(i) ) return true ;
-  return false ; 
+  //    some inits
+  int numZeroes(0), numPositives(0);
+
+  //    loop over all HCAL FEDs
+  for (int fed=FEDNumbering::MINHCALFEDID;
+       fed<=FEDNumbering::MAXHCALuTCAFEDID; fed++) 
+  {
+      //    skip FEDs in between VME and uTCA    
+      if (fed>FEDNumbering::MAXHCALFEDID && fed<FEDNumbering::MINHCALuTCAFEDID)
+            continue;
+
+      //    get raw data and check if there are empty feds
+      const FEDRawData& fedData = rawdata->FEDData(fed) ; 
+      if ( fedData.size() < 24 ) continue ;
+
+      if (fed<=FEDNumbering::MAXHCALFEDID)
+      {
+          //    VME get event type
+          int eventtype = ((const HcalDCCHeader*)(fedData.data()))->getCalibType(); 
+          eventtype==0 ? numZeroes++ : numPositives++;
+      }
+      else 
+      {
+          //    UTCA
+          hcal::AMC13Header const *hamc13 = (hcal::AMC13Header const*) fedData.data();
+          for (int iamc=0; iamc<hamc13->NAMC(); iamc++)
+          {
+              HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
+              int eventtype = uhtr.getEventType();
+              eventtype==0 ? numZeroes++ : numPositives++;
+          }
+      }
+  }
+
+  //
+  //    if there are FEDs with Non-Collission event type, check what the majority is
+  //    if calibs - true
+  //    if 0s - false
+  //
+  if (numPositives>0)
+  {
+    if (numPositives>numZeroes) return true;
+    else
+        edm::LogWarning("HLTHcalCalibTypeFilter") 
+            << "Conflicting Calibration Types found";
+  }
+
+  //    return false if there are no positives
+  //    and if the majority has 0 calib type
+  return false;
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/HLTrigger/special/src/HLTHcalCalibTypeFilter.cc
+++ b/HLTrigger/special/src/HLTHcalCalibTypeFilter.cc
@@ -103,7 +103,7 @@ HLTHcalCalibTypeFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Eve
       {
           //    VME get event type
           int eventtype = ((const HcalDCCHeader*)(fedData.data()))->getCalibType(); 
-          eventtype==0 ? numZeroes++ : numPositives++;
+          if (eventtype==0) numZeroes++; else numPositives++;
       }
       else 
       {
@@ -113,7 +113,7 @@ HLTHcalCalibTypeFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Eve
           {
               HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
               int eventtype = uhtr.getEventType();
-              eventtype==0 ? numZeroes++ : numPositives++;
+              if (eventtype==0) numZeroes++; else numPositives++;
           }
       }
   }


### PR DESCRIPTION
HCAL HLT Calibration/Event Type Filter updates provided.

Changes:
- HcalUHTRData class has been updated with a method to extract the event type.
- HLTHcalCalibTypeFilter has been rewritten to simply accumulate the number of zeroes (Normal/Collision type) and the number of positives (calibration type). 
  Since EDFilter::filter has a bool in the return type, we do not need to differentiate between the Hcal Pedestal/laser types at the HLT level => code is simplified

For earlier data in 2016, there would be a mismatch seen in the calibration type and edm::LogWarning would be present, that is the result of HBHE FEDs (which are majority among HCAL FEDs) to have incorrect event type being delivered, that has been fixed and most recent data 2016 B,C,E,F is fine.

VK
