### PR TITLE
Offline DQM for 2016 pPb Muon HLT

### DIFF
--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -32,20 +32,25 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
       "HLT_IsoTkMu22_eta2p1_v",
       "HLT_IsoMu18_v",
       "HLT_IsoTkMu18_v",
-      "HLT_HIL1DoubleMu0", #for HI
-      "HLT_HIL1DoubleMu0BPTX", #for HI
-      "HLT_HIL2Mu3", #for HI
-      "HLT_HIL2Mu3BPTX", #for HI
-      "HLT_HIL2Mu7", #for HI
-      "HLT_HIL2Mu15", #for HI
-      "HLT_HIL2Mu3_NHitQ", #for HI
-      "HLT_HIL2DoubleMu0", #for HI
-      "HLT_HIL2DoubleMu0BPTX", #for HI
-      "HLT_HIL2DoubleMu0_NHitQ", #for HI
-      "HLT_HIL2DoubleMu3", #for HI
-      "HLT_HIL3Mu3", #for HI
-      "HLT_HIL3Mu3BPTX", #for HI
-      "HLT_HIL3DoubleMuOpen" #for HI
+      "HLT_PAL1DoubleMuOpen_v", #for HI
+      "HLT_PAL1DoubleMuOpen_OS_v", #for HI
+      "HLT_PAL1DoubleMuOpen_SS_v", #for HI
+      "HLT_PAL1DoubleMu0_v", #for HI
+      "HLT_PAL1DoubleMu0_HighQ_v", #for HI
+      "HLT_PAL1DoubleMu0_MGT1_v", #for HI
+      "HLT_PAL1DoubleMu10_v", #for HI
+      "HLT_PAL2DoubleMuOpen_v", #for HI
+      "HLT_PAL2DoubleMu10_v", #for HI
+      "HLT_PAL3DoubleMuOpen_v", #for HI
+      "HLT_PAL3DoubleMuOpen_HIon_v", #for HI
+      "HLT_PAL3DoubleMu10_v", #for HI
+      "HLT_PAL2Mu12_v", #for HI
+      "HLT_PAL2Mu15_v", #for HI
+      "HLT_PAL3Mu3_v", #for HI 
+      "HLT_PAL3Mu5_v", #for HI 
+      "HLT_PAL3Mu7_v", #for HI 
+      "HLT_PAL3Mu12_v", #for HI
+      "HLT_PAL3Mu15_v" #for HI
     ),
 
 #HLT_Mu15_eta2p1_TriCentral_40_20_20_BTagIP3D1stTrack_v3 matches HLT_Mu15_eta2p1_v


### PR DESCRIPTION
This PR is meant for pPb 2016 run and it includes the modifications needed in Offline DQM for the muon HLT triggers.  The first change corresponds to update the list of trigger paths in HLTMuonOfflineAnalyzer so that it includes the new muon pPb triggers. We might also consider to change the pT cut of the Jpsi efficiency plots (see https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc#L305 ) but this is still under discussion.
