### PR TITLE
Descoped puppi update (80X)

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -4,7 +4,7 @@ puppiCentral = cms.VPSet(
                  cms.PSet(
                   algoId           = cms.int32(5),  #0 is default Puppi
                   useCharged       = cms.bool(True),
-                  applyLowPUCorr   = cms.bool(True),
+                  applyLowPUCorr   = cms.bool(False),
                   combOpt          = cms.int32(0),
                   cone             = cms.double(0.4),
                   rmsPtMin         = cms.double(0.1),
@@ -16,7 +16,7 @@ puppiForward = cms.VPSet(
                 cms.PSet(
                  algoId         = cms.int32(5),  #0 is default Puppi
                  useCharged     = cms.bool(False),
-                 applyLowPUCorr = cms.bool(True),
+                 applyLowPUCorr = cms.bool(False),
                  combOpt        = cms.int32(0),
                  cone           = cms.double(0.4),
                  rmsPtMin       = cms.double(0.5),
@@ -58,7 +58,7 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                          etaMin              = cms.vdouble( 2.5,  3.0),
                          etaMax              = cms.vdouble( 3.0, 10.0),
                          ptMin               = cms.vdouble( 0.0,  0.0),
-                         MinNeutralPt        = cms.vdouble( 0.2,  0.2),
+                         MinNeutralPt        = cms.vdouble( 1.7,  2.0),
                          MinNeutralPtSlope   = cms.vdouble(0.08, 0.08),
                          RMSEtaSF            = cms.vdouble(1.20, 0.95),
                          MedEtaSF            = cms.vdouble(0.90, 0.75),

--- a/CommonTools/PileupAlgos/test/testPUMods.py
+++ b/CommonTools/PileupAlgos/test/testPUMods.py
@@ -4,21 +4,22 @@ process = cms.Process('TestPUMods')
 process.load('Configuration/StandardSequences/Services_cff')
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.MessageLogger.cerr.FwkReport.reportEvery = 10
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.load('CommonTools/PileupAlgos/Puppi_cff')
 process.load('CommonTools/PileupAlgos/PhotonPuppi_cff')
-from CommonTools.PileupAlgos.PhotonPuppi_cff import setupPuppiPhoton
+from CommonTools.PileupAlgos.PhotonPuppi_cff        import setupPuppiPhoton
+from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
 
 process.load('CommonTools/PileupAlgos/softKiller_cfi')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source("PoolSource",
 	fileNames  = cms.untracked.vstring(
-		'/store/mc/RunIISpring15MiniAODv2/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/E2B9A332-966F-E511-9BAA-0026B927865E.root'
+        '/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/70000/FECFE7D4-B01D-E611-9908-001E67248566.root'
 		)
 )
 process.source.inputCommands = cms.untracked.vstring("keep *",
@@ -30,21 +31,12 @@ process.options = cms.untracked.PSet(
   fileMode    = cms.untracked.string('NOMERGE')
 )
 
-process.puppi.candName = 'packedPFCandidates'
-process.puppi.candName = cms.InputTag('packedPFCandidates')
-process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
-
-process.packedPFCandidatesNoLep = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("abs(pdgId) != 13 && abs(pdgId) != 11"))
-process.puppiNoLep = process.puppi.clone()
-process.puppiNoLep.candName = cms.InputTag('packedPFCandidatesNoLep')
-process.puppiNoLep.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
+makePuppiesFromMiniAOD(process)
 
 process.load('RecoMET.METProducers.PFMET_cfi')
-process.pfMet.src = cms.InputTag('puppiPhoton')
-setupPuppiPhoton(process)
-process.puppiPhoton.puppiCandName    = 'puppiNoLep'
-
-process.puSequence = cms.Sequence(process.packedPFCandidatesNoLep*process.puppi*process.puppiNoLep*process.egmPhotonIDSequence*process.puppiPhoton*process.pfMet)
+process.pfMet.src = cms.InputTag('puppiForMET')
+#process.puSequence = cms.Sequence(process.pfNoLepPUPPI*process.puppi*process.puppiNoLep*process.egmPhotonIDSequence*process.puppiForMET*process.pfMet)
+process.puSequence = cms.Sequence(process.pfNoLepPUPPI*process.puppi*process.puppiNoLep*process.puppiForMET*process.pfMet)
 process.p = cms.Path(process.puSequence)
 process.output = cms.OutputModule("PoolOutputModule",
                                   outputCommands = cms.untracked.vstring('keep *'),

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from CommonTools.PileupAlgos.Puppi_cff import *
-# from CommonTools.PileupAlgos.PhotonPuppi_cff import setupPuppiPhoton
+from CommonTools.PileupAlgos.PhotonPuppi_cff        import setupPuppiPhoton
 
 def makePuppies( process ):
 
@@ -15,60 +15,29 @@ def makePuppies( process ):
                                            src = cms.InputTag("particleFlow"),
                                            pdgId = cms.vint32(-11,11,-13,13),
                                            )
-
-
     process.puppiNoLep = process.puppi.clone()
     process.puppiNoLep.candName = cms.InputTag('pfNoLepPUPPI') 
 
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
-
-## puppi met
-    process.puppiForMET = cms.EDProducer("PuppiPhoton",
-                                         candName       = cms.InputTag('packedPFCandidates'),
-                                         puppiCandName  = cms.InputTag('puppi'),
-                                         photonName     = cms.InputTag('slimmedPhotons'),
-                                         photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID_PHYS14_PU20bx25_V2p1-standalone-loose"),
-                                         pt             = cms.double(10),
-                                         useRefs        = cms.bool(True),
-                                         dRMatch        = cms.vdouble(10,10,10,10),
-                                         pdgids         = cms.vint32 (22,11,211,130),
-                                         weight         = cms.double(1.),
-                                         useValueMap    = cms.bool(False),
-                                         weightsName    = cms.InputTag('puppi'),
-                                         )
+    process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
+    process.puppiForMET = process.puppiPhoton.clone()
     process.puppiForMET.puppiCandName    = 'puppiMerged'
 
 
 
 def makePuppiesFromMiniAOD( process ):
-
     process.load('CommonTools.PileupAlgos.Puppi_cff')
-
     process.puppi.candName = cms.InputTag('packedPFCandidates')
     process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
-# kind of ugly, is there a better way to do this?
-
     process.pfNoLepPUPPI = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut =  cms.string("abs(pdgId) != 13 && abs(pdgId) != 11 && abs(pdgId) != 15"))
     process.pfLeptonsPUPPET   = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("abs(pdgId) == 13 || abs(pdgId) == 11 || abs(pdgId) == 15"))
-
     process.puppiNoLep = process.puppi.clone()
     process.puppiNoLep.candName = cms.InputTag('pfNoLepPUPPI') 
-
+    process.puppiNoLep.useWeightsNoLep = cms.bool(True)
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
-
-## puppi met
-    process.puppiForMET = cms.EDProducer("PuppiPhoton",
-                                         candName       = cms.InputTag('packedPFCandidates'),
-                                         puppiCandName  = cms.InputTag('puppi'),
-                                         photonName     = cms.InputTag('slimmedPhotons'),
-                                         photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID_PHYS14_PU20bx25_V2p1-standalone-loose"),
-                                         pt             = cms.double(10),
-                                         useRefs        = cms.bool(True),
-                                         dRMatch        = cms.vdouble(10,10,10,10),
-                                         pdgids         = cms.vint32 (22,11,211,130),
-                                         weight         = cms.double(1.),
-                                         useValueMap    = cms.bool(False),
-                                         weightsName    = cms.InputTag('puppi'),
-                                         )
-    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
+    process.puppiForMET = process.puppiPhoton.clone()
+    setupPuppiPhoton(process)
+    #Line below doesn't work because of an issue with references in MiniAOD
+    #process.puppiForMET.puppiCandName    = 'puppiMerged'
     

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -21,7 +21,7 @@ def makePuppies( process ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
-    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    #process.puppiForMET.puppiCandName    = 'puppiMerged'
 
 
 


### PR DESCRIPTION
As discussed at yesteday reco meeting,
here the descoped puppiMET version of PR #15429:
removed various puppiPhoton changes until understood differences between miniAOD and AOD
See discussion in (81X) #15562 #15669

benefit from this PR
1) difference in the forward puppi jets and removed PU dependency in MET due to changes in CommonTools/PileupAlgos/python/Puppi_cff.py 
2) the sequence in makePuppiesFromMiniAOD is ready to be used for offline, no changes from makePuppies that run on AOD are expected

@slava77 @violatingcp @zdemirag
