### PR TITLE
Create a context around TFile::Open() so the context is unregistered …

### DIFF
--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -18,6 +18,13 @@ namespace edm {
   InputFile::InputFile(char const* fileName, char const* msg, InputType inputType) :
     file_(), fileName_(fileName), reportToken_(0), inputType_(inputType) {
 
+    // ROOT's context management implicitly assumes that a file is opened and
+    // closed on the same thread.  To avoid the problem, we declare a local
+    // TContext object; when it goes out of scope, its destructor unregisters
+    // the context, guaranteeing the context is unregistered in the same thread
+    // it was registered in.  Fixes issue #15524.
+    TDirectory::TContext contextEraser;
+
     logFileAction(msg, fileName);
     file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
     std::exception_ptr e = edm::threadLocalException::getException();


### PR DESCRIPTION
…in the same thread it was registered in

ROOT's context management implicitly assumes that a file is opened and closed on the same thread, which may not be true for secondary files opened by the MixingModule, and in the future may not be true for primary input files.  To avoid the problem, this PR declares a local TContext object in the scope where TFile::Open() is called; when the TContext goes out of scope, its destructor unregisters the context, guaranteeing the context is unregistered in the same thread it was registered in.  Hopefully fixes issue #15524.
