### PR TITLE
Reapply lost patch to L1TCaloLayer1 unpacker 81X

### DIFF
--- a/EventFilter/L1TXRawToDigi/plugins/UCTCTP7RawData.h
+++ b/EventFilter/L1TXRawToDigi/plugins/UCTCTP7RawData.h
@@ -230,21 +230,33 @@ public:
 
   bool isLinkMisaligned(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
     uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if ( cType == EBEE && (cEta==17||cEta==21) ) {
+      return ((linkStatus & 0x00000100) != 0);
+    }
     return ((linkStatus & 0x00001000) != 0);
   }
 
   bool isLinkInError(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
     uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if ( cType == EBEE && (cEta==17||cEta==21) ) {
+      return ((linkStatus & 0x00000200) != 0);
+    }
     return ((linkStatus & 0x00002000) != 0);
   }
 
   bool isLinkDown(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
     uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if ( cType == EBEE && (cEta==17||cEta==21) ) {
+      return ((linkStatus & 0x00000400) != 0);
+    }
     return ((linkStatus & 0x00004000) != 0);
   }
 
   bool isLinkMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
     uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if ( cType == EBEE && (cEta==17||cEta==21) ) {
+      return ((linkStatus & 0x00000800) != 0);
+    }
     return ((linkStatus & 0x00008000) != 0);
   }
 


### PR DESCRIPTION
Fixes ECAL link error readout unpacking for links with 4 towers
Was 86f3ebcc692dd6efae533e8b9b1f7d04cc29804b, then reverted

81X version of #15360 
