### PR TITLE
Usage of Obsolete 2023 Scenarios Cleanup

### DIFF
--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -3,7 +3,7 @@ import sys
 import FWCore.ParameterSet.VarParsing as VarParsing
 from FWCore.Utilities.Enumerate import Enumerate
 
-varType = Enumerate ("Run1 2015 2017 2019 PhaseIPixel 2023 2023Muon GEMDev MaPSA SLHC")
+varType = Enumerate ("Run1 2015 2017 2019 2023D1 2023D2 2023D3 MaPSA")
 
 def help():
    print "Usage: cmsRun dumpFWRecoGeometry_cfg.py  tag=TAG "
@@ -47,10 +47,6 @@ def recoGeoLoad(score):
        from Configuration.AlCa.autoCond import autoCond
        process.GlobalTag.globaltag = autoCond['upgrade2017']
        process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
-       # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
-       #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2017 
-       #process.load("SLHCUpgradeSimulations.Configuration.combinedCustoms.cust_2017")
-       #process = cust_2017(process)
 
     elif  score == "2019":
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
@@ -63,39 +59,23 @@ def recoGeoLoad(score):
        process.DTGeometryESModule.applyAlignment = cms.bool(False)
        process.CSCGeometryESModule.applyAlignment = cms.bool(False)
 
-    elif score == "PhaseIPixel":
-       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-       from Configuration.AlCa.GlobalTag import GlobalTag
-       process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
-       process.load('Configuration.Geometry.GeometryExtendedPhaseIPixelReco_cff')
-
-    elif  score == "2023":
+    elif  score == "2023D1":
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
-      #from Configuration.AlCa.GlobalTag import GlobalTag
-      #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')
-       process.load('Configuration.Geometry.GeometryExtended2023simReco_cff')
-      #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2019
-      #process = cust_2019(process)
+       process.GlobalTag.globaltag = autoCond['run2_mc']
+       process.load('Configuration.Geometry.GeometryExtended2023D1Reco_cff')
       
-    elif  score == "2023Muon":
+    elif  score == "2023D2":
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
-      #from Configuration.AlCa.GlobalTag import GlobalTag
-      #process.GlobalTag = GlobalTag(process.GlobalTag, 'PH2_1K_FB_V6::All', '')
-       process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
-      # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
-      #from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023Muon
-      #call to customisation function cust_2023Muon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
-      #process = cust_2023Muon(process)
+       process.GlobalTag.globaltag = autoCond['run2_mc']
+       process.load('Configuration.Geometry.GeometryExtended2023D2Reco_cff')
 
-    elif  score == "GEMDev":
+    elif  score == "2023D3":
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
-       process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
+       process.GlobalTag.globaltag = autoCond['run2_mc']
+       process.load('Configuration.Geometry.GeometryExtended2023D3Reco_cff')
 
     elif score == "MaPSA":
        process.load('Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff')
@@ -108,15 +88,6 @@ def recoGeoLoad(score):
        process.load('RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi')
 
        process.load('Geometry.CommonDetUnit.bareGlobalTrackingGeometry_cfi')
-
-    elif score == "SLHC": # orig dumpFWRecoGeometrySLHC_cfg.py
-       process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-       from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['mc']
-       process.load("Configuration.Geometry.GeometrySLHCSimIdeal_cff")
-       process.load("Configuration.Geometry.GeometrySLHCReco_cff")
-       process.load("Configuration.StandardSequences.Reconstruction_cff")
-       process.trackerSLHCGeometry.applyAlignment = False
 
     else:
       help()

--- a/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
@@ -3,7 +3,7 @@ import sys
 import FWCore.ParameterSet.VarParsing as VarParsing
 from FWCore.Utilities.Enumerate import Enumerate
 
-varType = Enumerate ("Run1 Ideal2015 Ideal2015dev 2015 2015dev GEMDev RPC4RE11 2017 2019 2023 2023dev 2023sim 2023Muon MaPSA CRack DB")
+varType = Enumerate ("Run1 Ideal2015 Ideal2015dev 2015 2015dev GEMDev RPC4RE11 2017 2019 2023D1 2023D2 2023D3 MaPSA CRack DB")
 
 def help():
    print "Usage: cmsRun dumpSimGeometry_cfg.py  tag=TAG "
@@ -45,17 +45,14 @@ def simGeoLoad(score):
     elif score == "2019":
        process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
   
-    elif score == "2023dev":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023devXML_cfi')
+    elif score == "2023D1":
+       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D1XML_cfi')
 
-    elif score == "2023sim":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023simXML_cfi')
+    elif score == "2023D2":
+       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D2XML_cfi')
  
-    elif score == "2023Muon":
-       process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
-
-    elif score == "2023":
-       process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
+    elif score == "2023D3":
+       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D3XML_cfi')
 
     elif score == "MaPSA":
        process.load('Geometry.TrackerCommonData.mapsaGeometryXML_cfi')

--- a/Geometry/GEMGeometry/test/GEMGeometryAnalyzer.cc
+++ b/Geometry/GEMGeometry/test/GEMGeometryAnalyzer.cc
@@ -51,7 +51,7 @@ GEMGeometryAnalyzer::GEMGeometryAnalyzer( const edm::ParameterSet& /*iConfig*/ )
   : dashedLineWidth_(104), dashedLine_( std::string(dashedLineWidth_, '-') ), 
     myName_( "GEMGeometryAnalyzer" ) 
 { 
-  ofos.open("MytestOutput.out"); 
+  ofos.open("GEMtestOutput.out"); 
   ofos <<"======================== Opening output file"<< std::endl;
 }
 

--- a/Geometry/GEMGeometry/test/ME0GeometryAnalyzer.cc
+++ b/Geometry/GEMGeometry/test/ME0GeometryAnalyzer.cc
@@ -51,7 +51,7 @@ ME0GeometryAnalyzer::ME0GeometryAnalyzer( const edm::ParameterSet& /*iConfig*/ )
   : dashedLineWidth_(104), dashedLine_( string(dashedLineWidth_, '-') ), 
     myName_( "ME0GeometryAnalyzer" ) 
 { 
-  ofos.open("MytestOutput.out"); 
+  ofos.open("ME0testOutput.out"); 
   ofos <<"======================== Opening output file"<< endl;
 }
 

--- a/Geometry/GEMGeometry/test/testGEMGeometry_cfg.py
+++ b/Geometry/GEMGeometry/test/testGEMGeometry_cfg.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
-process.load('Configuration.Geometry.GeometryExtended2023Muon_cff')
-process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D3_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D3Reco_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/GEMGeometry/test/testME0Geometry_cfg.py
+++ b/Geometry/GEMGeometry/test/testME0Geometry_cfg.py
@@ -1,17 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
-process.load("Configuration.Geometry.GeometryExtended2023Muon_cff")
-process.load("Configuration.Geometry.GeometryExtended2023MuonReco_cff")
+process.load('Configuration.Geometry.GeometryExtended2023D3_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D3Reco_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
 process.MessageLogger.debugModules = cms.untracked.vstring('ME0GeometryBuilderFromDDD')
-process.MessageLogger.destinations = cms.untracked.vstring("cout")
-process.MessageLogger.cout = cms.untracked.PSet(threshold = cms.untracked.string("DEBUG"))
+process.MessageLogger.destinations = cms.untracked.vstring('cout')
+process.MessageLogger.cout = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG'))
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDDAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDDAnalyzer_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("HcalParametersTest")
 
-process.load('Configuration.Geometry.GeometryExtended2023Dev_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D3_cff')
 process.load('Geometry.HcalCommonData.hcalParameters_cfi')
 
 process.source = cms.Source("EmptySource")

--- a/Geometry/HcalTowerAlgo/test/runHcalTransGeometryAnalyzer_cfg.py
+++ b/Geometry/HcalTowerAlgo/test/runHcalTransGeometryAnalyzer_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HcalGeometryTest")
 
-process.load("Configuration.Geometry.GeometryExtended2023_cff")
+process.load("Configuration.Geometry.GeometryExtended2023D3_cff")
 process.load("Geometry.HcalCommonData.hcalDDConstants_cff")
 process.load("Geometry.HcalEventSetup.hcalTopologyIdeal_cfi")
 

--- a/Geometry/RPCGeometry/test/rpccsc_cfg.py
+++ b/Geometry/RPCGeometry/test/rpccsc_cfg.py
@@ -11,17 +11,9 @@ process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("DQMServices.Components.MEtoEDMConverter_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.connect = "frontier://PromptProd/CMS_COND_21X_GLOBALTAG"
-#process.GlobalTag.globaltag = "CRUZET4_V5P::All"
-#process.GlobalTag.globaltag = "IDEAL_V9::All"
-#process.GlobalTag.globaltag = "COSMMC_21X::All"
-#process.GlobalTag.globaltag = "CRAFT_ALL_V4::All"
 
-
-process.GlobalTag.globaltag = 'MC_31X_V1::All'
-
-process.prefer("GlobalTag")
-
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 

--- a/Geometry/RPCGeometry/test/rpcgeo.py
+++ b/Geometry/RPCGeometry/test/rpcgeo.py
@@ -2,9 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
 
-# process.load("Configuration.Geometry.GeometryExtended2015Reco_cff")
-# process.load('Configuration.Geometry.GeometryExtended2023Reco_cff')
-process.load("Configuration.Geometry.GeometryExtended2015Reco_RPC4RE11_cff")
+process.load("Configuration.Geometry.GeometryExtended2015Reco_cff")
 process.load("Geometry.RPCGeometry.rpcGeometry_cfi")
 
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
- Replace obsolete 2023 scenarios with new ones in all python configurations
- Use appropriate GTs
- Remove usage of other obsolete scenarios
- Rename test dump files to avoid clashes
