### PR TITLE
Phase1 Pixel Triplets Seeding by CA - LayerCache cleared after use

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -144,6 +144,9 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 
 	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
 			caHardPtCut);
+
+	theLayerCache.clear();
+
 	unsigned int numberOfFoundTriplets = foundTriplets.size();
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitTripletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitTripletGenerator_cfi.py
@@ -10,7 +10,8 @@ CAHitTripletGenerator = cms.PSet(
     ),
     useBendingCorrection = cms.bool(False),
     CAThetaCut = cms.double(0.00125),
-    CAPhiCut = cms.double(1),
+    CAPhiCut = cms.double(0.1),
+    CAHardPtCut = cms.double(0),   
 )
 
 

--- a/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseForTripletsByCellularAutomaton(process):
+    for module in process._Process__producers.values():
+        if not hasattr(module, "OrderedHitsFactoryPSet"):
+            continue
+	pset = getattr(module, "OrderedHitsFactoryPSet")
+        if not hasattr(pset, "ComponentName"):
+	    continue
+	if not (pset.ComponentName == "StandardHitTripletGenerator"):
+	    continue
+        # Adjust seeding layers
+        seedingLayersName = module.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+   
+
+
+        # Configure seed generator / pixel track producer
+        Triplets = module.OrderedHitsFactoryPSet.clone()
+        from RecoPixelVertexing.PixelTriplets.CAHitTripletGenerator_cfi import CAHitTripletGenerator as _CAHitTripletGenerator
+
+        module.OrderedHitsFactoryPSet  = _CAHitTripletGenerator.clone(
+            ComponentName = cms.string("CAHitTripletGenerator"),
+            extraHitRPhitolerance = Triplets.GeneratorPSet.extraHitRPhitolerance,
+            maxChi2 = dict(
+                pt1    = 0.8, pt2    = 2,
+                value1 = 200, value2 = 100,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            SeedingLayers = cms.InputTag(seedingLayersName),
+            CAThetaCut = cms.double(0.00125),
+            CAPhiCut = cms.double(0.1),
+            CAHardPtCut = cms.double(0),
+        )
+
+        if hasattr(Triplets.GeneratorPSet, "SeedComparitorPSet"):
+            pset.SeedComparitorPSet = Triplets.GeneratorPSet.SeedComparitorPSet
+    return process

--- a/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
@@ -23,13 +23,13 @@ def customiseForTripletsByCellularAutomaton(process):
             extraHitRPhitolerance = Triplets.GeneratorPSet.extraHitRPhitolerance,
             maxChi2 = dict(
                 pt1    = 0.8, pt2    = 2,
-                value1 = 200, value2 = 100,
+                value1 = 20, value2 = 10,
                 enabled = True,
             ),
             useBendingCorrection = True,
             SeedingLayers = cms.InputTag(seedingLayersName),
-            CAThetaCut = cms.double(0.00125),
-            CAPhiCut = cms.double(0.1),
+            CAThetaCut = cms.double(0.0015),
+            CAPhiCut = cms.double(0.01),
             CAHardPtCut = cms.double(0),
         )
 

--- a/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
@@ -33,6 +33,7 @@ def customiseForTripletsHLTPixelTracksByCellularAutomaton(process):
             SeedingLayers = cms.InputTag(seedingLayersName),
             CAThetaCut = cms.double(0.0015),
             CAPhiCut = cms.double(0.01),
+            CAHardPtCut = cms.double(0),
         )
 
         if hasattr(triplets.GeneratorPSet, "SeedComparitorPSet"):


### PR DESCRIPTION
The LayerCache should be cleared after use so that we don't get unexpected behavior in following events.

You can test triplets by customizing the process with: customiseForTripletsHLTPixelTracksByCellularAutomaton

@makortel @mtosi @VinInn @rovere 
