### PR TITLE
Use unique_ptr, not auto_ptr in RecoEgamma and RecoEcal

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -115,9 +115,9 @@ class PFECALSuperClusterAlgo {
   void update(const edm::EventSetup&);
   
   
-  std::auto_ptr<reco::SuperClusterCollection>&
+  std::unique_ptr<reco::SuperClusterCollection>&
     getEBOutputSCCollection() { return superClustersEB_; }
-  std::auto_ptr<reco::SuperClusterCollection>&
+  std::unique_ptr<reco::SuperClusterCollection>&
     getEEOutputSCCollection() { return superClustersEE_; }
 
   void loadAndSortPFClusters(const edm::Event &evt);
@@ -135,8 +135,8 @@ class PFECALSuperClusterAlgo {
   
   CalibratedClusterPtrVector _clustersEB;
   CalibratedClusterPtrVector _clustersEE;
-  std::auto_ptr<reco::SuperClusterCollection> superClustersEB_;
-  std::auto_ptr<reco::SuperClusterCollection> superClustersEE_;
+  std::unique_ptr<reco::SuperClusterCollection> superClustersEB_;
+  std::unique_ptr<reco::SuperClusterCollection> superClustersEE_;
   const reco::PFCluster::EEtoPSAssociation* EEtoPS_;
   std::shared_ptr<PFEnergyCalibration> _pfEnergyCalibration;
   clustering_type _clustype;

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -240,9 +240,9 @@ loadAndSortPFClusters(const edm::Event &iEvent) {
   }  
   
   // reset the system for running
-  superClustersEB_.reset(new reco::SuperClusterCollection);
+  superClustersEB_ = std::make_unique<reco::SuperClusterCollection>();
   _clustersEB.clear();
-  superClustersEE_.reset(new reco::SuperClusterCollection);    
+  superClustersEE_ = std::make_unique<reco::SuperClusterCollection>();
   _clustersEE.clear();  
   EEtoPS_ = &psclusters;
 

--- a/RecoEcal/EgammaClusterProducers/src/CleanAndMergeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/CleanAndMergeProducer.cc
@@ -166,10 +166,10 @@ void CleanAndMergeProducer::produce(edm::Event& evt,
         // now you have the collection of basic clusters of the SC to be remain in the
         // in the clean collection, export them to the event
         // you will need to reread them later in order to make correctly the refs to the SC
-        std::auto_ptr< reco::BasicClusterCollection> basicClusters_p(new reco::BasicClusterCollection);
+        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
         basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
         edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(basicClusters_p, bcCollection_);
+                evt.put(std::move(basicClusters_p), bcCollection_);
         if (!(bccHandle.isValid())) {
 	  edm::LogWarning("MissingInput")<<"could not get a handle on the BasicClusterCollection!" << std::endl;
 	  return;
@@ -201,13 +201,13 @@ void CleanAndMergeProducer::produce(edm::Event& evt,
 	  
         }
         // export the collection of references to the clean collection
-        std::auto_ptr< reco::SuperClusterRefVector >  scRefs_p( scRefs );
-        evt.put(scRefs_p, refScCollection_);
+        std::unique_ptr<reco::SuperClusterRefVector> scRefs_p(scRefs);
+        evt.put(std::move(scRefs_p), refScCollection_);
 
         // the collection of basic clusters is already in the event
         // the collection of uncleaned SC
-        std::auto_ptr< reco::SuperClusterCollection > superClusters_p(new reco::SuperClusterCollection);
+        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
         superClusters_p->assign(superClusters.begin(), superClusters.end());
-        evt.put(superClusters_p, scCollection_);
+        evt.put(std::move(superClusters_p), scCollection_);
         LogDebug("EcalCleaning")<< "Hybrid Clusters (Basic/Super) added to the Event! :-)";
 }

--- a/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
@@ -166,33 +166,32 @@ void CosmicClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
   }
   
   //Put clustershapes in event, but retain a Handle on them.
-  std::auto_ptr< reco::ClusterShapeCollection> clustersshapes_p(new reco::ClusterShapeCollection);
+  auto clustersshapes_p = std::make_unique<reco::ClusterShapeCollection>();
   clustersshapes_p->assign(ClusVec.begin(), ClusVec.end());
   edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle; 
   if (ecalPart == CosmicClusterAlgo::barrel) 
-    clusHandle= evt.put(clustersshapes_p, clustershapecollectionEB_);
+    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
   else
-    clusHandle= evt.put(clustersshapes_p, clustershapecollectionEE_);
+    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
   
-  // create an auto_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   
   if (ecalPart == CosmicClusterAlgo::barrel) 
-    bccHandle = evt.put(clusters_p, barrelClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
-    bccHandle = evt.put(clusters_p, endcapClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
   
   // BasicClusterShapeAssociationMap 
-  std::auto_ptr<reco::BasicClusterShapeAssociationCollection> shapeAssocs_p(
-    new reco::BasicClusterShapeAssociationCollection(bccHandle, clusHandle));
+  auto shapeAssocs_p = std::make_unique<reco::BasicClusterShapeAssociationCollection>(bccHandle, clusHandle);
 
   for (unsigned int i = 0; i < clusHandle->size(); i++){
     shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle,i),edm::Ref<reco::ClusterShapeCollection>(clusHandle,i));
   }  
-  evt.put(shapeAssocs_p,clusterShapeAssociation);
+  evt.put(std::move(shapeAssocs_p),clusterShapeAssociation);
   
   delete topology_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -101,8 +101,8 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
     }
   }
   
-  std::auto_ptr<EBDigiCollection> SEBDigiCol(new EBDigiCollection);
-  std::auto_ptr<EEDigiCollection> SEEDigiCol(new EEDigiCollection);
+  auto SEBDigiCol = std::make_unique<EBDigiCollection>();
+  auto SEEDigiCol = std::make_unique<EEDigiCollection>();
   int TotClus = saveBarrelSuperClusters.size() + saveEndcapSuperClusters.size();
 
   if (TotClus >= nclus_sel_ || meet_single_thresh){
@@ -235,7 +235,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
   //Empty collection, or full, still put in event.
   SEBDigiCol->sort();
   SEEDigiCol->sort();
-  evt.put(SEBDigiCol, selectedEcalEBDigiCollection_);
-  evt.put(SEEDigiCol, selectedEcalEEDigiCollection_);
+  evt.put(std::move(SEBDigiCol), selectedEcalEBDigiCollection_);
+  evt.put(std::move(SEEDigiCol), selectedEcalEEDigiCollection_);
   
 }

--- a/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
@@ -157,7 +157,7 @@ EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
   const reco::SuperClusterCollection *rawClusters = pRawSuperClusters.product();
    
   // Define a collection of corrected SuperClusters to put back into the event
-  std::auto_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
+  auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
   
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;
@@ -193,7 +193,7 @@ EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
     }
 
   // Put collection of corrected SuperClusters into the event
-  evt.put(corrClusters, outputCollection_);   
+  evt.put(std::move(corrClusters), outputCollection_);   
   
 }
 

--- a/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
@@ -117,13 +117,13 @@ void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   es.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
   const CaloSubdetectorGeometry *geometry_p;
-  std::auto_ptr<const CaloSubdetectorTopology> topology;
+  std::unique_ptr<const CaloSubdetectorTopology> topology;
 
   edm::ESHandle<EcalSeverityLevelAlgo> sevLv;
   es.get<EcalSeverityLevelAlgoRcd>().get(sevLv);
  
   geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  topology.reset(new EcalBarrelTopology(geoHandle));
+  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
 
   // make the Basic clusters!
   reco::BasicClusterCollection basicClusters;
@@ -132,10 +132,10 @@ void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   LogTrace("EcalClusters") << "Finished clustering - BasicClusterCollection returned to producer..." ;
 
-  // create an auto_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > basicclusters_p(new reco::BasicClusterCollection);
+  // create a unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
+  auto basicclusters_p = std::make_unique<reco::BasicClusterCollection>();
   basicclusters_p->assign(basicClusters.begin(), basicClusters.end());
-  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(basicclusters_p,basicclusterCollection_);
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(std::move(basicclusters_p),basicclusterCollection_);
 								       
   //Basic clusters now in the event.
   LogTrace("EcalClusters") << "Basic Clusters now put into event." ;
@@ -161,10 +161,10 @@ void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   reco::SuperClusterCollection superClusters = hybrid_p->makeSuperClusters(clusterPtrVector);
   LogTrace("EcalClusters") << "Found: " << superClusters.size() << " superclusters." ;
 
-  std::auto_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
+  auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   superclusters_p->assign(superClusters.begin(), superClusters.end());
   
-  evt.put(superclusters_p, superclusterCollection_);
+  evt.put(std::move(superclusters_p), superclusterCollection_);
   LogTrace("EcalClusters") << "Hybrid Clusters (Basic/Super) added to the Event! :-)" ;
 
   

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
@@ -159,9 +159,7 @@ InterestingDetIdCollectionProducer::produce (edm::Event& iEvent,
   std::sort(indexToStore.begin(),indexToStore.end());
   std::unique(indexToStore.begin(),indexToStore.end());
   
-  std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection(indexToStore) ) ;
-
  
-  iEvent.put( detIdCollection, interestingDetIdCollection_ );
+  iEvent.put(std::make_unique<DetIdCollection>(indexToStore), interestingDetIdCollection_);
 
 }

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
@@ -161,9 +161,9 @@ InterestingDetIdFromSuperClusterProducer::produce (edm::Event& iEvent,
   std::sort(indexToStore.begin(),indexToStore.end());
   std::unique(indexToStore.begin(),indexToStore.end());
   
-  std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection(indexToStore) ) ;
+  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
 
  
-  iEvent.put( detIdCollection, interestingDetIdCollection_ );
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 
 }

--- a/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
@@ -117,7 +117,7 @@ InterestingTrackEcalDetIdProducer::produce(edm::Event& iEvent, const edm::EventS
 {
    using namespace edm;
 
-   std::auto_ptr< DetIdCollection > interestingDetIdCollection( new DetIdCollection() ) ;
+   auto interestingDetIdCollection = std::make_unique<DetIdCollection>();
 
    // Get tracks from event
    edm::Handle<reco::TrackCollection> tracks;
@@ -150,7 +150,7 @@ InterestingTrackEcalDetIdProducer::produce(edm::Event& iEvent, const edm::EventS
 
    }
 
-   iEvent.put(interestingDetIdCollection);
+   iEvent.put(std::move(interestingDetIdCollection));
 
 }
 

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -150,30 +150,30 @@ void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
   }
 
   //Put clustershapes in event, but retain a Handle on them.
-  std::auto_ptr< reco::ClusterShapeCollection> clustersshapes_p(new reco::ClusterShapeCollection);
+  auto clustersshapes_p = std::make_unique<reco::ClusterShapeCollection>();
   clustersshapes_p->assign(ClusVec.begin(), ClusVec.end());
   edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle; 
   if (ecalPart == IslandClusterAlgo::barrel) 
-    clusHandle= evt.put(clustersshapes_p, clustershapecollectionEB_);
+    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
   else
-    clusHandle= evt.put(clustersshapes_p, clustershapecollectionEE_);
+    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
 
-  // create an auto_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (ecalPart == IslandClusterAlgo::barrel) 
-    bccHandle = evt.put(clusters_p, barrelClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
-    bccHandle = evt.put(clusters_p, endcapClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
 
   // BasicClusterShapeAssociationMap
-  std::auto_ptr<reco::BasicClusterShapeAssociationCollection> shapeAssocs_p(new reco::BasicClusterShapeAssociationCollection(bccHandle, clusHandle));
+  auto shapeAssocs_p = std::make_unique<reco::BasicClusterShapeAssociationCollection>(bccHandle, clusHandle);
   for (unsigned int i = 0; i < clusHandle->size(); i++){
     shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle,i),edm::Ref<reco::ClusterShapeCollection>(clusHandle,i));
   }  
-  evt.put(shapeAssocs_p,clusterShapeAssociation);
+  evt.put(std::move(shapeAssocs_p),clusterShapeAssociation);
 
   delete topology_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
@@ -145,14 +145,14 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
   reco::BasicClusterCollection clusters;
   clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, detector);
 
-  // create an auto_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::auto_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (detector == reco::CaloID::DET_ECAL_BARREL) 
-    bccHandle = evt.put(clusters_p, barrelClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
-    bccHandle = evt.put(clusters_p, endcapClusterCollection_);
+    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
   delete topology_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5SuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5SuperClusterProducer.cc
@@ -101,8 +101,7 @@ produceSuperclustersForECALPart(edm::Event& evt,
   getClusterPtrVector(evt, clustersToken, clusterPtrVector_p);
 
   // run the brem recovery and get the SC collection
-  std::auto_ptr<reco::SuperClusterCollection> 
-    superclusters_ap(new reco::SuperClusterCollection(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p)));
+  auto superclusters_ap = std::make_unique<reco::SuperClusterCollection>(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p));
 
   // count the total energy and the number of superclusters
   reco::SuperClusterCollection::iterator it;
@@ -113,7 +112,7 @@ produceSuperclustersForECALPart(edm::Event& evt,
     }
 
   // put the SC collection in the event
-  evt.put(superclusters_ap, superclusterCollection);
+  evt.put(std::move(superclusters_ap), superclusterCollection);
 
   delete clusterPtrVector_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -184,9 +184,9 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
   superClusterAlgo_.run();
   
   //build collections of output CaloClusters from the used PFClusters
-  std::auto_ptr<reco::CaloClusterCollection> caloClustersEB(new reco::CaloClusterCollection);
-  std::auto_ptr<reco::CaloClusterCollection> caloClustersEE(new reco::CaloClusterCollection);
-  std::auto_ptr<reco::CaloClusterCollection> caloClustersES(new reco::CaloClusterCollection);
+  auto caloClustersEB = std::make_unique<reco::CaloClusterCollection>();
+  auto caloClustersEE = std::make_unique<reco::CaloClusterCollection>();
+  auto caloClustersES = std::make_unique<reco::CaloClusterCollection>();
   
   std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapEB; //maps of pfclusters to caloclusters 
   std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapEE;
@@ -235,8 +235,8 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
   }
   
   //create ValueMaps from output CaloClusters back to original PFClusters
-  std::auto_ptr<edm::ValueMap<reco::CaloClusterPtr> > pfClusterAssociationEBEE(new edm::ValueMap<reco::CaloClusterPtr>);
-  std::auto_ptr<edm::ValueMap<reco::CaloClusterPtr> > pfClusterAssociationES(new edm::ValueMap<reco::CaloClusterPtr>);    
+  auto pfClusterAssociationEBEE = std::make_unique<edm::ValueMap<reco::CaloClusterPtr>>();
+  auto pfClusterAssociationES = std::make_unique<edm::ValueMap<reco::CaloClusterPtr>>();    
   
   //vectors to fill ValueMaps
   std::vector<reco::CaloClusterPtr> clusptrsEB(caloClustersEB->size());
@@ -244,9 +244,9 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
   std::vector<reco::CaloClusterPtr> clusptrsES(caloClustersES->size());  
   
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEB = iEvent.put(caloClustersEB,PFBasicClusterCollectionBarrel_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEE = iEvent.put(caloClustersEE,PFBasicClusterCollectionEndcap_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleES = iEvent.put(caloClustersES,PFBasicClusterCollectionPreshower_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEB = iEvent.put(std::move(caloClustersEB),PFBasicClusterCollectionBarrel_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEE = iEvent.put(std::move(caloClustersEE),PFBasicClusterCollectionEndcap_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleES = iEvent.put(std::move(caloClustersES),PFBasicClusterCollectionPreshower_);
     
   //relink superclusters to output caloclusters and fill vectors for ValueMaps
   for( auto& ebsc : *(superClusterAlgo_.getEBOutputSCCollection()) ) {
@@ -296,11 +296,11 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
   fillerES.fill();  
 
   //store in the event
-  iEvent.put(pfClusterAssociationEBEE,PFClusterAssociationEBEE_);
-  iEvent.put(pfClusterAssociationES,PFClusterAssociationES_);
-  iEvent.put(superClusterAlgo_.getEBOutputSCCollection(),
+  iEvent.put(std::move(pfClusterAssociationEBEE),PFClusterAssociationEBEE_);
+  iEvent.put(std::move(pfClusterAssociationES),PFClusterAssociationES_);
+  iEvent.put(std::move(superClusterAlgo_.getEBOutputSCCollection()),
 	     PFSuperClusterCollectionBarrel_);
-  iEvent.put(superClusterAlgo_.getEEOutputSCCollection(), 
+  iEvent.put(std::move(superClusterAlgo_.getEEOutputSCCollection()), 
 	     PFSuperClusterCollectionEndcapWithPreshower_);
 }
 

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterProducer.cc
@@ -98,11 +98,11 @@ void PreshowerClusterProducer::produce(edm::Event& evt, const edm::EventSetup& e
   const CaloSubdetectorGeometry *geometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   const CaloSubdetectorGeometry *& geometry_p = geometry;
   
-  // create auto_ptr to a PreshowerClusterCollection
-  std::auto_ptr< reco::PreshowerClusterCollection > clusters_p1(new reco::PreshowerClusterCollection);
-  std::auto_ptr< reco::PreshowerClusterCollection > clusters_p2(new reco::PreshowerClusterCollection);
+  // create unique_ptr to a PreshowerClusterCollection
+  auto clusters_p1 = std::make_unique<reco::PreshowerClusterCollection>();
+  auto clusters_p2 = std::make_unique<reco::PreshowerClusterCollection>();
   // create new collection of corrected super clusters
-  std::auto_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
+  auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   
   CaloSubdetectorTopology * topology_p=0;
   if (geometry)
@@ -247,13 +247,13 @@ void PreshowerClusterProducer::produce(edm::Event& evt, const edm::EventSetup& e
   clusters_p1->assign(clusters1.begin(), clusters1.end());
   clusters_p2->assign(clusters2.begin(), clusters2.end());
   // put collection of preshower clusters to the event
-  evt.put( clusters_p1, preshClusterCollectionX_ );
-  evt.put( clusters_p2, preshClusterCollectionY_ );
+  evt.put(std::move(clusters_p1), preshClusterCollectionX_);
+  evt.put(std::move(clusters_p2), preshClusterCollectionY_);
   LogTrace("EcalClusters") << "Preshower clusters added to the event" ;
   
   // put collection of corrected super clusters to the event
   superclusters_p->assign(new_SC.begin(), new_SC.end());
-  evt.put(superclusters_p, assocSClusterCollection_);
+  evt.put(std::move(superclusters_p), assocSClusterCollection_);
   LogTrace("EcalClusters") << "Corrected SClusters added to the event" ;
   
   if (topology_p)

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
@@ -91,9 +91,9 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
   const CaloSubdetectorGeometry *& geometry_p = geometry;
 
 
-  // create an auto_ptr to a PreshowerClusterShapeCollection
-  std::auto_ptr< reco::PreshowerClusterShapeCollection > ps_cl_for_pi0_disc_x(new reco::PreshowerClusterShapeCollection);
-  std::auto_ptr< reco::PreshowerClusterShapeCollection > ps_cl_for_pi0_disc_y(new reco::PreshowerClusterShapeCollection);
+  // create a unique_ptr to a PreshowerClusterShapeCollection
+  auto ps_cl_for_pi0_disc_x = std::make_unique<reco::PreshowerClusterShapeCollection>();
+  auto ps_cl_for_pi0_disc_y = std::make_unique<reco::PreshowerClusterShapeCollection>();
 
 
   CaloSubdetectorTopology* topology_p=0;
@@ -186,8 +186,8 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
   ps_cl_for_pi0_disc_x->assign(ps_cl_x.begin(), ps_cl_x.end());
   ps_cl_for_pi0_disc_y->assign(ps_cl_y.begin(), ps_cl_y.end());
   
-  evt.put(ps_cl_for_pi0_disc_x, PreshowerClusterShapeCollectionX_);
-  evt.put(ps_cl_for_pi0_disc_y, PreshowerClusterShapeCollectionY_);  
+  evt.put(std::move(ps_cl_for_pi0_disc_x), PreshowerClusterShapeCollectionX_);
+  evt.put(std::move(ps_cl_for_pi0_disc_y), PreshowerClusterShapeCollectionY_);  
   LogTrace("EcalClusters") << "PreshowerClusterShapeCollection added to the event" ;
   
   if (topology_p)

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
@@ -90,11 +90,11 @@ void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup
   const CaloSubdetectorGeometry *geometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   const CaloSubdetectorGeometry *& geometry_p = geometry;
   
-  // create auto_ptr to a PreshowerClusterCollection
-  std::auto_ptr< reco::PreshowerClusterCollection > clusters_p1(new reco::PreshowerClusterCollection);
-  std::auto_ptr< reco::PreshowerClusterCollection > clusters_p2(new reco::PreshowerClusterCollection);
+  // create unique_ptr to a PreshowerClusterCollection
+  auto clusters_p1 = std::make_unique<reco::PreshowerClusterCollection>();
+  auto clusters_p2 = std::make_unique<reco::PreshowerClusterCollection>();
   // create new collection of corrected super clusters
-  std::auto_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
+  auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   
   CaloSubdetectorTopology * topology_p=0;
   if (geometry)
@@ -265,13 +265,13 @@ void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup
   clusters_p1->assign(clusters1.begin(), clusters1.end());
   clusters_p2->assign(clusters2.begin(), clusters2.end());
   // put collection of preshower clusters to the event
-  evt.put( clusters_p1, preshClusterCollectionX_ );
-  evt.put( clusters_p2, preshClusterCollectionY_ );
+  evt.put(std::move(clusters_p1), preshClusterCollectionX_ );
+  evt.put(std::move(clusters_p2), preshClusterCollectionY_ );
   LogTrace("EcalClusters") << "Preshower clusters added to the event" ;
   
   // put collection of corrected super clusters to the event
   superclusters_p->assign(new_SC.begin(), new_SC.end());
-  evt.put(superclusters_p, assocSClusterCollection_);
+  evt.put(std::move(superclusters_p), assocSClusterCollection_);
   LogTrace("EcalClusters") << "Corrected SClusters added to the event" ;
   
   if (topology_p) delete topology_p;

--- a/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
+++ b/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
@@ -50,8 +50,8 @@ void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup
   int nTot = hit_collection->size();
   int nRed = 0;
 
-  // create an auto_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
-  std::auto_ptr< EcalRecHitCollection > redCollection(new EcalRecHitCollection);
+  // create a unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
+  auto redCollection = std::make_unique<EcalRecHitCollection>();
 
   for(EcalRecHitCollection::const_iterator it = hit_collection->begin(); it != hit_collection->end(); ++it) {
     //std::cout << *it << std::endl;
@@ -64,6 +64,6 @@ void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup
 
   edm::LogInfo("")<< "total # hits: " << nTot << "  #hits with E > " << noiseEnergyThreshold_ << " GeV  and  chi2 < " <<  noiseChi2Threshold_ << " : " << nRed << std::endl;
 
-  evt.put(redCollection, reducedHitCollection_);
+  evt.put(std::move(redCollection), reducedHitCollection_);
 
 }

--- a/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
@@ -72,7 +72,7 @@ void ReducedESRecHitCollectionProducer::produce(edm::Event & e, const edm::Event
   edm::Handle<ESRecHitCollection> ESRecHits_;
   e.getByToken(InputRecHitES_, ESRecHits_);
   
-  std::auto_ptr<EcalRecHitCollection> output(new EcalRecHitCollection);
+  auto output = std::make_unique<EcalRecHitCollection>();
 
   edm::Handle<reco::SuperClusterCollection> pEndcapSuperClusters;
   e.getByToken(InputSuperClusterEE_, pEndcapSuperClusters);
@@ -161,7 +161,7 @@ void ReducedESRecHitCollectionProducer::produce(edm::Event & e, const edm::Event
   }
   collectedIds_.clear();
 
-  e.put(output, OutputLabelES_);
+  e.put(std::move(output), OutputLabelES_);
 
 }
 

--- a/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
@@ -100,7 +100,7 @@ ReducedRecHitCollectionProducer::produce (edm::Event& iEvent,
      }
    
    //Create empty output collections
-   std::auto_ptr< EcalRecHitCollection > miniRecHitCollection (new EcalRecHitCollection) ;
+   auto miniRecHitCollection  = std::make_unique<EcalRecHitCollection>();
    
    for (unsigned int iCry=0;iCry<xtalsToStore.size();iCry++)
      {
@@ -113,5 +113,5 @@ ReducedRecHitCollectionProducer::produce (edm::Event& iEvent,
 	std::unique(xtalsToStore.begin(), xtalsToStore.end());   
    
    //   std::cout << "New Collection " << reducedHitsCollection_ << " size is " << miniRecHitCollection->size() << " original is " << recHitsHandle->size() << std::endl;
-   iEvent.put( miniRecHitCollection,reducedHitsCollection_ );
+   iEvent.put(std::move(miniRecHitCollection),reducedHitsCollection_ );
 }

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -121,10 +121,10 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt,
         }
         //
         // now export the basic clusters into the event and get them back
-        std::auto_ptr< reco::BasicClusterCollection> basicClusters_p(new reco::BasicClusterCollection);
+        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
         basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
         edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(basicClusters_p, bcCollection_);
+                evt.put(std::move(basicClusters_p), bcCollection_);
         if (!(bccHandle.isValid())) {
 
                 edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
@@ -181,11 +181,10 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt,
                 superClusters.push_back(newSC);
         }
 
-        std::auto_ptr< reco::SuperClusterCollection> 
-                superClusters_p(new reco::SuperClusterCollection);
+        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
         superClusters_p->assign(superClusters.begin(), superClusters.end());
 
-        evt.put(superClusters_p, scCollection_);
+        evt.put(std::move(superClusters_p), scCollection_);
 
         LogTrace("EcalCleaning")<<"Clusters (Basic/Super) added to the Event! :-)";
 

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -274,11 +274,10 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt,
 			      <<  " uncleaned SC: "   << uncleanSize ;
         //
         // export the clusters to the event from the clean clusters
-        std::auto_ptr< reco::BasicClusterCollection> 
-                basicClusters_p(new reco::BasicClusterCollection);
+        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
         basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
         edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(basicClusters_p, bcCollection_);
+                evt.put(std::move(basicClusters_p), bcCollection_);
         if (!(bccHandle.isValid())) {
               
 	  edm::LogWarning("MissingInput")<< "could not handle the new BasicClusters!";
@@ -289,12 +288,11 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt,
 	LogTrace("UnifiedSC")<< "Got the BasicClusters from the event again" ;
         //
         // export the clusters to the event: from the unclean only clusters
-        std::auto_ptr< reco::BasicClusterCollection> 
-                basicClustersUncleanOnly_p(new reco::BasicClusterCollection);
+        auto basicClustersUncleanOnly_p = std::make_unique<reco::BasicClusterCollection>();
         basicClustersUncleanOnly_p->assign(basicClustersUncleanOnly.begin(), 
                                            basicClustersUncleanOnly.end());
         edm::OrphanHandle<reco::BasicClusterCollection> bccHandleUncleanOnly =  
-                evt.put(basicClustersUncleanOnly_p, bcCollectionUncleanOnly_);
+                evt.put(std::move(basicClustersUncleanOnly_p), bcCollectionUncleanOnly_);
         if (!(bccHandleUncleanOnly.isValid())) {
 
 	  edm::LogWarning("MissingInput")<< "could not handle the new BasicClusters (Unclean Only)!" ;
@@ -398,20 +396,18 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt,
 
 	LogTrace("UnifiedSC")<< "New SC collection was created";
 
-        std::auto_ptr< reco::SuperClusterCollection> 
-                superClusters_p(new reco::SuperClusterCollection);
+        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
         superClusters_p->assign(superClusters.begin(), superClusters.end());
 
-        evt.put(superClusters_p, scCollection_);
+        evt.put(std::move(superClusters_p), scCollection_);
 	
 	LogTrace("UnifiedSC") << "Clusters (Basic/Super) added to the Event! :-)";
 
-        std::auto_ptr< reco::SuperClusterCollection> 
-                superClustersUncleanOnly_p(new reco::SuperClusterCollection);
+        auto superClustersUncleanOnly_p = std::make_unique<reco::SuperClusterCollection>();
         superClustersUncleanOnly_p->assign(superClustersUncleanOnly.begin(), 
                                            superClustersUncleanOnly.end());
 
-        evt.put(superClustersUncleanOnly_p, scCollectionUncleanOnly_);
+        evt.put(std::move(superClustersUncleanOnly_p), scCollectionUncleanOnly_);
 
         // ----- debugging ----------
         // print the new collection SC quantities

--- a/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
@@ -87,7 +87,7 @@ SeedFilter::~SeedFilter() {
 void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::SuperClusterRef &scRef, TrajectorySeedCollection *output) {
 
   setup.get<IdealMagneticFieldRecord>().get(theMagField);
-  std::auto_ptr<TrajectorySeedCollection> seedColl(new TrajectorySeedCollection());
+  auto seedColl = std::make_unique<TrajectorySeedCollection>();
 
   GlobalPoint vtxPos;
   double deltaZVertex;

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -206,7 +206,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
   }
 
   // store the accumulated result
-  std::auto_ptr<ElectronSeedCollection> pSeeds(seeds) ;
+  std::unique_ptr<ElectronSeedCollection> pSeeds(seeds);
   ElectronSeedCollection::iterator is ;
   for ( is=pSeeds->begin() ; is!=pSeeds->end() ; is++ ) {
     edm::RefToBase<CaloCluster> caloCluster = is->caloCluster() ;
@@ -218,7 +218,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
       << " and cluster energy " << superCluster->energy()
       << " PID "<<superCluster.id() ;
   }
-  e.put(pSeeds) ;
+  e.put(std::move(pSeeds));
   if (fromTrackerSeeds_ && prefilteredSeeds_) delete theInitialSeedColl;
  }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronCoreProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronCoreProducer.cc
@@ -44,13 +44,13 @@ void GEDGsfElectronCoreProducer::produce( edm::Event & event, const edm::EventSe
   event.getByToken(gedEMUnbiasedTag_,gedEMUnbiasedH_);
 
   // output
-  std::auto_ptr<GsfElectronCoreCollection> electrons(new GsfElectronCoreCollection) ;
+  auto electrons = std::make_unique<GsfElectronCoreCollection>();
 
   const PFCandidateCollection * pfCandidateCollection = gedEMUnbiasedH_.product();
   for ( unsigned int i=0 ; i<pfCandidateCollection->size() ; ++i )
            produceElectronCore((*pfCandidateCollection)[i],electrons.get()) ;
     
-  event.put(electrons) ;
+  event.put(std::move(electrons));
  }
 
 void GEDGsfElectronCoreProducer::produceElectronCore( const reco::PFCandidate & pfCandidate, reco::GsfElectronCoreCollection * electrons )

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -57,7 +57,7 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
  {
    
    // Output collection
-   std::auto_ptr<reco::GsfElectronCollection> outputElectrons_p(new reco::GsfElectronCollection);
+   auto outputElectrons_p = std::make_unique<reco::GsfElectronCollection>();
    
    if( gedRegression_ ) {
      gedRegression_->setEvent(event);
@@ -128,7 +128,7 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
      outputElectrons_p->push_back(newElectron);
    }
    
-   event.put(outputElectrons_p,outputCollectionLabel_);
+   event.put(std::move(outputElectrons_p),outputCollectionLabel_);
  }
 
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -51,11 +51,11 @@ void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup 
   fillEvent(event) ;
 
   // ValueMap
-  std::auto_ptr<edm::ValueMap<reco::GsfElectronRef> > valMap_p(new edm::ValueMap<reco::GsfElectronRef>);
+  auto valMap_p = std::make_unique<edm::ValueMap<reco::GsfElectronRef>>();
   edm::ValueMap<reco::GsfElectronRef>::Filler valMapFiller(*valMap_p);
   fillGsfElectronValueMap(event,valMapFiller);
   valMapFiller.fill();
-  event.put(valMap_p,outputValueMapLabel_);  
+  event.put(std::move(valMap_p),outputValueMapLabel_);  
   // Done with the ValueMap
 
   endEvent() ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -429,9 +429,9 @@ void GsfElectronBaseProducer::fillEvent( edm::Event & event )
     algo_->displayInternalElectrons("GsfElectronAlgo Info (after amb. solving)") ;
    }
   // final filling
-  std::auto_ptr<GsfElectronCollection> finalCollection( new GsfElectronCollection ) ;
+  auto finalCollection = std::make_unique<GsfElectronCollection>();
   algo_->copyElectrons(*finalCollection) ;
-  orphanHandle_ = event.put(finalCollection) ;
+  orphanHandle_ = event.put(std::move(finalCollection));
 }
 
 void GsfElectronBaseProducer::endEvent()

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -37,7 +37,7 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
 
     static std::unique_ptr<gsfAlgoHelpers::HeavyObjectCache> 
     initializeGlobalCache( const edm::ParameterSet& conf ) {
-       return std::unique_ptr<gsfAlgoHelpers::HeavyObjectCache>(new gsfAlgoHelpers::HeavyObjectCache(conf));
+       return std::make_unique<gsfAlgoHelpers::HeavyObjectCache>(conf);
    }
   
   static void globalEndJob(gsfAlgoHelpers::HeavyObjectCache const* ) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreEcalDrivenProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreEcalDrivenProducer.cc
@@ -34,7 +34,7 @@ void GsfElectronCoreEcalDrivenProducer::produce( edm::Event & event, const edm::
   GsfElectronCoreBaseProducer::initEvent(event,setup) ;
 
   // output
-  std::auto_ptr<GsfElectronCoreCollection> electrons(new GsfElectronCoreCollection) ;
+  auto electrons = std::make_unique<GsfElectronCoreCollection>();
 
   // loop on ecal driven tracks
   if (useGsfPfRecTracks_)
@@ -59,7 +59,7 @@ void GsfElectronCoreEcalDrivenProducer::produce( edm::Event & event, const edm::
      }
    }
 
-  event.put(electrons) ;
+  event.put(std::move(electrons));
  }
 
 void GsfElectronCoreEcalDrivenProducer::produceEcalDrivenCore( const GsfTrackRef & gsfTrackRef, GsfElectronCoreCollection * electrons )

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreProducer.cc
@@ -114,7 +114,7 @@ void GsfElectronCoreProducer::produce( edm::Event & event, const edm::EventSetup
    }
 
   // store
-  std::auto_ptr<GsfElectronCoreCollection> collection(new GsfElectronCoreCollection) ;
+  auto collection = std::make_unique<GsfElectronCoreCollection>();
   for ( eleCore = electrons.begin() ; eleCore != electrons.end() ; eleCore++ )
    {
     if ((*eleCore)->superCluster().isNull())
@@ -123,7 +123,7 @@ void GsfElectronCoreProducer::produce( edm::Event & event, const edm::EventSetup
      { collection->push_back(**eleCore) ; }
     delete (*eleCore) ;
    }
-  event.put(collection) ;
+  event.put(std::move(collection));
  }
 
 void GsfElectronCoreProducer::produceTrackerDrivenCore( const GsfTrackRef & gsfTrackRef, std::list<GsfElectronCore *> & electrons )

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.cc
@@ -72,7 +72,7 @@ GsfElectronFull5x5Filler::~GsfElectronFull5x5Filler()
 // ------------ method called to produce the data  ------------
 void GsfElectronFull5x5Filler::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-   std::auto_ptr<reco::GsfElectronCollection> out(new reco::GsfElectronCollection);
+   auto out = std::make_unique<reco::GsfElectronCollection>();
    
    edm::Handle<reco::GsfElectronCollection> eles;
    event.getByToken(_source,eles);
@@ -88,7 +88,7 @@ void GsfElectronFull5x5Filler::produce( edm::Event & event, const edm::EventSetu
      out->push_back(temp);
    }
    
-   event.put(out);
+   event.put(std::move(out));
  }
 
 void GsfElectronFull5x5Filler::beginLuminosityBlock(edm::LuminosityBlock const& lb, 

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
@@ -82,7 +82,7 @@ SiStripElectronAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iS
    }
 
    // Output the high-level Electrons
-   std::auto_ptr<reco::ElectronCollection> output(new reco::ElectronCollection);
+   auto output = std::make_unique<reco::ElectronCollection>();
 
    LogDebug("SiStripElectronAssociator") << " About to loop over tracks " << std::endl ;
    LogDebug("SiStripElectronAssociator") << " Number of tracks in Associator " << tracks.product()->size() ;
@@ -200,5 +200,5 @@ SiStripElectronAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iS
    
    LogDebug("SiStripElectronAssociator") << " Number of SiStripElectrons returned with a good fit " 
                                          << countSiElFit << "\n"<<  std::endl ;
-   iEvent.put(output, electronsLabel_.label());
+   iEvent.put(std::move(output), electronsLabel_.label());
 }

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronProducer.cc
@@ -137,8 +137,8 @@ SiStripElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    algo_p->prepareEvent(trackerHandle, rphiHitsHandle, stereoHitsHandle, matchedHitsHandle, magneticFieldHandle);
 
    // Prepare the output electron candidates and clouds to be filled
-   std::auto_ptr<reco::SiStripElectronCollection> electronOut(new reco::SiStripElectronCollection);
-   std::auto_ptr<TrackCandidateCollection> trackCandidateOut(new TrackCandidateCollection);
+   auto electronOut = std::make_unique<reco::SiStripElectronCollection>();
+   auto trackCandidateOut = std::make_unique<TrackCandidateCollection>();
 
    //Retrieve tracker topology from geometry
    edm::ESHandle<TrackerTopology> tTopoHand;
@@ -174,8 +174,8 @@ SiStripElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    LogDebug("SiStripElectronProducer") << str.str();
 
    // Put the electron candidates and the tracking trajectories into the event
-   iEvent.put(electronOut, siStripElectronsLabel_);
-   iEvent.put(trackCandidateOut, trackCandidatesLabel_);
+   iEvent.put(std::move(electronOut), siStripElectronsLabel_);
+   iEvent.put(std::move(trackCandidateOut), trackCandidatesLabel_);
 }
 
 //

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronSeedProducer.cc
@@ -80,7 +80,7 @@ void SiStripElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& 
   matcher_->setupES(iSetup);
 
   ElectronSeedCollection *seeds = new ElectronSeedCollection;
-  std::auto_ptr<ElectronSeedCollection> pSeeds;
+  std::unique_ptr<ElectronSeedCollection> pSeeds;
 
   // do both barrel and endcap instances
   for (unsigned int i=0; i<2; i++) {
@@ -94,9 +94,9 @@ void SiStripElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& 
 
   }
 
-  pSeeds = std::auto_ptr<ElectronSeedCollection>(seeds);
+  pSeeds = std::unique_ptr<ElectronSeedCollection>(seeds);
 
-  e.put(pSeeds);
+  e.put(std::move(pSeeds));
 
 }
 

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
@@ -36,8 +36,8 @@ void HFEMClusterProducer::produce(edm::Event & e, edm::EventSetup const& iSetup)
   iSetup.get<CaloGeometryRecord>().get(geometry);
   
   // create return data
-  std::auto_ptr<reco::HFEMClusterShapeCollection> retdata1(new HFEMClusterShapeCollection());
-  std::auto_ptr<reco::SuperClusterCollection> retdata2(new SuperClusterCollection());
+  auto retdata1 = std::make_unique<HFEMClusterShapeCollection>();
+  auto retdata2 = std::make_unique<SuperClusterCollection>();
 
   algo_.isMC(!e.isRealData());
  
@@ -47,17 +47,16 @@ void HFEMClusterProducer::produce(edm::Event & e, edm::EventSetup const& iSetup)
   edm::OrphanHandle<reco::HFEMClusterShapeCollection> ShapeHandle;
 
   // put the results
-  ShapeHandle=e.put(retdata1);
-  SupHandle=e.put(retdata2);
+  ShapeHandle=e.put(std::move(retdata1));
+  SupHandle=e.put(std::move(retdata2));
 
-  std::auto_ptr<reco::HFEMClusterShapeAssociationCollection> retdata3(
-    new HFEMClusterShapeAssociationCollection(SupHandle, ShapeHandle));
+  auto retdata3 = std::make_unique<HFEMClusterShapeAssociationCollection>(SupHandle, ShapeHandle);
 
   for (unsigned int i=0; i < ShapeHandle->size();i++){
     retdata3->insert(edm::Ref<reco::SuperClusterCollection>(SupHandle,i),edm::Ref<reco::HFEMClusterShapeCollection>(ShapeHandle,i));
   }
 
 
-  e.put(retdata3);
+  e.put(std::move(retdata3));
 
 }

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
@@ -87,12 +87,12 @@ void HFRecoEcalCandidateProducer::produce(edm::Event & e, edm::EventSetup const&
   
 
   // create return data
-  std::auto_ptr<reco::RecoEcalCandidateCollection> retdata1(new reco::RecoEcalCandidateCollection());
+  auto retdata1 = std::make_unique<reco::RecoEcalCandidateCollection>();
 
   
   algo_.produce(super_clus,*hf_assoc,*retdata1,nvertex);
  
-  e.put(retdata1);
+  e.put(std::move(retdata1));
 
 }
 

--- a/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.cc
@@ -61,12 +61,12 @@ void HLTHFRecoEcalCandidateProducer::produce(edm::Event & e, edm::EventSetup con
   int nvertex = 1;
    
   // create return data
-  std::auto_ptr<reco::RecoEcalCandidateCollection> retdata1(new reco::RecoEcalCandidateCollection());
+  auto retdata1 = std::make_unique<reco::RecoEcalCandidateCollection>();
 
   
   algo_.produce(super_clus,*hf_assoc,*retdata1,nvertex);
  
-  e.put(retdata1);
+  e.put(std::move(retdata1));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
@@ -123,7 +123,7 @@ class HLTCaloObjInRegionsProducer : public edm::stream::EDProducer<> {
 
  private:
   EtaPhiRegionDataBase* createEtaPhiRegionData(const std::string&,const edm::ParameterSet&,edm::ConsumesCollector &&); //calling function owns this
-  static std::auto_ptr<CaloObjCollType> 
+  static std::unique_ptr<CaloObjCollType> 
   makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 		   const edm::ESHandle<CaloGeometry>& caloGeomHandle,
 		   const std::vector<EtaPhiRegion>& regions);
@@ -210,19 +210,19 @@ void HLTCaloObjInRegionsProducer<CaloObjType,CaloObjCollType>::produce(edm::Even
       continue;
     }
     auto outputColl = makeFilteredColl(inputColl,caloGeomHandle,regions);
-    event.put(outputColl,outputProductNames_[inputCollNr]);
+    event.put(std::move(outputColl),outputProductNames_[inputCollNr]);
   }
 }
 
 template<typename CaloObjType,typename CaloObjCollType>
-std::auto_ptr<CaloObjCollType> 
+std::unique_ptr<CaloObjCollType> 
 HLTCaloObjInRegionsProducer<CaloObjType,CaloObjCollType>::
 makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 		 const edm::ESHandle<CaloGeometry>& caloGeomHandle,
 		 const std::vector<EtaPhiRegion>& regions)
 {  
   
-  std::auto_ptr<CaloObjCollType> outputColl(new CaloObjCollType);
+  auto outputColl = std::make_unique<CaloObjCollType>();
   if(!inputColl->empty()){
     const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(inputColl->front().id());
     if(!regions.empty()){

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
@@ -217,7 +217,7 @@ void HLTRecHitInAllL1RegionsProducer<RecHitType>::produce(edm::Event& event, con
       continue;
     }
 
-    std::unique_ptr<RecHitCollectionType> filteredRecHits(new RecHitCollectionType);
+    auto filteredRecHits = std::make_unique<RecHitCollectionType>();
       
     if(!recHits->empty()){
       const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(recHits->front().id());

--- a/RecoEgamma/EgammaHLTProducers/src/ESListOfFEDSProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/ESListOfFEDSProducer.cc
@@ -136,7 +136,7 @@ void ESListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSetup
     first_ = false;
   }                                                                                              
   
-  std::unique_ptr<ESListOfFEDS> productAddress(new ESListOfFEDS);
+  auto productAddress = std::make_unique<ESListOfFEDS>();
   std::vector<int> feds;		// the list of Ecal FEDS produced 
   
   ///

--- a/RecoEgamma/EgammaHLTProducers/src/ESRecHitsMerger.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/ESRecHitsMerger.cc
@@ -72,7 +72,7 @@ void ESRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
  std::vector< edm::Handle<ESRecHitCollection> > EcalRecHits_done;
  e.getManyByType(EcalRecHits_done);
  
- std::unique_ptr<EcalRecHitCollection> ESMergedRecHits(new EcalRecHitCollection);
+ auto ESMergedRecHits = std::make_unique<EcalRecHitCollection>();
  
  
  unsigned int nColl = EcalRecHits_done.size();

--- a/RecoEgamma/EgammaHLTProducers/src/EcalListOfFEDSProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EcalListOfFEDSProducer.cc
@@ -133,7 +133,7 @@ void EcalListOfFEDSProducer::produce(edm::Event & e, const edm::EventSetup& iSet
     first_ = false;
   }                                                                                              
   
-  std::unique_ptr<EcalListOfFEDS> productAddress(new EcalListOfFEDS);
+  auto productAddress = std::make_unique<EcalListOfFEDS>();
   
   std::vector<int> feds;		// the list of FEDS produced by this module
   

--- a/RecoEgamma/EgammaHLTProducers/src/EcalRecHitsMerger.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EcalRecHitsMerger.cc
@@ -86,8 +86,8 @@ void EcalRecHitsMerger::produce(edm::Event & e, const edm::EventSetup& iSetup){
  std::vector< edm::Handle<EcalRecHitCollection> > EcalRecHits_done;
  e.getManyByType(EcalRecHits_done);
 
- std::unique_ptr<EcalRecHitCollection> EBMergedRecHits(new EcalRecHitCollection);
- std::unique_ptr<EcalRecHitCollection> EEMergedRecHits(new EcalRecHitCollection);
+ auto EBMergedRecHits = std::make_unique<EcalRecHitCollection>();
+ auto EEMergedRecHits = std::make_unique<EcalRecHitCollection>();
 
  unsigned int nColl = EcalRecHits_done.size();
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTBcHcalIsolationProducersRegional.cc
@@ -161,6 +161,5 @@ void EgammaHLTBcHcalIsolationProducersRegional::produce(edm::Event& iEvent, cons
     isoMap.insert(recoEcalCandRef, isol);
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCaloTowerProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCaloTowerProducer.cc
@@ -57,7 +57,7 @@ void EgammaHLTCaloTowerProducer::produce(edm::StreamID, edm::Event & evt, edm::E
   evt.getByToken(l1isoseeds_, emIsolColl);
   edm::Handle<edm::View<reco::Candidate> > emNonIsolColl;
   evt.getByToken(l1nonisoseeds_, emNonIsolColl);
-  std::unique_ptr<CaloTowerCollection> cands(new CaloTowerCollection);
+  auto cands = std::make_unique<CaloTowerCollection>();
   cands->reserve(caloTowers->size());
 
   for (unsigned idx = 0; idx < caloTowers->size(); idx++) {

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTClusterShapeProducer.cc
@@ -75,10 +75,6 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid, edm::Event& iEven
   
   }
 
-  
-
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> clushMap(new reco::RecoEcalCandidateIsolationMap(clshMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> clush5x5Map(new reco::RecoEcalCandidateIsolationMap(clsh5x5Map));
-  iEvent.put(std::move(clushMap));
-  iEvent.put(std::move(clush5x5Map),"sigmaIEtaIEta5x5");
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clshMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clsh5x5Map),"sigmaIEtaIEta5x5");
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCombinedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTCombinedIsolationProducer.cc
@@ -78,8 +78,7 @@ EgammaHLTCombinedIsolationProducer::produce(edm::Event& iEvent, const edm::Event
     
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> Map(new reco::RecoEcalCandidateIsolationMap(TotalIsolMap));
-  iEvent.put(std::move(Map));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(TotalIsolMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalIsolationProducersRegional.cc
@@ -101,7 +101,6 @@ void EgammaHLTEcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
 
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalRecIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTEcalRecIsolationProducer.cc
@@ -176,8 +176,7 @@ void EgammaHLTEcalRecIsolationProducer::produce(edm::Event& iEvent, const edm::E
     isoMap.insert(recoecalcandref, isol);
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronCombinedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronCombinedIsolationProducer.cc
@@ -97,8 +97,7 @@ void EgammaHLTElectronCombinedIsolationProducer::produce(edm::Event& iEvent, con
     
   }
 
-  std::unique_ptr<reco::ElectronIsolationMap> isolMap(new reco::ElectronIsolationMap(TotalIsolMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::ElectronIsolationMap>(TotalIsolMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
@@ -103,18 +103,14 @@ void EgammaHLTElectronDetaDphiProducer::produce(edm::Event& iEvent, const edm::E
        dphiCandMap.insert(recoEcalCandRef, dEtaDPhi.second);
      }//end loop over reco ecal candidates
 
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> detaCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(detaCandMap));
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dphiCandMapForEvent(new reco::RecoEcalCandidateIsolationMap(dphiCandMap));
-    iEvent.put(std::move(detaCandMapForEvent), "Deta" );
-    iEvent.put(std::move(dphiCandMapForEvent), "Dphi" );
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(detaCandMap), "Deta" );
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(dphiCandMap), "Dphi" );
 
   }//end if between electrons or reco ecal candidates
 
   if(!useSCRefs_){
-    std::unique_ptr<reco::ElectronIsolationMap> detMap(new reco::ElectronIsolationMap(detaMap));
-    std::unique_ptr<reco::ElectronIsolationMap> dphMap(new reco::ElectronIsolationMap(dphiMap));
-    iEvent.put(std::move(detMap), "Deta" );
-    iEvent.put(std::move(dphMap), "Dphi" );
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(detaMap), "Deta" );
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(dphiMap), "Dphi" );
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronTrackIsolationProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronTrackIsolationProducers.cc
@@ -105,8 +105,7 @@ void EgammaHLTElectronTrackIsolationProducers::produce(edm::StreamID sid, edm::E
       recoEcalCandMap.insert(recoEcalCandRef,isol);
     }//end reco ecal candidate ref
 
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandMap));
 
   }else{ //we are going to loop over electron instead
     for(reco::ElectronCollection::const_iterator iElectron = electronHandle->begin(); iElectron != electronHandle->end(); iElectron++){
@@ -116,8 +115,7 @@ void EgammaHLTElectronTrackIsolationProducers::produce(edm::StreamID sid, edm::E
       eleMap.insert(eleRef, isol);
     }
 
-    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(eleMap));
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -188,14 +188,14 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     chi2Map.insert(recoEcalCandRef, chi2Value);
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaSeedMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> missingHitsForEvent(new reco::RecoEcalCandidateIsolationMap(missingHitsMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> validHitsForEvent(new reco::RecoEcalCandidateIsolationMap(validHitsMap));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> chi2ForEvent(new reco::RecoEcalCandidateIsolationMap(chi2Map));
+  auto dEtaMapForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(dEtaMap);
+  auto dEtaSeedMapForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(dEtaSeedMap);
+  auto dPhiMapForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(dPhiMap);
+  auto oneOverESuperMinusOneOverPMapForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(oneOverESuperMinusOneOverPMap);
+  auto oneOverESeedMinusOneOverPMapForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(oneOverESeedMinusOneOverPMap);
+  auto missingHitsForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(missingHitsMap);
+  auto validHitsForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(validHitsMap);
+  auto chi2ForEvent = std::make_unique<reco::RecoEcalCandidateIsolationMap>(chi2Map);
 
   iEvent.put(std::move(dEtaMapForEvent), "Deta" );
   iEvent.put(std::move(dEtaSeedMapForEvent), "DetaSeed" );

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationDoubleConeProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationDoubleConeProducers.cc
@@ -79,7 +79,6 @@ void EgammaHLTHcalIsolationDoubleConeProducers::produce(edm::Event& iEvent, cons
     isoMap.insert(recoecalcandref, isol);
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
@@ -140,8 +140,7 @@ void EgammaHLTHcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
     isoMap.insert(recoEcalCandRef, isol);   
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 
 }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
@@ -291,7 +291,7 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
   hybrid_p->makeClusters(hit_collection, geometry_p, basicClusters, sevLevel, true, regions);
   
   // create an unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
-  std::unique_ptr< reco::BasicClusterCollection > basicclusters_p(new reco::BasicClusterCollection);
+  auto basicclusters_p = std::make_unique<reco::BasicClusterCollection>();
   basicclusters_p->assign(basicClusters.begin(), basicClusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(std::move(basicclusters_p),
                                                                        basicclusterCollection_);
@@ -307,7 +307,7 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
 
   reco::SuperClusterCollection superClusters = hybrid_p->makeSuperClusters(clusterRefVector);
 
-  std::unique_ptr< reco::SuperClusterCollection > superclusters_p(new reco::SuperClusterCollection);
+  auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   superclusters_p->assign(superClusters.begin(), superClusters.end());
   evt.put(std::move(superclusters_p), superclusterCollection_);
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
@@ -294,7 +294,7 @@ void EgammaHLTIslandClusterProducer::clusterizeECALPart(edm::Event &evt, const e
   clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, ecalPart, true, regions);
 
   // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (ecalPart == IslandClusterAlgo::barrel) 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
@@ -302,7 +302,7 @@ void EgammaHLTMulti5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const
   clusters = Multi5x5_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, detector, true, regions);
 
   // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
   if (detector == reco::CaloID::DET_ECAL_BARREL) 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -249,7 +249,7 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   
   
   //Create empty output collections
-  std::unique_ptr< reco::BasicClusterCollection > clusters_p(new reco::BasicClusterCollection);
+  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   if (detector == reco::CaloID::DET_ECAL_BARREL){
     if(debug_>=1) LogDebug("")<<"nxnclusterProducer: "<<clusters_p->size() <<" made in barrel"<<std::endl;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFChargedIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFChargedIsolationProducer.cc
@@ -116,8 +116,7 @@ void EgammaHLTPFChargedIsolationProducer::produce(edm::Event& iEvent, const edm:
       
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandMap));
 
   } else {
 
@@ -161,7 +160,6 @@ void EgammaHLTPFChargedIsolationProducer::produce(edm::Event& iEvent, const edm:
 
       eleMap.insert(eleRef, sum);
     }   
-    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(eleMap));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFNeutralIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFNeutralIsolationProducer.cc
@@ -161,8 +161,7 @@ void EgammaHLTPFNeutralIsolationProducer::produce(edm::Event& iEvent, const edm:
        
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandMap));
     
   } else {
 
@@ -219,7 +218,6 @@ void EgammaHLTPFNeutralIsolationProducer::produce(edm::Event& iEvent, const edm:
  
       eleMap.insert(eleRef, sum);
     }   
-    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(eleMap));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFPhotonIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPFPhotonIsolationProducer.cc
@@ -188,8 +188,7 @@ void EgammaHLTPFPhotonIsolationProducer::produce(edm::Event& iEvent, const edm::
       
       recoEcalCandMap.insert(candRef, sum);
     }
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> mapForEvent(new reco::RecoEcalCandidateIsolationMap(recoEcalCandMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandMap));
     
   } else {
 
@@ -270,7 +269,6 @@ void EgammaHLTPFPhotonIsolationProducer::produce(edm::Event& iEvent, const edm::
 
       eleMap.insert(eleRef, sum);
     }   
-    std::unique_ptr<reco::ElectronIsolationMap> mapForEvent(new reco::ElectronIsolationMap(eleMap));
-    iEvent.put(std::move(mapForEvent));
+    iEvent.put(std::make_unique<reco::ElectronIsolationMap>(eleMap));
   }
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPhotonTrackIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPhotonTrackIsolationProducersRegional.cc
@@ -85,7 +85,6 @@ EgammaHLTPhotonTrackIsolationProducersRegional::produce(edm::StreamID sid, edm::
 
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> isolMap(new reco::RecoEcalCandidateIsolationMap(isoMap));
-  iEvent.put(std::move(isolMap));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(isoMap));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
@@ -65,7 +65,7 @@ void EgammaHLTPixelMatchElectronProducers::produce(edm::StreamID sid, edm::Event
   algo_->setupES(iSetup);  
   
   // Create the output collections   
-  std::unique_ptr<ElectronCollection> pOutEle(new ElectronCollection);
+  auto pOutEle = std::make_unique<ElectronCollection>();
   
   // invoke algorithm
     algo_->run(e,*pOutEle);

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -126,10 +126,10 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
 
   if(!recoEcalCandHandle.isValid() || !pixelSeedsHandle.isValid()) return;
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhi1BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dPhi2BestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> dzBestS2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> s2Map(new reco::RecoEcalCandidateIsolationMap(recoEcalCandHandle));
+  auto dPhi1BestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  auto dPhi2BestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  auto dzBestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  auto s2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   
   for(unsigned int candNr = 0; candNr<recoEcalCandHandle->size(); candNr++) {
     

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
@@ -70,11 +70,9 @@ void EgammaHLTR9IDProducer::produce(edm::StreamID sid, edm::Event& iEvent, const
     
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
-  iEvent.put(std::move(R9Map));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(r9Map));
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R95x5Map(new reco::RecoEcalCandidateIsolationMap(r95x5Map));
-  iEvent.put(std::move(R95x5Map),"r95x5");
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(r95x5Map),"r95x5");
 }
 
 //define this as a plug-in

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9Producer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9Producer.cc
@@ -70,7 +70,6 @@ void EgammaHLTR9Producer::produce(edm::StreamID sid, edm::Event& iEvent, const e
     
   }
 
-  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
-  iEvent.put(std::move(R9Map));
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(r9Map));
 
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRecoEcalCandidateProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRecoEcalCandidateProducers.cc
@@ -47,7 +47,7 @@ void EgammaHLTRecoEcalCandidateProducers::produce(edm::StreamID sid, edm::Event&
   //
 
   reco::RecoEcalCandidateCollection outputRecoEcalCandidateCollection;
-  std::unique_ptr< reco::RecoEcalCandidateCollection > outputRecoEcalCandidateCollection_p(new reco::RecoEcalCandidateCollection);
+  auto outputRecoEcalCandidateCollection_p = std::make_unique<reco::RecoEcalCandidateCollection>();
 
   // Get the  Barrel Super Cluster collection
   Handle<reco::SuperClusterCollection> scBarrelHandle;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
@@ -115,7 +115,7 @@ void EgammaHLTRegionalPixelSeedGeneratorProducers::produce(edm::Event& iEvent, c
 {
 
   // resulting collection
-  std::unique_ptr<TrajectorySeedCollection> output(new TrajectorySeedCollection());    
+  auto output = std::make_unique< TrajectorySeedCollection>();    
 
   // Get the recoEcalCandidates
   edm::Handle<reco::RecoEcalCandidateCollection> recoecalcands;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRemoveDuplicatedSC.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRemoveDuplicatedSC.cc
@@ -55,7 +55,7 @@ EgammaHLTRemoveDuplicatedSC::produce(edm::Event& evt, const edm::EventSetup& es)
 
 
   // Define a collection of corrected SuperClusters to put back into the event
-  std::unique_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
+  auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
   
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTTimeCleanedRechitProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTTimeCleanedRechitProducer.cc
@@ -60,7 +60,7 @@ void EgammaHLTTimeCleanedRechitProducer::produce(edm::Event& evt, const edm::Eve
     
 
   for (unsigned int i=0; i<hitLabels.size(); i++) {
-    std::unique_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
+    auto hits = std::make_unique<EcalRecHitCollection>();
     
     evt.getByToken(hitTokens[i], rhcH[i]);  
     if (!(rhcH[i].isValid())) {

--- a/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTEcalPFClusterIsolationProducer.cc
@@ -137,8 +137,7 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
     recoCandMap.insert(candRef, sum);
   }
   
-  std::unique_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
-  iEvent.put(std::move(mapForEvent));
+  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMap));
 }
 
 typedef HLTEcalPFClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTEcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTHcalPFClusterIsolationProducer.cc
@@ -151,8 +151,7 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid, edm::Even
     recoCandMap.insert(candRef, sum);
   }
   
-  std::unique_ptr<T1IsolationMap> mapForEvent(new T1IsolationMap(recoCandMap));
-  iEvent.put(std::move(mapForEvent));
+  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMap));
 }
 
 typedef HLTHcalPFClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTHcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
@@ -130,7 +130,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 
     edm::Handle<EcalUncalibratedRecHitCollection> urhcH[3];
     for (unsigned int i=0; i<hitLabels.size(); i++) {
-      std::unique_ptr<EcalUncalibratedRecHitCollection> uhits(new EcalUncalibratedRecHitCollection);
+      auto uhits = std::make_unique<EcalUncalibratedRecHitCollection>();
       
       evt.getByToken(uncalibHitTokens[i], urhcH[i]);  
       if (!(urhcH[i].isValid())) {
@@ -142,13 +142,13 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
       if (uncalibRecHits->size() > 0) {
 	if ((*uncalibRecHits)[0].id().subdetId() == EcalBarrel) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-	  topology.reset(new EcalBarrelTopology(geoHandle));
+	  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
 	} else if ((*uncalibRecHits)[0].id().subdetId() == EcalEndcap) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-	  topology.reset(new EcalEndcapTopology(geoHandle));
+	  topology = std::make_unique<EcalEndcapTopology>(geoHandle);
 	} else if ((*uncalibRecHits)[0].id().subdetId() == EcalPreshower) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-	  topology.reset(new EcalPreshowerTopology (geoHandle));
+	  topology = std::make_unique<EcalPreshowerTopology>(geoHandle);
 	} else throw(std::runtime_error("\n\nProducer encountered invalied ecalhitcollection type.\n\n"));
 	
 	if(regions.size() != 0) {
@@ -175,7 +175,7 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 
     edm::Handle<EcalRecHitCollection> rhcH[3];
     for (unsigned int i=0; i<hitLabels.size(); i++) {
-      std::unique_ptr<EcalRecHitCollection> hits(new EcalRecHitCollection);
+      auto hits = std::make_unique<EcalRecHitCollection>();
     
       evt.getByToken(hitTokens[i], rhcH[i]);  
       if (!(rhcH[i].isValid())) {
@@ -187,13 +187,13 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
       if (recHits->size() > 0) {
 	if ((*recHits)[0].id().subdetId() == EcalBarrel) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-	  topology.reset(new EcalBarrelTopology(geoHandle));
+	  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
 	} else if ((*recHits)[0].id().subdetId() == EcalEndcap) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-	  topology.reset(new EcalEndcapTopology(geoHandle));
+	  topology = std::make_unique<EcalEndcapTopology>(geoHandle);
 	} else if ((*recHits)[0].id().subdetId() == EcalPreshower) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-	  topology.reset(new EcalPreshowerTopology (geoHandle));
+	  topology = std::make_unique<EcalPreshowerTopology>(geoHandle);
 	} else throw(std::runtime_error("\n\nProducer encountered invalied ecalhitcollection type.\n\n"));
 	
 	if(regions.size() != 0) {

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalPFClusterIsolationProducer.cc
@@ -57,7 +57,7 @@ void EgammaEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const
   edm::Handle<T1Collection> emObjectHandle;
   iEvent.getByToken(emObjectProducer_, emObjectHandle);
 
-  std::auto_ptr<edm::ValueMap<float> > isoMap(new edm::ValueMap<float>());
+  auto isoMap = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler filler(*isoMap);
   std::vector<float> retV(emObjectHandle->size(),0);
 
@@ -74,7 +74,7 @@ void EgammaEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const
   filler.insert(emObjectHandle,retV.begin(),retV.end());
   filler.fill();
 
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 }
 
 typedef EgammaEcalPFClusterIsolationProducer<reco::GsfElectron> ElectronEcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
@@ -97,7 +97,7 @@ EgammaEcalRecHitIsolationProducer::produce(edm::Event& iEvent, const edm::EventS
   const CaloGeometry* caloGeom = pG.product();
 
   //reco::CandViewDoubleAssociations* isoMap = new reco::CandViewDoubleAssociations( reco::CandidateBaseRefProd( emObjectHandle ) );
-  std::auto_ptr<edm::ValueMap<double> > isoMap(new edm::ValueMap<double>());
+  auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
   std::vector<double> retV(emObjectHandle->size(),0);
 
@@ -149,8 +149,7 @@ EgammaEcalRecHitIsolationProducer::produce(edm::Event& iEvent, const edm::EventS
   filler.insert(emObjectHandle,retV.begin(),retV.end());
   filler.fill();
 
-  //std::auto_ptr<reco::CandViewDoubleAssociations> isolMap(isoMap);
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.cc
@@ -62,7 +62,7 @@ void EgammaElectronTkIsolationProducer::produce(edm::Event& iEvent, const edm::E
   const reco::TrackCollection* trackCollection = tracks.product();
   
   //prepare product
-  std::auto_ptr<edm::ValueMap<double> > isoMap(new edm::ValueMap<double>());
+  auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
   std::vector<double> retV(electronHandle->size(),0);
  
@@ -80,5 +80,5 @@ void EgammaElectronTkIsolationProducer::produce(edm::Event& iEvent, const edm::E
   //fill and insert valuemap
   filler.insert(electronHandle,retV.begin(),retV.end());
   filler.fill();
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.cc
@@ -62,7 +62,7 @@ void EgammaElectronTkNumIsolationProducer::produce(edm::Event& iEvent, const edm
   const reco::TrackCollection* trackCollection = tracks.product();
 
   //prepare product
-  std::auto_ptr<edm::ValueMap<int> > isoMap(new edm::ValueMap<int>());
+  auto isoMap = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler filler(*isoMap);
   std::vector<int> retV(electronHandle->size(),0);
 
@@ -81,5 +81,5 @@ void EgammaElectronTkNumIsolationProducer::produce(edm::Event& iEvent, const edm
   //fill and insert valuemap
   filler.insert(electronHandle,retV.begin(),retV.end());
   filler.fill();
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.cc
@@ -71,7 +71,7 @@ void EgammaHcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const
   edm::Handle<T1Collection> emObjectHandle;
   iEvent.getByToken(emObjectProducer_, emObjectHandle);
 
-  std::auto_ptr<edm::ValueMap<float> > isoMap(new edm::ValueMap<float>());
+  auto isoMap = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler filler(*isoMap);
   std::vector<float> retV(emObjectHandle->size(),0);
 
@@ -99,7 +99,7 @@ void EgammaHcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const
   filler.insert(emObjectHandle,retV.begin(),retV.end());
   filler.fill();
 
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 }
 
 typedef EgammaHcalPFClusterIsolationProducer<reco::GsfElectron> ElectronHcalPFClusterIsolationProducer;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
@@ -95,9 +95,9 @@ EgammaIsoESDetIdCollectionProducer::produce (edm::Event& iEvent,
   std::sort(indexToStore.begin(),indexToStore.end());
   std::unique(indexToStore.begin(),indexToStore.end());
   
-  std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection(indexToStore) ) ;
+  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
    
-  iEvent.put( detIdCollection, interestingDetIdCollection_ );
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
@@ -92,9 +92,9 @@ EgammaIsoHcalDetIdCollectionProducer::produce (edm::Event& iEvent,
   std::sort(indexToStore.begin(),indexToStore.end());
   std::unique(indexToStore.begin(),indexToStore.end());
   
-  std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection(indexToStore) ) ;
+  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
    
-  iEvent.put( detIdCollection, interestingDetIdCollection_ );
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.cc
@@ -71,7 +71,7 @@ EgammaPhotonTkIsolationProducer::produce(edm::Event& iEvent, const edm::EventSet
   reco::TrackBase::Point beamspot = beamSpotH->position();
 
   //prepare product
-  std::auto_ptr<edm::ValueMap<double> > isoMap(new edm::ValueMap<double>());
+  auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
   std::vector<double> retV(photonHandle->size(),0);
 
@@ -85,7 +85,7 @@ EgammaPhotonTkIsolationProducer::produce(edm::Event& iEvent, const edm::EventSet
   //fill and insert valuemap
   filler.insert(photonHandle,retV.begin(),retV.end());
   filler.fill();
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.cc
@@ -69,7 +69,7 @@ EgammaPhotonTkNumIsolationProducer::produce(edm::Event& iEvent, const edm::Event
   reco::TrackBase::Point beamspot = beamSpotH->position();
 
   //prepare product
-  std::auto_ptr<edm::ValueMap<int> > isoMap(new edm::ValueMap<int>());
+  auto isoMap = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler filler(*isoMap);
   std::vector<int> retV(photonHandle->size(),0);
 
@@ -85,7 +85,7 @@ EgammaPhotonTkNumIsolationProducer::produce(edm::Event& iEvent, const edm::Event
   //fill and insert valuemap
   filler.insert(photonHandle,retV.begin(),retV.end());
   filler.fill();
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 
 
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.cc
@@ -60,7 +60,7 @@ EgammaTowerIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup&
   iEvent.getByLabel(towerProducer_, towerHandle);
   const CaloTowerCollection* towers = towerHandle.product();
 
-  std::auto_ptr<edm::ValueMap<double> > isoMap(new edm::ValueMap<double>());
+  auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
   std::vector<double> retV(emObjectHandle->size(),0);
 
@@ -78,7 +78,7 @@ EgammaTowerIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
   filler.insert(emObjectHandle,retV.begin(),retV.end());
   filler.fill();
-  iEvent.put(isoMap);
+  iEvent.put(std::move(isoMap));
 
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
@@ -108,7 +108,7 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
         doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
 
     //Create empty output collections
-    std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection() ) ;
+    auto detIdCollection = std::make_unique<DetIdCollection>();
 
     reco::GsfElectronCollection::const_iterator emObj;
     if(doubleConeSel_) { //if cone selector was created
@@ -176,5 +176,5 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
         delete doubleConeSel_;
     } //end if cone selector was created
     
-    iEvent.put( detIdCollection, interestingDetIdCollection_ );
+    iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
@@ -107,7 +107,7 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
         doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
 
     //Create empty output collections
-    std::auto_ptr< DetIdCollection > detIdCollection (new DetIdCollection() ) ;
+    auto detIdCollection = std::make_unique<DetIdCollection>();
 
     reco::PhotonCollection::const_iterator emObj;
     if(doubleConeSel_) { //if cone selector was created
@@ -175,5 +175,5 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
         delete doubleConeSel_;
     } //end if cone selector was created
     
-    iEvent.put( detIdCollection, interestingDetIdCollection_ );
+    iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
@@ -187,26 +187,24 @@ void ParticleBasedIsoProducer::produce(edm::Event& theEvent, const edm::EventSet
 
 
 
-  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef>> >  
-    phoToPFCandIsoMap_p(new edm::ValueMap<std::vector<reco::PFCandidateRef>>());
+  auto phoToPFCandIsoMap_p = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
   edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler 
     fillerPhotons(*phoToPFCandIsoMap_p);
   
   //// fill the isolation value map for photons
   fillerPhotons.insert(photonHandle,pfCandIsoPairVecPho.begin(),pfCandIsoPairVecPho.end());
   fillerPhotons.fill(); 
-  theEvent.put(phoToPFCandIsoMap_p,valueMapPhoPFCandIso_);
+  theEvent.put(std::move(phoToPFCandIsoMap_p),valueMapPhoPFCandIso_);
 
 
-  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef>> >  
-    eleToPFCandIsoMap_p(new edm::ValueMap<std::vector<reco::PFCandidateRef>>());
+  auto eleToPFCandIsoMap_p = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
   edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler 
     fillerElectrons(*eleToPFCandIsoMap_p);
   
   //// fill the isolation value map for electrons 
   fillerElectrons.insert(electronHandle,pfCandIsoPairVecEle.begin(),pfCandIsoPairVecEle.end());
   fillerElectrons.fill(); 
-  theEvent.put(eleToPFCandIsoMap_p,valueMapElePFCandIso_);
+  theEvent.put(std::move(eleToPFCandIsoMap_p),valueMapElePFCandIso_);
 
 
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackMerger.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackMerger.h
@@ -43,7 +43,7 @@
     edm::EDGetTokenT<reco::ConversionTrackCollection> trackProducer1;
     edm::EDGetTokenT<reco::ConversionTrackCollection> trackProducer2;
 
-    std::auto_ptr<reco::ConversionTrackCollection> outputTrks;
+    std::unique_ptr<reco::ConversionTrackCollection> outputTrks;
   };
 
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
@@ -80,6 +80,6 @@ namespace reco {
     IdealHelixParameters ConvTrackPreSelector;
     //--------------------------------------------------
 
-    std::auto_ptr<reco::ConversionTrackCollection> outputTrks;
+    std::unique_ptr<reco::ConversionTrackCollection> outputTrks;
   };
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -44,10 +44,10 @@ private:
   void putInEvt(edm::Event& evt,
 		const Propagator* thePropagator,
 		const MeasurementTracker* theMeasTk,
-		std::auto_ptr<TrackingRecHitCollection>& selHits,
-		std::auto_ptr<reco::TrackCollection>& selTracks,
-		std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
-		std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
+		std::unique_ptr<TrackingRecHitCollection> selHits,
+		std::unique_ptr<reco::TrackCollection> selTracks,
+		std::unique_ptr<reco::TrackExtraCollection> selTrackExtras,
+		std::unique_ptr<std::vector<Trajectory>> selTrajectories,
 		AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder,
                 const TrackerTopology *ttopo);
 };

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
@@ -185,7 +185,7 @@ ConversionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace edm;
 
   reco::ConversionCollection outputConvPhotonCollection;
-  std::auto_ptr<reco::ConversionCollection> outputConvPhotonCollection_p(new reco::ConversionCollection);
+  auto outputConvPhotonCollection_p = std::make_unique<reco::ConversionCollection>();
 
   //std::cout << " ConversionProducer::produce " << std::endl;
   //Read multiple track input collections
@@ -226,7 +226,7 @@ ConversionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     the_pvtx = *(vertexCollection.begin());
     
   if (trackCollectionHandle->size()> maxNumOfTrackInPU_){
-    iEvent.put( outputConvPhotonCollection_p, ConvertedPhotonCollection_);
+    iEvent.put(std::move(outputConvPhotonCollection_p), ConvertedPhotonCollection_);
     return;
   }
     
@@ -241,7 +241,7 @@ ConversionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   buildCollection( iEvent, iSetup, convTrackMap,  superClusterPtrs, basicClusterPtrs, the_pvtx, outputConvPhotonCollection);//allow empty basicClusterPtrs
     
   outputConvPhotonCollection_p->assign(outputConvPhotonCollection.begin(), outputConvPhotonCollection.end());
-  iEvent.put( outputConvPhotonCollection_p, ConvertedPhotonCollection_);
+  iEvent.put(std::move(outputConvPhotonCollection_p), ConvertedPhotonCollection_);
     
 }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -185,12 +185,12 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
   // create empty output collections
   //
   //  Out In Track Candidates
-  std::auto_ptr<TrackCandidateCollection> outInTrackCandidate_p(new TrackCandidateCollection); 
+  auto outInTrackCandidate_p = std::make_unique<TrackCandidateCollection>(); 
   //  In Out  Track Candidates
-  std::auto_ptr<TrackCandidateCollection> inOutTrackCandidate_p(new TrackCandidateCollection); 
+  auto inOutTrackCandidate_p = std::make_unique<TrackCandidateCollection>(); 
   //   Track Candidate  calo  Cluster Association
-  std::auto_ptr<reco::TrackCandidateCaloClusterPtrAssociation> outInAssoc_p(new reco::TrackCandidateCaloClusterPtrAssociation);
-  std::auto_ptr<reco::TrackCandidateCaloClusterPtrAssociation> inOutAssoc_p(new reco::TrackCandidateCaloClusterPtrAssociation);
+  auto outInAssoc_p = std::make_unique<reco::TrackCandidateCaloClusterPtrAssociation>();
+  auto inOutAssoc_p = std::make_unique<reco::TrackCandidateCaloClusterPtrAssociation>();
     
   // Get the basic cluster collection in the Barrel 
   bool validBarrelBCHandle=true;
@@ -274,11 +274,11 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
   // put all products in the event
  // Barrel
  //std::cout  << "ConversionTrackCandidateProducer Putting in the event " << (*outInTrackCandidate_p).size() << " Out In track Candidates " << "\n";
- const edm::OrphanHandle<TrackCandidateCollection> refprodOutInTrackC = theEvent.put( outInTrackCandidate_p, OutInTrackCandidateCollection_ );
+ const edm::OrphanHandle<TrackCandidateCollection> refprodOutInTrackC = theEvent.put(std::move(outInTrackCandidate_p), OutInTrackCandidateCollection_ );
  //std::cout  << "ConversionTrackCandidateProducer  refprodOutInTrackC size  " <<  (*(refprodOutInTrackC.product())).size()  <<  "\n";
  //
  //std::cout  << "ConversionTrackCandidateProducer Putting in the event  " << (*inOutTrackCandidate_p).size() << " In Out track Candidates " <<  "\n";
- const edm::OrphanHandle<TrackCandidateCollection> refprodInOutTrackC = theEvent.put( inOutTrackCandidate_p, InOutTrackCandidateCollection_ );
+ const edm::OrphanHandle<TrackCandidateCollection> refprodInOutTrackC = theEvent.put(std::move(inOutTrackCandidate_p), InOutTrackCandidateCollection_ );
  //std::cout  << "ConversionTrackCandidateProducer  refprodInOutTrackC size  " <<  (*(refprodInOutTrackC.product())).size()  <<  "\n";
 
 
@@ -292,10 +292,10 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
 
   
  // std::cout  << "ConversionTrackCandidateProducer Putting in the event   OutIn track - SC association: size  " <<  (*outInAssoc_p).size() << "\n";  
- theEvent.put( outInAssoc_p, OutInTrackSuperClusterAssociationCollection_);
+ theEvent.put(std::move(outInAssoc_p), OutInTrackSuperClusterAssociationCollection_);
  
  // std::cout << "ConversionTrackCandidateProducer Putting in the event   InOut track - SC association: size  " <<  (*inOutAssoc_p).size() << "\n";  
- theEvent.put( inOutAssoc_p, InOutTrackSuperClusterAssociationCollection_);
+ theEvent.put(std::move(inOutAssoc_p), InOutTrackSuperClusterAssociationCollection_);
 
  theOutInSeedFinder_->clear();
  theInOutSeedFinder_->clear();

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -102,7 +102,7 @@
     reco::ConversionTrackCollection tC2 = *TC2;
 
     // Step B: create empty output collection
-    outputTrks = std::auto_ptr<reco::ConversionTrackCollection>(new reco::ConversionTrackCollection);
+    outputTrks = std::make_unique<reco::ConversionTrackCollection>();
     int i;
 
     std::vector<int> selected1; for (unsigned int i=0; i<tC1.size(); ++i){selected1.push_back(1);}
@@ -246,7 +246,7 @@
     }//end faux loop over tracks
    }//end more than 0 track
   
-    e.put(outputTrks);
+    e.put(std::move(outputTrks));
     return;
 
   }//end produce

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -103,7 +103,7 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf) 
     }
 
     // Step B: create empty output collection
-    outputTrks = std::auto_ptr<reco::ConversionTrackCollection>(new reco::ConversionTrackCollection);    
+    outputTrks = std::make_unique<reco::ConversionTrackCollection>();    
 
     //--------------------------------------------------
     //Added by D. Giordano
@@ -161,7 +161,7 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf) 
       outputTrks->push_back(convTrack);
     }
     
-    e.put(outputTrks);
+    e.put(std::move(outputTrks));
     return;
 
   }//end produce

--- a/RecoEgamma/EgammaPhotonProducers/src/ConvertedPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConvertedPhotonProducer.cc
@@ -167,10 +167,10 @@ void ConvertedPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetu
   //
   // Converted photon candidates
   reco::ConversionCollection outputConvPhotonCollection;
-  std::auto_ptr<reco::ConversionCollection> outputConvPhotonCollection_p(new reco::ConversionCollection);
+  auto outputConvPhotonCollection_p = std::make_unique<reco::ConversionCollection>();
   // Converted photon candidates
   reco::ConversionCollection cleanedConversionCollection;
-  std::auto_ptr<reco::ConversionCollection> cleanedConversionCollection_p(new reco::ConversionCollection);
+  auto cleanedConversionCollection_p = std::make_unique<reco::ConversionCollection>();
 
   
   // Get the Super Cluster collection in the Barrel
@@ -298,7 +298,7 @@ void ConvertedPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetu
   // put the product in the event
   outputConvPhotonCollection_p->assign(outputConvPhotonCollection.begin(),outputConvPhotonCollection.end());
   //LogDebug("ConvertedPhotonProducer") << " ConvertedPhotonProducer Putting in the event    converted photon candidates " << (*outputConvPhotonCollection_p).size() << "\n";  
-  const edm::OrphanHandle<reco::ConversionCollection> conversionHandle= theEvent.put( outputConvPhotonCollection_p, ConvertedPhotonCollection_);
+  const edm::OrphanHandle<reco::ConversionCollection> conversionHandle= theEvent.put(std::move(outputConvPhotonCollection_p), ConvertedPhotonCollection_);
 
 
   // Loop over barrel and endcap SC collections and fill the  photon collection
@@ -311,7 +311,7 @@ void ConvertedPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetu
 						
 
   cleanedConversionCollection_p->assign(cleanedConversionCollection.begin(),cleanedConversionCollection.end());   
-  theEvent.put( cleanedConversionCollection_p, CleanedConvertedPhotonCollection_);
+  theEvent.put(std::move(cleanedConversionCollection_p), CleanedConvertedPhotonCollection_);
 
   
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
@@ -65,7 +65,7 @@ void GEDPhotonCoreProducer::produce(edm::Event &theEvent, const edm::EventSetup&
   //  nEvt_++;
 
   reco::PhotonCoreCollection outputPhotonCoreCollection;
-  std::auto_ptr< reco::PhotonCoreCollection > outputPhotonCoreCollection_p(new reco::PhotonCoreCollection);
+  auto outputPhotonCoreCollection_p = std::make_unique<reco::PhotonCoreCollection>();
 
   // Get the  PF refined cluster  collection
   Handle<reco::PFCandidateCollection> pfCandidateHandle;
@@ -142,7 +142,7 @@ void GEDPhotonCoreProducer::produce(edm::Event &theEvent, const edm::EventSetup&
   // put the product in the event
   //  edm::LogInfo("GEDPhotonCoreProducer") << " Put in the event " << iSC << " Photon Candidates \n";
   outputPhotonCoreCollection_p->assign(outputPhotonCoreCollection.begin(),outputPhotonCoreCollection.end());
-  theEvent.put( outputPhotonCoreCollection_p, GEDPhotonCoreCollection_);
+  theEvent.put(std::move(outputPhotonCoreCollection_p), GEDPhotonCoreCollection_);
   
 
 

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -235,7 +235,7 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   //  nEvt_++;
  
   reco::PhotonCollection outputPhotonCollection;
-  std::auto_ptr< reco::PhotonCollection > outputPhotonCollection_p(new reco::PhotonCollection);
+  auto outputPhotonCollection_p = std::make_unique<reco::PhotonCollection>();
   edm::ValueMap<reco::PhotonRef> pfEGCandToPhotonMap;
 
 
@@ -398,12 +398,12 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   // put the product in the event
   edm::LogInfo("GEDPhotonProducer") << " Put in the event " << iSC << " Photon Candidates \n";
   outputPhotonCollection_p->assign(outputPhotonCollection.begin(),outputPhotonCollection.end());
-  const edm::OrphanHandle<reco::PhotonCollection> photonOrphHandle = theEvent.put(outputPhotonCollection_p, photonCollection_);
+  const edm::OrphanHandle<reco::PhotonCollection> photonOrphHandle = theEvent.put(std::move(outputPhotonCollection_p), photonCollection_);
 
 
   if ( reconstructionStep_ != "final" ) { 
     //// Define the value map which associate to each  Egamma-unbiassaed candidate (key-ref) the corresponding PhotonRef 
-    std::auto_ptr<edm::ValueMap<reco::PhotonRef> >  pfEGCandToPhotonMap_p(new edm::ValueMap<reco::PhotonRef>());
+    auto pfEGCandToPhotonMap_p = std::make_unique<edm::ValueMap<reco::PhotonRef>>();
     edm::ValueMap<reco::PhotonRef>::Filler filler(*pfEGCandToPhotonMap_p);
     unsigned nObj = pfEGCandidateHandle->size();
     std::vector<reco::PhotonRef> values(nObj);
@@ -423,7 +423,7 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     
     filler.insert(pfEGCandidateHandle,values.begin(),values.end());
     filler.fill(); 
-    theEvent.put(pfEGCandToPhotonMap_p,valueMapPFCandPhoton_);
+    theEvent.put(std::move(pfEGCandToPhotonMap_p),valueMapPFCandPhoton_);
 
 
   }

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonCoreProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonCoreProducer.cc
@@ -52,7 +52,7 @@ void PhotonCoreProducer::produce(edm::Event &theEvent, const edm::EventSetup& th
   //  nEvt_++;
 
   reco::PhotonCoreCollection outputPhotonCoreCollection;
-  std::auto_ptr< reco::PhotonCoreCollection > outputPhotonCoreCollection_p(new reco::PhotonCoreCollection);
+  auto outputPhotonCoreCollection_p = std::make_unique<reco::PhotonCoreCollection>();
 
   // Get the  Barrel Super Cluster collection
   bool validBarrelSCHandle=true;
@@ -120,7 +120,7 @@ void PhotonCoreProducer::produce(edm::Event &theEvent, const edm::EventSetup& th
   // put the product in the event
   edm::LogInfo("PhotonCoreProducer") << " Put in the event " << iSC << " Photon Candidates \n";
   outputPhotonCoreCollection_p->assign(outputPhotonCoreCollection.begin(),outputPhotonCoreCollection.end());
-  theEvent.put( outputPhotonCoreCollection_p, PhotonCoreCollection_);
+  theEvent.put(std::move(outputPhotonCoreCollection_p), PhotonCoreCollection_);
 
 }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -174,7 +174,7 @@ void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEve
   //  nEvt_++;
 
   reco::PhotonCollection outputPhotonCollection;
-  std::auto_ptr< reco::PhotonCollection > outputPhotonCollection_p(new reco::PhotonCollection);
+  auto outputPhotonCollection_p = std::make_unique<reco::PhotonCollection>();
 
 
   // Get the PhotonCore collection
@@ -269,7 +269,7 @@ void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEve
   // put the product in the event
   edm::LogInfo("PhotonProducer") << " Put in the event " << iSC << " Photon Candidates \n";
   outputPhotonCollection_p->assign(outputPhotonCollection.begin(),outputPhotonCollection.end());
-  theEvent.put( outputPhotonCollection_p, PhotonCollection_);
+  theEvent.put(std::move(outputPhotonCollection_p), PhotonCollection_);
 
 }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -206,37 +206,37 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   const CaloTopology *caloTopology = & (*theCaloTopology);  
   
   //initialize output collections
-  std::auto_ptr<reco::PhotonCollection> photons(new reco::PhotonCollection);
-  std::auto_ptr<reco::PhotonCoreCollection> photonCores(new reco::PhotonCoreCollection);
-  std::auto_ptr<reco::GsfElectronCollection> gsfElectrons(new reco::GsfElectronCollection);
-  std::auto_ptr<reco::GsfElectronCoreCollection> gsfElectronCores(new reco::GsfElectronCoreCollection);
-  std::auto_ptr<reco::ConversionCollection> conversions(new reco::ConversionCollection);
-  std::auto_ptr<reco::ConversionCollection> singleConversions(new reco::ConversionCollection);
-  std::auto_ptr<reco::SuperClusterCollection> superClusters(new reco::SuperClusterCollection);
-  std::auto_ptr<reco::CaloClusterCollection> ebeeClusters(new reco::CaloClusterCollection);
-  std::auto_ptr<reco::CaloClusterCollection> esClusters(new reco::CaloClusterCollection);
-  std::auto_ptr<EcalRecHitCollection> ebRecHits(new EcalRecHitCollection);
-  std::auto_ptr<EcalRecHitCollection> eeRecHits(new EcalRecHitCollection);
-  std::auto_ptr<EcalRecHitCollection> esRecHits(new EcalRecHitCollection);
-  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMap(new edm::ValueMap<std::vector<reco::PFCandidateRef> >);
-  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMap(new edm::ValueMap<std::vector<reco::PFCandidateRef> >);
+  auto photons = std::make_unique<reco::PhotonCollection>();
+  auto photonCores = std::make_unique<reco::PhotonCoreCollection>();
+  auto gsfElectrons = std::make_unique<reco::GsfElectronCollection>();
+  auto gsfElectronCores = std::make_unique<reco::GsfElectronCoreCollection>();
+  auto conversions = std::make_unique<reco::ConversionCollection>();
+  auto singleConversions = std::make_unique<reco::ConversionCollection>();
+  auto superClusters = std::make_unique<reco::SuperClusterCollection>();
+  auto ebeeClusters = std::make_unique<reco::CaloClusterCollection>();
+  auto esClusters = std::make_unique<reco::CaloClusterCollection>();
+  auto ebRecHits = std::make_unique<EcalRecHitCollection>();
+  auto eeRecHits = std::make_unique<EcalRecHitCollection>();
+  auto esRecHits = std::make_unique<EcalRecHitCollection>();
+  auto photonPfCandMap = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
+  auto gsfElectronPfCandMap = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
   
-  std::vector<std::auto_ptr<edm::ValueMap<bool> > > photonIds;
+  std::vector<std::unique_ptr<edm::ValueMap<bool> > > photonIds;
   for (unsigned int iid=0; iid<photonIdHandles.size(); ++iid) {
     photonIds.emplace_back(new edm::ValueMap<bool>);
   }
     
-  std::vector<std::auto_ptr<edm::ValueMap<float> > > gsfElectronIds;
+  std::vector<std::unique_ptr<edm::ValueMap<float> > > gsfElectronIds;
   for (unsigned int iid=0; iid<gsfElectronIdHandles.size(); ++iid) {
     gsfElectronIds.emplace_back(new edm::ValueMap<float>);
   }
 
-  std::vector<std::auto_ptr<edm::ValueMap<float> > > photonPFClusterIsos;
+  std::vector<std::unique_ptr<edm::ValueMap<float> > > photonPFClusterIsos;
   for (unsigned int iid=0; iid<photonPFClusterIsoHandles.size(); ++iid) {
     photonPFClusterIsos.emplace_back(new edm::ValueMap<float>);
   }
 
-  std::vector<std::auto_ptr<edm::ValueMap<float> > > gsfElectronPFClusterIsos;
+  std::vector<std::unique_ptr<edm::ValueMap<float> > > gsfElectronPFClusterIsos;
   for (unsigned int iid=0; iid<gsfElectronPFClusterIsoHandles.size(); ++iid) {
     gsfElectronPFClusterIsos.emplace_back(new edm::ValueMap<float>);
   }
@@ -532,8 +532,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     }
   }
  
-  theEvent.put(ebRecHits,outEBRecHits_);
-  theEvent.put(eeRecHits,outEERecHits_);
+  theEvent.put(std::move(ebRecHits),outEBRecHits_);
+  theEvent.put(std::move(eeRecHits),outEERecHits_);
 
   if (doPreshowerEcalHits_) { 
       for (const EcalRecHit &rechit : *preshowerHitHandle) {
@@ -541,13 +541,13 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
           esRecHits->push_back(rechit);
         }
       }
-      theEvent.put(esRecHits,outESRecHits_);  
+      theEvent.put(std::move(esRecHits),outESRecHits_);  
   }
   
   //CaloClusters
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const edm::OrphanHandle<reco::CaloClusterCollection> &outEBEEClusterHandle = theEvent.put(ebeeClusters,outEBEEClusters_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &outESClusterHandle = theEvent.put(esClusters,outESClusters_);;  
+  const edm::OrphanHandle<reco::CaloClusterCollection> &outEBEEClusterHandle = theEvent.put(std::move(ebeeClusters),outEBEEClusters_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &outESClusterHandle = theEvent.put(std::move(esClusters),outESClusters_);;  
   
   //loop over output superclusters and relink to output caloclusters
   for (reco::SuperCluster &superCluster : *superClusters) {
@@ -600,9 +600,9 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
   
   //put superclusters and conversions in the event
-  const edm::OrphanHandle<reco::SuperClusterCollection> &outSuperClusterHandle = theEvent.put(superClusters,outSuperClusters_);
-  const edm::OrphanHandle<reco::ConversionCollection> &outConversionHandle = theEvent.put(conversions,outConversions_);
-  const edm::OrphanHandle<reco::ConversionCollection> &outSingleConversionHandle = theEvent.put(singleConversions,outSingleConversions_);
+  const edm::OrphanHandle<reco::SuperClusterCollection> &outSuperClusterHandle = theEvent.put(std::move(superClusters),outSuperClusters_);
+  const edm::OrphanHandle<reco::ConversionCollection> &outConversionHandle = theEvent.put(std::move(conversions),outConversions_);
+  const edm::OrphanHandle<reco::ConversionCollection> &outSingleConversionHandle = theEvent.put(std::move(singleConversions),outSingleConversions_);
   
   //loop over photoncores and relink superclusters (and conversions)
   for (reco::PhotonCore &photonCore : *photonCores) {
@@ -664,8 +664,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
   
   //put photon and gsfelectroncores into the event
-  const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle = theEvent.put(photonCores,outPhotonCores_);
-  const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle = theEvent.put(gsfElectronCores,outGsfElectronCores_);
+  const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle = theEvent.put(std::move(photonCores),outPhotonCores_);
+  const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle = theEvent.put(std::move(gsfElectronCores),outGsfElectronCores_);
   
   //loop over photons and electrons and relink the cores
   for (reco::Photon &photon : *photons) {
@@ -687,8 +687,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
   
   //(finally) store the output photon and electron collections
-  const edm::OrphanHandle<reco::PhotonCollection> &outPhotonHandle = theEvent.put(photons,outPhotons_);  
-  const edm::OrphanHandle<reco::GsfElectronCollection> &outGsfElectronHandle = theEvent.put(gsfElectrons,outGsfElectrons_);
+  const edm::OrphanHandle<reco::PhotonCollection> &outPhotonHandle = theEvent.put(std::move(photons),outPhotons_);  
+  const edm::OrphanHandle<reco::GsfElectronCollection> &outGsfElectronHandle = theEvent.put(std::move(gsfElectrons),outGsfElectrons_);
   
   //still need to output relinked valuemaps
   
@@ -702,15 +702,15 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   fillerGsfElectrons.insert(outGsfElectronHandle,pfCandIsoPairVecEle.begin(),pfCandIsoPairVecEle.end());
   fillerGsfElectrons.fill();
   
-  theEvent.put(photonPfCandMap,outPhotonPfCandMap_);
-  theEvent.put(gsfElectronPfCandMap,outGsfElectronPfCandMap_);
+  theEvent.put(std::move(photonPfCandMap),outPhotonPfCandMap_);
+  theEvent.put(std::move(gsfElectronPfCandMap),outGsfElectronPfCandMap_);
   
   //photon id value maps
   for (unsigned int iid=0; iid<photonIds.size(); ++iid) {
     edm::ValueMap<bool>::Filler fillerPhotonId(*photonIds[iid]);
     fillerPhotonId.insert(outPhotonHandle,photonIdVals[iid].begin(),photonIdVals[iid].end());
     fillerPhotonId.fill();
-    theEvent.put(photonIds[iid],outPhotonIds_[iid]);
+    theEvent.put(std::move(photonIds[iid]),outPhotonIds_[iid]);
   }
   
   //electron id value maps
@@ -718,7 +718,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     edm::ValueMap<float>::Filler fillerGsfElectronId(*gsfElectronIds[iid]);
     fillerGsfElectronId.insert(outGsfElectronHandle,gsfElectronIdVals[iid].begin(),gsfElectronIdVals[iid].end());
     fillerGsfElectronId.fill();
-    theEvent.put(gsfElectronIds[iid],outGsfElectronIds_[iid]);
+    theEvent.put(std::move(gsfElectronIds[iid]),outGsfElectronIds_[iid]);
   }  
 
   //photon iso value maps
@@ -726,14 +726,14 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     edm::ValueMap<float>::Filler fillerPhotonPFClusterIso(*photonPFClusterIsos[iid]);
     fillerPhotonPFClusterIso.insert(outPhotonHandle,photonPFClusterIsoVals[iid].begin(),photonPFClusterIsoVals[iid].end());
     fillerPhotonPFClusterIso.fill();
-    theEvent.put(photonPFClusterIsos[iid],outPhotonPFClusterIsos_[iid]);
+    theEvent.put(std::move(photonPFClusterIsos[iid]),outPhotonPFClusterIsos_[iid]);
   }
   //electron iso value maps
   for (unsigned int iid=0; iid<gsfElectronPFClusterIsos.size(); ++iid) {
     edm::ValueMap<float>::Filler fillerGsfElectronPFClusterIso(*gsfElectronPFClusterIsos[iid]);
     fillerGsfElectronPFClusterIso.insert(outGsfElectronHandle,gsfElectronPFClusterIsoVals[iid].begin(),gsfElectronPFClusterIsoVals[iid].end());
     fillerGsfElectronPFClusterIso.fill();
-    theEvent.put(gsfElectronPFClusterIsos[iid],outGsfElectronPFClusterIsos_[iid]);
+    theEvent.put(std::move(gsfElectronPFClusterIsos[iid]),outGsfElectronPFClusterIsos_[iid]);
   }  
 }
 

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -28,7 +28,7 @@ class MVAValueMapProducer : public edm::stream::EDProducer< edm::GlobalCache<ega
   
   static std::unique_ptr<egamma::MVAObjectCache>
   initializeGlobalCache(const edm::ParameterSet& conf) {
-    return std::unique_ptr<egamma::MVAObjectCache>(new egamma::MVAObjectCache(conf));
+    return std::make_unique<egamma::MVAObjectCache>(conf);
    }
 
   static void globalEndJob(const egamma::MVAObjectCache * ) {
@@ -154,11 +154,11 @@ void MVAValueMapProducer<ParticleType>::writeValueMap(edm::Event &iEvent,
 {
   using namespace edm; 
   using namespace std;
-  auto_ptr<ValueMap<T> > valMap(new ValueMap<T>());
+  auto valMap = std::make_unique<ValueMap<T>>();
   typename edm::ValueMap<T>::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(valMap, label);
+  iEvent.put(std::move(valMap), label);
 }
 
 template <class ParticleType>

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDExternalProducer.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDExternalProducer.h
@@ -52,12 +52,12 @@ void ElectronIDExternalProducer<algo>::produce(edm::Event & iEvent, const edm::E
      }
 
      // fill in the ValueMap
-     std::auto_ptr<edm::ValueMap<float> > out(new edm::ValueMap<float>());
+     auto out = std::make_unique<edm::ValueMap<float>>();
      edm::ValueMap<float>::Filler filler(*out);
      filler.insert(electrons, values.begin(), values.end());
      filler.fill();
      // and put it into the event
-     iEvent.put(out);
+     iEvent.put(std::move(out));
 
 }
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDValueMapProducer.cc
@@ -177,11 +177,11 @@ void ElectronIDValueMapProducer::writeValueMap(edm::Event &iEvent,
 {
   using namespace edm; 
   using namespace std;
-  auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+  auto valMap = std::make_unique<ValueMap<float>>();
   edm::ValueMap<float>::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(valMap, label);
+  iEvent.put(std::move(valMap), label);
 }
 
 void ElectronIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -62,7 +62,7 @@ public:
   
   static std::unique_ptr<gsfidhelper::HeavyObjectCache> 
   initializeGlobalCache( const edm::ParameterSet& conf ) {
-    return std::unique_ptr<gsfidhelper::HeavyObjectCache>(new gsfidhelper::HeavyObjectCache(conf));
+    return std::make_unique<gsfidhelper::HeavyObjectCache>(conf);
   }
   
   static void globalEndJob(gsfidhelper::HeavyObjectCache const* ) {
@@ -124,7 +124,7 @@ bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
 
   constexpr double etaEBEE = 1.485;
   
-  std::auto_ptr<reco::GsfElectronCollection> mvaElectrons(new reco::GsfElectronCollection);
+  auto mvaElectrons = std::make_unique<reco::GsfElectronCollection>();
   
   Handle<reco::VertexCollection>  vertexCollection;
   iEvent.getByToken(vertexToken, vertexCollection);
@@ -151,7 +151,7 @@ bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }
     
-  iEvent.put(mvaElectrons);
+  iEvent.put(std::move(mvaElectrons));
   
   return true;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -186,7 +186,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
   
-  return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+  return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>(tmpTMVAReader.FindMVA(_MethodName) ) );
 }
 
 // A function that should work on both pat and reco objects

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
@@ -210,7 +210,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+  return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }
 
 // A function that should work on both pat and reco objects

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
@@ -189,7 +189,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+  return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }
 
 // A function that should work on both pat and reco objects

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
@@ -226,11 +226,11 @@ void ElectronRegressionValueMapProducer::writeValueMap(edm::Event &iEvent,
   using namespace std;
   typedef ValueMap<T> TValueMap;
 
-  auto_ptr<TValueMap> valMap(new TValueMap());
+  auto valMap = std::make_unique<TValueMap>();
   typename TValueMap::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(valMap, label);
+  iEvent.put(std::move(valMap), label);
 }
 
 void ElectronRegressionValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
@@ -56,26 +56,26 @@ void PhotonIDProducer::produce(edm::Event& e, const edm::EventSetup& c) {
   }
   
 
-  std::auto_ptr<edm::ValueMap<Bool_t> > outlooseEM(new edm::ValueMap<Bool_t>());
+  auto outlooseEM = std::make_unique<edm::ValueMap<Bool_t>>();
   edm::ValueMap<Bool_t>::Filler fillerlooseEM(*outlooseEM);
   fillerlooseEM.insert(photons, LooseEM.begin(), LooseEM.end());
   fillerlooseEM.fill();
   // and put it into the event
-  e.put(outlooseEM, photonCutBasedIDLooseEMLabel_);
+  e.put(std::move(outlooseEM), photonCutBasedIDLooseEMLabel_);
 
-  std::auto_ptr<edm::ValueMap<Bool_t> > outloose(new edm::ValueMap<Bool_t>());
+  auto outloose = std::make_unique<edm::ValueMap<Bool_t>>();
   edm::ValueMap<Bool_t>::Filler fillerloose(*outloose);
   fillerloose.insert(photons, Loose.begin(), Loose.end());
   fillerloose.fill();
   // and put it into the event
-  e.put(outloose, photonCutBasedIDLooseLabel_);
+  e.put(std::move(outloose), photonCutBasedIDLooseLabel_);
   
-  std::auto_ptr<edm::ValueMap<Bool_t> > outtight(new edm::ValueMap<Bool_t>());
+  auto outtight = std::make_unique<edm::ValueMap<Bool_t>>();
   edm::ValueMap<Bool_t>::Filler fillertight(*outtight);
   fillertight.insert(photons, Tight.begin(), Tight.end());
   fillertight.fill();
   // and put it into the event
-  e.put(outtight, photonCutBasedIDTightLabel_);
+  e.put(std::move(outtight), photonCutBasedIDTightLabel_);
   
   
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -224,24 +224,24 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
   // Configure Lazy Tools
   if (usesES_) {
       if( isAOD )
-        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+        lazyToolnoZS = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, 
                                                       ebReducedRecHitCollection_,
                                                       eeReducedRecHitCollection_,
-                                                      esReducedRecHitCollection_));
+                                                      esReducedRecHitCollection_);
       else
-        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+        lazyToolnoZS = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, 
                                                       ebReducedRecHitCollectionMiniAOD_,
                                                       eeReducedRecHitCollectionMiniAOD_,
-                                                      esReducedRecHitCollectionMiniAOD_)); 
+                                                      esReducedRecHitCollectionMiniAOD_); 
   } else {
       if( isAOD )
-        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+        lazyToolnoZS = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, 
                                                       ebReducedRecHitCollection_,
-                                                      eeReducedRecHitCollection_));
+                                                      eeReducedRecHitCollection_);
       else
-        lazyToolnoZS = std::unique_ptr<noZS::EcalClusterLazyTools>(new noZS::EcalClusterLazyTools(iEvent, iSetup, 
+        lazyToolnoZS = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, 
                                                       ebReducedRecHitCollectionMiniAOD_,
-                                                      eeReducedRecHitCollectionMiniAOD_)); 
+                                                      eeReducedRecHitCollectionMiniAOD_); 
 
   }
   
@@ -426,11 +426,11 @@ void PhotonIDValueMapProducer::writeValueMap(edm::Event &iEvent,
 {
   using namespace edm; 
   using namespace std;
-  auto_ptr<ValueMap<float> > valMap(new ValueMap<float>());
+  auto valMap = std::make_unique<ValueMap<float>>();
   edm::ValueMap<float>::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(valMap, label);
+  iEvent.put(std::move(valMap), label);
 }
 
 void PhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -177,7 +177,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+  return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }
 
 // A function that should work on both pat and reco objects

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -186,7 +186,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+  return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 
 }
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonRegressionValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonRegressionValueMapProducer.cc
@@ -244,11 +244,11 @@ void PhotonRegressionValueMapProducer::writeValueMap(edm::Event &iEvent,
   using namespace std;
   typedef ValueMap<T> TValueMap;
   
-  auto_ptr<TValueMap> valMap(new TValueMap());
+  auto valMap = std::make_unique<TValueMap>();
   typename TValueMap::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(valMap, label);
+  iEvent.put(std::move(valMap), label);
 }
 
 void PhotonRegressionValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoEgamma and RecoEcal packages. Also, std::make_unique is used when appropriate. Also, there was a case where a reference to an auto_ptr was an input argument to a function, which is a bad practice because it obscures the possible transfer of ownership. In the cases here, ownership was transferred, so the  unique_ptr was passed by value.
