### PR TITLE
Using actual type name instead of typedef in plugin registration

### DIFF
--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -77,4 +77,4 @@ REGISTER_PLUGIN(HcalSiPMParametersRcd,HcalSiPMParameters);
 REGISTER_PLUGIN(HcalSiPMCharacteristicsRcd,HcalSiPMCharacteristics);
 REGISTER_PLUGIN(HcalTPParametersRcd,HcalTPParameters);
 REGISTER_PLUGIN(HcalTPChannelParametersRcd,HcalTPChannelParameters);
-REGISTER_PLUGIN(HFPhase1PMTParamsRcd,HFPhase1PMTParams);
+REGISTER_PLUGIN(HFPhase1PMTParamsRcd,HcalItemCollById<HFPhase1PMTData>);


### PR DESCRIPTION
Changed the plugin registration line to simplify type parsing for cmsDbBrowser (by request of Marco Musich)
