### PR TITLE
bsunanda:Run2-alca64 Allow to define dummy parameters for non-SiPM cells

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -55,12 +55,14 @@ class HcalDbHardcode {
     void setHFUpgrade(HcalHardcodeParameters p) { theHFUpgradeParameters_ = p; setHFUpgrade_ = true; }
     void useHBUpgrade(bool b) { useHBUpgrade_ = b; }
     void useHEUpgrade(bool b) { useHEUpgrade_ = b; }
+    void useHOUpgrade(bool b) { useHOUpgrade_ = b; }
     void useHFUpgrade(bool b) { useHFUpgrade_ = b; }
     void testHFQIE10(bool b) { testHFQIE10_ = b; }
     
     //getters
     const bool useHBUpgrade() const { return useHBUpgrade_; }
     const bool useHEUpgrade() const { return useHEUpgrade_; }
+    const bool useHOUpgrade() const { return useHOUpgrade_; }
     const bool useHFUpgrade() const { return useHFUpgrade_; }
     const HcalHardcodeParameters& getParameters(HcalGenericDetId fId);
     const int getGainIndex(HcalGenericDetId fId);
@@ -90,7 +92,7 @@ class HcalDbHardcode {
     HcalHardcodeParameters theHBParameters_, theHEParameters_, theHFParameters_, theHOParameters_;
     HcalHardcodeParameters theHBUpgradeParameters_, theHEUpgradeParameters_, theHFUpgradeParameters_;
     bool setHB_, setHE_, setHF_, setHO_, setHBUpgrade_, setHEUpgrade_, setHFUpgrade_;
-    bool useHBUpgrade_, useHEUpgrade_, useHFUpgrade_, testHFQIE10_;
+    bool useHBUpgrade_, useHEUpgrade_, useHOUpgrade_, useHFUpgrade_, testHFQIE10_;
 };
 
 #endif

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -17,7 +17,8 @@ HcalDbHardcode::HcalDbHardcode()
 : theDefaultParameters_(3.0,0.5,{0.2,0.2},{0.0,0.0},0,{0.0,0.0,0.0,0.0},{0.9,0.9,0.9,0.9},125,105), //"generic" set of conditions
   setHB_(false), setHE_(false), setHF_(false), setHO_(false), 
   setHBUpgrade_(false), setHEUpgrade_(false), setHFUpgrade_(false), 
-  useHBUpgrade_(false), useHEUpgrade_(false), useHFUpgrade_(false), testHFQIE10_(false)
+  useHBUpgrade_(false), useHEUpgrade_(false), useHOUpgrade_(true),
+  useHFUpgrade_(false), testHFQIE10_(false)
 {
 }
 
@@ -543,14 +544,17 @@ HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fI
   //  These numbers come from some measurements done with SiPM's
   if (fId.isHcalDetId()) {
     if (fId.subdetId() == HcalBarrel) {
-      return HcalSiPMParameter(fId.rawId(), HcalHBHamamatsu1, 57.5, 0.055, 0, 0);
+      if (useHBUpgrade_) 
+	return HcalSiPMParameter(fId.rawId(), HcalHBHamamatsu1, 57.5, 0.055, 0, 0);
     } else if (fId.subdetId() == HcalEndcap) {
-      return HcalSiPMParameter(fId.rawId(), HcalHEHamamatsu1, 57.5, 0.055, 0, 0);
+      if (useHEUpgrade_) 
+	return HcalSiPMParameter(fId.rawId(), HcalHEHamamatsu1, 57.5, 0.055, 0, 0);
     } else if (fId.subdetId() == HcalOuter) {
-      return HcalSiPMParameter(fId.rawId(), HcalHOHamamatsu, 4.0, 0.055, 0, 0);
+      if (useHOUpgrade_)
+	return HcalSiPMParameter(fId.rawId(), HcalHOHamamatsu, 4.0, 0.055, 0, 0);
     }
   } 
-  return HcalSiPMParameter(fId.rawId(), 0, 0, 0, 0, 0);
+  return HcalSiPMParameter(fId.rawId(), HcalNoSiPM, 0, 0, 0, 0);
 }
 
 void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm) {

--- a/CalibFormats/HcalObjects/interface/HcalSiPMType.h
+++ b/CalibFormats/HcalObjects/interface/HcalSiPMType.h
@@ -1,7 +1,8 @@
 #ifndef CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H
 #define CALIBFORMATS_HCALOBJECTS_HCALSIPMTYPER_H 1
 
-enum HcalSiPMType {HcalHOZecotek=0, HcalHOHamamatsu=1, HcalHEHamamatsu1=2, 
-		   HcalHEHamamatsu2=3, HcalHBHamamatsu1=4, HcalHBHamamatsu2=5};
+enum HcalSiPMType {HcalNoSiPM=0, HcalHOZecotek=1, HcalHOHamamatsu=2, 
+		   HcalHEHamamatsu1=3, HcalHEHamamatsu2=4, HcalHBHamamatsu1=5,
+		   HcalHBHamamatsu2=6};
 
 #endif


### PR DESCRIPTION
Correct HCAL hardcode loader for SiPM parameters 
