### PR TITLE
Updating in all the relevant Global Tags the L1 menu to the version for post-TS2 data-taking: L1Menu_Collisions2016_v6r5_ugt_1board_xml

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '81X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v6',
+    'run2_design'       :   '81X_mcRun2_design_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v8',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v7',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v8',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v6',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v8',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
@@ -26,19 +26,19 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '81X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v2',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v9',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v10',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v11',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v12',
     # Global Tag for MC production with development HCAL conditions for Phase1 2017 detector
     'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v7) as [81X_mcRun2_design_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v7/81X_mcRun2_design_v6): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v6) as [81X_mcRun2cosmics_startup_peak_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v6/81X_mcRun2cosmics_startup_peak_v7): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v7) as [81X_mcRun2_asymptotic_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v7/81X_mcRun2_asymptotic_v8): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
- **RunII Startup scenario** : [81X_mcRun2_startup_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v8) as [81X_mcRun2_startup_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v8/81X_mcRun2_startup_v9): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
## RunII data
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v3) as [81X_dataRun2_HLT_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v2/81X_dataRun2_HLT_relval_v3): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
- **RunII Offline relval processing** : [81X_dataRun2_relval_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v9) as [81X_dataRun2_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v9/81X_dataRun2_relval_v8): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v11) as [81X_upgrade2017_realistic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v11/81X_upgrade2017_realistic_v12): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
- **PhaseI design scenario** : [81X_upgrade2017_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v9) as [81X_upgrade2017_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v9/81X_upgrade2017_design_v10): 
  - updated L1 uGT menu to `L1Menu_Collisions2016_v6r5_ugt_1board_xml`
