### PR TITLE
check for sequence size before extending patMetUncertaintySequence (to avoid unrunnable pythonDump)

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -380,7 +380,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not hasattr(process, "patMetCorrectionSequence"+postfix):
             setattr(process, "patMetCorrectionSequence"+postfix, patMetCorrectionSequence)
         if not hasattr(process, "patMetUncertaintySequence"+postfix):
-            patMetUncertaintySequence += tmpUncSequence
+            if not len(tmpUncSequence.moduleNames())==0: patMetUncertaintySequence += tmpUncSequence
             setattr(process, "patMetUncertaintySequence"+postfix, patMetUncertaintySequence)
         else:
             if not len(configtools.listModules(tmpUncSequence))==0:


### PR DESCRIPTION
the title says it all.
This gets rid of "++" in the resulting sequence, which can not be parsed for running.

Submission to be in sync with 80X.

https://github.com/cms-sw/cmssw/issues/15786 should provide a more robust solution

for 81X there are many more places where None appears. In this case it is from modules.
So, the DataProcessing in 81X will not be fixed by this PR, other changes will be necessary, to be provided at some point soon.
