### PR TITLE
set Pilot Blade to false by default

### DIFF
--- a/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
@@ -7,7 +7,7 @@ using namespace std;
 
 namespace {
   //const bool phase1 = false;
-  const bool pilot_blade = true;  
+  const bool pilot_blade = false;  
 }
 
 // Decodes the pixel name from the cmssw DetID, uses tracker topology


### PR DESCRIPTION
No changes expected beside removing the flood of error messages reported by @slava77  in data wfs related to Pilot Blade (which should not be used by default in any std workflows)
