### PR TITLE
fixing a typo in pseudodigi

### DIFF
--- a/DataFormats/RPCDigi/interface/RPCDigi.h
+++ b/DataFormats/RPCDigi/interface/RPCDigi.h
@@ -28,7 +28,7 @@ public:
   int strip() const { return strip_; }
   int bx() const { return bx_; }
   double time() const { return time_; }
-  double coordinateX() const { return coordinateY_; }
+  double coordinateX() const { return coordinateX_; }
   double coordinateY() const { return coordinateY_; }
   bool hasTime() const { return hasTime_; }
   bool hasX() const { return hasX_; }


### PR DESCRIPTION
Fixing typographic bug  in the digi. Member function coordinateX() has never be used till now in the code. So, the bug has not caused any problems. We plane to use a new digitizer, which will use coordinateX() and we want to fix the typo.
