### PR TITLE
Fix two issues in Phase2 tracking spotted by the era migration

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -22,20 +22,7 @@ eras.trackingPhase1.toModify(detachedQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 eras.trackingPhase2PU140.toModify(detachedQuadStepSeedLayers, 
-##FIXME::ERICA layerList need to be moved to PixelLayerTriplets.layerList when the validation to era is done 
-#    layerList = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.layerList.value()
-    layerList = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
-                  'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
-                  'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
-                  'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
-                  'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
-                  'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
-                  'FPix2_pos+FPix3_pos+FPix4_pos', 'FPix2_neg+FPix3_neg+FPix4_neg',
-                  'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
-                  'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
-                  'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
-                  'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg',
-                  'FPix6_pos+FPix7_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix9_neg']
+    layerList = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.layerList.value()
 )
 
 # SEEDS

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -34,9 +34,6 @@ for era in _cfg.allEras():
     locals()["_seedProducers"+pf] = _seedProd + _cfg.seedProducers(era)
     locals()["_trackProducers"+pf] = _trackProd + _cfg.trackProducers(era)
 
-#FIXME::ERICA : # for strict "no changes" in phase2 era migration, this line will be removed later
-_algos_trackingPhase2PU140.remove("duplicateMerge") 
-
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",
                                  "muonSeededSeedsInOut",


### PR DESCRIPTION
As reported in the PR #15183 , two part of the code were not changed respect to the baseline in order to have the transition to era as smooth as possible. These part have been changed in this PR and the FIXME have been removed. 
The results show an increment in the efficiency for the `detachedQuadStep` tracks (as expected thanks to the fix [here](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/MovingToEra/20160908/plots_building_summary/summary.pdf)) and a new category `duplicateMerge` in the validation tool has been added [here](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/MovingToEra/20160908/plots_summary/summary.pdf).

No difference are expected respect to the other phases and the other part of the phase1 tracking.

Thanks to @makortel 
Informing @VinInn @rovere @kpedro88 
