### PR TITLE
Fix low stat behavior of Qt Summaries

### DIFF
--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -211,7 +211,7 @@ namespace ecaldqm
         meanFED = meanFEDEE;
         rmsFED  = rmsFEDEE;
       }
-      float threshold( meanFED < nRMS*rmsFED ? 10. : meanFED - nRMS*rmsFED );
+      float threshold( meanFED < nRMS*rmsFED ? minHits_ : meanFED - nRMS*rmsFED );
       if ( meanFED > 1000. && Nrhentries[iDCC] < threshold )
         meQualitySummary.setBinContent( id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad );
     }

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -115,10 +115,6 @@ namespace ecaldqm
       // Initialize individual Quality Summaries
       // NOTE: These represent quality over *cumulative* statistics
       int integrity(sIntegrity ? sIntegrity->getBinContent(id) : kUnknown);
-      if(integrity == kMUnknown){
-        qItr->setBinContent(integrity);
-        if ( onlineMode_ ) continue;
-      }
       int presample(sPresample ? sPresample->getBinContent(id) : kUnknown);
       int hotcell(sHotCell ? sHotCell->getBinContent(id) : kUnknown);
       int timing(sTiming ? sTiming->getBinContent(id) : kUnknown);
@@ -136,6 +132,13 @@ namespace ecaldqm
         status = kBad;
       else if(integrity == kUnknown && presample == kUnknown && timing == kUnknown && rawdata == kUnknown && trigprim == kUnknown)
         status = kUnknown;
+      // Skip channels with no/low integrity statistics (based on digi occupancy)
+      // Normally, ensures Global Quality and Report Summaries are not filled when stats are still low / channel masked / ECAL not in run 
+      // However, problematic FEDs can sometimes drop hits so check that channel is not flagged as BAD elsewhere 
+      if( status != kBad && (integrity == kUnknown || integrity == kMUnknown)) {
+        qItr->setBinContent(integrity);
+        if ( onlineMode_ ) continue;
+      }
       qItr->setBinContent(status);
 
       // Keep running count of good/bad channels/towers
@@ -160,7 +163,7 @@ namespace ecaldqm
     } // qItr channel loop
 
     // search clusters of bad towers
-    if(onlineMode_){
+    /*if(onlineMode_){
 
       // EB
       for(int iz(-1); iz < 2; iz += 2){
@@ -220,7 +223,7 @@ namespace ecaldqm
         } // ix
       } // iz
 
-    } // cluster search
+    } // cluster search */
 
     // Fill Report Summaries
     double nBad(0.);

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -157,7 +157,7 @@ namespace ecaldqm
         meanFED = meanFEDEE;
         rmsFED  = rmsFEDEE;
       }
-      float threshold( meanFED < nRMS*rmsFED ? 10. : meanFED - nRMS*rmsFED );
+      float threshold( meanFED < nRMS*rmsFED ? minEntries_ : meanFED - nRMS*rmsFED );
       if ( meanFED > 100. && Nentries[iDCC] < threshold )
         meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
     }


### PR DESCRIPTION
In Global Summary Client, only skip Integrity=kUnknown/kMUnknown (low stat) channels if these channels are not flagged as BAD in some other Quality evaluation:
- Normally, we need to skip low stat channels for proper propagation to Report Summaries that we have too low stats too be publishing reports
- However, during data-taking, certain problems (e.g. Disabled FE) appear as low stats in Integrity but will show BAD in other Quality evaluations (e.g. Emulation Quality)
- To prevent the Global Quality from skipping over these channels, need to make sure the low stat Integrity channels are not already flagged as BAD elsewhere
- TO BE CHECKED: If this fix leads to false alarms (from individual Quality Sumaries) being propagated to Global Quality during low statistics.

Additionally, fine tune minimum occupancy threshold for FED alarms in Emulation and Hot Cell Quality Summaries:
- Should not be less than the minimum hits required to be in a channel for Client analysis
- Should prevent false alarms during cosmics

In conjunction with 81X PR https://github.com/cms-sw/cmssw/pull/15830
