### PR TITLE
Use unique_Ptr, not auto_ptr in RecoMuon and RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.h
@@ -67,7 +67,7 @@ class CSCMake2DRecHit
   // Cache pointer to conditions for current event
   const CSCRecoConditions* recoConditions_;
 
-  const std::auto_ptr<CSCFindPeakTime> peakTimeFinder_;
+  const std::unique_ptr<CSCFindPeakTime> peakTimeFinder_;
 
 
 };

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.cc
@@ -68,14 +68,14 @@ void  CSCRecHitDProducer::produce( edm::Event& ev, const edm::EventSetup& setup 
   ev.getByToken( w_token, wireDigis);
 
   // Create empty collection of rechits  
-  std::auto_ptr<CSCRecHit2DCollection> oc( new CSCRecHit2DCollection );
+  auto oc = std::make_unique<CSCRecHit2DCollection>();
 
   // Fill the CSCRecHit2DCollection
   recHitBuilder_->build( stripDigis.product(), wireDigis.product(), *oc);
 
   // Put collection in event
   LogTrace("CSCRecHit")<< "[CSCRecHitDProducer] putting collection of " << oc->size() << " rechits into event.";
-  ev.put( oc );
+  ev.put(std::move(oc));
 
 }
 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -892,8 +892,7 @@ bool CSCSegAlgoRU::replaceHit(const CSCRecHit2D* h, int layer) {
 
 void CSCSegAlgoRU::compareProtoSegment(const CSCRecHit2D* h, int layer) { 
    // Copy the input CSCSegFit                                                                                                                                                       
-  std::unique_ptr<CSCSegFit> oldfit;// =  new CSCSegFit( *sfit_ );                                                                                                                  
-  oldfit.reset(new CSCSegFit( theChamber, proto_segment ));
+  std::unique_ptr<CSCSegFit> oldfit = std::make_unique<CSCSegFit>(theChamber, proto_segment);
   oldfit->fit();
 
    // May create a new fit
@@ -906,8 +905,7 @@ void CSCSegAlgoRU::compareProtoSegment(const CSCRecHit2D* h, int layer) {
 
 void CSCSegAlgoRU::increaseProtoSegment(const CSCRecHit2D* h, int layer, int chi2_factor) { 
   // Creates a new fit                                                                                                                                                              
-  std::unique_ptr<CSCSegFit> oldfit;
-  oldfit.reset(new CSCSegFit( theChamber, proto_segment ));
+  std::unique_ptr<CSCSegFit> oldfit = std::make_unique<CSCSegFit>(theChamber, proto_segment);
 
   bool ok = addHit(h, layer);
   //@@ TEST ON ndof<=0 IS JUST TO ACCEPT nhits=2 CASE??

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.cc
@@ -46,11 +46,11 @@ void CSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
     ev.getByToken( m_token, cscRecHits);
 
     // create empty collection of Segments
-    std::auto_ptr<CSCSegmentCollection> oc( new CSCSegmentCollection );
+    auto oc = std::make_unique<CSCSegmentCollection>();
 
   	// fill the collection
     segmentBuilder_->build(cscRecHits.product(), *oc); //@@ FILL oc
 
     // put collection in event
-    ev.put(oc);
+    ev.put(std::move(oc));
 }

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
@@ -68,7 +68,7 @@ void DTRecHitProducer::produce(Event& event, const EventSetup& setup) {
   theAlgo->setES(setup);
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecHitCollection> recHitCollection(new DTRecHitCollection());
+  auto recHitCollection = std::make_unique<DTRecHitCollection>();
 
 
   // Iterate through all digi collections ordered by LayerId   
@@ -93,5 +93,5 @@ void DTRecHitProducer::produce(Event& event, const EventSetup& setup) {
       recHitCollection->put(layerId, recHits.begin(), recHits.end());
   }
 
-  event.put(recHitCollection);
+  event.put(std::move(recHitCollection));
 }

--- a/RecoLocalMuon/DTSegment/src/DTClusterer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTClusterer.cc
@@ -70,7 +70,7 @@ void DTClusterer::produce(edm::Event& event, const edm::EventSetup& setup) {
   event.getByToken(recHits1DToken_, allHits);
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecClusterCollection> clusters(new DTRecClusterCollection());
+  auto clusters = std::make_unique<DTRecClusterCollection>();
 
   // Iterate through all hit collections ordered by LayerId
   DTRecHitCollection::id_iterator dtLayerIt;
@@ -98,7 +98,7 @@ void DTClusterer::produce(edm::Event& event, const edm::EventSetup& setup) {
     if (clus.size() > 0 )
       clusters->put(sl->id(), clus.begin(), clus.end());
   }
-  event.put(clusters);
+  event.put(std::move(clusters));
 }
 
 vector<DTSLRecCluster> DTClusterer::buildClusters(const DTSuperLayer* sl,

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
@@ -167,7 +167,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
     for (vector<DTSegmentCand*>::const_iterator phi=resultPhi.begin();
          phi!=resultPhi.end(); ++phi) {
 
-      std::auto_ptr<DTChamberRecSegment2D> superPhi(**phi);
+      std::unique_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
       theUpdator->update(superPhi.get(),0);
       if(debug) cout << "superPhi: " << *superPhi << endl;
@@ -303,11 +303,11 @@ DTRecSegment4D* DTCombinatorialPatternReco4D::segmentSpecialZed(const DTRecSegme
   LocalPoint posInMiddleLayer = posInSL+dirInSL*(-posInSL.z())/cos(dirInSL.theta());
 
   // create a hit with position and error as the Zed projection one's
-  auto_ptr<DTRecHit1D> hit(new DTRecHit1D( middle.wireId(),
-                                           middle.lrSide(),
-                                           middle.digiTime(),
-                                           posInMiddleLayer,
-                                           zedSeg->localPositionError()));
+  auto hit = std::make_unique<DTRecHit1D>(middle.wireId(),
+                                          middle.lrSide(),
+                                          middle.digiTime(),
+                                          posInMiddleLayer,
+                                          zedSeg->localPositionError());
 
   std::vector<DTRecHit1D> newHits(1,*hit);
 
@@ -317,12 +317,12 @@ DTRecSegment4D* DTCombinatorialPatternReco4D::segmentSpecialZed(const DTRecSegme
   AlgebraicSymMatrix cov(zedSeg->covMatrix());
   double chi2(zedSeg->chi2());
   //cout << "zed " << *zedSeg << endl;
-  auto_ptr<DTSLRecSegment2D> newZed(new DTSLRecSegment2D(zedSeg->superLayerId(),
-                                                         pos,
-                                                         dir,
-                                                         cov,
-                                                         chi2,
-                                                         newHits));
+  auto newZed = std::make_unique<DTSLRecSegment2D>(zedSeg->superLayerId(),
+                                                   pos,
+                                                   dir,
+                                                   cov,
+                                                   chi2,
+                                                   newHits);
   //cout << "newZed " << *newZed << endl;
 
   // create a 4d segment with the special zed

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
@@ -165,7 +165,7 @@ DTMeantimerPatternReco::buildSegments(const DTSuperLayer* sl,
 //          }
         
           DTSegmentCand::AssPointCont pointSet;
-          std::unique_ptr<DTSegmentCand> segCand(new DTSegmentCand(pointSet,sl));
+          auto segCand = std::make_unique<DTSegmentCand>(pointSet,sl);
           segCand->add(*firstHit,codes[firstLR]);
           segCand->add(*lastHit,codes[lastLR]);
 

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
@@ -168,7 +168,7 @@ DTMeantimerPatternReco4D::reconstruct(){
     for (vector<DTSegmentCand*>::const_iterator phi=resultPhi.begin();
          phi!=resultPhi.end(); ++phi) {
 
-      std::auto_ptr<DTChamberRecSegment2D> superPhi(**phi);
+      std::unique_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
       theUpdator->update(superPhi.get(),1);
       if(debug) cout << "superPhi: " << *superPhi << endl;

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.cc
@@ -78,7 +78,7 @@ void DTRecSegment2DExtendedProducer::produce(edm::Event& event, const
                                               dtClusters->end()));
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecSegment2DCollection> segments(new DTRecSegment2DCollection());
+  auto segments = std::make_unique<DTRecSegment2DCollection>();
 
   // Iterate through all hit collections ordered by LayerId
   DTRecHitCollection::id_iterator dtLayerIt;
@@ -114,7 +114,7 @@ void DTRecSegment2DExtendedProducer::produce(edm::Event& event, const
     if (segs.size() > 0 )
       segments->put(SLId, segs.begin(),segs.end());
   }
-  event.put(segments);
+  event.put(std::move(segments));
 }
 
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
@@ -75,7 +75,7 @@ void DTRecSegment2DProducer::produce(edm::Event& event, const
   event.getByToken(recHits1DToken_, allHits);
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecSegment2DCollection> segments(new DTRecSegment2DCollection());
+  auto segments = std::make_unique<DTRecSegment2DCollection>();
 
   // Iterate through all hit collections ordered by LayerId
   DTRecHitCollection::id_iterator dtLayerIt;
@@ -107,7 +107,7 @@ void DTRecSegment2DProducer::produce(edm::Event& event, const
     if (segs.size() > 0 )
       segments->put(SLId, segs.begin(),segs.end());
   }
-  event.put(segments);
+  event.put(std::move(segments));
 }
 
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
@@ -64,7 +64,7 @@ void DTRecSegment4DProducer::produce(Event& event, const EventSetup& setup){
     event.getByToken(recHits2DToken_, all2DSegments);
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecSegment4DCollection> segments4DCollection(new DTRecSegment4DCollection());
+  auto segments4DCollection = std::make_unique<DTRecSegment4DCollection>();
 
   // get the geometry
   ESHandle<DTGeometry> theGeom;
@@ -110,5 +110,5 @@ void DTRecSegment4DProducer::produce(Event& event, const EventSetup& setup){
       segments4DCollection->put(chId, segments4D.begin(),segments4D.end());
   }
   // Load the output in the Event
-  event.put(segments4DCollection);
+  event.put(std::move(segments4DCollection));
 }

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
@@ -57,7 +57,7 @@ void DTSegment4DT0Corrector::produce(Event& event, const EventSetup& setup){
 
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<DTRecSegment4DCollection> segments4DCollection(new DTRecSegment4DCollection());
+  auto segments4DCollection = std::make_unique<DTRecSegment4DCollection>();
 
   // Iterate over the input DTSegment4D
   DTRecSegment4DCollection::id_iterator chamberId;
@@ -95,5 +95,5 @@ void DTSegment4DT0Corrector::produce(Event& event, const EventSetup& setup){
     cout << "[DTSegment4DT0Corrector] Saving modified segments into the event" << endl;
 
   // Load the output in the Event
-  event.put(segments4DCollection);
+  event.put(std::move(segments4DCollection));
 }

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
@@ -62,11 +62,11 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
     ev.getByToken(gem_token, gemRecHits);    
 
     // create empty collection of GEMCSC Segments
-    std::auto_ptr<GEMCSCSegmentCollection> oc( new GEMCSCSegmentCollection );
+    auto oc = std::make_unique<GEMCSCSegmentCollection>();
 
     // pass the empty collection of GEMCSC Segments and fill it
     segmentBuilder_->build(gemRecHits.product(), cscSegment.product(), *oc); //@@ FILL oc
     
     // put the filled collection in event
-    ev.put(oc);
+    ev.put(std::move(oc));
 }

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
@@ -163,7 +163,7 @@ void GEMRecHitProducer::produce(Event& event, const EventSetup& setup) {
 
   // Create the pointer to the collection which will store the rechits
 
-  auto_ptr<GEMRecHitCollection> recHitCollection(new GEMRecHitCollection());
+  auto recHitCollection = std::make_unique<GEMRecHitCollection>();
 
   // Iterate through all digi collections ordered by LayerId   
 
@@ -210,7 +210,7 @@ void GEMRecHitProducer::produce(Event& event, const EventSetup& setup) {
       recHitCollection->put(gemId, recHits.begin(), recHits.end());
   }
 
-  event.put(recHitCollection);
+  event.put(std::move(recHitCollection));
 
 }
 

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
@@ -51,7 +51,7 @@ void ME0RecHitProducer::produce(edm::Event& event, const edm::EventSetup& setup)
 
   // Create the pointer to the collection which will store the rechits
 
-  std::auto_ptr<ME0RecHitCollection> recHitCollection(new ME0RecHitCollection());
+  auto recHitCollection = std::make_unique<ME0RecHitCollection>();
 
   // Iterate through all digi collections ordered by LayerId   
 
@@ -75,7 +75,7 @@ void ME0RecHitProducer::produce(edm::Event& event, const edm::EventSetup& setup)
       recHitCollection->put(me0Id, recHits.begin(), recHits.end());
   }
 
-  event.put(recHitCollection);
+  event.put(std::move(recHitCollection));
 
 }
 

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
@@ -341,7 +341,7 @@ void GEMSegmentAlgorithm::buildSegments(const GEMEnsemble& ensemble, const Ensem
   #endif
 
   // The actual fit on all hits of the vector of the selected Tracking RecHits:
-  sfit_ = std::unique_ptr<MuonSegFit>(new MuonSegFit(muonRecHits));
+  sfit_ = std::make_unique<MuonSegFit>(muonRecHits);
   bool goodfit = sfit_->fit();
   edm::LogVerbatim("GEMSegmentAlgorithm") << "[GEMSegmentAlgorithm::buildSegments] GEMSegment fit done :: fit is good = "<<goodfit;
 

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentProducer.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentProducer.cc
@@ -38,7 +38,7 @@ private:
 GEMSegmentProducer::GEMSegmentProducer(const edm::ParameterSet& ps) : iev(0) {
 	
   theGEMRecHitToken = consumes<GEMRecHitCollection>(ps.getParameter<edm::InputTag>("gemRecHitLabel"));
-  segmentBuilder_ = std::unique_ptr<GEMSegmentBuilder>(new GEMSegmentBuilder(ps)); // pass on the Parameter Set
+  segmentBuilder_ = std::make_unique<GEMSegmentBuilder>(ps); // pass on the Parameter Set
 
   // register what this produces
   produces<GEMSegmentCollection>();
@@ -60,13 +60,13 @@ void GEMSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
   ev.getByToken(theGEMRecHitToken,gemRecHits);
 
   // create empty collection of Segments
-  std::auto_ptr<GEMSegmentCollection> oc( new GEMSegmentCollection );
+  auto oc = std::make_unique<GEMSegmentCollection>();
 
   // fill the collection
   segmentBuilder_->build(gemRecHits.product(), *oc); //@@ FILL oc
 
   // put collection in event
-  ev.put(oc);
+  ev.put(std::move(oc));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -319,7 +319,7 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const Ensem
   }
 
   // The actual fit on all hits of the vector of the selected Tracking RecHits:
-  sfit_ = std::unique_ptr<MuonSegFit>(new MuonSegFit(muonRecHits));
+  sfit_ = std::make_unique<MuonSegFit>(muonRecHits);
   //  bool goodfit = sfit_->fit();
   sfit_->fit();
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] ME0Segment fit done";

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentProducer.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentProducer.cc
@@ -39,7 +39,7 @@ private:
 ME0SegmentProducer::ME0SegmentProducer(const edm::ParameterSet& ps) : iev(0) {
 	
   theME0RecHitToken = consumes<ME0RecHitCollection>(ps.getParameter<edm::InputTag>("me0RecHitLabel"));
-  segmentBuilder_ = std::unique_ptr<ME0SegmentBuilder>(new ME0SegmentBuilder(ps)); // pass on the Parameter Set
+  segmentBuilder_ = std::make_unique<ME0SegmentBuilder>(ps); // pass on the Parameter Set
 
   // register what this produces
   produces<ME0SegmentCollection>();
@@ -61,13 +61,13 @@ void ME0SegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
   ev.getByToken(theME0RecHitToken,me0RecHits);
 
   // create empty collection of Segments
-  std::auto_ptr<ME0SegmentCollection> oc( new ME0SegmentCollection );
+  auto oc = std::make_unique<ME0SegmentCollection>();
 
   // fill the collection
   segmentBuilder_->build(me0RecHits.product(), *oc); //@@ FILL oc
 
   // put collection in event
-  ev.put(oc);
+  ev.put(std::move(oc));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -26,7 +26,7 @@ CSCSegtoRPC::CSCSegtoRPC(const CSCSegmentCollection * allCSCSegments, const edm:
 
   if(debug) std::cout<<"CSC \t Number of CSC Segments in this event = "<<allCSCSegments->size()<<std::endl;
 
-  _ThePoints.reset(new RPCRecHitCollection());
+  _ThePoints = std::make_unique<RPCRecHitCollection>();
 
   if(allCSCSegments->size()==0){
     if(debug) std::cout<<"CSC 0 segments skiping event"<<std::endl;

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -61,7 +61,7 @@ DTSegtoRPC::DTSegtoRPC(const DTRecSegment4DCollection * all4DSegments, const edm
     clock_gettime(CLOCK_REALTIME, &start_time);
   */
 
-  _ThePoints.reset(new RPCRecHitCollection());
+  _ThePoints = std::make_unique<RPCRecHitCollection>();
 
   if(all4DSegments->size()>8){
     if(debug) std::cout<<"Too many segments in this event we are not doing the extrapolation"<<std::endl;

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -51,7 +51,7 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     iEvent.getByToken(dt4DSegments, all4DSegments);
     if(all4DSegments.isValid()){
       DTSegtoRPC DTClass(all4DSegments.product(), iSetup, debug, ExtrapolatedRegion);
-      iEvent.put(DTClass.thePoints(), "RPCDTExtrapolatedPoints"); 
+      iEvent.put(std::move(DTClass.thePoints()), "RPCDTExtrapolatedPoints"); 
     }else{
       if(debug) std::cout<<"RPCHLT Invalid DTSegments collection"<<std::endl;
     }
@@ -62,7 +62,7 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     iEvent.getByToken(cscSegments, allCSCSegments);
     if(allCSCSegments.isValid()){
       CSCSegtoRPC CSCClass(allCSCSegments.product(), iSetup, debug, ExtrapolatedRegion);
-      iEvent.put(CSCClass.thePoints(), "RPCCSCExtrapolatedPoints"); 
+      iEvent.put(std::move(CSCClass.thePoints()), "RPCCSCExtrapolatedPoints"); 
     }else{
       if(debug) std::cout<<"RPCHLT Invalid CSCSegments collection"<<std::endl;
     }
@@ -72,7 +72,7 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     iEvent.getByToken(tracks,alltracks);
     if(!(alltracks->empty())){
       TracktoRPC TrackClass(alltracks.product(), iSetup, debug, trackTransformerParam, tracks_);
-      iEvent.put(TrackClass.thePoints(), "RPCTrackExtrapolatedPoints");
+      iEvent.put(std::move(TrackClass.thePoints()), "RPCTrackExtrapolatedPoints");
     }else{
       if(debug) std::cout<<"RPCHLT Invalid Tracks collection"<<std::endl;
     }

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
@@ -39,8 +39,8 @@ RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config):
                 config.getParameter<ParameterSet>("recAlgoConfig")));
 
   // Get masked- and dead-strip information
-  theRPCMaskedStripsObj.reset(new RPCMaskedStrips());
-  theRPCDeadStripsObj.reset(new RPCDeadStrips());
+  theRPCMaskedStripsObj = std::make_unique<RPCMaskedStrips>();
+  theRPCDeadStripsObj = std::make_unique<RPCDeadStrips>();
 
   const string maskSource = config.getParameter<std::string>("maskSource");
   if (maskSource == "File") {
@@ -130,7 +130,7 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
   theAlgo->setES(setup);
 
   // Create the pointer to the collection which will store the rechits
-  auto_ptr<RPCRecHitCollection> recHitCollection(new RPCRecHitCollection());
+  auto recHitCollection = std::make_unique<RPCRecHitCollection>();
 
   // Iterate through all digi collections ordered by LayerId   
 
@@ -172,7 +172,7 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
       recHitCollection->put(rpcId, recHits.begin(), recHits.end());
   }
 
-  event.put(recHitCollection);
+  event.put(std::move(recHitCollection));
 
 }
 

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -53,7 +53,7 @@ bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::E
 
 TracktoRPC::TracktoRPC(const reco::TrackCollection * alltracks, const edm::EventSetup& iSetup, bool debug,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel){ 
 
- _ThePoints.reset(new RPCRecHitCollection());
+ _ThePoints = std::make_unique<RPCRecHitCollection>();
 // if(alltracks->empty()) return;
 
  if(tracklabel.label().find("cosmic")==0) theTrackTransformer = new TrackTransformerForCosmicMuons(iConfig);

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
@@ -100,8 +100,7 @@ CosmicMuonLinksProducer::produce(Event& iEvent, const EventSetup& iSetup)
     LogTrace(category_) << "Mapped: "<<
     theTrackLinkNames[counter].first  <<" "<<subTracks->size()<< " and "<<theTrackLinkNames[counter].second<<" "<<parentTracks->size()<<", results: "<< ttmap.size() <<endl;
 
-    auto_ptr<reco::TrackToTrackMap> trackToTrackmap(new reco::TrackToTrackMap(ttmap));
-    iEvent.put(trackToTrackmap, mapname);
+    iEvent.put(std::make_unique<reco::TrackToTrackMap>(ttmap), mapname);
 
     counter++;
   }

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
@@ -111,7 +111,7 @@ void TevMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   Handle<reco::TrackCollection> glbMuons;
   event.getByToken(glbMuonsToken,glbMuons);
 
-  std::auto_ptr<DYTestimators> dytInfo(new DYTestimators);
+  auto dytInfo = std::make_unique<DYTestimators>();
   DYTestimators::Filler filler(*dytInfo);
   size_t GLBmuonSize = glbMuons->size();
   vector<DYTInfo> dytTmp(GLBmuonSize);
@@ -153,7 +153,7 @@ void TevMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
 
   filler.insert(glbMuons, dytTmp.begin(), dytTmp.end());
   filler.fill();
-  event.put(dytInfo, "dytInfo");
+  event.put(std::move(dytInfo), "dytInfo");
     
   LogTrace(metname) << "Done." << endl;    
 }

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -163,13 +163,13 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   */
 
   // create and fill value maps
-  std::auto_ptr<edm::ValueMap<reco::MuonQuality> > outQual(new edm::ValueMap<reco::MuonQuality>());
+  auto outQual = std::make_unique<edm::ValueMap<reco::MuonQuality>>();
   edm::ValueMap<reco::MuonQuality>::Filler fillerQual(*outQual);
   fillerQual.insert(glbMuons, valuesQual.begin(), valuesQual.end());
   fillerQual.fill();
   
   // put value map into event
-  iEvent.put(outQual);
+  iEvent.put(std::move(outQual));
 }
 
 std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) const {

--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
@@ -133,9 +133,9 @@ void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
 
   // Find deposits and load into event
   LogDebug(metname)<<" Get energy around";
-  std::auto_ptr<reco::IsoDepositMap> depMap( new reco::IsoDepositMap());
-  std::auto_ptr<edm::ValueMap<bool> > isoMap( new edm::ValueMap<bool> ());
-  std::auto_ptr<edm::ValueMap<float> > isoFloatMap( new edm::ValueMap<float> ());
+  auto depMap = std::make_unique<reco::IsoDepositMap>();
+  auto isoMap = std::make_unique<edm::ValueMap<bool>>();
+  auto isoFloatMap = std::make_unique<edm::ValueMap<float>>();
 
   unsigned int nMuons = muons->size();
   std::vector<IsoDeposit> deps(nMuons);
@@ -170,19 +170,19 @@ void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   reco::IsoDepositMap::Filler depFiller(*depMap);
   depFiller.insert(muons, deps.begin(), deps.end());
   depFiller.fill();
-  event.put(depMap);
+  event.put(std::move(depMap));
 
   if (optOutputDecision){
     edm::ValueMap<bool> ::Filler isoFiller(*isoMap);
     isoFiller.insert(muons, isos.begin(), isos.end());
     isoFiller.fill();//! annoying -- I will forget it at some point
-    event.put(isoMap);
+    event.put(std::move(isoMap));
 
     if (optOutputIsolatorFloat){
       edm::ValueMap<float> ::Filler isoFloatFiller(*isoFloatMap);
       isoFloatFiller.insert(muons, isoFloats.begin(), isoFloats.end());
       isoFloatFiller.fill();//! annoying -- I will forget it at some point
-      event.put(isoFloatMap);
+      event.put(std::move(isoFloatMap));
     }
   }
 

--- a/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.cc
@@ -61,7 +61,7 @@ void L2MuonCandidateProducer::produce(edm::StreamID sid, Event& event, const Eve
 
   // Create a RecoChargedCandidate collection
   LogTrace(metname)<<" Creating the RecoChargedCandidate collection";
-  auto_ptr<RecoChargedCandidateCollection> candidates( new RecoChargedCandidateCollection());
+  auto candidates = std::make_unique<RecoChargedCandidateCollection>();
 
   for (unsigned int i=0; i<tracks->size(); i++) {
       TrackRef tkref(tracks,i);
@@ -76,7 +76,7 @@ void L2MuonCandidateProducer::produce(edm::StreamID sid, Event& event, const Eve
       candidates->push_back(cand);
   }
   
-  event.put(candidates);
+  event.put(std::move(candidates));
  
   LogTrace(metname)<<" Event loaded"
 		   <<"================================";

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
@@ -84,7 +84,7 @@ void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   const std::string metname = "Muon|RecoMuon|L2MuonSeedGenerator";
   MuonPatternRecoDumper debug;
 
-  auto_ptr<L2MuonTrajectorySeedCollection> output(new L2MuonTrajectorySeedCollection());
+  auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
   
   // Muon particles and GMT readout collection
   edm::Handle<L1MuGMTReadoutCollection> gmtrc_handle;
@@ -315,7 +315,7 @@ void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     }
   }
   
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -122,7 +122,7 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
   const std::string metname = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1T";
   MuonPatternRecoDumper debug;
 
-  auto_ptr<L2MuonTrajectorySeedCollection> output(new L2MuonTrajectorySeedCollection());
+  auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
   
   edm::Handle<MuonBxCollection> muColl;
   iEvent.getByToken(muCollToken_, muColl);
@@ -364,7 +364,7 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
     }
   }
   
-  iEvent.put(output);
+  iEvent.put(std::move(output));
 }
 
 

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
@@ -201,13 +201,13 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   if( useRhoCorrectedCaloDeps )
     event.getByToken(theCaloDepsToken, caloDepWithCorrMap);
 
-  std::auto_ptr<reco::IsoDepositMap> caloDepMap( new reco::IsoDepositMap());
-  std::auto_ptr<reco::IsoDepositMap> trkDepMap( new reco::IsoDepositMap());
+  auto caloDepMap = std::make_unique<reco::IsoDepositMap>();
+  auto trkDepMap = std::make_unique<reco::IsoDepositMap>();
 
-  std::auto_ptr<edm::ValueMap<bool> > comboIsoDepMap( new edm::ValueMap<bool> ());
+  auto comboIsoDepMap = std::make_unique<edm::ValueMap<bool>>();
 
-  //std::auto_ptr<std::vector<double> > combinedRelativeDeps(new std::vector<double>());
-  std::auto_ptr<edm::ValueMap<double> > combinedRelativeDepMap(new edm::ValueMap<double>());
+  //auto combinedRelativeDeps = std::make_unique<std::vector<double>>();
+  auto combinedRelativeDepMap = std::make_unique<edm::ValueMap<double>>();
 
 
   //
@@ -325,26 +325,26 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
     reco::IsoDepositMap::Filler depFillerTrk(*trkDepMap);
     depFillerTrk.insert(muons, trkDeps.begin(), trkDeps.end());
     depFillerTrk.fill();
-    event.put(trkDepMap, "trkIsoDeposits");
+    event.put(std::move(trkDepMap), "trkIsoDeposits");
 
     if( useCaloIso && (useRhoCorrectedCaloDeps==false) ) {
       reco::IsoDepositMap::Filler depFillerCalo(*caloDepMap);
       depFillerCalo.insert(muons, caloDeps.begin(), caloDeps.end());
       depFillerCalo.fill();
-      event.put(caloDepMap, "caloIsoDeposits");
+      event.put(std::move(caloDepMap), "caloIsoDeposits");
     }
 
-    //event.put(combinedRelativeDeps, "combinedRelativeIsoDeposits");
+    //event.put(std::move(combinedRelativeDeps, "combinedRelativeIsoDeposits");
     edm::ValueMap<double>::Filler depFillerCombRel(*combinedRelativeDepMap);
     depFillerCombRel.insert(muons, combinedRelativeDeps.begin(), combinedRelativeDeps.end());
     depFillerCombRel.fill();
-    event.put(combinedRelativeDepMap, "combinedRelativeIsoDeposits");
+    event.put(std::move(combinedRelativeDepMap), "combinedRelativeIsoDeposits");
 
   }
   edm::ValueMap<bool>::Filler isoFiller(*comboIsoDepMap);
   isoFiller.insert(muons, combinedRelativeIsos.begin(), combinedRelativeIsos.end());
   isoFiller.fill();
-  event.put(comboIsoDepMap);
+  event.put(std::move(comboIsoDepMap));
 
   if (printDebug) std::cout  <<" END OF EVENT " <<"================================";
 }

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
@@ -102,8 +102,8 @@ void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   Handle<TrackCollection> muons;
   event.getByToken(theMuonCollectionToken,muons);
 
-  std::auto_ptr<reco::IsoDepositMap> depMap( new reco::IsoDepositMap());
-  std::auto_ptr<edm::ValueMap<bool> > isoMap( new edm::ValueMap<bool> ());
+  auto depMap = std::make_unique<reco::IsoDepositMap>();
+  auto isoMap = std::make_unique<edm::ValueMap<bool>>();
 
 
   //
@@ -156,12 +156,12 @@ void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
     reco::IsoDepositMap::Filler depFiller(*depMap);
     depFiller.insert(muons, deps.begin(), deps.end());
     depFiller.fill();
-    event.put(depMap);
+    event.put(std::move(depMap));
   }
   edm::ValueMap<bool> ::Filler isoFiller(*isoMap);
   isoFiller.insert(muons, isos.begin(), isos.end());
   isoFiller.fill();
-  event.put(isoMap);
+  event.put(std::move(isoMap));
 
   LogTrace(metname) <<" END OF EVENT " <<"================================";
 }

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.cc
@@ -59,7 +59,7 @@ void L3MuonSumCaloPFIsolationProducer::produce(edm::StreamID, edm::Event& iEvent
     edm::Handle<reco::RecoChargedCandidateIsolationMap> hcalIsolation;
     iEvent.getByToken (pfHcalClusterProducer_,hcalIsolation);
     
-    std::auto_ptr<edm::ValueMap<float> > caloIsoMap( new edm::ValueMap<float> ());
+    auto caloIsoMap = std::make_unique<edm::ValueMap<float>>();
     std::vector<float> isoFloats(recochargedcandHandle->size(), 0);
     
     for (unsigned int iReco = 0; iReco < recochargedcandHandle->size(); iReco++) {
@@ -75,6 +75,6 @@ void L3MuonSumCaloPFIsolationProducer::produce(edm::StreamID, edm::Event& iEvent
     edm::ValueMap<float> ::Filler isoFloatFiller(*caloIsoMap);
     isoFloatFiller.insert(recochargedcandHandle, isoFloats.begin(), isoFloats.end());
     isoFloatFiller.fill();
-    iEvent.put(caloIsoMap);
+    iEvent.put(std::move(caloIsoMap));
 
 }

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
@@ -92,7 +92,7 @@ void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& 
 
   // Create a RecoChargedCandidate collection
   LogTrace(category)<<" Creating the RecoChargedCandidate collection";
-  auto_ptr<RecoChargedCandidateCollection> candidates( new RecoChargedCandidateCollection());
+  auto candidates = std::make_unique<RecoChargedCandidateCollection>();
   LogDebug(category) << " size = " << tracks->size();
   for (unsigned int i=0; i<tracks->size(); i++) {
     TrackRef inRef(tracks,i);
@@ -150,7 +150,7 @@ void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& 
     candidates->push_back(cand);
   }
 
-  event.put(candidates);
+  event.put(std::move(candidates));
 
   LogTrace(category)<<" Event loaded"
                    <<"================================";

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
@@ -49,7 +49,7 @@ L3MuonCandidateProducerFromMuons::~L3MuonCandidateProducerFromMuons(){
 void L3MuonCandidateProducerFromMuons::produce(StreamID, Event& event, const EventSetup& eventSetup) const {
   // Create a RecoChargedCandidate collection
   LogTrace(category)<<" Creating the RecoChargedCandidate collection";
-  auto_ptr<RecoChargedCandidateCollection> candidates( new RecoChargedCandidateCollection());
+  auto candidates = std::make_unique<RecoChargedCandidateCollection>();
 
   // Take the L3 container
   LogTrace(category)<<" Taking the L3/GLB muons: "<<m_L3CollectionLabel.label();
@@ -77,5 +77,5 @@ void L3MuonCandidateProducerFromMuons::produce(StreamID, Event& event, const Eve
       candidates->push_back(cand);
     }
   }
-  event.put(candidates);
+  event.put(std::move(candidates));
 }

--- a/RecoMuon/L3MuonProducer/src/L3MuonCleaner.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCleaner.cc
@@ -40,13 +40,13 @@ L3MuonCleaner::L3MuonCleaner(const edm::ParameterSet& parameterSet){
 void L3MuonCleaner::produce(edm::StreamID, edm::Event& event, const edm::EventSetup&) const{
   edm::Handle<reco::TrackCollection> tracks; 
   event.getByToken(inputToken_,tracks);
-  std::auto_ptr<reco::TrackCollection> outTracks( new reco::TrackCollection() );
+  auto outTracks = std::make_unique<reco::TrackCollection>();
   for ( reco::TrackCollection::const_iterator trk=tracks->begin(); trk!=tracks->end(); ++trk ){
     if (trk->normalizedChi2()>m_maxNormalizedChi2) continue;
     if (trk->hitPattern().numberOfValidTrackerHits()<m_minTrkHits) continue;
     if (trk->hitPattern().numberOfValidMuonHits()<m_minMuonHits) continue;
     outTracks->push_back(*trk);
   }
-  event.put(outTracks);
+  event.put(std::move(outTracks));
 }
 DEFINE_FWK_MODULE(L3MuonCleaner);

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -193,10 +193,10 @@ void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
 
 
   //prepare the output
-  std::auto_ptr<TrackCollection> outTracks( new TrackCollection(LXtoL3s.size()));
-  std::auto_ptr<TrackExtraCollection> outTrackExtras( new TrackExtraCollection(LXtoL3s.size()));
+  auto outTracks = std::make_unique<TrackCollection>(LXtoL3s.size());
+  auto outTrackExtras = std::make_unique<TrackExtraCollection>(LXtoL3s.size());
   reco::TrackExtraRefProd rTrackExtras = event.getRefBeforePut<TrackExtraCollection>();
-  std::auto_ptr<TrackingRecHitCollection> outRecHits( new TrackingRecHitCollection());
+  auto outRecHits = std::make_unique<TrackingRecHitCollection>();
   TrackingRecHitRefProd rHits = event.getRefBeforePut<TrackingRecHitCollection>();
 
   LogDebug(metname)<<"reading the map to make "<< LXtoL3s.size()<<"products.";
@@ -233,9 +233,9 @@ void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
 
   //put the collection in the event
   LogDebug(metname)<<"loading...";
-  event.put(outTracks);
-  event.put(outTrackExtras);
-  event.put(outRecHits);
+  event.put(std::move(outTracks));
+  event.put(std::move(outTrackExtras));
+  event.put(std::move(outRecHits));
   LogDebug(metname)<<" Event loaded"
 		   <<"================================";
 }

--- a/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.cc
+++ b/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.cc
@@ -73,7 +73,7 @@ QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   //
   // the product
   //
-  std::auto_ptr<reco::TrackCollection> product(new reco::TrackCollection);
+  auto product = std::make_unique<reco::TrackCollection>();
   //
   // Muons
   //
@@ -88,7 +88,7 @@ QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   // Verification
   //
   if ( !muonHandle.isValid() || !trackHandle.isValid() || minMasses_.empty() ) {
-    iEvent.put(product);
+    iEvent.put(std::move(product));
     return;
   }
   //
@@ -174,7 +174,7 @@ QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     LogDebug("QuarkoniaTrackSelector") << stream.str();
   }
   //
-  iEvent.put(product);
+  iEvent.put(std::move(product));
 }
 
 

--- a/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
+++ b/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
@@ -39,7 +39,7 @@ void HLTMuonL2SelectorForL3IO::produce(edm::Event& iEvent, const edm::EventSetup
 	iEvent.getByToken(l3OISrc_, l3TrackCol);
 
 //	OUT:
-	std::auto_ptr<std::vector<reco::Track> > result(new std::vector<reco::Track>());
+	auto result = std::make_unique<std::vector<reco::Track>>();
 
 	auto const& l2Tracks = *l2TrackCol.product();
 	auto const& l3Tracks = *l3TrackCol.product();
@@ -62,7 +62,7 @@ void HLTMuonL2SelectorForL3IO::produce(edm::Event& iEvent, const edm::EventSetup
 		if (!l2found) result->push_back(l2);
 	}
 
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 void HLTMuonL2SelectorForL3IO::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
@@ -41,7 +41,7 @@ void MuonCkfTrajectoryBuilder::setEvent_(const edm::Event& iEvent, const edm::Ev
 
   // theEstimator is set for this event in the base class
   if(theEstimatorWatcher.check(iSetup) && theDeltaEta>0 && theDeltaPhi>0)
-    theEtaPhiEstimator.reset(new EtaPhiEstimator(theDeltaEta, theDeltaPhi, theEstimator));
+    theEtaPhiEstimator = std::make_unique<EtaPhiEstimator>(theDeltaEta, theDeltaPhi, theEstimator);
 }
 
 

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonMerger.cc
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonMerger.cc
@@ -74,7 +74,7 @@ CaloMuonMerger::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     if(mergeCaloMuons_) iEvent.getByToken(caloMuonToken_,caloMuons);
       if(mergeTracks_) iEvent.getByToken(trackToken_,tracks);
 
-    std::auto_ptr<std::vector<reco::Muon> >  out(new std::vector<reco::Muon>());
+    auto out = std::make_unique<std::vector<reco::Muon>>();
     out->reserve(muons->size() + (mergeTracks_?tracks->size():0));
 
     // copy reco::Muons, turning on the CaloCompatibility flag if enabled and possible
@@ -143,7 +143,7 @@ CaloMuonMerger::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
         }
     }
 
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.cc
@@ -37,11 +37,11 @@ void CaloMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 {
    edm::Handle<reco::CaloMuonCollection> iMuons;
    iEvent.getByToken(muonToken_,iMuons);
-   std::auto_ptr<reco::CaloMuonCollection> oMuons( new reco::CaloMuonCollection );
+   auto oMuons = std::make_unique<reco::CaloMuonCollection>();
    for ( reco::CaloMuonCollection::const_iterator muon = iMuons->begin();
 	 muon != iMuons->end(); ++muon )
      oMuons->push_back( *muon );
-   iEvent.put(oMuons);
+   iEvent.put(std::move(oMuons));
 }
 
 //define this as a plug-in

--- a/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
@@ -82,19 +82,19 @@ CosmicsMuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     }
 
   // create and fill value map
-  std::auto_ptr<edm::ValueMap<unsigned int> > out(new edm::ValueMap<unsigned int>());
+  auto out = std::make_unique<edm::ValueMap<unsigned int>>();
   edm::ValueMap<unsigned int>::Filler filler(*out);
   filler.insert(muons, values.begin(), values.end());
   filler.fill();
 
 
-  std::auto_ptr<edm::ValueMap<reco::MuonCosmicCompatibility> > outC(new edm::ValueMap<reco::MuonCosmicCompatibility>());
+  auto outC = std::make_unique<edm::ValueMap<reco::MuonCosmicCompatibility>>();
   edm::ValueMap<reco::MuonCosmicCompatibility>::Filler fillerC(*outC);
   fillerC.insert(muons, compValues.begin(), compValues.end());
   fillerC.fill();
 
   // put value map into event
-  iEvent.put(out);
-  iEvent.put(outC);
+  iEvent.put(std::move(out));
+  iEvent.put(std::move(outC));
 }
 DEFINE_FWK_MODULE(CosmicsMuonIdProducer);

--- a/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.cc
@@ -62,14 +62,14 @@ void GlobalMuonToMuonProducer::produce(edm::StreamID, edm::Event& event, const e
    const std::string metname = "Muon|RecoMuon|MuonIdentification|GlobalMuonToMuonProducer";
 
    // the muon collection, it will be loaded in the event
-   std::auto_ptr<reco::MuonCollection> muonCollection(new reco::MuonCollection());
+   auto muonCollection = std::make_unique<reco::MuonCollection>();
    
 
    edm::Handle<reco::MuonTrackLinksCollection> linksCollection; 
    event.getByToken(trackLinkToken_,linksCollection);
 
    if(linksCollection->empty()) {
-     event.put(muonCollection);
+     event.put(std::move(muonCollection));
      return;
    }
    
@@ -112,5 +112,5 @@ void GlobalMuonToMuonProducer::produce(edm::StreamID, edm::Event& event, const e
      
    }
 
-   event.put(muonCollection);
+   event.put(std::move(muonCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.cc
@@ -45,7 +45,7 @@ InterestingEcalDetIdProducer::produce (edm::Event& iEvent,
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(muonToken_,muons);
   
-  std::auto_ptr< DetIdCollection > interestingDetIdCollection( new DetIdCollection() ) ;
+  auto interestingDetIdCollection = std::make_unique<DetIdCollection>();
 
   for(reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon){
     if (! muon->isEnergyValid() ) continue;
@@ -57,5 +57,5 @@ InterestingEcalDetIdProducer::produce (edm::Event& iEvent,
 	 == interestingDetIdCollection->end()) 
 	interestingDetIdCollection->push_back(*id);
   }
-  iEvent.put(interestingDetIdCollection);
+  iEvent.put(std::move(interestingDetIdCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
@@ -104,7 +104,7 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
   Handle <ME0MuonCollection> OurMuons;
   ev.getByToken(OurMuonsToken_, OurMuons);
 
-  std::auto_ptr<RecoChargedCandidateCollection> oc( new RecoChargedCandidateCollection());
+  auto oc = std::make_unique<RecoChargedCandidateCollection>();
 
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
        thisMuon != OurMuons->end(); ++thisMuon){
@@ -121,7 +121,7 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
     oc->push_back(cand);
   }
     
-  ev.put(oc);
+  ev.put(std::move(oc));
 }
 
 

--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -148,7 +148,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
     //ev.getByLabel("me0Segments","",OurSegments);
     ev.getByToken(OurSegmentsToken_,OurSegments);
 
-    std::auto_ptr<std::vector<ME0Muon> > oc( new std::vector<ME0Muon> ); 
+    auto oc = std::make_unique<std::vector<ME0Muon>>(); 
     std::vector<ME0Muon> TempStore; 
 
     Handle <TrackCollection > generalTracks;
@@ -305,7 +305,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
 
     // put collection in event
 
-    ev.put(oc);
+    ev.put(std::move(oc));
 }
 
 FreeTrajectoryState

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -133,7 +133,7 @@ muIsoExtractorCalo_(0),muIsoExtractorTrack_(0),muIsoExtractorJet_(0)
    }
 
    if (fillTrackerKink_) {
-     trackerKinkFinder_.reset(new MuonKinkFinder(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters")));
+     trackerKinkFinder_ = std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"));
    }
 
    //create mesh holder
@@ -449,8 +449,8 @@ bool validateGlobalMuonPair( const reco::MuonTrackLinks& goodMuon,
 void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-   std::auto_ptr<reco::MuonCollection> outputMuons(new reco::MuonCollection);
-   std::auto_ptr<reco::CaloMuonCollection> caloMuons( new reco::CaloMuonCollection );
+   auto outputMuons = std::make_unique<reco::MuonCollection>();
+   auto caloMuons = std::make_unique<reco::CaloMuonCollection>();
 
    init(iEvent, iSetup);
 
@@ -714,11 +714,11 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    LogTrace("MuonIdentification") << "number of muons produced: " << outputMuons->size();
    if ( fillMatching_ ) fillArbitrationInfo( outputMuons.get() );
-   edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(outputMuons);
+   edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outputMuons));
 
    auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = ""){
      typedef  edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
-     std::unique_ptr<MapType > oMap(new MapType());
+     auto oMap = std::make_unique<MapType>();
      {
        typename MapType::Filler filler(*oMap);
        filler.insert(refH, vec.begin(), vec.end());
@@ -739,7 +739,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      fillMap(muonHandle, jetDepColl, iEvent, jetDepositName_);
    }
 
-   iEvent.put(caloMuons);
+   iEvent.put(std::move(caloMuons));
 }
 
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -228,7 +228,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    edm::InputTag globalTrackQualityInputTag_;
 
    bool fillTrackerKink_;
-   std::auto_ptr<MuonKinkFinder> trackerKinkFinder_;
+   std::unique_ptr<MuonKinkFinder> trackerKinkFinder_;
 
    double caloCut_;
    

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
@@ -41,7 +41,7 @@ MuonLinksProducer::~MuonLinksProducer()
 
 void MuonLinksProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-   std::auto_ptr<reco::MuonTrackLinksCollection> output(new reco::MuonTrackLinksCollection());
+   auto output = std::make_unique<reco::MuonTrackLinksCollection>();
    edm::Handle<reco::MuonCollection> muons; 
    iEvent.getByToken(muonToken_,muons);
    
@@ -51,5 +51,5 @@ void MuonLinksProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
 	if ( ! muon->isGlobalMuon() ) continue;
 	output->push_back( reco::MuonTrackLinks( muon->track(), muon->standAloneMuon(), muon->combinedMuon() ) );
      }
-   iEvent.put( output );
+   iEvent.put(std::move(output));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
@@ -40,7 +40,7 @@ MuonLinksProducerForHLT::~MuonLinksProducerForHLT()
 
 void MuonLinksProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-   std::auto_ptr<reco::MuonTrackLinksCollection> output(new reco::MuonTrackLinksCollection());
+   auto output = std::make_unique<reco::MuonTrackLinksCollection>();
 
    edm::Handle<reco::MuonTrackLinksCollection> links; 
    iEvent.getByToken(linkToken_, links);
@@ -88,5 +88,5 @@ void MuonLinksProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const e
 					      link->standAloneTrack(), 
 					      link->globalTrack() ) );
    }  
-   iEvent.put( output );
+   iEvent.put(std::move(output));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -186,7 +186,7 @@ void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
    const std::string metname = "Muon|RecoMuon|MuonIdentification|MuonProducer";
 
    // the muon collection, it will be loaded in the event
-   std::auto_ptr<reco::MuonCollection> outputMuons(new reco::MuonCollection());
+   auto outputMuons = std::make_unique<reco::MuonCollection>();
    reco::MuonRefProd outputMuonsRefProd = event.getRefBeforePut<reco::MuonCollection>();
 
    edm::Handle<reco::MuonCollection> inputMuons; 
@@ -292,7 +292,7 @@ void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 
 
    if(inputMuons->empty()) {
-     edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(outputMuons);
+     edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
      
      if(fillTimingInfo_){
        fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl,"combined");
@@ -432,7 +432,7 @@ void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
    }
    
    dout << "Number of Muons in the new muon collection: " << outputMuons->size() << endl;
-   edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(outputMuons);
+   edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
 
    if(fillTimingInfo_){
      fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl,"combined");
@@ -485,13 +485,13 @@ void MuonProducer::fillMuonMap(edm::Event& event,
  
   typedef typename edm::ValueMap<TYPE>::Filler FILLER; 
 
-  std::auto_ptr<edm::ValueMap<TYPE> > muonMap(new edm::ValueMap<TYPE>());
+  auto muonMap = std::make_unique<edm::ValueMap<TYPE>>();
   if(!muonExtra.empty()){
     FILLER filler(*muonMap);
     filler.insert(muonHandle, muonExtra.begin(), muonExtra.end());
     filler.fill();
   }
-  event.put(muonMap,label);
+  event.put(std::move(muonMap),label);
 }
 
 

--- a/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
@@ -64,7 +64,7 @@ MuonRefProducer::~MuonRefProducer(){}
 
 void MuonRefProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-   std::auto_ptr<edm::RefVector<std::vector<reco::Muon> > > outputCollection(new edm::RefVector<std::vector<reco::Muon> >);
+   auto outputCollection = std::make_unique<edm::RefVector<std::vector<reco::Muon>>>();
 
    edm::Handle<reco::MuonCollection> muons;
    iEvent.getByToken(muonToken_, muons);
@@ -74,5 +74,5 @@ void MuonRefProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
      if ( muon::isGoodMuon( (*muons)[i], type_, minNumberOfMatches_,
 	  maxAbsDx_, maxAbsPullX_, maxAbsDy_, maxAbsPullY_, maxChamberDist_, maxChamberDistPull_, arbitrationType_) )
        outputCollection->push_back( edm::RefVector<std::vector<reco::Muon> >::value_type(muons,i) );
-   iEvent.put(outputCollection);
+   iEvent.put(std::move(outputCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
@@ -53,13 +53,13 @@ MuonSelectionTypeValueMapProducer::produce(edm::Event& iEvent, const edm::EventS
         values.push_back(muon::isGoodMuon(*it, selectionType_));
 
     // create and fill value map
-    std::auto_ptr<edm::ValueMap<bool> > out(new edm::ValueMap<bool>());
+    auto out = std::make_unique<edm::ValueMap<bool>>();
     edm::ValueMap<bool>::Filler filler(*out);
     filler.insert(muonsH, values.begin(), values.end());
     filler.fill();
 
     // put value map into event
-    iEvent.put(out);
+    iEvent.put(std::move(out));
 }
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
@@ -63,12 +63,12 @@ MuonShowerInformationProducer::produce(edm::Event& iEvent, const edm::EventSetup
     }
 
   // create and fill value map
-  std::auto_ptr<edm::ValueMap<reco::MuonShower> > outC(new edm::ValueMap<reco::MuonShower>());
+  auto outC = std::make_unique<edm::ValueMap<reco::MuonShower>>();
   edm::ValueMap<reco::MuonShower>::Filler fillerC(*outC);
   fillerC.insert(muons, showerInfoValues.begin(), showerInfoValues.end());
   fillerC.fill();
 
   // put value map into event
-  iEvent.put(outC);
+  iEvent.put(std::move(outC));
 }
 DEFINE_FWK_MODULE(MuonShowerInformationProducer);

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
@@ -68,11 +68,11 @@ MuonTimingProducer::~MuonTimingProducer()
 void
 MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMap(new reco::MuonTimeExtraMap());
+  auto muonTimeMap = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler filler(*muonTimeMap);
-  std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMapDT(new reco::MuonTimeExtraMap());
+  auto muonTimeMapDT = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler fillerDT(*muonTimeMapDT);
-  std::auto_ptr<reco::MuonTimeExtraMap> muonTimeMapCSC(new reco::MuonTimeExtraMap());
+  auto muonTimeMapCSC = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler fillerCSC(*muonTimeMapCSC);
   
   edm::Handle<reco::MuonCollection> muons; 
@@ -108,9 +108,9 @@ MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   fillerCSC.insert(muons, cscTimeColl.begin(), cscTimeColl.end());
   fillerCSC.fill();
 
-  iEvent.put(muonTimeMap,"combined");
-  iEvent.put(muonTimeMapDT,"dt");
-  iEvent.put(muonTimeMapCSC,"csc");
+  iEvent.put(std::move(muonTimeMap),"combined");
+  iEvent.put(std::move(muonTimeMapDT),"dt");
+  iEvent.put(std::move(muonTimeMapCSC),"csc");
 
 }
 

--- a/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
@@ -235,7 +235,7 @@ void MuonsFromRefitTracksProducer::produce(edm::Event& event, const edm::EventSe
     ok = storeMatchMaps(event);
 
   // Make the output collection.
-  std::auto_ptr<reco::MuonCollection> cands(new reco::MuonCollection);
+  auto cands = std::make_unique<reco::MuonCollection>();
 
   if (ok) {
     edm::View<reco::Muon>::const_iterator muon;
@@ -296,7 +296,7 @@ void MuonsFromRefitTracksProducer::produce(edm::Event& event, const edm::EventSe
       << "either " << src << " or the track map(s) " << tevMuonTracks
       << " not present in the event; producing empty collection";
   
-  event.put(cands);
+  event.put(std::move(cands));
 }
 
 DEFINE_FWK_MODULE(MuonsFromRefitTracksProducer);

--- a/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
@@ -80,7 +80,7 @@ void TrajectorySeedFromMuonProducer::produce(edm::Event& iEvent, const edm::Even
   using namespace std;
 
   // Product
-  std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
+  auto result = std::make_unique<TrajectorySeedCollection>();
   
   edm::ESHandle<MagneticField> magneticField;
   iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -129,7 +129,7 @@ void TrajectorySeedFromMuonProducer::produce(edm::Event& iEvent, const edm::Even
     result->push_back(trajectorySeed);
   }
   
-  iEvent.put(result);
+  iEvent.put(std::move(result));
 
 }
 

--- a/RecoMuon/MuonIsolation/plugins/MuPFIsoEmbedder.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuPFIsoEmbedder.cc
@@ -112,7 +112,7 @@ MuPFIsoEmbedder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iEvent.getByToken(muonToken_,muons);
 
 
-   std::auto_ptr<MuonCollection> out(new MuonCollection);
+   auto out = std::make_unique<MuonCollection>();
 
    for(unsigned int i=0;i<muons->size();++i) {
      MuonRef muonRef(muons,i);
@@ -121,7 +121,7 @@ MuPFIsoEmbedder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      out->push_back(muon);
    }
 
-   iEvent.put(out);
+   iEvent.put(std::move(out));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
@@ -60,8 +60,7 @@ void MuIsoDepositCopyProducer::produce(Event& event, const EventSetup& eventSetu
     Handle<reco::IsoDepositMap > inDep;
     event.getByToken(theInputTokens[iDep], inDep);
 
-    std::unique_ptr<reco::IsoDepositMap> outDep(new reco::IsoDepositMap(*inDep));
-    event.put(std::move(outDep), theDepositNames[iDep]);
+    event.put(std::move(std::make_unique<reco::IsoDepositMap>(*inDep)), theDepositNames[iDep]);
   }//! end iDep
 
   LogTrace(metname) <<" END OF EVENT " <<"================================";

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
@@ -137,11 +137,11 @@ void MuIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup){
   }
 
   static const unsigned int MAX_DEPS=10;
-  std::auto_ptr<reco::IsoDepositMap> depMaps[MAX_DEPS];
+  std::unique_ptr<reco::IsoDepositMap> depMaps[MAX_DEPS];
 
   if (nDeps >10 ) LogError(metname)<<"Unable to handle more than 10 input deposits";
   for (unsigned int i =0;i<nDeps; ++i){
-    depMaps[i] =  std::auto_ptr<reco::IsoDepositMap>(new reco::IsoDepositMap());
+    depMaps[i] = std::make_unique<reco::IsoDepositMap>();
   }
 
   //! OK, now we know how many deps for how many muons each we will create
@@ -229,7 +229,7 @@ void MuIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup){
     LogTrace(metname)<<"About to put a deposit named "<<theDepositNames[iMap]
 		     <<" of size "<<depMaps[iMap]->size()
 		     <<" into edm::Event";
-    event.put(depMaps[iMap], theDepositNames[iMap]);
+    event.put(std::move(depMaps[iMap]), theDepositNames[iMap]);
   }
 
   LogTrace(metname) <<" END OF EVENT " <<"================================";

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsolatorResultProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsolatorResultProducer.h
@@ -121,7 +121,7 @@ void MuIsolatorResultProducer<BT>::writeOutImpl(edm::Event& event, const CandMap
   //! make an output vec of what's to be written with a concrete type
   std::vector<RT> resV(results.size());   
   for (unsigned int i = 0; i< resV.size(); ++i) resV[i] = results[i].val<RT>(); 
-  std::auto_ptr<edm::ValueMap<RT> > outMap(new edm::ValueMap<RT>()); 
+  auto outMap = std::make_unique<edm::ValueMap<RT>>(); 
   typename edm::ValueMap<RT>::Filler filler(*outMap); 
 
   //! fill/insert of non-empty values only
@@ -130,7 +130,7 @@ void MuIsolatorResultProducer<BT>::writeOutImpl(edm::Event& event, const CandMap
     filler.fill(); 
   }
   
-  event.put(outMap); 
+  event.put(std::move(outMap)); 
 }
 
 

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
@@ -98,7 +98,7 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
 
   eSetup.get<IdealMagneticFieldRecord>().get(theField);
 
-  auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   TrajectorySeedCollection seeds;
  
@@ -198,7 +198,7 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
         output->push_back(*seed);
   }
 
-  event.put(output);
+  event.put(std::move(output));
   seeds.clear();
 
 }

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.cc
@@ -77,7 +77,7 @@ MuonSeedGenerator::~MuonSeedGenerator(){
 void MuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& eSetup)
 {
   // create the pointer to the Seed container
-  auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   edm::ESHandle<MagneticField> field;
   eSetup.get<IdealMagneticFieldRecord>().get(field);
@@ -111,7 +111,7 @@ void MuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& eSetup
 
   theSeedCleaner->clean(*output);
 
-  event.put(output);
+  event.put(std::move(output));
 }
 
   

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedMerger.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedMerger.cc
@@ -44,7 +44,7 @@ void MuonSeedMerger::produce(Event& event, const EventSetup& eventSetup){
   
   const string metname = "Muon|RecoMuon|MuonSeedMerger";  
 
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   Handle<View<TrajectorySeed> > seeds; 
   
@@ -56,5 +56,5 @@ void MuonSeedMerger::produce(Event& event, const EventSetup& eventSetup){
       output->push_back(*seed);
   }
   
-  event.put(output);
+  event.put(std::move(output));
 }

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.cc
@@ -83,13 +83,13 @@ void MuonSeedProducer::produce(edm::Event& event, const edm::EventSetup& eSetup)
 
    // Create pointer to the seed container
 
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection() );
+  auto output = std::make_unique<TrajectorySeedCollection>();
 
   //UNUED:  int nSeeds = 0;
   //UNUSED: nSeeds = 
   muonSeedBuilder_->build( event, eSetup, *output);
 
   // Append muon seed collection to event
-  event.put( output );
+  event.put(std::move(output));
 
 }

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.cc
@@ -84,7 +84,7 @@ void SETMuonSeedProducer::produce(edm::Event& event, const edm::EventSetup& even
   //Get the CSC Geometry :
   theService->update(eventSetup);
 
-  std::auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   Handle<View<TrajectorySeed> > seeds; 
 
@@ -221,7 +221,7 @@ void SETMuonSeedProducer::produce(edm::Event& event, const edm::EventSetup& even
       continue;
     }
   }
-  event.put(output);
+  event.put(std::move(output));
   theFilter->reset();
 }
 

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
@@ -178,8 +178,8 @@ RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     candidateweightedSeeds.clear();
 
     // Create the pointer to the Seed container
-    auto_ptr<TrajectorySeedCollection> goodCollection(new TrajectorySeedCollection());
-    auto_ptr<TrajectorySeedCollection> candidateCollection(new TrajectorySeedCollection());
+    auto goodCollection = std::make_unique<TrajectorySeedCollection>();
+    auto candidateCollection = std::make_unique<TrajectorySeedCollection>();
 
     // Muon Geometry - DT, CSC and RPC 
     edm::ESHandle<MuonDetLayerGeometry> muonLayers;
@@ -250,8 +250,8 @@ RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         candidateCollection->push_back((*weightedseed).first);
 
     // Put the seed to event
-    iEvent.put(goodCollection, "goodSeeds");
-    iEvent.put(candidateCollection, "candidateSeeds");
+    iEvent.put(std::move(goodCollection), "goodSeeds");
+    iEvent.put(std::move(candidateCollection), "candidateSeeds");
 
     // Unset the input of RPCSeedFinder, PCSeedrecHitFinder, RPCSeedLayerFinder
     recHitFinder.unsetInput();

--- a/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.cc
@@ -71,7 +71,7 @@ void MCMuonSeedGenerator2::produce(edm::Event& event, const edm::EventSetup& set
 {
   const std::string metname = "Muon|RecoMuon|MCMuonSeedGenerator2";
 
-  auto_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());
+  auto output = std::make_unique<TrajectorySeedCollection>();
   
   // Update the services
   theService->update(setup);
@@ -162,7 +162,7 @@ void MCMuonSeedGenerator2::produce(edm::Event& event, const edm::EventSetup& set
     if(seed) output->push_back(*seed);
   }
 
-  event.put(output);
+  event.put(std::move(output));
 }
 
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/CollectionCombiner.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/CollectionCombiner.h
@@ -55,12 +55,12 @@ void CollectionCombiner<Collection>::produce(edm::StreamID, edm::Event& iEvent, 
 {
   unsigned int i=0,i_max=labels.size();
   edm::Handle<Collection> handle;
-  std::auto_ptr<Collection> merged(new Collection());
+  auto merged = std::make_unique<Collection>();
   for (;i!=i_max;++i){
     iEvent.getByToken(collectionTokens[i], handle);
     merged->insert(merged->end(), handle->begin(), handle->end());
   }
-  iEvent.put(merged);
+  iEvent.put(std::move(merged));
 }
 
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -57,7 +57,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	edm::Handle<reco::TrackCollection> l2TrackCol;					iEvent.getByToken(src_, l2TrackCol);
 
 //	The product:
-	std::auto_ptr<std::vector<TrajectorySeed> > result(new std::vector<TrajectorySeed>());
+	auto result = std::make_unique<std::vector<TrajectorySeed>>();
 
 //	Get vector of Detector layers once:
 	std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
@@ -77,7 +77,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	edm::LogInfo(theCategory) << "TSGForOI::produce: Number of L2's: " << l2TrackCol->size();
 	for (unsigned int l2TrackColIndex(0);l2TrackColIndex!=l2TrackCol->size();++l2TrackColIndex){
 		const reco::TrackRef l2(l2TrackCol, l2TrackColIndex);
-		std::auto_ptr<std::vector<TrajectorySeed> > out(new std::vector<TrajectorySeed>());
+		auto out = std::make_unique<std::vector<TrajectorySeed>>();
 
 		FreeTrajectoryState fts = trajectoryStateTransform::initialFreeState(*l2, magfield_.product());
 		dummyPlane_->move(fts.position() - dummyPlane_->position());
@@ -143,7 +143,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	} //L2Collection
 	edm::LogInfo(theCategory) << "TSGForOI::produce: number of seeds made: " << result->size();
 
-	iEvent.put(result);
+	iEvent.put(std::move(result));
 }
 
 void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
@@ -152,7 +152,7 @@ void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
 		const Propagator& propagatorAlong,
 		const Propagator& propagatorOpposite,
 		const reco::TrackRef l2,
-		std::auto_ptr<std::vector<TrajectorySeed> >& out) {
+		std::unique_ptr<std::vector<TrajectorySeed> >& out) {
 
 	if (numSeedsMade_<numOfMaxSeeds_){
 		double errorSFHits_=1.0;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -111,7 +111,7 @@ private:
 			const Propagator& propagatorAlong,
 			const Propagator& propagatorOpposite,
 			const reco::TrackRef l2,
-			std::auto_ptr<std::vector<TrajectorySeed> >& seeds);
+			std::unique_ptr<std::vector<TrajectorySeed> >& seeds);
 
 	/// Function used to calculate the dynamic error SF by analysing the L2
 	double calculateSFFromL2(const GeometricSearchDet& layer,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
@@ -94,7 +94,7 @@ void TSGFromL1Muon::beginRun(const edm::Run & run, const edm::EventSetup&es)
 
 void TSGFromL1Muon::produce(edm::Event& ev, const edm::EventSetup& es)
 {
-  std::auto_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
+  auto result = std::make_unique<L3MuonTrajectorySeedCollection>();
 
   edm::Handle<L1MuonParticleCollection> l1muon;
   ev.getByToken(theSourceToken, l1muon);
@@ -153,6 +153,6 @@ void TSGFromL1Muon::produce(edm::Event& ev, const edm::EventSetup& es)
   }
 
   LogDebug("TSGFromL1Muon")<<result->size()<<" seeds to the event.";
-  ev.put(result);
+  ev.put(std::move(result));
 }
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -61,7 +61,7 @@ void TSGFromL2Muon::beginRun(const edm::Run & run, const edm::EventSetup&es){
 
 
 void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es){
-  std::auto_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
+  auto result = std::make_unique<L3MuonTrajectorySeedCollection>();
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
@@ -122,7 +122,7 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es){
   LogDebug("TSGFromL2Muon")<<result->size()<<" trajectory seeds to the events";
 
   //put in the event
-  ev.put(result);
+  ev.put(std::move(result));
 }
 
 // FillDescription generated from hltL3TrajSeedOIState with additions from OIHit and IOHit

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
@@ -182,9 +182,9 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   const TrackerTopology& ttopo = *httopo;
 
   //prepare the output collection
-  std::auto_ptr<reco::TrackCollection> Toutput(new reco::TrackCollection());
-  std::auto_ptr<TrackingRecHitCollection> TRHoutput(new TrackingRecHitCollection());
-  std::auto_ptr<reco::TrackExtraCollection> TEoutput(new reco::TrackExtraCollection());
+  auto Toutput = std::make_unique<reco::TrackCollection>();
+  auto TRHoutput = std::make_unique<TrackingRecHitCollection>();
+  auto TEoutput = std::make_unique<reco::TrackExtraCollection>();
   theRefprodTE = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
   theTEi=0;
   theRefprodRH =iEvent.getRefBeforePut<TrackingRecHitCollection>();
@@ -230,9 +230,9 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   
   LogDebug( theCategory)<<"writing: "<<Toutput->size()<<" corrected reco::Track to the event.";
   
-  iEvent.put(Toutput, theInstanceName);
-  iEvent.put(TEoutput);
-  iEvent.put(TRHoutput);
+  iEvent.put(std::move(Toutput), theInstanceName);
+  iEvent.put(std::move(TEoutput));
+  iEvent.put(std::move(TRHoutput));
 
 }
 

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
@@ -162,12 +162,12 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
   if(reportGhosts_) {
     LogTrace(metname) << " Creating map between chosen seed and ghost seeds." << std::endl;
 
-    auto_ptr<L2SeedAssoc> seedToSeedsMap(new L2SeedAssoc);
+    auto seedToSeedsMap = std::make_unique<L2SeedAssoc>();
     if(!seeds->empty()) {
       edm::Ptr<TrajectorySeed> ptr = seeds->ptrAt(0);
       edm::Handle<L2MuonTrajectorySeedCollection> seedsHandle;
       event.get(ptr.id(), seedsHandle);
-      seedToSeedsMap.reset(new L2SeedAssoc(seedsHandle, seedsHandle));
+      seedToSeedsMap = std::make_unique<L2SeedAssoc>(seedsHandle, seedsHandle);
     }
 
     int seedcnt(0);
@@ -184,7 +184,7 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
       }
     }
 
-    event.put(seedToSeedsMap, "");
+    event.put(std::move(seedToSeedsMap), "");
 
   } // end if(reportGhosts_)
 


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoMuon and RecoLocalMuon  packages. Also, std::make_unique is used when appropriate. 
