### PR TITLE
Improvements to the Phase I quadruplet pixel seeding by Cellular Automaton

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -241,13 +241,9 @@ public:
         	{
                 unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
                 for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-
-                	if(theOuterNeighbors[i]->getCAState() >= theCAState - 1)
-                	{
-                		tmpNtuplet.push_back((theOuterNeighbors[i]));
-                		theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-                		tmpNtuplet.pop_back();
-                	}
+                    tmpNtuplet.push_back((theOuterNeighbors[i]));
+                    theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+                    tmpNtuplet.pop_back();
                 }
         	}
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -241,9 +241,13 @@ public:
         	{
                 unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
                 for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-                    tmpNtuplet.push_back((theOuterNeighbors[i]));
-                    theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-                    tmpNtuplet.pop_back();
+
+                	if(theOuterNeighbors[i]->getCAState() >= theCAState - 1)
+                	{
+                		tmpNtuplet.push_back((theOuterNeighbors[i]));
+                		theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+                		tmpNtuplet.pop_back();
+                	}
                 }
         	}
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -99,17 +99,26 @@ public:
     }
 
 
-    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut, const float hardPtCut) {
+    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x,
+    		const float region_origin_y, const float region_origin_radius, const float thetaCut,
+			const float phiCut, const float hardPtCut) {
 
-        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y, region_origin_radius, phiCut, hardPtCut)) {
+        if (areAlignedRZ(innerCell, ptmin, thetaCut) &&
+        		haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y,
+        				region_origin_radius, phiCut, hardPtCut)) {
             tagAsInnerNeighbor(innerCell);
             innerCell->tagAsOuterNeighbor(this);
         }
     }
 
-    void checkAlignmentAndPushTriplet(CACell* innerCell, std::vector<CACell::CAntuplet>& foundTriplets, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut, const float hardPtCut) {
+    void checkAlignmentAndPushTriplet(CACell* innerCell, std::vector<CACell::CAntuplet>& foundTriplets,
+    		const float ptmin, const float region_origin_x, const float region_origin_y,
+			const float region_origin_radius, const float thetaCut, const float phiCut,
+			const float hardPtCut) {
 
-        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y, region_origin_radius, phiCut, hardPtCut)) {
+        if (areAlignedRZ(innerCell, ptmin, thetaCut) &&
+        		haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y,
+        				region_origin_radius, phiCut, hardPtCut)) {
         	foundTriplets.emplace_back(CACell::CAntuplet{innerCell,this});
 
         }
@@ -157,7 +166,7 @@ public:
 
         float distance_13_squared = (x1 - x3)*(x1 - x3) + (y1 - y3)*(y1 - y3);
         float tan_12_13_half_mul_distance_13_squared = fabs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
-        if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4*distance_13_squared)
+        if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4f*distance_13_squared)
         {
         	return true;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -98,34 +98,55 @@ public:
 
     }
 
-    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut) {
 
-        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell, region_origin_x, region_origin_y, region_origin_radius, phiCut)) {
+    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut, const float hardPtCut) {
+
+        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y, region_origin_radius, phiCut, hardPtCut)) {
             tagAsInnerNeighbor(innerCell);
             innerCell->tagAsOuterNeighbor(this);
         }
     }
 
-    bool areAlignedRZ(const CACell* otherCell, const float ptmin, const float thetaCut) const {
+    void checkAlignmentAndPushTriplet(CACell* innerCell, std::vector<CACell::CAntuplet>& foundTriplets, const float ptmin, const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float thetaCut, const float phiCut, const float hardPtCut) {
+
+        if (areAlignedRZ(innerCell, ptmin, thetaCut) && haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y, region_origin_radius, phiCut, hardPtCut)) {
+        	foundTriplets.emplace_back(CACell::CAntuplet{innerCell,this});
+
+        }
+    }
+
+
+
+    bool areAlignedRZ(const CACell* otherCell, const float ptmin, const float thetaCut) const
+    {
 
         float r1 = otherCell->getInnerR();
         float z1 = otherCell->getInnerZ();
-        float distance_13_squared = (r1 - theOuterR)*(r1 - theOuterR) + (z1 - theOuterZ)*(z1 - theOuterZ);
+        float radius_diff = fabs(r1 - theOuterR);
+        float distance_13_squared = radius_diff*radius_diff + (z1 - theOuterZ)*(z1 - theOuterZ);
+
+        float pMin = ptmin*sqrt(distance_13_squared); //this needs to be divided by radius_diff later
+
         float tan_12_13_half_mul_distance_13_squared = fabs(z1 * (theInnerR - theOuterR) + theInnerZ * (theOuterR - r1) + theOuterZ * (r1 - theInnerR)) ;
-        return tan_12_13_half_mul_distance_13_squared * ptmin <= thetaCut * distance_13_squared;
+        return tan_12_13_half_mul_distance_13_squared * pMin <= thetaCut * distance_13_squared * radius_diff;
     }
 
-    void tagAsOuterNeighbor(CACell* otherCell) {
+    void tagAsOuterNeighbor(CACell* otherCell)
+    {
         theOuterNeighbors.push_back(otherCell);
     }
 
-    void tagAsInnerNeighbor(CACell* otherCell) {
+    void tagAsInnerNeighbor(CACell* otherCell)
+    {
         theInnerNeighbors.push_back(otherCell);
     }
 
-    bool haveSimilarCurvature(const CACell* otherCell,
-            const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut) const {
-        auto x1 = otherCell->getInnerX();
+    bool haveSimilarCurvature(const CACell* otherCell, const float ptmin,
+            const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut, const float hardPtCut) const
+    {
+
+
+    	auto x1 = otherCell->getInnerX();
         auto y1 = otherCell->getInnerY();
 
         auto x2 = getInnerX();
@@ -134,18 +155,29 @@ public:
         auto x3 = getOuterX();
         auto y3 = getOuterY();
 
-        auto precision = 0.5f;
+        float distance_13_squared = (x1 - x3)*(x1 - x3) + (y1 - y3)*(y1 - y3);
+        float tan_12_13_half_mul_distance_13_squared = fabs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
+        if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4*distance_13_squared)
+        {
+        	return true;
+
+        }
+
+        //87 cm/GeV = 1/(3.8T * 0.3)
+
+        //take less than radius given by the hardPtCut and reject everything below
+        float minRadius = hardPtCut*87.f;
+
+        auto det = (x1 - x2) * (y2 - y3) - (x2 - x3) * (y1 - y2);
+
+
         auto offset = x2 * x2 + y2*y2;
 
         auto bc = (x1 * x1 + y1 * y1 - offset)*0.5f;
 
         auto cd = (offset - x3 * x3 - y3 * y3)*0.5f;
 
-        auto det = (x1 - x2) * (y2 - y3) - (x2 - x3)* (y1 - y2);
 
-        //points are aligned
-        if (fabs(det) < precision)
-            return true;
 
         auto idet = 1.f / det;
 
@@ -153,12 +185,15 @@ public:
         auto y_center = (cd * (x1 - x2) - bc * (x2 - x3)) * idet;
 
         auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
-        auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
 
-        auto minimumOfIntersectionRange = (radius - region_origin_radius)*(radius - region_origin_radius) - phiCut;
+        if(radius < minRadius)
+        	return false;
+        auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
+        auto region_origin_radius_plus_tolerance = region_origin_radius + phiCut;
+        auto minimumOfIntersectionRange = (radius - region_origin_radius_plus_tolerance)*(radius - region_origin_radius_plus_tolerance);
 
         if (centers_distance_squared >= minimumOfIntersectionRange) {
-            auto minimumOfIntersectionRange = (radius + region_origin_radius)*(radius + region_origin_radius) + phiCut;
+            auto minimumOfIntersectionRange = (radius + region_origin_radius_plus_tolerance)*(radius + region_origin_radius_plus_tolerance);
             return centers_distance_squared <= minimumOfIntersectionRange;
         } else {
 
@@ -188,23 +223,32 @@ public:
     void findNtuplets(std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
 
         // the building process for a track ends if:
-        // it has no right neighbor
+        // it has no outer neighbor
         // it has no compatible neighbor
         // the ntuplets is then saved if the number of hits it contains is greater than a threshold
 
-        if (theOuterNeighbors.size() == 0) {
-            if (tmpNtuplet.size() >= minHitsPerNtuplet - 1)
-                foundNtuplets.push_back(tmpNtuplet);
-            else
-                return;
-        } else {
-            unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
-            for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-                tmpNtuplet.push_back((theOuterNeighbors[i]));
-                theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-                tmpNtuplet.pop_back();
-            }
+        if (tmpNtuplet.size() == minHitsPerNtuplet - 1)
+        {
+            foundNtuplets.push_back(tmpNtuplet);
         }
+        else
+        {
+        	if(theOuterNeighbors.size() == 0)
+        	{
+        		return;
+        	}
+        	else
+        	{
+                unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
+                for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
+                    tmpNtuplet.push_back((theOuterNeighbors[i]));
+                    theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+                    tmpNtuplet.pop_back();
+                }
+        	}
+
+        }
+
     }
     
     

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
@@ -19,8 +19,8 @@ class CALayer
 {
 public:
 	CALayer(const std::string& layerName, std::size_t numberOfHits )
+	: theName(layerName)
 	{
-		theName = layerName;
 		isOuterHitOfCell.resize(numberOfHits);
 	}
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
@@ -1,0 +1,81 @@
+/*
+ * CAGraph.h
+ *
+ *  Created on: Aug 19, 2016
+ *      Author: fpantale
+ */
+
+#ifndef CAGRAPH_H_
+#define CAGRAPH_H_
+
+#include <vector>
+#include <array>
+#include <string>
+#include <queue>
+#include <functional>
+#include "CACell.h"
+
+class CALayer
+{
+public:
+	CALayer(const std::string& layerName, std::size_t numberOfHits )
+	{
+		theName = layerName;
+		isOuterHitOfCell.resize(numberOfHits);
+	}
+
+	bool operator==(const std::string& otherString)
+	{
+		return otherString == theName;
+	}
+
+	std::string name() const
+	{
+		return theName;
+	}
+
+	std::vector<int> theOuterLayerPairs;
+	std::vector<int> theInnerLayerPairs;
+
+	std::vector<int> theOuterLayers;
+	std::vector<int> theInnerLayers;
+	std::vector< std::vector<CACell*> >  isOuterHitOfCell;
+
+
+private:
+
+	std::string theName;
+};
+
+struct CALayerPair
+{
+
+	CALayerPair(int a, int b)
+
+	{
+		theLayers[0] = a;
+		theLayers[1] = b;
+	}
+
+
+
+	bool operator==(const CALayerPair& otherLayerPair)
+	{
+		return (theLayers[0] == otherLayerPair.theLayers[0])
+				&& (theLayers[1] == otherLayerPair.theLayers[1]);
+	}
+
+	std::array<int, 2> theLayers;
+	std::vector<CACell> theFoundCells;
+
+};
+
+struct CAGraph
+{
+	std::vector<CALayer> theLayers;
+	std::vector<CALayerPair> theLayerPairs;
+	std::vector<int> theRootLayers;
+
+};
+
+#endif /* CAGRAPH_H_ */

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
@@ -1,12 +1,5 @@
-/*
- * CAGraph.h
- *
- *  Created on: Aug 19, 2016
- *      Author: fpantale
- */
-
-#ifndef CAGRAPH_H_
-#define CAGRAPH_H_
+#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
+#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
 
 #include <vector>
 #include <array>
@@ -15,9 +8,8 @@
 #include <functional>
 #include "CACell.h"
 
-class CALayer
+struct CALayer
 {
-public:
 	CALayer(const std::string& layerName, std::size_t numberOfHits )
 	: theName(layerName)
 	{

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -41,9 +41,9 @@ maxChi2(cfg.getParameter<edm::ParameterSet>("maxChi2")),
 fitFastCircle(cfg.getParameter<bool>("fitFastCircle")),
 fitFastCircleChi2Cut(cfg.getParameter<bool>("fitFastCircleChi2Cut")),
 useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
-CAThetaCut(cfg.getParameter<double>("CAThetaCut")),
-CAPhiCut(cfg.getParameter<double>("CAPhiCut")),
-CAHardPtCut(cfg.getParameter<double>("CAHardPtCut"))
+caThetaCut(cfg.getParameter<double>("CAThetaCut")),
+caPhiCut(cfg.getParameter<double>("CAPhiCut")),
+caHardPtCut(cfg.getParameter<double>("CAHardPtCut"))
 {
   if (cfg.exists("SeedComparitorPSet"))
   {
@@ -146,8 +146,8 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	CellularAutomaton ca(g);
 
-	ca.createAndConnectCells(hitDoublets, region, CAThetaCut,
-			CAPhiCut, CAHardPtCut);
+	ca.createAndConnectCells(hitDoublets, region, caThetaCut,
+			caPhiCut, caHardPtCut);
 
 	ca.evolve(numberOfHitsInNtuplet);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -121,9 +121,9 @@ private:
     const bool fitFastCircleChi2Cut;
     const bool useBendingCorrection;
 
-    const float CAThetaCut = 0.00125f;
-    const float CAPhiCut = 0.1f;
-    const float CAHardPtCut = 0.f;
+    const float caThetaCut = 0.00125f;
+    const float caPhiCut = 0.1f;
+    const float caHardPtCut = 0.f;
 
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -32,15 +32,13 @@ using namespace ctfseeding;
 
 CAHitTripletGenerator::CAHitTripletGenerator(const edm::ParameterSet& cfg,
 		edm::ConsumesCollector& iC) :
-		theSeedingLayerToken(
-				iC.consumes < SeedingLayerSetsHits
-						> (cfg.getParameter < edm::InputTag > ("SeedingLayers"))), extraHitRPhitolerance(
-				cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
-		maxChi2(cfg.getParameter < edm::ParameterSet > ("maxChi2")), useBendingCorrection(
-				cfg.getParameter<bool>("useBendingCorrection")), CAThetaCut(
-				cfg.getParameter<double>("CAThetaCut")), CAPhiCut(
-				cfg.getParameter<double>("CAPhiCut")), CAHardPtCut(
-				cfg.getParameter<double>("CAHardPtCut"))
+		theSeedingLayerToken(iC.consumes < SeedingLayerSetsHits	> (cfg.getParameter < edm::InputTag > ("SeedingLayers"))),
+		extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
+		maxChi2(cfg.getParameter < edm::ParameterSet > ("maxChi2")),
+		useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
+		caThetaCut(	cfg.getParameter<double>("CAThetaCut")),
+		caPhiCut(cfg.getParameter<double>("CAPhiCut")),
+		caHardPtCut(cfg.getParameter<double>("CAHardPtCut"))
 {
 	if (cfg.exists("SeedComparitorPSet"))
 	{
@@ -144,8 +142,8 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 	std::vector<CACell::CAntuplet> foundTriplets;
 	CellularAutomaton ca(g);
 
-	ca.findTriplets(hitDoublets, foundTriplets, region, CAThetaCut, CAPhiCut,
-			CAHardPtCut);
+	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
+			caHardPtCut);
 	unsigned int numberOfFoundTriplets = foundTriplets.size();
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -1,0 +1,226 @@
+#include <unordered_map>
+
+#include "CAHitTripletGenerator.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTrackFitting/src/RZLine.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
+#include "CellularAutomaton.h"
+
+#include "CommonTools/Utils/interface/DynArray.h"
+
+#include "FWCore/Utilities/interface/isFinite.h"
+
+namespace
+{
+
+template<typename T>
+T sqr(T x)
+{
+	return x * x;
+}
+}
+
+using namespace std;
+using namespace ctfseeding;
+
+CAHitTripletGenerator::CAHitTripletGenerator(const edm::ParameterSet& cfg,
+		edm::ConsumesCollector& iC) :
+		theSeedingLayerToken(
+				iC.consumes < SeedingLayerSetsHits> (cfg.getParameter < edm::InputTag > ("SeedingLayers"))),
+				extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
+				maxChi2(cfg.getParameter < edm::ParameterSet > ("maxChi2")),
+				useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
+				CAThetaCut(cfg.getParameter<double>("CAThetaCut")),
+				CAPhiCut(cfg.getParameter<double>("CAPhiCut"))
+{
+	if (cfg.exists("SeedComparitorPSet"))
+	{
+		edm::ParameterSet comparitorPSet = cfg.getParameter < edm::ParameterSet
+				> ("SeedComparitorPSet");
+		std::string comparitorName = comparitorPSet.getParameter < std::string
+				> ("ComponentName");
+		if (comparitorName != "none")
+		{
+			theComparitor.reset(
+					SeedComparitorFactory::get()->create(comparitorName,
+							comparitorPSet, iC));
+		}
+	}
+}
+
+CAHitTripletGenerator::~CAHitTripletGenerator()
+{
+}
+
+void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
+		OrderedHitTriplets & result, const edm::Event& ev,
+		const edm::EventSetup& es)
+{
+	edm::Handle<SeedingLayerSetsHits> hlayers;
+	ev.getByToken(theSeedingLayerToken, hlayers);
+	const SeedingLayerSetsHits& layers = *hlayers;
+	if (layers.numberOfLayersInSet() != 3)
+		throw cms::Exception("Configuration")
+				<< "CAHitTripletGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 3, got "
+				<< layers.numberOfLayersInSet();
+
+	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+	std::unordered_map<std::string, HitDoublets> doubletsMap;
+	std::array<const HitDoublets*, 2> layersDoublets;
+
+	for (unsigned int j = 0; j < layers.size(); j++)
+	{
+		for (unsigned int i = 0; i < 2; ++i)
+		{
+			auto const & inner = layers[j][i];
+			auto const & outer = layers[j][i + 1];
+			auto layersPair = inner.name() + '+' + outer.name();
+			auto it = doubletsMap.find(layersPair);
+			if (it == doubletsMap.end())
+			{
+
+				std::tie(it, std::ignore) = doubletsMap.insert(
+						std::make_pair(layersPair,
+								thePairGenerator.doublets(region, ev, es, inner,
+										outer)));
+			}
+			layersDoublets[i] = &it->second;
+
+		}
+
+		findTriplets(region, result, ev, es, layers[j], layersDoublets);
+	}
+
+	theLayerCache.clear();
+}
+
+void CAHitTripletGenerator::findTriplets(const TrackingRegion& region,
+		OrderedHitTriplets& result, const edm::Event& ev,
+		const edm::EventSetup& es,
+		const SeedingLayerSetsHits::SeedingLayerSet& threeLayers,
+		const std::array<const HitDoublets*, 2> layersDoublets)
+{
+//	if (theComparitor)
+//		theComparitor->init(ev, es);
+//	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+//
+//	std::vector<CACell::CAntuplet> foundTriplets;
+//
+//	CellularAutomaton<3> ca;
+//
+//	ca.findTriplets(layersDoublets, threeLayers, foundTriplets, region,
+//			CAThetaCut, CAPhiCut);
+//	unsigned int numberOfFoundTriplets = foundTriplets.size();
+//
+//	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
+//
+//	// re-used thoughout, need to be vectors because of RZLine interface
+//	std::vector<float> bc_r(3), bc_z(3), bc_errZ(3);
+//
+//	std::vector<GlobalPoint> gps(3);
+//	std::vector<GlobalError> ges(3);
+//	std::vector<bool> barrels(3);
+//
+//	for (unsigned int tripletId = 0; tripletId < numberOfFoundTriplets;
+//			++tripletId)
+//	{
+//
+//		OrderedHitTriplet tmpTriplet(foundTriplets[tripletId][0]->getInnerHit(),
+//				foundTriplets[tripletId][0]->getOuterHit(),
+//				foundTriplets[tripletId][1]->getOuterHit());
+//
+//
+//
+//
+//		auto isBarrel = [](const unsigned id) -> bool
+//		{
+//			return id == PixelSubdetector::PixelBarrel;
+//		};
+//		for (unsigned int i = 0; i < 2; ++i)
+//		{
+//			auto const& ahit = foundTriplets[tripletId][i]->getInnerHit();
+//			gps[i] = ahit->globalPosition();
+//			ges[i] = ahit->globalPositionError();
+//			barrels[i] = isBarrel(ahit->geographicalId().subdetId());
+//		}
+//
+//		auto const& ahit = foundTriplets[tripletId][1]->getOuterHit();
+//		gps[2] = ahit->globalPosition();
+//		ges[2] = ahit->globalPositionError();
+//		barrels[2] = isBarrel(ahit->geographicalId().subdetId());
+//
+//
+//
+//		PixelRecoLineRZ line(gps[0], gps[2]);
+//		ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2],
+//				extraHitRPhitolerance);
+//		const float curvature = predictionRPhi.curvature(
+//				ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
+//		const float abscurv = std::abs(curvature);
+//		const float thisMaxChi2 = maxChi2Eval.value(abscurv);
+//		float chi2 = std::numeric_limits<float>::quiet_NaN();
+//		// TODO: Do we have any use case to not use bending correction?
+//		if (useBendingCorrection)
+//		{
+//			// Following PixelFitterByConformalMappingAndLine
+//			const float simpleCot = (gps.back().z() - gps.front().z())
+//					/ (gps.back().perp() - gps.front().perp());
+//			const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
+//			for (int i = 0; i < 3; ++i)
+//			{
+//				const GlobalPoint & point = gps[i];
+//				const GlobalError & error = ges[i];
+//				bc_r[i] = sqrt(
+//						sqr(point.x() - region.origin().x())
+//								+ sqr(point.y() - region.origin().y()));
+//				bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt,
+//						es)(bc_r[i]);
+//				bc_z[i] = point.z() - region.origin().z();
+//				bc_errZ[i] =
+//						(barrels[i]) ?
+//								sqrt(error.czz()) :
+//								sqrt(error.rerr(point)) * simpleCot;
+//			}
+//			RZLine rzLine(bc_r, bc_z, bc_errZ);
+//			float cottheta, intercept, covss, covii, covsi;
+//			rzLine.fit(cottheta, intercept, covss, covii, covsi);
+//			chi2 = rzLine.chi2(cottheta, intercept);
+//		}
+//		else
+//		{
+//			RZLine rzLine(gps, ges, barrels);
+//			float cottheta, intercept, covss, covii, covsi;
+//			rzLine.fit(cottheta, intercept, covss, covii, covsi);
+//			chi2 = rzLine.chi2(cottheta, intercept);
+//		}
+//
+//		if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
+//		{
+//			continue;
+//
+//		}
+//
+//		if (theComparitor)
+//		{
+//			if (!theComparitor->compatible(tmpTriplet, region))
+//			{
+//
+//
+//				continue;
+//			}
+//		}
+//
+//		result.push_back(tmpTriplet);
+//
+//
+//	}
+}
+

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -34,12 +34,14 @@ using namespace ctfseeding;
 CAHitTripletGenerator::CAHitTripletGenerator(const edm::ParameterSet& cfg,
 		edm::ConsumesCollector& iC) :
 		theSeedingLayerToken(
-				iC.consumes < SeedingLayerSetsHits> (cfg.getParameter < edm::InputTag > ("SeedingLayers"))),
-				extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
-				maxChi2(cfg.getParameter < edm::ParameterSet > ("maxChi2")),
-				useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
-				CAThetaCut(cfg.getParameter<double>("CAThetaCut")),
-				CAPhiCut(cfg.getParameter<double>("CAPhiCut"))
+				iC.consumes < SeedingLayerSetsHits
+						> (cfg.getParameter < edm::InputTag > ("SeedingLayers"))), extraHitRPhitolerance(
+				cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
+		maxChi2(cfg.getParameter < edm::ParameterSet > ("maxChi2")), useBendingCorrection(
+				cfg.getParameter<bool>("useBendingCorrection")), CAThetaCut(
+				cfg.getParameter<double>("CAThetaCut")), CAPhiCut(
+				cfg.getParameter<double>("CAPhiCut")), CAHardPtCut(
+				cfg.getParameter<double>("CAHardPtCut"))
 {
 	if (cfg.exists("SeedComparitorPSet"))
 	{
@@ -72,155 +74,175 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 				<< "CAHitTripletGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 3, got "
 				<< layers.numberOfLayersInSet();
 
-	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
-	std::unordered_map<std::string, HitDoublets> doubletsMap;
-	std::array<const HitDoublets*, 2> layersDoublets;
+	CAGraph g;
 
-	for (unsigned int j = 0; j < layers.size(); j++)
+	std::vector<HitDoublets> hitDoublets;
+
+	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+	for (unsigned int i = 0; i < layers.size(); i++)
 	{
-		for (unsigned int i = 0; i < 2; ++i)
+		for (unsigned int j = 0; j < 3; ++j)
 		{
-			auto const & inner = layers[j][i];
-			auto const & outer = layers[j][i + 1];
-			auto layersPair = inner.name() + '+' + outer.name();
-			auto it = doubletsMap.find(layersPair);
-			if (it == doubletsMap.end())
+			auto vertexIndex = 0;
+			auto foundVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
+					layers[i][j].name());
+			if (foundVertex == g.theLayers.end())
+			{
+				g.theLayers.emplace_back(layers[i][j].name(),
+						layers[i][j].hits().size());
+				vertexIndex = g.theLayers.size() - 1;
+			}
+			else
+			{
+				vertexIndex = foundVertex - g.theLayers.begin();
+			}
+			if (j == 0)
 			{
 
-				std::tie(it, std::ignore) = doubletsMap.insert(
-						std::make_pair(layersPair,
-								thePairGenerator.doublets(region, ev, es, inner,
-										outer)));
+				if (std::find(g.theRootLayers.begin(), g.theRootLayers.end(),
+						vertexIndex) == g.theRootLayers.end())
+				{
+					g.theRootLayers.emplace_back(vertexIndex);
+
+				}
+
 			}
-			layersDoublets[i] = &it->second;
+			else
+			{
+
+				auto innerVertex = std::find(g.theLayers.begin(),
+						g.theLayers.end(), layers[i][j - 1].name());
+
+				CALayerPair tmpInnerLayerPair(innerVertex - g.theLayers.begin(),
+						vertexIndex);
+
+				if (std::find(g.theLayerPairs.begin(), g.theLayerPairs.end(),
+						tmpInnerLayerPair) == g.theLayerPairs.end())
+				{
+					hitDoublets.emplace_back(
+							thePairGenerator.doublets(region, ev, es,
+									layers[i][j - 1], layers[i][j]));
+
+					g.theLayerPairs.push_back(tmpInnerLayerPair);
+					g.theLayers[vertexIndex].theInnerLayers.push_back(
+							innerVertex - g.theLayers.begin());
+					innerVertex->theOuterLayers.push_back(vertexIndex);
+					g.theLayers[vertexIndex].theInnerLayerPairs.push_back(
+							g.theLayerPairs.size() - 1);
+					innerVertex->theOuterLayerPairs.push_back(
+							g.theLayerPairs.size() - 1);
+
+				}
+
+			}
+
+		}
+	}
+
+	if (theComparitor)
+		theComparitor->init(ev, es);
+
+	std::vector<CACell::CAntuplet> foundTriplets;
+	CellularAutomaton ca(g);
+
+	ca.findTriplets(hitDoublets, foundTriplets, region, CAThetaCut, CAPhiCut,
+			CAHardPtCut);
+	unsigned int numberOfFoundTriplets = foundTriplets.size();
+
+	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
+
+	// re-used thoughout, need to be vectors because of RZLine interface
+	std::vector<float> bc_r(3), bc_z(3), bc_errZ(3);
+
+	declareDynArray(GlobalPoint, 3, gps);
+	declareDynArray(GlobalError, 3, ges);
+	declareDynArray(bool, 3, barrels);
+
+	for (unsigned int tripletId = 0; tripletId < numberOfFoundTriplets;
+			++tripletId)
+	{
+
+		OrderedHitTriplet tmpTriplet(foundTriplets[tripletId][0]->getInnerHit(),
+				foundTriplets[tripletId][0]->getOuterHit(),
+				foundTriplets[tripletId][1]->getOuterHit());
+
+		auto isBarrel = [](const unsigned id) -> bool
+		{
+			return id == PixelSubdetector::PixelBarrel;
+		};
+		for (unsigned int i = 0; i < 2; ++i)
+		{
+			auto const& ahit = foundTriplets[tripletId][i]->getInnerHit();
+			gps[i] = ahit->globalPosition();
+			ges[i] = ahit->globalPositionError();
+			barrels[i] = isBarrel(ahit->geographicalId().subdetId());
+		}
+
+		auto const& ahit = foundTriplets[tripletId][1]->getOuterHit();
+		gps[2] = ahit->globalPosition();
+		ges[2] = ahit->globalPositionError();
+		barrels[2] = isBarrel(ahit->geographicalId().subdetId());
+
+		PixelRecoLineRZ line(gps[0], gps[2]);
+		ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2],
+				extraHitRPhitolerance);
+		const float curvature = predictionRPhi.curvature(
+				ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
+		const float abscurv = std::abs(curvature);
+		const float thisMaxChi2 = maxChi2Eval.value(abscurv);
+		float chi2 = std::numeric_limits<float>::quiet_NaN();
+		// TODO: Do we have any use case to not use bending correction?
+		if (useBendingCorrection)
+		{
+			// Following PixelFitterByConformalMappingAndLine
+			const float simpleCot = (gps.back().z() - gps.front().z())
+					/ (gps.back().perp() - gps.front().perp());
+			const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
+			for (int i = 0; i < 3; ++i)
+			{
+				const GlobalPoint & point = gps[i];
+				const GlobalError & error = ges[i];
+				bc_r[i] = sqrt(
+						sqr(point.x() - region.origin().x())
+								+ sqr(point.y() - region.origin().y()));
+				bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt,
+						es)(bc_r[i]);
+				bc_z[i] = point.z() - region.origin().z();
+				bc_errZ[i] =
+						(barrels[i]) ?
+								sqrt(error.czz()) :
+								sqrt(error.rerr(point)) * simpleCot;
+			}
+			RZLine rzLine(bc_r, bc_z, bc_errZ);
+			float cottheta, intercept, covss, covii, covsi;
+			rzLine.fit(cottheta, intercept, covss, covii, covsi);
+			chi2 = rzLine.chi2(cottheta, intercept);
+		}
+		else
+		{
+			RZLine rzLine(gps, ges, barrels);
+			float cottheta, intercept, covss, covii, covsi;
+			rzLine.fit(cottheta, intercept, covss, covii, covsi);
+			chi2 = rzLine.chi2(cottheta, intercept);
+		}
+
+		if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
+		{
+			continue;
 
 		}
 
-		findTriplets(region, result, ev, es, layers[j], layersDoublets);
+		if (theComparitor)
+		{
+			if (!theComparitor->compatible(tmpTriplet, region))
+			{
+
+				continue;
+			}
+		}
+
+		result.push_back(tmpTriplet);
+
 	}
-
-	theLayerCache.clear();
-}
-
-void CAHitTripletGenerator::findTriplets(const TrackingRegion& region,
-		OrderedHitTriplets& result, const edm::Event& ev,
-		const edm::EventSetup& es,
-		const SeedingLayerSetsHits::SeedingLayerSet& threeLayers,
-		const std::array<const HitDoublets*, 2> layersDoublets)
-{
-//	if (theComparitor)
-//		theComparitor->init(ev, es);
-//	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
-//
-//	std::vector<CACell::CAntuplet> foundTriplets;
-//
-//	CellularAutomaton<3> ca;
-//
-//	ca.findTriplets(layersDoublets, threeLayers, foundTriplets, region,
-//			CAThetaCut, CAPhiCut);
-//	unsigned int numberOfFoundTriplets = foundTriplets.size();
-//
-//	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
-//
-//	// re-used thoughout, need to be vectors because of RZLine interface
-//	std::vector<float> bc_r(3), bc_z(3), bc_errZ(3);
-//
-//	std::vector<GlobalPoint> gps(3);
-//	std::vector<GlobalError> ges(3);
-//	std::vector<bool> barrels(3);
-//
-//	for (unsigned int tripletId = 0; tripletId < numberOfFoundTriplets;
-//			++tripletId)
-//	{
-//
-//		OrderedHitTriplet tmpTriplet(foundTriplets[tripletId][0]->getInnerHit(),
-//				foundTriplets[tripletId][0]->getOuterHit(),
-//				foundTriplets[tripletId][1]->getOuterHit());
-//
-//
-//
-//
-//		auto isBarrel = [](const unsigned id) -> bool
-//		{
-//			return id == PixelSubdetector::PixelBarrel;
-//		};
-//		for (unsigned int i = 0; i < 2; ++i)
-//		{
-//			auto const& ahit = foundTriplets[tripletId][i]->getInnerHit();
-//			gps[i] = ahit->globalPosition();
-//			ges[i] = ahit->globalPositionError();
-//			barrels[i] = isBarrel(ahit->geographicalId().subdetId());
-//		}
-//
-//		auto const& ahit = foundTriplets[tripletId][1]->getOuterHit();
-//		gps[2] = ahit->globalPosition();
-//		ges[2] = ahit->globalPositionError();
-//		barrels[2] = isBarrel(ahit->geographicalId().subdetId());
-//
-//
-//
-//		PixelRecoLineRZ line(gps[0], gps[2]);
-//		ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2],
-//				extraHitRPhitolerance);
-//		const float curvature = predictionRPhi.curvature(
-//				ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
-//		const float abscurv = std::abs(curvature);
-//		const float thisMaxChi2 = maxChi2Eval.value(abscurv);
-//		float chi2 = std::numeric_limits<float>::quiet_NaN();
-//		// TODO: Do we have any use case to not use bending correction?
-//		if (useBendingCorrection)
-//		{
-//			// Following PixelFitterByConformalMappingAndLine
-//			const float simpleCot = (gps.back().z() - gps.front().z())
-//					/ (gps.back().perp() - gps.front().perp());
-//			const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
-//			for (int i = 0; i < 3; ++i)
-//			{
-//				const GlobalPoint & point = gps[i];
-//				const GlobalError & error = ges[i];
-//				bc_r[i] = sqrt(
-//						sqr(point.x() - region.origin().x())
-//								+ sqr(point.y() - region.origin().y()));
-//				bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt,
-//						es)(bc_r[i]);
-//				bc_z[i] = point.z() - region.origin().z();
-//				bc_errZ[i] =
-//						(barrels[i]) ?
-//								sqrt(error.czz()) :
-//								sqrt(error.rerr(point)) * simpleCot;
-//			}
-//			RZLine rzLine(bc_r, bc_z, bc_errZ);
-//			float cottheta, intercept, covss, covii, covsi;
-//			rzLine.fit(cottheta, intercept, covss, covii, covsi);
-//			chi2 = rzLine.chi2(cottheta, intercept);
-//		}
-//		else
-//		{
-//			RZLine rzLine(gps, ges, barrels);
-//			float cottheta, intercept, covss, covii, covsi;
-//			rzLine.fit(cottheta, intercept, covss, covii, covsi);
-//			chi2 = rzLine.chi2(cottheta, intercept);
-//		}
-//
-//		if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
-//		{
-//			continue;
-//
-//		}
-//
-//		if (theComparitor)
-//		{
-//			if (!theComparitor->compatible(tmpTriplet, region))
-//			{
-//
-//
-//				continue;
-//			}
-//		}
-//
-//		result.push_back(tmpTriplet);
-//
-//
-//	}
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -4,6 +4,7 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 #include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -39,11 +39,6 @@ public:
     virtual void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets & triplets,
             const edm::Event & ev, const edm::EventSetup& es);
 
-    void findTriplets(const TrackingRegion& region, OrderedHitTriplets& result,
-            const edm::Event& ev, const edm::EventSetup& es,
-            const SeedingLayerSetsHits::SeedingLayerSet& threeLayers,
-			const std::array<const HitDoublets*,2> layerDoublets);
-
 
 private:
     edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
@@ -122,7 +117,8 @@ private:
     const bool useBendingCorrection;
 
     const float CAThetaCut = 0.00125f;
-    const float CAPhiCut = 10.f;
+    const float CAPhiCut = 1.f;
+    const float CAHardPtCut = 0.f;
 
 };
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -1,15 +1,13 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
+#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITTRIPLETGENERATOR_H
+#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITTRIPLETGENERATOR_H
 
-#include "RecoPixelVertexing/PixelTriplets/interface/HitQuadrupletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
-#include "RecoPixelVertexing/PixelTrackFitting/src/RZLine.h"
-#include "RecoTracker/TkSeedGenerator/interface/FastCircleFit.h"
+
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 #include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "CAGraph.h"
 
 
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
@@ -18,7 +16,6 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class TrackingRegion;
-class HitQuadrupletGeneratorFromTripletAndLayers;
 class SeedingLayerSetsHits;
 
 namespace edm {
@@ -28,19 +25,24 @@ namespace edm {
     class EventSetup;
 }
 
-class CAHitQuadrupletGenerator : public HitQuadrupletGenerator {
+class CAHitTripletGenerator : public HitTripletGenerator {
 public:
     typedef LayerHitMapCache LayerCacheType;
 
 public:
 
-    CAHitQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
+    CAHitTripletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-    virtual ~CAHitQuadrupletGenerator();
+    virtual ~CAHitTripletGenerator();
 
     /// from base class
-    virtual void hitQuadruplets(const TrackingRegion& reg, OrderedHitSeeds & quadruplets,
+    virtual void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets & triplets,
             const edm::Event & ev, const edm::EventSetup& es);
+
+    void findTriplets(const TrackingRegion& region, OrderedHitTriplets& result,
+            const edm::Event& ev, const edm::EventSetup& es,
+            const SeedingLayerSetsHits::SeedingLayerSet& threeLayers,
+			const std::array<const HitDoublets*,2> layerDoublets);
 
 
 private:
@@ -90,11 +92,11 @@ private:
         pt2_(pset.getParameter<double>("pt2")),
         enabled_(pset.getParameter<bool>("enabled")) {
             if (enabled_ && pt1_ >= pt2_)
-                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
+                throw cms::Exception("Configuration") << "CAHitTripletGenerator::QuantityDependsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
             if (pt1_ <= 0)
-                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt1 needs to be > 0; is " << pt1_;
+                throw cms::Exception("Configuration") << "CAHitTripletGenerator::QuantityDependsPt: pt1 needs to be > 0; is " << pt1_;
             if (pt2_ <= 0)
-                throw cms::Exception("Configuration") << "PixelQuadrupletGenerator::QuantityDependsPt: pt2 needs to be > 0; is " << pt2_;
+                throw cms::Exception("Configuration") << "CAHitTripletGenerator::QuantityDependsPt: pt2 needs to be > 0; is " << pt2_;
         }
 
         QuantityDependsPtEval evaluator(const edm::EventSetup& es) const {
@@ -117,13 +119,14 @@ private:
     const float extraHitRPhitolerance;
 
     const QuantityDependsPt maxChi2;
-    const bool fitFastCircle;
-    const bool fitFastCircleChi2Cut;
     const bool useBendingCorrection;
 
     const float CAThetaCut = 0.00125f;
-    const float CAPhiCut = 0.1f;
-    const float CAHardPtCut = 0.f;
+    const float CAPhiCut = 10.f;
 
 };
+
+
+
+
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -117,9 +117,9 @@ private:
     const QuantityDependsPt maxChi2;
     const bool useBendingCorrection;
 
-    const float CAThetaCut = 0.00125f;
-    const float CAPhiCut = 1.f;
-    const float CAHardPtCut = 0.f;
+    const float caThetaCut = 0.00125f;
+    const float caPhiCut = 1.f;
+    const float caHardPtCut = 0.f;
 
 };
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -1,116 +1,225 @@
-
 #include "CellularAutomaton.h"
 
-template <unsigned int numberOfLayers>
-void CellularAutomaton<numberOfLayers>::createAndConnectCells (std::vector<const HitDoublets*> doublets, const SeedingLayerSetsHits::SeedingLayerSet& fourLayers, const TrackingRegion& region, const float thetaCut, const float phiCut)
+void CellularAutomaton::createAndConnectCells(const std::vector<HitDoublets>& hitDoublets, const TrackingRegion& region,
+		const float thetaCut, const float phiCut, const float hardPtCut)
 {
-  unsigned int cellId = 0;
-  constexpr unsigned int numberOfLayerPairs =   numberOfLayers - 1;
-  float ptmin = region.ptMin();
-  float region_origin_x = region.origin().x();
-  float region_origin_y = region.origin().y();
-  float region_origin_radius = region.originRBound();
-  unsigned int layerPairId = 0;
-  auto innerLayerId = layerPairId;
-  auto outerLayerId = innerLayerId + 1;
-  auto & doubletLayerPairId = doublets[layerPairId];
-  auto numberOfDoublets = doubletLayerPairId->size ();
+	unsigned int cellId = 0;
+	float ptmin = region.ptMin();
+	float region_origin_x = region.origin().x();
+	float region_origin_y = region.origin().y();
+	float region_origin_radius = region.originRBound();
 
-  isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
+	std::vector<bool> alreadyVisitedLayerPairs;
+	alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
+	for (auto visited : alreadyVisitedLayerPairs)
+	{
+		visited = false;
+	}
+	for (int rootVertex : theLayerGraph.theRootLayers)
+	{
 
-  theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
-  for (unsigned int i = 0; i < numberOfDoublets; ++i)
-  {
-    theFoundCellsPerLayer[layerPairId].emplace_back (doubletLayerPairId, i,  cellId,  doubletLayerPairId->innerHitId(i), doubletLayerPairId->outerHitId(i));
+		std::queue<int> LayerPairsToVisit;
 
-    isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
-    cellId++;
+		for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs)
+		{
+			LayerPairsToVisit.push(LayerPair);
 
-  }
+		}
 
-  for (layerPairId = 1; layerPairId < numberOfLayerPairs; ++layerPairId)
-  {
-	doubletLayerPairId = doublets[layerPairId];
-    innerLayerId = layerPairId;
-    outerLayerId = innerLayerId + 1;
-    numberOfDoublets =doubletLayerPairId->size ();
-    isOuterHitOfCell[outerLayerId].resize(fourLayers[outerLayerId].hits().size());
+		unsigned int numberOfLayerPairsToVisitAtThisDepth =
+				LayerPairsToVisit.size();
 
-    theFoundCellsPerLayer[layerPairId].reserve (numberOfDoublets);
-    for (unsigned int i = 0; i < numberOfDoublets; ++i)
-    {
-      theFoundCellsPerLayer[layerPairId].emplace_back (doublets[layerPairId], i, cellId, doubletLayerPairId->innerHitId(i), doubletLayerPairId->outerHitId(i));
-      isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back (&(theFoundCellsPerLayer[layerPairId][i]));
-      cellId++;
-      for (auto neigCell : isOuterHitOfCell[innerLayerId][doubletLayerPairId->innerHitId(i)])
-      {
-        theFoundCellsPerLayer[layerPairId][i].checkAlignmentAndTag (neigCell, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut, phiCut);
-      }
-    }
-  }
-}
+		while (!LayerPairsToVisit.empty())
+		{
+			auto currentLayerPair = LayerPairsToVisit.front();
+			auto & currentLayerPairRef = theLayerGraph.theLayerPairs[currentLayerPair];
+			auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
+			auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
+			bool allInnerLayerPairsAlreadyVisited	{ true };
 
-template <unsigned int numberOfLayers>
-void
-CellularAutomaton<numberOfLayers>::evolve ()
-{
-  constexpr unsigned int numberOfIterations = numberOfLayers - 2;
-  unsigned int numberOfCellsFound ;
-  for (unsigned int iteration = 0; iteration < numberOfIterations - 1; ++iteration)
-  {
-    for (unsigned int innerLayerId = 0; innerLayerId < numberOfIterations - iteration ; ++innerLayerId)
-    {
+			for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs)
+			{
+				allInnerLayerPairsAlreadyVisited &=
+						alreadyVisitedLayerPairs[innerLayerPair];
+			}
 
-      for (auto& cell : theFoundCellsPerLayer[innerLayerId])
-      {
-        cell.evolve();
-      }
-    }
+			if (alreadyVisitedLayerPairs[currentLayerPair] == false
+					&& allInnerLayerPairsAlreadyVisited)
+			{
 
-    for (unsigned int innerLayerId = 0; innerLayerId < numberOfLayers - iteration - 2; ++innerLayerId)
-    {
+				const HitDoublets* doubletLayerPairId =
+						&(hitDoublets[currentLayerPair]);
+				auto numberOfDoublets = doubletLayerPairId->size();
+				currentLayerPairRef.theFoundCells.reserve(numberOfDoublets);
+				for (unsigned int i = 0; i < numberOfDoublets; ++i)
+				{
+					currentLayerPairRef.theFoundCells.emplace_back(
+							doubletLayerPairId, i, cellId,
+							doubletLayerPairId->innerHitId(i),
+							doubletLayerPairId->outerHitId(i));
+					currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(
+							&(currentLayerPairRef.theFoundCells[i]));
+					cellId++;
 
-      for (auto& cell : theFoundCellsPerLayer[innerLayerId])
-      {
-        cell.updateState();
-      }
-    }
-  }
+					for (auto neigCell : currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)])
+					{
+						currentLayerPairRef.theFoundCells[i].checkAlignmentAndTag(
+								neigCell, ptmin, region_origin_x,
+								region_origin_y, region_origin_radius, thetaCut,
+								phiCut, hardPtCut);
+					}
 
-  //last iteration 
-  numberOfCellsFound = theFoundCellsPerLayer[0].size();
+				}
 
-  for (unsigned int cellId = 0; cellId < numberOfCellsFound; ++cellId)
-  {
-    theFoundCellsPerLayer[0][cellId].evolve();
-  }
+				for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs)
+				{
+					LayerPairsToVisit.push(outerLayerPair);
+				}
 
-  for (auto& cell : theFoundCellsPerLayer[0])
-  {
-    cell.updateState();
-    if (cell.isRootCell (numberOfLayers - 2 ))
-    {
-      theRootCells.push_back (&cell);
-    }
-  }
-}
+				alreadyVisitedLayerPairs[currentLayerPair] = true;
+			}
+			LayerPairsToVisit.pop();
+			numberOfLayerPairsToVisitAtThisDepth--;
+			if (numberOfLayerPairsToVisitAtThisDepth == 0)
+			{
+				numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
+			}
 
-template <unsigned int numberOfLayers>
-void
-CellularAutomaton<numberOfLayers>::findNtuplets(std::vector<CACell::CAntuplet>& foundNtuplets,  const unsigned int minHitsPerNtuplet)
-{
-  std::vector<CACell*> tmpNtuplet;
-  tmpNtuplet.reserve(numberOfLayers);
+		}
 
-  for (CACell* root_cell : theRootCells)
-  {
-    tmpNtuplet.clear();
-    tmpNtuplet.push_back(root_cell);
-    root_cell->findNtuplets (foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-  }
+	}
 
 }
 
-template class CellularAutomaton<4>;
+void CellularAutomaton::evolve(const unsigned int minHitsPerNtuplet)
+{
+	unsigned int numberOfIterations = minHitsPerNtuplet - 2;
+	// keeping the last iteration for later
+	for (unsigned int iteration = 0; iteration < numberOfIterations - 1;
+			++iteration)
+	{
+		for (auto& layerPair : theLayerGraph.theLayerPairs)
+		{
+			for (auto& cell : layerPair.theFoundCells)
+			{
+				cell.evolve();
+			}
+		}
+
+		for (auto& layerPair : theLayerGraph.theLayerPairs)
+		{
+			for (auto& cell : layerPair.theFoundCells)
+			{
+				cell.updateState();
+			}
+		}
+
+	}
+
+	//last iteration
 
 
+	for(int rootLayerId : theLayerGraph.theRootLayers)
+	{
+		for(int rootLayerPair: theLayerGraph.theLayers[rootLayerId].theOuterLayerPairs)
+		{
+			for (auto& cell : theLayerGraph.theLayerPairs[rootLayerPair].theFoundCells)
+			{
+				cell.evolve();
+				cell.updateState();
+				if (cell.isRootCell(minHitsPerNtuplet - 2))
+				{
+					theRootCells.push_back(&cell);
+				}
+			}
+		}
+	}
+
+}
+
+void CellularAutomaton::findNtuplets(
+		std::vector<CACell::CAntuplet>& foundNtuplets,
+		const unsigned int minHitsPerNtuplet)
+{
+	std::vector<CACell*> tmpNtuplet;
+	tmpNtuplet.reserve(minHitsPerNtuplet);
+
+	for (CACell* root_cell : theRootCells)
+	{
+		tmpNtuplet.clear();
+		tmpNtuplet.push_back(root_cell);
+		root_cell->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+	}
+
+}
+
+
+//template<unsigned int numberOfLayers>
+//void CellularAutomaton<numberOfLayers>::findTriplets(
+//		std::array<const HitDoublets*, numberOfLayers - 1> doublets,
+//		const SeedingLayerSetsHits::SeedingLayerSet& fourLayers,
+//		std::vector<CACell::CAntuplet>& foundTriplets,
+//		const TrackingRegion& region, const float thetaCut, const float phiCut)
+//{
+//	unsigned int cellId = 0;
+//	constexpr unsigned int numberOfLayerPairs = numberOfLayers - 1;
+//	float ptmin = region.ptMin();
+//	float region_origin_x = region.origin().x();
+//	float region_origin_y = region.origin().y();
+//	float region_origin_radius = region.originRBound();
+//	unsigned int layerPairId = 0;
+//	auto innerLayerId = layerPairId;
+//	auto outerLayerId = innerLayerId + 1;
+//	auto & doubletLayerPairId = doublets[layerPairId];
+//	auto numberOfDoublets = doubletLayerPairId->size();
+//
+//	isOuterHitOfCell[outerLayerId].resize(
+//			fourLayers[outerLayerId].hits().size());
+//
+//	theFoundCellsPerLayer[layerPairId].reserve(numberOfDoublets);
+//	for (unsigned int i = 0; i < numberOfDoublets; ++i)
+//	{
+//		theFoundCellsPerLayer[layerPairId].emplace_back(doubletLayerPairId, i,
+//				cellId, doubletLayerPairId->innerHitId(i),
+//				doubletLayerPairId->outerHitId(i));
+//
+//		isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back(
+//				&(theFoundCellsPerLayer[layerPairId][i]));
+//		cellId++;
+//
+//	}
+//
+//	for (layerPairId = 1; layerPairId < numberOfLayerPairs; ++layerPairId)
+//	{
+//		doubletLayerPairId = doublets[layerPairId];
+//		innerLayerId = layerPairId;
+//		outerLayerId = innerLayerId + 1;
+//		numberOfDoublets = doubletLayerPairId->size();
+//		isOuterHitOfCell[outerLayerId].resize(
+//				fourLayers[outerLayerId].hits().size());
+//
+//		theFoundCellsPerLayer[layerPairId].reserve(numberOfDoublets);
+//		for (unsigned int i = 0; i < numberOfDoublets; ++i)
+//		{
+//			theFoundCellsPerLayer[layerPairId].emplace_back(
+//					doublets[layerPairId], i, cellId,
+//					doubletLayerPairId->innerHitId(i),
+//					doubletLayerPairId->outerHitId(i));
+//			isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back(
+//					&(theFoundCellsPerLayer[layerPairId][i]));
+//			cellId++;
+//			for (auto neigCell : isOuterHitOfCell[innerLayerId][doubletLayerPairId->innerHitId(
+//					i)])
+//			{
+//				theFoundCellsPerLayer[layerPairId][i].checkAlignmentAndPushTriplet(
+//						neigCell, foundTriplets, ptmin, region_origin_x,
+//						region_origin_y, region_origin_radius, thetaCut,
+//						phiCut);
+//			}
+//		}
+//	}
+//}
+//
+//template class CellularAutomaton<4> ;
+//template class CellularAutomaton<3> ;
+//

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -154,72 +154,93 @@ void CellularAutomaton::findNtuplets(
 }
 
 
-//template<unsigned int numberOfLayers>
-//void CellularAutomaton<numberOfLayers>::findTriplets(
-//		std::array<const HitDoublets*, numberOfLayers - 1> doublets,
-//		const SeedingLayerSetsHits::SeedingLayerSet& fourLayers,
-//		std::vector<CACell::CAntuplet>& foundTriplets,
-//		const TrackingRegion& region, const float thetaCut, const float phiCut)
-//{
-//	unsigned int cellId = 0;
-//	constexpr unsigned int numberOfLayerPairs = numberOfLayers - 1;
-//	float ptmin = region.ptMin();
-//	float region_origin_x = region.origin().x();
-//	float region_origin_y = region.origin().y();
-//	float region_origin_radius = region.originRBound();
-//	unsigned int layerPairId = 0;
-//	auto innerLayerId = layerPairId;
-//	auto outerLayerId = innerLayerId + 1;
-//	auto & doubletLayerPairId = doublets[layerPairId];
-//	auto numberOfDoublets = doubletLayerPairId->size();
-//
-//	isOuterHitOfCell[outerLayerId].resize(
-//			fourLayers[outerLayerId].hits().size());
-//
-//	theFoundCellsPerLayer[layerPairId].reserve(numberOfDoublets);
-//	for (unsigned int i = 0; i < numberOfDoublets; ++i)
-//	{
-//		theFoundCellsPerLayer[layerPairId].emplace_back(doubletLayerPairId, i,
-//				cellId, doubletLayerPairId->innerHitId(i),
-//				doubletLayerPairId->outerHitId(i));
-//
-//		isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back(
-//				&(theFoundCellsPerLayer[layerPairId][i]));
-//		cellId++;
-//
-//	}
-//
-//	for (layerPairId = 1; layerPairId < numberOfLayerPairs; ++layerPairId)
-//	{
-//		doubletLayerPairId = doublets[layerPairId];
-//		innerLayerId = layerPairId;
-//		outerLayerId = innerLayerId + 1;
-//		numberOfDoublets = doubletLayerPairId->size();
-//		isOuterHitOfCell[outerLayerId].resize(
-//				fourLayers[outerLayerId].hits().size());
-//
-//		theFoundCellsPerLayer[layerPairId].reserve(numberOfDoublets);
-//		for (unsigned int i = 0; i < numberOfDoublets; ++i)
-//		{
-//			theFoundCellsPerLayer[layerPairId].emplace_back(
-//					doublets[layerPairId], i, cellId,
-//					doubletLayerPairId->innerHitId(i),
-//					doubletLayerPairId->outerHitId(i));
-//			isOuterHitOfCell[outerLayerId][doubletLayerPairId->outerHitId(i)].push_back(
-//					&(theFoundCellsPerLayer[layerPairId][i]));
-//			cellId++;
-//			for (auto neigCell : isOuterHitOfCell[innerLayerId][doubletLayerPairId->innerHitId(
-//					i)])
-//			{
-//				theFoundCellsPerLayer[layerPairId][i].checkAlignmentAndPushTriplet(
-//						neigCell, foundTriplets, ptmin, region_origin_x,
-//						region_origin_y, region_origin_radius, thetaCut,
-//						phiCut);
-//			}
-//		}
-//	}
-//}
-//
-//template class CellularAutomaton<4> ;
-//template class CellularAutomaton<3> ;
-//
+void CellularAutomaton::findTriplets(const std::vector<HitDoublets>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
+		const float thetaCut, const float phiCut, const float hardPtCut)
+{
+	unsigned int cellId = 0;
+	float ptmin = region.ptMin();
+	float region_origin_x = region.origin().x();
+	float region_origin_y = region.origin().y();
+	float region_origin_radius = region.originRBound();
+
+	std::vector<bool> alreadyVisitedLayerPairs;
+	alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
+	for (auto visited : alreadyVisitedLayerPairs)
+	{
+		visited = false;
+	}
+	for (int rootVertex : theLayerGraph.theRootLayers)
+	{
+
+		std::queue<int> LayerPairsToVisit;
+
+		for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs)
+		{
+			LayerPairsToVisit.push(LayerPair);
+
+		}
+
+		unsigned int numberOfLayerPairsToVisitAtThisDepth =
+				LayerPairsToVisit.size();
+
+		while (!LayerPairsToVisit.empty())
+		{
+			auto currentLayerPair = LayerPairsToVisit.front();
+			auto & currentLayerPairRef = theLayerGraph.theLayerPairs[currentLayerPair];
+			auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
+			auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
+			bool allInnerLayerPairsAlreadyVisited	{ true };
+
+			for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs)
+			{
+				allInnerLayerPairsAlreadyVisited &=
+						alreadyVisitedLayerPairs[innerLayerPair];
+			}
+
+			if (alreadyVisitedLayerPairs[currentLayerPair] == false
+					&& allInnerLayerPairsAlreadyVisited)
+			{
+
+				const HitDoublets* doubletLayerPairId =
+						&(hitDoublets[currentLayerPair]);
+				auto numberOfDoublets = doubletLayerPairId->size();
+				currentLayerPairRef.theFoundCells.reserve(numberOfDoublets);
+				for (unsigned int i = 0; i < numberOfDoublets; ++i)
+				{
+					currentLayerPairRef.theFoundCells.emplace_back(
+							doubletLayerPairId, i, cellId,
+							doubletLayerPairId->innerHitId(i),
+							doubletLayerPairId->outerHitId(i));
+					currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(
+							&(currentLayerPairRef.theFoundCells[i]));
+					cellId++;
+
+					for (auto neigCell : currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)])
+					{
+						currentLayerPairRef.theFoundCells[i].checkAlignmentAndPushTriplet(
+								neigCell, foundTriplets, ptmin, region_origin_x,
+								region_origin_y, region_origin_radius, thetaCut,
+								phiCut, hardPtCut);
+					}
+
+				}
+
+				for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs)
+				{
+					LayerPairsToVisit.push(outerLayerPair);
+				}
+
+				alreadyVisitedLayerPairs[currentLayerPair] = true;
+			}
+			LayerPairsToVisit.pop();
+			numberOfLayerPairsToVisitAtThisDepth--;
+			if (numberOfLayerPairsToVisitAtThisDepth == 0)
+			{
+				numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
+			}
+
+		}
+
+	}
+
+}

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -4,33 +4,31 @@
 #include "CACell.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
-
-template<unsigned int theNumberOfLayers>
-class CellularAutomaton {
+#include "CAGraph.h"
+class CellularAutomaton
+{
 public:
+	CellularAutomaton(const CAGraph& graph)
+	: theLayerGraph(graph)
+	{
 
-    CellularAutomaton() {
+	}
 
-    }
+	void createAndConnectCells(const std::vector<HitDoublets>&,
+			const TrackingRegion&, const float, const float, const float);
 
-    void createAndConnectCells(std::vector<const HitDoublets*>, const SeedingLayerSetsHits::SeedingLayerSet&, const TrackingRegion&, const float, const float);
-    void evolve();
-    void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
-
-
+	void evolve(const unsigned int);
+	void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
+	void findTriplets(std::vector<const HitDoublets*>,
+			const SeedingLayerSetsHits::SeedingLayerSet&,
+			std::vector<CACell::CAntuplet>&, const TrackingRegion&, const float,
+			const float);
 
 private:
-
-
-
-    //for each hit in each layer, store the pointers of the Cells of which it is outerHit
-    std::array<std::vector<std::vector<CACell*> >, theNumberOfLayers> isOuterHitOfCell;
-    std::array<std::vector<CACell>, theNumberOfLayers> theFoundCellsPerLayer;
-
-    std::vector<CACell*> theRootCells;
-    std::vector<std::vector<CACell*> > theNtuplets;
+	CAGraph theLayerGraph;
+	std::vector<CACell*> theRootCells;
+	std::vector<std::vector<CACell*> > theNtuplets;
 
 };
-
 
 #endif 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -19,10 +19,8 @@ public:
 
 	void evolve(const unsigned int);
 	void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
-	void findTriplets(std::vector<const HitDoublets*>,
-			const SeedingLayerSetsHits::SeedingLayerSet&,
-			std::vector<CACell::CAntuplet>&, const TrackingRegion&, const float,
-			const float);
+	void findTriplets(const std::vector<HitDoublets>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
+			const float thetaCut, const float phiCut, const float hardPtCut);
 
 private:
 	CAGraph theLayerGraph;

--- a/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
@@ -18,6 +18,9 @@ DEFINE_EDM_PLUGIN(HitTripletGeneratorFromPairAndLayersFactory,PixelTripletNoTipG
 #include "CombinedHitTripletGenerator.h"
 DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitTripletGenerator, "StandardHitTripletGenerator");
 
+#include "CAHitTripletGenerator.h"
+DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CAHitTripletGenerator, "CAHitTripletGenerator");
+
 #include "CombinedHitQuadrupletGenerator.h"
 DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitQuadrupletGenerator, "CombinedHitQuadrupletGenerator");
 

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
@@ -13,4 +13,5 @@ CAHitQuadrupletGenerator = cms.PSet(
     useBendingCorrection = cms.bool(False),
     CAThetaCut = cms.double(0.00125),
     CAPhiCut = cms.double(10),
+    CAHardPtCut = cms.double(0),
 )

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitTripletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitTripletGenerator_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+CAHitTripletGenerator = cms.PSet(
+    ComponentName = cms.string("CAHitTripletGenerator"),
+    extraHitRPhitolerance = cms.double(0.06),
+    maxChi2 = cms.PSet(
+        pt1    = cms.double(0.8), pt2    = cms.double(2),
+        value1 = cms.double(50), value2 = cms.double(8),
+        enabled = cms.bool(True),
+    ),
+    useBendingCorrection = cms.bool(False),
+    CAThetaCut = cms.double(0.00125),
+    CAPhiCut = cms.double(1),
+)
+
+

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
@@ -31,7 +31,8 @@ def customiseForQuadrupletsByCellularAutomaton(process):
             fitFastCircleChi2Cut = True,
             SeedingLayers = cms.InputTag(seedingLayersName),
             CAThetaCut = cms.double(0.00125),
-            CAPhiCut = cms.double(10),
+            CAPhiCut = cms.double(0.1),
+            CAHardPtCut = cms.double(0),
         )
 
         if hasattr(quadruplets.GeneratorPSet, "SeedComparitorPSet"):

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
@@ -36,7 +36,7 @@ def customiseForQuadrupletsHLTPixelTracksByCellularAutomaton(process):
             SeedingLayers = cms.InputTag(seedingLayersName),
             CAThetaCut = cms.double(0.00125),
             CAPhiCut = cms.double(0.1),
-            CAHardPtCut = cms.double(0.2),
+            CAHardPtCut = cms.double(0),
             
         )
 

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+
+def producers_by_type(process, *types):
+    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
+    
+def customiseForQuadrupletsHLTPixelTracksByCellularAutomaton(process):
+    for module in producers_by_type(process, "PixelTrackProducer"):
+        if not hasattr(module, "OrderedHitsFactoryPSet"):
+            continue
+	pset = getattr(module, "OrderedHitsFactoryPSet")
+        if not hasattr(pset, "ComponentName"):
+	    continue
+	if not (pset.ComponentName == "CombinedHitQuadrupletGenerator"):
+	    continue    
+        # Adjust seeding layers
+        seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+   
+
+
+        # Configure seed generator / pixel track producer
+        quadruplets = module.OrderedHitsFactoryPSet.clone()
+        from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
+
+        module.OrderedHitsFactoryPSet  = _CAHitQuadrupletGenerator.clone(
+            ComponentName = cms.string("CAHitQuadrupletGenerator"),
+            extraHitRPhitolerance = quadruplets.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = dict(
+                pt1    = 0.8, pt2    = 2,
+                value1 = 200, value2 = 100,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            fitFastCircle = True,
+            fitFastCircleChi2Cut = True,
+            SeedingLayers = cms.InputTag(seedingLayersName),
+            CAThetaCut = cms.double(0.00125),
+            CAPhiCut = cms.double(0.1),
+            CAHardPtCut = cms.double(0.2),
+            
+        )
+
+        if hasattr(quadruplets.GeneratorPSet, "SeedComparitorPSet"):
+            pset.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
+    return process

--- a/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+
+def producers_by_type(process, *types):
+    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
+
+
+def customiseForTripletsHLTPixelTracksByCellularAutomaton(process):
+    for module in producers_by_type(process, "PixelTrackProducer"):
+        if not hasattr(module, "OrderedHitsFactoryPSet"):
+            continue
+	pset = getattr(module, "OrderedHitsFactoryPSet")
+        if not hasattr(pset, "ComponentName"):
+	    continue
+	if not (pset.ComponentName == "StandardHitTripletGenerator"):
+	    continue    
+        # Adjust seeding layers
+        seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+   
+        # Configure seed generator / pixel track producer
+        triplets = module.OrderedHitsFactoryPSet.clone()
+        from RecoPixelVertexing.PixelTriplets.CAHitTripletGenerator_cfi import CAHitTripletGenerator as _CAHitTripletGenerator
+
+        module.OrderedHitsFactoryPSet  = _CAHitTripletGenerator.clone(
+            ComponentName = cms.string("CAHitTripletGenerator"),
+            extraHitRPhitolerance = triplets.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = cms.PSet(
+                pt1    = cms.double(0.9), pt2    = cms.double(2),
+                value1 = cms.double(20), value2 = cms.double(10),
+                enabled = cms.bool(True),
+            ),
+            useBendingCorrection = cms.bool(True),
+            SeedingLayers = cms.InputTag(seedingLayersName),
+            CAThetaCut = cms.double(0.0015),
+            CAPhiCut = cms.double(0.01),
+        )
+
+        if hasattr(triplets.GeneratorPSet, "SeedComparitorPSet"):
+            pset.SeedComparitorPSet = triplets.GeneratorPSet.SeedComparitorPSet
+    return process


### PR DESCRIPTION
The Cellular Automaton for quadruplet pixel seeding at HLT in Phase I has been improved. 

The new version, evaluates the quadruplets for all the configurations of four layers in a single step, hence improving timing.
A better definition of the cut in the xy-plane improves the fake rejection at PixelTracks step. 
A new hardPtCut is introduced, giving the possibility, when evaluating the radius of a triplet in the xy plane, to reject those triplets that would result from a pT lower than a threshold.
The CA is still disabled by default and can be run by customizing the process. 

It is referred in the following slides as CA all-in-1.

[160902_trackingHLT.pdf](https://github.com/cms-sw/cmssw/files/457220/160902_trackingHLT.pdf)

@VinInn @rovere @makortel @mtosi 
