### PR TITLE
fix memory leak in HcalDbService

### DIFF
--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -27,6 +27,7 @@ class HcalTopology;
 class HcalDbService {
  public:
   HcalDbService (const edm::ParameterSet&);
+  ~HcalDbService();
 
   const HcalTopology* getTopologyUsed() const;
   

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -29,6 +29,11 @@ HcalDbService::HcalDbService (const edm::ParameterSet& cfg):
   mCalibSet(nullptr), mCalibWidthSet(nullptr)
  {}
 
+HcalDbService::~HcalDbService() {
+    delete mCalibSet.load();
+    delete mCalibWidthSet.load();
+}
+
 const HcalTopology* HcalDbService::getTopologyUsed() const {
   if (mPedestals && mPedestals->topo()) return mPedestals->topo();
   if (mGains && mGains->topo()) return mGains->topo();


### PR DESCRIPTION
Some dynamically allocated members of HcalDbService were never deleted, causing a memory leak. This PR fixes the problem (checked with igprof mp).
