### PR TITLE
Changed order of sequences to be consistent with reconstruction path

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
@@ -15,6 +15,6 @@ ALCARECOEcalUncalElectronECALSeq = cms.Sequence( uncalibRecHitSeq )
 
 ############################################### FINAL SEQUENCES
 # sequences used in AlCaRecoStreams_cff.py
-seqALCARECOEcalUncalZElectron   = cms.Sequence(ZeeSkimFilterSeq  * ALCARECOEcalCalElectronNonECALSeq * ALCARECOEcalUncalElectronECALSeq)
-seqALCARECOEcalUncalZSCElectron = cms.Sequence(ZSCSkimFilterSeq  * ALCARECOEcalCalElectronNonECALSeq * ALCARECOEcalUncalElectronECALSeq)
-seqALCARECOEcalUncalWElectron   = cms.Sequence(WenuSkimFilterSeq * ALCARECOEcalCalElectronNonECALSeq * ALCARECOEcalUncalElectronECALSeq)
+seqALCARECOEcalUncalZElectron   = cms.Sequence(ZeeSkimFilterSeq  * ALCARECOEcalUncalElectronECALSeq * ALCARECOEcalCalElectronNonECALSeq)
+seqALCARECOEcalUncalZSCElectron = cms.Sequence(ZSCSkimFilterSeq  * ALCARECOEcalUncalElectronECALSeq * ALCARECOEcalCalElectronNonECALSeq)
+seqALCARECOEcalUncalWElectron   = cms.Sequence(WenuSkimFilterSeq * ALCARECOEcalUncalElectronECALSeq* ALCARECOEcalCalElectronNonECALSeq)


### PR DESCRIPTION
The order of the sequences ALCARECOEcalUncalElectronECALSeq and
ALCARECOEcalCalElectronNonECALSeq were changed so that the module ordering
would match the reconstruction path. This consistency requirement is
driven by upcoming framework changes.
