### PR TITLE
CastorFullReco needs to be before globalRecoPbPb in sequence order

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -53,7 +53,7 @@ localReco_HcalNZS = cms.Sequence(bunchSpacingProducer*offlineBeamSpot*muonReco*c
 
 #--------------------------------------------------------------------------
 # Main Sequence
-reconstruct_PbPb = cms.Sequence(localReco*globalRecoPbPb*CastorFullReco)
+reconstruct_PbPb = cms.Sequence(localReco*CastorFullReco*globalRecoPbPb)
 reconstructionHeavyIons = cms.Sequence(reconstruct_PbPb)
 
 reconstructionHeavyIons_HcalNZS = cms.Sequence(localReco_HcalNZS*globalRecoPbPb)


### PR DESCRIPTION
The module hiEvtPlane wants data from CastorTowerReco so the sequences
containing those modules need to be in the correct order.
