### PR TITLE
Use unique_ptr, not auto_ptr in RecoLocalCalo

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.cc
@@ -29,7 +29,7 @@ void CaloTowerCandidateCreator::produce( Event& evt, const EventSetup& ) {
   Handle<CaloTowerCollection> caloTowers;
   evt.getByToken( tok_src_, caloTowers );
   
-  auto_ptr<CandidateCollection> cands( new CandidateCollection );
+  auto cands = std::make_unique<CandidateCollection>();
   cands->reserve( caloTowers->size() );
   unsigned idx = 0;
   for (; idx < caloTowers->size (); idx++) {
@@ -53,5 +53,5 @@ void CaloTowerCandidateCreator::produce( Event& evt, const EventSetup& ) {
   if (mVerbose >= 1) {
     std::cout << "CaloTowerCandidateCreator::produce-> " << cands->size () << " candidates created" << std::endl;
   }
-  evt.put( cands );
+  evt.put(std::move(cands));
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -274,7 +274,7 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   }
 
   // Step B: Create empty output
-  std::auto_ptr<CaloTowerCollection> prod(new CaloTowerCollection());
+  auto prod = std::make_unique<CaloTowerCollection>();
 
   // Step C: Process
   algo_.finish(*prod);
@@ -287,8 +287,8 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   */
 
   // Step D: Put into the event
-  if (eScales_.instanceLabel=="") e.put(prod);
-  else e.put(prod,eScales_.instanceLabel);
+  if (eScales_.instanceLabel=="") e.put(std::move(prod));
+  else e.put(std::move(prod),eScales_.instanceLabel);
 
 
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersMerger.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersMerger.cc
@@ -110,23 +110,19 @@ CaloTowersMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(tok_reg_,regTower);
   iEvent.getByToken(tok_ext_,extraTower);
 
-  std::auto_ptr<CaloTowerCollection> output;
-
   if (!regTower.isValid() && !extraTower.isValid()){
     edm::LogError("CaloTowersMerger")<<"both input tag:"<<regularTowerTag<<" and "<<extraTowerTag<<" are invalid. empty merged collection";
-    output.reset(new CaloTowerCollection());
-    iEvent.put(output);
+    iEvent.put(std::make_unique<CaloTowerCollection>());
     return;
   }else if (!regTower.isValid()  || !extraTower.isValid()){
     if (!regTower.isValid() && extraTower.isValid())
       regTower=extraTower;
-    output.reset(new CaloTowerCollection(*regTower));
-    iEvent.put(output);
+    iEvent.put(std::make_unique<CaloTowerCollection>(*regTower));
     return;
   }
   else{
     //both valid input collections: merging
-    output.reset(new CaloTowerCollection());
+    auto output = std::make_unique<CaloTowerCollection>();
     output->reserve(regTower->size()+extraTower->size());
   
     CaloTowerCollection::const_iterator rt_begin = regTower->begin();
@@ -165,7 +161,7 @@ CaloTowersMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	//copy the extra tower over
 	output->push_back(*et_it);
     }
-    iEvent.put(output);
+    iEvent.put(std::move(output));
   }
   
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -96,7 +96,7 @@ void CaloTowersReCreator::produce(edm::Event& e, const edm::EventSetup& c) {
     }
   } else {
     // Step B: Create empty output
-    std::auto_ptr<CaloTowerCollection> prod(new CaloTowerCollection());
+    auto prod = std::make_unique<CaloTowerCollection>();
 
     // step C: rescale (without going threough metataowers)
     algo_.rescaleTowers(*calt, *prod);

--- a/RecoLocalCalo/Castor/src/CastorCellProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorCellProducer.cc
@@ -105,7 +105,7 @@ void CastorCellProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   edm::Handle<CastorRecHitCollection> InputRecHits;
   iEvent.getByToken(tok_input_, InputRecHits);
     
-  std::auto_ptr<CastorCellCollection> OutputCells (new CastorCellCollection);
+  auto OutputCells = std::make_unique<CastorCellCollection>();
    
   // looping over all CastorRecHits
 
@@ -170,7 +170,7 @@ void CastorCellProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   LogDebug("CastorCellProducer")
     <<"total number of cells in the event: "<<InputRecHits->size();
 
-  iEvent.put(OutputCells);
+  iEvent.put(std::move(OutputCells));
 
 
 }

--- a/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
@@ -127,7 +127,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   edm::Handle<CastorTowerCollection> InputTowers;
   iEvent.getByToken(tok_input_, InputTowers);
 
-  std::auto_ptr<CastorClusterCollection> OutputClustersfromClusterAlgo (new CastorClusterCollection);
+  auto OutputClustersfromClusterAlgo = std::make_unique<CastorClusterCollection>();
   
   // get and check input size
   int nTowers = InputTowers->size();
@@ -145,7 +145,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   // build cluster from ClusterAlgo
   if (clusteralgo_ == true) {
     // code
-    iEvent.put(OutputClustersfromClusterAlgo);
+    iEvent.put(std::move(OutputClustersfromClusterAlgo));
   }
   
   }
@@ -158,7 +158,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 	Handle<CastorTowerCollection> ctCollection;
 	iEvent.getByToken(tok_tower_,ctCollection);
 	
-	std::auto_ptr<CastorClusterCollection> OutputClustersfromBasicJets (new CastorClusterCollection);
+	auto OutputClustersfromBasicJets = std::make_unique<CastorClusterCollection>();
 	
 	if (bjCollection->size()==0) LogDebug("CastorClusterProducer")<< "Warning: You are trying to run the Cluster algorithm with 0 input basicjets.";
    
@@ -233,7 +233,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 		OutputClustersfromBasicJets->push_back(cc);
    	}
 	
-	iEvent.put(OutputClustersfromBasicJets);
+	iEvent.put(std::move(OutputClustersfromBasicJets));
   
   }
  

--- a/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
@@ -118,7 +118,7 @@ void CastorTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   edm::Handle<CastorRecHitCollection> InputRecHits;
   iEvent.getByToken(tok_input_,InputRecHits);
 
-  std::auto_ptr<CastorTowerCollection> OutputTowers (new CastorTowerCollection);
+  auto OutputTowers = std::make_unique<CastorTowerCollection>();
    
   // get and check input size
   int nRecHits = InputRecHits->size();
@@ -260,7 +260,7 @@ void CastorTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     
   } // end loop over the 16 towers possibilities
   
-  iEvent.put(OutputTowers);
+  iEvent.put(std::move(OutputTowers));
 } 
 
 

--- a/RecoLocalCalo/Castor/src/RecHitCorrector.cc
+++ b/RecoLocalCalo/Castor/src/RecHitCorrector.cc
@@ -118,7 +118,7 @@ RecHitCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    
    CastorCalibrations calibrations;
    
-   std::auto_ptr<CastorRecHitCollection> rec(new CastorRecHitCollection);
+   auto rec = std::make_unique<CastorRecHitCollection>();
    
    for (unsigned int i=0;i<rechits->size();i++) {
    	CastorRecHit rechit = (*rechits)[i];
@@ -166,7 +166,7 @@ RecHitCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
    }
    
-   iEvent.put(rec);
+   iEvent.put(std::move(rec));
  
 }
 

--- a/RecoLocalCalo/CastorReco/interface/CastorSimpleRecAlgo.h
+++ b/RecoLocalCalo/CastorReco/interface/CastorSimpleRecAlgo.h
@@ -46,7 +46,7 @@ public:
 private:
   int firstSample_, samplesToAdd_;
   bool correctForTimeslew_;
-  std::auto_ptr<CastorPulseContainmentCorrection> pulseCorr_;
+  std::unique_ptr<CastorPulseContainmentCorrection> pulseCorr_;
 };
 
 #endif

--- a/RecoLocalCalo/CastorReco/plugins/CastorSimpleReconstructor.cc
+++ b/RecoLocalCalo/CastorReco/plugins/CastorSimpleReconstructor.cc
@@ -85,7 +85,7 @@ void CastorSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& ev
         e.getByToken(tok_input_,digi);
         
         // create empty output
-        std::auto_ptr<CastorRecHitCollection> rec(new CastorRecHitCollection);
+        auto rec = std::make_unique<CastorRecHitCollection>();
         // run the algorithm
         CastorDigiCollection::const_iterator i;
         for (i=digi->begin(); i!=digi->end(); i++) {
@@ -118,6 +118,6 @@ void CastorSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& ev
             }
         }
         // return result
-        e.put(rec);     
+        e.put(std::move(rec));
     }
 }

--- a/RecoLocalCalo/CastorReco/src/CastorSimpleRecAlgo.cc
+++ b/RecoLocalCalo/CastorReco/src/CastorSimpleRecAlgo.cc
@@ -12,7 +12,7 @@ CastorSimpleRecAlgo::CastorSimpleRecAlgo(int firstSample, int samplesToAdd, bool
   samplesToAdd_(samplesToAdd), 
   correctForTimeslew_(correctForTimeslew) {
   if (correctForPulse) 
-    pulseCorr_=std::auto_ptr<CastorPulseContainmentCorrection>(new CastorPulseContainmentCorrection(samplesToAdd_,phaseNS,MaximumFractionalError));
+    pulseCorr_ = std::make_unique<CastorPulseContainmentCorrection>(samplesToAdd_,phaseNS,MaximumFractionalError);
 }
 
 CastorSimpleRecAlgo::CastorSimpleRecAlgo(int firstSample, int samplesToAdd) : 

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/test/plugins/EcalChannelKiller.cc
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/test/plugins/EcalChannelKiller.cc
@@ -80,9 +80,9 @@ void EcalChannelKiller<DetIdT>::produce(edm::Event& iEvent,
 
   int nRed = 0;
 
-  // create an auto_ptr to a EcalRecHitCollection, copy the RecHits into it and
+  // create a unique_ptr to a EcalRecHitCollection, copy the RecHits into it and
   // put in the Event:
-  std::auto_ptr<EcalRecHitCollection> redCollection(new EcalRecHitCollection);
+  auto redCollection = std::make_unique<EcalRecHitCollection>();
 
   for (EcalRecHitCollection::const_iterator it = hit_collection->begin();
        it != hit_collection->end(); ++it) {
@@ -117,7 +117,7 @@ void EcalChannelKiller<DetIdT>::produce(edm::Event& iEvent,
     }
   }
 
-  iEvent.put(redCollection, reducedHitCollection_);
+  iEvent.put(std::move(redCollection), reducedHitCollection_);
 
 }
 

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/test/plugins/EcalDeadChannelRecoveryProducers.cc
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/test/plugins/EcalDeadChannelRecoveryProducers.cc
@@ -67,9 +67,9 @@ void EcalDeadChannelRecoveryProducers<DetIdT>::produce(
   }
   const EcalRecHitCollection* hit_collection = rhcHandle.product();
 
-  // create an auto_ptr to a EcalRecHitCollection, copy the RecHits into it and
+  // create a unique_ptr to a EcalRecHitCollection, copy the RecHits into it and
   // put it in the Event:
-  std::auto_ptr<EcalRecHitCollection> redCollection(new EcalRecHitCollection);
+  auto redCollection = std::make_unique<EcalRecHitCollection>();
   deadChannelCorrector.setCaloTopology(theCaloTopology.product());
 
   //
@@ -105,7 +105,7 @@ void EcalDeadChannelRecoveryProducers<DetIdT>::produce(
     }
   }
 
-  evt.put(redCollection, reducedHitCollection_);
+  evt.put(std::move(redCollection), reducedHitCollection_);
 }
 
 // method called once each job just before starting event loop  ------------

--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
@@ -37,7 +37,7 @@ void ESRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   LogDebug("ESRecHitInfo") << "total # ESdigis: " << digi->size();
   
   // Create empty output
-  std::auto_ptr<ESRecHitCollection> rec(new ESRecHitCollection );
+  auto rec = std::make_unique<ESRecHitCollection>();
   
   if ( digi ) {
     rec->reserve(digi->size()); 
@@ -51,7 +51,7 @@ void ESRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     }
   }
   
-  e.put(rec,rechitCollection_);
+  e.put(std::move(rec),rechitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"  

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalCompactTrigPrimProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalCompactTrigPrimProducer.cc
@@ -21,7 +21,7 @@ EcalCompactTrigPrimProducer::EcalCompactTrigPrimProducer(const edm::ParameterSet
 
 void EcalCompactTrigPrimProducer::produce(edm::Event& event, const edm::EventSetup& es)
 {
-  std::auto_ptr<EcalTrigPrimCompactColl> outColl(new EcalTrigPrimCompactColl);
+  auto outColl = std::make_unique<EcalTrigPrimCompactColl>();
   edm::Handle<EcalTrigPrimDigiCollection> hTPDigis;
   event.getByToken(inCollectionToken_, hTPDigis);
   
@@ -31,5 +31,5 @@ void EcalCompactTrigPrimProducer::produce(edm::Event& event, const edm::EventSet
       trigPrim != trigPrims->end(); ++trigPrim){
     outColl->setValue(trigPrim->id().ieta(), trigPrim->id().iphi(), trigPrim->sample(trigPrim->sampleOfInterest()).raw());
   }
-  event.put(outColl, outCollection_);
+  event.put(std::move(outColl), outCollection_);
 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.cc
@@ -85,10 +85,10 @@ void EcalDetIdToBeRecoveredProducer::produce(edm::Event& ev, const edm::EventSet
         std::vector< edm::Handle<EEDetIdCollection> > eeDetIdColls;
         std::vector< edm::Handle<EcalElectronicsIdCollection> > ttColls;
 
-        std::auto_ptr< std::set<EBDetId> > ebDetIdToRecover( new std::set<EBDetId> ); // isolated channels to be recovered
-        std::auto_ptr< std::set<EEDetId> > eeDetIdToRecover( new std::set<EEDetId> ); // isolated channels to be recovered
-        std::auto_ptr< std::set<EcalTrigTowerDetId> > ebTTDetIdToRecover( new std::set<EcalTrigTowerDetId> ); // tt to be recovered
-        std::auto_ptr< std::set<EcalScDetId> > eeSCDetIdToRecover( new std::set<EcalScDetId> ); // sc to be recovered
+        auto ebDetIdToRecover = std::make_unique<std::set<EBDetId>>(); // isolated channels to be recovered
+        auto eeDetIdToRecover = std::make_unique<std::set<EEDetId>>(); // isolated channels to be recovered
+        auto ebTTDetIdToRecover = std::make_unique<std::set<EcalTrigTowerDetId>>(); // tt to be recovered
+        auto eeSCDetIdToRecover = std::make_unique<std::set<EcalScDetId>>(); // sc to be recovered
 
         /*
          * get collections
@@ -310,10 +310,10 @@ void EcalDetIdToBeRecoveredProducer::produce(edm::Event& ev, const edm::EventSet
         }
 
         // return the collections
-        ev.put( ebDetIdToRecover, ebDetIdCollection_ );
-        ev.put( eeDetIdToRecover, eeDetIdCollection_ );
-        ev.put( ebTTDetIdToRecover, ttDetIdCollection_ );
-        ev.put( eeSCDetIdToRecover, scDetIdCollection_ );
+        ev.put(std::move(ebDetIdToRecover), ebDetIdCollection_ );
+        ev.put(std::move(eeDetIdToRecover), eeDetIdCollection_ );
+        ev.put(std::move(ebTTDetIdToRecover), ttDetIdCollection_ );
+        ev.put(std::move(eeSCDetIdToRecover), scDetIdCollection_ );
 }
 
 void EcalDetIdToBeRecoveredProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
@@ -106,8 +106,8 @@ EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 	LogDebug("EcalRecHitDebug") << "total # EE uncalibrated rechits: " << eeUncalibRecHits->size();
        
         // collection of rechits to put in the event
-        std::auto_ptr< EBRecHitCollection > ebRecHits( new EBRecHitCollection );
-        std::auto_ptr< EERecHitCollection > eeRecHits( new EERecHitCollection );
+        auto ebRecHits = std::make_unique<EBRecHitCollection>();
+        auto eeRecHits = std::make_unique<EERecHitCollection>();
 
         worker_->set(es);
 
@@ -267,8 +267,8 @@ EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es)
         LogInfo("EcalRecHitInfo") << "total # EB calibrated rechits: " << ebRecHits->size();
         LogInfo("EcalRecHitInfo") << "total # EE calibrated rechits: " << eeRecHits->size();
 
-        evt.put( ebRecHits, ebRechitCollection_ );
-        evt.put( eeRecHits, eeRechitCollection_ );
+        evt.put(std::move(ebRecHits), ebRechitCollection_);
+        evt.put(std::move(eeRecHits), eeRechitCollection_);
 }
 
 void EcalRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.cc
@@ -69,8 +69,8 @@ void EcalRecalibRecHitProducer::produce(edm::StreamID sid, edm::Event& evt, cons
 	}
 
         // collection of rechits to put in the event
-        std::auto_ptr< EBRecHitCollection > EBRecalibRecHits( new EBRecHitCollection );
-        std::auto_ptr< EERecHitCollection > EERecalibRecHits( new EERecHitCollection );
+        auto EBRecalibRecHits = std::make_unique<EBRecHitCollection>();
+        auto EERecalibRecHits = std::make_unique<EERecHitCollection>();
 
         // now fetch all conditions we need to make rechits
         // ADC to GeV constant
@@ -179,8 +179,8 @@ void EcalRecalibRecHitProducer::produce(edm::StreamID sid, edm::Event& evt, cons
         LogInfo("EcalRecalibRecHitInfo") << "total # EB re-calibrated rechits: " << EBRecalibRecHits->size();
         LogInfo("EcalRecalibRecHitInfo") << "total # EE re-calibrated rechits: " << EERecalibRecHits->size();
 
-        evt.put( EBRecalibRecHits, EBRecalibRecHitCollection_ );
-        evt.put( EERecalibRecHits, EERecalibRecHitCollection_ );
+        evt.put(std::move(EBRecalibRecHits), EBRecalibRecHitCollection_);
+        evt.put(std::move(EERecalibRecHits), EERecalibRecHitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalTPSkimmer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalTPSkimmer.cc
@@ -50,10 +50,10 @@ EcalTPSkimmer::produce(edm::Event& evt, const edm::EventSetup& es)
         es.get<IdealGeometryRecord>().get(ttMap_);
 
         // collection of rechits to put in the event
-        std::auto_ptr< EcalTrigPrimDigiCollection > tpOut( new EcalTrigPrimDigiCollection );
+        auto tpOut = std::make_unique<EcalTrigPrimDigiCollection>();
         
         if ( skipModule_ ) {
-                evt.put( tpOut, tpOutputCollection_ );
+                evt.put(std::move(tpOut), tpOutputCollection_);
                 return;
         }
 
@@ -117,7 +117,7 @@ EcalTPSkimmer::produce(edm::Event& evt, const edm::EventSetup& es)
         // put the collection of reconstructed hits in the event   
         LogInfo("EcalTPSkimmer") << "total # of TP inserted: " << tpOut->size();
 
-        evt.put( tpOut, tpOutputCollection_ );
+        evt.put(std::move(tpOut), tpOutputCollection_);
 }
 
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -111,8 +111,8 @@ EcalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
         worker_->set(evt);
 
         // prepare output
-        std::auto_ptr< EBUncalibratedRecHitCollection > ebUncalibRechits( new EBUncalibratedRecHitCollection );
-        std::auto_ptr< EEUncalibratedRecHitCollection > eeUncalibRechits( new EEUncalibratedRecHitCollection );
+        auto ebUncalibRechits = std::make_unique<EBUncalibratedRecHitCollection>();
+        auto eeUncalibRechits = std::make_unique<EEUncalibratedRecHitCollection>();
 
         // loop over EB digis
         if (ebDigis)
@@ -133,8 +133,8 @@ EcalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
         }
 
         // put the collection of recunstructed hits in the event
-        evt.put( ebUncalibRechits, ebHitCollection_ );
-        evt.put( eeUncalibRechits, eeHitCollection_ );
+        evt.put(std::move(ebUncalibRechits), ebHitCollection_);
+        evt.put(std::move(eeUncalibRechits), eeHitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"                                                                                                            

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMaxSample.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMaxSample.cc
@@ -57,7 +57,7 @@ edm::ParameterSetDescription
 EcalUncalibRecHitWorkerMaxSample::getAlgoDescription() {
 
   edm::ParameterSetDescription psd;
-  return psd;//.addNode(std::auto_ptr<edm::ParameterDescriptionNode>(new edm::EmptyGroupDescription()));
+  return psd;//.addNode(std::unique_ptr<edm::ParameterDescriptionNode>(new edm::EmptyGroupDescription()));
 }
 
 

--- a/RecoLocalCalo/EcalRecProducers/test/EcalLocalRecoTask.cc
+++ b/RecoLocalCalo/EcalRecProducers/test/EcalLocalRecoTask.cc
@@ -162,8 +162,7 @@ void EcalLocalRecoTask::analyze(const edm::Event& e, const edm::EventSetup& c)
   c.get<EcalPedestalsRcd>().get(pPeds);
   
 
-  std::auto_ptr<MixCollection<PCaloHit> > 
-    barrelHits (new MixCollection<PCaloHit>(crossingFrame.product ())) ;
+  auto barrelHits = std::make_unique<MixCollection<PCaloHit>>(crossingFrame.product()) ;
 
   MapType EBSimMap;
   

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
@@ -85,9 +85,9 @@ HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   hebUncalibRecHits = pHGChebUncalibRecHits.product();
     
   // collection of rechits to put in the event
-  std::auto_ptr< HGCeeRecHitCollection > eeRecHits( new HGCeeRecHitCollection );
-  std::auto_ptr< HGChefRecHitCollection > hefRecHits( new HGChefRecHitCollection );
-  std::auto_ptr< HGChebRecHitCollection > hebRecHits( new HGChebRecHitCollection );
+  auto eeRecHits = std::make_unique<HGCeeRecHitCollection>();
+  auto hefRecHits = std::make_unique<HGChefRecHitCollection>();
+  auto hebRecHits = std::make_unique<HGChebRecHitCollection>();
     
   worker_->set(es);
   
@@ -116,9 +116,9 @@ HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   LogInfo("HGCalRecHitInfo") << "total # HGChef calibrated rechits: " << hefRecHits->size();
   LogInfo("HGCalRecHitInfo") << "total # HGCheb calibrated rechits: " << hebRecHits->size();
   
-  evt.put( eeRecHits, eeRechitCollection_ );
-  evt.put( hefRecHits, hefRechitCollection_ );
-  evt.put( hebRecHits, hebRechitCollection_ );
+  evt.put(std::move(eeRecHits), eeRechitCollection_);
+  evt.put(std::move(hefRecHits), hefRechitCollection_);
+  evt.put(std::move(hebRecHits), hebRechitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
@@ -45,9 +45,9 @@ HGCalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   worker_->set(es);
   
   // prepare output
-  std::auto_ptr< HGCeeUncalibratedRecHitCollection > eeUncalibRechits( new HGCeeUncalibratedRecHitCollection );
-  std::auto_ptr< HGChefUncalibratedRecHitCollection > hefUncalibRechits( new HGChefUncalibratedRecHitCollection );
-  std::auto_ptr< HGChefUncalibratedRecHitCollection > hebUncalibRechits( new HGChebUncalibratedRecHitCollection );
+  auto eeUncalibRechits = std::make_unique<HGCeeUncalibratedRecHitCollection>();
+  auto hefUncalibRechits = std::make_unique<HGChefUncalibratedRecHitCollection>();
+  auto hebUncalibRechits = std::make_unique<HGChebUncalibratedRecHitCollection>();
   
   // loop over HGCEE digis
   if (isEE_) {
@@ -84,9 +84,9 @@ HGCalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   }
   
   // put the collection of recunstructed hits in the event
-  evt.put( eeUncalibRechits, eeHitCollection_ );
-  evt.put( hefUncalibRechits, hefHitCollection_ );
-  evt.put( hebUncalibRechits, hebHitCollection_ );
+  evt.put(std::move(eeUncalibRechits), eeHitCollection_);
+  evt.put(std::move(hefUncalibRechits), hefHitCollection_);
+  evt.put(std::move(hebUncalibRechits), hebHitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"                                                                                                            

--- a/RecoLocalCalo/HcalLaserReco/src/HcalLaserReco.cc
+++ b/RecoLocalCalo/HcalLaserReco/src/HcalLaserReco.cc
@@ -42,8 +42,7 @@ void HcalLaserReco::produce(edm::Event& e, const edm::EventSetup&)
   e.getByToken(tok_raw_, rawraw);
 
   // Step B: Create empty output    
-  std::auto_ptr<HcalLaserDigi>
-    digi(new HcalLaserDigi);
+  auto digi = std::make_unique<HcalLaserDigi>();
     
   if (qdctdcFed_ >=0) {
     // Step C: unpack all requested FEDs
@@ -52,7 +51,7 @@ void HcalLaserReco::produce(edm::Event& e, const edm::EventSetup&)
   }
   
   // Step D: Put outputs into event
-  e.put(digi);
+  e.put(std::move(digi));
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -81,7 +81,7 @@ public:
   void setpuCorrMethod(int method){ 
     puCorrMethod_ = method;
     if( puCorrMethod_ == 2 )
-        psFitOOTpuCorr_ = std::auto_ptr<PulseShapeFitOOTPileupCorrection>(new PulseShapeFitOOTPileupCorrection());
+        psFitOOTpuCorr_ = std::make_unique<PulseShapeFitOOTPileupCorrection>();
   }
 
   void setpuCorrParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,bool iApplyTimeSlew,
@@ -97,7 +97,7 @@ private:
   bool correctForTimeslew_;
   bool correctForPulse_;
   float phaseNS_;
-  std::auto_ptr<HcalPulseContainmentManager> pulseCorr_;
+  std::unique_ptr<HcalPulseContainmentManager> pulseCorr_;
   int runnum_;  // data run numer
   bool setLeakCorrection_;
   int pileupCleaningID_;
@@ -111,12 +111,12 @@ private:
 
   int puCorrMethod_;
 
-  std::auto_ptr<PulseShapeFitOOTPileupCorrection> psFitOOTpuCorr_;
+  std::unique_ptr<PulseShapeFitOOTPileupCorrection> psFitOOTpuCorr_;
   
-  std::auto_ptr<PedestalSub> pedSubFxn_;
+  std::unique_ptr<PedestalSub> pedSubFxn_;
 
   // S.Brandt Feb19 : Add a pointer to the HLT algo
-  std::auto_ptr<HcalDeterministicFit> hltOOTpuCorr_;
+  std::unique_ptr<HcalDeterministicFit> hltOOTpuCorr_;
 };
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -130,7 +130,7 @@ private:
     double chargeThreshold_;
     int fitTimes_;
 
-    std::auto_ptr<FitterFuncs::PulseShapeFunctor> psfPtr_;
+    std::unique_ptr<FitterFuncs::PulseShapeFunctor> psfPtr_;
     ROOT::Math::Functor *spfunctor_;
     ROOT::Math::Functor *dpfunctor_;
     ROOT::Math::Functor *tpfunctor_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/ZdcSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/ZdcSimpleRecAlgo.h
@@ -50,7 +50,7 @@ private:
    // new lowGainEnergy variables
    int lowGainOffset_;
    double lowGainFrac_;
-  std::auto_ptr<HcalPulseContainmentCorrection> pulseCorr_;
+  std::unique_ptr<HcalPulseContainmentCorrection> pulseCorr_;
 };
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -21,9 +21,9 @@ HcalSimpleRecAlgo::HcalSimpleRecAlgo(bool correctForTimeslew, bool correctForPul
   correctForPulse_(correctForPulse),
   phaseNS_(phaseNS), runnum_(0), setLeakCorrection_(false), puCorrMethod_(0)
 {  
-  pulseCorr_ = std::auto_ptr<HcalPulseContainmentManager>(new HcalPulseContainmentManager(MaximumFractionalError));
-  pedSubFxn_ = std::auto_ptr<PedestalSub>(new PedestalSub());
-  hltOOTpuCorr_ = std::auto_ptr<HcalDeterministicFit>(new HcalDeterministicFit());
+  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError);
+  pedSubFxn_ = std::make_unique<PedestalSub>();
+  hltOOTpuCorr_ = std::make_unique<HcalDeterministicFit>();
 }
 
 

--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
@@ -25,7 +25,7 @@ ZdcSimpleRecAlgo::ZdcSimpleRecAlgo(int recoMethod) :
 }
 void ZdcSimpleRecAlgo::initPulseCorr(int toadd) {
   if (correctForPulse_) {    
-    pulseCorr_=std::auto_ptr<HcalPulseContainmentCorrection>(new HcalPulseContainmentCorrection(toadd,phaseNS_,MaximumFractionalError));
+    pulseCorr_ = std::make_unique<HcalPulseContainmentCorrection>(toadd,phaseNS_,MaximumFractionalError);
   }
 }
 //static float timeshift_ns_zdc(float wpksamp);

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
@@ -202,7 +202,7 @@ HcalRecHitReflagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    topo = &*topo_;
 
    // prepare the output HF RecHit collection
-   std::auto_ptr<HFRecHitCollection> pOut(new HFRecHitCollection());
+   auto pOut = std::make_unique<HFRecHitCollection>();
    
    // loop over rechits, and set the new bit you wish to use
    for (HFRecHitCollection::const_iterator recHit=hfRecHits->begin(); recHit!=hfRecHits->end(); ++recHit) {
@@ -261,7 +261,7 @@ HcalRecHitReflagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
    
    // put the re-flagged HF RecHit collection into the Event
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
  
 }
 

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
@@ -233,7 +233,7 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
   }
 
   // prepare the output HBHE RecHit collection
-  std::auto_ptr<HBHERecHitCollection> pOut(new HBHERecHitCollection());
+  auto pOut = std::make_unique<HBHERecHitCollection>();
   // loop over rechits, and set the new bit you wish to use
   for(HBHERecHitCollection::const_iterator it=hbhehits_h->begin(); it!=hbhehits_h->end(); ++it) {
     const HBHERecHit* hit=&(*it);
@@ -244,7 +244,7 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
     pOut->push_back(newhit);
   }
 
-  iEvent.put(pOut);
+  iEvent.put(std::move(pOut));
 
   return;  
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -449,7 +449,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
       e.getByToken(tok_hbhe_,digi);
       
       // create empty output
-      std::auto_ptr<HBHERecHitCollection> rec(new HBHERecHitCollection);
+      auto rec = std::make_unique<HBHERecHitCollection>();
       rec->reserve(digi->size());
       // run the algorithm
       if (setNoiseFlags_) hbheFlagSetter_->Clear();
@@ -589,7 +589,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
       if (setNoiseFlags_) hbheFlagSetter_->SetFlagsFromRecHits(*rec);
       if (setHSCPFlags_)  hbheHSCPFlagSetter_->hbheSetTimeFlagsFromDigi(rec.get(), HBDigis, RecHitIndex);
       // return result
-      e.put(rec);
+      e.put(std::move(rec));
 
       //  HO ------------------------------------------------------------------
     } else if (subdet_==HcalOuter) {
@@ -597,7 +597,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
       e.getByToken(tok_ho_,digi);
       
       // create empty output
-      std::auto_ptr<HORecHitCollection> rec(new HORecHitCollection);
+      auto rec = std::make_unique<HORecHitCollection>();
       rec->reserve(digi->size());
       // run the algorithm
       HODigiCollection::const_iterator i;
@@ -672,7 +672,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	  HcalTimingCorrector::Correct(rec->back(), *i, favorite_capid);
       }
       // return result
-      e.put(rec);    
+      e.put(std::move(rec));    
 
       // HF -------------------------------------------------------------------
     } else if (subdet_==HcalForward) {
@@ -682,7 +682,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 
       ///////////////////////////////////////////////////////////////// HF
       // create empty output
-      std::auto_ptr<HFRecHitCollection> rec(new HFRecHitCollection);
+      auto rec = std::make_unique<HFRecHitCollection>();
       rec->reserve(digi->size());
       // run the algorithm
       HFDigiCollection::const_iterator i;
@@ -817,13 +817,13 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	}
 
       // return result
-      e.put(rec);     
+      e.put(std::move(rec));     
     } else if (subdet_==HcalOther && subdetOther_==HcalCalibration) {
       edm::Handle<HcalCalibDigiCollection> digi;
       e.getByToken(tok_calib_,digi);
       
       // create empty output
-      std::auto_ptr<HcalCalibRecHitCollection> rec(new HcalCalibRecHitCollection);
+      auto rec = std::make_unique<HcalCalibRecHitCollection>();
       rec->reserve(digi->size());
       // run the algorithm
       int first = firstSample_;
@@ -868,7 +868,7 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	*/
       }
       // return result
-      e.put(rec);     
+      e.put(std::move(rec));     
     }
   } 
   //DL  delete myqual;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -131,7 +131,7 @@ void HcalSimpleReconstructor::process(edm::Event& e, const edm::EventSetup& even
   e.getByToken(tok,digi);
 
   // create empty output
-  std::auto_ptr<RECHITCOLL> rec(new RECHITCOLL);
+  auto rec = std::make_unique<RECHITCOLL>();
   rec->reserve(digi->size());
   // run the algorithm
   int first = firstSample_;
@@ -158,7 +158,7 @@ void HcalSimpleReconstructor::process(edm::Event& e, const edm::EventSetup& even
     rec->push_back(reco_.reconstruct(*i,first,toadd,coder,calibrations));   
   }
   // return result
-  e.put(rec);
+  e.put(std::move(rec));
 }
 
 
@@ -174,7 +174,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
     e.getByToken(tok_hbheUp_, digi);
 
     // create empty output
-    std::auto_ptr<HBHERecHitCollection> rec(new HBHERecHitCollection);
+    auto rec = std::make_unique<HBHERecHitCollection>();
     rec->reserve(digi->size()); 
 
     // run the algorithm
@@ -203,7 +203,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
 
     }
 
-    e.put(rec); // put results
+    e.put(std::move(rec)); // put results
   }// End of upgradeHBHE
 
   if(upgradeHF_){
@@ -212,7 +212,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
     e.getByToken(tok_hfUp_, digi);
 
     // create empty output
-    std::auto_ptr<HFRecHitCollection> rec(new HFRecHitCollection);
+    auto rec = std::make_unique<HFRecHitCollection>();
     rec->reserve(digi->size()); 
 
     // run the algorithm
@@ -240,7 +240,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
       rec->push_back(reco_.reconstructHFUpgrade(*i,first,toadd,coder,calibrations));
 
     }  
-    e.put(rec); // put results
+    e.put(std::move(rec)); // put results
   }// End of upgradeHF
 
   if(HFQIE10_){
@@ -249,7 +249,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
     e.getByToken(tok_hfQIE10_, digi);
 
     // create empty output
-    std::auto_ptr<HFRecHitCollection> rec(new HFRecHitCollection);
+    auto rec = std::make_unique<HFRecHitCollection>();
     rec->reserve(digi->size()); 
 
     // run the algorithm
@@ -281,7 +281,7 @@ void HcalSimpleReconstructor::processUpgrade(edm::Event& e, const edm::EventSetu
       rec->push_back(reco_.reconstructQIE10(frame,first,toadd,coder,calibrations));
 
     }  
-    e.put(rec); // put results
+    e.put(std::move(rec)); // put results
   }// End of upgradeHF
   
 }

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
@@ -107,7 +107,7 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
      }
         
      // create empty output
-     std::auto_ptr<ZDCRecHitCollection> rec(new ZDCRecHitCollection);
+     auto rec = std::make_unique<ZDCRecHitCollection>();
      rec->reserve(digi->size());
      // run the algorithm
      ZDCDigiCollection::const_iterator i;
@@ -150,7 +150,7 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
 	(rec->back()).setAux(auxflag);
      }
      // return result
-     e.put(rec);     
+     e.put(std::move(rec));     
    } // else if (det_==DetId::Calo...)
 
 } // void HcalHitReconstructor::produce(...)

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
@@ -71,7 +71,7 @@ void ZdcSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& event
      }
     
     // create empty output
-    std::auto_ptr<ZDCRecHitCollection> rec(new ZDCRecHitCollection);
+    auto rec = std::make_unique<ZDCRecHitCollection>();
     rec->reserve(digi->size());
     // run the algorithm
     unsigned int toaddMem = 0;
@@ -104,6 +104,6 @@ void ZdcSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& event
       rec->push_back(reco_.reconstruct(*i,myNoiseTS,mySignalTS,coder,calibrations));
     }
     // return result
-    e.put(rec);     
+    e.put(std::move(rec));     
   }
 }


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoLocalCalo packages. Also, std::make_unique is used when appropriate. Also, there was a case where a reference to an auto_ptr was an input argument to a function, which is a bad practice because it obscures the possible transfer of ownership. In the cases here, ownership was not transferred, so the object itself was passed by reference.
