### PR TITLE
add DigiPhase1Task

### DIFF
--- a/DQM/HcalTasks/interface/DigiPhase1Task.h
+++ b/DQM/HcalTasks/interface/DigiPhase1Task.h
@@ -53,12 +53,24 @@ class DigiPhase1Task : public hcaldqm::DQTask
 		double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
 		double _thresh_unihf;
 
+		//	flag vector
+		std::vector<hcaldqm::flag::Flag> _vflags;
+		enum DigiFlag
+		{
+			fDigiSize=0,
+			fUni = 1,
+			fNChsHF = 2,
+			fUnknownIds = 3,
+			nDigiFlag = 4
+		};
+
 		//	hashes/FED vectors
 		std::vector<uint32_t> _vhashFEDs;
 
 		//	emap
 		HcalElectronicsMap const* _emap;
 		hcaldqm::electronicsmap::ElectronicsMap _ehashmap; // online only
+		hcaldqm::electronicsmap::ElectronicsMap _dhashmap;
 
 		//	Filters
 		hcaldqm::filter::HashFilter _filter_VME;
@@ -93,8 +105,8 @@ class DigiPhase1Task : public hcaldqm::DQTask
 		//	Only for Online mode! just filling - no summary!
 		hcaldqm::ContainerProf1D _cQ2Q12CutvsLS_FEDHF;	//	online only!
 
-		//	Occupancy w/o a Cut - whatever is sitting in the DigiPhase1 Collection
-		//	used to determine Missing DigiPhase1s => used for Summary!
+		//	Occupancy w/o a Cut - whatever is sitting in the Digi Collection
+		//	used to determine Missing Digis => used for Summary!
 		hcaldqm::Container2D _cOccupancy_FEDVME;
 		hcaldqm::Container2D _cOccupancy_FEDuTCA;
 		hcaldqm::Container2D _cOccupancy_ElectronicsVME;
@@ -131,6 +143,8 @@ class DigiPhase1Task : public hcaldqm::DQTask
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
+		MonitorElement *meUnknownIds1LS;
+		bool _unknownIdsPresent;
 
 		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
 		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -102,6 +102,14 @@ def customise_Hcal2017(process):
         process.digiTask.tagHBHE = cms.untracked.InputTag("simHcalDigis")
         process.digiTask.tagHF = cms.untracked.InputTag("simHcalDigis")
         process.digiTask.tagHO = cms.untracked.InputTag("simHcalDigis")
+
+        #add phase1 digi task
+        process.load('DQM.HcalTasks.DigiPhase1Task')
+        process.dqmoffline_step += process.digiPhase1Task
+        process.digiPhase1Task.tagHBHE = cms.untracked.InputTag("simHcalDigis","HBHEQIE11DigiCollection")
+        process.digiPhase1Task.tagHO = cms.untracked.InputTag("simHcalDigis")
+        process.digiPhase1Task.tagHF = cms.untracked.InputTag("simHcalDigis","HFQIE10DigiCollection")
+        
     if hasattr(process,'validation_step'):
         process.AllHcalDigisValidation.digiLabel = cms.InputTag("simHcalDigis")
 


### PR DESCRIPTION
the DigiPhase1Task is now activated in the customise_Hcal2017 scenario. it will go through Eras soon.
the task produces plots for:
- QIE11Digis for HBHE
- QIE10Digis for HF

the module doesn't run in any central sequence for now and has been tested following the recipe at:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/HcalPhase1SoftwareSimulationRecipe
plots are available at:
http://cern.ch/go/wcc7
