### PR TITLE
bsunanda:Run2-TB09 Add possibility of using beam line in TB simulation of HGCal for CERN setup

### DIFF
--- a/SimG4CMS/HGCalTestBeam/plugins/HGCalTBCheckGunPosition.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCalTBCheckGunPosition.cc
@@ -1,0 +1,162 @@
+// -*- C++ -*-
+//
+// Package:    HGCalTestBeam/HGCalTBCheckGunPostion
+// Class:      HGCalTBCheckGunPostion
+// 
+/**\class HGCalTBCheckGunPostion HGCalTBCheckGunPostion.cc Geometry/HGCalTestBeam/plugins/HGCalTBCheckGunPostion.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Shilpi Jain
+//         Created:  Wed, 31 Aug 2016 17:47:22 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include <iostream>
+
+
+//
+// class declaration
+//
+
+class HGCalTBCheckGunPostion : public edm::stream::EDFilter<> {
+
+public:
+  explicit HGCalTBCheckGunPostion(const edm::ParameterSet&);
+  ~HGCalTBCheckGunPostion();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginStream(edm::StreamID) override {}
+  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  virtual void endStream() override {}
+
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override {}
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {}
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {}
+
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<edm::HepMCProduct>      hepMCproductLabel_;
+  bool                                     verbosity_, method2_;
+  double                                   tan30deg_, hexwidth_, hexside_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+HGCalTBCheckGunPostion::HGCalTBCheckGunPostion(const edm::ParameterSet& iConfig) {
+  //now do what ever initialization is needed
+  edm::InputTag tmp0 = iConfig.getParameter<edm::InputTag>("HepMCProductLabel");
+  verbosity_         = iConfig.getUntrackedParameter<bool>("Verbosity",false);
+  method2_           = iConfig.getUntrackedParameter<bool>("Method2",false);
+  hepMCproductLabel_ = consumes<edm::HepMCProduct>(tmp0);
+  
+  //hexside = 7; //cm - check it
+  tan30deg_ = 0.5773502693;
+  hexwidth_ = 6.185;
+  hexside_  = 2.0 * hexwidth_ * tan30deg_;
+}
+
+HGCalTBCheckGunPostion::~HGCalTBCheckGunPostion() { }
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool HGCalTBCheckGunPostion::filter(edm::Event& iEvent, 
+				    const edm::EventSetup& iSetup) {
+  edm::Handle<edm::HepMCProduct> hepmc;
+  iEvent.getByToken(hepMCproductLabel_, hepmc);
+#ifdef DebugLog
+  if (verbosity_) 
+    std::cout << "isHandle valid: " << isHandle valid << std::endl;
+#endif
+  double x(0), y(0);
+   
+  if (hepmc.isValid()) {
+    const HepMC::GenEvent* Evt = hepmc->GetEvent();
+     
+#ifdef DebugLog
+    if (verbosity_) 
+      std::cout << "vertex " << Evt->vertices_size() << std::endl;
+#endif
+    for (HepMC::GenEvent::vertex_const_iterator p = Evt->vertices_begin();
+	 p != Evt->vertices_end(); ++p) {
+      x = (*p)->position().x()/10.; // in cm
+      y = (*p)->position().y()/10.; // in cm
+#ifdef DebugLog
+      z = (*p)->position().z()/10.; // in cm
+      if (verbosity_) 
+	std::cout << " x: " << (*p)->position().x() << ":" << x
+		  << " y: " << (*p)->position().y() << ":" << y
+		  << " z: " << (*p)->position().z() << ":" << z
+		  << std::endl;
+#endif
+    }
+  }//if (genEventInfoHandle.isValid())
+
+  bool   flag(false);
+  if (method2_) {
+    bool cond1 = y==0 && x >=(-hexside_ * sqrt(3)/2.);
+    bool cond2 = ((y+hexside_) >= -x/sqrt(3)) && (y<0&&x<0);
+    bool cond3 = (y*sqrt(3) >= (x - hexside_*sqrt(3))) && (y<0 && x>0);
+    bool cond4 = y==0 && x <=(hexside_ * sqrt(3)/2.);
+    bool cond5 = (-y*sqrt(3) >= (x - hexside_*sqrt(3))) && (y>0&&x>0);
+    bool cond6 = ((y-hexside_) <= x/sqrt(3)) && (y>0&&x<0);
+    flag = cond1 || cond2 || cond3 || cond4 || cond5 || cond6;
+  } else {
+    double absx = std::abs(x);
+    double absy = std::abs(y);
+    if (absx <= hexwidth_ && absy <= hexside_) {
+      if (absy <= hexwidth_*tan30deg_ || 
+	  absx <= (2.*hexwidth_ - absy/tan30deg_)) flag = true;
+    }
+  }
+  
+#ifdef DebugLog
+  if (verbosity_) std::cout << "Selection Flag " << flag << std::endl;
+#endif
+  return flag;
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HGCalTBCheckGunPostion::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HGCalTBCheckGunPostion);

--- a/SimG4CMS/HGCalTestBeam/python/HGCalTB161Module8XML_cfi.py
+++ b/SimG4CMS/HGCalTestBeam/python/HGCalTB161Module8XML_cfi.py
@@ -5,12 +5,12 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/CMSCommonData/data/rotations.xml',
         'Geometry/HGCalCommonData/data/TB161/cms.xml',
         'Geometry/HGCalCommonData/data/TB161/hgcal.xml',
-        'Geometry/HGCalCommonData/data/TB161/1Module/hgcalEE.xml',
+        'Geometry/HGCalCommonData/data/TB161/8Module/hgcalEE.xml',
         'Geometry/HGCalCommonData/data/v7/hgcalwafer.xml',
         'Geometry/HGCalCommonData/data/TB161/hgcalBeam.xml',
         'Geometry/HGCalCommonData/data/TB161/hgcalsense.xml',
         'Geometry/HGCalCommonData/data/TB161/hgcProdCuts.xml',
-        'Geometry/HGCalCommonData/data/TB161/1Module/hgcalCons.xml'),
+        'Geometry/HGCalCommonData/data/TB161/8Module/hgcalCons.xml'),
     rootNodeName = cms.string('cms:OCMS')
 )
 

--- a/SimG4CMS/HGCalTestBeam/python/HGCalTBCheckGunPosition_cfi.py
+++ b/SimG4CMS/HGCalTestBeam/python/HGCalTBCheckGunPosition_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+HGCalTBCheckGunPostion = cms.EDFilter("HGCalTBCheckGunPostion",
+                                      HepMCProductLabel = cms.InputTag('generatorSmeared'),
+                                      Verbosity         = cms.untracked.bool(False),
+                                      Method2           = cms.untracked.bool(False),
+)

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERN_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERN_cfg.py
@@ -7,7 +7,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('SimG4CMS.HGCalTestBeam.HGCalTB161Module1XML_cfi')
+process.load('SimG4CMS.HGCalTestBeam.HGCalTB161Module8XML_cfi')
 process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
 process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
 process.load('Configuration.StandardSequences.MagneticField_0T_cff')
@@ -17,6 +17,7 @@ process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('SimG4CMS.HGCalTestBeam.HGCalTBCheckGunPosition_cfi')
 process.load('SimG4CMS.HGCalTestBeam.HGCalTBAnalyzer_cfi')
 
 process.maxEvents = cms.untracked.PSet(
@@ -79,8 +80,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 process.generator = cms.EDProducer("FlatRandomEThetaGunProducer",
     AddAntiParticle = cms.bool(True),
     PGunParameters = cms.PSet(
-        MinE = cms.double(99.99),
-        MaxE = cms.double(100.01),
+        MinE = cms.double(9.99),
+        MaxE = cms.double(10.01),
         MinTheta = cms.double(0.0),
         MaxTheta = cms.double(0.0),
         MinPhi = cms.double(-3.14159265359),
@@ -91,8 +92,8 @@ process.generator = cms.EDProducer("FlatRandomEThetaGunProducer",
     firstRun = cms.untracked.uint32(1),
     psethack = cms.string('single muon E 100')
 )
-process.VtxSmeared.MinZ = -499.90
-process.VtxSmeared.MaxZ = -499.90
+process.VtxSmeared.MinZ = -800.0
+process.VtxSmeared.MaxZ = -800.0
 process.VtxSmeared.MinX = -7.5
 process.VtxSmeared.MaxX =  7.5
 process.VtxSmeared.MinY = -7.5
@@ -102,6 +103,7 @@ process.HGCalTBAnalyzer.DoRecHits = False
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)
+process.gunfilter_step  = cms.Path(process.HGCalTBCheckGunPostion)
 process.simulation_step = cms.Path(process.psim)
 process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
 process.analysis_step = cms.Path(process.HGCalTBAnalyzer)
@@ -109,7 +111,7 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.analysis_step,process.endjob_step,process.RAWSIMoutput_step)
+process.schedule = cms.Schedule(process.generation_step,process.gunfilter_step,process.genfiltersummary_step,process.simulation_step,process.analysis_step,process.endjob_step,process.RAWSIMoutput_step)
 # filter all path with the production filter sequence
 for path in process.paths:
 	getattr(process,path)._seq = process.generator * getattr(process,path)._seq 


### PR DESCRIPTION
This adds a GenLevel filter to select a region of beam profile matching hexagonal face of the wafer. Also provides facility to use beam line 
