### PR TITLE
Fix memory leaks in GEM-CSC trigger

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -1590,7 +1590,7 @@ void CSCMotherboardME11GEM::buildCoincidencePads(const GEMPadDigiCollection* out
 void CSCMotherboardME11GEM::createGEMRollEtaLUT(bool isEven)
 {
   int ch(isEven ? 2 : 1);
-  auto chamber(gem_g->chamber(GEMDetId(1,1,1,1,ch,0)));
+  std::unique_ptr<const GEMChamber> chamber(gem_g->chamber(GEMDetId(1,1,1,1,ch,0)));
   if (chamber==nullptr) return;
 
   int n = 1;
@@ -1912,7 +1912,7 @@ void CSCMotherboardME11GEM::printGEMTriggerPads(int bx_start, int bx_stop, bool 
 
 void CSCMotherboardME11GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads, unsigned id)
 {
-  auto superChamber(gem_g->superChamber(id));
+  std::unique_ptr<const GEMSuperChamber> superChamber(gem_g->superChamber(id));
   for (auto ch : superChamber->chambers()) {
     for (auto roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());
@@ -1929,7 +1929,7 @@ void CSCMotherboardME11GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads,
 
 void CSCMotherboardME11GEM::retrieveGEMCoPads(const GEMCoPadDigiCollection* gemPads, unsigned id)
 {
-  auto superChamber(gem_g->superChamber(id));
+  std::unique_ptr<const GEMSuperChamber>  superChamber(gem_g->superChamber(id));
   for (auto ch : superChamber->chambers()) {
     for (auto roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -1006,11 +1006,11 @@ CSCMotherboardME21GEM::createGEMRollEtaLUT()
 {
   std::map<int,std::pair<double,double> > result;
 
-  auto chamber(gem_g->chamber(GEMDetId(1,1,3,1,1,0)));
+  std::unique_ptr<const GEMChamber> chamber(gem_g->chamber(GEMDetId(1,1,3,1,1,0)));
   if (chamber==nullptr) return result;
 
   for(int i = 1; i<= chamber->nEtaPartitions(); ++i){
-    auto roll(chamber->etaPartition(i));
+    std::unique_ptr<const GEMEtaPartition> roll(chamber->etaPartition(i));
     if (roll==nullptr) continue;
     const float half_striplength(roll->specs()->specificTopology().stripLength()/2.);
     const LocalPoint lp_top(0., half_striplength, 0.);
@@ -1025,7 +1025,7 @@ CSCMotherboardME21GEM::createGEMRollEtaLUT()
 
 void CSCMotherboardME21GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads, unsigned id)
 {
-  auto superChamber(gem_g->superChamber(id));
+  std::unique_ptr<const GEMSuperChamber> superChamber(gem_g->superChamber(id));
   for (auto ch : superChamber->chambers()) {
     for (auto roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());
@@ -1043,7 +1043,7 @@ void CSCMotherboardME21GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads,
 
 void CSCMotherboardME21GEM::retrieveGEMCoPads(const GEMCoPadDigiCollection* gemPads, unsigned id)
 {
-  auto superChamber(gem_g->superChamber(id));
+  std::unique_ptr<const GEMSuperChamber> superChamber(gem_g->superChamber(id));
   for (auto ch : superChamber->chambers()) {
     for (auto roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141RPC.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141RPC.cc
@@ -263,7 +263,7 @@ CSCMotherboardME3141RPC::run(const CSCWireDigiCollection* wiredc,
     }
 
     // pick any roll
-    auto randRoll(rpcChamber->roll(2));
+    std::unique_ptr<const RPCRoll> randRoll(rpcChamber->roll(2));
 
     auto nStrips(keyLayerGeometry->numberOfStrips());
     for (float i = 0; i< nStrips; i = i+0.5){
@@ -532,8 +532,8 @@ CSCMotherboardME3141RPC::run(const CSCWireDigiCollection* wiredc,
 bool CSCMotherboardME3141RPC::hasRE31andRE41()
 {
   // just pick two random chambers
-  auto aRE31(rpc_g->chamber(RPCDetId(1,1,3,2,1,1,0)));
-  auto aRE41(rpc_g->chamber(RPCDetId(-1,1,4,3,1,2,0)));  
+  std::unique_ptr<const RPCChamber> aRE31(rpc_g->chamber(RPCDetId(1,1,3,2,1,1,0)));
+  std::unique_ptr<const RPCChamber> aRE41(rpc_g->chamber(RPCDetId(-1,1,4,3,1,2,0)));
   return aRE31 and aRE41;
 }
 
@@ -578,7 +578,7 @@ int CSCMotherboardME3141RPC::assignRPCRoll(double eta)
 
 void CSCMotherboardME3141RPC::retrieveRPCDigis(const RPCDigiCollection* rpcDigis, unsigned id)
 {
-  auto chamber(rpc_g->chamber(RPCDetId(id)));
+  std::unique_ptr<const RPCChamber> chamber(rpc_g->chamber(RPCDetId(id)));
   for (auto roll : chamber->rolls()) {
     RPCDetId roll_id(roll->id());
     auto digis_in_det = rpcDigis->get(roll_id);


### PR DESCRIPTION
@kpedro88 I noticed that I used `auto`as type for `const GEMChamber*` or similar pointers. I replaced those with `std::unique_ptr<const GEMChamber>`.  That should fix the memory leaks in the functions `CSCMotherboardME21GEM::createGEMRollEtaLUT()`, `CSCMotherboardME11GEM::createGEMRollEtaLUT()`, `CSCMotherboardME11GEM::retrieveGEMPads` and `CSCMotherboardME21GEM::retrieveGEMPads`. I'm not sure how to fix the one in `CSCMotherboardME11GEM::buildCoincidencePads` or `CSCMotherboardME21GEM::buildCoincidencePads`. 
