### PR TITLE
New stop-run control and more debugging info on JSON parse error in input source (DAQ) - 81X

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -210,6 +210,7 @@ namespace evf{
       bool readEolsDefinition_ = true;
       unsigned int eolsNFilesIndex_ = 1;
       std::string stopFilePath_;
+      std::string stopFilePathPid_;
       unsigned int stop_ls_override_ = 0;
 
       std::shared_ptr<Json::Value> transferSystemJson_;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -252,6 +252,9 @@ namespace evf {
     pthread_mutex_init(&init_lock_,NULL);
 
     stopFilePath_ = run_dir_+"/CMSSW_STOP";
+    std::stringstream sstp;
+    sstp << stopFilePath_ << "_pid" << getpid();
+    stopFilePathPid_ = sstp.str();
   }
 
   EvFDaqDirector::~EvFDaqDirector()
@@ -487,8 +490,13 @@ namespace evf {
 
     struct stat buf;
     int stopFileLS = -1;
-    if (stat(stopFilePath_.c_str(),&buf)==0) {
-        stopFileLS = readLastLSEntry(stopFilePath_);
+    int stopFileCheck = stat(stopFilePath_.c_str(),&buf);
+    int stopFilePidCheck = stat(stopFilePathPid_.c_str(),&buf);
+    if (stopFileCheck==0 || stopFilePidCheck==0) {
+        if (stopFileCheck==0)
+          stopFileLS = readLastLSEntry(stopFilePath_);
+        else
+          stopFileLS = 1;//stop without drain if only pid is stopped
         if (!stop_ls_override_) {
           //if lumisection is higher than in stop file, should quit at next from current
           if (stopFileLS>=0 && (int)ls>=stopFileLS) stopFileLS = stop_ls_override_ = ls;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -840,8 +840,14 @@ int FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& jsonS
     Json::Value deserializeRoot;
     Json::Reader reader;
 
-    if (!reader.parse(ij, deserializeRoot))
+    std::stringstream ss;
+    ss << ij.rdbuf();
+    if (!reader.parse(ss.str(), deserializeRoot)) {
+      edm::LogError("FedRawDataInputSource") << "Failed to deserialize JSON file -: " << jsonDestPath
+                                               << "\nERROR:\n" << reader.getFormatedErrorMessages()
+                                               << "CONTENT:\n" << ss.str()<<".";
       throw std::runtime_error("Cannot deserialize input JSON file");
+    }
 
     //read BU JSON
     std::string data;


### PR DESCRIPTION
81X port of #15647
- File-based based mechanism to stop data processing based on specific pid
- dump json library message full content of the json file in case before parsing exception is thrown
