### PR TITLE
Use unique_ptr, not auto_ptr in RecoHI

### DIFF
--- a/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
@@ -166,8 +166,7 @@ CentralityBinProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   }
 
-   std::auto_ptr<int> binp(new int(bin));
-   iEvent.put(binp,centralityVariable_.data());
+   iEvent.put(std::make_unique<int>(bin),centralityVariable_.data());
  
 }
 

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
@@ -186,7 +186,7 @@ CentralityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   if(producePixelhits_) iSetup.get<TrackerDigiGeometryRecord>().get(tGeo);
   if(produceEcalhits_) iSetup.get<CaloGeometryRecord>().get(cGeo);
 
-  std::auto_ptr<Centrality> creco(new Centrality());
+  auto creco = std::make_unique<Centrality>();
   Handle<Centrality> inputCentrality;
 
   if(reuseAny_) iEvent.getByToken(reuseTag_,inputCentrality);
@@ -458,7 +458,7 @@ CentralityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
   }
   
-  iEvent.put(creco);
+  iEvent.put(std::move(creco));
 
 }
 

--- a/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
@@ -84,7 +84,7 @@ ClusterCompatibilityProducer::~ClusterCompatibilityProducer() {}
 void
 ClusterCompatibilityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::auto_ptr<reco::ClusterCompatibility> creco(new reco::ClusterCompatibility());
+  auto creco = std::make_unique<reco::ClusterCompatibility>();
 
   // get hold of products from Event
   edm::Handle<SiPixelRecHitCollection> hRecHits;
@@ -145,7 +145,7 @@ ClusterCompatibilityProducer::produce(edm::Event& iEvent, const edm::EventSetup&
     }
 
   }
-  iEvent.put(creco);
+  iEvent.put(std::move(creco));
 
 }
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.cc
@@ -143,7 +143,7 @@ HiEgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
   const reco::SuperClusterCollection *rawClusters = pRawSuperClusters.product();
    
   // Define a collection of corrected SuperClusters to put back into the event
-  std::auto_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
+  auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
   
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;
@@ -160,7 +160,7 @@ HiEgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
      }
   }
   // Put collection of corrected SuperClusters into the event
-  evt.put(corrClusters, outputCollection_);   
+  evt.put(std::move(corrClusters), outputCollection_);   
 }
 
 DEFINE_FWK_MODULE(HiEgammaSCCorrectionMaker);

--- a/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
@@ -151,7 +151,7 @@ HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    EcalClusterLazyTools lazyTool(iEvent, iSetup, rHInputProducerBToken_,rHInputProducerEToken_);
 
    // Define a collection of corrected SuperClusters to put back into the event
-   std::auto_ptr<reco::SuperClusterCollection> corrClusters(new reco::SuperClusterCollection);
+   auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
    
    //  Loop over raw clusters and make corrected ones
    reco::SuperClusterCollection::const_iterator aClus;
@@ -205,7 +205,7 @@ HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
    
    // Put collection of corrected SuperClusters into the event
-   iEvent.put(corrClusters, outputCollection_);   
+   iEvent.put(std::move(corrClusters), outputCollection_);   
    
 }
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.cc
@@ -115,8 +115,7 @@ void HiSuperClusterProducer::produceSuperclustersForECALPart(edm::Event& evt,
   getClusterPtrVector(evt, clustersToken, clusterPtrVector_p);
 
   // run the brem recovery and get the SC collection
-  std::auto_ptr<reco::SuperClusterCollection> 
-    superclusters_ap(new reco::SuperClusterCollection(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p)));
+  auto superclusters_ap = std::make_unique<reco::SuperClusterCollection>(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p));
 
   // count the total energy and the number of superclusters
   reco::SuperClusterCollection::iterator it;
@@ -127,7 +126,7 @@ void HiSuperClusterProducer::produceSuperclustersForECALPart(edm::Event& evt,
     }
 
   // put the SC collection in the event
-  evt.put(superclusters_ap, superclusterCollection);
+  evt.put(std::move(superclusters_ap), superclusterCollection);
 
   delete clusterPtrVector_p;
 }

--- a/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
@@ -89,7 +89,7 @@ photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   edm::Handle<reco::TrackCollection> trackCollection;
   evt.getByToken(tracks_, trackCollection);
 
-  std::auto_ptr<reco::HIPhotonIsolationMap> outputMap (new reco::HIPhotonIsolationMap);
+  auto outputMap = std::make_unique<reco::HIPhotonIsolationMap>();
   reco::HIPhotonIsolationMap::Filler filler(*outputMap);
   std::vector<reco::HIPhotonIsolation> isoVector;
 
@@ -143,7 +143,7 @@ photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   }
   filler.insert(photons, isoVector.begin(), isoVector.end() );
   filler.fill();
-  evt.put(outputMap);
+  evt.put(std::move(outputMap));
 }
 
 void

--- a/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
+++ b/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
@@ -92,7 +92,7 @@ PATHIPhotonTestModule::analyze(const edm::Event& iEvent, const edm::EventSetup& 
    edm::Handle<edm::View<pat::Photon> > photons;
    iEvent.getByLabel(photons_,photons);
 
-   std::auto_ptr<std::vector<pat::Photon> > output(new std::vector<pat::Photon>());
+   auto output = std::make_unique<std::vector<pat::Photon>>();
 
    for (edm::View<pat::Photon>::const_iterator photon = photons->begin(), end = photons->end(); photon != end; ++photon) {
    	   

--- a/RecoHI/HiEvtPlaneAlgos/src/EvtPlaneProducer.cc
+++ b/RecoHI/HiEvtPlaneAlgos/src/EvtPlaneProducer.cc
@@ -490,7 +490,7 @@ EvtPlaneProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       } //end for
     }
 
-    std::auto_ptr<EvtPlaneCollection> evtplaneOutput(new EvtPlaneCollection);
+    auto evtplaneOutput = std::make_unique<EvtPlaneCollection>();
 
     double ang=-10;
     double sv = 0;
@@ -510,7 +510,7 @@ EvtPlaneProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       evtplaneOutput->back().addLevel(3, 0., svNoWgt, cvNoWgt);
     }
 
-    iEvent.put(evtplaneOutput);
+    iEvent.put(std::move(evtplaneOutput));
 }
 
 //define this as a plug-in

--- a/RecoHI/HiEvtPlaneAlgos/src/HiEvtPlaneFlatProducer.cc
+++ b/RecoHI/HiEvtPlaneAlgos/src/HiEvtPlaneFlatProducer.cc
@@ -263,7 +263,7 @@ HiEvtPlaneFlatProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     return ;
   }
 
-  std::auto_ptr<EvtPlaneCollection> evtplaneOutput(new EvtPlaneCollection);
+  auto evtplaneOutput = std::make_unique<EvtPlaneCollection>();
   EvtPlane * ep[NumEPNames];
   for(int i = 0; i<NumEPNames; i++) {
     ep[i]=0;
@@ -294,7 +294,7 @@ HiEvtPlaneFlatProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     if(ep[i]!=0) evtplaneOutput->push_back(*ep[i]);
     
   }
-  iEvent.put(evtplaneOutput);
+  iEvent.put(std::move(evtplaneOutput));
   for(int i = 0; i<indx; i++) delete ep[i];
 }
 

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -101,10 +101,10 @@ HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& 
   //Define output vectors
   int neta = (int)mapEtaRanges->size();
    
-  std::unique_ptr<std::vector<double>> mapToRhoCorrOut ( new std::vector<double>(neta-1,1e-6));
-  std::unique_ptr<std::vector<double>> mapToRhoMCorrOut ( new std::vector<double>(neta-1,1e-6));
-  std::unique_ptr<std::vector<double>> mapToRhoCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
-  std::unique_ptr<std::vector<double>> mapToRhoMCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+  auto mapToRhoCorrOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoMCorrOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoCorr1BinOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoMCorr1BinOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
 
   setupGrid(mapEtaRanges->at(0), mapEtaRanges->at(neta-1));
   
@@ -151,10 +151,10 @@ HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& 
   
   //calculate rho from grid as a function of eta over full range using PF candidates
   
-  std::unique_ptr<std::vector<double>> mapRhoVsEtaGridOut ( new std::vector<double>(ny_,0.));
-  std::unique_ptr<std::vector<double>> mapMeanRhoVsEtaGridOut ( new std::vector<double>(ny_,0.));
-  std::unique_ptr<std::vector<double>> mapEtaMaxGridOut ( new std::vector<double>(ny_,0.));
-  std::unique_ptr<std::vector<double>> mapEtaMinGridOut ( new std::vector<double>(ny_,0.));
+  auto mapRhoVsEtaGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapMeanRhoVsEtaGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapEtaMaxGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapEtaMinGridOut = std::make_unique<std::vector<double>>(ny_,0.);
   calculateGridRho(iEvent, iSetup);
   if(keepGridInfo_){
     for(int ieta = 0; ieta < ny_; ieta++) {

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -89,19 +89,19 @@ void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(jetsToken_, jets);
 
   int neta = (int)etaRanges.size();
-  std::unique_ptr<std::vector<double>> mapEtaRangesOut ( new std::vector<double>(neta,-999.));
+  auto mapEtaRangesOut = std::make_unique<std::vector<double>>(neta,-999.);
 
   for(int ieta = 0; ieta < neta; ieta++){
    mapEtaRangesOut->at(ieta) = etaRanges[ieta];
   }
-  std::unique_ptr<std::vector<double>> mapToRhoOut ( new std::vector<double>(neta-1,1e-6));
-  std::unique_ptr<std::vector<double>> mapToRhoMOut ( new std::vector<double>(neta-1,1e-6));
+  auto mapToRhoOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoMOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
   
   int njets = jets->size();
   
-  std::unique_ptr<std::vector<double>> ptJetsOut ( new std::vector<double>(njets,1e-6));
-  std::unique_ptr<std::vector<double>> areaJetsOut ( new std::vector<double>(njets,1e-6));
-  std::unique_ptr<std::vector<double>> etaJetsOut ( new std::vector<double>(njets,1e-6));
+  auto ptJetsOut = std::make_unique<std::vector<double>>(njets,1e-6);
+  auto areaJetsOut = std::make_unique<std::vector<double>>(njets,1e-6);
+  auto etaJetsOut = std::make_unique<std::vector<double>>(njets,1e-6);
     
   double rhoVec[999];
   double rhomVec[999];

--- a/RecoHI/HiJetAlgos/plugins/HiL1Subtractor.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiL1Subtractor.cc
@@ -62,7 +62,7 @@ HiL1Subtractor::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // right now, identical loop for calo and PF jets, should template
    if(jetType_ == "GenJet"){
-      std::auto_ptr<reco::GenJetCollection> jets( new reco::GenJetCollection);
+      auto jets = std::make_unique<reco::GenJetCollection>();
       edm::Handle< edm::View<reco::GenJet> > h_jets;
       iEvent.getByToken( genJetSrc_, h_jets );
 
@@ -115,10 +115,10 @@ HiL1Subtractor::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
       }
-      iEvent.put(jets);
+      iEvent.put(std::move(jets));
 
    }else if(jetType_ == "CaloJet"){
-    std::auto_ptr<reco::CaloJetCollection> jets( new reco::CaloJetCollection);
+    auto jets = std::make_unique<reco::CaloJetCollection>();
     edm::Handle< edm::View<reco::CaloJet> > h_jets;
     iEvent.getByToken( caloJetSrc_, h_jets );
 
@@ -175,11 +175,11 @@ HiL1Subtractor::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
     }
-    iEvent.put(jets);
+    iEvent.put(std::move(jets));
 
   }
   else if(jetType_ == "PFJet"){
-    std::auto_ptr<reco::PFJetCollection> jets( new reco::PFJetCollection);
+    auto jets = std::make_unique<reco::PFJetCollection>();
     edm::Handle< edm::View<reco::PFJet> > h_jets;
     iEvent.getByToken( pfJetSrc_, h_jets );
 
@@ -236,7 +236,7 @@ HiL1Subtractor::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
     }
-    iEvent.put(jets);
+    iEvent.put(std::move(jets));
 
   }
 

--- a/RecoHI/HiJetAlgos/plugins/VoronoiBackgroundProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/VoronoiBackgroundProducer.cc
@@ -161,8 +161,8 @@ VoronoiBackgroundProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
    std::vector<double> equalized_momenta = voronoi_->subtracted_equalized_perp();
    std::vector<double> particle_area = voronoi_->particle_area();
    std::vector<double> voronoi_vn = voronoi_->perp_fourier();
-   std::auto_ptr<std::vector<float> > vnout(new std::vector<float>(voronoi_vn.begin(), voronoi_vn.end()));
-   std::auto_ptr<reco::VoronoiMap> mapout(new reco::VoronoiMap());
+   auto vnout = std::make_unique<std::vector<float>>(voronoi_vn.begin(), voronoi_vn.end());
+   auto mapout = std::make_unique<reco::VoronoiMap>();
    reco::VoronoiMap::Filler filler(*mapout);
 
    for(unsigned int i = 0; i < inputsHandle->size(); ++i){
@@ -181,8 +181,8 @@ VoronoiBackgroundProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
    filler.insert(inputsHandle,vvm.begin(),vvm.end());
    filler.fill();
-   iEvent.put(vnout);
-   iEvent.put(mapout);
+   iEvent.put(std::move(vnout));
+   iEvent.put(std::move(mapout));
  
 }
 

--- a/RecoHI/HiJetAlgos/src/HiGenCleaner.cc
+++ b/RecoHI/HiJetAlgos/src/HiGenCleaner.cc
@@ -93,8 +93,7 @@ HiGenCleaner<T2>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    using namespace edm;
    using namespace reco;
 
-   auto_ptr<T2Collection> jets;
-   jets = auto_ptr<T2Collection>(new T2Collection);
+   auto jets = std::make_unique<T2Collection>();
    
    edm::Handle<edm::View<T2> > genjets;
    iEvent.getByToken(jetSrc_,genjets);
@@ -141,7 +140,7 @@ HiGenCleaner<T2>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	 jets->push_back(*jet1);
       }
    }
-   iEvent.put(jets);
+   iEvent.put(std::move(jets));
 
 }
 

--- a/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
@@ -160,7 +160,7 @@ ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
    }
    
    
-   std::auto_ptr<CaloTowerCollection> prod(new CaloTowerCollection());
+   auto prod = std::make_unique<CaloTowerCollection>();
 
    for ( std::map< DetId, double >::const_iterator iter = towers_.begin();
 	 iter != towers_.end(); ++iter ){
@@ -202,7 +202,7 @@ ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
    */
 
 
-   iEvent.put(prod);
+   iEvent.put(std::move(prod));
 
 
 }

--- a/RecoHI/HiTracking/interface/HICaloCompatibleTrackSelector.h
+++ b/RecoHI/HiTracking/interface/HICaloCompatibleTrackSelector.h
@@ -104,12 +104,12 @@ namespace reco { namespace modules {
       std::string funcCaloComp_;
       
       /// storage
-      std::auto_ptr<reco::TrackCollection> selTracks_;
-      std::auto_ptr<reco::TrackExtraCollection> selTrackExtras_;
-      std::auto_ptr< TrackingRecHitCollection>  selHits_;
-      std::auto_ptr< std::vector<Trajectory> > selTrajs_;
-      std::auto_ptr< std::vector<const Trajectory *> > selTrajPtrs_;
-      std::auto_ptr< TrajTrackAssociationCollection >  selTTAss_;
+      std::unique_ptr<reco::TrackCollection> selTracks_;
+      std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+      std::unique_ptr<TrackingRecHitCollection> selHits_;
+      std::unique_ptr<std::vector<Trajectory>> selTrajs_;
+      std::unique_ptr<std::vector<const Trajectory*>> selTrajPtrs_;
+      std::unique_ptr<TrajTrackAssociationCollection> selTTAss_;
       reco::TrackRefProd rTracks_;
       reco::TrackExtraRefProd rTrackExtras_;
       TrackingRecHitRefProd rHits_;

--- a/RecoHI/HiTracking/plugins/HIBestVertexProducer.cc
+++ b/RecoHI/HiTracking/plugins/HIBestVertexProducer.cc
@@ -43,7 +43,7 @@ void HIBestVertexProducer::produce
   // 3. use beamspot if netither vertexing method succeeds
 
   // New vertex collection
-  std::auto_ptr<reco::VertexCollection> newVertexCollection(new reco::VertexCollection);
+  auto newVertexCollection = std::make_unique<reco::VertexCollection>();
 
   //** Get precise adaptive vertex **/
   edm::Handle<reco::VertexCollection> vc1;
@@ -118,7 +118,7 @@ void HIBestVertexProducer::produce
   }
   
   // put new vertex collection into event
-  ev.put(newVertexCollection);
+  ev.put(std::move(newVertexCollection));
   
 }
 

--- a/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
+++ b/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
@@ -320,7 +320,7 @@ void HIMultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) con
 
   for (unsigned int i=0; i<qualityToSet_.size(); i++) {  
     std::vector<int> selTracks(trkSize,0);
-    auto_ptr<edm::ValueMap<int> > selTracksValueMap = auto_ptr<edm::ValueMap<int> >(new edm::ValueMap<int>);
+    auto selTracksValueMap = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler filler(*selTracksValueMap);
 
     std::vector<Point> points;
@@ -389,8 +389,8 @@ void HIMultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) con
     filler.insert(hSrcTrack, selTracks.begin(),selTracks.end());
     filler.fill();
 
-    //    evt.put(selTracks,name_[i]);
-    evt.put(selTracksValueMap,name_[i]);
+    //    evt.put(std::move(selTracks),name_[i]);
+    evt.put(std::move(selTracksValueMap),name_[i]);
   }
 }
 
@@ -609,7 +609,7 @@ void HIMultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es
   const TrackingRecHitCollection & srcHits(*hSrcHits);
 
 
-  auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);
+  auto mvaValValueMap = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler mvaFiller(*mvaValValueMap);
 
 
@@ -617,7 +617,7 @@ void HIMultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es
     // mvaVals_ already initalized...
     mvaFiller.insert(hSrcTrack,mvaVals_.begin(),mvaVals_.end());
     mvaFiller.fill();
-    evt.put(mvaValValueMap,"MVAVals");
+    evt.put(std::move(mvaValValueMap),"MVAVals");
     return;
   }
 
@@ -697,7 +697,7 @@ void HIMultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es
   }
   mvaFiller.insert(hSrcTrack,mvaVals_.begin(),mvaVals_.end());
   mvaFiller.fill();
-  evt.put(mvaValValueMap,"MVAVals");
+  evt.put(std::move(mvaValValueMap),"MVAVals");
 
 }
 

--- a/RecoHI/HiTracking/plugins/HIPixelClusterVtxProducer.cc
+++ b/RecoHI/HiTracking/plugins/HIPixelClusterVtxProducer.cc
@@ -52,7 +52,7 @@ void HIPixelClusterVtxProducer::produce(edm::Event& ev, const edm::EventSetup& e
 {
 
   // new vertex collection
-  std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);
+  auto vertices = std::make_unique<reco::VertexCollection>();
 
   // get pixel rechits
   edm::Handle<SiPixelRecHitCollection> hRecHits;
@@ -132,7 +132,7 @@ void HIPixelClusterVtxProducer::produce(edm::Event& ev, const edm::EventSetup& e
     vertices->push_back(ver);
   }
 
-  ev.put(vertices);
+  ev.put(std::move(vertices));
 }
 
 /*****************************************************************************/

--- a/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
+++ b/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
@@ -59,11 +59,11 @@ void HIPixelMedianVtxProducer::produce
     << ") above pt = " << thePtMin; 
 	
   // Output vertex collection
-  std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);
+  auto vertices = std::make_unique<reco::VertexCollection>();
 
   // No tracks -> return empty collection
   if(tracks.size() == 0) {
-      ev.put(vertices);
+      ev.put(std::move(vertices));
       return;
   }
 
@@ -111,7 +111,7 @@ void HIPixelMedianVtxProducer::produce
       reco::Vertex ver(reco::Vertex::Point(0,0,99999.),
                        err, 0, 0, 1);
       vertices->push_back(ver);
-      ev.put(vertices);
+      ev.put(std::move(vertices));
       return;
     }
 
@@ -150,7 +150,7 @@ void HIPixelMedianVtxProducer::produce
     reco::Vertex ver(reco::Vertex::Point(0,0,med),
 		     err, 0, 1, 1);
     vertices->push_back(ver);
-    ev.put(vertices);
+    ev.put(std::move(vertices));
     return;
   }
 
@@ -173,7 +173,7 @@ void HIPixelMedianVtxProducer::produce
 		   err, 0, 1, 1);
   vertices->push_back(ver);
   
-  ev.put(vertices);
+  ev.put(std::move(vertices));
   return;
 
 }

--- a/RecoHI/HiTracking/src/HICaloCompatibleTrackSelector.cc
+++ b/RecoHI/HiTracking/src/HICaloCompatibleTrackSelector.cc
@@ -92,11 +92,11 @@ void HICaloCompatibleTrackSelector::produce( edm::Event& evt, const edm::EventSe
 
   evt.getByToken(srcTracks_,hSrcTrack);
   
-  selTracks_ = auto_ptr<TrackCollection>(new TrackCollection());
+  selTracks_ = std::make_unique<TrackCollection>();
   rTracks_ = evt.getRefBeforePut<TrackCollection>();      
   if (copyExtras_) {
-    selTrackExtras_ = auto_ptr<TrackExtraCollection>(new TrackExtraCollection());
-    selHits_ = auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+    selTrackExtras_ = std::make_unique<TrackExtraCollection>();
+    selHits_ = std::make_unique<TrackingRecHitCollection>();
     rHits_ = evt.getRefBeforePut<TrackingRecHitCollection>();
     rTrackExtras_ = evt.getRefBeforePut<TrackExtraCollection>();
   }
@@ -162,9 +162,9 @@ void HICaloCompatibleTrackSelector::produce( edm::Event& evt, const edm::EventSe
     Handle< TrajTrackAssociationCollection > hTTAss;
     evt.getByToken(srcTrackTrajs_, hTTAss);
     evt.getByToken(srcTrackTrajAssoc_, hTraj);
-    selTrajs_ = auto_ptr< vector<Trajectory> >(new vector<Trajectory>()); 
+    selTrajs_ = std::make_unique<std::vector<Trajectory>>(); 
     rTrajectories_ = evt.getRefBeforePut< vector<Trajectory> >();
-    selTTAss_ = auto_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection());
+    selTTAss_ = std::make_unique<TrajTrackAssociationCollection>();
     for (size_t i = 0, n = hTraj->size(); i < n; ++i) {
       Ref< vector<Trajectory> > trajRef(hTraj, i);
       TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
@@ -180,14 +180,14 @@ void HICaloCompatibleTrackSelector::produce( edm::Event& evt, const edm::EventSe
   }
   
   static const string emptyString;
-  evt.put(selTracks_);
+  evt.put(std::move(selTracks_));
   if (copyExtras_ ) {
-    evt.put(selTrackExtras_); 
-    evt.put(selHits_);
+    evt.put(std::move(selTrackExtras_)); 
+    evt.put(std::move(selHits_));
   }
   if ( copyTrajectories_ ) {
-    evt.put(selTrajs_);
-    evt.put(selTTAss_);
+    evt.put(std::move(selTrajs_));
+    evt.put(std::move(selTTAss_));
   }
 }
 

--- a/RecoHI/HiTracking/test/HIPixelClusterVtxAnalyzer.cc
+++ b/RecoHI/HiTracking/test/HIPixelClusterVtxAnalyzer.cc
@@ -60,7 +60,7 @@ void HIPixelClusterVtxAnalyzer::analyze(const edm::Event& ev, const edm::EventSe
   TH1D *hClusterVtx = fs->make<TH1D>(Form("hClusterVtx_%llu",evtnum),"compatibility of pixel cluster length with vertex hypothesis; z [cm]",(int)((maxZ_-minZ_)/zStep_),minZ_,maxZ_);
 
   // new vertex collection
-  std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);
+  auto vertices = std::make_unique<reco::VertexCollection>();
 
   // get pixel rechits
   edm::Handle<SiPixelRecHitCollection> hRecHits;


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoHI packages. Also, std::make_unique is used when appropriate. 
