### PR TITLE
Cleanup G4 User actions

### DIFF
--- a/SimG4Core/Application/interface/CustomUIsession.h
+++ b/SimG4Core/Application/interface/CustomUIsession.h
@@ -11,8 +11,8 @@ class CustomUIsession : public G4UIsession
 
  public:
 
-  CustomUIsession();
-  ~CustomUIsession();
+  explicit CustomUIsession();
+  virtual ~CustomUIsession();
 
   G4int ReceiveG4cout(const G4String& coutString) override;
   G4int ReceiveG4cerr(const G4String& cerrString) override;

--- a/SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h
+++ b/SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h
@@ -16,8 +16,8 @@ class CustomUIsessionThreadPrefix : public CustomUIsession
 
  public:
 
-  CustomUIsessionThreadPrefix(const std::string& threadPrefix, int threadId);
-  ~CustomUIsessionThreadPrefix();
+  explicit CustomUIsessionThreadPrefix(const std::string& threadPrefix, int threadId);
+  virtual ~CustomUIsessionThreadPrefix();
 
   G4int ReceiveG4cout(const G4String& coutString) override;
   G4int ReceiveG4cerr(const G4String& cerrString) override;

--- a/SimG4Core/Application/interface/EventAction.h
+++ b/SimG4Core/Application/interface/EventAction.h
@@ -16,6 +16,7 @@
 
 #include <vector>
 #include <map>
+#include <string>
  
 class SimRunInterface;
 class BeginOfEvent;
@@ -26,29 +27,34 @@ class EventAction: public G4UserEventAction
 {
 public:
 
-    EventAction(const edm::ParameterSet& ps,
-                SimRunInterface*,
-		SimTrackManager*,
-		CMSSteppingVerbose*);
-    ~EventAction();
+    explicit EventAction(const edm::ParameterSet& ps,
+			 SimRunInterface*, SimTrackManager*,
+			 CMSSteppingVerbose*);
+    virtual ~EventAction();
 
-    void BeginOfEventAction(const G4Event * evt);
-    void EndOfEventAction(const G4Event * evt);
+    virtual void BeginOfEventAction(const G4Event * evt);
+    virtual void EndOfEventAction(const G4Event * evt);
 
     void abortEvent();
 
-    const TrackContainer * trackContainer() const { 
+    inline const TrackContainer * trackContainer() const { 
       return m_trackManager->trackContainer();
     }
-    void addTrack(TrackWithHistory* iTrack, bool inHistory, bool withAncestor);
-    void addTkCaloStateInfo(uint32_t t,const std::pair<math::XYZVectorD,math::XYZTLorentzVectorD>& p); 
-    void prepareForNewPrimary() { m_trackManager->cleanTracksWithHistory(); }
+
+    inline void addTrack(TrackWithHistory* iTrack, bool inHistory, bool withAncestor) {
+      m_trackManager->addTrack(iTrack, inHistory, withAncestor);
+    }
+
+    void addTkCaloStateInfo(uint32_t t,
+			    const std::pair<math::XYZVectorD,math::XYZTLorentzVectorD>& p);
+
+    inline void prepareForNewPrimary() { m_trackManager->cleanTracksWithHistory(); }
 
     SimActivityRegistry::BeginOfEventSignal m_beginOfEventSignal;
     SimActivityRegistry::EndOfEventSignal m_endOfEventSignal;
 
 private:
-    //does not own the manager
+
     SimRunInterface* m_runInterface;
     SimTrackManager* m_trackManager;
     CMSSteppingVerbose* m_SteppingVerbose;

--- a/SimG4Core/Application/interface/RunAction.h
+++ b/SimG4Core/Application/interface/RunAction.h
@@ -16,7 +16,9 @@ class G4Timer;
 class RunAction: public G4UserRunAction
 {
 public:
-    RunAction(const edm::ParameterSet & ps, SimRunInterface*);
+    explicit RunAction(const edm::ParameterSet & ps, SimRunInterface*, bool master);
+    virtual ~RunAction();
+
     void BeginOfRunAction(const G4Run * aRun);
     void EndOfRunAction(const G4Run * aRun);
     
@@ -27,6 +29,7 @@ private:
     SimRunInterface* m_runInterface;
     std::string m_stopFile;
     G4Timer* m_timer;
+    bool m_isMaster; 
 };
 
 #endif

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -51,6 +51,7 @@ class CMSSteppingVerbose;
 
 class DDDWorld;
 class DDG4ProductionCuts;
+class CustomUIsession;
 
 class G4RunManagerKernel;
 class G4Run;
@@ -111,14 +112,18 @@ private:
   edm::EDGetTokenT<edm::LHCTransportLinkContainer> m_LHCtr;
     
   bool m_nonBeam;
+  std::unique_ptr<CustomUIsession> m_UIsession;
   std::unique_ptr<PhysicsList> m_physicsList;
   PrimaryTransformer * m_primaryTransformer;
+
   bool m_managerInitialized;
   bool m_runInitialized;
   bool m_runTerminated;
   bool m_runAborted;
   bool firstRun;
   bool m_pUseMagneticField;
+  bool m_hasWatchers;
+
   G4Run * m_currentRun;
   G4Event * m_currentEvent;
   G4SimEvent * m_simEvent;

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -75,9 +75,12 @@ private:
   Generator m_generator;
   edm::EDGetTokenT<edm::HepMCProduct> m_InToken;
   edm::EDGetTokenT<edm::LHCTransportLinkContainer> m_theLHCTlinkToken;
-  const bool m_nonBeam;
-  const bool m_pUseMagneticField;
-  const int m_EvtMgrVerbosity;
+
+  bool m_nonBeam;
+  bool m_pUseMagneticField;
+  bool m_hasWatchers;
+  int  m_EvtMgrVerbosity;
+
   edm::ParameterSet m_pField;
   edm::ParameterSet m_pRunAction;
   edm::ParameterSet m_pEventAction;

--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -2,6 +2,7 @@
 #define SimG4Core_StackingAction_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 
 #include "G4UserStackingAction.hh"
 #include "G4Region.hh"
@@ -18,12 +19,12 @@ class CMSSteppingVerbose;
 class StackingAction : public G4UserStackingAction {
 
 public:
-  StackingAction(const TrackingAction*, const edm::ParameterSet & ps, 
-                 const CMSSteppingVerbose*);
+  explicit StackingAction(const TrackingAction*, const edm::ParameterSet & ps, 
+			  const CMSSteppingVerbose*);
 
   virtual ~StackingAction();
 
-  virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track * aTrack);
+  virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track * aTrack) final;
 
   void NewStage();
   void PrepareNewEvent();
@@ -38,7 +39,7 @@ private:
 
   bool rrApplicable(const G4Track*, const G4Track&) const;
 
-  bool isItLongLived(const G4Track*) const;
+  bool isItOutOfTimeWindow(const G4Region*, const G4Track*) const;
 
   bool isThisRegion(const G4Region*, std::vector<const G4Region*>&) const;
 
@@ -52,6 +53,7 @@ private:
   bool                          savePDandCinAll;
   bool                          killInCalo, killInCaloEfH;
   bool                          killHeavy, trackNeutrino, killDeltaRay;
+  bool                          killExtra;
   bool                          killGamma;
   double                        limitEnergyForVacuum;
   double                        kmaxIon, kmaxNeutron, kmaxProton;
@@ -69,9 +71,11 @@ private:
   std::vector<const G4Region*>  lowdensRegions;
   std::vector<const G4Region*>  deadRegions;
 
+  G4VSolid*                     worldSolid;
   const TrackingAction*         trackAction;
   const CMSSteppingVerbose*     steppingVerbose;
   NewTrackAction*               newTA;
+  TrackInformationExtractor     extractor;
 
   // Russian roulette regions
   const G4Region*               regionEcal;
@@ -84,31 +88,23 @@ private:
   // Russian roulette energy limits
   double                        gRusRoEnerLim;
   double                        nRusRoEnerLim;
-  double                        pRusRoEnerLim;
 
   // Russian roulette factors
   double                        gRusRoEcal;
   double                        nRusRoEcal;
-  double                        pRusRoEcal;
   double                        gRusRoHcal;
   double                        nRusRoHcal;
-  double                        pRusRoHcal;
   double                        gRusRoMuonIron;
   double                        nRusRoMuonIron;
-  double                        pRusRoMuonIron;
   double                        gRusRoPreShower;
   double                        nRusRoPreShower;
-  double                        pRusRoPreShower;
   double                        gRusRoCastor;
   double                        nRusRoCastor;
-  double                        pRusRoCastor;
   double                        gRusRoWorld;
   double                        nRusRoWorld;
-  double                        pRusRoWorld;
   // flags
   bool                          gRRactive;
   bool                          nRRactive;
-  bool                          pRRactive;
 };
 
 #endif

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -8,22 +8,32 @@
 #include "G4Region.hh"
 #include "G4UserSteppingAction.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4VTouchable.hh"
 #include "G4Track.hh"
 
 #include <string>
 #include <vector>
 
 class EventAction;
-class G4VTouchable;
 class CMSSteppingVerbose;
+
+enum TrackStatus { 
+  sAlive = 0, 
+  sKilledByProcess = 1, 
+  sDeadRegion = 2, 
+  sOutOfTime = 3, 
+  sLowEnergy = 4, 
+  sLowEnergyInVacuum = 5
+};
 
 class SteppingAction: public G4UserSteppingAction {
 
 public:
-  SteppingAction(EventAction * ea,const edm::ParameterSet & ps, const CMSSteppingVerbose*);
+  explicit SteppingAction(EventAction * ea, const edm::ParameterSet & ps, 
+			  const CMSSteppingVerbose*, bool hasW);
   virtual ~SteppingAction();
 
-  virtual void UserSteppingAction(const G4Step * aStep);
+  virtual void UserSteppingAction(const G4Step * aStep) final;
   
   SimActivityRegistry::G4StepSignal m_g4StepSignal;
 
@@ -31,17 +41,15 @@ private:
 
   bool initPointer();
 
-  bool killInsideDeadRegion(G4Track * theTrack, const G4Region* reg) const;
-  bool catchLongLived(G4Track* theTrack, const G4Region* reg) const;
-  bool killLowEnergy(const G4Step * aStep) const;
+  bool isInsideDeadRegion(const G4Region* reg) const;
+  bool isOutOfTimeWindow(G4Track* theTrack, const G4Region* reg) const;
+  bool isThisVolume(const G4VTouchable* touch, const G4VPhysicalVolume* pv) const;
 
-  bool isThisVolume(const G4VTouchable* touch, G4VPhysicalVolume* pv) const;
-  void PrintKilledTrack(const G4Track*, const std::string&) const;
-
-private:
+  bool isLowEnergy(const G4Step * aStep) const;
+  void PrintKilledTrack(const G4Track*, const TrackStatus&) const;
 
   EventAction                   *eventAction_;
-  G4VPhysicalVolume             *tracker, *calo;
+  const G4VPhysicalVolume       *tracker, *calo;
   const CMSSteppingVerbose*     steppingVerbose;
   double                        theCriticalEnergyForVacuum;
   double                        theCriticalDensity;
@@ -60,7 +68,39 @@ private:
 
   bool                          initialized;
   bool                          killBeamPipe;
-
+  bool                          hasWatcher;
 };
+
+inline bool SteppingAction::isInsideDeadRegion(const G4Region* reg) const
+{
+  bool res = false;
+  for(unsigned int i=0; i<ndeadRegions; ++i) {
+    if(reg == deadRegions[i]) {
+      res = true;
+      break;
+    }
+  }
+  return res;
+}
+
+inline bool 
+SteppingAction::isOutOfTimeWindow(G4Track* theTrack, const G4Region* reg) const
+{
+  double tofM = maxTrackTime;
+  for (unsigned int i=0; i<numberTimes; ++i) {
+    if (reg == maxTimeRegions[i]) {
+      tofM = maxTrackTimes[i];
+      break;
+    }
+  }
+  return (theTrack->GetGlobalTime() > tofM) ? true : false;
+}
+
+inline bool SteppingAction::isThisVolume(const G4VTouchable* touch, 
+					 const G4VPhysicalVolume* pv) const
+{
+  int level = (touch->GetHistoryDepth())+1;
+  return (level >= 3) ? (touch->GetVolume(level - 3) == pv) : false; 
+}
 
 #endif

--- a/SimG4Core/Application/interface/TrackingAction.h
+++ b/SimG4Core/Application/interface/TrackingAction.h
@@ -3,9 +3,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+#include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 
 #include "G4UserTrackingAction.hh"
-#include "G4VSolid.hh"
 
 class EventAction;
 class TrackWithHistory; 
@@ -23,22 +23,21 @@ public:
     virtual void PreUserTrackingAction(const G4Track * aTrack);
     virtual void PostUserTrackingAction(const G4Track * aTrack);
 
-    TrackWithHistory * currentTrackWithHistory() { return currentTrack_; }
-    const G4Track * geant4Track() const { return g4Track_; }
-    G4TrackingManager * getTrackManager();
+    inline TrackWithHistory* currentTrackWithHistory() { return currentTrack_; }
+    inline const G4Track* geant4Track() const { return g4Track_; }
+    inline G4TrackingManager * getTrackManager() { return fpTrackingManager; }
 
     SimActivityRegistry::BeginOfTrackSignal m_beginOfTrackSignal;
     SimActivityRegistry::EndOfTrackSignal m_endOfTrackSignal;
 
 private:
+
+    TrackInformationExtractor extractor_;
     EventAction * eventAction_;
     TrackWithHistory * currentTrack_;
     CMSSteppingVerbose* steppingVerbose_;
     const G4Track * g4Track_;
-    G4VSolid * worldSolid;
-    bool detailedTiming;
-    bool checkTrack;
-    int  trackMgrVerbose;
+    bool checkTrack_;
 };
 
 #endif

--- a/SimG4Core/Application/src/EventAction.cc
+++ b/SimG4Core/Application/src/EventAction.cc
@@ -29,20 +29,11 @@ EventAction::~EventAction() {}
     
 void EventAction::BeginOfEventAction(const G4Event * anEvent)
 {
-  if (std::ifstream(m_stopFile.c_str()))
-    {
-      edm::LogWarning("SimG4CoreApplication")
-        << "BeginOfEventAction: termination signal received at event "
-	<< anEvent->GetEventID();
-      /*
-        G4cout << "BeginOfEventAction: termination signal received at event "
-	       << anEvent->GetEventID() << G4endl;
-      */
-      m_runInterface->abortRun(true);
-    }
   m_trackManager->reset();
+
   BeginOfEvent e(anEvent);
   m_beginOfEventSignal(&e);
+
   if(nullptr != m_SteppingVerbose) { m_SteppingVerbose->BeginOfEvent(anEvent); }
 }
 
@@ -52,8 +43,6 @@ void EventAction::EndOfEventAction(const G4Event * anEvent)
     {
       edm::LogInfo("SimG4CoreApplication") << " Event " << anEvent->GetEventID()
 					   << " Random number: " << G4UniformRand();  
-      //std::cout << " Event " << anEvent->GetEventID()
-      //	<< " Random number: " << G4UniformRand() << std::endl;  
       //CLHEP::HepRandom::showEngineStatus();
     }
   if (std::ifstream(m_stopFile.c_str()))
@@ -82,14 +71,8 @@ void EventAction::EndOfEventAction(const G4Event * anEvent)
   m_trackManager->cleanTkCaloStateInfoMap();
 }
 
-void EventAction::addTrack(TrackWithHistory* iTrack, bool inHistory, 
-			   bool withAncestor)
-{
-  m_trackManager->addTrack(iTrack, inHistory, withAncestor);
-}
-
-void EventAction::addTkCaloStateInfo(uint32_t t,const std::pair< math::XYZVectorD,
-				     math::XYZTLorentzVectorD>& p)
+void EventAction::addTkCaloStateInfo(uint32_t t,
+				     const std::pair<math::XYZVectorD,math::XYZTLorentzVectorD>& p) 
 {
   m_trackManager->addTkCaloStateInfo(t,p);
 }

--- a/SimG4Core/Application/src/RunAction.cc
+++ b/SimG4Core/Application/src/RunAction.cc
@@ -10,12 +10,13 @@
 #include <iostream>
 #include <fstream>
 
-//using std::cout;
-//using std::endl;
- 
-RunAction::RunAction(const edm::ParameterSet& p, SimRunInterface* rm) 
-   : m_runInterface(rm), 
-     m_stopFile(p.getParameter<std::string>("StopFile")), m_timer(0) 
+RunAction::RunAction(const edm::ParameterSet& p, SimRunInterface* rm, bool master) 
+  : m_runInterface(rm), 
+    m_stopFile(p.getParameter<std::string>("StopFile")),
+    m_timer(nullptr), m_isMaster(master)
+{}
+
+RunAction::~RunAction()
 {}
 
 void RunAction::BeginOfRunAction(const G4Run * aRun)
@@ -29,7 +30,7 @@ void RunAction::BeginOfRunAction(const G4Run * aRun)
   BeginOfRun r(aRun);
   m_beginOfRunSignal(&r);
   /*
-  if (isMaster) {
+  if (m_isMaster) {
     m_timer = new G4Timer();
     m_timer->Start();
   }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -73,14 +73,13 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_p(p),m_fieldBuilder(nullptr)
 {    
   m_currentRun = nullptr;
+  m_UIsession.reset(new CustomUIsession());
   m_kernel = new G4MTRunManagerKernel();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");
   m_FieldFile = p.getUntrackedParameter<std::string>("FileNameField","");
   m_RegionFile = p.getUntrackedParameter<std::string>("FileNameRegions","");
-
-  m_UIsession.reset(new CustomUIsession());
 }
 
 RunManagerMT::~RunManagerMT() 
@@ -226,7 +225,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
 void RunManagerMT::initializeUserActions() {
   m_runInterface.reset(new SimRunInterface(this, true));
-  m_userRunAction = new RunAction(m_pRunAction, m_runInterface.get());
+  m_userRunAction = new RunAction(m_pRunAction, m_runInterface.get(), true);
   Connect(m_userRunAction);
 }
 

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -2,7 +2,6 @@
 #include "SimG4Core/Application/interface/TrackingAction.h"
 #include "SimG4Core/Notification/interface/NewTrackAction.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -13,10 +12,9 @@
 #include "G4RegionStore.hh"
 #include "Randomize.hh"
 #include "G4SystemOfUnits.hh"
-
-#include<algorithm>
-
-//#define DebugLog
+#include "G4VSolid.hh"
+//#include "G4PhysicalVolumeStore.hh"
+#include "G4TransportationManager.hh"
 
 StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterSet & p,
 			       const CMSSteppingVerbose* sv)
@@ -62,7 +60,6 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
 
   gRusRoEnerLim = p.getParameter<double>("RusRoGammaEnergyLimit")*MeV;
   nRusRoEnerLim = p.getParameter<double>("RusRoNeutronEnergyLimit")*MeV;
-  pRusRoEnerLim = p.getParameter<double>("RusRoProtonEnergyLimit")*MeV;
 
   gRusRoEcal = p.getParameter<double>("RusRoEcalGamma");
   gRusRoHcal = p.getParameter<double>("RusRoHcalGamma");
@@ -78,16 +75,8 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   nRusRoCastor = p.getParameter<double>("RusRoCastorNeutron");
   nRusRoWorld = p.getParameter<double>("RusRoWorldNeutron");
 
-  pRusRoEcal = p.getParameter<double>("RusRoEcalProton");
-  pRusRoHcal = p.getParameter<double>("RusRoHcalProton");
-  pRusRoMuonIron = p.getParameter<double>("RusRoMuonIronProton");
-  pRusRoPreShower = p.getParameter<double>("RusRoPreShowerProton");
-  pRusRoCastor = p.getParameter<double>("RusRoCastorProton");
-  pRusRoWorld = p.getParameter<double>("RusRoWorldProton");
-
   gRRactive = false;
   nRRactive = false;
-  pRRactive = false;
   if(gRusRoEnerLim > 0.0 && 
      (gRusRoEcal < 1.0 || gRusRoHcal < 1.0 || 
       gRusRoMuonIron < 1.0 || gRusRoPreShower < 1.0 || gRusRoCastor < 1.0 ||
@@ -96,10 +85,6 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
      (nRusRoEcal < 1.0 || nRusRoHcal < 1.0 || 
       nRusRoMuonIron < 1.0 || nRusRoPreShower < 1.0 || nRusRoCastor < 1.0 ||
       nRusRoWorld < 1.0)) { nRRactive = true; }
-  if(pRusRoEnerLim > 0.0 && 
-     (pRusRoEcal < 1.0 || pRusRoHcal < 1.0 || 
-      pRusRoMuonIron < 1.0 || pRusRoPreShower < 1.0 || pRusRoCastor < 1.0 ||
-      pRusRoWorld < 1.0)) { pRRactive = true; }
 
   if ( p.exists("TestKillingOptions") ) {
     killInCalo = (p.getParameter<edm::ParameterSet>("TestKillingOptions"))
@@ -139,6 +124,7 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
 					 << kmaxNeutron/MeV << " MeV and ions"
 					 << " below " << kmaxIon/MeV << " MeV";
   }
+  killExtra = killDeltaRay || killHeavy || killInCalo || killInCaloEfH;
 
   edm::LogInfo("SimG4CoreApplication") << "StackingAction kill tracks with "
 				       << "time larger than " << maxTrackTime/ns
@@ -187,18 +173,6 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
       << "               CASTOR Prob= " << nRusRoCastor << "\n"
       << "                World Prob= " << nRusRoWorld;
   }
-  if(pRRactive) {
-    edm::LogInfo("SimG4CoreApplication") 
-      << "StackingAction: "
-      << "Russian Roulette for proton Elimit(MeV)= " 
-      << pRusRoEnerLim/MeV << "\n"
-      << "                 ECAL Prob= " << pRusRoEcal << "\n"
-      << "                 HCAL Prob= " << pRusRoHcal << "\n"
-      << "             MuonIron Prob= " << pRusRoMuonIron << "\n"
-      << "            PreShower Prob= " << pRusRoPreShower << "\n"
-      << "               CASTOR Prob= " << pRusRoCastor << "\n"
-      << "                World Prob= " << pRusRoWorld;
-  }
 
   if(savePDandCinTracker) {
     edm::LogInfo("SimG4CoreApplication") << "StackingAction Tracker regions: ";
@@ -212,6 +186,7 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
     edm::LogInfo("SimG4CoreApplication") << "StackingAction Muon regions: ";
     printRegions(muonRegions,"Muon"); 
   }
+  worldSolid = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume()->GetLogicalVolume()->GetSolid();
 }
 
 StackingAction::~StackingAction() 
@@ -223,195 +198,149 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track * aTra
 {
   // G4 interface part
   G4ClassificationOfNewTrack classification = fUrgent;
-  if (aTrack->GetCreatorProcess()==0 || aTrack->GetParentID()==0) {
-    /*
-    std::cout << "StackingAction: primary weight= " 
-	      << aTrack->GetWeight() << " "
-	      << aTrack->GetDefinition()->GetParticleName()
-	      << " " << aTrack->GetKineticEnergy()
-	      << " Id=" << aTrack->GetTrackID()
-	      << "  trackInfo " << aTrack->GetUserInformation() 
-	      << std::endl;
-    */
-    newTA->primary(aTrack);
-    /*
-    if (!trackNeutrino) {
-      int pdg = std::abs(aTrack->GetDefinition()->GetPDGEncoding());
-      if (pdg == 12 || pdg == 14 || pdg == 16 || pdg == 18) {
-	classification = fKill;
-      }
-    }
-    */
-  } else if (aTrack->GetTouchable() == 0) {
-    edm::LogError("SimG4CoreApplication")
-      << "StackingAction: no touchable for track " << aTrack->GetTrackID()
-      << " from " << aTrack->GetParentID()
-      << " with PDG code " << aTrack->GetDefinition()->GetParticleName();
-    classification = fKill;
-  } else {
-    int pdg = aTrack->GetDefinition()->GetPDGEncoding();
-    double ke  = aTrack->GetKineticEnergy();
+  int pdg = aTrack->GetDefinition()->GetPDGEncoding();
+  int abspdg = std::abs(pdg);
 
-    if (aTrack->GetTrackStatus() == fStopAndKill) { classification = fKill; }
-    if (killHeavy && classification != fKill) {
-      if (((pdg/1000000000 == 1) && (((pdg/10000)%100) > 0) && 
-	   (((pdg/10)%100) > 0) && (ke<kmaxIon)) || 
-	  ((pdg == 2212) && (ke < kmaxProton)) ||
-	  ((pdg == 2112) && (ke < kmaxNeutron))) { classification = fKill; }
-    }
-    if (!trackNeutrino  && classification != fKill) {
-      if (pdg == 12 || pdg == 14 || pdg == 16 || pdg == 18 ||
-	  pdg ==-12 || pdg ==-14 || pdg ==-16 || pdg ==-18 ) 
-	classification = fKill;
-    }
-    if (classification != fKill && isItLongLived(aTrack)) 
-      { classification = fKill; }
-    
-    if (classification != fKill && killGamma && pdg == 22 && ke < kmaxGamma) 
-      { 
-	classification = fKill; 
-	//std::cout << "### next gamma killed E(MeV)= " << ke
-	//	  << "  " <<  aTrack->GetCreatorProcess()->GetProcessName()
-	//	  << std::endl;
-      }
-    
-
-    if (killDeltaRay && classification != fKill 
-	&& aTrack->GetCreatorProcess()->GetProcessSubType() == fIonisation) {
+  // primary
+  if (aTrack->GetCreatorProcess()==nullptr || aTrack->GetParentID()==0) {
+    if (!trackNeutrino && (abspdg == 12 || abspdg == 14 || abspdg == 16 || abspdg == 18)) {
       classification = fKill;
+    } else if (worldSolid->Inside(aTrack->GetVertexPosition()) == kOutside) {
+      classification = fKill;
+      //  G4cout << "Kill primary track outside world volume " << aTrack->GetTrackID() << G4endl;
+    } else {
+      newTA->primary(aTrack);
     }
+  } else {
 
+    // secondary
     const G4Region* reg = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
-    if (killInCalo && classification != fKill 
-	&& isThisRegion(reg, caloRegions)) {
-      classification = fKill; 
-    }
-    if (classification != fKill && ke <= limitEnergyForVacuum  
-	&& isThisRegion(reg, lowdensRegions)) {
-      classification = fKill; 
-    }
-    if (classification != fKill && isThisRegion(reg, deadRegions)) {
-      classification = fKill; 
-    }
+    // definetly killed tracks
+    if (aTrack->GetTrackStatus() == fStopAndKill) { classification = fKill; }
+    else if (!trackNeutrino && (abspdg == 12 || abspdg == 14 || abspdg == 16 || abspdg == 18)) 
+      { classification = fKill; }
+    else if (isItOutOfTimeWindow(reg, aTrack)) { classification = fKill; }
 
-    // Russian roulette && MC truth
-    if(classification != fKill) {
-      const G4Track * mother = trackAction->geant4Track();
-      int flag = 0;
-      if(savePDandCinAll) {
-	flag = isItPrimaryDecayProductOrConversion(aTrack, *mother);
+    // potentially good for tracking
+    else {
+      double ke  = aTrack->GetKineticEnergy();
+
+      // kill tracks in specific regions
+      if (classification != fKill && isThisRegion(reg, deadRegions)) {
+	classification = fKill; 
+      }
+      if (ke <= limitEnergyForVacuum && isThisRegion(reg, lowdensRegions) ) {
+	classification = fKill; 
+
       } else {
-	if ((savePDandCinTracker && isThisRegion(reg,trackerRegions)) ||
-	    (savePDandCinCalo    && isThisRegion(reg,caloRegions)) ||
-	    (savePDandCinMuon    && isThisRegion(reg,muonRegions))) {
-	  flag = isItPrimaryDecayProductOrConversion(aTrack, *mother);
-	}
-      }
-      if (saveFirstSecondary && 0 == flag) { 
-	flag = isItFromPrimary(*mother, flag); 
-      }
-
-      // Russian roulette
-      if(2112 == pdg || 22 == pdg || 2212 == pdg) {
-	double currentWeight = aTrack->GetWeight();
-
-	if(1.0 >= currentWeight) {
-	  double prob = 1.0;
-	  double elim = 0.0;
-
-	  // neutron
-	  if(nRRactive && pdg == 2112) {
-	    elim = nRusRoEnerLim;
-	    if(reg == regionEcal)             { prob = nRusRoEcal; }
-	    else if(reg == regionHcal)        { prob = nRusRoHcal; }
-	    else if(reg == regionMuonIron)    { prob = nRusRoMuonIron; }
-	    else if(reg == regionPreShower)   { prob = nRusRoPreShower; }
-	    else if(reg == regionCastor)      { prob = nRusRoCastor; }
-	    else if(reg == regionWorld)       { prob = nRusRoWorld; }
-
-	    // gamma
-	  } else if(gRRactive && pdg == 22) {
-	    elim = gRusRoEnerLim;
-	    if(reg == regionEcal || reg == regionPreShower) {
-              if(rrApplicable(aTrack, *mother)) {
-		if(reg == regionEcal)         { prob = gRusRoEcal; }
-                else                          { prob = gRusRoPreShower; }
-	      }
-	    } else {
-	      if(reg == regionHcal)           { prob = gRusRoHcal; }
-	      else if(reg == regionMuonIron)  { prob = gRusRoMuonIron; }
-	      else if(reg == regionCastor)    { prob = gRusRoCastor; }
-	      else if(reg == regionWorld)     { prob = gRusRoWorld; }
-	    }
-
-	    // proton
-	  } else if(pRRactive && pdg == 2212) {
-	    elim = pRusRoEnerLim;
-	    if(reg == regionEcal)             { prob = pRusRoEcal; }
-	    else if(reg == regionHcal)        { prob = pRusRoHcal; }
-	    else if(reg == regionMuonIron)    { prob = pRusRoMuonIron; }
-	    else if(reg == regionPreShower)   { prob = pRusRoPreShower; }
-	    else if(reg == regionCastor)      { prob = pRusRoCastor; }
-	    else if(reg == regionWorld)       { prob = pRusRoWorld; }
+	// very low-energy gamma
+	if (pdg == 22 && killGamma && ke < kmaxGamma) { classification = fKill; }
+      
+	// specific track killing - not for production
+	if(killExtra && classification != fKill) {
+	  if (killHeavy && classification != fKill) {
+	    if (((pdg/1000000000 == 1) && (((pdg/10000)%100) > 0) && 
+		 (((pdg/10)%100) > 0) && (ke<kmaxIon)) || 
+		((pdg == 2212) && (ke < kmaxProton)) ||
+		((pdg == 2112) && (ke < kmaxNeutron))) { classification = fKill; }
 	  }
-	  if(prob < 1.0 && aTrack->GetKineticEnergy() < elim) {
-	    if(G4UniformRand() < prob) {
-	      const_cast<G4Track*>(aTrack)->SetWeight(currentWeight/prob);
-	    } else {
-	      classification = fKill;
-	    }
+    
+	  if (killDeltaRay && classification != fKill 
+	      && aTrack->GetCreatorProcess()->GetProcessSubType() == fIonisation) {
+	    classification = fKill;
 	  }
-	}
-      }
-	
-      if(classification != fKill && killInCaloEfH) {
-	int pdgMother = mother->GetDefinition()->GetPDGEncoding();
-	if ( (pdg == 22 || std::abs(pdg) == 11) && 
-	     (std::abs(pdgMother) < 11 || std::abs(pdgMother) > 17) && 
-	     pdgMother != 22  ) {
-	  if ( isThisRegion(reg,caloRegions)) { 
+	  if (killInCalo && classification != fKill 
+	      && isThisRegion(reg, caloRegions)) {
 	    classification = fKill; 
 	  }
+	  if (killInCaloEfH && classification != fKill) {
+	    int pdgMother = std::abs(trackAction->geant4Track()->GetDefinition()->GetPDGEncoding());
+	    if ((pdg == 22 || abspdg == 11) && pdgMother != 11 && pdgMother != 22 && 
+		isThisRegion(reg,caloRegions)) { 
+	      classification = fKill; 
+	    }
+	  }
+	}
+
+	// Russian roulette && MC truth
+	if(classification != fKill) {
+	  const G4Track* mother = trackAction->geant4Track();
+	  int flag = 0;
+	  if(savePDandCinAll) {
+	    flag = isItPrimaryDecayProductOrConversion(aTrack, *mother);
+	  } else {
+	    if ((savePDandCinTracker && isThisRegion(reg,trackerRegions)) ||
+		(savePDandCinCalo    && isThisRegion(reg,caloRegions)) ||
+		(savePDandCinMuon    && isThisRegion(reg,muonRegions))) {
+	      flag = isItPrimaryDecayProductOrConversion(aTrack, *mother);
+	    }
+	  }
+	  if (saveFirstSecondary && 0 == flag) { 
+	    flag = isItFromPrimary(*mother, flag); 
+	  }
+
+	  // Russian roulette
+	  if(2112 == pdg || 22 == pdg) {
+	    double currentWeight = aTrack->GetWeight();
+
+	    if(1.0 >= currentWeight) {
+	      double prob = 1.0;
+	      double elim = 0.0;
+
+	      // neutron
+	      if(nRRactive && pdg == 2112) {
+		elim = nRusRoEnerLim;
+		if(reg == regionEcal)             { prob = nRusRoEcal; }
+		else if(reg == regionHcal)        { prob = nRusRoHcal; }
+		else if(reg == regionMuonIron)    { prob = nRusRoMuonIron; }
+		else if(reg == regionPreShower)   { prob = nRusRoPreShower; }
+		else if(reg == regionCastor)      { prob = nRusRoCastor; }
+		else if(reg == regionWorld)       { prob = nRusRoWorld; }
+
+		// gamma
+	      } else if(gRRactive && pdg == 22) {
+		elim = gRusRoEnerLim;
+		if(reg == regionEcal || reg == regionPreShower) {
+		  if(rrApplicable(aTrack, *mother)) {
+		    if(reg == regionEcal)         { prob = gRusRoEcal; }
+		    else                          { prob = gRusRoPreShower; }
+		  }
+		} else {
+		  if(reg == regionHcal)           { prob = gRusRoHcal; }
+		  else if(reg == regionMuonIron)  { prob = gRusRoMuonIron; }
+		  else if(reg == regionCastor)    { prob = gRusRoCastor; }
+		  else if(reg == regionWorld)     { prob = gRusRoWorld; }
+		}
+	      }
+	      if(prob < 1.0 && aTrack->GetKineticEnergy() < elim) {
+		if(G4UniformRand() < prob) {
+		  const_cast<G4Track*>(aTrack)->SetWeight(currentWeight/prob);
+		} else {
+		  classification = fKill;
+		}
+	      }
+	    }
+	  }
+	  if (classification != fKill) {
+	    newTA->secondary(aTrack, *mother, flag);
+	  }
+	  LogDebug("SimG4CoreApplication") << "StackingAction:Classify Track "
+					   << aTrack->GetTrackID() << " Parent " 
+					   << aTrack->GetParentID() << " Type "
+					   << aTrack->GetDefinition()->GetParticleName() 
+					   << " K.E. " << aTrack->GetKineticEnergy()/MeV
+					   << " MeV from process/subprocess " 
+					   << aTrack->GetCreatorProcess()->GetProcessType() 
+					   << "|"
+					   <<aTrack->GetCreatorProcess()->GetProcessSubType()
+					   << " as " << classification << " Flag " << flag;
 	}
       }
-      
-      if (classification != fKill) {
-	newTA->secondary(aTrack, *mother, flag);
-      }
     }
-  /*
-  double wt2 = aTrack->GetWeight();
-  if(wt2 != 1.0) { 
-    G4Region* reg = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
-    std::cout << "StackingAction: weight= " << wt2 << " "
-	      << aTrack->GetDefinition()->GetParticleName()
-	      << " " << aTrack->GetKineticEnergy()
-	      << " Id=" << aTrack->GetTrackID()
-	      << " IdP=" << aTrack->GetParentID();
-    const G4VProcess* pr = aTrack->GetCreatorProcess();
-    if(pr) std::cout << " from  " << pr->GetProcessName();
-    if(reg) std::cout << " in  " << reg->GetName()
-		      << "  trackInfo " << aTrack->GetUserInformation(); 
-    std::cout << std::endl;
   }
-  */
-  }
-#ifdef DebugLog
-  LogDebug("SimG4CoreApplication") << "StackingAction:Classify Track "
-				   << aTrack->GetTrackID() << " Parent " 
-				   << aTrack->GetParentID() << " Type "
-				   << aTrack->GetDefinition()->GetParticleName() 
-				   << " K.E. " << aTrack->GetKineticEnergy()/MeV
-				   << " MeV from process/subprocess " 
-				   << aTrack->GetCreatorProcess()->GetProcessType() 
-				   << "|"
-				   <<aTrack->GetCreatorProcess()->GetProcessSubType()
-				   << " as " << classification << " Flag " << flag;
-#endif
   if(nullptr != steppingVerbose) { 
     steppingVerbose->StackFilled(aTrack, (classification == fKill)); 
   }
-  
   return classification;
 }
 
@@ -429,28 +358,22 @@ void StackingAction::initPointer()
   for (rcite = rs->begin(); rcite != rs->end(); ++rcite) {
     const G4Region* reg = (*rcite);
     G4String rname = reg->GetName(); 
-    if ((gRusRoEcal < 1.0 || nRusRoEcal < 1.0 || pRusRoEcal < 1.0) && 
-	rname == "EcalRegion") {  
+    if ((gRusRoEcal < 1.0 || nRusRoEcal < 1.0) && rname == "EcalRegion") {  
       regionEcal = reg; 
     }
-    if ((gRusRoHcal < 1.0 || nRusRoHcal < 1.0 || pRusRoHcal < 1.0) && 
-	rname == "HcalRegion") {  
+    if ((gRusRoHcal < 1.0 || nRusRoHcal < 1.0) && rname == "HcalRegion") {  
       regionHcal = reg; 
     }
-    if ((gRusRoMuonIron < 1.0 || nRusRoMuonIron < 1.0 || pRusRoMuonIron < 1.0) && 
-	rname == "MuonIron") {  
+    if ((gRusRoMuonIron < 1.0 || nRusRoMuonIron < 1.0) && rname == "MuonIron") {  
       regionMuonIron = reg; 
     }
-    if ((gRusRoPreShower < 1.0 || nRusRoPreShower < 1.0 || pRusRoPreShower < 1.0) 
-	&& rname == "PreshowerRegion") {  
+    if ((gRusRoPreShower < 1.0 || nRusRoPreShower < 1.0) && rname == "PreshowerRegion") {  
       regionPreShower = reg; 
     }
-    if ((gRusRoCastor < 1.0 || nRusRoCastor < 1.0 || pRusRoCastor < 1.0) && 
-	rname == "CastorRegion") {  
+    if ((gRusRoCastor < 1.0 || nRusRoCastor < 1.0) && rname == "CastorRegion") {  
       regionCastor = reg; 
     }
-    if ((nRusRoWorld < 1.0 || nRusRoWorld < 1.0 || pRusRoWorld < 1.0) && 
-	rname == "DefaultRegionForTheWorld") {  
+    if ((nRusRoWorld < 1.0 || nRusRoWorld < 1.0) && rname == "DefaultRegionForTheWorld") {  
       regionWorld = reg; 
     }
 
@@ -513,7 +436,6 @@ int StackingAction::isItPrimaryDecayProductOrConversion(const G4Track * aTrack,
 							const G4Track & mother) const
 {
   int flag = 0;
-  TrackInformationExtractor extractor;
   const TrackInformation & motherInfo(extractor(mother));
   // Check whether mother is a primary
   if (motherInfo.isPrimary()) {
@@ -529,58 +451,33 @@ int StackingAction::isItPrimaryDecayProductOrConversion(const G4Track * aTrack,
 bool StackingAction::rrApplicable(const G4Track * aTrack,
 				  const G4Track & mother) const
 {
-  bool flag = true;
-  TrackInformationExtractor extractor;
   const TrackInformation & motherInfo(extractor(mother));
-  // Check whether mother is a primary
-  //if (motherInfo.isPrimary()) {
-  // }   
+
+  // Check whether mother is gamma, e+, e-
   int genID = motherInfo.genParticlePID();
-  if(22 == genID || 11 == genID || -11 == genID) { flag = false; }
-    
-  /*
-  //check if the primary was g, e+, e-
-  int genID = motherInfo.genParticlePID();
-  double genp = motherInfo.genParticleP();
-  std::cout << "Track# " << aTrack->GetTrackID() << "  " 
-	    << aTrack->GetDefinition()->GetParticleName()  
-	    << "  E(MeV)= " << aTrack->GetKineticEnergy()/MeV 
-	    << " mother: " << mother.GetTrackID()
-	    << "  " << mother.GetDefinition()->GetParticleName()
-	    << " E(GeV)= " <<  mother.GetKineticEnergy()/GeV
-	    << " flag: " << flag << " genID= " << genID 
-	    << " p(GeV)= " << genp/GeV << std::endl; 
-    */
-  return flag;
+  return (22 == genID || 11 == genID || -11 == genID) ? false : true;     
 }
 
 int StackingAction::isItFromPrimary(const G4Track & mother, int flagIn) const 
 {
   int flag = flagIn;
   if (flag != 1) {
-    TrackInformationExtractor extractor;
     const TrackInformation & motherInfo(extractor(mother));
     if (motherInfo.isPrimary()) { flag = 3; }
   }
   return flag;
 }
 
-bool StackingAction::isItLongLived(const G4Track * aTrack) const 
+ bool StackingAction::isItOutOfTimeWindow(const G4Region* reg, const G4Track* aTrack) const 
 {
-  bool   flag = false;
   double tofM = maxTrackTime;
-  if (numberTimes > 0) {
-    G4Region* reg = 
-      aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
-    for (unsigned int i=0; i<numberTimes; ++i) {
-      if (reg == maxTimeRegions[i]) {
-	tofM = maxTrackTimes[i];
-	break;
-      }
+  for (unsigned int i=0; i<numberTimes; ++i) {
+    if (reg == maxTimeRegions[i]) {
+      tofM = maxTrackTimes[i];
+      break;
     }
   }
-  if (aTrack->GetGlobalTime() > tofM) { flag = true; }
-  return flag;
+  return (aTrack->GetGlobalTime() > tofM) ? true : false;
 }
 
 void StackingAction::printRegions(const std::vector<const G4Region*>& reg, 

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -13,7 +13,6 @@
 #include "Randomize.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4VSolid.hh"
-//#include "G4PhysicalVolumeStore.hh"
 #include "G4TransportationManager.hh"
 
 StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterSet & p,

--- a/SimG4Core/Application/src/TrackingAction.cc
+++ b/SimG4Core/Application/src/TrackingAction.cc
@@ -6,29 +6,20 @@
 #include "SimG4Core/Notification/interface/EndOfTrack.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/TrackWithHistory.h"
-#include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4UImanager.hh" 
 #include "G4TrackingManager.hh"
-#include "G4PhysicalVolumeStore.hh"
-#include "G4TransportationManager.hh"
 
 //#define DebugLog
-
-//using namespace std;
 
 TrackingAction::TrackingAction(EventAction * e, const edm::ParameterSet & p,
 			       CMSSteppingVerbose* sv) 
   : eventAction_(e),currentTrack_(nullptr),steppingVerbose_(sv),g4Track_(nullptr),
-  detailedTiming(p.getUntrackedParameter<bool>("DetailedTiming",false)),
-  checkTrack(p.getUntrackedParameter<bool>("CheckTrack",false)),
-  trackMgrVerbose(p.getUntrackedParameter<int>("G4TrackManagerVerbosity",0)) 
-{
-  worldSolid = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume()->GetLogicalVolume()->GetSolid();
-}
+  checkTrack_(p.getUntrackedParameter<bool>("CheckTrack",false))
+{}
 
 TrackingAction::~TrackingAction() {}
 
@@ -37,43 +28,15 @@ void TrackingAction::PreUserTrackingAction(const G4Track * aTrack)
   g4Track_ = aTrack;
   currentTrack_ = new TrackWithHistory(aTrack);
 
-  /*
-    Trick suggested by Vladimir I. in order to debug with high 
-    level verbosity only a single problematic tracks
-  */      
-
-  /*
-    if ( aTrack->GetTrackID() == palce_here_the_trackid_of_problematic_tracks  ) {
-      G4UImanager::GetUIpointer()->ApplyCommand("/tracking/verbose 6");
-    } else if ( aTrack->GetTrackID() == place_here_the_trackid_of_following_track_to_donwgrade_the_severity ) {
-      G4UImanager::GetUIpointer()->ApplyCommand("/tracking/verbose 0");
-    }
-  */
   BeginOfTrack bt(aTrack);
   m_beginOfTrackSignal(&bt);
-
+ 
   TrackInformation * trkInfo = (TrackInformation *)aTrack->GetUserInformation();
   if(trkInfo && trkInfo->isPrimary()) {
     eventAction_->prepareForNewPrimary();
   }
-  /*
-    G4cout << "Track " << aTrack->GetTrackID() << " R " 
-    << (aTrack->GetVertexPosition()).r() << " Z " 
-    << std::abs((aTrack->GetVertexPosition()).z()) << G4endl << "Top Solid " 
-    << worldSolid->GetName() << " is it inside " 
-    << worldSolid->Inside(aTrack->GetVertexPosition()) 
-    << " compared to " << kOutside << G4endl;
-  */
-  // VI: why this check is TrackingAction?
-  bool killed = false;
-  if (worldSolid->Inside(aTrack->GetVertexPosition()) == kOutside) {
-    //      G4cout << "Kill Track " << aTrack->GetTrackID() << G4endl;
-    G4Track* theTrack = (G4Track *)(aTrack);
-    theTrack->SetTrackStatus(fStopAndKill);
-    killed = true;
-  }
   if(nullptr != steppingVerbose_) { 
-    steppingVerbose_->TrackStarted(aTrack, killed); 
+    steppingVerbose_->TrackStarted(aTrack, false); 
   }
 }
 
@@ -81,8 +44,7 @@ void TrackingAction::PostUserTrackingAction(const G4Track * aTrack)
 {
   if (eventAction_->trackContainer() != nullptr) {
 
-    TrackInformationExtractor extractor;
-    if (extractor(aTrack).storeTrack()) {
+    if (extractor_(aTrack).storeTrack()) {
       currentTrack_->save();
 	  
       math::XYZVectorD pos((aTrack->GetStep()->GetPostStepPoint()->GetPosition()).x(),
@@ -101,13 +63,13 @@ void TrackingAction::PostUserTrackingAction(const G4Track * aTrack)
     }
 
     bool withAncestor = 
-      ((extractor(aTrack).getIDonCaloSurface() == aTrack->GetTrackID()) 
-       || (extractor(aTrack).isAncestor()));
+      ((extractor_(aTrack).getIDonCaloSurface() == aTrack->GetTrackID()) 
+       || (extractor_(aTrack).isAncestor()));
 
-    if (extractor(aTrack).isInHistory()) {
+    if (extractor_(aTrack).isInHistory()) {
 
       // check with end-of-track information
-      if(checkTrack) { currentTrack_->checkAtEnd(aTrack); }
+      if(checkTrack_) { currentTrack_->checkAtEnd(aTrack); }
 
       eventAction_->addTrack(currentTrack_, true, withAncestor);
       /*
@@ -140,15 +102,9 @@ void TrackingAction::PostUserTrackingAction(const G4Track * aTrack)
     }
   }
   if(nullptr != steppingVerbose_) { steppingVerbose_->TrackEnded(aTrack); }
+
   EndOfTrack et(aTrack);
   m_endOfTrackSignal(&et);
+ 
   currentTrack_ = nullptr; // reset for next track
-}
-
-G4TrackingManager * TrackingAction::getTrackManager()
-{
-  G4TrackingManager * theTrackingManager = nullptr;
-  theTrackingManager = fpTrackingManager;
-  theTrackingManager->SetVerboseLevel(trackMgrVerbose);
-  return theTrackingManager;
 }


### PR DESCRIPTION
A general clean-up of Geant4 User action classes:
  1) trying to reduce number of instructions (number of order of "if") in run time;
  2) few simple methods inlined;
  3) removed unnecessary headers;
  4) use some c++11 keywords;
  5) by default, kill primary neutrinos;
  6) removed code implementing Russian roulette for protons (not useful).
Results should be not affected. 
