### PR TITLE
Update to fix late validation plots  from PR 15562

### DIFF
--- a/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
+++ b/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
@@ -9,7 +9,7 @@ puppiPhoton = cms.EDProducer("PuppiPhoton",
                              pt             = cms.double(10),
                              eta            = cms.double(2.5),
                              useRefs        = cms.bool(True),
-                             dRMatch        = cms.vdouble(10,10,10,10),
+                             dRMatch        = cms.vdouble(0.005,0.005,0.005,0.005),
                              pdgids         = cms.vint32 (22,11,211,130),
                              weight         = cms.double(1.),
                              useValueMap    = cms.bool(False),
@@ -18,6 +18,13 @@ puppiPhoton = cms.EDProducer("PuppiPhoton",
 
 
 def setupPuppiPhoton(process):
+    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_25ns_V1_cff']
+    switchOnVIDPhotonIdProducer(process, DataFormat.AOD)
+    for idmod in my_id_modules:
+        setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
+
+
+def setupPuppiPhotonMiniAOD(process):
     my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_25ns_V1_cff']
     switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD)
     for idmod in my_id_modules:

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -21,8 +21,8 @@ def makePuppies( process ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
-    process.puppiForMET.puppiCandName    = 'puppiMerged'
-
+    #process.puppiForMET.puppiCandName    = 'puppiMerged'
+    
 
 
 def makePuppiesFromMiniAOD( process ):

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from CommonTools.PileupAlgos.Puppi_cff import *
-from CommonTools.PileupAlgos.PhotonPuppi_cff        import setupPuppiPhoton
+from CommonTools.PileupAlgos.PhotonPuppi_cff        import setupPuppiPhoton,setupPuppiPhotonMiniAOD
 
 def makePuppies( process ):
-
+    
     process.load('CommonTools.PileupAlgos.Puppi_cff')
-
+    
     process.pfNoLepPUPPI = cms.EDFilter("PdgIdCandViewSelector",
                                         src = cms.InputTag("particleFlow"), 
                                         pdgId = cms.vint32( 1,2,22,111,130,310,2112,211,-211,321,-321,999211,2212,-2212 )
@@ -15,14 +15,16 @@ def makePuppies( process ):
                                            src = cms.InputTag("particleFlow"),
                                            pdgId = cms.vint32(-11,11,-13,13),
                                            )
+
     process.puppiNoLep = process.puppi.clone()
     process.puppiNoLep.candName = cms.InputTag('pfNoLepPUPPI') 
-
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
-    #process.puppiForMET.puppiCandName    = 'puppiMerged'
-    
+    #Line below replaces reference linking wiht delta R matching this is because the reference key in packed candidates differs to PF candidates (must be done when reading Reco)
+    process.puppiForMET.useRefs          = False
+    #Line below points puppi MET to puppi no lepton which increases the response
+    process.puppiForMET.puppiCandName    = 'puppiMerged'
 
 
 def makePuppiesFromMiniAOD( process ):
@@ -37,7 +39,8 @@ def makePuppiesFromMiniAOD( process ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
-    setupPuppiPhoton(process)
-    #Line below doesn't work because of an issue with references in MiniAOD
+    setupPuppiPhotonMiniAOD(process)
+    #Line below doesn't work because of an issue with references in MiniAOD without setting useRefs=>False and using delta R
     #process.puppiForMET.puppiCandName    = 'puppiMerged'
-    
+    #process.puppiForMET.useRefs          = False
+


### PR DESCRIPTION
Following concerns in    #15562 we have fix based on the validation plots. This results from the fact that when CandViewMerger is used, the referening of the packedcandidates to the orignal leptons is somehow broken. PuppiPhoton relies on these references to remove the give pfcandidates assigned to a good photon weight 1. If this is broken Puppi photon will add back the missing candidates even if they are there. The solution is to either run puppi no lepton or puppiphoton, but not both. The problem with this is that puppi vs puppi no lepton will reduce the MET response by a 2-3% whereas puppiphoton vs puppi will make puppiMET robust in photon+jet events. We prfer to have puppi photon. On another note, after miniAOD is run, the puppinolepton weights attached to the packed candidates give weight 1 for the leptons, so puppiphoton can be run on the miniAOD using the precomputed puppinolepton weights allowing for the best puppiMET peformance.
