### PR TITLE
add options to HLTMuonDimuonL3Filter 

### DIFF
--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -36,8 +36,9 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
       edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
       edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // tokenidentifying product contains muons passing the previous level
-
+      bool   previousCandIsL2_;
       bool   fast_Accept_;      // flag to save time: stop processing after identification of the first valid pair
+      int    min_N_;            // minimum number of muons to fire the trigger
       double max_Eta_;          // Eta cut
       int    min_Nhits_;        // threshold on number of hits on muon
       double max_Dr_;           // impact parameter cut


### PR DESCRIPTION
make the filter a bit more flexible, so that it can be used to build more complex conditions.
- allow requiring multiple pairs per event
- allow to have PreviousCandTag pointing to a L3 filter instead of a L2 one

the default values of the parameters, set in fillDescriptions, don't change the current behaviour

will be used in a proposal to reduce drastically the rate of `HLT_TripleMu_5_3_3_v2` by adding &Delta;z and dilepton mass cuts
