### PR TITLE
restore doSiPMSmearing parameter

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -121,8 +121,9 @@ eras.run2_HE_2017.toModify( hcalSimParameters,
         photoelectronsToAnalog = cms.vdouble([57.5]*14),
         pixels = cms.int32(27370), 
         sipmDarkCurrentuA = cms.double(0.055),
-        sipmCrossTalk = cms.double(0.32)
-        )
+        sipmCrossTalk = cms.double(0.32),
+        doSiPMSmearing = cms.bool(True),
+    )
 )
 
 _newFactors = cms.vdouble(
@@ -149,13 +150,15 @@ eras.phase2_hcal.toModify( hcalSimParameters,
         photoelectronsToAnalog = cms.vdouble([57.5]*16),
         pixels = cms.int32(27370),
         sipmDarkCurrentuA = cms.double(0.055),
-        sipmCrossTalk = cms.double(0.32)
+        sipmCrossTalk = cms.double(0.32),
+        doSiPMSmearing = cms.bool(True),
     ),
     he = dict(
         samplingFactors = _newFactors,
         photoelectronsToAnalog = cms.vdouble([57.5]*len(_newFactors)),
         pixels = cms.int32(27370),
         sipmDarkCurrentuA = cms.double(0.055),
-        sipmCrossTalk = cms.double(0.32)
+        sipmCrossTalk = cms.double(0.32),
+        doSiPMSmearing = cms.bool(True),
     )
 )


### PR DESCRIPTION
The odd-looking MC pulses that have been observed for SiPMs were caused by a missing python parameter, which is restored in the appropriate Eras here (2017/Phase1 and Phase2).

Todo in later PRs:
- propagate this change also to HO (in `run2_HCAL_2017` Era, to be introduced in the upcoming workflow PR, to avoid changes in the Run2 HO MC config for previous years)
- remove all uses of `iConfig.exists()` from `HcalSimParameters` to prevent any future similar bugs

Here is a plot showing better agreement of pulse shape with the 62XSLHC version when the `doSiPMSmearing` parameter is used:
![pulse shape plot](http://www.kjplanet.com/pr/profile_curve_norm_81Xpre8_old_62XSLHC_old_81Xpre8_smear.png)

attn: @mariadalfonso, @pdudero, @abdoulline
