### PR TITLE
Updating Jet Probability tagger calibration in all asymptotic-like MC and data workflows

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,23 +10,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '81X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v5',
+    'run2_design'       :   '81X_mcRun2_design_v6',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '81X_mcRun2_startup_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v6',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v7',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v8',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v6',
+    'run1_data'         :   '81X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v6',
+    'run2_data'         :   '81X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v8',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v9',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v10',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
Since btag HIP mitigation track selection is default (via https://github.com/cms-sw/cmssw/pull/15421) in 81X an update of the BTV JetProbability tagger calibration is needed. See for performance this [talk](https://indico.cern.ch/event/565738/contributions/2293407/attachments/1331660/2001508/bloch_AlCaDB_JPcalib_5sep16.pdf)
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v6) as [81X_mcRun2_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v6/81X_mcRun2_design_v5): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
- **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v2) as [81X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v2/81X_mcRun2_pA_v1): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v7) as [81X_mcRun2_asymptotic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v7/81X_mcRun2_asymptotic_v6): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v8) as [81X_mcRun2_HeavyIon_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v8/81X_mcRun2_HeavyIon_v7): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v7) as [81X_dataRun2_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v7/81X_dataRun2_v6): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation (added 1 IOV for 2016 era)
- **RunII Offline relval processing** : [81X_dataRun2_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v8) as [81X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v8/81X_dataRun2_relval_v7): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation (added 1 IOV for 2016 era)
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v11) as [81X_upgrade2017_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v11/81X_upgrade2017_realistic_v10): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
- **PhaseI design scenario** : [81X_upgrade2017_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v9) as [81X_upgrade2017_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v9/81X_upgrade2017_design_v8): 
  - updated BTV jet probability tagger calibration for BTV HIP mitigation
