### PR TITLE
Reduce time in Phase2TrackerDigitizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -50,7 +50,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 
@@ -109,6 +109,8 @@ namespace cms
     
     if (theTkDigiGeomWatcher.check(iSetup)) {
       iSetup.get<TrackerDigiGeometryRecord>().get(geometryType_, pDD_);
+      //reset cache
+      ModuleTypeCache().swap(moduleTypeCache_);
       detectorUnits_.clear();
       for (auto const & det_u : pDD_->detUnits()) {
 	unsigned int detId_raw = det_u->geographicalId().rawId();
@@ -218,7 +220,17 @@ namespace cms
     DetId detId(detId_raw); 
 
     AlgorithmType algotype = AlgorithmType::Unknown;
-    TrackerGeometry::ModuleType mType = pDD_->getDetectorType(detId);    
+    
+    //get mType either from the geometry or from our cache (faster)
+    TrackerGeometry::ModuleType mType = TrackerGeometry::ModuleType::UNKNOWN;
+    auto itr = moduleTypeCache_.find(detId_raw);
+    if( itr != moduleTypeCache_.end() ) {
+      mType = itr->second; 
+    } else {
+      mType = pDD_->getDetectorType(detId);
+      moduleTypeCache_.emplace(detId_raw,mType);
+    }
+    
     switch(mType){
 
     case TrackerGeometry::ModuleType::Ph1PXB:

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -22,6 +22,9 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/stream/EDProducerBase.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include <unordered_map>
 
 // Forward declaration
 namespace CLHEP {
@@ -40,7 +43,6 @@ class MagneticField;
 class PileUpEventPrincipal;
 class PSimHit;
 class Phase2TrackerDigitizerAlgorithm;
-class TrackerGeometry;
 class TrackerDigiGeometryRecord;
 
 namespace cms 
@@ -48,6 +50,8 @@ namespace cms
   class Phase2TrackerDigitizer: public DigiAccumulatorMixMod {
 
   public:
+    typedef std::unordered_map<unsigned, TrackerGeometry::ModuleType>  ModuleTypeCache;
+
     explicit Phase2TrackerDigitizer(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
     virtual ~Phase2TrackerDigitizer();
     virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
@@ -105,6 +109,9 @@ namespace cms
     edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
     const edm::ParameterSet& iconfig_;
 
+    // cache for detector types
+    ModuleTypeCache moduleTypeCache_;
+    
   };
 }
 #endif


### PR DESCRIPTION
Add a cache in getAlgoType() to avoid repeated calls to expensive function. 

Digitizer time for phase 2 tracker reduced by about 1/3rd in ttbar with PU.
