### PR TITLE
Use unique_ptr, not auto_ptr in RecoTracker

### DIFF
--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -175,13 +175,13 @@ namespace cms{
     edm::Handle<MeasurementTrackerEvent> data;
     e.getByToken(theMTELabel, data);
 
-    std::auto_ptr<MeasurementTrackerEvent> dataWithMasks;
+    std::unique_ptr<MeasurementTrackerEvent> dataWithMasks;
     if (skipClusters_) {
         edm::Handle<PixelClusterMask> pixelMask;
         e.getByToken(maskPixels_, pixelMask);
         edm::Handle<StripClusterMask> stripMask;
         e.getByToken(maskStrips_, stripMask);
-        dataWithMasks.reset(new MeasurementTrackerEvent(*data, *stripMask, *pixelMask));
+        dataWithMasks = std::make_unique<MeasurementTrackerEvent>(*data, *stripMask, *pixelMask);
         //std::cout << "Trajectory builder " << conf_.getParameter<std::string>("@module_label") << " created with masks " << std::endl;
         theTrajectoryBuilder->setEvent(e, es, &*dataWithMasks);
     } else if (phase2skipClusters_) {
@@ -190,7 +190,7 @@ namespace cms{
         e.getByToken(maskPixels_, pixelMask);
         edm::Handle<Phase2OTClusterMask> phase2OTMask;
         e.getByToken(maskPhase2OTs_, phase2OTMask);
-        dataWithMasks.reset(new MeasurementTrackerEvent(*data, *pixelMask, *phase2OTMask));
+        dataWithMasks = std::make_unique<MeasurementTrackerEvent>(*data, *pixelMask, *phase2OTMask);
         //std::cout << "Trajectory builder " << conf_.getParameter<std::string>("@module_label") << " created with phase2 masks " << std::endl;
         theTrajectoryBuilder->setEvent(e, es, &*dataWithMasks);
     } else {
@@ -206,13 +206,13 @@ namespace cms{
     e.getByToken(theSeedLabel, collseed);
 
     // Step C: Create empty output collection
-    std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection);
-    std::auto_ptr<std::vector<Trajectory> > outputT (new std::vector<Trajectory>());
+    auto output = std::make_unique<TrackCandidateCollection>();
+    auto outputT = std::make_unique<std::vector<Trajectory>>();
 
     if ( (*collseed).size()>theMaxNSeeds ) {
       LogError("TooManySeeds")<<"Exceeded maximum numeber of seeds! theMaxNSeeds="<<theMaxNSeeds<<" nSeed="<<(*collseed).size();
-      if (theTrackCandidateOutput){ e.put(output);}
-      if (theTrajectoryOutput){e.put(outputT);}
+      if (theTrackCandidateOutput){e.put(std::move(output));}
+      if (theTrajectoryOutput){e.put(std::move(outputT));}
       return;
     }
 
@@ -513,8 +513,8 @@ namespace cms{
     deleteAssocDebugger();
 
     // Step G: write output to file
-    if (theTrackCandidateOutput){ e.put(output);}
-    if (theTrajectoryOutput){e.put(outputT);}
+    if (theTrackCandidateOutput){e.put(std::move(output));}
+    if (theTrajectoryOutput){e.put(std::move(outputT));}
   }
 
 }

--- a/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilter.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilter.cc
@@ -100,7 +100,7 @@ void ConversionSeedFilter::produce(edm::Event& iEvent, const edm::EventSetup& iS
    iSetup.get<TrackerDigiGeometryRecord>().get(theG);
    iSetup.get<IdealMagneticFieldRecord>().get(theMF);  
 
-   std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+   auto result = std::make_unique<TrajectorySeedCollection>();
 
    TrajectorySeedCollection selectedColl;
    
@@ -142,7 +142,7 @@ void ConversionSeedFilter::produce(edm::Event& iEvent, const edm::EventSetup& iS
       
    edm::LogInfo("ConversionSeedFilter") << "\nNew Event : result size " << result->size()<< std::endl;
 
-   iEvent.put(result);
+   iEvent.put(std::move(result));
    
 }
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilterCharge.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilterCharge.cc
@@ -77,7 +77,7 @@ void ConversionSeedFilterCharge::produce(edm::StreamID, edm::Event& iEvent, cons
    edm::ESHandle<MagneticField> theMF;
    iSetup.get<IdealMagneticFieldRecord>().get(theMF);  
 
-   std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+   auto result = std::make_unique<TrajectorySeedCollection>();
    result->reserve(pInPos->size());
 
    if (pInPos->size()<maxInputSeeds && pInNeg->size()<maxInputSeeds) {
@@ -132,7 +132,7 @@ void ConversionSeedFilterCharge::produce(edm::StreamID, edm::Event& iEvent, cons
    edm::LogInfo("ConversionSeedFilterCharge") << "\nNew Event : result size " << result->size() << std::endl;
 
    //cout << "sizes: pInPos=" << pInPos->size() << " pInNeg=" << pInNeg->size() << " result=" << result->size() << endl; 
-   iEvent.put(result);
+   iEvent.put(std::move(result));
    
 }
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadruplets.cc
@@ -37,7 +37,7 @@ PhotonConversionTrajectorySeedProducerFromQuadruplets(const edm::ParameterSet& c
 
 void PhotonConversionTrajectorySeedProducerFromQuadruplets::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<TrajectorySeedCollection> result( new TrajectorySeedCollection() );  
+  auto result = std::make_unique<TrajectorySeedCollection>();  
   try{
     _theFinder->analyze(ev,es);
     if(_theFinder->getTrajectorySeedCollection()->size())
@@ -52,7 +52,7 @@ void PhotonConversionTrajectorySeedProducerFromQuadruplets::produce(edm::Event& 
 
   
   edm::LogInfo("debugTrajSeedFromQuadruplets") << " TrajectorySeedCollection size " << result->size();
-  ev.put(result, _newSeedCandidates);  
+  ev.put(std::move(result), _newSeedCandidates);  
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
@@ -40,11 +40,11 @@ void PhotonConversionTrajectorySeedProducerFromSingleLeg::produce(edm::Event& ev
 {
 
 
-  std::auto_ptr<TrajectorySeedCollection> result( new TrajectorySeedCollection() );  
+  auto result = std::make_unique<TrajectorySeedCollection>();  
 
   _theFinder->find(ev,es,*result);
   result->shrink_to_fit();
-  ev.put(result, _newSeedCandidates);  
+  ev.put(std::move(result), _newSeedCandidates);  
 
 
 }

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedGeneratorFromTrackingParticleEDProducer.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedGeneratorFromTrackingParticleEDProducer.cc
@@ -44,7 +44,7 @@ SeedGeneratorFromTrackingParticleEDProducer::SeedGeneratorFromTrackingParticleED
 
 void SeedGeneratorFromTrackingParticleEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+  auto result = std::make_unique<TrajectorySeedCollection>();
   Handle<reco::TrackCollection> trks;
   ev.getByLabel(theInputCollectionTag, trks);
 
@@ -75,6 +75,6 @@ void SeedGeneratorFromTrackingParticleEDProducer::produce(edm::Event& ev, const 
     }
   } 
 
-  ev.put(result);
+  ev.put(std::move(result));
 }
 */

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -110,7 +110,7 @@ void  DeDxEstimatorProducer::beginRun(edm::Run const& run, const edm::EventSetup
 
 void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  auto_ptr<ValueMap<DeDxData> > trackDeDxEstimateAssociation(new ValueMap<DeDxData> );  
+  auto trackDeDxEstimateAssociation = std::make_unique<ValueMap<DeDxData>>();  
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
@@ -173,7 +173,7 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // fill the association map and put it into the event
   filler.fill();
-  iEvent.put(trackDeDxEstimateAssociation);   
+  iEvent.put(std::move(trackDeDxEstimateAssociation));
 }
 
 

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
@@ -74,7 +74,7 @@ void DeDxHitInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   if(useTrajectory)iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
 
   // creates the output collection
-  std::auto_ptr<reco::DeDxHitInfoCollection> resultdedxHitColl(new reco::DeDxHitInfoCollection);
+  auto resultdedxHitColl = std::make_unique<reco::DeDxHitInfoCollection>();
 
   std::vector<int> indices;
 
@@ -126,14 +126,14 @@ void DeDxHitInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   ///////////////////////////////////////
  
 
-  edm::OrphanHandle<reco::DeDxHitInfoCollection> dedxHitCollHandle = iEvent.put(resultdedxHitColl);
+  edm::OrphanHandle<reco::DeDxHitInfoCollection> dedxHitCollHandle = iEvent.put(std::move(resultdedxHitColl));
 
   //create map passing the handle to the matched collection
-  std::auto_ptr<reco::DeDxHitInfoAss> dedxMatch(new reco::DeDxHitInfoAss(dedxHitCollHandle));
+  auto dedxMatch = std::make_unique<reco::DeDxHitInfoAss>(dedxHitCollHandle);
   reco::DeDxHitInfoAss::Filler filler(*dedxMatch);  
   filler.insert(trackCollectionHandle, indices.begin(), indices.end()); 
   filler.fill();
-  iEvent.put(dedxMatch);
+  iEvent.put(std::move(dedxMatch));
 }
 
 void DeDxHitInfoProducer::processHit(const TrackingRecHit* recHit, const float trackMomentum, const float cosine, reco::DeDxHitInfo& hitDeDxInfo,  const LocalPoint& hitLocalPos){

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -94,7 +94,7 @@ bool
   using namespace reco;
   using namespace trigger;
 
-  auto_ptr<RecoChargedCandidateCollection> chargedCandidates( new std::vector<RecoChargedCandidate> );
+  auto chargedCandidates = std::make_unique<std::vector<RecoChargedCandidate>>();
 
   ModuleDescription moduleDesc_;
 
@@ -182,7 +182,7 @@ bool
 
   // put filter object into the Event
    if(saveTags()){
-     edm::OrphanHandle<RecoChargedCandidateCollection> chargedCandidatesHandle = iEvent.put(chargedCandidates);
+     edm::OrphanHandle<RecoChargedCandidateCollection> chargedCandidatesHandle = iEvent.put(std::move(chargedCandidates));
      for(int i=0; i<NTracks; i++){
           filterproduct.addObject(TriggerMuon,RecoChargedCandidateRef(chargedCandidatesHandle,i));
      }

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
@@ -50,9 +50,9 @@ void
 TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
      // create output collection instance
-    std::auto_ptr<RecoTracktoTPCollection> outputAlgoA(new RecoTracktoTPCollection());
-    std::auto_ptr<RecoTracktoTPCollection> outputAlgoB(new RecoTracktoTPCollection());
-    std::auto_ptr<TPtoRecoTrackCollection> outputTP(new TPtoRecoTrackCollection());
+    auto outputAlgoA = std::make_unique<RecoTracktoTPCollection>();
+    auto outputAlgoB = std::make_unique<RecoTracktoTPCollection>();
+    auto outputTP = std::make_unique<TPtoRecoTrackCollection>();
   
     // Get Inputs
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
@@ -263,9 +263,9 @@ TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
 
 
     // put the collection in the event record
-    iEvent.put(outputAlgoA, "AlgoA");
-    iEvent.put(outputAlgoB, "AlgoB");
-    iEvent.put(outputTP, "TP");
+    iEvent.put(std::move(outputAlgoA), "AlgoA");
+    iEvent.put(std::move(outputAlgoB), "AlgoB");
+    iEvent.put(std::move(outputTP), "TP");
 }
 
 // ------------ Producer Specific Meber Fucntions ----------------------------------------

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -242,12 +242,12 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
 {
 
             // storage....
-            std::auto_ptr<reco::TrackCollection> selTracks_;
-            std::auto_ptr<reco::TrackExtraCollection> selTrackExtras_;
-            std::auto_ptr< TrackingRecHitCollection>  selHits_;
-            std::auto_ptr< std::vector<Trajectory> > selTrajs_;
-            std::auto_ptr< std::vector<const Trajectory *> > selTrajPtrs_;
-            std::auto_ptr< TrajTrackAssociationCollection >  selTTAss_;
+            std::unique_ptr<reco::TrackCollection> selTracks_;
+            std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+            std::unique_ptr<TrackingRecHitCollection>  selHits_;
+            std::unique_ptr<std::vector<Trajectory> > selTrajs_;
+            std::unique_ptr<std::vector<const Trajectory *> > selTrajPtrs_;
+            std::unique_ptr<TrajTrackAssociationCollection >  selTTAss_;
             reco::TrackRefProd rTracks_;
             reco::TrackExtraRefProd rTrackExtras_;
             TrackingRecHitRefProd rHits_;
@@ -290,11 +290,11 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
 
 
 
-  selTracks_ = auto_ptr<TrackCollection>(new TrackCollection());
+  selTracks_ = std::make_unique<TrackCollection>();
   rTracks_ = evt.getRefBeforePut<TrackCollection>();      
   if (copyExtras_) {
-    selTrackExtras_ = auto_ptr<TrackExtraCollection>(new TrackExtraCollection());
-    selHits_ = auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+    selTrackExtras_ = std::make_unique<TrackExtraCollection>();
+    selHits_ = std::make_unique<TrackingRecHitCollection>();
     rHits_ = evt.getRefBeforePut<TrackingRecHitCollection>();
     rTrackExtras_ = evt.getRefBeforePut<TrackExtraCollection>();
   }
@@ -369,9 +369,9 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
     Handle< TrajTrackAssociationCollection > hTTAss;
     evt.getByToken(srcTass_, hTTAss);
     evt.getByToken(srcTraj_, hTraj);
-    selTrajs_ = auto_ptr< vector<Trajectory> >(new vector<Trajectory>()); 
+    selTrajs_ = std::make_unique<std::vector<Trajectory>>(); 
     rTrajectories_ = evt.getRefBeforePut< vector<Trajectory> >();
-    selTTAss_ = auto_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection(rTrajectories_, rTracks_));
+    selTTAss_ = std::make_unique<TrajTrackAssociationCollection>(rTrajectories_, rTracks_);
     for (size_t i = 0, n = hTraj->size(); i < n; ++i) {
       Ref< vector<Trajectory> > trajRef(hTraj, i);
       TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
@@ -386,14 +386,14 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
     }
   }
 
-  evt.put(selTracks_);
+  evt.put(std::move(selTracks_));
   if (copyExtras_ ) {
-    evt.put(selTrackExtras_); 
-    evt.put(selHits_);
+    evt.put(std::move(selTrackExtras_)); 
+    evt.put(std::move(selHits_));
   }
   if ( copyTrajectories_ ) {
-    evt.put(selTrajs_);
-    evt.put(selTTAss_);
+    evt.put(std::move(selTrajs_));
+    evt.put(std::move(selTTAss_));
   }
 }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
@@ -79,12 +79,12 @@ using namespace reco;
 		     uint32_t max_lostLayers_;
 		     
 		     // storage
-		     std::auto_ptr<reco::TrackCollection> selTracks_;
-		     std::auto_ptr<reco::TrackExtraCollection> selTrackExtras_;
-		     std::auto_ptr< TrackingRecHitCollection>  selHits_;
-		     std::auto_ptr< std::vector<Trajectory> > selTrajs_;
-		     std::auto_ptr< std::vector<const Trajectory *> > selTrajPtrs_;
-		     std::auto_ptr< TrajTrackAssociationCollection >  selTTAss_;
+		     std::unique_ptr<reco::TrackCollection> selTracks_;
+		     std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+		     std::unique_ptr<TrackingRecHitCollection>  selHits_;
+		     std::unique_ptr<std::vector<Trajectory> > selTrajs_;
+		     std::unique_ptr<std::vector<const Trajectory *> > selTrajPtrs_;
+		     std::unique_ptr<TrajTrackAssociationCollection >  selTTAss_;
 		     reco::TrackRefProd rTracks_;
 		     reco::TrackExtraRefProd rTrackExtras_;
 		     TrackingRecHitRefProd rHits_;
@@ -172,11 +172,11 @@ void CosmicTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
   // Get tracks 
   evt.getByToken( src_, hSrcTrack );
   
-  selTracks_ = auto_ptr<TrackCollection>(new TrackCollection());
+  selTracks_ = std::make_unique<TrackCollection>();
   rTracks_ = evt.getRefBeforePut<TrackCollection>();      
   if (copyExtras_) {
-    selTrackExtras_ = auto_ptr<TrackExtraCollection>(new TrackExtraCollection());
-    selHits_ = auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+    selTrackExtras_ = std::make_unique<TrackExtraCollection>();
+    selHits_ = std::make_unique<TrackingRecHitCollection>();
     rHits_ = evt.getRefBeforePut<TrackingRecHitCollection>();
     rTrackExtras_ = evt.getRefBeforePut<TrackExtraCollection>();
   }
@@ -221,9 +221,9 @@ void CosmicTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
     Handle< TrajTrackAssociationCollection > hTTAss;
     evt.getByToken(srcTass_, hTTAss);
     evt.getByToken(srcTraj_, hTraj);
-    selTrajs_ = auto_ptr< vector<Trajectory> >(new vector<Trajectory>()); 
+    selTrajs_ = std::make_unique<std::vector<Trajectory>>(); 
     rTrajectories_ = evt.getRefBeforePut< vector<Trajectory> >();
-    selTTAss_ = auto_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection(&evt.productGetter()));
+    selTTAss_ = std::make_unique<TrajTrackAssociationCollection>(&evt.productGetter());
     for (size_t i = 0, n = hTraj->size(); i < n; ++i) {
       Ref< vector<Trajectory> > trajRef(hTraj, i);
       TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
@@ -239,14 +239,14 @@ void CosmicTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
   }
   
   static const std::string emptyString;
-  evt.put(selTracks_);
+  evt.put(std::move(selTracks_));
   if (copyExtras_ ) {
-    evt.put(selTrackExtras_); 
-    evt.put(selHits_);
+    evt.put(std::move(selTrackExtras_)); 
+    evt.put(std::move(selHits_));
   }
   if ( copyTrajectories_ ) {
-    evt.put(selTrajs_);
-    evt.put(selTTAss_);
+    evt.put(std::move(selTrajs_));
+    evt.put(std::move(selTTAss_));
   }
 }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -154,7 +154,7 @@ namespace reco { namespace modules {
 		iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
 		// prepare output collection
-		std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection());
+		auto output = std::make_unique<TrackCandidateCollection>();
 		output->reserve(tracks->size());
 
 		// working area and tools
@@ -370,7 +370,7 @@ namespace reco { namespace modules {
 			} // loop twice for top and bottom
 		} // loop on tracks
 		LogDebug("CosmicTrackSplitter") << "totalTracks_ = " << totalTracks_;
-		iEvent.put(output);
+		iEvent.put(std::move(output));
 	}
 
 	TrackCandidate

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -226,9 +226,9 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
   iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
   TwoTrackMinimumDistance ttmd;
   TSCPBuilderNoMaterial tscpBuilder;
-  std::unique_ptr<std::vector<TrackCandidate> > out_duplicateCandidates(new std::vector<TrackCandidate>());
+  auto out_duplicateCandidates = std::make_unique<std::vector<TrackCandidate>>();
 
-  std::unique_ptr<CandidateToDuplicate> out_candidateMap(new CandidateToDuplicate());
+  auto out_candidateMap = std::make_unique<CandidateToDuplicate>();
 
   for(int i = 0; i < (int)tracks.size(); i++){
     const reco::Track *rt1 = &tracks[i];

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -256,7 +256,7 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
     std::vector<float> mvaVals_(srcTracks.size(),-99.f);
     processMVA(evt,es,vertexBeamSpot,*(hVtx.product()), i, mvaVals_, i == 0 ? true : false);
     std::vector<int> selTracks(trkSize,0);
-    auto_ptr<edm::ValueMap<int> > selTracksValueMap = auto_ptr<edm::ValueMap<int> >(new edm::ValueMap<int>);
+    auto selTracksValueMap = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler filler(*selTracksValueMap);
 
     if (useVertices_) selectVertices(i,*hVtx, points, vterr, vzerr);
@@ -322,8 +322,8 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
     filler.insert(hSrcTrack, selTracks.begin(),selTracks.end());
     filler.fill();
 
-    //    evt.put(selTracks,name_[i]);
-    evt.put(selTracksValueMap,name_[i]);
+    //    evt.put(std::move(selTracks),name_[i]);
+    evt.put(std::move(selTracksValueMap),name_[i]);
     for (auto & q : selTracks) q=std::max(q,0);
     auto quals = std::make_unique<QualityMaskCollection>(selTracks.begin(),selTracks.end());
     evt.put(std::move(quals),name_[i]);
@@ -530,7 +530,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
   const TrackingRecHitCollection & srcHits(*hSrcHits);
   
   
-  auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);
+  auto mvaValValueMap = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler mvaFiller(*mvaValValueMap);
 
 
@@ -538,7 +538,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
     // mvaVals_ already initalized...
     mvaFiller.insert(hSrcTrack,mvaVals_.begin(),mvaVals_.end());
     mvaFiller.fill();
-    evt.put(mvaValValueMap,"MVAVals");
+    evt.put(std::move(mvaValValueMap),"MVAVals");
     auto mvas = std::make_unique<MVACollection>(mvaVals_.begin(),mvaVals_.end());
     evt.put(std::move(mvas),"MVAValues");
     return;
@@ -626,7 +626,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
   if(writeIt){
     mvaFiller.insert(hSrcTrack,mvaVals_.begin(),mvaVals_.end());
     mvaFiller.fill();
-    evt.put(mvaValValueMap,"MVAVals");
+    evt.put(std::move(mvaValValueMap),"MVAVals");
     auto mvas = std::make_unique<MVACollection>(mvaVals_.begin(),mvaVals_.end());
     evt.put(std::move(mvas),"MVAValues");
   }

--- a/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
@@ -41,12 +41,12 @@ class SimpleTrackListMerger : public edm::stream::EDProducer<> {
   private:
     edm::ParameterSet conf_;
 
-    std::auto_ptr<reco::TrackCollection> outputTrks;
-    std::auto_ptr<reco::TrackExtraCollection> outputTrkExtras;
-    std::auto_ptr< TrackingRecHitCollection>  outputTrkHits;
-    std::auto_ptr< std::vector<Trajectory> > outputTrajs;
-    std::auto_ptr< TrajTrackAssociationCollection >  outputTTAss;
-    std::auto_ptr< TrajectorySeedCollection > outputSeeds;
+    std::unique_ptr<reco::TrackCollection> outputTrks;
+    std::unique_ptr<reco::TrackExtraCollection> outputTrkExtras;
+    std::unique_ptr<TrackingRecHitCollection>  outputTrkHits;
+    std::unique_ptr<std::vector<Trajectory>> outputTrajs;
+    std::unique_ptr<TrajTrackAssociationCollection>  outputTTAss;
+    std::unique_ptr<TrajectorySeedCollection> outputSeeds;
 
     reco::TrackRefProd refTrks;
     reco::TrackExtraRefProd refTrkExtras;
@@ -229,26 +229,26 @@ namespace {
     const reco::TrackCollection tC2 = *TC2;
 
     // Step B: create empty output collection
-    outputTrks = std::auto_ptr<reco::TrackCollection>(new reco::TrackCollection);
+    outputTrks = std::make_unique<reco::TrackCollection>();
     refTrks = e.getRefBeforePut<reco::TrackCollection>();
 
     if (copyExtras_) {
-        outputTrkExtras = std::auto_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection);
+        outputTrkExtras = std::make_unique<reco::TrackExtraCollection>();
 	outputTrkExtras->reserve(TC1->size()+TC2->size());
         refTrkExtras    = e.getRefBeforePut<reco::TrackExtraCollection>();
-        outputTrkHits   = std::auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection);
+        outputTrkHits   = std::make_unique<TrackingRecHitCollection>();
 	outputTrkHits->reserve((TC1->size()+TC2->size())*25);
         refTrkHits      = e.getRefBeforePut<TrackingRecHitCollection>();
 	if (makeReKeyedSeeds_){
-	  outputSeeds = std::auto_ptr<TrajectorySeedCollection>(new TrajectorySeedCollection);
+	  outputSeeds = std::make_unique<TrajectorySeedCollection>();
 	  outputSeeds->reserve(TC1->size()+TC2->size());
 	  refTrajSeeds = e.getRefBeforePut<TrajectorySeedCollection>();
 	}
     }
 
-    outputTrajs = std::auto_ptr< std::vector<Trajectory> >(new std::vector<Trajectory>());
+    outputTrajs = std::make_unique<std::vector<Trajectory>>();
     outputTrajs->reserve(TC1->size()+TC2->size());
-    outputTTAss = std::auto_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection());
+    outputTTAss = std::make_unique<TrajTrackAssociationCollection>();
     //outputTTAss->reserve(TC1->size()+TC2->size());//how do I reserve space for an association map?
 
   //
@@ -257,7 +257,7 @@ namespace {
 
 //    if ( tC1.empty() ){
 //      LogDebug("RoadSearch") << "Found " << output.size() << " clouds.";
-//      e.put(output);
+//      e.put(std::move(output);
 //      return;
 //    }
 
@@ -652,15 +652,15 @@ namespace {
      }
    }}
 
-    e.put(outputTrks);
+    e.put(std::move(outputTrks));
     if (copyExtras_) {
-        e.put(outputTrkExtras);
-        e.put(outputTrkHits);
+        e.put(std::move(outputTrkExtras));
+        e.put(std::move(outputTrkHits));
 	if (makeReKeyedSeeds_)
-	  e.put(outputSeeds);
+	  e.put(std::move(outputSeeds));
     }
-    e.put(outputTrajs);
-    e.put(outputTTAss);
+    e.put(std::move(outputTrajs));
+    e.put(std::move(outputTTAss));
     return;
 
   }//end produce

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
@@ -76,7 +76,7 @@ void TrackCandidateTopBottomHitFilter::produce(edm::Event& iEvent, const edm::Ev
 
   Handle<TrackCandidateCollection> pIn;
   iEvent.getByToken(label,pIn);
-  std::auto_ptr<TrackCandidateCollection> pOut(new TrackCandidateCollection);
+  auto pOut = std::make_unique<TrackCandidateCollection>();
   for (TrackCandidateCollection::const_iterator it=pIn->begin(); it!=pIn->end();++it) {
     PTrajectoryStateOnDet state = it->trajectoryStateOnDet();
     TrackCandidate::range oldhits = it->recHits();
@@ -94,7 +94,7 @@ void TrackCandidateTopBottomHitFilter::produce(edm::Event& iEvent, const edm::Ev
       pOut->push_back(newTC);
     }
   }
-  iEvent.put(pOut);
+  iEvent.put(std::move(pOut));
 }
 
 void TrackCandidateTopBottomHitFilter::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -380,7 +380,7 @@ TrackerTrackHitFilter::produce(edm::Event &iEvent, const edm::EventSetup &iSetup
   size_t  candcollsize;
   if(useTrajectories_)candcollsize= assoMap->size();
   else candcollsize=tracks->size();
-  std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection());
+  auto output = std::make_unique<TrackCandidateCollection>();
 
   output->reserve(candcollsize);
 
@@ -516,7 +516,7 @@ TrackerTrackHitFilter::produce(edm::Event &iEvent, const edm::EventSetup &iSetup
 
   // std::cout<<"OUTPUT SIZE: "<<output->size()<<std::endl;
 
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 TrackCandidate

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
@@ -78,7 +78,7 @@ public:
   void  improveSeeds( const MeasurementTrackerEvent &event );
 
   /// Fill 'output' with persistent nuclear seeds
-  std::auto_ptr<TrajectorySeedCollection>  getPersistentSeeds();
+  std::unique_ptr<TrajectorySeedCollection>  getPersistentSeeds();
 
   TrajectoryStateOnSurface rescaleError(float rescale, const TSOS& state) const;
 

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearSeedsEDProducer.cc
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearSeedsEDProducer.cc
@@ -47,8 +47,8 @@ NuclearSeedsEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
    LogDebug("NuclearSeedGenerator") << "Number of trajectory in event :" << m_TrajectoryCollection->size() << "\n";
 
-   std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection);
-   std::auto_ptr<TrajectoryToSeedsMap> outAssoc(new TrajectoryToSeedsMap);
+   auto output = std::make_unique<TrajectorySeedCollection>();
+   auto outAssoc = std::make_unique<TrajectoryToSeedsMap>();
 
    
    edm::Handle<MeasurementTrackerEvent> data;
@@ -68,7 +68,7 @@ NuclearSeedsEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
          if( improveSeeds == true ) theNuclearInteractionFinder->improveSeeds( *data );
 
          // push back the new persistent seeds in output
-         std::auto_ptr<TrajectorySeedCollection> newSeeds(theNuclearInteractionFinder->getPersistentSeeds());
+         std::unique_ptr<TrajectorySeedCollection> newSeeds(theNuclearInteractionFinder->getPersistentSeeds());
          output->insert(output->end(), newSeeds->begin(), newSeeds->end());
 
          // fill the id of the Trajectory and the if of the seed in assocPair
@@ -78,12 +78,12 @@ NuclearSeedsEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
    }
 
-   const edm::OrphanHandle<TrajectorySeedCollection> refprodTrajSeedColl = iEvent.put(output);
+   const edm::OrphanHandle<TrajectorySeedCollection> refprodTrajSeedColl = iEvent.put(std::move(output));
 
    for(std::vector<std::pair<int, int> >::const_iterator iVecP = assocPair.begin(); iVecP != assocPair.end(); iVecP++) {
         outAssoc->insert(edm::Ref<TrajectoryCollection>(m_TrajectoryCollection,iVecP->first), edm::Ref<TrajectorySeedCollection>(refprodTrajSeedColl, iVecP->second));
    }
-   iEvent.put(outAssoc);
+   iEvent.put(std::move(outAssoc));
 
 }
 

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
@@ -64,12 +64,12 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 {
   // Create Output Collections
   // --------------------------------------------------------------------------------------------------
-  std::auto_ptr<TrajectoryCollection>           Output_traj          ( new TrajectoryCollection );
-  std::auto_ptr<TrajectoryToTrajectoryMap>      Output_trajmap       ( new TrajectoryToTrajectoryMap );
+  auto Output_traj           = std::make_unique<TrajectoryCollection>();
+  auto Output_trajmap        = std::make_unique<TrajectoryToTrajectoryMap>();
 
-  std::auto_ptr<reco::TrackExtraCollection>	Output_trackextra    ( new reco::TrackExtraCollection );
-  std::auto_ptr<reco::TrackCollection>          Output_track         ( new reco::TrackCollection );
-  std::auto_ptr<TrackToTrajectoryMap>           Output_trackmap      ( new TrackToTrajectoryMap );
+  auto Output_trackextra     = std::make_unique<reco::TrackExtraCollection>();
+  auto Output_track          = std::make_unique<reco::TrackCollection>();
+  auto Output_trackmap       = std::make_unique<TrackToTrajectoryMap>();
 
 
 
@@ -157,9 +157,9 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
         }
 
   }
-  const edm::OrphanHandle<TrajectoryCollection>     Handle_traj = iEvent.put(Output_traj);
-  const edm::OrphanHandle<reco::TrackCollection> Handle_tracks = iEvent.put(Output_track);
-  iEvent.put(Output_trackextra);
+  const edm::OrphanHandle<TrajectoryCollection> Handle_traj = iEvent.put(std::move(Output_traj));
+  const edm::OrphanHandle<reco::TrackCollection> Handle_tracks = iEvent.put(std::move(Output_track));
+  iEvent.put(std::move(Output_trackextra));
 
   // Make Maps between elements
   // --------------------------------------------------------------------------------------------------
@@ -169,7 +169,7 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
      return;
   }
 
-  std::auto_ptr<TrackToTrackMap>  	        Output_tracktrackmap ( new TrackToTrackMap(Handle_tracks, m_TrajToTrackCollection->refProd().val) );
+  auto Output_tracktrackmap = std::make_unique<TrackToTrackMap>(Handle_tracks, m_TrajToTrackCollection->refProd().val);
 
   for(unsigned int i = 0 ; i < Indice_Map.size() ; i++)
   {
@@ -186,9 +186,9 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
         }catch(edm::Exception event){}
 	
   }
-  iEvent.put(Output_trajmap);
-  iEvent.put(Output_trackmap);
-  iEvent.put(Output_tracktrackmap);
+  iEvent.put(std::move(Output_trajmap));
+  iEvent.put(std::move(Output_trackmap));
+  iEvent.put(std::move(Output_tracktrackmap));
 
 
   if(verbosity>=3)printf("-----------------------\n");

--- a/RecoTracker/NuclearSeedGenerator/src/NuclearInteractionFinder.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/NuclearInteractionFinder.cc
@@ -210,8 +210,8 @@ void NuclearInteractionFinder::fillSeeds( const std::pair<TrajectoryMeasurement,
              return;
 }
 //----------------------------------------------------------------------
-std::auto_ptr<TrajectorySeedCollection> NuclearInteractionFinder::getPersistentSeeds() {
-   std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection);
+std::unique_ptr<TrajectorySeedCollection> NuclearInteractionFinder::getPersistentSeeds() {
+   auto output = std::make_unique<TrajectorySeedCollection>();
    for(std::vector<SeedFromNuclearInteraction>::const_iterator it_seed = allSeeds.begin(); it_seed != allSeeds.end(); it_seed++) {
        if(it_seed->isValid()) {
            output->push_back( it_seed->TrajSeed() );

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
@@ -89,7 +89,7 @@ namespace cms
     e.getByToken(stereorecHitsToken_, stereorecHits);
 
     // Step B: create empty output collection
-    std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection);
+    auto output = std::make_unique<TrackCandidateCollection>();
 
     edm::ESHandle<TrackerGeometry> tracker;
     es.get<TrackerDigiGeometryRecord>().get(tracker);
@@ -192,7 +192,7 @@ namespace cms
 	// protection againt invalid initial states
 	if (! firstState.isValid()) {
 	  edm::LogWarning("CosmicTrackFinder") << "invalid innerState, will not make TrackCandidate";
-	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(output);  
+	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
 	  return;
 	}
 
@@ -200,7 +200,7 @@ namespace cms
 	if(firstId != recHits.front().rawId()){
 	  edm::LogWarning("CosmicTrackFinder") <<"Mismatch in DetID of first hit: firstID= " <<firstId
 					       << "   DetId= " << recHits.front().geographicalId().rawId();
-	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(output);  
+	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
 	  return;
 	}
 
@@ -212,6 +212,6 @@ namespace cms
       }
 
     }
-    edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(output);  
+    edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
   }
 }

--- a/RecoTracker/SpecialSeedGenerators/src/CRackSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CRackSeedGenerator.cc
@@ -44,7 +44,7 @@ void CRackSeedGenerator::produce(edm::Event& ev, const edm::EventSetup& es)
   ev.getByToken(matchedrecHitsToken_, matchedrecHits);
  
 
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection);
+  auto output = std::make_unique<TrajectorySeedCollection>();
   //
  
   cosmic_seed.init(*stereorecHits,*rphirecHits,*matchedrecHits, es);
@@ -56,5 +56,5 @@ void CRackSeedGenerator::produce(edm::Event& ev, const edm::EventSetup& es)
   LogDebug("CRackSeedGenerator")<<" number of seeds = "<< output->size();
 
 
-  ev.put(output);
+  ev.put(std::move(output));
 }

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
@@ -47,7 +47,7 @@ void CosmicSeedGenerator::produce(edm::Event& ev, const edm::EventSetup& es)
   ev.getByToken( matchedrecHitsToken_, matchedrecHits);
  
 
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection);
+  auto output = std::make_unique<TrajectorySeedCollection>();
 
   //check on the number of clusters
   size_t clustsOrZero = check.tooManyClusters(ev);
@@ -62,5 +62,5 @@ void CosmicSeedGenerator::produce(edm::Event& ev, const edm::EventSetup& es)
   LogDebug("CosmicSeedGenerator")<<" number of seeds = "<< output->size();
 
 
-  ev.put(output);
+  ev.put(std::move(output));
 }

--- a/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
@@ -124,7 +124,7 @@ void CtfSpecialSeedGenerator::beginRun(edm::Run const&, const edm::EventSetup& i
 void CtfSpecialSeedGenerator::produce(edm::Event& e, const edm::EventSetup& iSetup)
 {
   // get Inputs
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection);
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   //check on the number of clusters
   if ( !requireBOFF || (theMagfield->inTesla(GlobalPoint(0,0,0)).mag() == 0.00) ) {
@@ -137,7 +137,7 @@ void CtfSpecialSeedGenerator::produce(edm::Event& e, const edm::EventSetup& iSet
   
   
   edm::LogVerbatim("CtfSpecialSeedGenerator") << " number of seeds = "<< output->size();
-  e.put(output);
+  e.put(std::move(output));
 }
 
 bool CtfSpecialSeedGenerator::run(const edm::EventSetup& iSetup,

--- a/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
@@ -81,7 +81,7 @@ MuonReSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     edm::ESHandle<TrackerTopology> tTopo;
     iSetup.get<TrackerTopologyRcd>().get(tTopo);
 
-    auto_ptr<vector<TrajectorySeed> > out(new vector<TrajectorySeed>());
+    auto out = std::make_unique<std::vector<TrajectorySeed>>();
     unsigned int nsrc = src->size();
     out->reserve(nsrc);
 
@@ -146,7 +146,7 @@ MuonReSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
         out->push_back(seed);
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -138,7 +138,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     iEvent.getByToken(src_, src);
 
 
-    auto_ptr<vector<TrajectorySeed> > out(new vector<TrajectorySeed>());
+    auto out = std::make_unique<std::vector<TrajectorySeed>>();
 
     for (View<reco::Muon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
         const reco::Muon &mu = *it;
@@ -207,7 +207,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 int

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -89,8 +89,8 @@ SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const& conf) :
 // Functions that gets called by framework every event
 void SimpleCosmicBONSeeder::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
-  std::auto_ptr<edm::OwnVector<TrackingRecHit> > outtriplets(new edm::OwnVector<TrackingRecHit>());
+  auto output = std::make_unique<TrajectorySeedCollection>();
+  auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
 
   es.get<IdealMagneticFieldRecord>().get(magfield);
   if (magfield->inTesla(GlobalPoint(0,0,0)).mag() > 0.01) {
@@ -121,9 +121,9 @@ void SimpleCosmicBONSeeder::produce(edm::Event& ev, const edm::EventSetup& es)
   }
 
   if (writeTriplets_) {
-      ev.put(outtriplets, "cosmicTriplets");
+      ev.put(std::move(outtriplets), "cosmicTriplets");
   }
-  ev.put(output);
+  ev.put(std::move(output));
 }
 
 void 

--- a/RecoTracker/TkDetLayers/src/Phase2OTEndcapLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTEndcapLayer.cc
@@ -21,7 +21,7 @@ typedef GeometricSearchDet::DetWithState DetWithState;
 //hopefully is never called!
 const std::vector<const GeometricSearchDet*>& Phase2OTEndcapLayer::components() const{
   if (not theComponents) {
-    std::unique_ptr<std::vector<const GeometricSearchDet*>> temp( new std::vector<const GeometricSearchDet*>() );
+    auto temp = std::make_unique<std::vector<const GeometricSearchDet*>>();
     temp->reserve(NOTECRINGS);
     for ( auto c: theComps) temp->push_back(c);
     std::vector<const GeometricSearchDet*>* expected = nullptr;

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -93,7 +93,7 @@ public:
 //hopefully is never called!
 const std::vector<const GeometricSearchDet*>& TIDLayer::components() const{
   if( not theComponents) {
-    std::unique_ptr<std::vector<const GeometricSearchDet*>> temp( new std::vector<const GeometricSearchDet*>() );
+    auto temp = std::make_unique<std::vector<const GeometricSearchDet*>>();
     temp->reserve(3);
     for ( auto c: theComps) temp->push_back(c);
     std::vector<const GeometricSearchDet*>* expected = nullptr;

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -207,7 +207,7 @@ TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
       CylinderBuilderFromDet cylbld;
       WrapTrieCB<CylinderBuilderFromDet> w(cylbld);
       edm::iterateTrieLeaves(w,*tobl);
-      auto_ptr<BoundCylinder> cyl(cylbld.build());
+      std::unique_ptr<BoundCylinder> cyl(cylbld.build());
       SimpleCylinderBounds const & cylb = static_cast<SimpleCylinderBounds const&>(cyl->bounds());
       std::cout << "cyl " << tobl.label() 
 		<< ": " << cylb.length()

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
@@ -61,7 +61,7 @@ void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es)
     }
 
     // Prepare output collections, with the correct capacity
-    std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+    auto result = std::make_unique<TrajectorySeedCollection>();
     result->reserve( nseeds );
 
     // Write into output collection
@@ -93,5 +93,5 @@ void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es)
     }
 
     // Save result into the event
-    ev.put(result);
+    ev.put(std::move(result));
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -79,7 +79,7 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
 
 void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+  auto result = std::make_unique<TrajectorySeedCollection>();
   Handle<reco::TrackCollection> trks;
   ev.getByToken(theInputCollectionTag, trks);
 
@@ -148,6 +148,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
     }
   } 
 
-  ev.put(result);
+  ev.put(std::move(result));
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -77,15 +77,15 @@ SeedGeneratorFromRegionHitsEDProducer::~SeedGeneratorFromRegionHitsEDProducer()
 
 void SeedGeneratorFromRegionHitsEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<TrajectorySeedCollection> triplets(new TrajectorySeedCollection());
-  std::auto_ptr<TrajectorySeedCollection> quadruplets( new TrajectorySeedCollection() );
+  auto triplets = std::make_unique<TrajectorySeedCollection>();
+  auto quadruplets = std::make_unique<TrajectorySeedCollection>();
 
   //protection for big ass events...
   size_t clustsOrZero = theClusterCheck.tooManyClusters(ev);
   if (clustsOrZero){
     if (!theSilentOnClusterCheck)
 	edm::LogError("TooManyClusters") << "Found too many clusters (" << clustsOrZero << "), bailing out.\n";
-    ev.put(triplets);
+    ev.put(std::move(triplets));
     return ;
   }
 
@@ -117,7 +117,7 @@ void SeedGeneratorFromRegionHitsEDProducer::produce(edm::Event& ev, const edm::E
 
   // put to event
   if ( theMerger_)
-    ev.put(quadruplets);
+    ev.put(std::move(quadruplets));
   else
-    ev.put(triplets);
+    ev.put(std::move(triplets));
 }

--- a/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
@@ -34,17 +34,17 @@ void SeedingLayersEDProducer::produce(edm::Event& iEvent, const edm::EventSetup&
   }
 
   // Get hits
-  std::auto_ptr<SeedingLayerSetsHits> prod(new SeedingLayerSetsHits(builder_.numberOfLayersInSet(),
-                                                                    &builder_.layerSetIndices(),
-                                                                    &builder_.layerNames(),
-                                                                    builder_.layerDets()));
+  auto prod = std::make_unique<SeedingLayerSetsHits>(builder_.numberOfLayersInSet(),
+                                                    &builder_.layerSetIndices(),
+                                                    &builder_.layerNames(),
+                                                     builder_.layerDets());
   std::vector<unsigned int> idx; ctfseeding::SeedingLayer::Hits hits; 
   builder_.hits(iEvent, iSetup,idx,hits);
   hits.shrink_to_fit();
   prod->swapHits(idx,hits);
   //prod->print();
 
-  iEvent.put(prod);
+  iEvent.put(std::move(prod));
 }
 
 DEFINE_FWK_MODULE(SeedingLayersEDProducer);


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoTracker packages. Also, std::make_unique is used when appropriate. 
