### PR TITLE
update MC GTs with conditions validated for MC Tranche-IV and prepare for 2016 data reprocessing

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,21 +12,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '81X_mcRun2_design_v5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_Candidate_2016_08_30_11_37_42',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v6',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_Candidate_2016_08_30_11_36_42',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_Candidate_2016_08_30_11_38_26',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_Candidate_2016_08_30_11_39_33',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v5',
+    'run1_data'         :   '81X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v5',
+    'run2_data'         :   '81X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -38,7 +38,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '81X_upgrade2017_design_v8',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_08_30_11_40_18',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2
@@ -63,10 +63,9 @@ autoCond['startup']          = ( autoCond['run1_mc'] )
 autoCond['starthi']          = ( autoCond['run1_mc_hi'] )
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
 autoCond['startpa']          = ( autoCond['run1_mc_pa'] )
-    # GlobalTag for data reprocessing: this should always be the GR_R tag
+    # GlobalTag for data reprocessing
 autoCond['com10']            = ( autoCond['run1_data'] )
-    # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
-    # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
+    # GlobalTag for running HLT on recent data: it points to the online GT (remove the snapshot!)
 autoCond['hltonline']        = ( autoCond['run1_hlt'] )
     # GlobalTag for POSTLS1 upgrade studies:
 autoCond['upgradePLS1']      = ( autoCond['run2_mc'] )


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v1) as [81X_mcRun2_pA_Candidate_2016_08_30_11_39_33](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_Candidate_2016_08_30_11_39_33) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v1/81X_mcRun2_pA_Candidate_2016_08_30_11_39_33): 
  - updated Tracker misalignment scenario (after Bpix centering)
  - updated Beamspot following tracker alignment update 
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v6) as [81X_mcRun2cosmics_startup_peak_Candidate_2016_08_30_11_36_42](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_Candidate_2016_08_30_11_36_42) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v6/81X_mcRun2cosmics_startup_peak_Candidate_2016_08_30_11_36_42): 
  -  reverting spurious change of misalignment scenario (Startup scenario is needed here) introduced in #15658
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v6) as [81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v6/81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55): 
  - updated Tracker misalignment scenario (after Bpix centering)
  - updated Beamspot following tracker alignment update 
- **RunII Startup scenario** : [81X_mcRun2_startup_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v8) as [81X_mcRun2_startup_Candidate_2016_08_30_11_37_42](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_Candidate_2016_08_30_11_37_42) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v8/81X_mcRun2_startup_Candidate_2016_08_30_11_37_42): 
  - just nomenclature change: no actual change of content
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v7) as [81X_mcRun2_HeavyIon_Candidate_2016_08_30_11_38_26](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_Candidate_2016_08_30_11_38_26) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v7/81X_mcRun2_HeavyIon_Candidate_2016_08_30_11_38_26): 
  - just nomenclature change: no actual change of content
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v6) as [81X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v6/81X_dataRun2_v5): 
  - updated AlCaRecoTriggerBits to allow creation of Run2 version of wf 1000.0 and 1001.0 
  - fixed history of ES channel status 
  - fixed history of Hcal channel status 
  - fixed history of Strip DetVOff 
  - updated Tracker Alignment with time-dependent PCL updates on top of 2016B re-reco geometry 
- **RunII Offline relval processing** : [81X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v7) as [81X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v7/81X_dataRun2_relval_v6): 
  - updated AlCaRecoTriggerBits to allow creation of Run2 version of wf 1000.0 and 1001.0 
  - fixed history of ES channel status 
  - fixed history of Hcal channel status 
  - fixed history of Strip DetVOff 
  - updated Tracker Alignment with time-dependent PCL updates on top of 2016B re-reco geometry 
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v10) as [81X_upgrade2017_realistic_Candidate_2016_08_30_11_40_18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_Candidate_2016_08_30_11_40_18) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v10/81X_upgrade2017_realistic_Candidate_2016_08_30_11_40_18): 
  - just nomenclature change: no actual change of content
