### PR TITLE
Use unique_ptr, not auto_ptr in some Reco* packages

### DIFF
--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -243,12 +243,12 @@ IPProducer<Container,Base,Helper>::produce(edm::Event& iEvent, const edm::EventS
    // m_algo.setTransientTrackBuilder(builder.product());
 
    // output collections 
-   std::auto_ptr<Product> result(new Product);
+   auto result = std::make_unique<Product>();
 
-   std::auto_ptr<reco::TrackCollection> ghostTracks;
+   std::unique_ptr<reco::TrackCollection> ghostTracks;
    reco::TrackRefProd ghostTrackRefProd;
    if (m_computeGhostTrack) {
-     ghostTracks.reset(new reco::TrackCollection);
+     ghostTracks = std::make_unique<reco::TrackCollection>();
      ghostTrackRefProd = iEvent.getRefBeforePut<reco::TrackCollection>("ghostTracks");
    }
 
@@ -417,8 +417,8 @@ IPProducer<Container,Base,Helper>::produce(edm::Event& iEvent, const edm::EventS
    }
  
    if (m_computeGhostTrack)
-     iEvent.put(ghostTracks, "ghostTracks");
-   iEvent.put(result);
+     iEvent.put(std::move(ghostTracks), "ghostTracks");
+   iEvent.put(std::move(result));
 }
 
 

--- a/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
@@ -82,7 +82,7 @@ BVertexFilterT<VTX>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
  edm::Handle<edm::View<VTX> > svHandle;
  iEvent.getByToken(token_secondaryVertex, svHandle);
 
- std::auto_ptr<std::vector<VTX> > recoVertices(new std::vector<VTX>);
+ auto recoVertices = std::make_unique<std::vector<VTX>>();
 
  if(pvHandle->size()!=0) {
    const reco::Vertex & primary = (*pvHandle.product())[0];
@@ -102,7 +102,7 @@ BVertexFilterT<VTX>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
      }
    }
  }
- iEvent.put(recoVertices);
+ iEvent.put(std::move(recoVertices));
 
  return(count >= minVertices);
 }

--- a/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
@@ -134,13 +134,12 @@ void BtoCharmDecayVertexMergerT<VTX>::produce(edm::Event &iEvent, const edm::Eve
   }
 
   // now create new vertex collection and add to event
-  std::auto_ptr<std::vector<VTX> > bvertColl(new std::vector<VTX>);
+  auto bvertColl = std::make_unique<std::vector<VTX>>();
   for(typename std::vector<VertexProxy>::const_iterator it=vertexProxyColl.begin(); it!=vertexProxyColl.end(); ++it) bvertColl->push_back((*it).vert);
-  iEvent.put(bvertColl);
+  iEvent.put(std::move(bvertColl));
   }
   else{
-    std::auto_ptr<std::vector<VTX> > bvertCollEmpty(new std::vector<VTX>);
-    iEvent.put(bvertCollEmpty);
+    iEvent.put(std::make_unique<std::vector<VTX>>());
   }
 }
 //------------------------------------

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -657,7 +657,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 
 	// result secondary vertices
 
-	std::auto_ptr<Product> tagInfos(new Product);
+	auto tagInfos = std::make_unique<Product>();
 
 	for(typename std::vector<IPTI>::const_iterator iterJets =
 		trackIPTagInfos->begin(); iterJets != trackIPTagInfos->end();
@@ -908,7 +908,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 					iterJets - trackIPTagInfos->begin())));
 	}
 
-	event.put(tagInfos);
+	event.put(std::move(tagInfos));
 }
 
 //Need specialized template because reco::Vertex iterators are TrackBase and it is a mess to make general

--- a/RecoBTag/SoftLepton/interface/GenericSelectorByValueMap.h
+++ b/RecoBTag/SoftLepton/interface/GenericSelectorByValueMap.h
@@ -83,7 +83,7 @@ GenericSelectorByValueMap<T,C>::GenericSelectorByValueMap(edm::ParameterSet cons
 template <typename T, typename C>
 void GenericSelectorByValueMap<T, C>::produce(edm::Event & event, const edm::EventSetup & setup)
 {
-  std::auto_ptr<edm::RefToBaseVector<candidate_type> > candidates(new edm::RefToBaseVector<candidate_type>());
+  auto candidates = std::make_unique<edm::RefToBaseVector<candidate_type>>();
 
   // read the collection of GsfElectrons from the Event
   edm::Handle<edm::View<candidate_type> > h_electrons;
@@ -102,7 +102,7 @@ void GenericSelectorByValueMap<T, C>::produce(edm::Event & event, const edm::Eve
   }
 
   // put the product in the event
-  event.put(candidates);
+  event.put(std::move(candidates));
 }
 
 } // namespace edm;

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -256,12 +256,12 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
   }
 
   // output collections
-  std::auto_ptr<reco::SoftLeptonTagInfoCollection> outputCollection(  new reco::SoftLeptonTagInfoCollection() );
+  auto outputCollection = std::make_unique<reco::SoftLeptonTagInfoCollection>();
   for (unsigned int i = 0; i < jets.size(); ++i) {
     reco::SoftLeptonTagInfo result = tag( jets[i], tracks[i], leptons, vertex );
     outputCollection->push_back( result );
   }
-  event.put( outputCollection );
+  event.put(std::move(outputCollection));
 }
 
 // ---------------------------------------------------------------------------------------

--- a/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.cc
@@ -46,7 +46,7 @@ SoftPFElectronTagInfoProducer::~SoftPFElectronTagInfoProducer()
 
 void SoftPFElectronTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-	std::auto_ptr<reco::CandSoftLeptonTagInfoCollection> theElecTagInfo(new reco::CandSoftLeptonTagInfoCollection);
+	auto theElecTagInfo = std::make_unique<reco::CandSoftLeptonTagInfoCollection>();
 	edm::ESHandle<TransientTrackBuilder> builder;
  	iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
  	transientTrackBuilder=builder.product();
@@ -120,7 +120,7 @@ void SoftPFElectronTagInfoProducer::produce(edm::Event& iEvent, const edm::Event
 		}
 		theElecTagInfo->push_back(tagInfo);
   	}
-  	iEvent.put(theElecTagInfo);
+  	iEvent.put(std::move(theElecTagInfo));
 }
 
 bool SoftPFElectronTagInfoProducer::isElecClean(edm::Event& iEvent,const reco::GsfElectron*candidate)

--- a/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
@@ -50,7 +50,7 @@ SoftPFMuonTagInfoProducer::~SoftPFMuonTagInfoProducer() {}
 
 void SoftPFMuonTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Declare produced collection
-  std::auto_ptr<reco::CandSoftLeptonTagInfoCollection> theMuonTagInfo(new reco::CandSoftLeptonTagInfoCollection);
+  auto theMuonTagInfo = std::make_unique<reco::CandSoftLeptonTagInfoCollection>();
   
   // Declare and open Jet collection
   edm::Handle<edm::View<reco::Jet> > theJetCollection;
@@ -149,7 +149,7 @@ void SoftPFMuonTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetu
   } // --- End loop on jets
   
   // Put the TagInfo collection in the event
-  iEvent.put(theMuonTagInfo);
+  iEvent.put(std::move(theMuonTagInfo));
 }
 
 

--- a/RecoBTau/JetCrystalsAssociator/src/JetCrystalsAssociator.cc
+++ b/RecoBTau/JetCrystalsAssociator/src/JetCrystalsAssociator.cc
@@ -73,7 +73,7 @@ class JetCrystalsAssociator : public edm::EDProducer {
 
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
    private:
-      std::auto_ptr<JetCrystalsAssociationCollection> associate( 
+      std::unique_ptr<JetCrystalsAssociationCollection> associate( 
           const edm::Handle<CaloJetCollection> & jets,
 	  const edm::OrphanHandle<EMLorentzVectorCollection> & myLorentzRecHits) const;
 
@@ -140,7 +140,7 @@ JetCrystalsAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
    iEvent.getByLabel( m_EBRecHits, EBRecHits );
    iEvent.getByLabel( m_EERecHits, EERecHits );
    
-   std::auto_ptr<EMLorentzVectorCollection> jetRecHits( new EMLorentzVectorCollection() );
+   auto jetRecHits = std::make_unique<EMLorentzVectorCollection>();
    //loop on jets and associate
    for (size_t t = 0; t < jets->size(); t++)
     {
@@ -201,18 +201,17 @@ JetCrystalsAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       }
     }
 
-  edm::OrphanHandle <reco::EMLorentzVectorCollection> myRecHits = iEvent.put(jetRecHits);
+  edm::OrphanHandle <reco::EMLorentzVectorCollection> myRecHits = iEvent.put(std::move(jetRecHits));
 
-  std::auto_ptr<JetCrystalsAssociationCollection> jetCrystals = associate(jets,myRecHits);
-  iEvent.put( jetCrystals );
+  iEvent.put(associate(jets,myRecHits));
 }
 
-std::auto_ptr<JetCrystalsAssociationCollection> JetCrystalsAssociator::associate( 
+std::unique_ptr<JetCrystalsAssociationCollection> JetCrystalsAssociator::associate( 
         const edm::Handle<CaloJetCollection> & jets,
         const edm::OrphanHandle<EMLorentzVectorCollection> & myLorentzRecHits) const
 {
   // we know we will save an element per input jet
-  std::auto_ptr<JetCrystalsAssociationCollection> outputCollection( new JetCrystalsAssociationCollection( jets->size() ) );
+  auto outputCollection = std::make_unique<JetCrystalsAssociationCollection>(jets->size());
 
   //loop on jets and associate
   for (size_t j = 0; j < jets->size(); j++) {

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
@@ -131,12 +131,12 @@ JetTagProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // take first tagInfo
   Handle< View<BaseTagInfo> > &tagInfoHandle = tagInfoHandles[0];
-  auto_ptr<JetTagCollection> jetTagCollection;
+  std::unique_ptr<JetTagCollection> jetTagCollection;
   if (tagInfoHandle.product()->size() > 0) {
     RefToBase<Jet> jj = tagInfoHandle->begin()->jet();
-    jetTagCollection.reset(new JetTagCollection(edm::makeRefToBaseProdFrom(jj, iEvent)));
+    jetTagCollection = std::make_unique<JetTagCollection>(edm::makeRefToBaseProdFrom(jj, iEvent));
   } else
-    jetTagCollection.reset(new JetTagCollection());
+    jetTagCollection = std::make_unique<JetTagCollection>();
 
   // now loop over the map and compute all JetTags
   for(JetToTagInfoMap::const_iterator iter = jetToTagInfos.begin();
@@ -149,7 +149,7 @@ JetTagProducer::produce(Event& iEvent, const EventSetup& iSetup)
     (*jetTagCollection)[iter->first] = discriminator;
   }
 
-  iEvent.put(jetTagCollection);
+  iEvent.put(std::move(jetTagCollection));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -63,9 +63,7 @@ BunchSpacingProducer::~BunchSpacingProducer(){
 void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
 { 
   if ( overRide_ ) {
-    std::auto_ptr<unsigned int> pOut1(new unsigned int);
-    *pOut1=bunchSpacingOverride_;
-    e.put(pOut1);
+    e.put(std::make_unique<unsigned int>(bunchSpacingOverride_));
     return;
   }
 
@@ -91,9 +89,7 @@ void BunchSpacingProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     bunchSpacing = *bunchSpacingH;
   }
 
-  std::auto_ptr<unsigned int> pOut1(new unsigned int);
-  *pOut1=bunchSpacing;
-  e.put(pOut1);
+  e.put(std::make_unique<unsigned int>(bunchSpacing));
   return;
 }
 

--- a/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
@@ -121,14 +121,8 @@ ExpressLumiProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
 
 void 
 ExpressLumiProducer::writeEmptyProductForEntry(edm::LuminosityBlock &iLBlock){
-  std::auto_ptr<LumiSummary> pOut1;
-  std::auto_ptr<LumiDetails> pOut2;
-  LumiSummary* pIn1=new LumiSummary;
-  LumiDetails* pIn2=new LumiDetails;
-  pOut1.reset(pIn1);
-  iLBlock.put(pOut1);
-  pOut2.reset(pIn2);
-  iLBlock.put(pOut2);
+  iLBlock.put(std::make_unique<LumiSummary>());
+  iLBlock.put(std::make_unique<LumiDetails>());
 }
 void 
 ExpressLumiProducer::beginLuminosityBlockProduce(edm::LuminosityBlock &iLBlock, edm::EventSetup const &iSetup)
@@ -357,17 +351,13 @@ ExpressLumiProducer::fillLSCache(unsigned int runnumber,unsigned int currentlsnu
 void
 ExpressLumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsigned int luminum){
   //std::cout<<"writing runnumber,luminum "<<runnumber<<" "<<luminum<<std::endl;
-  std::auto_ptr<LumiSummary> pOut1;
-  std::auto_ptr<LumiDetails> pOut2;
-  LumiSummary* pIn1=new LumiSummary;
-  LumiDetails* pIn2=new LumiDetails;
+  auto pIn1 = std::make_unique<LumiSummary>();
+  auto pIn2 = std::make_unique<LumiDetails>();
   if(m_isNullRun){
     pIn1->setLumiVersion("DIP");
     pIn2->setLumiVersion("DIP");
-    pOut1.reset(pIn1);
-    iLBlock.put(pOut1);
-    pOut2.reset(pIn2);
-    iLBlock.put(pOut2);
+    iLBlock.put(std::move(pIn1));
+    iLBlock.put(std::move(pIn2));
     return;
   }
   PerLSData& lsdata=m_lscache[luminum];
@@ -380,10 +370,8 @@ ExpressLumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsign
 
   pIn2->setLumiVersion("DIP");
   pIn2->fill(LumiDetails::kOCC1,lsdata.bunchlumivalue,lsdata.bunchlumierror,lsdata.bunchlumiquality);
-  pOut1.reset(pIn1);
-  iLBlock.put(pOut1);
-  pOut2.reset(pIn2);
-  iLBlock.put(pOut2);
+  iLBlock.put(std::move(pIn1));
+  iLBlock.put(std::move(pIn2));
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(ExpressLumiProducer);

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -449,14 +449,8 @@ void LumiProducer::beginLuminosityBlockProduce(edm::LuminosityBlock &iLBlock, ed
   //std::cout<<"beg of beginLuminosityBlock "<<luminum<<std::endl;
   //if is null run, fill empty values and return
   if(m_isNullRun){
-    std::auto_ptr<LumiSummary> pOut1;
-    std::auto_ptr<LumiDetails> pOut2;
-    LumiSummary* pIn1=new LumiSummary;
-    LumiDetails* pIn2=new LumiDetails;
-    pOut1.reset(pIn1);
-    iLBlock.put(pOut1);
-    pOut2.reset(pIn2);
-    iLBlock.put(pOut2);
+    iLBlock.put(std::make_unique<LumiSummary>());
+    iLBlock.put(std::make_unique<LumiDetails>());
     return;
   }
   if(m_lscache.find(luminum)==m_lscache.end()){
@@ -472,10 +466,10 @@ LumiProducer::endRun(edm::Run const& run,edm::EventSetup const &iSetup)
 void 
 LumiProducer::endRunProduce(edm::Run& run,edm::EventSetup const &iSetup)
 {
-  std::auto_ptr<LumiSummaryRunHeader> lsrh(new LumiSummaryRunHeader());
+  auto lsrh = std::make_unique<LumiSummaryRunHeader>();
   lsrh->swapL1Names(m_runcache.TRGBitNames);
   lsrh->swapHLTNames(m_runcache.HLTPathNames);
-  run.put(lsrh);
+  run.put(std::move(lsrh));
   m_runcache.TRGBitNameToIndex.clear();
   m_runcache.HLTPathNameToIndex.clear();
 }
@@ -818,17 +812,13 @@ LumiProducer::fillLSCache(unsigned int luminum){
 void
 LumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsigned int runnumber,unsigned int luminum){
   //std::cout<<"writing runnumber,luminum "<<runnumber<<" "<<luminum<<std::endl;
-  std::auto_ptr<LumiSummary> pOut1;
-  std::auto_ptr<LumiDetails> pOut2;
-  LumiSummary* pIn1=new LumiSummary;
-  LumiDetails* pIn2=new LumiDetails;
+  auto pIn1 = std::make_unique<LumiSummary>();
+  auto pIn2 = std::make_unique<LumiDetails>();
   if(m_isNullRun){
     pIn1->setLumiVersion("-1");
     pIn2->setLumiVersion("-1");
-    pOut1.reset(pIn1);
-    iLBlock.put(pOut1);
-    pOut2.reset(pIn2);
-    iLBlock.put(pOut2);
+    iLBlock.put(std::move(pIn1));
+    iLBlock.put(std::move(pIn2));
     return;
   }
   PerLSData& lsdata=m_lscache[luminum];
@@ -873,10 +863,8 @@ LumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsigned int 
     }
   }
   pIn2->setLumiVersion(m_lumiversion);
-  pOut1.reset(pIn1);
-  iLBlock.put(pOut1);
-  pOut2.reset(pIn2);
-  iLBlock.put(pOut2);
+  iLBlock.put(std::move(pIn1));
+  iLBlock.put(std::move(pIn2));
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(LumiProducer);

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
@@ -94,7 +94,7 @@ void PixelVertexProducerClusters::produce
 
   const SiPixelRecHitCollection* thePixelHits = pixelColl.product();
 
-  std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);
+  auto vertices = std::make_unique<reco::VertexCollection>();
 
   if(thePixelHits->size() > 0)
   {
@@ -177,6 +177,6 @@ void PixelVertexProducerClusters::produce
     vertices->push_back(ver);
   }
 
-  ev.put(vertices);
+  ev.put(std::move(vertices));
 }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
@@ -72,7 +72,7 @@ void PixelVertexProducerMedian::produce
             << tracks.size() << " (out of " << tracks_.size()
             << ")"; 
 
-  std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);
+  auto vertices = std::make_unique<reco::VertexCollection>();
 
   if(tracks.size() > 0)
   {
@@ -138,6 +138,6 @@ void PixelVertexProducerMedian::produce
     vertices->push_back(ver);
   }
   }
-  ev.put(vertices);
+  ev.put(std::move(vertices));
 }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
@@ -63,7 +63,7 @@ void SiPixelClusterShapeCacheProducer::produce(edm::StreamID, edm::Event& iEvent
   edm::ESHandle<TrackerGeometry> geom;
   iSetup.get<TrackerDigiGeometryRecord>().get(geom);
 
-  std::auto_ptr<SiPixelClusterShapeCache> output(new SiPixelClusterShapeCache(input));
+  auto output = std::make_unique<SiPixelClusterShapeCache>(input);
   output->resize(input->data().size());
 
 
@@ -87,7 +87,7 @@ void SiPixelClusterShapeCacheProducer::produce(edm::StreamID, edm::Event& iEvent
   }
   output->shrink_to_fit();
 
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 DEFINE_FWK_MODULE(SiPixelClusterShapeCacheProducer);

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
@@ -35,16 +35,11 @@ TrackListCombiner::~TrackListCombiner()
 /*****************************************************************************/
 void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const
 {
-  auto_ptr<reco::TrackCollection>          recoTracks
-      (new reco::TrackCollection);
-  auto_ptr<reco::TrackExtraCollection>     recoTrackExtras
-      (new reco::TrackExtraCollection);
-  auto_ptr<TrackingRecHitCollection>       recoHits
-      (new TrackingRecHitCollection);
-  auto_ptr<vector<Trajectory> >            recoTrajectories
-      (new vector<Trajectory>);
-  auto_ptr<TrajTrackAssociationCollection> recoTrajTrackMap
-      (new TrajTrackAssociationCollection());
+  auto recoTracks = std::make_unique<reco::TrackCollection>();
+  auto recoTrackExtras = std::make_unique<reco::TrackExtraCollection>();
+  auto recoHits = std::make_unique<TrackingRecHitCollection>();
+  auto recoTrajectories = std::make_unique<vector<Trajectory>>();
+  auto recoTrajTrackMap = std::make_unique<TrajTrackAssociationCollection>();
 
   LogTrace("MinBiasTracking")
     << "[TrackListCombiner]";
@@ -119,7 +114,7 @@ void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventS
                                     << "|" << recoTrajectories->size();
 
   // Save the tracking recHits
-  edm::OrphanHandle<TrackingRecHitCollection> theRecoHits = ev.put(recoHits);
+  edm::OrphanHandle<TrackingRecHitCollection> theRecoHits = ev.put(std::move(recoHits));
   
   edm::RefProd<TrackingRecHitCollection> theRecoHitsProd(theRecoHits);
   // Create the track extras and add the references to the rechits
@@ -151,7 +146,7 @@ void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventS
   
   // Save the track extras
   edm::OrphanHandle<reco::TrackExtraCollection> theRecoTrackExtras =
-    ev.put(recoTrackExtras);
+    ev.put(std::move(recoTrackExtras));
   
   // Add the reference to the track extra in the tracks
   for(unsigned index = 0; index<nTracks; ++index)
@@ -161,11 +156,11 @@ void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventS
   }
   
   // Save the tracks
-  edm::OrphanHandle<reco::TrackCollection> theRecoTracks = ev.put(recoTracks);
+  edm::OrphanHandle<reco::TrackCollection> theRecoTracks = ev.put(std::move(recoTracks));
   
   // Save the trajectories
   edm::OrphanHandle<vector<Trajectory> > theRecoTrajectories =
-    ev.put(recoTrajectories);
+    ev.put(std::move(recoTrajectories));
   
   // Create and set the trajectory/track association map 
   for(unsigned index = 0; index<nTracks; ++index)
@@ -176,6 +171,6 @@ void TrackListCombiner::produce(edm::StreamID, edm::Event& ev, const edm::EventS
   }
   
   // Save the association map
-  ev.put(recoTrajTrackMap);
+  ev.put(std::move(recoTrajTrackMap));
 }
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -56,9 +56,9 @@ void PixelTrackProducer::produce(edm::Event& ev, const edm::EventSetup& es)
 
 void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWithHits, const TrackerTopology& ttopo)
 {
-  std::auto_ptr<reco::TrackCollection> tracks(new reco::TrackCollection());
-  std::auto_ptr<TrackingRecHitCollection> recHits(new TrackingRecHitCollection());
-  std::auto_ptr<reco::TrackExtraCollection> trackExtras(new reco::TrackExtraCollection());
+  auto tracks = std::make_unique<reco::TrackCollection>();
+  auto recHits = std::make_unique<TrackingRecHitCollection>();
+  auto trackExtras = std::make_unique<reco::TrackExtraCollection>();
 
   int cc = 0, nTracks = tracksWithHits.size();
 
@@ -80,7 +80,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
   }
 
   LogDebug("TrackProducer") << "put the collection of TrackingRecHit in the event" << "\n";
-  edm::OrphanHandle <TrackingRecHitCollection> ohRH = ev.put( recHits );
+  edm::OrphanHandle <TrackingRecHitCollection> ohRH = ev.put(std::move(recHits));
 
   edm::RefProd<TrackingRecHitCollection> hitCollProd(ohRH);
   for (int k = 0; k < nTracks; k++)
@@ -95,7 +95,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
   }
 
   LogDebug("TrackProducer") << "put the collection of TrackExtra in the event" << "\n";
-  edm::OrphanHandle<reco::TrackExtraCollection> ohTE = ev.put(trackExtras);
+  edm::OrphanHandle<reco::TrackExtraCollection> ohTE = ev.put(std::move(trackExtras));
 
   for (int k = 0; k < nTracks; k++)
   {
@@ -103,6 +103,6 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     (tracks->at(k)).setExtra(theTrackExtraRef);
   }
 
-  ev.put(tracks);
+  ev.put(std::move(tracks));
 
 }

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexProducer.cc
@@ -231,9 +231,9 @@ FastPrimaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
      e(2, 2) = 1.5 * 1.5;
      Vertex::Point p(beamSpot->x(res), beamSpot->y(res), res);
      Vertex thePV(p, e, 1, 1, 0);
-     std::auto_ptr<reco::VertexCollection> pOut(new reco::VertexCollection());
+     auto pOut = std::make_unique<reco::VertexCollection>();
      pOut->push_back(thePV);
-     iEvent.put(pOut);
+     iEvent.put(std::move(pOut));
    } else
    {
   //   std::cout << "DUMMY " << res << std::endl;
@@ -244,9 +244,9 @@ FastPrimaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
      e(2, 2) = 1.5 * 1.5;
      Vertex::Point p(beamSpot->x(res), beamSpot->y(res), res);
      Vertex thePV(p, e, 0, 0, 0);
-     std::auto_ptr<reco::VertexCollection> pOut(new reco::VertexCollection());
+     auto pOut = std::make_unique<reco::VertexCollection>();
      pOut->push_back(thePV);
-     iEvent.put(pOut);
+     iEvent.put(std::move(pOut));
 
    }
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
@@ -410,9 +410,9 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
      e(2, 2) = 1.5 * 1.5;
      Vertex::Point p(beamSpot->x(res), beamSpot->y(res), res);
      Vertex thePV(p, e, 1, 1, 0);
-     std::auto_ptr<reco::VertexCollection> pOut(new reco::VertexCollection());
+     auto pOut = std::make_unique<reco::VertexCollection>();
      pOut->push_back(thePV);
-     iEvent.put(pOut);
+     iEvent.put(std::move(pOut));
    } else
    {
      Vertex::Error e;
@@ -421,9 +421,9 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
      e(2, 2) = 1.5 * 1.5;
      Vertex::Point p(beamSpot->x(res), beamSpot->y(res), res);
      Vertex thePV(p, e, 0, 0, 0);
-     std::auto_ptr<reco::VertexCollection> pOut(new reco::VertexCollection());
+     auto pOut = std::make_unique<reco::VertexCollection>();
      pOut->push_back(thePV);
-     iEvent.put(pOut);
+     iEvent.put(std::move(pOut));
    }
 
 //Finally, calculate the zClusterQuality as Sum(weights near the fastPV)/sqrt(Sum(total weights)) [a kind of zCluster significance]
@@ -442,15 +442,15 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
 	}
   }
 
-std::auto_ptr<float > zClusterQuality(new float());
+auto zClusterQuality = std::make_unique<float>();
 *zClusterQuality=-1;
 if(nWeightedTot!=0)
 {
    *zClusterQuality=nWeightedTotPeak / sqrt(nWeightedTot/(2*half_width_peak)); // where 30 is the beam spot lenght 
-   iEvent.put(zClusterQuality);
+   iEvent.put(std::move(zClusterQuality));
 }
 else
-   iEvent.put(zClusterQuality);
+   iEvent.put(std::move(zClusterQuality));
 
 }
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
@@ -127,7 +127,7 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    using namespace edm;
    Handle<reco::JetTracksAssociationCollection> jetTracksAssociation;
    iEvent.getByToken(m_associator, jetTracksAssociation);
-   std::auto_ptr<std::vector<reco::CaloJet> > pOut(new std::vector<reco::CaloJet> );
+   auto pOut = std::make_unique<std::vector<reco::CaloJet>>();
 
    bool result=true;
    int i = 0;
@@ -156,7 +156,7 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
      }
     }
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
 
    edm::Handle<reco::BeamSpot> beamSpot;
    iEvent.getByToken(m_beamSpot,beamSpot);
@@ -167,9 +167,9 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    e(2, 2) = m_pvErr_z * m_pvErr_z;
    reco::Vertex::Point p(beamSpot->x0(), beamSpot->y0(), beamSpot->z0());
    reco::Vertex thePV(p, e, 0, 0, 0);
-   std::auto_ptr<reco::VertexCollection> pOut2(new reco::VertexCollection);
+   auto pOut2 = std::make_unique<reco::VertexCollection>();
    pOut2->push_back(thePV);
-   iEvent.put(pOut2);
+   iEvent.put(std::move(pOut2));
 
    if(m_doFilter) return result;
    else 

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -85,7 +85,7 @@ PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup&
 {
   using namespace edm;
    
-  std::auto_ptr<reco::VertexCollection> vtxs_trim(new reco::VertexCollection);
+  auto vtxs_trim = std::make_unique<reco::VertexCollection>();
 
   edm::Handle<reco::VertexCollection> vtxs;
   iEvent.getByToken(vtxToken_,vtxs);
@@ -114,7 +114,7 @@ PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup&
     if (sumpt2 >= sumpt2first*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
   }
   //  std::cout << " ==> # vertices: " << vtxs_trim->size() << std::endl;
-  iEvent.put(vtxs_trim);
+  iEvent.put(std::move(vtxs_trim));
     
 }
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -87,7 +87,7 @@ void PixelVertexProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   if (bsHandle.isValid()) myPoint = math::XYZPoint(bsHandle->x0(),bsHandle->y0(), 0. ); //FIXME: fix last coordinate with vertex.z() at same time
 
   // Third, ship these tracks off to be vertexed
-  std::auto_ptr<reco::VertexCollection> vertexes(new reco::VertexCollection);
+  auto vertexes = std::make_unique<reco::VertexCollection>();
   bool ok;
   if (method2) {
     ok = dvf_->findVertexesAlt(trks,       // input
@@ -166,7 +166,7 @@ void PixelVertexProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       edm::LogWarning("PixelVertexProducer") << "No beamspot and no vertex found. No vertex returned.";
     }
   
-  e.put(vertexes);
+  e.put(std::move(vertexes));
   
 }
 

--- a/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
@@ -40,7 +40,7 @@ class FP420ClusterMain
 //       	   const std::vector<ClusterNoiseFP420>& noise 
 //     	   );
     void run(edm::Handle<DigiCollectionFP420> &input,
-       	   std::auto_ptr<ClusterCollectionFP420> &soutput,
+       	   ClusterCollectionFP420 *soutput,
        	   std::vector<ClusterNoiseFP420>& noise 
      	   );
 

--- a/RecoRomanPot/RecoFP420/interface/FP420RecoMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420RecoMain.h
@@ -28,7 +28,7 @@ class FP420RecoMain
 
   /// Runs the algorithm
   void run(edm::Handle<TrackCollectionFP420> &input,
-	   std::auto_ptr<RecoCollectionFP420> &toutput,
+	   RecoCollectionFP420 *toutput,
 	   double VtxX, double VtxY, double VtxZ
 	   );
 

--- a/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
@@ -27,7 +27,7 @@ class FP420TrackMain
 
   /// Runs the algorithm
   void run(edm::Handle<ClusterCollectionFP420> &input,
-	   std::auto_ptr<TrackCollectionFP420> &toutput
+	   TrackCollectionFP420 *toutput
 	   );
 
  private:

--- a/RecoRomanPot/RecoFP420/plugins/ClusterizerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/ClusterizerFP420.cc
@@ -150,7 +150,7 @@ namespace cms
     }
 
     // Step C: create empty output collection
-    std::auto_ptr<ClusterCollectionFP420> soutput(new ClusterCollectionFP420);
+    auto soutput = std::make_unique<ClusterCollectionFP420>();
     ///////////////////////////////////////////////////////////////////////////////////////////// 
     /*    
    std::vector<SimVertex> input;
@@ -214,7 +214,7 @@ namespace cms
     if (verbosity > 0) {
       std::cout << "ClusterizerFP420: OK2" << std::endl;
     }
-      sClusterizerFP420_->run(input, soutput, noise);
+      sClusterizerFP420_->run(input, soutput.get(), noise);
 
     if (verbosity > 0) {
       std::cout << "ClusterizerFP420: OK3" << std::endl;
@@ -225,7 +225,7 @@ namespace cms
     //  std::cout <<"=======           ClusterizerFP420:                    end of produce     " <<  std::endl;
     
 	// Step D: write output to file
-	iEvent.put(soutput);
+	iEvent.put(std::move(soutput));
     if (verbosity > 0) {
       std::cout << "ClusterizerFP420: OK4" << std::endl;
     }

--- a/RecoRomanPot/RecoFP420/plugins/ReconstructerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/ReconstructerFP420.cc
@@ -179,7 +179,7 @@ namespace cms
        
     
     // Step C: create empty output collection
-    std::auto_ptr<RecoCollectionFP420> toutput(new RecoCollectionFP420);
+    auto toutput = std::make_unique<RecoCollectionFP420>();
     
     
     
@@ -207,16 +207,16 @@ namespace cms
     
     //                                RUN now:                                                                                 !!!!!!     
     //   startFP420RecoMain_.run(input, toutput);
-    sFP420RecoMain_->run(input, toutput, VtxX, VtxY, VtxZ);
+    sFP420RecoMain_->run(input, toutput.get(), VtxX, VtxY, VtxZ);
     // std::cout <<"=======           ReconstructerFP420:                    end of produce     " << endl;
     
 	// Step D: write output to file
     if (verbosity > 0) {
-      std::cout << "ReconstructerFP420: iEvent.put(toutput)" << std::endl;
+      std::cout << "ReconstructerFP420: iEvent.put(std::move(toutput)" << std::endl;
     }
-	iEvent.put(toutput);
+	iEvent.put(std::move(toutput));
     if (verbosity > 0) {
-      std::cout << "ReconstructerFP420: iEvent.put(toutput) DONE" << std::endl;
+      std::cout << "ReconstructerFP420: iEvent.put(std::move(toutput) DONE" << std::endl;
     }
   }//produce
   

--- a/RecoRomanPot/RecoFP420/plugins/TrackerizerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/TrackerizerFP420.cc
@@ -84,7 +84,7 @@ namespace cms
        
     
     // Step C: create empty output collection
-    std::auto_ptr<TrackCollectionFP420> toutput(new TrackCollectionFP420);
+    auto toutput = std::make_unique<TrackCollectionFP420>();
     
     
     
@@ -112,11 +112,11 @@ namespace cms
     
     //                                RUN now:                                                                                 !!!!!!     
     //   startFP420TrackMain_.run(input, toutput);
-    sFP420TrackMain_->run(input, toutput);
+    sFP420TrackMain_->run(input, toutput.get());
     // std::cout <<"=======           TrackerizerFP420:                    end of produce     " << std::endl;
     
 	// Step D: write output to file
-	iEvent.put(toutput);
+	iEvent.put(std::move(toutput));
   }//produce
   
 } // namespace cms

--- a/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
@@ -114,9 +114,9 @@ FP420ClusterMain::~FP420ClusterMain() {
 }
 
 
-//void FP420ClusterMain::run(const DigiCollectionFP420 *input, ClusterCollectionFP420 &soutput,
+//void FP420ClusterMain::run(const DigiCollectionFP420 *input, ClusterCollectionFP420 *soutput,
 //			   const std::vector<ClusterNoiseFP420>& electrodnoise)
-void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420> &input, std::auto_ptr<ClusterCollectionFP420> &soutput,
+void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420> &input, ClusterCollectionFP420 *soutput,
 			   std::vector<ClusterNoiseFP420>& electrodnoise)
 
 {

--- a/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
@@ -60,7 +60,7 @@ FP420RecoMain::~FP420RecoMain() {
 
 
 
-void FP420RecoMain::run(edm::Handle<TrackCollectionFP420> &input, std::auto_ptr<RecoCollectionFP420> &toutput, double VtxX, double VtxY, double VtxZ)  
+void FP420RecoMain::run(edm::Handle<TrackCollectionFP420> &input, RecoCollectionFP420 *toutput, double VtxX, double VtxY, double VtxZ)  
 {
   // initialization
   bool first = true;

--- a/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
@@ -134,7 +134,7 @@ FP420TrackMain::~FP420TrackMain() {
 
 
 
-void FP420TrackMain::run(edm::Handle<ClusterCollectionFP420> &input, std::auto_ptr<TrackCollectionFP420> &toutput )
+void FP420TrackMain::run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput )
 {
   
   if ( validTrackerizer_ ) {

--- a/RecoTBCalo/EcalTBHodoscopeReconstructor/src/EcalTBHodoscopeRecInfoProducer.cc
+++ b/RecoTBCalo/EcalTBHodoscopeReconstructor/src/EcalTBHodoscopeRecInfoProducer.cc
@@ -62,9 +62,8 @@ void EcalTBHodoscopeRecInfoProducer::produce(edm::Event& e, const edm::EventSetu
      }
 
   // Create empty output
-  std::auto_ptr<EcalTBHodoscopeRecInfo> recInfo(new EcalTBHodoscopeRecInfo(algo_->reconstruct(*ecalRawHodoscope)));
   
-  e.put(recInfo,recInfoCollection_);
+  e.put(std::make_unique<EcalTBHodoscopeRecInfo>(algo_->reconstruct(*ecalRawHodoscope)),recInfoCollection_);
 } 
 
 

--- a/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
+++ b/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
@@ -160,8 +160,8 @@ EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetu
 #endif
    // collection of reco'ed ampltudes to put in the event
 
-   std::auto_ptr< EBUncalibratedRecHitCollection > EBuncalibRechits( new EBUncalibratedRecHitCollection );
-   std::auto_ptr< EEUncalibratedRecHitCollection > EEuncalibRechits( new EEUncalibratedRecHitCollection );
+   auto EBuncalibRechits = std::make_unique<EBUncalibratedRecHitCollection>();
+   auto EEuncalibRechits = std::make_unique<EEUncalibratedRecHitCollection>();
 
    EcalPedestalsMapIterator pedIter; // pedestal iterator
 
@@ -321,8 +321,8 @@ EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetu
 #endif
        }
      }
-   // put the collection of recunstructed hits in the event
-   evt.put( EBuncalibRechits, EBhitCollection_ );
+   // put the collection of reconstructed hits in the event
+   evt.put(std::move(EBuncalibRechits), EBhitCollection_);
 
 
    if (EEdigis)
@@ -471,8 +471,8 @@ EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetu
 #endif
        }
      }
-   // put the collection of recunstructed hits in the event
-   evt.put( EEuncalibRechits, EEhitCollection_ );
+   // put the collection of reconstructed hits in the event
+   evt.put(std::move(EEuncalibRechits), EEhitCollection_);
 }
 
 // HepMatrix

--- a/RecoTBCalo/EcalTBTDCReconstructor/src/EcalTBH2TDCRecInfoProducer.cc
+++ b/RecoTBCalo/EcalTBTDCReconstructor/src/EcalTBH2TDCRecInfoProducer.cc
@@ -81,13 +81,11 @@ void EcalTBH2TDCRecInfoProducer::produce(edm::Event& e, const edm::EventSetup& e
   
   if (!h2TriggerData->wasBeamTrigger())
     {
-      std::auto_ptr<EcalTBTDCRecInfo> recInfo(new EcalTBTDCRecInfo(0.5));
-      e.put(recInfo,recInfoCollection_);
+      e.put(std::make_unique<EcalTBTDCRecInfo>(0.5),recInfoCollection_);
     }
    else
      {
-       std::auto_ptr<EcalTBTDCRecInfo> recInfo(new EcalTBTDCRecInfo(algo_->reconstruct(runNumber,*ecalRawTDC)));
-       e.put(recInfo,recInfoCollection_);
+       e.put(std::make_unique<EcalTBTDCRecInfo>(algo_->reconstruct(runNumber,*ecalRawTDC)),recInfoCollection_);
      }
   
 

--- a/RecoTBCalo/EcalTBTDCReconstructor/src/EcalTBTDCRecInfoProducer.cc
+++ b/RecoTBCalo/EcalTBTDCReconstructor/src/EcalTBTDCRecInfoProducer.cc
@@ -93,9 +93,8 @@ void EcalTBTDCRecInfoProducer::produce(edm::Event& e, const edm::EventSetup& es)
      }
 
   // Create empty output
-  std::auto_ptr<EcalTBTDCRecInfo> recInfo(new EcalTBTDCRecInfo(algo_->reconstruct(*ecalRawTDC,*tbEventHeader,use2004OffsetConvention_)));
   
-  e.put(recInfo,recInfoCollection_);
+  e.put(std::make_unique<EcalTBTDCRecInfo>(algo_->reconstruct(*ecalRawTDC,*tbEventHeader,use2004OffsetConvention_)),recInfoCollection_);
 } 
 
 

--- a/RecoTBCalo/HcalTBObjectUnpacker/plugins/HcalTBObjectUnpacker.cc
+++ b/RecoTBCalo/HcalTBObjectUnpacker/plugins/HcalTBObjectUnpacker.cc
@@ -96,23 +96,17 @@ using namespace std;
     e.getByToken(tok_raw_, rawraw);           
 
     // Step B: Create empty output    
-    std::auto_ptr<HcalTBTriggerData>
-      trigd(new HcalTBTriggerData);
+    auto trigd = std::make_unique<HcalTBTriggerData>();
 
-    std::auto_ptr<HcalTBRunData>
-      rund(new HcalTBRunData);
+    auto rund = std::make_unique<HcalTBRunData>();
 
-    std::auto_ptr<HcalTBEventPosition>
-      epd(new HcalTBEventPosition);
+    auto epd = std::make_unique<HcalTBEventPosition>();
 
-    std::auto_ptr<HcalTBTiming>
-      tmgd(new HcalTBTiming);
+    auto tmgd = std::make_unique<HcalTBTiming>();
 
-    std::auto_ptr<HcalTBBeamCounters>
-      bcntd(new HcalTBBeamCounters);
+    auto bcntd = std::make_unique<HcalTBBeamCounters>();
 
-    std::auto_ptr<HcalSourcePositionData>
-      spd(new HcalSourcePositionData);
+    auto spd = std::make_unique<HcalSourcePositionData>();
     
     if (triggerFed_ >=0) {
       // Step C: unpack all requested FEDs
@@ -147,12 +141,12 @@ using namespace std;
     }
 
     // Step D: Put outputs into event
-    if (doTriggerData_) e.put(trigd);
-    if (doRunData_) e.put(rund);
-    if (doEventPosition_) e.put(epd);
-    if (doTiming_) e.put(tmgd);
-    if (doBeamADC_) e.put(bcntd);
-    if (doSourcePos_) e.put(spd);
+    if (doTriggerData_) e.put(std::move(trigd));
+    if (doRunData_) e.put(std::move(rund));
+    if (doEventPosition_) e.put(std::move(epd));
+    if (doTiming_) e.put(std::move(tmgd));
+    if (doBeamADC_) e.put(std::move(bcntd));
+    if (doSourcePos_) e.put(std::move(spd));
   }
 
 

--- a/RecoVZero/VZeroFinding/plugins/VZeroProducer.cc
+++ b/RecoVZero/VZeroFinding/plugins/VZeroProducer.cc
@@ -73,7 +73,7 @@ void VZeroProducer::produce(Event& ev, const EventSetup& es)
        << " +" << positives.size()
        << " -" << negatives.size();
 
-  auto_ptr<reco::VZeroCollection> result(new reco::VZeroCollection);
+  auto result = std::make_unique<reco::VZeroCollection>();
 
   // Check all combination of positives and negatives
   if(positives.size() > 0 && negatives.size() > 0)
@@ -105,6 +105,6 @@ void VZeroProducer::produce(Event& ev, const EventSetup& es)
     << "[VZeroProducer] found candidates : " << result->size();
 
   // Put result back to the event
-  ev.put(result);
+  ev.put(std::move(result));
 }
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
@@ -69,7 +69,7 @@ void DoubleVertexFilter::produce(edm::StreamID, edm::Event &event, const edm::Ev
 
 	std::vector<reco::Vertex>::const_iterator pv = primaryVertices->begin();
 
-	std::auto_ptr<VertexCollection> recoVertices(new VertexCollection);
+	auto recoVertices = std::make_unique<VertexCollection>();
 	for(std::vector<reco::Vertex>::const_iterator sv = secondaryVertices->begin();
 	    sv != secondaryVertices->end(); ++sv) {
 		if (computeSharedTracks(*pv, *sv) > maxFraction)
@@ -78,7 +78,7 @@ void DoubleVertexFilter::produce(edm::StreamID, edm::Event &event, const edm::Ev
 		recoVertices->push_back(*sv);
 	}
 
-	event.put(recoVertices);
+	event.put(std::move(recoVertices));
 }
 
 DEFINE_FWK_MODULE(DoubleVertexFilter);

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -129,7 +129,7 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 	                                   trackBuilder);
 
 
-        std::auto_ptr<Product> recoVertices(new Product);
+        auto recoVertices = std::make_unique<Product>();
         if(primaryVertices->size()!=0) {
      
 	const reco::Vertex &pv = (*primaryVertices)[0];
@@ -229,7 +229,7 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 #endif  
         }
  
-	event.put(recoVertices);
+	event.put(std::move(recoVertices));
 
 }
 #endif 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -91,7 +91,7 @@ void TemplatedVertexArbitrator<InputContainer,VTX>::produce(edm::Event &event, c
 	edm::Handle<VertexCollection> primaryVertices;
 	event.getByToken(token_primaryVertex, primaryVertices);
 
-	std::auto_ptr<Product> recoVertices(new Product);
+	auto recoVertices = std::make_unique<Product>();
 	if(primaryVertices->size()!=0){ 
 		const reco::Vertex &pv = (*primaryVertices)[0];
 
@@ -122,7 +122,7 @@ void TemplatedVertexArbitrator<InputContainer,VTX>::produce(edm::Event &event, c
 		}
 
 	}	
-	event.put(recoVertices);
+	event.put(std::move(recoVertices));
 
 
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
@@ -52,7 +52,7 @@ void TemplatedVertexMerger<VTX>::produce(edm::Event &event, const edm::EventSetu
 	event.getByToken(token_secondaryVertex, secondaryVertices);
 
         VertexDistance3D dist;
-	std::auto_ptr<Product> recoVertices(new Product);
+	auto recoVertices = std::make_unique<Product>();
 	for(typename Product::const_iterator sv = secondaryVertices->begin();
 	    sv != secondaryVertices->end(); ++sv) {
           recoVertices->push_back(*sv);
@@ -82,7 +82,7 @@ void TemplatedVertexMerger<VTX>::produce(edm::Event &event, const edm::EventSetu
      //    std::cout << "it = " <<  sv-recoVertices->begin() << " new size is: " << recoVertices->size() <<   std::endl;
        }
 
-	event.put(recoVertices);
+	event.put(std::move(recoVertices));
 
 
 

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -53,7 +53,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
   BeamSpotOnline spotOnline;
 
   // product is a reco::BeamSpot object
-  std::auto_ptr<reco::BeamSpot> result(new reco::BeamSpot);
+  auto result = std::make_unique<reco::BeamSpot>();
   
   reco::BeamSpot aSpot;
 
@@ -154,7 +154,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   *result = aSpot;
 
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 
 }
 

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotProducer.cc
@@ -40,7 +40,7 @@ BeamSpotProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	
 	using namespace edm;
 
-	std::auto_ptr<reco::BeamSpot> result(new reco::BeamSpot);
+	auto result = std::make_unique<reco::BeamSpot>();
 
 	reco::BeamSpot aSpot;
 
@@ -90,7 +90,7 @@ BeamSpotProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 	*result = aSpot;
 	
-	iEvent.put(result);
+	iEvent.put(std::move(result));
 	
 }
 

--- a/RecoVertex/NuclearInteractionProducer/plugins/NuclearInteractionEDProducer.cc
+++ b/RecoVertex/NuclearInteractionProducer/plugins/NuclearInteractionEDProducer.cc
@@ -78,7 +78,7 @@ NuclearInteractionEDProducer::produce(edm::Event& iEvent, const edm::EventSetup&
    iEvent.getByToken(token_additionalSecTracks, additionalSecTracks);
 
    /// Definition of the output
-   std::auto_ptr<reco::NuclearInteractionCollection> theNuclearInteractions(new reco::NuclearInteractionCollection);
+   auto theNuclearInteractions = std::make_unique<reco::NuclearInteractionCollection>();
 
    typedef edm::Ref<TrajectoryCollection> TrajectoryRef;
 
@@ -126,7 +126,7 @@ NuclearInteractionEDProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
 
    LogDebug("NuclearInteractionMaker") << "End of NuclearInteractionMaker - Number of nuclear interactions found :" << theNuclearInteractions->size();
-   iEvent.put(theNuclearInteractions);
+   iEvent.put(std::move(theNuclearInteractions));
 }
 
 // ------ method used to check whether the seed of a track belong to the vector of seeds --

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -165,7 +165,7 @@ PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   for( std::vector <algo>::const_iterator algorithm=algorithms.begin(); algorithm!=algorithms.end(); algorithm++){
 
 
-    std::auto_ptr<reco::VertexCollection> result(new reco::VertexCollection);
+    auto result = std::make_unique<reco::VertexCollection>();
     reco::VertexCollection & vColl = (*result);
 
 
@@ -263,7 +263,7 @@ PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       }
     }
 
-    iEvent.put(result, algorithm->label); 
+    iEvent.put(std::move(result), algorithm->label); 
   }
   
 }

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -69,11 +69,9 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 
    // Create auto_ptr for each collection to be stored in the Event
-   std::auto_ptr< reco::VertexCompositeCandidateCollection > 
-     kShortCandidates( new reco::VertexCompositeCandidateCollection );
+   auto kShortCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
 
-   std::auto_ptr< reco::VertexCompositeCandidateCollection >
-     lambdaCandidates( new reco::VertexCompositeCandidateCollection );
+   auto lambdaCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
 
   // invoke the fitter which reconstructs the vertices and fills,
    //  collections of Kshorts, Lambda0s
@@ -81,8 +79,8 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 
    // Write the collections to the Event
-   kShortCandidates->shrink_to_fit(); iEvent.put( kShortCandidates, std::string("Kshort") );
-   lambdaCandidates->shrink_to_fit(); iEvent.put( lambdaCandidates, std::string("Lambda") );
+   kShortCandidates->shrink_to_fit(); iEvent.put(std::move(kShortCandidates), std::string("Kshort") );
+   lambdaCandidates->shrink_to_fit(); iEvent.put(std::move(lambdaCandidates), std::string("Lambda") );
 
 }
 


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in some Reco\* packages. Also, std::make_unique is used when appropriate. Also, there were a few cases where a reference to an auto_ptr was an input argument to a function, which is a bad practice because it obscures the possible transfer of ownership. This was corrected.
