### PR TITLE
fix nan Calo-towers, when HO is deactivated, but has energy deposit (and ECAL/HCAL do not have any energy deposits) 

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -999,8 +999,8 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
     
     
     // insert in collection (remove and return if below threshold)
-    if unlikely ( (towerP4[3]==0) & (E_outer>0)  ) {
-      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(0,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
+    if unlikely ( (towerP4[3]==0) & (E_outer>0) & (!theHOIsUsed) ) {
+      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(1e-9,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
     } else {
       collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
     }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -999,8 +999,9 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
     
     
     // insert in collection (remove and return if below threshold)
-    if unlikely ( (towerP4[3]==0) & (E_outer>0) & (!theHOIsUsed) ) {
-      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(1e-9,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint);
+    if unlikely ( (towerP4[3]==0) & (E_outer>0)  ) {
+        float val = theHOIsUsed ? 0 : 1E-9; // to keep backwards compatibility for theHOIsUsed == true
+        collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(val,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint); 
     } else {
       collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
     }


### PR DESCRIPTION
add precaution for deactivated HO (theHOIsUsed==false): set tower energy to tiny value to avoid nan-eta for HO-only towers (when HO is'deactivated', i.e. energy set to zero)
backport of #15568
