### PR TITLE
Extension of PAT TauPFEssential event content to be able to run anti-electron discriminators in miniAOD input

### DIFF
--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -337,6 +337,21 @@ namespace pat {
       /// return normalized chi2 of leading track
       float leadingTrackNormChi2() const { return pfEssential().leadingTrackNormChi2_; }
 
+      /// ---- Information for anti-electron training ----
+      /// Needed to recompute on MiniAOD
+      /// return ecal energy from LeadChargedHadrCand
+      float ecalEnergyLeadChargedHadrCand() const { return pfEssential().ecalEnergyLeadChargedHadrCand_; }
+      /// return hcal energy from LeadChargedHadrCand
+      float hcalEnergyLeadChargedHadrCand() const { return pfEssential().hcalEnergyLeadChargedHadrCand_; }
+      /// return etaAtEcalEntrance
+      float etaAtEcalEntrance() const { return pfEssential().etaAtEcalEntrance_; }
+      /// return etaAtEcalEntrance from LeadChargedCand
+      float etaAtEcalEntranceLeadChargedCand() const { return pfEssential().etaAtEcalEntranceLeadChargedCand_; }
+      /// return pt from  LeadChargedCand
+      float ptLeadChargedCand() const { return pfEssential().ptLeadChargedCand_; }
+      /// return emFraction_MVA
+      float emFraction_MVA() const { return pfEssential().emFraction_; }
+
       /// Methods copied from reco::Jet.
       /// (accessible from reco::CaloTau/reco::PFTau via reco::CaloTauTagInfo/reco::PFTauTagInfo)
       reco::Candidate::LorentzVector p4Jet() const;

--- a/DataFormats/PatCandidates/interface/TauPFEssential.h
+++ b/DataFormats/PatCandidates/interface/TauPFEssential.h
@@ -50,10 +50,15 @@ struct TauPFEssential {
   CovMatrix svCov_;
   float ip3d_;
   float ip3d_error_;
-  float ip3d_Sig_;
   float ecalEnergy_;
   float hcalEnergy_;
   float leadingTrackNormChi2_;
+  float etaAtEcalEntrance_;
+  float ecalEnergyLeadChargedHadrCand_;
+  float hcalEnergyLeadChargedHadrCand_;
+  float etaAtEcalEntranceLeadChargedCand_;
+  float ptLeadChargedCand_;
+  float emFraction_;
 };
 
 } }

--- a/DataFormats/PatCandidates/src/TauPFEssential.cc
+++ b/DataFormats/PatCandidates/src/TauPFEssential.cc
@@ -13,7 +13,13 @@ pat::tau::TauPFEssential::TauPFEssential(const reco::PFTau& tau) :
     ip3d_error_(1.e+3),
     ecalEnergy_(0.),
     hcalEnergy_(0.),
-    leadingTrackNormChi2_(1.e+3)
+    leadingTrackNormChi2_(1.e+3),
+    etaAtEcalEntrance_(0.),
+    ecalEnergyLeadChargedHadrCand_(0.),
+    hcalEnergyLeadChargedHadrCand_(0.),
+    etaAtEcalEntranceLeadChargedCand_(0.),
+    ptLeadChargedCand_(0.),
+    emFraction_(0.)
 {
   if ( tau.jetRef().isAvailable() && tau.jetRef().isNonnull() ) { // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
     p4Jet_ = tau.jetRef()->p4();

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -150,7 +150,7 @@
   </class>
   <class name="std::vector<pat::tau::TauCaloSpecific>" />
   <class name="pat::tau::TauPFEssential" ClassVersion="12">
-    <version ClassVersion="12" checksum="853010979" />
+    <version ClassVersion="12" checksum="1052833547" /> 
     <version ClassVersion="11" checksum="1193752112" />
     <version ClassVersion="10" checksum="1628501942" />
   </class>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -149,8 +149,9 @@
    <version ClassVersion="10" checksum="2692173055"/>
   </class>
   <class name="std::vector<pat::tau::TauCaloSpecific>" />
-  <class name="pat::tau::TauPFEssential" ClassVersion="12">
-    <version ClassVersion="12" checksum="1052833547" /> 
+  <class name="pat::tau::TauPFEssential" ClassVersion="13">
+    <version ClassVersion="13" checksum="1052833547" />
+    <version ClassVersion="12" checksum="3865233356" /> 
     <version ClassVersion="11" checksum="1193752112" />
     <version ClassVersion="10" checksum="1628501942" />
   </class>

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -361,95 +361,91 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     // extraction of variables needed to rerun MVA isolation and ant-electron discriminator on MiniAOD
     // (only available for PFTaus)
     if( aTau.isPFTau() ) {
-        edm::Handle<reco::PFTauCollection> pfTaus;
-        iEvent.getByToken(pfTauToken_, pfTaus);
-        reco::PFTauRef pfTauRef(pfTaus, idx);
+      edm::Handle<reco::PFTauCollection> pfTaus;
+      iEvent.getByToken(pfTauToken_, pfTaus);
+      reco::PFTauRef pfTauRef(pfTaus, idx);
+      pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
+      float ecalEnergy = 0;
+      float hcalEnergy = 0;
+      float sumEtaTimesEnergy = 0.;
+      float sumEnergy = 0.;
+      float leadChargedCandPt = -99;
+      float leadChargedCandEtaAtEcalEntrance = -99;	
+      const std::vector<reco::PFCandidatePtr>& signalCands = pfTauRef->signalPFCands();
+      for(std::vector<reco::PFCandidatePtr>::const_iterator it = signalCands.begin(); it != signalCands.end(); ++it) {
+        const reco::PFCandidatePtr& icand = *it;
+        ecalEnergy += icand->ecalEnergy();
+        hcalEnergy += icand->hcalEnergy();		
+	sumEtaTimesEnergy += icand->positionAtECALEntrance().eta()*icand->energy();
+        sumEnergy += icand->energy();	 
+	const reco::Track* track = 0;
+     	if ( icand->trackRef().isNonnull() ) track = icand->trackRef().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull()  ) track = icand->muonRef()->innerTrack().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull() ) track = icand->muonRef()->globalTrack().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull()  ) track = icand->muonRef()->outerTrack().get();
+     	else if ( icand->gsfTrackRef().isNonnull() ) track = icand->gsfTrackRef().get();
+     	if( track ) {
+     	  if( track->pt() > leadChargedCandPt ) {
+     	    leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
+     	    leadChargedCandPt = track->pt();
+     	  }
+        } 		
+      }
+      aTauPFEssential.ecalEnergy_ = ecalEnergy;
+      aTauPFEssential.hcalEnergy_ = hcalEnergy;
+      aTauPFEssential.ptLeadChargedCand_ = leadChargedCandPt;      
+      aTauPFEssential.etaAtEcalEntranceLeadChargedCand_ = leadChargedCandEtaAtEcalEntrance;
+      if (sumEnergy != 0.) {
+        aTauPFEssential.etaAtEcalEntrance_ = sumEtaTimesEnergy/sumEnergy;
+      }
+      else {
+        aTauPFEssential.etaAtEcalEntrance_ = -99.;
+      }	
+      float leadingTrackNormChi2 = 0;
+      float ecalEnergyLeadChargedHadrCand = -99.;
+      float hcalEnergyLeadChargedHadrCand = -99.;
+      float emFraction = -1.;
+      float myHCALenergy = 0.;
+      float myECALenergy = 0.;	
+      const reco::PFCandidatePtr& leadingPFCharged = pfTauRef->leadPFChargedHadrCand();
+      if(leadingPFCharged.isNonnull()) {
+	ecalEnergyLeadChargedHadrCand = leadingPFCharged->ecalEnergy();
+        hcalEnergyLeadChargedHadrCand = leadingPFCharged->hcalEnergy(); 
+        reco::TrackRef trackRef = leadingPFCharged->trackRef();
+        if( trackRef.isNonnull() ) {
+          leadingTrackNormChi2 = trackRef->normalizedChi2();			
+	  for( std::vector<reco::PFCandidatePtr>::const_iterator tauIt = pfTauRef->isolationPFCands().begin(); tauIt!=pfTauRef->isolationPFCands().end(); ++tauIt ){
+	    myHCALenergy += (*tauIt)->hcalEnergy();
+	    myECALenergy += (*tauIt)->ecalEnergy();
+	  }
+	  for( std::vector<reco::PFCandidatePtr>::const_iterator tauIt = pfTauRef->signalPFCands().begin(); tauIt!=pfTauRef->signalPFCands().end(); ++tauIt ){
+	    myHCALenergy += (*tauIt)->hcalEnergy();
+	    myECALenergy += (*tauIt)->ecalEnergy();
+	  }	  
+	  if( myHCALenergy + myECALenergy != 0. ) {
+            emFraction = myECALenergy/( myHCALenergy + myECALenergy);    
+	  }
+        }
+      }
+      aTauPFEssential.emFraction_ = emFraction;
+      aTauPFEssential.leadingTrackNormChi2_ = leadingTrackNormChi2;
+      aTauPFEssential.ecalEnergyLeadChargedHadrCand_ = ecalEnergyLeadChargedHadrCand;
+      aTauPFEssential.hcalEnergyLeadChargedHadrCand_ = hcalEnergyLeadChargedHadrCand; 	
+      // extraction of tau lifetime information
+      if( tauTransverseImpactParameterSrc_.label() != "" ) {
+        edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
+        iEvent.getByToken(tauTransverseImpactParameterToken_, tauLifetimeInfos);
+        const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTauRef];
         pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
-        float ecalEnergy = 0;
-        float hcalEnergy = 0;
-	float sumEtaTimesEnergy = 0.;
-        float sumEnergy = 0.;
-        float leadChargedCandPt = -99;
-        float leadChargedCandEtaAtEcalEntrance = -99;	
-        const std::vector<reco::PFCandidatePtr>& signalCands = pfTauRef->signalPFCands();
-        for(std::vector<reco::PFCandidatePtr>::const_iterator it = signalCands.begin(); it != signalCands.end(); ++it) {
-        	const reco::PFCandidatePtr& icand = *it;
-        	ecalEnergy += icand->ecalEnergy();
-        	hcalEnergy += icand->hcalEnergy();		
-		sumEtaTimesEnergy += icand->positionAtECALEntrance().eta()*icand->energy();
-                sumEnergy += icand->energy();	 
-		const reco::Track* track = 0;
-     	        if ( icand->trackRef().isNonnull() ) track = icand->trackRef().get();
-     	        else if ( icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull()  ) track = icand->muonRef()->innerTrack().get();
-     	        else if ( icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull() ) track = icand->muonRef()->globalTrack().get();
-     	        else if ( icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull()  ) track = icand->muonRef()->outerTrack().get();
-     	        else if ( icand->gsfTrackRef().isNonnull() ) track = icand->gsfTrackRef().get();
-     	        if ( track ) {
-     	          if ( track->pt() > leadChargedCandPt ) {
-     	            leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
-     	            leadChargedCandPt = track->pt();
-     	          }
-                } 		
-        }
-        aTauPFEssential.ecalEnergy_ = ecalEnergy;
-        aTauPFEssential.hcalEnergy_ = hcalEnergy;
-	aTauPFEssential.ptLeadChargedCand_ = leadChargedCandPt;      
-        aTauPFEssential.etaAtEcalEntranceLeadChargedCand_ = leadChargedCandEtaAtEcalEntrance;
-	if (sumEnergy != 0.) {
-          aTauPFEssential.etaAtEcalEntrance_ = sumEtaTimesEnergy/sumEnergy;
-        }
-	else {
-          aTauPFEssential.etaAtEcalEntrance_ = -99.;
-	}	
-        float leadingTrackNormChi2 = 0;
-	float ecalEnergyLeadChargedHadrCand = -99.;
-        float hcalEnergyLeadChargedHadrCand = -99.;
-	float emFraction = -1.;
-	float myHCALenergy = 0.;
-        float myECALenergy = 0.;	
-        const reco::PFCandidatePtr& leadingPFCharged = pfTauRef->leadPFChargedHadrCand();
-        if(leadingPFCharged.isNonnull()) {
-		ecalEnergyLeadChargedHadrCand = leadingPFCharged->ecalEnergy();
-                hcalEnergyLeadChargedHadrCand = leadingPFCharged->hcalEnergy(); 
-        	reco::TrackRef trackRef = leadingPFCharged->trackRef();
-        	if(trackRef.isNonnull()) {
-        		leadingTrackNormChi2 = trackRef->normalizedChi2();			
-
-			std::vector<reco::PFCandidatePtr> myPFCands;
-                        myPFCands.reserve(pfTauRef->isolationPFCands().size()+pfTauRef->signalPFCands().size()); 
-                        std::copy(pfTauRef->isolationPFCands().begin(), pfTauRef->isolationPFCands().end(),
-                        std::back_inserter(myPFCands));
-                        std::copy(pfTauRef->signalPFCands().begin(), pfTauRef->signalPFCands().end(),
-                        std::back_inserter(myPFCands));
-			
-			for(int i=0;i<(int)myPFCands.size();++i){
-	                  myHCALenergy += myPFCands[i]->hcalEnergy();
-	                  myECALenergy += myPFCands[i]->ecalEnergy();
-			}
-			if( myHCALenergy + myECALenergy != 0. ){
-                          emFraction = myECALenergy/( myHCALenergy + myECALenergy);    
-			}
-        	}
-        }
-	aTauPFEssential.emFraction_ = emFraction;
-        aTauPFEssential.leadingTrackNormChi2_ = leadingTrackNormChi2;
-	aTauPFEssential.ecalEnergyLeadChargedHadrCand_ = ecalEnergyLeadChargedHadrCand;
-        aTauPFEssential.hcalEnergyLeadChargedHadrCand_ = hcalEnergyLeadChargedHadrCand; 	
-        // extraction of tau lifetime information
-        if( tauTransverseImpactParameterSrc_.label() != "" ) {
-          edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
-          iEvent.getByToken(tauTransverseImpactParameterToken_, tauLifetimeInfos);
-          const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTauRef];
-          pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
-          aTauPFEssential.dxy_PCA_ = tauLifetimeInfo.dxy_PCA();
-          aTauPFEssential.dxy_ = tauLifetimeInfo.dxy();
-          aTauPFEssential.dxy_error_ = tauLifetimeInfo.dxy_error();
-          aTauPFEssential.hasSV_ = tauLifetimeInfo.hasSecondaryVertex();
-          aTauPFEssential.flightLength_ = tauLifetimeInfo.flightLength();
-          aTauPFEssential.flightLengthSig_ = tauLifetimeInfo.flightLengthSig();
-          aTauPFEssential.ip3d_ = tauLifetimeInfo.ip3d();
-          aTauPFEssential.ip3d_error_ = tauLifetimeInfo.ip3d_error();
-        }
+        aTauPFEssential.dxy_PCA_ = tauLifetimeInfo.dxy_PCA();
+        aTauPFEssential.dxy_ = tauLifetimeInfo.dxy();
+        aTauPFEssential.dxy_error_ = tauLifetimeInfo.dxy_error();
+        aTauPFEssential.hasSV_ = tauLifetimeInfo.hasSecondaryVertex();
+        aTauPFEssential.flightLength_ = tauLifetimeInfo.flightLength();
+        aTauPFEssential.flightLengthSig_ = tauLifetimeInfo.flightLengthSig();
+        aTauPFEssential.ip3d_ = tauLifetimeInfo.ip3d();
+        aTauPFEssential.ip3d_error_ = tauLifetimeInfo.ip3d_error();
+      }
     }
 
     // Isolation


### PR DESCRIPTION
This includes minimal extensions to the TauPFEssential class in DataFormats/PatCandidates to be able to run the tau anti-electron MVA discriminator in miniAOD input. The variables in question are:
- float etaAtEcalEntrance_;
- float ecalEnergyLeadChargedHadrCand_;
- float hcalEnergyLeadChargedHadrCand_;
- float etaAtEcalEntranceLeadChargedCand_;
- float ptLeadChargedCand_;
- float emFraction_;

this comes as an anticipated addition to the pull request https://github.com/cms-sw/cmssw/pull/15731 which allowed re-running only of the MVA based tau isolation and ID discriminator in the first place. The addition to the event content has been discussed in todays XPOG meeting (*). Usual tests have been applied without any occurence of showstoppers so far. 

Once this PR is also integrated successfully the plan is close in time to backport it to 80X to have this essential additions to the miniAOD event content available from the 80X RERECO campaign.   

Cheers,
Roger

(*)
https://indico.cern.ch/event/565391/
