### PR TITLE
Use unique_ptr, not auto_ptr in RecoJet and RecoMET

### DIFF
--- a/RecoJets/FFTJetProducers/plugins/FFTJetCorrectionProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetCorrectionProducer.cc
@@ -228,7 +228,7 @@ void FFTJetCorrectionProducer::applyCorrections(edm::Event& iEvent,
 
     // Create the output collection
     const unsigned nJets = jets->size();
-    std::auto_ptr<MyCollection> coll(new MyCollection());
+    auto coll = std::make_unique<MyCollection>();
     coll->reserve(nJets);
 
     // Cycle over jets and apply the corrector sequences
@@ -340,7 +340,7 @@ void FFTJetCorrectionProducer::applyCorrections(edm::Event& iEvent,
     // Create the uncertainty sequence
     if (writeUncertainties)
     {
-        std::auto_ptr<std::vector<float> > unc(new std::vector<float>());
+        auto unc = std::make_unique<std::vector<float>>();
         unc->reserve(nJets);
         for (unsigned ijet=0; ijet<nJets; ++ijet)
         {
@@ -348,10 +348,10 @@ void FFTJetCorrectionProducer::applyCorrections(edm::Event& iEvent,
             unc->push_back(j.pileup());
             j.setPileup(0.f);
         }
-        iEvent.put(unc, outputLabel);
+        iEvent.put(std::move(unc), outputLabel);
     }
 
-    iEvent.put(coll, outputLabel);
+    iEvent.put(std::move(coll), outputLabel);
     ++eventCount;
 }
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -225,11 +225,11 @@ void FFTJetEFlowSmoother::produce(
     const double bin0edge = g.phiBin0Edge();
 
     // We will fill the following histo
-    std::auto_ptr<TH3F> pTable(
-        new TH3F("FFTJetEFlowSmoother", "FFTJetEFlowSmoother",
+    auto pTable = std::make_unique<TH3F>(
+                 "FFTJetEFlowSmoother", "FFTJetEFlowSmoother",
                  nScales+1U, -1.5, nScales-0.5,
                  nEta, g.etaMin(), g.etaMax(),
-                 nPhi, bin0edge, bin0edge+2.0*M_PI));
+                 nPhi, bin0edge, bin0edge+2.0*M_PI);
     TH3F* h = pTable.get();
     h->SetDirectory(0);
     h->GetXaxis()->SetTitle("Scale");
@@ -264,7 +264,7 @@ void FFTJetEFlowSmoother::produce(
         }
     }
 
-    iEvent.put(pTable, outputLabel);
+    iEvent.put(std::move(pTable), outputLabel);
 }
 
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPFPileupCleaner.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPFPileupCleaner.cc
@@ -193,8 +193,7 @@ void FFTJetPFPileupCleaner::produce(
     edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
     // get PFCandidates
-    std::auto_ptr<reco::PFCandidateCollection> 
-        pOutput(new reco::PFCandidateCollection);
+    auto pOutput = std::make_unique<reco::PFCandidateCollection>();
 
     edm::Handle<reco::PFCandidateCollection> pfCandidates;
     iEvent.getByToken(PFCandidatesToken, pfCandidates);
@@ -264,7 +263,7 @@ void FFTJetPFPileupCleaner::produce(
         }
     }
 
-    iEvent.put(pOutput);
+    iEvent.put(std::move(pOutput));
 }
 
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
@@ -370,7 +370,7 @@ void FFTJetPatRecoProducer::buildSparseProduct(edm::Event& ev) const
 {
     typedef reco::PattRecoTree<Real,reco::PattRecoPeak<Real> > StoredTree;
 
-    std::auto_ptr<StoredTree> tree(new StoredTree());
+    auto tree = std::make_unique<StoredTree>();
 
     sparsePeakTreeToStorable(sparseTree,
                              sequencer->maxAdaptiveScales(),
@@ -388,7 +388,7 @@ void FFTJetPatRecoProducer::buildSparseProduct(edm::Event& ev) const
                 << std::endl;
     }
 
-    ev.put(tree, outputLabel);
+    ev.put(std::move(tree), outputLabel);
 }
 
 
@@ -397,7 +397,7 @@ void FFTJetPatRecoProducer::buildDenseProduct(edm::Event& ev) const
 {
     typedef reco::PattRecoTree<Real,reco::PattRecoPeak<Real> > StoredTree;
 
-    std::auto_ptr<StoredTree> tree(new StoredTree());
+    auto tree = std::make_unique<StoredTree>();
 
     densePeakTreeToStorable(*clusteringTree,
                             sequencer->maxAdaptiveScales(),
@@ -415,7 +415,7 @@ void FFTJetPatRecoProducer::buildDenseProduct(edm::Event& ev) const
                 << std::endl;
     }
 
-    ev.put(tree, outputLabel);
+    ev.put(std::move(tree), outputLabel);
 }
 
 
@@ -460,10 +460,9 @@ void FFTJetPatRecoProducer::produce(
     {
         const fftjet::Grid2d<Real>& g(*energyFlow);
 
-        std::auto_ptr<reco::DiscretizedEnergyFlow> flow(
-            new reco::DiscretizedEnergyFlow(
+        auto flow = std::make_unique<reco::DiscretizedEnergyFlow>(
                 g.data(), g.title(), g.etaMin(), g.etaMax(),
-                g.phiBin0Edge(), g.nEta(), g.nPhi()));
+                g.phiBin0Edge(), g.nEta(), g.nPhi());
 
         if (verifyDataConversion)
         {
@@ -474,7 +473,7 @@ void FFTJetPatRecoProducer::produce(
             assert(g == check);
         }
 
-        iEvent.put(flow, outputLabel);
+        iEvent.put(std::move(flow), outputLabel);
     }
 
     if (storeGridsExternally)

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -290,15 +290,11 @@ void FFTJetPileupProcessor::produce(
 
     // Convert percentile data into a more convenient storable object
     // and put it into the event record
-    std::auto_ptr<reco::DiscretizedEnergyFlow> pTable(
-        new reco::DiscretizedEnergyFlow(
+    iEvent.put(std::make_unique<reco::DiscretizedEnergyFlow>(
             &percentileData[0], "FFTJetPileupProcessor",
-            -0.5, nScales-0.5, 0.0, nScales, nPercentiles));
-    iEvent.put(pTable, outputLabel);
+            -0.5, nScales-0.5, 0.0, nScales, nPercentiles), outputLabel);
 
-    std::auto_ptr<std::pair<double,double> > etSum(
-        new std::pair<double,double>(densityBeforeMixing, densityAfterMixing));
-    iEvent.put(etSum, outputLabel);
+    iEvent.put(std::make_unique<std::pair<double,double>>(densityBeforeMixing, densityAfterMixing), outputLabel);
 }
 
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -633,7 +633,7 @@ void FFTJetProducer::writeJets(edm::Event& iEvent,
                    pileupEnergyFlow->phiBinWidth();
 
     // allocate output jet collection
-    std::auto_ptr<OutputCollection> jets(new OutputCollection());
+    auto jets = std::make_unique<OutputCollection>();
     const unsigned nJets = recoJets.size();
     jets->reserve(nJets);
 
@@ -705,7 +705,7 @@ void FFTJetProducer::writeJets(edm::Event& iEvent,
         std::sort(jets->begin(), jets->end(), LocalSortByPt());
 
     // put the collection into the event
-    iEvent.put(jets, outputLabel);
+    iEvent.put(std::move(jets), outputLabel);
 }
 
 
@@ -732,15 +732,13 @@ void FFTJetProducer::saveResults(edm::Event& ev, const edm::EventSetup& iSetup,
     const double maxScale = maxLevel ? sparseTree.getScale(maxLevel) : 0.0;
     const double scaleUsed = usedLevel ? sparseTree.getScale(usedLevel) : 0.0;
 
-    std::auto_ptr<reco::FFTJetProducerSummary> summary(
-        new reco::FFTJetProducerSummary(
+    ev.put(std::make_unique<reco::FFTJetProducerSummary>(
             thresholds, occupancy, unclusE,
             constituents[0], unused,
             minScale, maxScale, scaleUsed,
             nPreclustersFound, iterationsPerformed,
             iterationsPerformed == 1U ||
-            iterationsPerformed <= maxIterations));
-    ev.put(summary, outputLabel);
+            iterationsPerformed <= maxIterations), outputLabel);
 }
 
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
@@ -130,7 +130,7 @@ void FFTJetVertexAdder::produce(
     CLHEP::RandGauss rGauss(rng->getEngine(iEvent.streamID()));
 
     // get PFCandidates
-    std::auto_ptr<reco::VertexCollection> pOutput(new reco::VertexCollection);
+    auto pOutput = std::make_unique<reco::VertexCollection>();
 
     double xmean = fixedX;
     double ymean = fixedY;
@@ -193,7 +193,7 @@ void FFTJetVertexAdder::produce(
             pOutput->push_back(*iv);
     }
 
-    iEvent.put(pOutput, outputLabel);
+    iEvent.put(std::move(pOutput), outputLabel);
 }
 
 

--- a/RecoJets/JetAnalyzers/src/JetIdSelector.cc
+++ b/RecoJets/JetAnalyzers/src/JetIdSelector.cc
@@ -155,7 +155,7 @@ JetIdSelector<T>::~JetIdSelector(){
 template<typename T>
 void JetIdSelector<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
-  auto_ptr<JetCollection> selectedJets(new JetCollection);
+  auto selectedJets = std::make_unique<JetCollection>();
   edm::Handle<reco::JetView> jets;  // uncorrected jets!
   iEvent.getByLabel(src_,jets);
 
@@ -241,7 +241,7 @@ void JetIdSelector<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 
   nJetsTot_  +=jets->size();
   nJetsPassed_+=selectedJets->size();  
-  iEvent.put(selectedJets);
+  iEvent.put(std::move(selectedJets));
 }
 
 

--- a/RecoJets/JetAssociationProducers/src/JetExtender.cc
+++ b/RecoJets/JetAssociationProducers/src/JetExtender.cc
@@ -35,8 +35,7 @@ void JetExtender::produce(edm::Event& fEvent, const edm::EventSetup& fSetup) {
   edm::Handle <reco::JetTracksAssociation::Container> j2tCALO_h;
   if (!(mJet2TracksAtCALO.label().empty())) fEvent.getByToken (token_mJet2TracksAtCALO, j2tCALO_h);
   
-  std::auto_ptr<reco::JetExtendedAssociation::Container> 
-    jetExtender (new reco::JetExtendedAssociation::Container (reco::JetRefBaseProd(jets_h)));
+  auto jetExtender = std::make_unique<reco::JetExtendedAssociation::Container>(reco::JetRefBaseProd(jets_h));
   
   // loop over jets (make sure jets in associations are the same as in collection
 
@@ -69,5 +68,5 @@ void JetExtender::produce(edm::Event& fEvent, const edm::EventSetup& fSetup) {
     }
     reco::JetExtendedAssociation::setValue (&*jetExtender, jet, extendedData);
   }
-  fEvent.put (jetExtender);
+  fEvent.put(std::move(jetExtender));
 }

--- a/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.cc
+++ b/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.cc
@@ -51,8 +51,7 @@ void JetSignalVertexCompatibility::produce(edm::Event &event,
 	edm::Handle<VertexCollection> primaryVertices;
 	event.getByToken(primaryVerticesToken, primaryVertices);
 
-	std::auto_ptr<JetFloatAssociation::Container> result(
-		new JetFloatAssociation::Container(jetTracksAssoc->keyProduct()));
+	auto result = std::make_unique<JetFloatAssociation::Container>(jetTracksAssoc->keyProduct());
 
 	for(JetTracksAssociationCollection::const_iterator iter =
 						jetTracksAssoc->begin();
@@ -70,5 +69,5 @@ void JetSignalVertexCompatibility::produce(edm::Event &event,
 
 	algo.resetEvent(0);
 
-	event.put(result);
+	event.put(std::move(result));
 }

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtCaloFace.cc
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtCaloFace.cc
@@ -56,7 +56,7 @@ void JetTracksAssociatorAtCaloFace::produce(edm::Event& fEvent, const edm::Event
     throw cms::Exception("InvalidInput") << " Jet-track association is only defined for CaloJets.";
   }
   
-  std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+  auto jetTracks = std::make_unique<reco::JetTracksAssociation::Container>(reco::JetRefBaseProd(jets_h));
 
 
   // format inputs
@@ -67,7 +67,7 @@ void JetTracksAssociatorAtCaloFace::produce(edm::Event& fEvent, const edm::Event
 
 
   // store output
-  fEvent.put (jetTracks);
+  fEvent.put(std::move(jetTracks));
 }
 
 

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtVertex.cc
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtVertex.cc
@@ -38,7 +38,7 @@ void JetTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::EventSe
   edm::Handle <reco::TrackCollection> tracks_h;
   fEvent.getByToken (mTracks, tracks_h);
   
-  std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+  auto jetTracks = std::make_unique<reco::JetTracksAssociation::Container>(reco::JetRefBaseProd(jets_h));
 
   // format inputs
   std::vector <edm::RefToBase<reco::Jet> > allJets;
@@ -61,5 +61,5 @@ void JetTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::EventSe
 
 
   // store output
-  fEvent.put (jetTracks);
+  fEvent.put(std::move(jetTracks));
 }

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.cc
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.cc
@@ -32,7 +32,7 @@ void JetTracksAssociatorExplicit::produce(edm::Event& fEvent, const edm::EventSe
   edm::Handle <reco::TrackCollection> tracks_h;
   fEvent.getByToken (mTracks, tracks_h);
   
-  std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+  auto jetTracks = std::make_unique<reco::JetTracksAssociation::Container>(reco::JetRefBaseProd(jets_h));
 
   // format inputs
   std::vector <edm::RefToBase<reco::Jet> > allJets;
@@ -50,5 +50,5 @@ void JetTracksAssociatorExplicit::produce(edm::Event& fEvent, const edm::EventSe
 
 
   // store output
-  fEvent.put (jetTracks);
+  fEvent.put(std::move(jetTracks));
 }

--- a/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
+++ b/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
@@ -50,7 +50,7 @@ TrackExtrapolator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle <reco::TrackCollection> tracks_h;
   iEvent.getByToken (tracksSrc_, tracks_h);
 
-  std::auto_ptr< std::vector<reco::TrackExtrapolation> > extrapolations( new std::vector<reco::TrackExtrapolation>() );
+  auto extrapolations = std::make_unique<std::vector<reco::TrackExtrapolation>>();
 
   // Get list of tracks we want to extrapolate
   std::vector <reco::TrackRef> goodTracks;
@@ -79,7 +79,7 @@ TrackExtrapolator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 							   vresultMom ) );
     }
   }
-  iEvent.put( extrapolations );
+  iEvent.put(std::move(extrapolations));
 }
 
 // -----------------------------------------------------------------------------

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
@@ -104,8 +104,8 @@ JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle <edm::View <reco::CaloJet> > jets_h;
   iEvent.getByToken (input_jets_token_, jets_h);
 
-//  std::auto_ptr<reco::CaloJetCollection> pOut(new reco::CaloJetCollection());
-  std::auto_ptr<reco::JPTJetCollection> pOut(new reco::JPTJetCollection());
+//  auto pOut = std::make_unique<reco::CaloJetCollection>();
+  auto pOut = std::make_unique<reco::JPTJetCollection>();
 
   for (unsigned i = 0; i < jets_h->size(); ++i) {
 
@@ -278,7 +278,7 @@ JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
           
   }
   
-  iEvent.put(pOut);
+  iEvent.put(std::move(pOut));
    
 }
 

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducerAA.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducerAA.cc
@@ -145,7 +145,7 @@ JetPlusTrackProducerAA::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 //  std::cout<<"JetPlusTrackProducerAA::produce, extrapolations_h="<<extrapolations_h->size()<<std::endl;  
 //=>
 
-  std::auto_ptr<reco::JPTJetCollection> pOut(new reco::JPTJetCollection());
+  auto pOut = std::make_unique<reco::JPTJetCollection>();
   
   reco::JPTJetCollection tmpColl;
 
@@ -380,7 +380,7 @@ JetPlusTrackProducerAA::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     
   }
   
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
    
 }
 // -----------------------------------------------

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -53,7 +53,7 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
   Event.getByToken(inputToken_, BasicJetColl);
 
   //now make the new pf jet collection
-  std::auto_ptr<reco::PFJetCollection> PFJetColl(new reco::PFJetCollection);
+  auto PFJetColl = std::make_unique<reco::PFJetCollection>();
   //reco::PFJetCollection* PFJetColl = new reco::PFJetCollection;
   //make the 'specific'
   reco::PFJet::Specific specific;
@@ -68,7 +68,7 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
   }
 
   //std::auto_ptr<reco::PFJetCollection> selectedPFJets(PFJetColl);
-  Event.put(PFJetColl);
+  Event.put(std::move(PFJetColl));
 }
 
  

--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -214,11 +214,11 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     std::cout << "#pfCandidates = " << pfCandidates->size() << std::endl;
   }
   
-  std::auto_ptr<reco::PFJetCollection> selectedSubjets(new reco::PFJetCollection());
+  auto selectedSubjets = std::make_unique<reco::PFJetCollection>();
   edm::RefProd<reco::PFJetCollection> selectedSubjetRefProd = evt.getRefBeforePut<reco::PFJetCollection>();
 
-  std::auto_ptr<JetToPFCandidateAssociation> selectedSubjetPFCandidateAssociationForIsolation(new JetToPFCandidateAssociation(&evt.productGetter()));
-  //std::auto_ptr<JetToPFCandidateAssociation> selectedSubjetPFCandidateAssociationForIsoDepositVetos(new JetToPFCandidateAssociation(&evt.productGetter()));
+  auto selectedSubjetPFCandidateAssociationForIsolation = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
+  //auto selectedSubjetPFCandidateAssociationForIsoDepositVetos = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
 
   for ( size_t idx = 0; idx < (subjets->size() / 2); ++idx ) {
     const reco::Jet* subjet1 = &subjets->at(2*idx);
@@ -268,8 +268,8 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     }
   }
 
-  evt.put(selectedSubjets);
-  evt.put(selectedSubjetPFCandidateAssociationForIsolation, "pfCandAssocMapForIsolation");
+  evt.put(std::move(selectedSubjets));
+  evt.put(std::move(selectedSubjetPFCandidateAssociationForIsolation), "pfCandAssocMapForIsolation");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoJets/JetProducers/plugins/CATopJetTagger.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetTagger.cc
@@ -43,7 +43,7 @@ CATopJetTagger::produce( edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 {
 
   // Set up output list
-  auto_ptr<CATopJetTagInfoCollection> tagInfos(new CATopJetTagInfoCollection() );
+  auto tagInfos = std::make_unique<CATopJetTagInfoCollection>();
 
   // Get the input list of basic jets corresponding to the hard jets
   Handle<View<Jet> > pBasicJets;
@@ -73,7 +73,7 @@ CATopJetTagger::produce( edm::StreamID, edm::Event& iEvent, const edm::EventSetu
     tagInfos->push_back( tagInfo );
   }// end loop over hard jets
   
-  iEvent.put( tagInfos );
+  iEvent.put(std::move(tagInfos));
  
   return;   
 }

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
@@ -45,7 +45,7 @@ CastorJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken( input_jet_token_, h_jets );
 
   // allocate the jet--->jetid value map
-  std::auto_ptr<reco::CastorJetIDValueMap> castorjetIdValueMap( new reco::CastorJetIDValueMap );
+  auto castorjetIdValueMap = std::make_unique<reco::CastorJetIDValueMap>();
   // instantiate the filler with the map
   reco::CastorJetIDValueMap::Filler filler(*castorjetIdValueMap);
   
@@ -81,7 +81,7 @@ CastorJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   filler.fill();
 
   // write map to the event
-  iEvent.put( castorjetIdValueMap );
+  iEvent.put(std::move(castorjetIdValueMap));
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
@@ -53,9 +53,9 @@ void CompoundJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSet
 {
 
   // get a list of output jets
-  std::auto_ptr<reco::BasicJetCollection>  jetCollection( new reco::BasicJetCollection() );
+  auto jetCollection = std::make_unique<reco::BasicJetCollection>();
   // get a list of output subjets
-  std::auto_ptr<std::vector<T> >  subjetCollection( new std::vector<T>() );
+  auto subjetCollection = std::make_unique<std::vector<T>>();
 
   // This will store the handle for the subjets after we write them
   edm::OrphanHandle< std::vector<T> > subjetHandleAfterPut;
@@ -114,7 +114,7 @@ void CompoundJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSet
     }
   }
   // put subjets into event record
-  subjetHandleAfterPut = iEvent.put( subjetCollection, jetCollInstanceName_ );
+  subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), jetCollInstanceName_);
   
   
   // Now create the hard jets with ptr's to the subjets as constituents
@@ -139,6 +139,6 @@ void CompoundJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSet
   }
   
   // put hard jets into event record
-  iEvent.put( jetCollection);
+  iEvent.put(std::move(jetCollection));
 
 }

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -40,12 +40,12 @@ void ECFAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
 	ecfN.push_back(t);
       }
 
-      std::auto_ptr<edm::ValueMap<float> > outT(new edm::ValueMap<float>());
+      auto outT = std::make_unique<edm::ValueMap<float>>();
       edm::ValueMap<float>::Filler fillerT(*outT);
       fillerT.insert(jets, ecfN.begin(), ecfN.end());
       fillerT.fill();
 
-      iEvent.put(outT,variables_[i].c_str());
+      iEvent.put(std::move(outT),variables_[i].c_str());
       ++i;
     }
 }

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -283,7 +283,7 @@ void FastjetJetProducer::produceTrackJets( edm::Event & iEvent, const edm::Event
     edm::Handle<reco::VertexCollection> pvCollection;
     iEvent.getByToken(input_vertex_token_, pvCollection);
     // define the overall output jet container
-    std::auto_ptr<std::vector<reco::TrackJet> > jets(new std::vector<reco::TrackJet>() );
+    auto jets = std::make_unique<std::vector<reco::TrackJet>>();
 
     // loop over the good vertices, clustering for each vertex separately
     for (reco::VertexCollection::const_iterator itVtx = pvCollection->begin(); itVtx != pvCollection->end(); ++itVtx) {
@@ -383,7 +383,7 @@ void FastjetJetProducer::produceTrackJets( edm::Event & iEvent, const edm::Event
 
     // put the jets in the collection
     LogDebug("FastjetTrackJetProducer") << "Put " << jets->size() << " jets in the event.\n";
-    iEvent.put(jets);
+    iEvent.put(std::move(jets));
 
     // Clear the work vectors so that memory is free for other modules.
     // Use the trick of swapping with an empty vector so that the memory

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducer.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducer.cc
@@ -30,8 +30,7 @@ void FixedGridRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
    algo = new FixedGridEnergyDensity(pfColl.product());
 
    double result = algo->fixedGridRho(myEtaRegion);
-   std::auto_ptr<double> output(new double(result));
-   iEvent.put(output);
+   iEvent.put(std::make_unique<double>(result));
 
    delete algo;
  

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.cc
@@ -29,8 +29,7 @@ void FixedGridRhoProducerFastjet::produce(edm::Event& iEvent, const edm::EventSe
      inputs.push_back( fastjet::PseudoJet(i->px(), i->py(), i->pz(), i->energy()) );
    }
    bge_.set_particles(inputs);
-   std::auto_ptr<double> outputRho(new double(bge_.rho()));
-   iEvent.put(outputRho);
+   iEvent.put(std::make_unique<double>(bge_.rho()));
 }
 
 DEFINE_FWK_MODULE(FixedGridRhoProducerFastjet);

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -189,7 +189,7 @@ void HTTTopJetProducer::addHTTTopJetTagInfoCollection( edm::Event& iEvent,
 
 
   // Set up output list
-  auto_ptr<HTTTopJetTagInfoCollection> tagInfos(new HTTTopJetTagInfoCollection() );
+  auto tagInfos = std::make_unique<HTTTopJetTagInfoCollection>();
 
   // Loop over jets
   for (size_t ij=0; ij != fjJets_.size(); ij++){
@@ -235,7 +235,7 @@ void HTTTopJetProducer::addHTTTopJetTagInfoCollection( edm::Event& iEvent,
     tagInfos->push_back( tagInfo );   
   }
 
-  iEvent.put( tagInfos );
+  iEvent.put(std::move(tagInfos));
   
 };
 

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -239,7 +239,7 @@ bool InputGenJetsParticleSelector::hasPartonChildren(ParticleBitmap &invalid,
 void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSetup &evtSetup){
 
  
-  std::auto_ptr<reco::CandidatePtrVector> selected_ (new reco::CandidatePtrVector);
+  auto selected_ = std::make_unique<reco::CandidatePtrVector>();
     
   ParticleVector particles;
   
@@ -316,7 +316,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
       //cout<<"Finally we have: ["<<setw(4)<<idx<<"] "<<setw(4)<<particle->pdgId()<<" "<<particle->pt()<<endl;
     }
   }
-  evt.put(selected_);
+  evt.put(std::move(selected_));
 }
       
       

--- a/RecoJets/JetProducers/plugins/JetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.cc
@@ -46,7 +46,7 @@ JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken( input_jet_token_, h_jets );
 
   // allocate the jet--->jetid value map
-  std::auto_ptr<reco::JetIDValueMap> jetIdValueMap( new reco::JetIDValueMap );
+  auto jetIdValueMap = std::make_unique<reco::JetIDValueMap>();
   // instantiate the filler with the map
   reco::JetIDValueMap::Filler filler(*jetIdValueMap);
   
@@ -101,7 +101,7 @@ JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   filler.fill();
 
   // write map to the event
-  iEvent.put( jetIdValueMap );
+  iEvent.put(std::move(jetIdValueMap));
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/MVAJetPuIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/MVAJetPuIdProducer.cc
@@ -181,27 +181,27 @@ MVAJetPuIdProducer::MVAJetPuIdProducer(const edm::ParameterSet& iConfig)
      if( runMvas_ ) {
          for(vector<pair<string,MVAJetPuId *> >::iterator ialgo = algos_.begin(); ialgo!=algos_.end(); ++ialgo) {
              vector<float> & mva = mvas[ialgo->first];
-             auto_ptr<ValueMap<float> > mvaout(new ValueMap<float>());
+             auto mvaout = std::make_unique<ValueMap<float>>();
              ValueMap<float>::Filler mvafiller(*mvaout);
              mvafiller.insert(jetHandle,mva.begin(),mva.end());
              mvafiller.fill();
-             iEvent.put(mvaout,ialgo->first+"Discriminant");
+             iEvent.put(std::move(mvaout),ialgo->first+"Discriminant");
              
              vector<int> & idflag = idflags[ialgo->first];
-             auto_ptr<ValueMap<int> > idflagout(new ValueMap<int>());
+             auto idflagout = std::make_unique<ValueMap<int>>();
              ValueMap<int>::Filler idflagfiller(*idflagout);
              idflagfiller.insert(jetHandle,idflag.begin(),idflag.end());
              idflagfiller.fill();
-             iEvent.put(idflagout,ialgo->first+"Id");
+             iEvent.put(std::move(idflagout),ialgo->first+"Id");
          }
      }
      if( produceJetIds_ ) {
          assert( jetHandle->size() == ids.size() );
-         auto_ptr<ValueMap<StoredPileupJetIdentifier> > idsout(new ValueMap<StoredPileupJetIdentifier>());
+         auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
          ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
          idsfiller.insert(jetHandle,ids.begin(),ids.end());
          idsfiller.fill();
-         iEvent.put(idsout);
+         iEvent.put(std::move(idsout));
      }
  }
  

--- a/RecoJets/JetProducers/plugins/NjettinessAdder.cc
+++ b/RecoJets/JetProducers/plugins/NjettinessAdder.cc
@@ -97,12 +97,12 @@ void NjettinessAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	tauN.push_back(t);
       }
 
-      std::auto_ptr<edm::ValueMap<float> > outT(new edm::ValueMap<float>());
+      auto outT = std::make_unique<edm::ValueMap<float>>();
       edm::ValueMap<float>::Filler fillerT(*outT);
       fillerT.insert(jets, tauN.begin(), tauN.end());
       fillerT.fill();
 
-      iEvent.put(outT,tauN_str.str().c_str());
+      iEvent.put(std::move(outT),tauN_str.str().c_str());
     }
 }
 

--- a/RecoJets/JetProducers/plugins/PUFilter.cc
+++ b/RecoJets/JetProducers/plugins/PUFilter.cc
@@ -49,12 +49,12 @@ PUFilter::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup &
   iEvent.getByToken( jetsToken_, jetsH );
   iEvent.getByToken( jetPuIdToken_, id_decisions );
   
-  std::auto_ptr<std::vector<reco::PFJet> > goodjets(new std::vector<reco::PFJet> );
+  auto goodjets = std::make_unique<std::vector<reco::PFJet>>();
   for( size_t i = 0; i < jetsH->size(); ++i ) {
     auto jet = jetsH->refAt(i);
     if((*id_decisions)[jet]) goodjets->push_back(*jet);
   }
-  iEvent.put(goodjets);
+  iEvent.put(std::move(goodjets));
 }
 
 void

--- a/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
@@ -108,17 +108,17 @@ PileupJPTJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     
     }
      
-    auto_ptr<ValueMap<float> > mvaout(new ValueMap<float>());
+    auto mvaout = std::make_unique<ValueMap<float>>();
     ValueMap<float>::Filler mvafiller(*mvaout);
     mvafiller.insert(jets,mva.begin(),mva.end());
     mvafiller.fill();
-    iEvent.put(mvaout,"JPTPUDiscriminant");
+    iEvent.put(std::move(mvaout),"JPTPUDiscriminant");
 
-    auto_ptr<ValueMap<int> > idflagout(new ValueMap<int>());
+    auto idflagout = std::make_unique<ValueMap<int>>();
     ValueMap<int>::Filler idflagfiller(*idflagout);
     idflagfiller.insert(jets,idflag.begin(),idflag.end());
     idflagfiller.fill();
-    iEvent.put(idflagout,"JPTPUId");
+    iEvent.put(std::move(idflagout),"JPTPUId");
        
 }
 

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -201,29 +201,29 @@ PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		for(vector<pair<string,PileupJetIdAlgo *> >::iterator ialgo = algos_.begin(); ialgo!=algos_.end(); ++ialgo) {
 			// MVA
 			vector<float> & mva = mvas[ialgo->first];
-			auto_ptr<ValueMap<float> > mvaout(new ValueMap<float>());
+			auto mvaout = std::make_unique<ValueMap<float>>();
 			ValueMap<float>::Filler mvafiller(*mvaout);
 			mvafiller.insert(jetHandle,mva.begin(),mva.end());
 			mvafiller.fill();
-			iEvent.put(mvaout,ialgo->first+"Discriminant");
+			iEvent.put(std::move(mvaout),ialgo->first+"Discriminant");
 			
 			// WP
 			vector<int> & idflag = idflags[ialgo->first];
-			auto_ptr<ValueMap<int> > idflagout(new ValueMap<int>());
+			auto idflagout = std::make_unique<ValueMap<int>>();
 			ValueMap<int>::Filler idflagfiller(*idflagout);
 			idflagfiller.insert(jetHandle,idflag.begin(),idflag.end());
 			idflagfiller.fill();
-			iEvent.put(idflagout,ialgo->first+"Id");
+			iEvent.put(std::move(idflagout),ialgo->first+"Id");
 		}
 	}
 	// input variables
 	if( produceJetIds_ ) {
 		assert( jetHandle->size() == ids.size() );
-		auto_ptr<ValueMap<StoredPileupJetIdentifier> > idsout(new ValueMap<StoredPileupJetIdentifier>());
+		auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
 		ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
 		idsfiller.insert(jetHandle,ids.begin(),ids.end());
 		idsfiller.fill();
-		iEvent.put(idsout);
+		iEvent.put(std::move(idsout));
 	}
 }
 

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -110,11 +110,11 @@ void QGTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
 
 /// Function to put product into event
 template <typename T> void QGTagger::putInEvent(std::string name, const edm::Handle<edm::View<reco::Jet>>& jets, std::vector<T>* product, edm::Event& iEvent){
-  std::auto_ptr<edm::ValueMap<T>> out(new edm::ValueMap<T>());
+  auto out = std::make_unique<edm::ValueMap<T>>();
   typename edm::ValueMap<T>::Filler filler(*out);
   filler.insert(jets, product->begin(), product->end());
   filler.fill();
-  iEvent.put(out, name);
+  iEvent.put(std::move(out), name);
   delete product;
 }
 

--- a/RecoJets/JetProducers/plugins/QjetsAdder.cc
+++ b/RecoJets/JetProducers/plugins/QjetsAdder.cc
@@ -86,12 +86,12 @@ void QjetsAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     QjetsVolatility.push_back(variance/mean);
   }//end loop on jets
 
-  std::auto_ptr<edm::ValueMap<float> > outQJV(new edm::ValueMap<float>());
+  auto outQJV = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler fillerQJV(*outQJV);
   fillerQJV.insert(jets, QjetsVolatility.begin(), QjetsVolatility.end());
   fillerQJV.fill();
 
-  iEvent.put(outQJV,"QjetsVolatility");
+  iEvent.put(std::move(outQJV),"QjetsVolatility");
 }
 
 

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -104,7 +104,7 @@ void SubEventGenJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& i
 
    ////////////////
 
-   std::auto_ptr<std::vector<GenJet> > jets(new std::vector<GenJet>() );
+   auto jets = std::make_unique<std::vector<GenJet>>();
    subJets_ = jets.get();
 
    LogDebug("VirtualJetProducer") << "Inputted towers\n";
@@ -122,7 +122,7 @@ void SubEventGenJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& i
    //Finalize
    LogDebug("SubEventJetProducer") << "Wrote jets\n";
 
-   iEvent.put(jets);  
+   iEvent.put(std::move(jets));  
    return;
 }
 

--- a/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
@@ -134,9 +134,9 @@ template< class T>
 void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent,
 						const edm::EventSetup& iSetup)
 {
-  auto_ptr<reco::BasicJetCollection> fatJets( new reco::BasicJetCollection() );
-  auto_ptr<vector<T> >  subJets( new vector<T>() );
-  auto_ptr<vector<T> >  filterJets( new vector<T>() );
+  auto fatJets = std::make_unique<reco::BasicJetCollection>();
+  auto subJets = std::make_unique< vector<T>>();
+  auto filterJets = std::make_unique< vector<T>>();
 
   edm::OrphanHandle< vector<T> > subJetsAfterPut;
   edm::OrphanHandle< vector<T> > filterJetsAfterPut;
@@ -194,8 +194,8 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent,
     }
   }
   
-  subJetsAfterPut    = iEvent.put(subJets,   "sub");
-  filterJetsAfterPut = iEvent.put(filterJets,"filter");
+  subJetsAfterPut    = iEvent.put(std::move(subJets),   "sub");
+  filterJetsAfterPut = iEvent.put(std::move(filterJets),"filter");
   
   vector<math::XYZTLorentzVector>::const_iterator itP4Begin(p4FatJets.begin());
   vector<math::XYZTLorentzVector>::const_iterator itP4End(p4FatJets.end());
@@ -228,7 +228,7 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent,
     fatJets->back().setJetArea(areaFatJets[fatIndex]);
   }
   
-  iEvent.put(fatJets,"fat");
+  iEvent.put(std::move(fatJets),"fat");
 }
 
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -614,8 +614,8 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
     if(fjexcluded_jets.size()>2) fjexcluded_jets.resize(nExclude_);
     
     if(doFastJetNonUniform_){
-      std::auto_ptr<std::vector<double> > rhos(new std::vector<double>);
-      std::auto_ptr<std::vector<double> > sigmas(new std::vector<double>);
+      auto rhos = std::make_unique<std::vector<double>>();
+      auto sigmas = std::make_unique<std::vector<double>>();
       int nEta = puCenters_.size();
       rhos->reserve(nEta);
       sigmas->reserve(nEta);
@@ -638,11 +638,11 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
 	  sigmas->push_back(bkgestim.sigma());
 	}
       }
-      iEvent.put(rhos,"rhos");
-      iEvent.put(sigmas,"sigmas");
+      iEvent.put(std::move(rhos),"rhos");
+      iEvent.put(std::move(sigmas),"sigmas");
     }else{
-      std::auto_ptr<double> rho(new double(0.0));
-      std::auto_ptr<double> sigma(new double(0.0));
+      auto rho = std::make_unique<double>(0.0);
+      auto sigma = std::make_unique<double>(0.0);
       double mean_area = 0;
       
       fastjet::ClusterSequenceAreaBase const* clusterSequenceWithArea =
@@ -665,8 +665,8 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
 	  *rho = 0;
 	}
       }
-      iEvent.put(rho,"rho");
-      iEvent.put(sigma,"sigma");
+      iEvent.put(std::move(rho),"rho");
+      iEvent.put(std::move(sigma),"sigma");
     }
   } // doRhoFastjet_
   
@@ -764,9 +764,9 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
   }
 
   // get a list of output jets
-  std::auto_ptr<reco::BasicJetCollection>  jetCollection( new reco::BasicJetCollection() );
+  auto jetCollection = std::make_unique<reco::BasicJetCollection>();
   // get a list of output subjets
-  std::auto_ptr<std::vector<T> >  subjetCollection( new std::vector<T>() );
+  auto subjetCollection = std::make_unique<std::vector<T>>();
 
   // This will store the handle for the subjets after we write them
   edm::OrphanHandle< std::vector<T> > subjetHandleAfterPut;
@@ -860,7 +860,7 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
   }
 
   // put subjets into event record
-  subjetHandleAfterPut = iEvent.put( subjetCollection, jetCollInstanceName_ );
+  subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), jetCollInstanceName_);
   
   // Now create the hard jets with ptr's to the subjets as constituents
   std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(),
@@ -885,7 +885,7 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
 
   // put hard jets into event record
   // Store the Orphan handle for adding HTT information
-  edm::OrphanHandle<reco::BasicJetCollection>  oh = iEvent.put( jetCollection);
+  edm::OrphanHandle<reco::BasicJetCollection>  oh = iEvent.put(std::move(jetCollection));
 
   if (fromHTTTopJetProducer_){
     addHTTTopJetTagInfoCollection( iEvent, iSetup, oh);

--- a/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHalo2015Filter.cc
@@ -34,7 +34,7 @@ bool CSCTightHalo2015Filter::filter(edm::StreamID iID, edm::Event & iEvent, cons
 
   const bool pass = !beamHaloSummary->CSCTightHaloId2015();
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/CSCTightHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloFilter.cc
@@ -34,7 +34,7 @@ bool CSCTightHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const ed
 
   const bool pass = !beamHaloSummary->CSCTightHaloId();
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
+++ b/RecoMET/METFilters/plugins/CSCTightHaloTrkMuUnvetoFilter.cc
@@ -34,7 +34,7 @@ bool CSCTightHaloTrkMuUnvetoFilter::filter(edm::StreamID iID, edm::Event & iEven
 
   const bool pass = !beamHaloSummary->CSCTightHaloIdTrkMuUnveto();
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/ChargedHadronTrackResolutionFilter.cc
+++ b/RecoMET/METFilters/plugins/ChargedHadronTrackResolutionFilter.cc
@@ -145,7 +145,7 @@ ChargedHadronTrackResolutionFilter::filter(edm::StreamID iID, edm::Event& iEvent
 
   bool pass = !foundBadTrack;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 }

--- a/RecoMET/METFilters/plugins/EEBadScFilter.cc
+++ b/RecoMET/METFilters/plugins/EEBadScFilter.cc
@@ -211,7 +211,7 @@ bool EEBadScFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) 
   if (pass==false && debug_) std::cout << "EEBadScFilter.cc:  REJECT EVENT!!!" << std::endl;
 
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   // return the decision
 

--- a/RecoMET/METFilters/plugins/EENoiseFilter.cc
+++ b/RecoMET/METFilters/plugins/EENoiseFilter.cc
@@ -44,7 +44,7 @@ bool EENoiseFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) 
 
   const bool pass = eeRHs->size() < slope_ * ebRHs->size() + intercept_;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 }

--- a/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
@@ -405,8 +405,8 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
 
    sameFlagDetIds.clear();
 
-   std::auto_ptr<AnomalousECALVariables> pAnomalousECALVariables(new AnomalousECALVariables(v_enNeighboursGap_EB,
-            v_enNeighboursGap_EE, v_boundaryInfoDeadCells_EB, v_boundaryInfoDeadCells_EE));
+   auto pAnomalousECALVariables = std::make_unique<AnomalousECALVariables>(v_enNeighboursGap_EB,
+            v_enNeighboursGap_EE, v_boundaryInfoDeadCells_EB, v_boundaryInfoDeadCells_EE);
 
 
    bool isGap = pAnomalousECALVariables->isGapEcalCluster(cutBoundEnergyGapEB, cutBoundEnergyGapEE);
@@ -414,9 +414,9 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
             limitDeadCellToChannelStatusEE_);
    pass = (!isBoundary && ((!isGap && enableGap_) || !enableGap_));
 
-   iEvent.put(pAnomalousECALVariables, "anomalousECALVariables");
+   iEvent.put(std::move(pAnomalousECALVariables), "anomalousECALVariables");
 
-   iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+   iEvent.put(std::make_unique<bool>(pass));
 
    if( taggingMode_ ){
       if (skimDead_ && (i_EBDead >= 1 || i_EEDead >= 1)) {
@@ -435,7 +435,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
    if (FilterAlgo_ == "TuningMode") {
       std::auto_ptr<AnomalousECALVariables> pAnomalousECALVariables(new AnomalousECALVariables(v_enNeighboursGap_EB,
             v_enNeighboursGap_EE, v_boundaryInfoDeadCells_EB, v_boundaryInfoDeadCells_EE));
-      iEvent.put(pAnomalousECALVariables, "anomalousECALVariables");
+      iEvent.put(std::move(pAnomalousECALVariables), "anomalousECALVariables");
 
       if (skimDead_ && (i_EBDead >= 1 || i_EEDead >= 1)) {
          return true;

--- a/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
@@ -325,15 +325,12 @@ bool EcalDeadCellDeltaRFilter::filter(edm::Event& iEvent, const edm::EventSetup&
 //     h1_dummy->Fill(xxx);
   }
 
-  std::auto_ptr<int> deadCellStatusPtr ( new int(deadCellStatus) );
-  std::auto_ptr<int> boundaryStatusPtr ( new int(boundaryStatus) );
-
-  iEvent.put( deadCellStatusPtr, "deadCellStatus");
-  iEvent.put( boundaryStatusPtr, "boundaryStatus");
+  iEvent.put(std::make_unique<int>(deadCellStatus), "deadCellStatus");
+  iEvent.put(std::make_unique<int>(boundaryStatus), "boundaryStatus");
 
   if( deadCellStatus || (doCracks_ && boundaryStatus) ) pass = false;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 }

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -369,8 +369,7 @@ bool EcalDeadCellTriggerPrimitiveFilter::filter(edm::Event& iEvent, const edm::E
      printf("\nrun : %8u  event : %10llu  lumi : %4u  evtTPstatus  ABS : %d  13 : % 2d\n", run, event, ls, evtstatusABS, evtTagged);
   }
 
-  std::auto_ptr<bool> pOut( new bool(pass) );
-  iEvent.put( pOut );
+  iEvent.put(std::make_unique<bool>(pass));
 
   if (taggingMode_) return true;
   else return pass;

--- a/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
@@ -142,7 +142,7 @@ bool EcalLaserCorrFilter::filter(edm::Event & iEvent, const edm::EventSetup & iS
   bool result = goodCalib;
   //std::cout << " *********** Result ******** " << result << std::endl;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(result)) );
+  iEvent.put(std::make_unique<bool>(result));
 
   return taggingMode_ || result;
 

--- a/RecoMET/METFilters/plugins/GlobalSuperTightHalo2016Filter.cc
+++ b/RecoMET/METFilters/plugins/GlobalSuperTightHalo2016Filter.cc
@@ -34,7 +34,7 @@ bool GlobalSuperTightHalo2016Filter::filter(edm::StreamID iID, edm::Event & iEve
 
   const bool pass = !beamHaloSummary->GlobalSuperTightHaloId2016();
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/GlobalTightHalo2016Filter.cc
+++ b/RecoMET/METFilters/plugins/GlobalTightHalo2016Filter.cc
@@ -34,7 +34,7 @@ bool GlobalTightHalo2016Filter::filter(edm::StreamID iID, edm::Event & iEvent, c
 
   const bool pass = !beamHaloSummary->GlobalTightHaloId2016();
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/GreedyMuonPFCandidateFilter.cc
+++ b/RecoMET/METFilters/plugins/GreedyMuonPFCandidateFilter.cc
@@ -90,8 +90,7 @@ GreedyMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& i
 
   bool foundMuon = false;
 
-  auto_ptr< reco::PFCandidateCollection >
-    pOutputCandidateCollection( new reco::PFCandidateCollection );
+  auto pOutputCandidateCollection = std::make_unique<reco::PFCandidateCollection>();
 
   for( unsigned i=0; i<pfCandidates->size(); i++ ) {
 
@@ -122,11 +121,11 @@ GreedyMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& i
     }
   }
 
-  iEvent.put( pOutputCandidateCollection, "muons" );
+  iEvent.put(std::move(pOutputCandidateCollection), "muons");
 
   bool pass = !foundMuon;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 

--- a/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
@@ -248,7 +248,7 @@ HcalLaserEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    if (reverseFilter_)
      filterDecision=!filterDecision;
 
-   iEvent.put( std::auto_ptr<bool>(new bool(filterDecision)) );
+   iEvent.put(std::make_unique<bool>(filterDecision));
 
    return taggingMode_ || filterDecision;
 }

--- a/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
@@ -54,7 +54,7 @@ bool HcalStripHaloFilter::filter(edm::StreamID iID, edm::Event & iEvent, const e
     }
   }
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;  // return false if it is a beamhalo event
 }

--- a/RecoMET/METFilters/plugins/InconsistentMuonPFCandidateFilter.cc
+++ b/RecoMET/METFilters/plugins/InconsistentMuonPFCandidateFilter.cc
@@ -84,8 +84,7 @@ InconsistentMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSe
 
   bool    foundMuon = false;
 
-  auto_ptr< reco::PFCandidateCollection >
-    pOutputCandidateCollection( new reco::PFCandidateCollection );
+  auto pOutputCandidateCollection = std::make_unique<reco::PFCandidateCollection>();
 
   for ( unsigned i=0; i<pfCandidates->size(); i++ ) {
 
@@ -118,11 +117,11 @@ InconsistentMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSe
     }
   } // end loop over PF candidates
 
-  iEvent.put( pOutputCandidateCollection, "muons" );
+  iEvent.put(std::move(pOutputCandidateCollection), "muons");
 
   bool pass = !foundMuon;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 }

--- a/RecoMET/METFilters/plugins/JetIDFailureFilter.cc
+++ b/RecoMET/METFilters/plugins/JetIDFailureFilter.cc
@@ -81,7 +81,7 @@ bool JetIDFailureFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSe
     }
   }
 
-  iEvent.put( std::auto_ptr<bool>(new bool(goodJetID)) );
+  iEvent.put(std::make_unique<bool>(goodJetID));
 
   return taggingMode_ || goodJetID;
 }

--- a/RecoMET/METFilters/plugins/MultiEventFilter.cc
+++ b/RecoMET/METFilters/plugins/MultiEventFilter.cc
@@ -79,7 +79,7 @@ bool MultiEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetu
         events_[i].lumi == iEvent.id().luminosityBlock()) pass = false; 
   }
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 

--- a/RecoMET/METFilters/plugins/MuonBadTrackFilter.cc
+++ b/RecoMET/METFilters/plugins/MuonBadTrackFilter.cc
@@ -210,7 +210,7 @@ MuonBadTrackFilter::filter(edm::StreamID iID, edm::Event& iEvent, const edm::Eve
 
   bool pass = !foundBadTrack;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass;
 }

--- a/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
+++ b/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
@@ -84,7 +84,7 @@ bool TrackingFailureFilter::filter(edm::Event & iEvent, const edm::EventSetup & 
               << " SumPt=" << sumpt
               << std::endl;
 
-  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+  iEvent.put(std::make_unique<bool>(pass));
 
   return taggingMode_ || pass; // return false if filtering and not enough tracks in event
 

--- a/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.cc
@@ -142,18 +142,18 @@ void JVFJetIdProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     jetIdFlags.push_back(jetIdFlag);
   }
  
-  std::auto_ptr<edm::ValueMap<double> > jetIdDiscriminants_ptr(new edm::ValueMap<double>());
+  auto jetIdDiscriminants_ptr = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler jetIdDiscriminantFiller(*jetIdDiscriminants_ptr);
   jetIdDiscriminantFiller.insert(jets, jetIdDiscriminants.begin(), jetIdDiscriminants.end());
   jetIdDiscriminantFiller.fill();
  
-  std::auto_ptr<edm::ValueMap<int> > jetIdFlags_ptr(new edm::ValueMap<int>());
+  auto jetIdFlags_ptr = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler jetIdFlagFiller(*jetIdFlags_ptr);
   jetIdFlagFiller.insert(jets, jetIdFlags.begin(), jetIdFlags.end());
   jetIdFlagFiller.fill();
 
-  evt.put(jetIdDiscriminants_ptr, "Discriminant");
-  evt.put(jetIdFlags_ptr, "Id");
+  evt.put(std::move(jetIdDiscriminants_ptr), "Discriminant");
+  evt.put(std::move(jetIdFlags_ptr), "Id");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
@@ -159,8 +159,8 @@ void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& 
   edm::Handle<reco::VertexCollection> hardScatterVertex;
   evt.getByToken(srcHardScatterVertex_, hardScatterVertex);
   
-  std::auto_ptr<reco::PUSubMETCandInfoCollection> jetInfos(new reco::PUSubMETCandInfoCollection());
-  std::auto_ptr<reco::PUSubMETCandInfoCollection> pfCandInfos(new reco::PUSubMETCandInfoCollection());
+  auto jetInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
+  auto pfCandInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
  
   const JetCorrector* jetEnOffsetCorrector = nullptr;
   if ( jetEnOffsetCorrLabel_ != "" ) {
@@ -266,8 +266,8 @@ void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& 
   
   LogDebug ("produce") << "#pfCandInfos = " << pfCandInfos->size() << std::endl;
     
-  evt.put(jetInfos,"jetInfos");
-  evt.put(pfCandInfos,"pfCandInfos");
+  evt.put(std::move(jetInfos),"jetInfos");
+  evt.put(std::move(pfCandInfos),"pfCandInfos");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
@@ -308,9 +308,9 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 	<< " pfCandidate is within jet --> skipping." << std::endl;
     }
   }
-  std::auto_ptr<CommonMETData> sumLeptons(new CommonMETData());
+  auto sumLeptons = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumLeptons);
-  std::auto_ptr<CommonMETData> sumLeptonIsoCones(new CommonMETData());
+  auto sumLeptonIsoCones = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumLeptonIsoCones);
   int leptonIdx = 0;
   for ( std::vector<CommonMETData>::iterator sumJetsPlusPFCandidates = sumJetsPlusPFCandidates_leptons.begin();
@@ -337,13 +337,13 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   reco::PUSubMETCandInfoCollection jets_cleaned = utils_.cleanJets(*jets, leptons, 0.5, false);
   reco::PUSubMETCandInfoCollection pfCandidates_cleaned = utils_.cleanPFCandidates(*pfCandidates, leptons, 0.3, false);
 
-  std::auto_ptr<CommonMETData> sumNoPUjets(new CommonMETData());
+  auto sumNoPUjets = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumNoPUjets);
   std::vector<metsig::SigInputObj> metSignObjectsNoPUjets;
-  std::auto_ptr<CommonMETData> sumNoPUjetOffsetEnCorr(new CommonMETData());
+  auto sumNoPUjetOffsetEnCorr = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumNoPUjetOffsetEnCorr);
   std::vector<metsig::SigInputObj> metSignObjectsNoPUjetOffsetEnCorr;
-  std::auto_ptr<CommonMETData> sumPUjets(new CommonMETData());
+  auto sumPUjets = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumPUjets);
   std::vector<metsig::SigInputObj> metSignObjectsPUjets;
   int jetIdx = 0;
@@ -374,13 +374,13 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     ++jetIdx;
   }
     
-  std::auto_ptr<CommonMETData> sumNoPUunclChargedCands(new CommonMETData());
+  auto sumNoPUunclChargedCands = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumNoPUunclChargedCands);
   std::vector<metsig::SigInputObj> metSignObjectsNoPUunclChargedCands;
-  std::auto_ptr<CommonMETData> sumPUunclChargedCands(new CommonMETData());
+  auto sumPUunclChargedCands = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumPUunclChargedCands);
   std::vector<metsig::SigInputObj> metSignObjectsPUunclChargedCands;
-  std::auto_ptr<CommonMETData> sumUnclNeutralCands(new CommonMETData());
+  auto sumUnclNeutralCands = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumUnclNeutralCands);
   std::vector<metsig::SigInputObj> metSignObjectsUnclNeutralCands;
   int pfCandIdx = 0;
@@ -405,7 +405,7 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   edm::Handle<CorrMETData> type0Correction_input;
   evt.getByToken(srcType0Correction_, type0Correction_input);
-  std::auto_ptr<CommonMETData> type0Correction_output(new CommonMETData());
+  auto type0Correction_output = std::make_unique<CommonMETData>();
   initializeCommonMETData(*type0Correction_output);
   type0Correction_output->mex = type0Correction_input->mex;
   type0Correction_output->mey = type0Correction_input->mey;
@@ -470,24 +470,23 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   
   
   // add no-PU MET object to the event
-  std::auto_ptr<reco::PFMETCollection> noPileUpMEtCollection(new reco::PFMETCollection());
+  auto noPileUpMEtCollection = std::make_unique<reco::PFMETCollection>();
   noPileUpMEtCollection->push_back(noPileUpMEt);
   
-  evt.put(noPileUpMEtCollection);
+  evt.put(std::move(noPileUpMEtCollection));
   if ( saveInputs_ ) {
-    evt.put(sumLeptons, sfLeptonsName_);
-    evt.put(sumNoPUjetOffsetEnCorr, sfNoPUjetOffsetEnCorrName_);
-    evt.put(sumNoPUjets, sfNoPUjetsName_);
-    evt.put(sumPUjets, sfPUjetsName_);
-    evt.put(sumNoPUunclChargedCands, sfNoPUunclChargedCandsName_);
-    evt.put(sumPUunclChargedCands, sfPUunclChargedCandsName_);
-    evt.put(sumUnclNeutralCands, sfUnclNeutralCandsName_);
-    evt.put(type0Correction_output, sfType0CorrectionName_);
-    evt.put(sumLeptonIsoCones, sfLeptonIsoConesName_);
+    evt.put(std::move(sumLeptons), sfLeptonsName_);
+    evt.put(std::move(sumNoPUjetOffsetEnCorr), sfNoPUjetOffsetEnCorrName_);
+    evt.put(std::move(sumNoPUjets), sfNoPUjetsName_);
+    evt.put(std::move(sumPUjets), sfPUjetsName_);
+    evt.put(std::move(sumNoPUunclChargedCands), sfNoPUunclChargedCandsName_);
+    evt.put(std::move(sumPUunclChargedCands), sfPUunclChargedCandsName_);
+    evt.put(std::move(sumUnclNeutralCands), sfUnclNeutralCandsName_);
+    evt.put(std::move(type0Correction_output), sfType0CorrectionName_);
+    evt.put(std::move(sumLeptonIsoCones), sfLeptonIsoConesName_);
   }
 
-  std::auto_ptr<double> sfNoPU(new double(noPileUpScaleFactor));
-  evt.put(sfNoPU, "sfNoPU");
+  evt.put(std::make_unique<double>(noPileUpScaleFactor), "sfNoPU");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -53,9 +53,9 @@ void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es)
 	<< " numLeptons = " << numLeptons << ", minNumLeptons = " << minNumLeptons_ << " --> skipping !!" << std::endl;
       
       reco::PFMET pfMEt;
-      std::auto_ptr<reco::PFMETCollection> pfMEtCollection(new reco::PFMETCollection());
+      auto pfMEtCollection = std::make_unique<reco::PFMETCollection>();
       pfMEtCollection->push_back(pfMEt);
-      evt.put(pfMEtCollection);
+      evt.put(std::move(pfMEtCollection));
       return;
     }
   }
@@ -132,9 +132,9 @@ void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es)
     <<(mvaMEtAlgo_.getMEtCov())(1,0)<<"  "<<(mvaMEtAlgo_.getMEtCov())(1,1)<<std::endl  << std::endl;
  
   // add PFMET object to the event
-  std::auto_ptr<reco::PFMETCollection> pfMEtCollection(new reco::PFMETCollection());
+  auto pfMEtCollection = std::make_unique<reco::PFMETCollection>();
   pfMEtCollection->push_back(pfMEt);
-  evt.put(pfMEtCollection);
+  evt.put(std::move(pfMEtCollection));
 }
 
 std::vector<reco::PUSubMETCandInfo>

--- a/RecoMET/METProducers/interface/MinMETProducerT.h
+++ b/RecoMET/METProducers/interface/MinMETProducerT.h
@@ -47,7 +47,7 @@ class MinMETProducerT : public edm::stream::EDProducer<>
 
   void produce(edm::Event& evt, const edm::EventSetup& es) override
   {
-    std::auto_ptr<METCollection> outputMETs(new METCollection());
+    auto outputMETs = std::make_unique<METCollection>();
 
     // check that all MET collections given as input have the same number of entries
     int numMEtObjects = -1;
@@ -80,7 +80,7 @@ class MinMETProducerT : public edm::stream::EDProducer<>
       outputMETs->push_back(T(*minMET));
     }
 
-    evt.put(outputMETs);
+    evt.put(std::move(outputMETs));
   }
 
   std::string moduleLabel_;

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -60,7 +60,7 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
 void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 {
   // BeamHaloSummary object 
-  std::auto_ptr<BeamHaloSummary> TheBeamHaloSummary( new BeamHaloSummary() );
+  auto TheBeamHaloSummary = std::make_unique<BeamHaloSummary>();
 
   // CSC Specific Halo Data
   Handle<CSCHaloData> TheCSCHaloData;
@@ -293,7 +293,7 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
  
 
 
-  iEvent.put(TheBeamHaloSummary);
+  iEvent.put(std::move(TheBeamHaloSummary));
   return;
 }
 

--- a/RecoMET/METProducers/src/CSCHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/CSCHaloDataProducer.cc
@@ -139,9 +139,8 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   }
 
 
-  std::auto_ptr<CSCHaloData> TheCSCData(new CSCHaloData( CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, hbhehits,ecalebhits,ecaleehits,TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent, iSetup) ) );
   // Put it in the event                                                                                                                                                
-  iEvent.put(TheCSCData);
+  iEvent.put(std::make_unique<CSCHaloData>(CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, hbhehits,ecalebhits,ecaleehits,TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent, iSetup)));
   return;
 }
 

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -73,10 +73,9 @@ namespace cms
 	calomet.setSignificanceMatrix(signcalospecalgo.getSignificanceMatrix());
       }
 */
-    std::auto_ptr<reco::CaloMETCollection> calometcoll;
-    calometcoll.reset(new reco::CaloMETCollection);
+    auto calometcoll = std::make_unique<reco::CaloMETCollection>();
     calometcoll->push_back(calomet);
-    event.put(calometcoll);
+    event.put(std::move(calometcoll));
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
+++ b/RecoMET/METProducers/src/CaloRecHitsBeamHaloCleaned.cc
@@ -144,7 +144,7 @@ CaloRecHitsBeamHaloCleaned::produce(edm::Event& iEvent, const edm::EventSetup& i
    //Cleaning of the various rechits collections:
 
    //  EcalRecHit EB
-   auto_ptr<EcalRecHitCollection> ebrhitscleaned(new EcalRecHitCollection()); 
+   auto ebrhitscleaned = std::make_unique<EcalRecHitCollection>(); 
    for(unsigned int i = 0;  i < ebrhitsuncleaned->size(); i++){
      const EcalRecHit & rhit = (*ebrhitsuncleaned)[i];
      bool isclean(true);
@@ -160,7 +160,7 @@ CaloRecHitsBeamHaloCleaned::produce(edm::Event& iEvent, const edm::EventSetup& i
    }
    
    //  EcalRecHit EE
-   auto_ptr<EcalRecHitCollection> eerhitscleaned(new EcalRecHitCollection()); 
+   auto eerhitscleaned = std::make_unique<EcalRecHitCollection>(); 
    for(unsigned int i = 0;  i < eerhitsuncleaned->size(); i++){
      const EcalRecHit & rhit = (*eerhitsuncleaned)[i];
      bool isclean(true);
@@ -176,7 +176,7 @@ CaloRecHitsBeamHaloCleaned::produce(edm::Event& iEvent, const edm::EventSetup& i
    }
 
    //  HBHERecHit
-   auto_ptr<HBHERecHitCollection> hbherhitscleaned(new HBHERecHitCollection()); 
+   auto hbherhitscleaned = std::make_unique<HBHERecHitCollection>(); 
    for(unsigned int i = 0;  i < hbherhitsuncleaned->size(); i++){
      const HBHERecHit & rhit = (*hbherhitsuncleaned)[i];
      bool isclean(true);
@@ -193,9 +193,9 @@ CaloRecHitsBeamHaloCleaned::produce(edm::Event& iEvent, const edm::EventSetup& i
 
 
 
-   iEvent.put(ebrhitscleaned,"EcalRecHitsEB");
-   iEvent.put(eerhitscleaned,"EcalRecHitsEE");
-   iEvent.put(hbherhitscleaned);
+   iEvent.put(std::move(ebrhitscleaned),"EcalRecHitsEB");
+   iEvent.put(std::move(eerhitscleaned),"EcalRecHitsEE");
+   iEvent.put(std::move(hbherhitscleaned));
 
 }
 

--- a/RecoMET/METProducers/src/EcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/EcalHaloDataProducer.cc
@@ -91,8 +91,7 @@ void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   EcalAlgo.SetPhiWedgeThresholds(SumEcalEnergyThreshold, NHitsEcalThreshold);
   
 
-  std::auto_ptr<EcalHaloData> EcalData( new EcalHaloData( EcalAlgo.Calculate(*TheCaloGeometry, ThePhotons, TheSuperClusters, TheEBRecHits, TheEERecHits, TheESRecHits, TheHBHERecHits,iSetup)));
-  iEvent.put( EcalData ) ; 
+  iEvent.put(std::make_unique<EcalHaloData>(EcalAlgo.Calculate(*TheCaloGeometry, ThePhotons, TheSuperClusters, TheEBRecHits, TheEERecHits, TheESRecHits, TheHBHERecHits,iSetup)));
 
   return;
 }

--- a/RecoMET/METProducers/src/ElseMETProducer.cc
+++ b/RecoMET/METProducers/src/ElseMETProducer.cc
@@ -53,10 +53,9 @@ namespace cms
     math::XYZTLorentzVector p4(commonMETdata.mex, commonMETdata.mey, 0.0, commonMETdata.met);
     math::XYZPoint vtx(0,0,0);
     reco::MET met(commonMETdata.sumet, p4, vtx);
-    std::auto_ptr<reco::METCollection> metcoll;
-    metcoll.reset(new reco::METCollection);
+    auto metcoll = std::make_unique<reco::METCollection>();
     metcoll->push_back(met);
-    event.put(metcoll);
+    event.put(std::move(metcoll));
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/GenMETProducer.cc
+++ b/RecoMET/METProducers/src/GenMETProducer.cc
@@ -48,10 +48,9 @@ namespace cms
     CommonMETData commonMETdata;
 
     GenSpecificAlgo gen;
-    std::auto_ptr<reco::GenMETCollection> genmetcoll;
-    genmetcoll.reset(new reco::GenMETCollection);
+    auto genmetcoll = std::make_unique<reco::GenMETCollection>();
     genmetcoll->push_back(gen.addInfo(input, &commonMETdata, globalThreshold_, onlyFiducial_, applyFiducialThresholdForFractions_, usePt_));
-    event.put(genmetcoll);
+    event.put(std::move(genmetcoll));
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
@@ -138,13 +138,11 @@ void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   if(TheCaloGeometry.isValid() && TheCaloMET.isValid() && TheCaloTowers.isValid() && TheCSCHaloData.isValid() && TheEcalHaloData.isValid() && TheHcalHaloData.isValid() )
     {
-      std::auto_ptr<GlobalHaloData> GlobalData( new GlobalHaloData(GlobalAlgo.Calculate(*TheCaloGeometry, *TheCSCGeometry,  *(&TheCaloMET.product()->front()), TheCaloTowers, TheCSCSegments, TheCSCRecHits, TheMuons, *TheCSCHaloData.product(), *TheEcalHaloData.product(), *TheHcalHaloData.product() ,ishlt)) );
-      iEvent.put(GlobalData);
+      iEvent.put(std::make_unique<GlobalHaloData>(GlobalHaloData(GlobalAlgo.Calculate(*TheCaloGeometry, *TheCSCGeometry,  *(&TheCaloMET.product()->front()), TheCaloTowers, TheCSCSegments, TheCSCRecHits, TheMuons, *TheCSCHaloData.product(), *TheEcalHaloData.product(), *TheHcalHaloData.product() ,ishlt))));
     }
   else 
     {
-      std::auto_ptr<GlobalHaloData> GlobalData( new GlobalHaloData() ) ;
-      iEvent.put(GlobalData);
+      iEvent.put(std::make_unique<GlobalHaloData>());
     }
 
   return;

--- a/RecoMET/METProducers/src/HcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/HcalHaloDataProducer.cc
@@ -71,8 +71,7 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
 
 
-  std::auto_ptr<HcalHaloData> HcalData( new HcalHaloData( HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits, TheCaloTowers, TheEBRecHits, TheEERecHits,iSetup)  ) ) ;
-  iEvent.put ( HcalData ) ;
+  iEvent.put(std::make_unique<HcalHaloData>(HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits, TheCaloTowers, TheEBRecHits, TheEERecHits,iSetup)));
   return;
 }
 

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -151,8 +151,8 @@ void
 HcalNoiseInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   // this is what we're going to actually write to the EDM
-  std::auto_ptr<HcalNoiseRBXCollection> result1(new HcalNoiseRBXCollection);
-  std::auto_ptr<HcalNoiseSummary> result2(new HcalNoiseSummary);
+  auto result1 = std::make_unique<HcalNoiseRBXCollection>();
+  auto result2 = std::make_unique<HcalNoiseSummary>();
 
   // define an empty HcalNoiseRBXArray that we're going to fill
   HcalNoiseRBXArray rbxarray;
@@ -212,8 +212,8 @@ HcalNoiseInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
   
   // put the rbxcollection and summary into the EDM
-  iEvent.put(result1);
-  iEvent.put(result2);
+  iEvent.put(std::move(result1));
+  iEvent.put(std::move(result2));
   
   return;
 }

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -92,16 +92,16 @@ namespace cms
    const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, *pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
    double sig  = metSigAlgo_->getSignificance(cov, met);
 
-   std::auto_ptr<double> significance (new double);
+   auto significance = std::make_unique<double>();
    (*significance) = sig;
    
-   std::auto_ptr<math::Error<2>::type> covPtr(new math::Error<2>::type());
+   auto covPtr = std::make_unique<math::Error<2>::type>();
    (*covPtr)(0,0) = cov(0,0);
    (*covPtr)(1,0) = cov(1,0);
    (*covPtr)(1,1) = cov(1,1);
 
-   event.put( covPtr, "METCovariance" );
-   event.put( significance, "METSignificance" );
+   event.put(std::move(covPtr), "METCovariance" );
+   event.put(std::move(significance), "METSignificance" );
 
   }
 

--- a/RecoMET/METProducers/src/MuonMET.cc
+++ b/RecoMET/METProducers/src/MuonMET.cc
@@ -54,17 +54,17 @@ namespace cms
       {
 	edm::Handle<edm::View<reco::CaloMET> > inputUncorMet;
 	iEvent.getByToken(inputCaloMETToken_, inputUncorMet);
-	std::auto_ptr<reco::CaloMETCollection> output( new reco::CaloMETCollection() );
+	auto output = std::make_unique<reco::CaloMETCollection>();
 	alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()), *(inputUncorMet.product()), &*output);
-	iEvent.put(output);
+	iEvent.put(std::move(output));
       }
     else
       {
 	edm::Handle<edm::View<reco::MET> > inputUncorMet;
 	iEvent.getByToken(inputMETToken_, inputUncorMet);
-	std::auto_ptr<reco::METCollection> output( new reco::METCollection() );
+	auto output = std::make_unique<reco::METCollection>();
 	alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()),*(inputUncorMet.product()), &*output);
-	iEvent.put(output);
+	iEvent.put(std::move(output));
       }
   }
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
@@ -108,14 +108,14 @@ void MuonMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
     }
     
-  std::auto_ptr<edm::ValueMap<reco::MuonMETCorrectionData> > valueMapMuCorrData(new edm::ValueMap<reco::MuonMETCorrectionData>());
+  auto valueMapMuCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
 
   edm::ValueMap<reco::MuonMETCorrectionData>::Filler dataFiller(*valueMapMuCorrData);
      
   dataFiller.insert(muons, muCorrDataList.begin(), muCorrDataList.end());
   dataFiller.fill();
 
-  iEvent.put(valueMapMuCorrData, "muCorrData");
+  iEvent.put(std::move(valueMapMuCorrData), "muCorrData");
     
 }
 

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -139,7 +139,7 @@ void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetu
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
   bField = theMagField.product();
 
-  std::auto_ptr<edm::ValueMap<reco::MuonMETCorrectionData> > vm_muCorrData(new edm::ValueMap<reco::MuonMETCorrectionData>());
+  auto vm_muCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
 
   std::vector<reco::MuonMETCorrectionData> v_muCorrData;
 
@@ -195,7 +195,7 @@ void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetu
   dataFiller.insert( muons_, v_muCorrData.begin(), v_muCorrData.end());
   dataFiller.fill();
     
-  iEvent.put(vm_muCorrData, "muCorrData");
+  iEvent.put(std::move(vm_muCorrData), "muCorrData");
 }
   
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFClusterMETProducer.cc
+++ b/RecoMET/METProducers/src/PFClusterMETProducer.cc
@@ -49,11 +49,10 @@ namespace cms
     CommonMETData commonMETdata = algo.run(*input.product(), globalThreshold_);
 
     PFClusterSpecificAlgo pfcluster;
-    std::auto_ptr<reco::PFClusterMETCollection> pfclustermetcoll;
-    pfclustermetcoll.reset (new reco::PFClusterMETCollection);
+    auto pfclustermetcoll = std::make_unique<reco::PFClusterMETCollection>();
 
     pfclustermetcoll->push_back(pfcluster.addInfo(input, commonMETdata));
-    event.put(pfclustermetcoll);
+    event.put(std::move(pfclustermetcoll));
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -62,11 +62,10 @@ namespace cms
 	pfmet.setSignificanceMatrix(sigcov);
       }
 
-    std::auto_ptr<reco::PFMETCollection> pfmetcoll;
-    pfmetcoll.reset(new reco::PFMETCollection);
+    auto pfmetcoll = std::make_unique<reco::PFMETCollection>();
 
     pfmetcoll->push_back(pfmet);
-    event.put(pfmetcoll);
+    event.put(std::move(pfmetcoll));
   }
 
 

--- a/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
+++ b/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
@@ -34,7 +34,7 @@ void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup&
   iEvent.getByToken(pfCandidatesToken, pfCandidates);
 
   // the output collection
-  auto_ptr<PFCandidateCollection> chargedPFCandidates( new PFCandidateCollection ) ;
+  auto chargedPFCandidates = std::make_unique<PFCandidateCollection>();
   if (pvCollection->size()>0) {
     for( unsigned i=0; i<pfCandidates->size(); i++ ) {
       const PFCandidate& pfCand = (*pfCandidates)[i];
@@ -58,7 +58,7 @@ void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup&
   }
 
 
-  iEvent.put(chargedPFCandidates); 
+  iEvent.put(std::move(chargedPFCandidates));
 
   return;
 }

--- a/RecoMET/METProducers/src/TCMETProducer.cc
+++ b/RecoMET/METProducers/src/TCMETProducer.cc
@@ -32,10 +32,9 @@ namespace cms
 //____________________________________________________________________________||
   void TCMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
   {
-    std::auto_ptr<reco::METCollection> tcmetcoll;
-    tcmetcoll.reset(new reco::METCollection);
+    auto tcmetcoll = std::make_unique<reco::METCollection>(); 
     tcmetcoll->push_back(tcMetAlgo_.CalculateTCMET(event, setup));
-    event.put(tcmetcoll);
+    event.put(std::move(tcmetcoll));
   }
 
 //____________________________________________________________________________||


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoJet and RecoMET packages. Also, std::make_unique is used when appropriate. 
