### PR TITLE
check for sequence size before extending patMetUncertaintySequence (to avoid unrunnable pythonDump)

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -380,7 +380,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not hasattr(process, "patMetCorrectionSequence"+postfix):
             setattr(process, "patMetCorrectionSequence"+postfix, patMetCorrectionSequence)
         if not hasattr(process, "patMetUncertaintySequence"+postfix):
-            patMetUncertaintySequence += tmpUncSequence
+            if not len(tmpUncSequence.moduleNames())==0: patMetUncertaintySequence += tmpUncSequence
             setattr(process, "patMetUncertaintySequence"+postfix, patMetUncertaintySequence)
         else:
             if not len(configtools.listModules(tmpUncSequence))==0:


### PR DESCRIPTION
the title says it all.
This gets rid of "++" in the resulting sequence, which can not be parsed for running.

https://github.com/cms-sw/cmssw/issues/15786 should provide a more robust solution

This so far was the only place that affected DataProcessing configs
