### PR TITLE
Pix raw2digi phase1 l1

### DIFF
--- a/CondFormats/SiPixelObjects/interface/PixelROC.h
+++ b/CondFormats/SiPixelObjects/interface/PixelROC.h
@@ -63,11 +63,14 @@ public:
     return result;
   }
 
-  // recognise the detector side 
+  // recognise the detector side and layer number
+  // this methods use hardwired constants
+  // if the numberg changes the methods have to be modified
   int bpixSidePhase0(uint32_t rawId) const;
   int fpixSidePhase0(uint32_t rawId) const;
   int bpixSidePhase1(uint32_t rawId) const;
   int fpixSidePhase1(uint32_t rawId) const;
+  static int bpixLayerPhase1(uint32_t rawId);
 
   /// printout for debug
   std::string print(int depth = 0) const;

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -125,6 +125,26 @@ int PixelROC::bpixSidePhase1(uint32_t rawId) const {
   if(module<5) side=-1; // modules 1-4 are on -z
   return side;
 }
+int PixelROC::bpixLayerPhase1(uint32_t rawId) {
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  const unsigned int layerStartBit_=   20;
+  //const unsigned int ladderStartBit_=  12;
+  //const unsigned int moduleStartBit_=   2;
+  /// two bits would be enough, but  we could use the number "0" as a wildcard
+  const unsigned int layerMask_=       0xF;
+  //const unsigned int ladderMask_=      0xFF;
+  //const unsigned int moduleMask_=      0x3FF;
+
+  /// layer id
+  unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
+  /// ladder  id
+  //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
+  /// det id
+  //unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
+
+  //if(module<5) side=-1; // modules 1-4 are on -z
+  return layer;
+}
 
 int PixelROC::fpixSidePhase0(uint32_t rawId) const {
   int side = 1;

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -99,13 +99,19 @@ private:
   ErrorChecker errorcheck;
 
   // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
-  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift;
-  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask;
+  // Add special layer 1 roc for phase1
+  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, 
+    ROW_shift, COL_shift;
+  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask,
+    ROW_mask, COL_mask;
   int maxROCIndex;
+  bool phase1;
 
   int checkError(const Word32& data) const;
 
   int digi2word(  cms_uint32_t detId, const PixelDigi& digi,
+                  std::map<int, std::vector<Word32> > & words) const;
+  int digi2wordPhase1Layer1(  cms_uint32_t detId, const PixelDigi& digi,
                   std::map<int, std::vector<Word32> > & words) const;
 
   int word2digi(  const int fedId,

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -240,7 +240,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
       int dcol = (ww >> DCOL_shift) & DCOL_mask;
       int pxid = (ww >> PXID_shift) & PXID_mask;
       //if(DANEK) cout<<" raw2digi "<<link<<" "<<roc<<" "
-	  <<dcol<<" "<<pxid<<" "<<adc<<" "<<layer<<endl;
+      //<<dcol<<" "<<pxid<<" "<<adc<<" "<<layer<<endl;
       
       LocalPixel::DcolPxid localDP = { dcol, pxid };
       //if(DANEK) cout<<localDP.dcol<<" "<<localDP.pxid<<endl;

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -173,7 +173,6 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
     LogTrace("")<<"DATA: " <<  print(*word);
 
     auto ww = *word;
-    //assert(ww==0);
     if unlikely(ww==0) { theWordCounter--; continue;}
     int nlink = (ww >> LINK_shift) & LINK_mask; 
     int nroc  = (ww >> ROC_shift) & ROC_mask;
@@ -197,8 +196,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
       else layer=0;
 
       //if(DANEK) cout<<" rocp "<<rocp->print()<<" layer "<<rocp->bpixLayerPhase1(rawId)<<" "
-      //  <<layer
-      //  <<" phase1 "<<phase1<<" rawid "<<rawId<<endl;
+      //  <<layer<<" phase1 "<<phase1<<" rawid "<<rawId<<endl;
 
       if (useQualityInfo&(nullptr!=badPixelInfo)) {
 	short rocInDet = (short) rocp->idInDetUnit();
@@ -216,7 +214,6 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
     if unlikely(skipROC || !rocp) continue;
     
     int adc  = (ww >> ADC_shift) & ADC_mask;
-    //LocalPixel *local=NULL;
     std::unique_ptr<LocalPixel> local;
 
     if(phase1 && layer==1) { // special case for layer 1ROC
@@ -235,7 +232,6 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
-      //local = new LocalPixel(localCR); // local pixel coordinate 
       local = std::make_unique<LocalPixel>(localCR); // local pixel coordinate 
       //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
 
@@ -255,17 +251,14 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
-      //local = new LocalPixel(localDP);
       local = std::make_unique<LocalPixel>(localDP); // local pixel coordinate 
       //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
     }    
 
-    //GlobalPixel global = rocp->toGlobal( LocalPixel(local) );
     GlobalPixel global = rocp->toGlobal( *local ); // global pixel coordinate (in module)
     (*detDigis).data.emplace_back(global.row, global.col, adc);
     //if(DANEK) cout<<global.row<<" "<<global.col<<" "<<adc<<endl;    
     LogTrace("") << (*detDigis).data.back();
-    //delete local;
   }
 
 }


### PR DESCRIPTION
Modify pixel raw2digi to handle phase1 layer 1 ROC data (PROC600).
The data format is different, roc-column and -row instead of double-column and pixel index.
Main modifications in EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc, minor in *.h 
and PixelRoc.cc/h.
Has the same problem as the previous version, it uses hardwired constants in PixelRoc
to recognized layer 1 ROCs. To fix it one needs to find a way to pass Topology to PixelROC 
in a way which is tread-safe.
