### PR TITLE
Fix HighPtTripletStep estimator CCC cut value

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -100,7 +100,7 @@ highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstim
     ComponentName = 'highPtTripletStepChi2Est',
     nSigma = 3.0,
     MaxChi2 = 30.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
     pTChargeCutThreshold = 15.
 )
 eras.trackingPhase1PU70.toModify(highPtTripletStepChi2Est,


### PR DESCRIPTION
In the PR disabling the VFP30 mitigation (#15590) the CCC cut value of estimator was left to Tiny while it was supposed to be set to Loose (thanks to @slava77 for pointing it out).

Tested in CMSSW_8_1_X_2016-09-01-1100, should have no effect on phase0/2, and small effect on phase1.

@rovere @VinInn 
