### PR TITLE
Bug Fix! Avoid unnecessary function calls by CLING interpreter in cutParser

### DIFF
--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -195,10 +195,10 @@ findMethod(const edm::TypeWithDict& t, /*class=in*/
   } else {
     edm::TypeFunctionMembers functions(type);
     for (auto const& F : functions) {
-      edm::FunctionWithDict f(F);
-      if (f.name() != name) {
+      if (std::string(F->GetName()) != name) {
         continue;
       }
+      edm::FunctionWithDict f(F);
       int casts = checkMethod(f, type, args, fixuppedArgs);
       if (casts > -1) {
         oks.push_back(std::make_pair(casts, f));


### PR DESCRIPTION
This is a fix for a bug introduced during the conversion to ROOT6. The bug causes unnecessary function calls in the cling interpreter. These calls occur during the construction of modules that use the cutParser. The bug may slow down the initialization of jobs that use the cutParser. There is no effect on the per event run time, as all the cost is paid at startup.
This bug has one other observed effect. If the unnecessary function call is one that takes an argument by value that is a std::unique_ptr, an error message will occur, as the interpreter will attempt to call the function without the equivalent of an std::move() around the argument. Such an error message was observed in the PhysicsTools/PatAlgos unit test output. This PR will avoid this error message.
Thanks to Carl Vuosalo for notifying me about this error message.
