### PR TITLE
Use unique_ptr, not auto_ptr in RecoTauTag

### DIFF
--- a/RecoTauTag/ImpactParameter/plugins/ImpactParameter.cc
+++ b/RecoTauTag/ImpactParameter/plugins/ImpactParameter.cc
@@ -78,13 +78,13 @@ void ImpactParameter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         edm::Handle<IsolatedTauTagInfoCollection> isolatedTaus;
         iEvent.getByLabel(jetTrackSrc,isolatedTaus);
 
-        std::auto_ptr<JetTagCollection>                 tagCollection;
-        std::auto_ptr<TauImpactParameterInfoCollection> extCollection( new TauImpactParameterInfoCollection() );
+        std::unique_ptr<JetTagCollection> tagCollection;
+        auto extCollection = std::make_unique<TauImpactParameterInfoCollection>();
         if (not isolatedTaus->empty()) {
           edm::RefToBaseProd<reco::Jet> prod( edm::makeRefToBaseProdFrom(isolatedTaus->begin()->jet(), iEvent) );
-          tagCollection.reset( new JetTagCollection(prod) );
+          tagCollection = std::make_unique<JetTagCollection>(prod);
         } else {
-          tagCollection.reset( new JetTagCollection() );
+          tagCollection = std::make_unique<JetTagCollection>();
         }
 
         edm::ESHandle<TransientTrackBuilder> builder;
@@ -121,8 +121,8 @@ void ImpactParameter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             extCollection->push_back(ipInfo.second);
         }
 
-        iEvent.put(extCollection);
-        iEvent.put(tagCollection);
+        iEvent.put(std::move(extCollection));
+        iEvent.put(std::move(tagCollection));
 }
 
 

--- a/RecoTauTag/ImpactParameter/plugins/PFTau3ProngReco.cc
+++ b/RecoTauTag/ImpactParameter/plugins/PFTau3ProngReco.cc
@@ -92,7 +92,7 @@ class PFTau3ProngReco : public EDProducer {
   edm::InputTag PFTauTIPTag_;
   int Algorithm_;
   DiscCutPairVec discriminators_;
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
   int ndfPVT_;
   KinematicParticleVertexFitter kpvFitter_;
 };
@@ -114,7 +114,7 @@ PFTau3ProngReco::PFTau3ProngReco(const edm::ParameterSet& iConfig):
     discriminators_.push_back(newCut);
   }
   // Build a string cut if desired
-  if (iConfig.exists("cut")) cut_.reset(new StringCutObjectSelector<reco::PFTau>(iConfig.getParameter<std::string>( "cut" )));
+  if (iConfig.exists("cut")) cut_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(iConfig.getParameter<std::string>("cut"));
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   produces<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTau3ProngSummaryRef> > >();
   produces<PFTau3ProngSummaryCollection>("PFTau3ProngSummary");
@@ -135,8 +135,8 @@ void PFTau3ProngReco::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
   edm::Handle<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > > TIPAV;
   iEvent.getByLabel(PFTauTIPTag_,TIPAV);
 
-  auto_ptr<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTau3ProngSummaryRef> > > AVPFTau3PS(new edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTau3ProngSummaryRef> >(PFTauRefProd(Tau)));
-  std::auto_ptr<PFTau3ProngSummaryCollection>  PFTau3PSCollection_out= std::auto_ptr<PFTau3ProngSummaryCollection>(new PFTau3ProngSummaryCollection());
+  auto AVPFTau3PS = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTau3ProngSummaryRef>>>(PFTauRefProd(Tau));
+  auto PFTau3PSCollection_out = std::make_unique<PFTau3ProngSummaryCollection>();
   reco::PFTau3ProngSummaryRefProd PFTau3RefProd_out = iEvent.getRefBeforePut<reco::PFTau3ProngSummaryCollection>("PFTau3ProngSummary");
 
   // Load each discriminator
@@ -263,8 +263,8 @@ void PFTau3ProngReco::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
       AVPFTau3PS->setValue(iPFTau,PFTau3PSRef);
     }
   }
-  iEvent.put(PFTau3PSCollection_out,"PFTau3ProngSummary");
-  iEvent.put(AVPFTau3PS);
+  iEvent.put(std::move(PFTau3PSCollection_out),"PFTau3ProngSummary");
+  iEvent.put(std::move(AVPFTau3PS));
 }
 
 DEFINE_FWK_MODULE(PFTau3ProngReco);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstElectron.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstElectron.cc
@@ -81,7 +81,7 @@ void CaloRecoTauDiscriminationAgainstElectron::produce(edm::Event& iEvent,const 
   iEvent.getByLabel(CaloTauProducer_,theCaloTauCollection);
 
   // fill the AssociationVector object
-  auto_ptr<CaloTauDiscriminator> theCaloTauDiscriminatorAgainstElectron(new CaloTauDiscriminator(CaloTauRefProd(theCaloTauCollection)));
+  auto theCaloTauDiscriminatorAgainstElectron = std::make_unique<CaloTauDiscriminator>(CaloTauRefProd(theCaloTauCollection));
 
   for(size_t iCaloTau=0;iCaloTau<theCaloTauCollection->size();++iCaloTau) {
     CaloTauRef theCaloTauRef(theCaloTauCollection,iCaloTau);
@@ -120,7 +120,7 @@ void CaloRecoTauDiscriminationAgainstElectron::produce(edm::Event& iEvent,const 
     }
   }
    
-  iEvent.put(theCaloTauDiscriminatorAgainstElectron);
+  iEvent.put(std::move(theCaloTauDiscriminatorAgainstElectron));
 }
 */
 

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByLeadingTrackPtCut.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByLeadingTrackPtCut.cc
@@ -42,7 +42,7 @@ DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByLeadingTrackPtCut);
    iEvent.getByLabel(CaloTauProducer_,theCaloTauCollection);
 
    double theleadTrackPtCutDiscriminator = 0.;
-   auto_ptr<CaloTauDiscriminator> theCaloTauDiscriminatorByLeadingTrackPtCut(new CaloTauDiscriminator(CaloTauRefProd(theCaloTauCollection)));
+   auto theCaloTauDiscriminatorByLeadingTrackPtCut = std::make_unique<CaloTauDiscriminator>(CaloTauRefProd(theCaloTauCollection));
 
    //loop over the CaloTau candidates
    for(size_t iCaloTau=0;iCaloTau<theCaloTauCollection->size();++iCaloTau) {
@@ -57,7 +57,7 @@ DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByLeadingTrackPtCut);
       theCaloTauDiscriminatorByLeadingTrackPtCut->setValue(iCaloTau,theleadTrackPtCutDiscriminator);
    }
 
-   iEvent.put(theCaloTauDiscriminatorByLeadingTrackPtCut);
+   iEvent.put(std::move(theCaloTauDiscriminatorByLeadingTrackPtCut));
 
 }
    

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauProducer.cc
@@ -63,8 +63,8 @@ CaloRecoTauProducer::~CaloRecoTauProducer(){
   
 void CaloRecoTauProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
 
-  auto_ptr<CaloTauCollection> resultCaloTau(new CaloTauCollection);
-  auto_ptr<DetIdCollection> selectedDetIds(new DetIdCollection);
+  auto resultCaloTau = std::make_unique<CaloTauCollection>();
+  auto selectedDetIds = std::make_unique<DetIdCollection>();
  
   edm::ESHandle<TransientTrackBuilder> myTransientTrackBuilder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",myTransientTrackBuilder);
@@ -105,7 +105,7 @@ void CaloRecoTauProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSet
     selectedDetIds->push_back(CaloRecoTauAlgo_->mySelectedDetId_[i]);
 
 
-   iEvent.put(resultCaloTau);
-  iEvent.put(selectedDetIds);
+   iEvent.put(std::move(resultCaloTau));
+   iEvent.put(std::move(selectedDetIds));
 }
 DEFINE_FWK_MODULE(CaloRecoTauProducer);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauTagInfoProducer.cc
@@ -75,7 +75,7 @@ void CaloRecoTauTagInfoProducer::produce(edm::Event& iEvent,const edm::EventSetu
   Vertex thePV;
   thePV=*(vertCollection.begin());
   
-  //  auto_ptr<DetIdCollection> selectedDetIds(new DetIdCollection);
+  //  auto selectedDetIds = std::make_unique<DetIdCollection>();
   CaloTauTagInfoCollection* extCollection=new CaloTauTagInfoCollection();
 
   for(JetTracksAssociationCollection::const_iterator iAssoc=theCaloJetTracksAssociatorCollection->begin();iAssoc!=theCaloJetTracksAssociatorCollection->end();iAssoc++){
@@ -89,8 +89,9 @@ void CaloRecoTauTagInfoProducer::produce(edm::Event& iEvent,const edm::EventSetu
     //      selectedDetIds->push_back(myDets[i]);
   }
   
-  auto_ptr<CaloTauTagInfoCollection> resultExt(extCollection);  
-  iEvent.put(resultExt);  
-  //  iEvent.put(selectedDetIds);
+  std::unique_ptr<CaloTauTagInfoCollection> resultExt(extCollection);  
+  iEvent.put(std::move(resultExt));  
+
+  //  iEvent.put(std::move(selectedDetIds));
 }
 DEFINE_FWK_MODULE(CaloRecoTauTagInfoProducer );

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -150,15 +150,15 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
   reco::PFJetRefVector pfJets = reco::tau::castView<reco::PFJetRefVector>(jets);
 
   // make our association
-  std::auto_ptr<reco::PFJetChargedHadronAssociation> pfJetChargedHadronAssociations;
+  std::unique_ptr<reco::PFJetChargedHadronAssociation> pfJetChargedHadronAssociations;
 
 
   if ( pfJets.size() ) {
     edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
     evt.get(pfJets.id(), pfJetCollectionHandle);
-    pfJetChargedHadronAssociations.reset(new reco::PFJetChargedHadronAssociation(reco::PFJetRefProd(pfJetCollectionHandle)));
+    pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>(reco::PFJetRefProd(pfJetCollectionHandle));
   } else {
-    pfJetChargedHadronAssociations.reset(new reco::PFJetChargedHadronAssociation);
+    pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>();
   }
 
   // loop over our jets
@@ -289,7 +289,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
     pfJetChargedHadronAssociations->setValue(pfJet.key(), cleanedChargedHadrons);
   }
 
-  evt.put(pfJetChargedHadronAssociations);
+  evt.put(std::move(pfJetChargedHadronAssociations));
 }
 
 template <typename T>

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
@@ -32,7 +32,7 @@ class PFRecoTauDiscriminationAgainstElectronMVA5 : public PFTauDiscriminationPro
   explicit PFRecoTauDiscriminationAgainstElectronMVA5(const edm::ParameterSet& cfg)
     : PFTauDiscriminationProducerBase(cfg),
       mva_(0),
-      category_output_(0)
+      category_output_()
   {
     mva_ = new AntiElectronIDMVA5(cfg);
 
@@ -70,7 +70,7 @@ private:
   edm::Handle<reco::GsfElectronCollection> gsfElectrons_;
   edm::Handle<TauCollection> taus_;
 
-  std::auto_ptr<PFTauDiscriminator> category_output_;
+  std::unique_ptr<PFTauDiscriminator> category_output_;
 
   int verbosity_;
 };
@@ -227,7 +227,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& 
 void PFRecoTauDiscriminationAgainstElectronMVA5::endEvent(edm::Event& evt)
 {
   // add all category indices to event
-  evt.put(category_output_, "category");
+  evt.put(std::move(category_output_), "category");
 }
 
 bool

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
@@ -30,7 +30,7 @@ class PFRecoTauDiscriminationAgainstElectronMVA6 : public PFTauDiscriminationPro
   explicit PFRecoTauDiscriminationAgainstElectronMVA6(const edm::ParameterSet& cfg)
     : PFTauDiscriminationProducerBase(cfg),
       mva_(0),
-      category_output_(0)
+      category_output_()
   {
     mva_ = new AntiElectronIDMVA6(cfg);
 
@@ -68,7 +68,7 @@ private:
   edm::Handle<reco::GsfElectronCollection> gsfElectrons_;
   edm::Handle<TauCollection> taus_;
 
-  std::auto_ptr<PFTauDiscriminator> category_output_;
+  std::unique_ptr<PFTauDiscriminator> category_output_;
 
   int verbosity_;
 };
@@ -231,7 +231,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
 void PFRecoTauDiscriminationAgainstElectronMVA6::endEvent(edm::Event& evt)
 {
   // add all category indices to event
-  evt.put(category_output_, "category");
+  evt.put(std::move(category_output_), "category");
 }
 
 bool

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
@@ -122,7 +122,7 @@ class PFRecoTauDiscriminationAgainstMuonMVA final : public PFTauDiscriminationPr
   double dRmuonMatch_;
 
   edm::Handle<TauCollection> taus_;
-  std::auto_ptr<PFTauDiscriminator> category_output_;
+  std::unique_ptr<PFTauDiscriminator> category_output_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -239,7 +239,7 @@ double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau) 
 void PFRecoTauDiscriminationAgainstMuonMVA::endEvent(edm::Event& evt)
 {
   // add all category indices to event
-  evt.put(category_output_, "category");
+  evt.put(std::move(category_output_), "category");
 }
 
 }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
@@ -58,7 +58,7 @@ void PFRecoTauDiscriminationByLeadingPionPtCut::produce(edm::Event& iEvent,const
    iEvent.getByLabel(PFTauProducer_,thePFTauCollection);
 
 
-   auto_ptr<PFTauDiscriminator> thePFTauDiscriminatorByLeadingPionPtCut(new PFTauDiscriminator(PFTauRefProd(thePFTauCollection)));
+   auto thePFTauDiscriminatorByLeadingPionPtCut = std::make_unique<PFTauDiscriminator(PFTauRefProd>(thePFTauCollection));
 
    //loop over the PFTau candidates
    for(size_t iPFTau=0;iPFTau<thePFTauCollection->size();++iPFTau) {
@@ -75,7 +75,7 @@ void PFRecoTauDiscriminationByLeadingPionPtCut::produce(edm::Event& iEvent,const
       thePFTauDiscriminatorByLeadingPionPtCut->setValue(iPFTau,theleadTrackPtCutDiscriminator);
    }
 
-   iEvent.put(thePFTauDiscriminatorByLeadingPionPtCut);
+   iEvent.put(std::move(thePFTauDiscriminatorByLeadingPionPtCut));
 
 }
    

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
@@ -70,7 +70,7 @@ class PFRecoTauDiscriminationByIsolationMVA2 : public PFTauDiscriminationProduce
       moduleLabel_(cfg.getParameter<std::string>("@module_label")),
       mvaReader_(0),
       mvaInput_(0),
-      category_output_(0)
+      category_output_()
   {
     mvaName_ = cfg.getParameter<std::string>("mvaName");
     loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB") : false;
@@ -143,7 +143,7 @@ class PFRecoTauDiscriminationByIsolationMVA2 : public PFTauDiscriminationProduce
   edm::Handle<reco::PFTauDiscriminator> puCorrPtSums_;
 
   edm::Handle<TauCollection> taus_;
-  std::auto_ptr<PFTauDiscriminator> category_output_;
+  std::unique_ptr<PFTauDiscriminator> category_output_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -237,7 +237,7 @@ double PFRecoTauDiscriminationByIsolationMVA2::discriminate(const PFTauRef& tau)
 void PFRecoTauDiscriminationByIsolationMVA2::endEvent(edm::Event& evt)
 {
   // add all category indices to event
-  evt.put(category_output_, "category");
+  evt.put(std::move(category_output_), "category");
 }
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationByIsolationMVA2);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
@@ -71,7 +71,7 @@ class PFRecoTauDiscriminationByMVAIsolationRun2 : public PFTauDiscriminationProd
       moduleLabel_(cfg.getParameter<std::string>("@module_label")),
       mvaReader_(0),
       mvaInput_(0),
-      category_output_(0)
+      category_output_()
   {
     mvaName_ = cfg.getParameter<std::string>("mvaName");
     loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB") : false;
@@ -156,7 +156,7 @@ class PFRecoTauDiscriminationByMVAIsolationRun2 : public PFTauDiscriminationProd
   edm::Handle<reco::PFTauDiscriminator> footprintCorrection_;
 
   edm::Handle<TauCollection> taus_;
-  std::auto_ptr<PFTauDiscriminator> category_output_;
+  std::unique_ptr<PFTauDiscriminator> category_output_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -310,7 +310,7 @@ double PFRecoTauDiscriminationByMVAIsolationRun2::discriminate(const PFTauRef& t
 void PFRecoTauDiscriminationByMVAIsolationRun2::endEvent(edm::Event& evt)
 {
   // add all category indices to event
-  evt.put(category_output_, "category");
+  evt.put(std::move(category_output_), "category");
 }
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationByMVAIsolationRun2);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
@@ -78,7 +78,7 @@ PFRecoTauProducer::~PFRecoTauProducer(){
 }
 
 void PFRecoTauProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
-  auto_ptr<PFTauCollection> resultPFTau(new PFTauCollection);
+  auto resultPFTau = std::make_unique<PFTauCollection>();
   
   edm::ESHandle<TransientTrackBuilder> myTransientTrackBuilder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",myTransientTrackBuilder);
@@ -122,7 +122,7 @@ void PFRecoTauProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup
     }
     ++iinfo;
   }
-  iEvent.put(resultPFTau);
+  iEvent.put(std::move(resultPFTau));
 }
 
 DEFINE_FWK_MODULE(PFRecoTauProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -96,14 +96,14 @@ else{
     thePV=Vertex(SimPVPoint,SimPVError,1,1,1);    
   }
   
-  auto_ptr<PFTauTagInfoCollection> resultExt(new PFTauTagInfoCollection);  
+  auto resultExt = std::make_unique<PFTauTagInfoCollection>();  
   for(JetTracksAssociationCollection::const_iterator iAssoc=thePFJetTracksAssociatorCollection->begin();iAssoc!=thePFJetTracksAssociatorCollection->end();iAssoc++){
     PFTauTagInfo myPFTauTagInfo=PFRecoTauTagInfoAlgo_->buildPFTauTagInfo((*iAssoc).first.castTo<PFJetRef>(),thePFCandsInTheEvent,(*iAssoc).second,thePV);
     resultExt->push_back(myPFTauTagInfo);
   }
   
 
-  //  OrphanHandle<PFTauTagInfoCollection> myPFTauTagInfoCollection=iEvent.put(resultExt);
-  iEvent.put(resultExt);
+  //  OrphanHandle<PFTauTagInfoCollection> myPFTauTagInfoCollection=iEvent.put(std::move(resultExt));
+  iEvent.put(std::move(resultExt));
 }
 DEFINE_FWK_MODULE(PFRecoTauTagInfoProducer);

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -166,8 +166,8 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
   iEvent.getByToken(TrackCollectionToken_,trackCollection);
 
   // Set Association Map
-  auto_ptr<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> > > AVPFTauPV(new edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> >(PFTauRefProd(Tau)));
-  std::auto_ptr<VertexCollection>  VertexCollection_out= std::auto_ptr<VertexCollection>(new VertexCollection);
+  auto AVPFTauPV = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>>(PFTauRefProd(Tau));
+  auto VertexCollection_out = std::make_unique<VertexCollection>();
   reco::VertexRefProd VertexRefProd_out = iEvent.getRefBeforePut<reco::VertexCollection>("PFTauPrimaryVertices");
 
   // Load each discriminator
@@ -288,8 +288,8 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
       AVPFTauPV->setValue(iPFTau, VRef);
     }
   }
-  iEvent.put(VertexCollection_out,"PFTauPrimaryVertices");
-  iEvent.put(AVPFTauPV);
+  iEvent.put(std::move(VertexCollection_out),"PFTauPrimaryVertices");
+  iEvent.put(std::move(AVPFTauPV));
 }
   
 DEFINE_FWK_MODULE(PFTauPrimaryVertexProducer);

--- a/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
@@ -80,8 +80,8 @@ void PFTauSecondaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent,con
   iEvent.getByToken(PFTauToken_,Tau);
 
   // Set Association Map
-  auto_ptr<edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef> > > > AVPFTauSV(new edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef> > >(PFTauRefProd(Tau)));
-  std::auto_ptr<VertexCollection>  VertexCollection_out= std::auto_ptr<VertexCollection>(new VertexCollection);
+  auto AVPFTauSV = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef>>>>(PFTauRefProd(Tau));
+  auto VertexCollection_out = std::make_unique<VertexCollection>();
   reco::VertexRefProd VertexRefProd_out = iEvent.getRefBeforePut<reco::VertexCollection>("PFTauSecondaryVertices");
 
   // For each Tau Run Algorithim
@@ -118,8 +118,8 @@ void PFTauSecondaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent,con
       AVPFTauSV->setValue(iPFTau, SV);
     }
   }
-  iEvent.put(VertexCollection_out,"PFTauSecondaryVertices");
-  iEvent.put(AVPFTauSV);
+  iEvent.put(std::move(VertexCollection_out),"PFTauSecondaryVertices");
+  iEvent.put(std::move(AVPFTauSV));
 }
 
 DEFINE_FWK_MODULE(PFTauSecondaryVertexProducer);

--- a/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
@@ -97,8 +97,8 @@ void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::Even
   iEvent.getByToken(PFTauSVAToken_,PFTauSVA);
 
   // Set Association Map
-  auto_ptr<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > > AVPFTauTIP(new edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> >(PFTauRefProd(Tau)));
-  std::auto_ptr<PFTauTransverseImpactParameterCollection>  TIPCollection_out= std::auto_ptr<PFTauTransverseImpactParameterCollection>(new PFTauTransverseImpactParameterCollection());
+  auto AVPFTauTIP = std::make_unique< edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(PFTauRefProd(Tau));
+  auto TIPCollection_out = std::make_unique<PFTauTransverseImpactParameterCollection>();
   reco::PFTauTransverseImpactParameterRefProd TIPRefProd_out = iEvent.getRefBeforePut<reco::PFTauTransverseImpactParameterCollection>("PFTauTIP");
 
 
@@ -161,8 +161,8 @@ void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::Even
       }
     }
   }
-  iEvent.put(TIPCollection_out,"PFTauTIP");
-  iEvent.put(AVPFTauTIP);
+  iEvent.put(std::move(TIPCollection_out),"PFTauTIP");
+  iEvent.put(std::move(AVPFTauTIP));
 }
 
 DEFINE_FWK_MODULE(PFTauTransverseImpactParameters);

--- a/RecoTauTag/RecoTau/plugins/PFTauViewRefMerger.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauViewRefMerger.cc
@@ -27,7 +27,7 @@ class PFTauViewRefMerger : public edm::EDProducer {
         }
   private:
     void produce(edm::Event & evt, const edm::EventSetup &) override {
-      std::auto_ptr<reco::PFTauRefVector> out(new reco::PFTauRefVector());
+      auto out = std::make_unique<reco::PFTauRefVector>();
       BOOST_FOREACH(const edm::InputTag& inputSrc, src_) {
         edm::Handle<reco::CandidateView> src;
         evt.getByLabel(inputSrc, src);
@@ -38,7 +38,7 @@ class PFTauViewRefMerger : public edm::EDProducer {
           out->push_back(tau);
         }
       }
-      evt.put(out);
+      evt.put(std::move(out));
     }
     std::vector<edm::InputTag> src_;
 };

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -277,7 +277,7 @@ void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& e
   PFTauRefs cleanTaus = reco::tau::cleanOverlaps<PFTauRefs, RemoveDuplicateJets>(dirty);
 
   // create output collection
-  std::auto_ptr<Prod> output(new Prod());
+  auto output = std::make_unique<Prod>();
   //output->reserve(cleanTaus.size());
 
   // Copy clean refs into output
@@ -292,7 +292,7 @@ void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& e
       output->push_back(convert<output_type>(*tau));
     }
   }
-  evt.put(output);
+  evt.put(std::move(output));
 }
 
 typedef RecoTauCleanerImpl<reco::PFTauCollection> RecoTauCleaner;

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -130,7 +130,7 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
     nOriginalJets = originalJets->size();
   }
 
-  std::auto_ptr<reco::PFJetCollection> newJets(new reco::PFJetCollection);
+  auto newJets = std::make_unique<reco::PFJetCollection>();
 
   // Keep track of the indices of the current jet and the old (original) jet
   // -1 indicates no match.
@@ -178,16 +178,16 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   }
 
   // Put our new jets into the event
-  edm::OrphanHandle<reco::PFJetCollection> newJetsInEvent = evt.put(newJets, "jets");
+  edm::OrphanHandle<reco::PFJetCollection> newJetsInEvent = evt.put(std::move(newJets), "jets");
 
   // Create a matching between original jets -> extra collection
-  std::auto_ptr<PFJetMatchMap> matching(new PFJetMatchMap(newJetsInEvent));
+  auto matching = std::make_unique<PFJetMatchMap>(newJetsInEvent);
   if ( nJets ) {
     PFJetMatchMap::Filler filler(*matching);
     filler.insert(originalJets, matchInfo.begin(), matchInfo.end());
     filler.fill();
   }
-  evt.put(matching);
+  evt.put(std::move(matching));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -136,15 +136,14 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   reco::PFJetRefVector jetRefs =
       reco::tau::castView<reco::PFJetRefVector>(jetView);
   // Make our association
-  std::auto_ptr<reco::JetPiZeroAssociation> association;
+  std::unique_ptr<reco::JetPiZeroAssociation> association;
 
   if (jetRefs.size()) {
     edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
     evt.get(jetRefs.id(), pfJetCollectionHandle);
-    association.reset(
-        new reco::JetPiZeroAssociation(reco::PFJetRefProd(pfJetCollectionHandle)));
+    association = std::make_unique<reco::JetPiZeroAssociation>(reco::PFJetRefProd(pfJetCollectionHandle));
   } else {
-    association.reset(new reco::JetPiZeroAssociation);
+    association = std::make_unique<reco::JetPiZeroAssociation>();
   }
 
   // Loop over our jets
@@ -225,7 +224,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     }
     association->setValue(jet.key(), cleanPiZeros);
   }
-  evt.put(association);
+  evt.put(std::move(association));
 }
 
 // Print some helpful information

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
@@ -40,9 +40,8 @@ RecoTauPiZeroUnembedder::RecoTauPiZeroUnembedder(const edm::ParameterSet& pset) 
   produces<reco::PFTauCollection>();
 }
 void RecoTauPiZeroUnembedder::produce(edm::Event& evt, const edm::EventSetup& es) {
-  std::auto_ptr<reco::RecoTauPiZeroCollection> piZerosOut(
-      new reco::RecoTauPiZeroCollection);
-  std::auto_ptr<reco::PFTauCollection> tausOut(new reco::PFTauCollection);
+  auto piZerosOut = std::make_unique<reco::RecoTauPiZeroCollection>();
+  auto tausOut = std::make_unique<reco::PFTauCollection>();
 
   edm::Handle<reco::CandidateView> tauView;
   evt.getByToken(token, tauView);
@@ -88,8 +87,8 @@ void RecoTauPiZeroUnembedder::produce(edm::Event& evt, const edm::EventSetup& es
     tausOut->push_back(myTau);
   }
 
-  evt.put(piZerosOut, "pizeros");
-  evt.put(tausOut);
+  evt.put(std::move(piZerosOut), "pizeros");
+  evt.put(std::move(tausOut));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
@@ -64,7 +64,7 @@ bool RecoTauPileUpVertexSelector::filter(
     edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::VertexCollection> vertices_;
   evt.getByToken(token, vertices_);
-  std::auto_ptr<reco::VertexCollection> output(new reco::VertexCollection);
+  auto output = std::make_unique<reco::VertexCollection>();
   // If there is only one vertex, there are no PU vertices!
   if (vertices_->size() > 1) {
     // Copy over all the vertices that have associatd tracks with pt greater
@@ -74,7 +74,7 @@ bool RecoTauPileUpVertexSelector::filter(
         std::back_inserter(*output), std::not1(vtxFilter_));
   }
   size_t nPUVtx = output->size();
-  evt.put(output);
+  evt.put(std::move(output));
   // If 'filter' is enabled, return whether true if there are PU vertices
   if (!filter_)
     return true;

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -159,7 +159,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   }
 
   // Create output collection
-  std::auto_ptr<reco::PFTauCollection> output(new reco::PFTauCollection());
+  auto output = std::make_unique<reco::PFTauCollection>();
   output->reserve(jets.size());
   
   // Loop over the jets and build the taus for each jet
@@ -243,7 +243,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     modifier->endEvent();
   }
   
-  evt.put(output);
+  evt.put(std::move(output));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
@@ -80,7 +80,7 @@ void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Even
    edm::ProductID tauProductID = taus.id();
 
    // output product
-   std::auto_ptr<TauDiscriminator> output(new TauDiscriminator(TauRefProd(taus)));
+   auto output = std::make_unique<TauDiscriminator>(TauRefProd(taus));
 
    size_t nTaus = taus->size();
 
@@ -150,7 +150,7 @@ void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Even
       // store the result of this tau into our new discriminator
       output->setValue(iTau, result);
    }
-   event.put(output);
+   event.put(std::move(output));
 
    // function to put additional information into the event - does nothing in base, but can be overridden in derived classes
    endEvent(event);

--- a/RecoTauTag/TauTagTools/interface/CastedRefProducer.h
+++ b/RecoTauTag/TauTagTools/interface/CastedRefProducer.h
@@ -38,7 +38,7 @@ class CastedRefProducer : public edm::EDProducer {
     /// process an event
     virtual void produce(edm::Event& evt, const edm::EventSetup& es) {
       // Output collection
-      std::auto_ptr<OutputCollection> coll(new OutputCollection());
+      auto coll = std::make_unique<OutputCollection>();
       // Get input
       edm::Handle<edm::View<BaseType> > input;
       evt.getByLabel(src_, input);
@@ -49,7 +49,7 @@ class CastedRefProducer : public edm::EDProducer {
         derived_ref derived = base.template castTo<derived_ref>();
         coll->push_back(derived);
       }
-      evt.put( coll );
+      evt.put(std::move(coll));
     }
   private:
     /// labels of the collection to be converted

--- a/RecoTauTag/TauTagTools/interface/CopyProducer.h
+++ b/RecoTauTag/TauTagTools/interface/CopyProducer.h
@@ -34,7 +34,7 @@ class CopyProducer : public edm::EDProducer {
     /// process an event
     virtual void produce(edm::Event& evt, const edm::EventSetup& es) {
       // Output collection
-      std::auto_ptr<Collection> coll(new Collection());
+      auto coll = std::make_unique<Collection>();
       typedef edm::View<typename Collection::value_type> CView;
       // Get input
       edm::Handle<CView> input;
@@ -43,7 +43,7 @@ class CopyProducer : public edm::EDProducer {
       coll->reserve(input->size());
       // Copy the input to the output
       std::copy(input->begin(), input->end(), std::back_inserter(*coll));
-      evt.put( coll );
+      evt.put(std::move(coll));
     }
   private:
     /// labels of the collection to be converted

--- a/RecoTauTag/TauTagTools/plugins/CandViewRefRandomSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/CandViewRefRandomSelector.cc
@@ -48,8 +48,7 @@ bool CandViewRefRandomSelector::filter(edm::Event& evt,
                                        const edm::EventSetup& es) {
   edm::Handle<edm::View<reco::Candidate> > cands;
   evt.getByLabel(src_, cands);
-  std::auto_ptr<reco::CandidateBaseRefVector> output(
-      new reco::CandidateBaseRefVector(cands));
+  auto output = std::make_unique<reco::CandidateBaseRefVector>(cands);
   // If we don't have enough elements to select, just copy what we have
   if (cands->size() <= choose_) {
     for (size_t i = 0; i < cands->size(); ++i)
@@ -66,7 +65,7 @@ bool CandViewRefRandomSelector::filter(edm::Event& evt,
     }
   }
   size_t outputSize = output->size();
-  evt.put(output);
+  evt.put(std::move(output));
   return ( !filter_ || outputSize );
 }
 

--- a/RecoTauTag/TauTagTools/plugins/CandViewRefTriggerBiasRemover.cc
+++ b/RecoTauTag/TauTagTools/plugins/CandViewRefTriggerBiasRemover.cc
@@ -41,8 +41,7 @@ void CandViewRefTriggerBiasRemover::produce(edm::Event& evt,
                                             const edm::EventSetup& es) {
   edm::Handle<edm::View<reco::Candidate> > cands;
   evt.getByLabel(src_, cands);
-  std::auto_ptr<reco::CandidateBaseRefVector> output(
-      new reco::CandidateBaseRefVector(cands));
+  auto output = std::make_unique<reco::CandidateBaseRefVector>(cands);
   // Only copy the output if there is more than one item in the input
   size_t nCands = cands->size();
   if (nCands > 1) {
@@ -51,7 +50,7 @@ void CandViewRefTriggerBiasRemover::produce(edm::Event& evt,
       output->push_back(cands->refAt(iCand));
     }
   }
-  evt.put(output);
+  evt.put(std::move(output));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/TauTagTools/plugins/PFTauMVAInputDiscriminantTranslator.cc
+++ b/RecoTauTag/TauTagTools/plugins/PFTauMVAInputDiscriminantTranslator.cc
@@ -108,8 +108,7 @@ void PFTauMVAInputDiscriminantTranslator::produce(edm::Event& evt,
 
   BOOST_FOREACH(const DiscriminantInfo& disc, discriminators_) {
     // output for this discriminator
-    std::auto_ptr<PFTauDiscriminator> output(
-        new PFTauDiscriminator(edm::RefProd<PFTauCollection>(pfTaus)));
+    auto output = std::make_unique<PFTauDiscriminator>(edm::RefProd<PFTauCollection>(pfTaus));
     // loop over taus
     for(size_t itau = 0; itau < pfTaus->size(); ++itau) {
       PFTauRef tauRef(pfTaus, itau);
@@ -122,7 +121,7 @@ void PFTauMVAInputDiscriminantTranslator::produce(edm::Event& evt,
       }
       output->setValue(itau, selected_result);
     }
-    evt.put(output, disc.collName);
+    evt.put(std::move(output), disc.collName);
   }
 }
 

--- a/RecoTauTag/TauTagTools/plugins/PFTauViewRefDiscriminantSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/PFTauViewRefDiscriminantSelector.cc
@@ -85,18 +85,16 @@ bool RecoTauDiscriminatorRefSelectorImpl<T>::filter(edm::Event& evt,
   edm::Handle<reco::PFTauDiscriminator> disc;
   evt.getByLabel(discriminatorSrc_, disc);
 
-//  std::auto_ptr<reco::PFTauRefVector> output(
-//      new reco::PFTauRefVector(inputRefs.id()));
-  //std::auto_ptr<OutputType> output(
-  //    new OutputType(inputRefs.id()));
-  std::auto_ptr<OutputType> output(new OutputType);
+//  auto output = std::make_unique<reco::PFTauRefVector>(inputRefs.id());
+  //auto output = std::make_unique<OutputType>(inputRefs.id());
+  auto output = std::make_unique<OutputType>();
 
   BOOST_FOREACH(reco::PFTauRef ref, inputRefs) {
     if ( (*disc)[ref] > cut_ )
       output->push_back(T::make(ref));
   }
   size_t selected = output->size();
-  evt.put(output);
+  evt.put(std::move(output));
   return (!filter_ || selected);
 }
 

--- a/RecoTauTag/TauTagTools/plugins/PFTauViewRefSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/PFTauViewRefSelector.cc
@@ -37,7 +37,7 @@ class PFTauViewRefSelector : public edm::EDFilter {
   private:
     edm::InputTag src_;
     std::string cut_;
-    std::auto_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
+    std::unique_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
     bool filter_;
 };
 
@@ -45,13 +45,13 @@ PFTauViewRefSelector::PFTauViewRefSelector(const edm::ParameterSet &pset) {
   src_ = pset.getParameter<edm::InputTag>("src");
   std::string cut = pset.getParameter<std::string>("cut");
   filter_ = pset.exists("filter") ? pset.getParameter<bool>("filter") : false;
-  outputSelector_.reset(new StringCutObjectSelector<reco::PFTau>(cut));
+  outputSelector_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(cut);
   produces<reco::PFTauRefVector>();
 }
 
 bool
 PFTauViewRefSelector::filter(edm::Event& evt, const edm::EventSetup& es) {
-  std::auto_ptr<reco::PFTauRefVector> output(new reco::PFTauRefVector());
+  auto output = std::make_unique<reco::PFTauRefVector>();
   // Get the input collection to clean
   edm::Handle<reco::CandidateView> input;
   evt.getByLabel(src_, input);
@@ -65,7 +65,7 @@ PFTauViewRefSelector::filter(edm::Event& evt, const edm::EventSetup& es) {
     }
   }
   size_t outputSize = output->size();
-  evt.put(output);
+  evt.put(std::move(output));
   // Filter if desired and no objects passed our cut
   return !(filter_ && outputSize == 0);
 }

--- a/RecoTauTag/TauTagTools/plugins/RecoTauEventFlagProducer.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauEventFlagProducer.cc
@@ -23,8 +23,7 @@ class RecoTauEventFlagProducer : public edm::EDProducer {
     }
     ~RecoTauEventFlagProducer() {}
     void produce(edm::Event& evt, const edm::EventSetup &es) override {
-      std::auto_ptr<int> toput(new int(flag_));
-      evt.put(toput);
+      evt.put(std::make_unique<int>(flag_));
     }
   private:
     int flag_;

--- a/RecoTauTag/TauTagTools/plugins/RecoTauGenJetMatchSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauGenJetMatchSelector.cc
@@ -66,7 +66,7 @@ class AssociationMatchRefSelector : public edm::EDFilter {
       evt.getByLabel(src_, input);
       edm::Handle<AssocType> match;
       evt.getByLabel(matching_, match);
-      std::auto_ptr<OutputType> output(new OutputType);
+      auto output = std::make_unique<OutputType>();
       for (size_t i = 0; i < input->size(); ++i) {
         typename AssocType::reference_type matched = (*match)[input->refAt(i)];
         // Check if matched
@@ -77,7 +77,7 @@ class AssociationMatchRefSelector : public edm::EDFilter {
         }
       }
       bool notEmpty = output->size();
-      evt.put(output);
+      evt.put(std::move(output));
       // Filter if no events passed
       return ( !filter_ || notEmpty );
     }

--- a/RecoTauTag/TauTagTools/plugins/RecoTauPiZeroFlattener.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauPiZeroFlattener.cc
@@ -56,8 +56,7 @@ RecoTauPiZeroFlattener::produce(edm::Event& evt, const edm::EventSetup& es) {
   evt.getByLabel(piZeroSrc_, piZeroAssoc);
 
   // Create output collection
-  std::auto_ptr<std::vector<reco::RecoTauPiZero> > output(
-      new std::vector<reco::RecoTauPiZero>());
+  auto output = std::make_unique<std::vector<reco::RecoTauPiZero>>();
 
   // Loop over the jets and append the pizeros for each jet to our output
   // collection.
@@ -67,7 +66,7 @@ RecoTauPiZeroFlattener::produce(edm::Event& evt, const edm::EventSetup& es) {
     output->insert(output->end(), pizeros.begin(), pizeros.end());
   }
 
-  evt.put(output);
+  evt.put(std::move(output));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/TauTagTools/plugins/TauDiscriminationByStringCut.cc
+++ b/RecoTauTag/TauTagTools/plugins/TauDiscriminationByStringCut.cc
@@ -32,7 +32,7 @@ class TauDiscriminationByStringCut :
       }
 
    private:
-      std::auto_ptr<StringCutObjectSelector<TauType> > cut_;
+      std::unique_ptr<StringCutObjectSelector<TauType> > cut_;
       double cutFailValue_;
       double cutPassValue_;
 };

--- a/RecoTauTag/TauTagTools/plugins/TruthTauDecayModeProducer.cc
+++ b/RecoTauTag/TauTagTools/plugins/TruthTauDecayModeProducer.cc
@@ -158,7 +158,7 @@ TruthTauDecayModeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
    }
 
    //output collection
-   std::auto_ptr<vector<PFTauDecayMode> > pOut( new std::vector<PFTauDecayMode> );
+   auto pOut = std::make_unique<std::vector<PFTauDecayMode>>();
    for(std::vector<tauObjectsHolder>::const_iterator iTempTau  = tausToAdd_.begin();
                                                 iTempTau != tausToAdd_.end();
                                               ++iTempTau)
@@ -205,7 +205,7 @@ TruthTauDecayModeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
          pOut->push_back(decayModeToAdd);
       }
    }
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
 }
 
 void 


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoTauTag packages. Also, std::make_unique is used when appropriate. 
