### PR TITLE
Extension of miniAOD event content to be able to run tau mva isolation discriminator on miniAOD input

### DIFF
--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -10,12 +10,12 @@
 
    pat::Tau implements the analysis-level tau class within the 'pat' namespace.
    It inherits from reco::BaseTau, copies all the information from the source
-   reco::CaloTau or reco::PFTau, and adds some PAT-specific variable.
+   reco::CaloTau or reco::PFTau, and adds some PAT-specific variables.
 
    Please post comments and questions to the Physics Tools hypernews:
    https://hypernews.cern.ch/HyperNews/CMS/get/physTools.html
 
-  \author   Steven Lowette, Christophe Delaere, Giovanni Petrucciani, Frederic Ronga, Colin Bernet
+  \author Steven Lowette, Christophe Delaere, Giovanni Petrucciani, Frederic Ronga, Colin Bernet
 */
 
 
@@ -33,11 +33,13 @@
 #include "DataFormats/PatCandidates/interface/TauPFEssential.h"
 
 #include "DataFormats/Common/interface/AtomicPtrCache.h"
+
 // Define typedefs for convenience
 namespace pat {
   class Tau;
   typedef std::vector<Tau>              TauCollection; 
   typedef edm::Ref<TauCollection>       TauRef; 
+  typedef edm::RefProd<TauCollection>	TauRefProd;
   typedef edm::RefVector<TauCollection> TauRefVector; 
 }
 
@@ -325,6 +327,33 @@ namespace pat {
       const reco::VertexRef& secondaryVertex() const { return pfEssential().sv_; }
       const pat::tau::TauPFEssential::Point& secondaryVertexPos() const { return pfEssential().svPos_; }
       const pat::tau::TauPFEssential::CovMatrix& secondaryVertexCov() const { return pfEssential().svCov_; }
+      float ip3d() const { return pfEssential().ip3d_; }
+      float ip3d_error() const { return pfEssential().ip3d_error_; }
+      float ip3d_Sig() const;
+
+      /// ---- Information for MVA isolation ----
+      /// Needed to recompute MVA isolation on MiniAOD
+      /// return sum of ecal energies from signal candidates
+      float ecalEnergy() const { return pfEssential().ecalEnergy_; }
+      /// return sum of hcal energies from signal candidates
+      float hcalEnergy() const { return pfEssential().hcalEnergy_; }
+      /// return normalized chi2 of leading track
+      float leadingTrackNormChi2() const { return pfEssential().leadingTrackNormChi2_; }
+
+      /// ---- Information for anti-electron training ----
+      /// Needed to recompute on MiniAOD
+      /// return ecal energy from LeadChargedHadrCand
+      float ecalEnergyLeadChargedHadrCand() const { return pfEssential().ecalEnergyLeadChargedHadrCand_; }
+      /// return hcal energy from LeadChargedHadrCand
+      float hcalEnergyLeadChargedHadrCand() const { return pfEssential().hcalEnergyLeadChargedHadrCand_; }
+      /// return etaAtEcalEntrance
+      float etaAtEcalEntrance() const { return pfEssential().etaAtEcalEntrance_; }
+      /// return etaAtEcalEntrance from LeadChargedCand
+      float etaAtEcalEntranceLeadChargedCand() const { return pfEssential().etaAtEcalEntranceLeadChargedCand_; }
+      /// return pt from  LeadChargedCand
+      float ptLeadChargedCand() const { return pfEssential().ptLeadChargedCand_; }
+      /// return emFraction_MVA
+      float emFraction_MVA() const { return pfEssential().emFraction_; }
 
       /// Methods copied from reco::Jet.
       /// (accessible from reco::CaloTau/reco::PFTau via reco::CaloTauTagInfo/reco::PFTauTagInfo)

--- a/DataFormats/PatCandidates/interface/TauPFEssential.h
+++ b/DataFormats/PatCandidates/interface/TauPFEssential.h
@@ -48,6 +48,17 @@ struct TauPFEssential {
   reco::VertexRef sv_;
   Point svPos_;
   CovMatrix svCov_;
+  float ip3d_;
+  float ip3d_error_;
+  float ecalEnergy_;
+  float hcalEnergy_;
+  float leadingTrackNormChi2_;
+  float etaAtEcalEntrance_;
+  float ecalEnergyLeadChargedHadrCand_;
+  float hcalEnergyLeadChargedHadrCand_;
+  float etaAtEcalEntranceLeadChargedCand_;
+  float ptLeadChargedCand_;
+  float emFraction_;
 };
 
 } }

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -286,6 +286,12 @@ pat::tau::TauPFEssential::CovMatrix Tau::flightLengthCov() const
   return cov;
 }
 
+float Tau::ip3d_Sig() const
+{
+	if( pfEssential().ip3d_error_ != 0 ) return (pfEssential().ip3d_/pfEssential().ip3d_error_);
+	else return 0.;
+}
+
 float Tau::etaetaMoment() const
 {
   if ( isCaloTau() ) return caloSpecific().etaetaMoment_;

--- a/DataFormats/PatCandidates/src/TauPFEssential.cc
+++ b/DataFormats/PatCandidates/src/TauPFEssential.cc
@@ -8,7 +8,18 @@ pat::tau::TauPFEssential::TauPFEssential(const reco::PFTau& tau) :
     decayMode_(tau.decayMode()),
     dxy_(0.),
     dxy_error_(1.e+3),
-    hasSV_(false)
+    hasSV_(false),
+    ip3d_(0.),
+    ip3d_error_(1.e+3),
+    ecalEnergy_(0.),
+    hcalEnergy_(0.),
+    leadingTrackNormChi2_(1.e+3),
+    etaAtEcalEntrance_(0.),
+    ecalEnergyLeadChargedHadrCand_(0.),
+    hcalEnergyLeadChargedHadrCand_(0.),
+    etaAtEcalEntranceLeadChargedCand_(0.),
+    ptLeadChargedCand_(0.),
+    emFraction_(0.)
 {
   if ( tau.jetRef().isAvailable() && tau.jetRef().isNonnull() ) { // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
     p4Jet_ = tau.jetRef()->p4();

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -149,8 +149,9 @@
    <version ClassVersion="10" checksum="2692173055"/>
   </class>
   <class name="std::vector<pat::tau::TauCaloSpecific>" />
-  <class name="pat::tau::TauPFEssential" ClassVersion="12">
-    <version ClassVersion="12" checksum="1052833547" />
+  <class name="pat::tau::TauPFEssential" ClassVersion="13">
+    <version ClassVersion="13" checksum="1052833547" />
+    <version ClassVersion="12" checksum="3865233356" /> 
     <version ClassVersion="11" checksum="1193752112" />
     <version ClassVersion="10" checksum="1628501942" />
   </class>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -149,7 +149,8 @@
    <version ClassVersion="10" checksum="2692173055"/>
   </class>
   <class name="std::vector<pat::tau::TauCaloSpecific>" />
-  <class name="pat::tau::TauPFEssential" ClassVersion="11">
+  <class name="pat::tau::TauPFEssential" ClassVersion="12">
+    <version ClassVersion="12" checksum="1052833547" />
     <version ClassVersion="11" checksum="1193752112" />
     <version ClassVersion="10" checksum="1628501942" />
   </class>

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -451,34 +451,6 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       }
     }
 
-/*
-    // extraction of tau lifetime information
-    // (only available for PFTaus)
-    if ( aTau.isPFTau() && tauTransverseImpactParameterSrc_.label() != "" ) {
-      edm::Handle<reco::PFTauCollection> pfTaus;
-      iEvent.getByToken(pfTauToken_, pfTaus);
-      reco::PFTauRef pfTauRef(pfTaus, idx);
-      edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
-      iEvent.getByToken(tauTransverseImpactParameterToken_, tauLifetimeInfos);
-      const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTauRef];
-      pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
-      aTauPFEssential.dxy_PCA_ = tauLifetimeInfo.dxy_PCA();
-      aTauPFEssential.dxy_ = tauLifetimeInfo.dxy();
-      aTauPFEssential.dxy_error_ = tauLifetimeInfo.dxy_error();
-      //      aTauPFEssential.pv_ = tauLifetimeInfo.primaryVertex();
-      // aTauPFEssential.pvPos_ = tauLifetimeInfo.primaryVertexPos();
-      // aTauPFEssential.pvCov_ = tauLifetimeInfo.primaryVertexCov();
-      aTauPFEssential.hasSV_ = tauLifetimeInfo.hasSecondaryVertex();
-      if(tauLifetimeInfo.hasSecondaryVertex()){
-	aTauPFEssential.flightLength_ = tauLifetimeInfo.flightLength();
-	aTauPFEssential.flightLengthSig_ = tauLifetimeInfo.flightLengthSig();
-	//      aTauPFEssential.sv_ = tauLifetimeInfo.secondaryVertex();
-	// aTauPFEssential.svPos_ = tauLifetimeInfo.secondaryVertexPos();
-	// aTauPFEssential.svCov_ = tauLifetimeInfo.secondaryVertexCov();
-      }
-    }
-*/
-
     // Isolation
     if (isolator_.enabled()) {
       isolator_.fill(*anyTaus, idx, isolatorTmpStorage_);

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -361,6 +361,97 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       aTau.setDecayMode(pfTauRef->decayMode());
     }
 
+    // extraction of variables needed to rerun MVA isolation and anti-electron discriminator on MiniAOD
+    // (only available for PFTaus)
+    if( aTau.isPFTau() ) {
+      edm::Handle<reco::PFTauCollection> pfTaus;
+      iEvent.getByToken(pfTauToken_, pfTaus);
+      reco::PFTauRef pfTauRef(pfTaus, idx);
+      pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
+      float ecalEnergy = 0;
+      float hcalEnergy = 0;
+      float sumEtaTimesEnergy = 0.;
+      float sumEnergy = 0.;
+      float leadChargedCandPt = -99;
+      float leadChargedCandEtaAtEcalEntrance = -99;	
+      const std::vector<reco::PFCandidatePtr>& signalCands = pfTauRef->signalPFCands();
+      for(std::vector<reco::PFCandidatePtr>::const_iterator it = signalCands.begin(); it != signalCands.end(); ++it) {
+        const reco::PFCandidatePtr& icand = *it;
+        ecalEnergy += icand->ecalEnergy();
+        hcalEnergy += icand->hcalEnergy();		
+	sumEtaTimesEnergy += icand->positionAtECALEntrance().eta()*icand->energy();
+        sumEnergy += icand->energy();	 
+	const reco::Track* track = 0;
+     	if ( icand->trackRef().isNonnull() ) track = icand->trackRef().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull()  ) track = icand->muonRef()->innerTrack().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull() ) track = icand->muonRef()->globalTrack().get();
+     	else if ( icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull()  ) track = icand->muonRef()->outerTrack().get();
+     	else if ( icand->gsfTrackRef().isNonnull() ) track = icand->gsfTrackRef().get();
+     	if( track ) {
+     	  if( track->pt() > leadChargedCandPt ) {
+     	    leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
+     	    leadChargedCandPt = track->pt();
+     	  }
+        } 		
+      }
+      aTauPFEssential.ecalEnergy_ = ecalEnergy;
+      aTauPFEssential.hcalEnergy_ = hcalEnergy;
+      aTauPFEssential.ptLeadChargedCand_ = leadChargedCandPt;      
+      aTauPFEssential.etaAtEcalEntranceLeadChargedCand_ = leadChargedCandEtaAtEcalEntrance;
+      if (sumEnergy != 0.) {
+        aTauPFEssential.etaAtEcalEntrance_ = sumEtaTimesEnergy/sumEnergy;
+      }
+      else {
+        aTauPFEssential.etaAtEcalEntrance_ = -99.;
+      }	
+      float leadingTrackNormChi2 = 0;
+      float ecalEnergyLeadChargedHadrCand = -99.;
+      float hcalEnergyLeadChargedHadrCand = -99.;
+      float emFraction = -1.;
+      float myHCALenergy = 0.;
+      float myECALenergy = 0.;	
+      const reco::PFCandidatePtr& leadingPFCharged = pfTauRef->leadPFChargedHadrCand();
+      if(leadingPFCharged.isNonnull()) {
+	ecalEnergyLeadChargedHadrCand = leadingPFCharged->ecalEnergy();
+        hcalEnergyLeadChargedHadrCand = leadingPFCharged->hcalEnergy(); 
+        reco::TrackRef trackRef = leadingPFCharged->trackRef();
+        if( trackRef.isNonnull() ) {
+          leadingTrackNormChi2 = trackRef->normalizedChi2();			
+	  for( std::vector<reco::PFCandidatePtr>::const_iterator tauIt = pfTauRef->isolationPFCands().begin(); tauIt!=pfTauRef->isolationPFCands().end(); ++tauIt ){
+	    myHCALenergy += (*tauIt)->hcalEnergy();
+	    myECALenergy += (*tauIt)->ecalEnergy();
+	  }
+	  for( std::vector<reco::PFCandidatePtr>::const_iterator tauIt = pfTauRef->signalPFCands().begin(); tauIt!=pfTauRef->signalPFCands().end(); ++tauIt ){
+	    myHCALenergy += (*tauIt)->hcalEnergy();
+	    myECALenergy += (*tauIt)->ecalEnergy();
+	  }	  
+	  if( myHCALenergy + myECALenergy != 0. ) {
+            emFraction = myECALenergy/( myHCALenergy + myECALenergy);    
+	  }
+        }
+      }
+      aTauPFEssential.emFraction_ = emFraction;
+      aTauPFEssential.leadingTrackNormChi2_ = leadingTrackNormChi2;
+      aTauPFEssential.ecalEnergyLeadChargedHadrCand_ = ecalEnergyLeadChargedHadrCand;
+      aTauPFEssential.hcalEnergyLeadChargedHadrCand_ = hcalEnergyLeadChargedHadrCand; 	
+      // extraction of tau lifetime information
+      if( tauTransverseImpactParameterSrc_.label() != "" ) {
+        edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
+        iEvent.getByToken(tauTransverseImpactParameterToken_, tauLifetimeInfos);
+        const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTauRef];
+        pat::tau::TauPFEssential& aTauPFEssential = aTau.pfEssential_[0];
+        aTauPFEssential.dxy_PCA_ = tauLifetimeInfo.dxy_PCA();
+        aTauPFEssential.dxy_ = tauLifetimeInfo.dxy();
+        aTauPFEssential.dxy_error_ = tauLifetimeInfo.dxy_error();
+        aTauPFEssential.hasSV_ = tauLifetimeInfo.hasSecondaryVertex();
+        aTauPFEssential.flightLength_ = tauLifetimeInfo.flightLength();
+        aTauPFEssential.flightLengthSig_ = tauLifetimeInfo.flightLengthSig();
+        aTauPFEssential.ip3d_ = tauLifetimeInfo.ip3d();
+        aTauPFEssential.ip3d_error_ = tauLifetimeInfo.ip3d_error();
+      }
+    }
+
+/*
     // extraction of tau lifetime information
     // (only available for PFTaus)
     if ( aTau.isPFTau() && tauTransverseImpactParameterSrc_.label() != "" ) {
@@ -386,6 +477,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 	// aTauPFEssential.svCov_ = tauLifetimeInfo.secondaryVertexCov();
       }
     }
+*/
 
     // Isolation
     if (isolator_.enabled()) {


### PR DESCRIPTION
This is the backport of https://github.com/cms-sw/cmssw/pull/15731 and https://github.com/cms-sw/cmssw/pull/15747. 

Since this backport only adds data members (of type float) to the class TauPFEssential in DataFormats/PatCandidates it is not expected to change any existing event content. Standard RECO sequences are not touched. The increase of the miniAOD event content is at the 1% level and has been discussed in the XPOG meeting of 06.09.2016 (*).  

Internal tests and standard RECO test were run to make sure the backport acts as expected (**).

Cheers,
Roger

(*)
https://indico.cern.ch/event/565391/

(**)
exceptions are runMatrix tests which failed due to CMS-DAS issues. 
