### PR TITLE
separate numbering for 2017 and 2023 workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -17,12 +17,12 @@ numWFStart=10000
 numWFSkip=200
 #2017 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias, TTbar PU, ZEE PU)
 numWFIB = [10021.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0]
-for i,key in enumerate(upgradeKeys):
+for i,key in enumerate(upgradeKeys[2017]):
     numWF=numWFStart+i*numWFSkip
     for frag in upgradeFragments:
         k=frag[:-4]+'_'+key
         stepList=[]
-        for step in upgradeProperties[key]['ScenToRun']:
+        for step in upgradeProperties[2017][key]['ScenToRun']:
             if 'Sim' in step:
                 stepList.append(k+'_'+step)
             else:

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -12,18 +12,18 @@ workflows = Matrix()
 
 #just define all of them
 
-numWFStart=10000
+numWFStart=20000
 numWFSkip=200
 #2023 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias)
-numWFIB = [10421.0,10424.0,10425.0,10426.0] #2023D1 scenario
-numWFIB.extend([10821.0,10824.0,10825.0,10826.0]) #2023D2
-numWFIB.extend([11221.0,11224.0,11225.0,11226.0]) #2023D3
-for i,key in enumerate(upgradeKeys):
+numWFIB = [20421.0,20424.0,20425.0,20426.0] #2023D1 scenario
+numWFIB.extend([20821.0,20824.0,20825.0,20826.0]) #2023D2
+numWFIB.extend([21221.0,21224.0,21225.0,21226.0]) #2023D3
+for i,key in enumerate(upgradeKeys[2023]):
     numWF=numWFStart+i*numWFSkip
     for frag in upgradeFragments:
         k=frag[:-4]+'_'+key
         stepList=[]
-        for step in upgradeProperties[key]['ScenToRun']:
+        for step in upgradeProperties[2023][key]['ScenToRun']:
             if 'Sim' in step:
                 stepList.append(k+'_'+step)
             else:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1637,16 +1637,16 @@ upgradeStepDict={}
 for step in upgradeSteps:
     upgradeStepDict[step]={}
 
-# just make all combinations - yes, some will be nonsense.. but then these are not used unless
-# specified above
-for k in upgradeKeys:
+# just make all combinations - yes, some will be nonsense.. but then these are not used unless specified above
+# collapse upgradeKeys using list comprehension
+for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     k2=k
     if 'PU' in k[-2:]:
         k2=k[:-2]
-    geom=upgradeProperties[k]['Geom']
-    gt=upgradeProperties[k]['GT']
-    cust=upgradeProperties[k].get('Custom', None)
-    era=upgradeProperties[k].get('Era', None)
+    geom=upgradeProperties[year][k]['Geom']
+    gt=upgradeProperties[year][k]['GT']
+    cust=upgradeProperties[year][k].get('Custom', None)
+    era=upgradeProperties[year][k].get('Era', None)
     upgradeStepDict['GenSimFull'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
@@ -1779,7 +1779,7 @@ for step in upgradeSteps:
    if 'Sim' in step:
         for frag in upgradeFragments:
             howMuch=howMuches[frag]
-            for key in upgradeKeys:
+            for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
                 k=frag[:-4]+'_'+key+'_'+step
                 steps[k]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])
                 #get inputs in case of -i...but no need to specify in great detail
@@ -1789,7 +1789,7 @@ for step in upgradeSteps:
                 if 'FastSim' not in k and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and '2023' not in k: # temporarily exclude 2023 WFs
                     steps[k+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+upgradeDatasetFromFragment[frag]+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
    else:
-        for key in upgradeKeys:
+        for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
             k=step+'_'+key
             if step in upgradeStepDict and key in upgradeStepDict[step]: 
                 steps[k]=merge([upgradeStepDict[step][key]])

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -13,38 +13,42 @@ workflows = Matrix()
 
 #just define all of them
 
-numWFStart=10000
+numWFStart={
+    2017: 10000,
+    2023: 20000,
+}
 numWFSkip=200
 
-for i,key in enumerate(upgradeKeys):
-    numWF=numWFStart+i*numWFSkip
-    for frag in upgradeFragments:
-        k=frag[:-4]+'_'+key
-        stepList=[]
-        for step in upgradeProperties[key]['ScenToRun']:
-            if 'Sim' in step:
-                stepList.append(k+'_'+step)
-            else:
-                stepList.append(step+'_'+key)
-        workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList]
-
-        # special workflows for tracker
-        if upgradeDatasetFromFragment[frag]=="TTbar_13" and not 'PU' in key:
-            stepListTk=[]
-            hasHarvest = False
-            for step in upgradeProperties[key]['ScenToRun']:
-                if 'Reco' in step:
-                    step = 'RecoFull_trackingOnly'
-                if 'HARVEST' in step:
-                    step = 'HARVESTFull_trackingOnly'
-                    hasHarvest = True
-
+for year in upgradeKeys:
+    for i,key in enumerate(upgradeKeys[year]):
+        numWF=numWFStart[year]+i*numWFSkip
+        for frag in upgradeFragments:
+            k=frag[:-4]+'_'+key
+            stepList=[]
+            for step in upgradeProperties[year][key]['ScenToRun']:
                 if 'Sim' in step:
-                    stepListTk.append(k+'_'+step)
+                    stepList.append(k+'_'+step)
                 else:
-                    stepListTk.append(step+'_'+key)
-             
-            if hasHarvest:
-                workflows[numWF+0.1] = [ upgradeDatasetFromFragment[frag], stepListTk]
+                    stepList.append(step+'_'+key)
+            workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList]
 
-        numWF+=1
+            # special workflows for tracker
+            if upgradeDatasetFromFragment[frag]=="TTbar_13" and not 'PU' in key:
+                stepListTk=[]
+                hasHarvest = False
+                for step in upgradeProperties[year][key]['ScenToRun']:
+                    if 'Reco' in step:
+                        step = 'RecoFull_trackingOnly'
+                    if 'HARVEST' in step:
+                        step = 'HARVESTFull_trackingOnly'
+                        hasHarvest = True
+
+                    if 'Sim' in step:
+                        stepListTk.append(k+'_'+step)
+                    else:
+                        stepListTk.append(step+'_'+key)
+                 
+                if hasHarvest:
+                    workflows[numWF+0.1] = [ upgradeDatasetFromFragment[frag], stepListTk]
+
+            numWF+=1

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,9 +1,15 @@
 from copy import deepcopy
 
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
-upgradeKeys=[
+
+upgradeKeys = {}
+
+upgradeKeys[2017] = [
     '2017',
     '2017PU',
+]
+
+upgradeKeys[2023] = [
     '2023D1',
     '2023D1PU',
     '2023D2',
@@ -35,13 +41,21 @@ upgradeSteps=[
     'HARVESTFullGlobalPU'
 ]
 
-upgradeProperties = {
+upgradeProperties = {}
+
+upgradeProperties[2017] = {
     '2017' : {
         'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2017_realistic',
         'Era' : 'Run2_2017',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
     },
+}
+
+upgradeProperties[2017]['2017PU'] = deepcopy(upgradeProperties[2017]['2017'])
+upgradeProperties[2017]['2017PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU']
+
+upgradeProperties[2023] = {
     '2023D1' : {
         'Geom' : 'Extended2023D1',
         'GT' : 'auto:run2_mc',
@@ -65,14 +79,12 @@ upgradeProperties = {
     },
 }
 
-upgradeProperties['2017PU'] = deepcopy(upgradeProperties['2017'])
-upgradeProperties['2017PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU']
-upgradeProperties['2023D1PU'] = deepcopy(upgradeProperties['2023D1'])
-upgradeProperties['2023D1PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
-upgradeProperties['2023D2PU'] = deepcopy(upgradeProperties['2023D2'])
-upgradeProperties['2023D2PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
-upgradeProperties['2023D3PU'] = deepcopy(upgradeProperties['2023D3'])
-upgradeProperties['2023D3PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D1PU'] = deepcopy(upgradeProperties[2023]['2023D1'])
+upgradeProperties[2023]['2023D1PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D2PU'] = deepcopy(upgradeProperties[2023]['2023D2'])
+upgradeProperties[2023]['2023D2PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D3PU'] = deepcopy(upgradeProperties[2023]['2023D3'])
+upgradeProperties[2023]['2023D3PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -59,8 +59,8 @@ if __name__ == '__main__':
                      135.4, #Run 2 Zee ttbar
                      10021.0, #2017 tenmu
                      10024.0, #2017 ttbar
-                     10424.0, #2023D1 ttbar (Run2 calo)
-                     11224.0, #2023D3 ttbar (HGCal)
+                     20424.0, #2023D1 ttbar (Run2 calo)
+                     21224.0, #2023D3 ttbar (HGCal)
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC


### PR DESCRIPTION
Due to an increasing number of conflicting upgrade PRs (#15662, #15613, #15805, with more coming), it was decided to separate the numbering for 2017 and 2023 workflows. The authors of the above PRs will have to rebase once this PR is merged.

The separate numbering is implemented by adding a new dimension to the dictionaries used to construct the upgrade workflows. This foresees possible expansions, e.g. using 30000 for 2019 workflows.

attn: @davidlange6 
