### PR TITLE
Updated IVF trackMinLayers cut in jetTools.py for MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -384,7 +384,6 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     _temp = getattr(process, btagPrefix+'candidateVertexArbitrator')
                     _temp.primaryVertices = pvSource
                     _temp.tracks = pfCandidates
-                    _temp.trackMinLayers = cms.int32(0) ## number of layers not available in MiniAOD so this cut needs to be disabled
                 if hasattr( process, btagPrefix+'inclusiveCandidateSecondaryVertices' ) and not hasattr( process, svSource.getModuleLabel() ):
                     setattr(process, svSource.getModuleLabel(), getattr(process, btagPrefix+'inclusiveCandidateSecondaryVertices').clone() )
         if (i for i in ivfcTagInfos if i in acceptedTagInfos):
@@ -404,7 +403,6 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                     _temp = getattr(process, btagPrefix+'candidateVertexArbitratorCvsL')
                     _temp.primaryVertices = pvSource
                     _temp.tracks = pfCandidates
-                    _temp.trackMinLayers = cms.int32(0) ## number of layers not available in MiniAOD so this cut needs to be disabled
                 if hasattr( process, btagPrefix+'inclusiveCandidateSecondaryVerticesCvsL' ) and not hasattr( process, svSourceCvsL.getModuleLabel() ):
                     setattr(process, svSourceCvsL.getModuleLabel(), getattr(process, btagPrefix+'inclusiveCandidateSecondaryVerticesCvsL').clone() )
         if 'inclusiveSecondaryVertexFinderTagInfos' in acceptedTagInfos:


### PR DESCRIPTION
With #15605 merged, it is no longer necessary to relax the `trackMinLayers` cut in jetTools.py.

The following plots show the impact of this update. In 1D histograms the thick red line is always the same and shows the discriminator value stored in MiniAOD (i.e. computed from AOD) while the thin blue line shows the same discriminator recomputed from MiniAOD.

**1) Using slimmed IVF vertices stored in MiniAOD:**

![csvv2ivf](https://cloud.githubusercontent.com/assets/4885289/18132421/0ba6fd3e-6f97-11e6-8f68-50ae1a4efa55.png)
![csvv2ivf_scatter](https://cloud.githubusercontent.com/assets/4885289/18132423/12de9706-6f97-11e6-9160-61641f23030d.png)
![csvv2ivf_diff](https://cloud.githubusercontent.com/assets/4885289/18206771/787df97a-7128-11e6-91ab-89c007295694.png)

**2) Using IVF vertices recomputed from MiniAOD using the default `trackMinLayers` cut:**

![csvv2ivf_ivffromminiaod](https://cloud.githubusercontent.com/assets/4885289/18132444/2eef14ca-6f97-11e6-816a-256ca98480e4.png)
![csvv2ivf_ivffromminiaod_scatter](https://cloud.githubusercontent.com/assets/4885289/18132450/35240be8-6f97-11e6-87ca-7334b904290c.png)
![csvv2ivf_ivffromminiaod_diff](https://cloud.githubusercontent.com/assets/4885289/18206777/7eabd0c4-7128-11e6-8471-0aa7165dfefd.png)

**3) Using IVF vertices recomputed from MiniAOD with `trackMinLayers=0`:**

![csvv2ivf_ivffromminiaod_trackminlayers0](https://cloud.githubusercontent.com/assets/4885289/18132470/51794ba0-6f97-11e6-8de8-19ec95e88fa5.png)
![csvv2ivf_ivffromminiaod_trackminlayers0_scatter](https://cloud.githubusercontent.com/assets/4885289/18132484/5871754a-6f97-11e6-9532-b6740d5dc085.png)
![csvv2ivf_ivffromminiaod_trackminlayers0_diff](https://cloud.githubusercontent.com/assets/4885289/18206782/84130154-7128-11e6-8b92-635a1f506baa.png)

**4) Using IVF vertices recomputed from MiniAOD produced with #15605 merged and using the default `trackMinLayers` cut:**

![csvv2ivf_ivffromminiaod_tklayersinminiaod](https://cloud.githubusercontent.com/assets/4885289/18132523/78c6d600-6f97-11e6-95fd-768d241467ec.png)
![csvv2ivf_ivffromminiaod_tklayersinminiaod_scatter](https://cloud.githubusercontent.com/assets/4885289/18132530/7d976c76-6f97-11e6-8b78-1c882417235d.png)
![csvv2ivf_ivffromminiaod_newminiaod_diff](https://cloud.githubusercontent.com/assets/4885289/18206785/89c9e5c2-7128-11e6-8004-c878e1942588.png)

**MiniAOD ROC curves:**

Legend
- filled red squares = 1)
- open black circles = 2)
- open blue triangles = 3)
- open green squares = 4)

![rocs](https://cloud.githubusercontent.com/assets/4885289/18149705/193ce24c-6fe2-11e6-8c25-f422630ffbe6.png)
