### PR TITLE
Phase1 Pixel DQM Booking changes and GUI markers

### DIFF
--- a/DQM/SiPixelPhase1Common/interface/AbstractHistogram.h
+++ b/DQM/SiPixelPhase1Common/interface/AbstractHistogram.h
@@ -56,6 +56,16 @@ struct AbstractHistogram {
   MonitorElement* me = nullptr;
   TH1* th1 = nullptr;
 
+  // full set of metadata. _Only_ used during the booking method.
+  double range_x_min = 1e12;
+  double range_x_max = -1e12;
+  double range_y_min = 1e12;
+  double range_y_max = -1e12;
+  int range_x_nbins = 0;
+  int range_y_nbins = 0;
+  std::string name, title, xlabel, ylabel;
+  MonitorElement::Kind kind = MonitorElement::DQM_KIND_INVALID;
+
   ~AbstractHistogram() {
     // if both are set the ME should own the TH1
     if (th1 && !me) {

--- a/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
+++ b/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
@@ -184,15 +184,15 @@ class GeometryInterface {
   // This holds closures that compute the column values in step1.
   // can be a Vector since ids are dense.
   std::vector<std::function<Value(InterestingQuantities const& iq)>> extractors;
-  // An estimate of the max value for a column. Used for step1 EXTEND (but not
-  // step2)
+  // quantity range if it is known. Can be UNDEFINED, in this case booking will
+  // determine the range.
   // map for ease of use.
   std::map<ID, Value> max_value;
   std::map<ID, Value> min_value;
 
   void addExtractor(ID id,
                     std::function<Value(InterestingQuantities const& iq)> func,
-                    Value min, Value max) {
+                    Value min = UNDEFINED, Value max = UNDEFINED) {
     max_value[id] = max;
     min_value[id] = min;
     extractors[id] = func;

--- a/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
+++ b/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
@@ -58,20 +58,14 @@ class SiPixelPhase1Base : public DQMEDAnalyzer, public HistogramManagerHolder {
 // This wraps the Histogram Managers into a DQMEDHarvester. It 
 // provides sane default implementations, so most plugins don't care about this.
 // However, you have to instantiate one with the same config as your Analyzer 
-// to get the Harvesting one.
-// For custom harvesting, you have to derive from this one.
+// to get the Harvesting done.
+// For custom harvesting, you have to derive from this.
 class SiPixelPhase1Harvester : public DQMEDHarvester, public HistogramManagerHolder {
   public:
   SiPixelPhase1Harvester(const edm::ParameterSet& iConfig) 
     : DQMEDHarvester(), HistogramManagerHolder(iConfig) {};
 
-  void dqmEndLuminosityBlock(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup) {
-    for (HistogramManager& histoman : histo)
-      histoman.executeHarvestingOnline(iBooker, iGetter, eSetup);
-  };
-  void dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {
-    for (HistogramManager& histoman : histo)
-      histoman.executeHarvestingOffline(iBooker, iGetter);
-  };
+  void dqmEndLuminosityBlock(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup) ;
+  void dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
 };
 #endif

--- a/DQM/SiPixelPhase1Common/plugins/BuildFile.xml
+++ b/DQM/SiPixelPhase1Common/plugins/BuildFile.xml
@@ -1,0 +1,14 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="DataFormats/SiPixelDetId"/>
+<use   name="DQMServices/Core"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="CalibTracker/Records"/>
+<use   name="Alignment/TrackerAlignment"/>
+<use   name="CondFormats/GeometryObjects"/>
+<use   name="CondFormats/SiPixelObjects"/>
+<use   name="DQM/SiPixelPhase1Common"/>
+
+<flags EDM_PLUGIN="1"/>
+

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1Harvester.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1Harvester.cc
@@ -1,0 +1,5 @@
+// This is only to declare a plugin, the implementation is in the header. 
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiPixelPhase1Harvester);
+

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -2,8 +2,8 @@
 //
 // Package:    SiPixelPhase1Common
 // Class:      GeometryInterface
-// 
-// Geometry depedence goes here. 
+//
+// Geometry depedence goes here.
 //
 // Original Author:  Marcel Schneider
 
@@ -39,7 +39,7 @@ void GeometryInterface::load(edm::EventSetup const& iSetup) {
   loadFEDCabling(iSetup, iConfig);
   edm::LogInfo log("GeometryInterface");
   log << "Known colum names:\n";
-  for (auto e : ids) log << "+++ column: " << e.first 
+  for (auto e : ids) log << "+++ column: " << e.first
     << " ok " << bool(extractors[e.second]) << " min " << min_value[e.second] << " max " << max_value[e.second] << "\n";
   is_loaded = true;
 }
@@ -56,9 +56,9 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
     const TrackerTopology* tt;
     TrackerTopology::DetIdFields field;
     Value operator()(InterestingQuantities const& iq) {
-      if (tt->hasField(iq.sourceModule, field)) 
+      if (tt->hasField(iq.sourceModule, field))
         return tt->getField(iq.sourceModule, field);
-      else 
+      else
         return UNDEFINED;
     };
   };
@@ -99,7 +99,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
     auto endcap = pxendcap(iq);
     return endcap == 1 ? -disk : disk;
   };
- 
+
   // Get a Geometry
   edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
   iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
@@ -108,7 +108,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   // some parameters to record the ROCs here
   auto module_rows = iConfig.getParameter<int>("module_rows") - 1;
   auto module_cols = iConfig.getParameter<int>("module_cols") - 1;
-  
+
   // We need to track some extra stuff here for the Shells later.
   auto pxlayer  = extractors[intern("PXLayer")];
   auto pxladder = extractors[intern("PXLadder")];
@@ -159,7 +159,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
       if (blade == UNDEFINED) return UNDEFINED;
       if (blade <= innerring) return Value(1);
       else return Value(2);
-    }, UNDEFINED, UNDEFINED
+    }
   );
 
   addExtractor(intern("HalfCylinder"),
@@ -189,13 +189,13 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
       auto ladder = pxladder(iq);
       int frac = (int) ((ladder-1) / float(maxladders[layer]) * 4); // floor semantics
       Value quarter = maxladders[layer] / 4;
-      if (frac == 0) return -ladder + quarter + 1; // top right - +1 for gap 
-      if (frac == 1) return -ladder + quarter; // top left - 
+      if (frac == 0) return -ladder + quarter + 1; // top right - +1 for gap
+      if (frac == 1) return -ladder + quarter; // top left -
       if (frac == 2) return -ladder + quarter; // bot left - same
       if (frac == 3) return -ladder  + 4*quarter + quarter + 1; // bot right - like top right but wrap around
       assert(!"Shell logic problem");
       return UNDEFINED;
-    }, UNDEFINED, UNDEFINED
+    }
   );
 
   addExtractor(intern("signedModule"),
@@ -205,7 +205,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
       mod -= (maxmodule/2 + 1); // range -(max_module/2)..-1, 0..
       if (mod >= 0) mod += 1;    // range -(max_module/2)..-1, 1..
       return mod;
-    }, UNDEFINED, UNDEFINED
+    }
   );
 
   auto signedladder = extractors[intern("signedLadder")];
@@ -264,7 +264,7 @@ void GeometryInterface::loadModuleLevel(edm::EventSetup const& iSetup, const edm
     [] (InterestingQuantities const& iq) {
       return Value(iq.col);
     },
-    0, iConfig.getParameter<int>("module_cols") - 1 
+    0, iConfig.getParameter<int>("module_cols") - 1
   );
 
   int   n_rocs     = iConfig.getParameter<int>("n_rocs");
@@ -279,8 +279,7 @@ void GeometryInterface::loadModuleLevel(edm::EventSetup const& iSetup, const edm
       if (fedrow == 0) return Value(fedcol);
       if (fedrow == 1) return Value(n_rocs - 1 - fedcol);
       return UNDEFINED;
-    },
-    UNDEFINED, UNDEFINED
+    }
   );
 
   // arbitrary per-ladder numbering (for inefficiencies)
@@ -290,16 +289,14 @@ void GeometryInterface::loadModuleLevel(edm::EventSetup const& iSetup, const edm
       auto mod = pxmodule(iq);
       if (mod == UNDEFINED) return UNDEFINED;
       return Value(roc(iq) + n_rocs * (mod-1));
-    },
-    UNDEFINED, UNDEFINED
+    }
   );
   addExtractor(intern("ROCinBlade"),
     [pxmodule, pxpanel, roc, n_rocs] (InterestingQuantities const& iq) {
       auto mod = pxpanel(iq);
       if (mod == UNDEFINED) return UNDEFINED;
       return Value(roc(iq) + n_rocs * (mod-1));
-    },
-    UNDEFINED, UNDEFINED
+    }
   );
 
   addExtractor(intern("DetId"),

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -483,9 +483,9 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
         h.range_y_nbins = int(h.range_y_max - h.range_y_min);
       }
 
-      //std::cout << "+++ " << makePath(e.first) << " " << h.name << "\n";
-      //std::cout << "+++ min_x " << h.range_x_min << " max_x " << h.range_x_max << " bins " << h.range_x_nbins << "\n";
-      //std::cout << "+++ min_y " << h.range_y_min << " max_y " << h.range_y_max << " bins " << h.range_y_nbins << "\n";
+      std::cout << "+++ " << makePath(e.first) << " " << h.name << "\n";
+      std::cout << "+++ min_x " << h.range_x_min << " max_x " << h.range_x_max << " bins " << h.range_x_nbins << "\n";
+      std::cout << "+++ min_y " << h.range_y_min << " max_y " << h.range_y_max << " bins " << h.range_y_nbins << "\n";
 
       if (h.kind == MonitorElement::DQM_KIND_TH1F) {
         h.me = iBooker.book1D(h.name, (h.title + ";" + h.xlabel).c_str(),

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -80,7 +80,7 @@ void HistogramManager::executeStep1Spec(
           break;
         }
         case SummationStep::EXTEND_X:
-          assert((x == 0.0 && dimensions != 1) || 
+          assert((x == 0.0 && dimensions != 1) ||
                  (y == 0.0 && dimensions == 1) ||
                  !"Illegal EXTEND in step1");
           if (dimensions == 1) y = x;
@@ -115,7 +115,7 @@ void HistogramManager::executeStep1Spec(
           break;
         }
         case SummationStep::REDUCE:
-          // assert(step.arg == "MEAN") 
+          // assert(step.arg == "MEAN")
           z = y = x;
           x = 0.0;
           dimensions = 2; // Profile always needs 2D (or 3D) fill
@@ -144,7 +144,7 @@ void HistogramManager::executeStep1Spec(
     fastpath->fill(x, y);
   else /* dimensions == 3 */
     fastpath->fill(x, y, z);
-  
+
 }
 
 void HistogramManager::fill(double x, double y, DetId sourceModule,
@@ -218,7 +218,7 @@ void HistogramManager::executePerEventHarvesting() {
         significantvalues[i].values = e.first.values;
 
         bool defined = true;
-        for (auto v : e.first.values) 
+        for (auto v : e.first.values)
           defined &= (v.second != GeometryInterface::UNDEFINED);
         if (!defined) {
           range_undefined = true;
@@ -237,7 +237,7 @@ void HistogramManager::executePerEventHarvesting() {
       for (auto it = t.begin(); it != t.end(); ++it) {
         if (it->first.values.size() == s.steps[0].columns.size()) {
           bool defined = true;
-          for (auto v : it->first.values) 
+          for (auto v : it->first.values)
             defined &= (v.second != GeometryInterface::UNDEFINED);
           if (defined) {
             it = t.erase(it);
@@ -351,7 +351,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
               dimensions = 2;
               title = title + " per " + colname;
               name = name + "_per_" + colname;
-              if (do_profile) { // we loose the Z- (former Y-) label here 
+              if (do_profile) { // we loose the Z- (former Y-) label here
                 title = title + " (Z: " + ylabel + ")";
               }
               observed_y = significantvalues.get(col0).second;
@@ -422,7 +422,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
 
       AbstractHistogram& histo = t[significantvalues];
 
-      // track min and max values for all modules to get Geometry-dependent 
+      // track min and max values for all modules to get Geometry-dependent
       // things (e.g. #Ladders per Layer) right
       if (observed_x != GeometryInterface::UNDEFINED) {
         if (observed_x > histo.range_x_max) histo.range_x_max = observed_x;
@@ -465,8 +465,8 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
       }
       assert(histo.kind != MonitorElement::DQM_KIND_INVALID);
     }
-    // above, we only saved all the parameters, but did not book yet. This is 
-    // needed since we determine the ranges iteratively, but we need to know 
+    // above, we only saved all the parameters, but did not book yet. This is
+    // needed since we determine the ranges iteratively, but we need to know
     // them precisely for booking; they cannot be changed later.
     for (auto& e : t) {
       iBooker.setCurrentFolder(makePath(e.first));
@@ -482,10 +482,6 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
         h.range_y_max += 0.5;
         h.range_y_nbins = int(h.range_y_max - h.range_y_min);
       }
-
-      std::cout << "+++ " << makePath(e.first) << " " << h.name << "\n";
-      std::cout << "+++ min_x " << h.range_x_min << " max_x " << h.range_x_max << " bins " << h.range_x_nbins << "\n";
-      std::cout << "+++ min_y " << h.range_y_min << " max_y " << h.range_y_max << " bins " << h.range_y_nbins << "\n";
 
       if (h.kind == MonitorElement::DQM_KIND_TH1F) {
         h.me = iBooker.book1D(h.name, (h.title + ";" + h.xlabel).c_str(),
@@ -558,7 +554,7 @@ void HistogramManager::loadFromDQMStore(SummationSpecification& s, Table& t,
             break;
           }
           case SummationStep::REDUCE:
-            break; // not visible in name 
+            break; // not visible in name
           case SummationStep::CUSTOM:
           case SummationStep::NO_TYPE:
             assert(!"Illegal step; booking should have caught this.");
@@ -660,7 +656,7 @@ void HistogramManager::executeReduce(SummationStep& step, Table& t) {
       edm::LogError("HistogramManager") << "+++ Reduction '" << step.arg
                                         << " not yet implemented\n";
     }
-    new_histo.th1 = new TH1F(name.c_str(), (std::string("") + th1->GetTitle() 
+    new_histo.th1 = new TH1F(name.c_str(), (std::string("") + th1->GetTitle()
                                             + ";;" + label).c_str(), 1, 0, 1);
     new_histo.th1->SetBinContent(1, reduced_quantity);
     new_histo.th1->SetBinError(1, reduced_quantity_error);

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
@@ -1,5 +1,14 @@
-// This is only to declare a plugin, the implementation is in the header. 
+// This is a plugin implementation, but it is in src/ to make it possible to 
+// derive from it in other packages. In plugins/ there is a dummy that declares
+// the plugin.
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(SiPixelPhase1Harvester);
 
+void SiPixelPhase1Harvester::dqmEndLuminosityBlock(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup) {
+  for (HistogramManager& histoman : histo)
+    histoman.executeHarvestingOnline(iBooker, iGetter, eSetup);
+};
+void SiPixelPhase1Harvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {
+  for (HistogramManager& histoman : histo)
+    histoman.executeHarvestingOffline(iBooker, iGetter);
+};

--- a/DQM/SiPixelPhase1Digis/interface/SiPixelPhase1Digis.h
+++ b/DQM/SiPixelPhase1Digis/interface/SiPixelPhase1Digis.h
@@ -37,4 +37,20 @@ class SiPixelPhase1Digis : public SiPixelPhase1Base {
 
 };
 
+class SiPixelPhase1DigisHarvester : public SiPixelPhase1Harvester {
+  enum {
+    ADC,
+    NDIGIS,
+    NDIGIS_FED, 
+    EVENT,
+    MAP,
+    DEBUG,
+
+    MAX_HIST
+  };
+  public:
+  explicit SiPixelPhase1DigisHarvester(const edm::ParameterSet& conf);
+
+};
+
 #endif

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -33,9 +33,9 @@ SiPixelPhase1DigisNdigis = DefaultHisto.clone(
 )
 
 SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
-  name = "digis",  # This is the same as above up to the ranges. maybe we 
-  title = "Digis", # should allow setting the range per spec, but OTOH a 
-  xlabel = "digis",# HistogramManager is almost free.
+  name = "feddigis", # This is the same as above up to the ranges. maybe we 
+  title = "Digis",   # should allow setting the range per spec, but OTOH a 
+  xlabel = "digis",  # HistogramManager is almost free.
   range_min = 0,
   range_max = 1000,
   range_nbins = 200,
@@ -45,6 +45,12 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
                    .reduce("COUNT")
                    .groupBy("FED")
                    .groupBy("", "EXTEND_Y")
+                   .save(),
+    Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection", "EXTEND_Y")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_X")
+                   .custom("ratio_to_average")
                    .save()
   )
 )
@@ -115,7 +121,7 @@ SiPixelPhase1DigisAnalyzer = cms.EDAnalyzer("SiPixelPhase1Digis",
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1DigisHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1DigisHarvester = cms.EDAnalyzer("SiPixelPhase1DigisHarvester",
         histograms = SiPixelPhase1DigisConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1Digis/src/SiPixelPhase1DigisHarvester.cc
+++ b/DQM/SiPixelPhase1Digis/src/SiPixelPhase1DigisHarvester.cc
@@ -1,0 +1,41 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1DigisHarvester
+// Class:       SiPixelPhase1DigisHarvester
+//
+
+// Original Author: Marcel Schneider
+
+#include "DQM/SiPixelPhase1Digis/interface/SiPixelPhase1Digis.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+SiPixelPhase1DigisHarvester::SiPixelPhase1DigisHarvester(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Harvester(iConfig) 
+{
+  histo[NDIGIS_FED].setCustomHandler([&] (SummationStep& s, HistogramManager::Table & t) {
+    for (auto e : t) {
+      TH1* th1 = e.second.th1;
+      assert(th1->GetDimension() == 2);
+
+      for (int x = 1; x <= th1->GetNbinsX(); x++) {
+        double sum = 0;
+        int nonzero = 0;
+        for (int y = 1; y <= th1->GetNbinsY(); y++) {
+          double val = th1->GetBinContent(x, y);
+          sum += val;
+          if (val != 0.0) nonzero++;
+        }
+
+        if (nonzero == 0) continue;
+
+        double avg = sum / nonzero;
+
+        for (int y = 1; y <= th1->GetNbinsY(); y++) {
+          th1->SetBinContent(x, y, th1->GetBinContent(x, y) / avg);
+        }
+      }
+    }
+  });
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1DigisHarvester);


### PR DESCRIPTION
This PR contains a number of different changes that accumulated over time.
- The main one is a slight restructuring in the booking process. This allows correctly computing the axis ranges for many more 2D plots (main application are 2D maps per layer, where ladder counts vary per layer). I am not happy with what the code looks like now, but it seems unlikely there is a simpler solution.
- With this change,  it also makes sense to add ROCs to the booking process. No real usages now, but 2D maps with ROC granularity will come. Main drawback here is that it slows down the booking process 4x. But if we figure out it is to slow, there is loads of low-hanging fruit to make it faster.
- There was a problem with how plugins were declared in the SiPixelPhase1Common package. It was pure luck that this worked before, it should be fixed now.
- There is an experimental version of a plot that was recently added to the Phase0 DQM. Not really useful yet, but it uncovered above problem.
- The CMSSW side support for adding blue layer/shell/etc. separator lines to the DQM gui is finally added here. To work, this needs support in the DQM GUI, which is merged already and should appear with the September release. W/o this support, the plot labels will look  bit messed up, but by the time this code makes it to the RelVals the GUI should also have it. 

(also @fioriNTU @davidcarbonis @lunik1 )
