### PR TITLE
EcalHaloDataProducer: setting input photon collection to empty string

### DIFF
--- a/RecoMET/METProducers/python/EcalHaloData_cfi.py
+++ b/RecoMET/METProducers/python/EcalHaloData_cfi.py
@@ -13,7 +13,7 @@ EcalHaloData= cms.EDProducer("EcalHaloDataProducer",
                              # Higher Level Reco
                              SuperClusterLabel = cms.InputTag("correctedHybridSuperClusters"),
 #                             SuperClusterLabel = cms.InputTag("cosmicSuperClusters","CosmicBarrelSuperClusters"),
-                             PhotonLabel = cms.InputTag("photons"),
+                             PhotonLabel = cms.InputTag(""),
                              
                              EBRecHitEnergyThresholdParam = cms.double(0.3),
                              EERecHitEnergyThresholdParam = cms.double(0.3),


### PR DESCRIPTION
Fix of the issue raised here: 
https://github.com/cms-sw/cmssw/issues/15781#issuecomment-245909412
This is the 80X equivalent of https://github.com/cms-sw/cmssw/pull/15799 
