### PR TITLE
Fix sherpa weights when no weight list is provided

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -317,12 +317,12 @@ bool SherpaHadronizer::generatePartonsAndHadronize()
         }
 
       }
-    }
 
     //Change original weights for reordered ones
-    evt->weights().clear();
-    for (auto& elem: newWeights) {
-      evt->weights().push_back(elem);
+      evt->weights().clear();
+      for (auto& elem: newWeights) {
+        evt->weights().push_back(elem);
+      }
     }
 
     if(unweighted){


### PR DESCRIPTION
Fix the sherpa event weights in case no reordering of weights is applied (the deletion of the original weight vector should only be done if we want to use the new vector)
