### PR TITLE
[Tau]: add parameter to isolation module

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -39,6 +39,12 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
     calculateWeights_ = pset.exists("ApplyDiscriminationByWeightedECALIsolation") ?
       pset.getParameter<bool>("ApplyDiscriminationByWeightedECALIsolation") : false;
 
+    // RIC: multiply neutral isolation by a flat factor.
+    //      Useful, for instance, to combine charged and neutral isolations
+    //      with different relative weights
+    weightGammas_ = pset.exists("WeightECALIsolation") ?
+      pset.getParameter<double>("WeightECALIsolation") : 1.0;
+
     // RIC: allow to relax the isolation completely beyond a given tau pt
     minPtForNoIso_ = pset.exists("minTauPtForNoIso") ?
       pset.getParameter<double>("minTauPtForNoIso") : -99.;
@@ -219,6 +225,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   bool includeTracks_;
   bool includeGammas_;
   bool calculateWeights_;
+  double weightGammas_;
   bool applyOccupancyCut_;
   uint32_t maximumOccupancy_;
   bool applySumPtCut_;
@@ -559,7 +566,7 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
       neutralPt = 0.;
     }
 
-    totalPt = chargedPt + neutralPt;
+    totalPt = chargedPt + weightGammas_ * neutralPt;
     LogTrace("discriminate") << "totalPt = " << totalPt << " (cut = " << maximumSumPt_ << ")" ;
 
     failsSumPtCut = (totalPt > maximumSumPt_);

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -15,6 +15,7 @@ pfRecoTauDiscriminationByIsolation = cms.EDProducer("PFRecoTauDiscriminationByIs
     ApplyDiscriminationByECALIsolation = cms.bool(True), # use PFGammas when isolating
     ApplyDiscriminationByTrackerIsolation = cms.bool(True), # use PFChargedHadr when isolating
     ApplyDiscriminationByWeightedECALIsolation = cms.bool(False), #do not use pileup weighting of neutral deposits by default
+    WeightECALIsolation = cms.double(1.), # apply a flat, overall weight to ECAL isolation. Useful to combine charged and neutral isolations with different relative weights. Default 1. 
 
     applyOccupancyCut = cms.bool(True), # apply a cut on number of isolation objects
     maximumOccupancy = cms.uint32(0), # no tracks > 1 GeV or gammas > 1.5 GeV allowed


### PR DESCRIPTION
- add possibility to differently weigh charged and neutral components of tau combined isolation, which translates into one additional parameter `WeightECALIsolation` for `RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc`
- needed to reduce Tau HLT rates, as presented here
  https://indico.cern.ch/event/546904/contributions/2218494/subcontributions/199662/attachments/1329420/1997233/trigger_iso_study.pdf
- used `pset.exists` plus default in `_cfi` rather than `fillDescriptions` just to stick to the current style of the module. There's a work ongoing in the Tau POG to migrate all (many) modules to `fillDecriptions` so I haven't interfered.
