### PR TITLE
Concurrent Path Processing

### DIFF
--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -61,6 +61,7 @@ ProductRegistry is frozen.
 #include <set>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace edm {
 
@@ -118,6 +119,9 @@ namespace edm {
                              char const* moduleLabel,
                              char const* instance,
                              char const* process = 0) const;
+    
+    using ModulesToIndiciesMap =std::unordered_multimap<std::string,ProductResolverIndex>;
+    ModulesToIndiciesMap indiciesForModulesInProcess( const std::string& iProcessName ) const;
 
     class Matches {
     public:

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -581,6 +581,24 @@ namespace edm {
     return 0;
   }
 
+  ProductResolverIndexHelper::ModulesToIndiciesMap
+  ProductResolverIndexHelper::indiciesForModulesInProcess(const std::string& iProcessName) const {
+    
+    ModulesToIndiciesMap result;
+    for(unsigned int i=0; i<beginElements_; ++i) {
+      auto const& range= ranges_[i];
+      for(unsigned int j=range.begin(); j<range.end();++j) {
+        auto const& indexAndNames = indexAndNames_[j];
+        if(0 == strcmp(&processNames_[indexAndNames.startInProcessNames()], iProcessName.c_str())) {
+          //The first null terminated string is the module label
+          result.emplace(&bigNamesContainer_[indexAndNames.startInBigNamesContainer()],indexAndNames.index());
+        }
+      }
+    }
+    return result;
+  }
+
+  
   void ProductResolverIndexHelper::sanityCheck() const {
     bool sanityChecksPass = true;
     if (sortedTypeIDs_.size() != ranges_.size()) sanityChecksPass = false;

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
@@ -125,6 +125,20 @@ void TestProductResolverIndexHelper::testOneEntry() {
 
   matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA");
   CPPUNIT_ASSERT(matches.numberOfMatches() == 0);
+
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processA");
+    CPPUNIT_ASSERT(indexToModules.size() == 1);
+    CPPUNIT_ASSERT(indexToModules.count("labelA") == 1);
+    auto const& range = indexToModules.equal_range("labelA");
+    CPPUNIT_ASSERT( range.first->second == indexWithProcess);
+  }
+  
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processNotHere");
+    CPPUNIT_ASSERT(indexToModules.size() == 0);
+  }
+
 }
 
 void TestProductResolverIndexHelper::testManyEntries() {
@@ -214,4 +228,31 @@ void TestProductResolverIndexHelper::testManyEntries() {
   ProductResolverIndex indexC = matches.index(1);
   CPPUNIT_ASSERT_THROW(matches.index(2), cms::Exception);
   CPPUNIT_ASSERT(indexC == 27);
+  
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processA");
+    CPPUNIT_ASSERT(indexToModules.size() == 1);
+  }
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processB");
+    CPPUNIT_ASSERT(indexToModules.size() == 5);
+    
+  }
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processB1");
+    CPPUNIT_ASSERT(indexToModules.size() == 1);
+  }
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processB2");
+    CPPUNIT_ASSERT(indexToModules.size() == 1);
+  }
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processB3");
+    CPPUNIT_ASSERT(indexToModules.size() == 1);
+  }
+  {
+    auto indexToModules = helper.indiciesForModulesInProcess("processC");
+    CPPUNIT_ASSERT(indexToModules.size() == 3);
+  }
+
 }

--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -69,6 +69,25 @@ namespace edm {
     
     std::atomic<std::exception_ptr*> m_ptr;
   };
+ 
+  template<typename F>
+  class FunctorWaitingTask : public WaitingTask {
+  public:
+    explicit FunctorWaitingTask( F f): func_(f) {}
+    
+    task* execute() override {
+      func_(exceptionPtr());
+      return nullptr;
+    };
+    
+  private:
+    F func_;
+  };
+  
+  template< typename ALLOC, typename F>
+  FunctorWaitingTask<F>* make_waiting_task( ALLOC&& iAlloc, F f) {
+    return new (iAlloc) FunctorWaitingTask<F>(f);
+  }
   
 }
 

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -256,7 +256,7 @@ namespace edm {
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
-    void commit_(std::vector<BranchID>* previousParentage= 0, ParentageID* previousParentageId = 0);
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, std::vector<BranchID>* previousParentage= 0, ParentageID* previousParentageId = 0);
     void commit_aux(ProductPtrVec& products, bool record_parents, std::vector<BranchID>* previousParentage = 0, ParentageID* previousParentageId = 0);
 
     BasicHandle

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -149,7 +149,7 @@ namespace edm {
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
 
-    void commit_();
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut);
 
     PrincipalGetAdapter provRecorder_;
     ProductPtrVec putProducts_;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -182,6 +182,10 @@ namespace edm {
     ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
 
     void readAllFromSourceAndMergeImmediately();
+    //For end Run/Lumi we need to reset products failed in the begin
+    // transition since they may be put into the Principal at the
+    // end transition
+    void resetFailedFromThisProcess();
     
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
 

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -9,8 +9,12 @@ EDProducts into an Event.
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
 #include <functional>
+#include <unordered_map>
+#include <string>
+#include<vector>
 
 namespace edm {
   class BranchDescription;
@@ -50,7 +54,14 @@ namespace edm {
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
        callWhenNewProductsRegistered_ = func;
     }
-          
+    
+    void resolvePutIndicies(BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& moduleLabel);
+    
+    std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const {
+      return putIndicies_[iBranchType];
+    }
   private:
     friend class EDProducer;
     friend class EDFilter;
@@ -71,6 +82,7 @@ namespace edm {
     }
 
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+    std::array<std::vector<edm::ProductResolverIndex>, edm::NumBranchTypes> putIndicies_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -20,6 +20,9 @@ namespace edm {
   class BranchDescription;
   class ModuleDescription;
   class ProductRegistry;
+  class Event;
+  class LuminosityBlock;
+  class Run;
   
   class EDProducer;
   class EDFilter;
@@ -33,6 +36,19 @@ namespace edm {
   }
   namespace stream {
     template<typename T> class ProducingModuleAdaptorBase;
+  }
+  
+  namespace producerbasehelper{
+    template<typename P> struct PrincipalTraits;
+    template<> struct PrincipalTraits<Run> {
+      static constexpr int kBranchType = InRun;
+    };
+    template<> struct PrincipalTraits<LuminosityBlock> {
+      static constexpr int kBranchType = InLumi;
+    };
+    template<> struct PrincipalTraits<Event> {
+      static constexpr int kBranchType = InEvent;
+    };
   }
   
   class ProducerBase : private ProductRegistryHelper {
@@ -73,12 +89,12 @@ namespace edm {
     
     template< typename P>
     void commit_(P& iPrincipal) {
-      iPrincipal.commit_();
+      iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType]);
     }
 
     template< typename P, typename L, typename I>
     void commit_(P& iPrincipal, L* iList, I* iID) {
-      iPrincipal.commit_(iList,iID);
+      iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType], iList,iID);
     }
 
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -76,6 +76,8 @@ namespace edm {
     }
     void resetProductData() { resetProductData_(false); }
 
+    virtual void resetFailedFromThisProcess();
+
     void unsafe_deleteProduct() const {
       const_cast<ProductResolverBase*>(this)->resetProductData_(true);
     }

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -160,7 +160,7 @@ namespace edm {
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
-    void commit_();
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut);
 
     PrincipalGetAdapter provRecorder_;
     ProductPtrVec putProducts_;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -129,9 +129,8 @@ namespace edm {
              PreallocationConfiguration const& config,
              ProcessContext const* processContext);
 
-    template <typename T>
     void processOneEvent(unsigned int iStreamID,
-                         typename T::MyPrincipal& principal,
+                         EventPrincipal& principal,
                          EventSetup const& eventSetup,
                          bool cleaningUpAfterException = false);
 
@@ -286,15 +285,6 @@ namespace edm {
     volatile bool           endpathsAreActive_;
   };
 
-
-  template <typename T>
-  void Schedule::processOneEvent(unsigned int iStreamID,
-                                 typename T::MyPrincipal& ep,
-                                 EventSetup const& es,
-                                 bool cleaningUpAfterException) {
-    assert(iStreamID<streamSchedules_.size());
-    streamSchedules_[iStreamID]->processOneEvent<T>(ep,es,cleaningUpAfterException);
-  }
 
   template <typename T>
   void Schedule::processOneStream(unsigned int iStreamID,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -106,14 +106,14 @@ namespace edm {
       }
       
       void commit(Run& iRun) {
-        iRun.commit_();
+        iRun.commit_(m_streamModules[0]->indiciesForPutProducts(InRun));
       }
       void commit(LuminosityBlock& iLumi) {
-        iLumi.commit_();
+        iLumi.commit_(m_streamModules[0]->indiciesForPutProducts(InLumi));
       }
       template<typename L, typename I>
       void commit(Event& iEvent, L* iList, I* iID) {
-        iEvent.commit_(iList,iID);
+        iEvent.commit_(m_streamModules[0]->indiciesForPutProducts(InEvent), iList,iID);
       }
 
       const EDConsumerBase* consumer() {

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -89,6 +90,12 @@ namespace edm {
                                            std::string const& processName) const;
 
       std::vector<ConsumesInfo> consumesInfo() const;
+
+      void resolvePutIndicies(BranchType iBranchType,
+                              std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                              std::string const& moduleLabel);
+      
+      std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const;
 
     protected:
       template<typename F> void createStreamModules(F iFunc) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2104,8 +2104,7 @@ namespace edm {
     //espController_->eventSetupForInstance(ts);
     EventSetup const& es = esp_->eventSetup();
     {
-      typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Traits;
-      schedule_->processOneEvent<Traits>(iStreamIndex,*pep, es);
+      schedule_->processOneEvent(iStreamIndex,*pep, es);
       if(hasSubProcesses()) {
         for(auto& subProcess : *subProcesses_) {
           subProcess.doEvent(*pep);

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -172,6 +172,11 @@ namespace edm {
     
     SendTerminationSignalIfException terminationSentry(actReg_.get(), &globalContext);
 
+    //If we are in an end transition, we need to reset failed items since they might
+    // be set this time around
+    if( not T::begin_) {
+      ep.resetFailedFromThisProcess();
+    }
     // This call takes care of the unscheduled processing.
     workerManager_.processOneOccurrence<T>(ep, es, StreamID::invalidStreamID(), &globalContext, &globalContext, cleaningUpAfterException);
 

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -479,28 +479,28 @@ namespace edm {
   InputSource::doBeginRun(RunPrincipal& rp, ProcessContext const* ) {
     Run run(rp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&run](){ beginRun(run); }, "Calling InputSource::beginRun" );
-    run.commit_();
+    run.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const* ) {
     Run run(rp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&run](){ endRun(run); }, "Calling InputSource::endRun", cleaningUpAfterException );
-    run.commit_();
+    run.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* ) {
     LuminosityBlock lb(lbp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&lb](){ beginLuminosityBlock(lb); }, "Calling InputSource::beginLuminosityBlock" );
-    lb.commit_();
+    lb.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const* ) {
     LuminosityBlock lb(lbp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&lb](){ endLuminosityBlock(lb); }, "Calling InputSource::endLuminosityBlock", cleaningUpAfterException );
-    lb.commit_();
+    lb.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -60,7 +60,7 @@ namespace edm {
   }
 
   void
-  LuminosityBlock::commit_() {
+  LuminosityBlock::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut) {
     LuminosityBlockPrincipal const& lbp = luminosityBlockPrincipal();
     ProductPtrVec::iterator pit(putProducts().begin());
     ProductPtrVec::iterator pie(putProducts().end());
@@ -68,6 +68,18 @@ namespace edm {
     while(pit != pie) {
         lbp.put(*pit->second, std::move(get_underlying_safe(pit->first)));
         ++pit;
+    }
+    
+    auto sz = iShouldPut.size();
+    if(sz !=0 and sz != putProducts().size()) {
+      //some were missed
+      auto& p = provRecorder_.principal();
+      for(auto index: iShouldPut){
+        auto resolver = p.getProductResolverByIndex(index);
+        if(not resolver->productResolved()) {
+          resolver->putProduct(std::unique_ptr<WrapperBase>());
+        }
+      }
     }
 
     // the cleanup is all or none

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -258,7 +258,7 @@ namespace edm {
     
     if (not shouldContinue) {
       //we are leaving the path early
-      for(auto it = workers_.begin()+iModuleIndex, itEnd=workers_.end();
+      for(auto it = workers_.begin()+nextIndex, itEnd=workers_.end();
           it != itEnd; ++it) {
         it->skipWorker(iEP);
       }

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -15,6 +15,7 @@ namespace edm {
              ExceptionToActionTable const& actions,
              std::shared_ptr<ActivityRegistry> areg,
              StreamContext const* streamContext,
+             std::atomic<bool>* stopProcessingEvent,
              PathContext::PathType pathType) :
     timesRun_(),
     timesPassed_(),
@@ -26,7 +27,8 @@ namespace edm {
     actReg_(areg),
     act_table_(&actions),
     workers_(workers),
-    pathContext_(path_name, streamContext, bitpos, pathType) {
+    pathContext_(path_name, streamContext, bitpos, pathType),
+    stopProcessingEvent_(stopProcessingEvent){
 
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
@@ -45,7 +47,8 @@ namespace edm {
     act_table_(r.act_table_),
     workers_(r.workers_),
     earlyDeleteHelpers_(r.earlyDeleteHelpers_),
-    pathContext_(r.pathContext_) {
+    pathContext_(r.pathContext_),
+    stopProcessingEvent_(r.stopProcessingEvent_){
 
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
@@ -77,6 +80,12 @@ namespace edm {
           edm::printCmsExceptionWarning("FailPath", e);
 	  break;
       }
+      case exception_actions::SkipEvent: {
+        //Need the other Paths to stop as soon as possible
+        if(stopProcessingEvent_) {
+          *stopProcessingEvent_ = true;
+        }
+      }
       default: {
 	  if (isEvent) ++timesExcept_;
 	  state_ = hlt::Exception;
@@ -90,7 +99,7 @@ namespace edm {
               e.addAdditionalInfo(ost.str());
             }
 	  }
-          throw;
+          throw e;
       }
     }
 
@@ -183,6 +192,120 @@ namespace edm {
     for(auto helper: earlyDeleteHelpers_) {
       helper->pathFinished(iEvent);
     }
+  }
+
+  void
+  Path::processOneOccurrenceAsync(WaitingTask* iTask,
+                                  EventPrincipal const& iEP,
+                                  EventSetup const& iES,
+                                  StreamID const& iStreamID,
+                                  StreamContext const* iStreamContext) {
+    waitingTasks_.reset();
+    ++timesRun_;
+    waitingTasks_.add(iTask);
+    if(actReg_) {
+      actReg_->prePathEventSignal_(*iStreamContext, pathContext_);
+    }
+    state_ = hlt::Ready;
+    
+    if(workers_.empty()) {
+      finished(-1, true, std::exception_ptr(), iStreamContext);
+      return;
+    }
+    
+    runNextWorkerAsync(0,iEP,iES,iStreamID, iStreamContext);
+  }
+
+  void
+  Path::workerFinished(std::exception_ptr const* iException,
+                       unsigned int iModuleIndex,
+                       EventPrincipal const& iEP, EventSetup const& iES,
+                       StreamID const& iID, StreamContext const* iContext) {
+    
+    //This call also allows the WorkerInPath to update statistics
+    // so should be done even if an exception happened
+    auto& worker = workers_[iModuleIndex];
+    bool shouldContinue = worker.checkResultsOfRunWorker(true);
+    std::exception_ptr finalException;
+    if(iException) {
+      std::unique_ptr<cms::Exception> pEx;
+      try {
+        std::rethrow_exception(*iException);
+      } catch(cms::Exception& oldEx) {
+        pEx = std::make_unique<cms::Exception>(oldEx);
+      }
+      try {
+        std::ostringstream ost;
+        ost << iEP.id();
+        shouldContinue = handleWorkerFailure(*pEx, iModuleIndex, /*isEvent*/ true, /*isBegin*/ true, InEvent,
+                                              worker.getWorker()->description(), ost.str());
+        //If we didn't rethrow, then we effectively skipped
+        worker.skipWorker(iEP);
+        finalException = std::exception_ptr();
+      } catch(...) {
+        shouldContinue = false;
+        finalException = std::current_exception();
+      }
+    }
+    if(stopProcessingEvent_ and *stopProcessingEvent_) {
+      shouldContinue = false;
+    }
+    auto const nextIndex = iModuleIndex +1;
+    if (shouldContinue and nextIndex < workers_.size()) {
+      runNextWorkerAsync(nextIndex, iEP, iES, iID, iContext);
+      return;
+    }
+    
+    if (not shouldContinue) {
+      //we are leaving the path early
+      for(auto it = workers_.begin()+iModuleIndex, itEnd=workers_.end();
+          it != itEnd; ++it) {
+        it->skipWorker(iEP);
+      }
+      handleEarlyFinish(iEP);
+    }
+    finished(iModuleIndex, shouldContinue, finalException, iContext);
+  }
+  
+  void
+  Path::finished(int iModuleIndex, bool iSucceeded, std::exception_ptr iException, StreamContext const* iContext) {
+    
+    if(not iException) {
+      updateCounters(iSucceeded, true);
+      recordStatus(iModuleIndex, true);
+    }
+    try {
+      HLTPathStatus status(state_, iModuleIndex);
+      actReg_->postPathEventSignal_(*iContext, pathContext_, status);
+    } catch(...) {
+      if(not iException) {
+        iException = std::current_exception();
+      }
+    }
+    waitingTasks_.doneWaiting(iException);
+  }
+  
+  void
+  Path::runNextWorkerAsync(unsigned int iNextModuleIndex,
+                           EventPrincipal const& iEP, EventSetup const& iES,
+                           StreamID const& iID, StreamContext const* iContext) {
+    
+    //need to make sure Service system is activated on the reading thread
+    auto token = ServiceRegistry::instance().presentToken();
+
+    auto nextTask = make_waiting_task( tbb::task::allocate_root(),
+                                      [this, iNextModuleIndex, &iEP,&iES, iID, iContext, token](std::exception_ptr const* iException)
+    {
+      ServiceRegistry::Operate guard(token);
+      this->workerFinished(iException, iNextModuleIndex, iEP,iES,iID,iContext);
+    });
+    
+    workers_[iNextModuleIndex].runWorkerAsync<
+    OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(nextTask,
+                                                                iEP,
+                                                                iES,
+                                                                iID,
+                                                                iContext);
   }
 
 }

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -37,6 +37,7 @@ namespace edm {
   class EarlyDeleteHelper;
   class StreamContext;
   class StreamID;
+  class WaitingTask;
 
   class Path {
   public:
@@ -52,6 +53,7 @@ namespace edm {
          ExceptionToActionTable const& actions,
          std::shared_ptr<ActivityRegistry> reg,
          StreamContext const* streamContext,
+         std::atomic<bool>* stopProcessEvent,
          PathContext::PathType pathType);
 
     Path(Path const&);
@@ -60,6 +62,8 @@ namespace edm {
     void processOneOccurrence(typename T::MyPrincipal const&, EventSetup const&,
                               StreamID const&, typename T::Context const*);
 
+    void processOneOccurrenceAsync(WaitingTask*, EventPrincipal const&, EventSetup const&, StreamID const&, StreamContext const*);
+    
     int bitPosition() const { return bitpos_; }
     std::string const& name() const { return pathContext_.pathName(); }
 
@@ -103,7 +107,11 @@ namespace edm {
     std::vector<EarlyDeleteHelper*> earlyDeleteHelpers_;
 
     PathContext pathContext_;
+    WaitingTaskList waitingTasks_;
+    std::atomic<bool>* stopProcessingEvent_;
 
+
+    
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
     bool handleWorkerFailure(cms::Exception & e,
@@ -123,9 +131,22 @@ namespace edm {
     void recordStatus(int nwrwue, bool isEvent);
     void updateCounters(bool succeed, bool isEvent);
     
+    void finished(int iModuleIndex, bool iSucceeded, std::exception_ptr,
+                  StreamContext const*);
+    
     void handleEarlyFinish(EventPrincipal const&);
     void handleEarlyFinish(RunPrincipal const&) {}
     void handleEarlyFinish(LuminosityBlockPrincipal const&) {}
+    
+    //Handle asynchronous processing
+    void workerFinished(std::exception_ptr const* iException,
+                        unsigned int iModuleIndex,
+                        EventPrincipal const& iEP, EventSetup const& iES,
+                        StreamID const& iID, StreamContext const* iContext);
+    void runNextWorkerAsync(unsigned int iNextModuleIndex,
+                            EventPrincipal const&, EventSetup const&,
+                            StreamID const&, StreamContext const*);
+
   };
 
   namespace {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -835,4 +835,11 @@ namespace edm {
       prod->retrieveAndMerge(*this);
     }
   }
+  
+  void
+  Principal::resetFailedFromThisProcess() {
+    for( auto & prod : *this) {
+      prod->resetFailedFromThisProcess();
+    }
+  }
 }

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -81,4 +81,14 @@ namespace edm {
        regService->watchProductAdditions(CallbackWrapper(producer, registrationCallback(), iReg, md));
     }
   }
+  
+  void ProducerBase::resolvePutIndicies(BranchType iBranchType,
+                          std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                          std::string const& moduleLabel) {
+    auto range = iIndicies.equal_range(moduleLabel);
+    putIndicies_[iBranchType].reserve(iIndicies.count(moduleLabel));
+    for(auto it = range.first; it != range.second;++it) {
+      putIndicies_[iBranchType].push_back(it->second);
+    }
+  }
 }

--- a/FWCore/Framework/src/ProductResolverBase.cc
+++ b/FWCore/Framework/src/ProductResolverBase.cc
@@ -52,4 +52,7 @@ namespace edm {
   
   void
   ProductResolverBase::setupUnscheduled(UnscheduledConfigurator const&) {}
+  
+  void ProductResolverBase::resetFailedFromThisProcess() {}
+
 }

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -295,8 +295,24 @@ namespace edm {
                                                bool skipCurrentProcess,
                                                SharedResourcesAcquirer* sra,
                                                ModuleCallingContext const* mcc) const {
-    //The caller should be checking to see if waitTask needs to be run
+    if(not skipCurrentProcess) {
+      m_waitingTasks.add(waitTask);
+    }
   }
+  
+  void
+  PuttableProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
+    ProducedProductResolver::putProduct_(std::move(edp));
+    m_waitingTasks.doneWaiting(std::exception_ptr());
+  }
+
+  
+  void
+  PuttableProductResolver::resetProductData_(bool deleteEarly) {
+    m_waitingTasks.reset();
+    DataManagingProductResolver::resetProductData_(deleteEarly);
+  }
+
   
   void
   UnscheduledProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -187,26 +187,6 @@ namespace edm {
     return new (iAlloc) FunctorTask<F>(f);
   }
 
-  template<typename F>
-  class FunctorWaitingTask : public WaitingTask {
-  public:
-    explicit FunctorWaitingTask( F f): func_(f) {}
-    
-    task* execute() override {
-      func_(exceptionPtr());
-      return nullptr;
-    };
-    
-  private:
-    F func_;
-  };
-  
-  template< typename ALLOC, typename F>
-  FunctorWaitingTask<F>* make_waiting_task( ALLOC&& iAlloc, F f) {
-    return new (iAlloc) FunctorWaitingTask<F>(f);
-  }
-
-  
   void InputProductResolver::prefetchAsync_(WaitingTask* waitTask,
                                             Principal const& principal,
                                             bool skipCurrentProcess,

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -407,7 +407,6 @@ namespace edm {
       throw Exception(errors::InsertFailure)
           << "Attempt to insert more than one product on branch " << branchDescription().branchName() << "\n";
     }
-    assert(edp.get() != nullptr);
     
     setProduct(std::move(edp));  // ProductResolver takes ownership
   }
@@ -423,6 +422,13 @@ namespace edm {
   bool
   ProducedProductResolver::isFromCurrentProcess() const {
     return true;
+  }
+  
+  void
+  ProducedProductResolver::resetFailedFromThisProcess() {
+    if(ProductStatus::ResolveFailed == status()) {
+      resetProductData_(false);
+    }
   }
 
   

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -134,10 +134,11 @@ namespace edm {
     public:
       ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus) : DataManagingProductResolver(bd, iDefaultStatus) {assert(bd->produced());}
 
-    virtual void resetFailedFromThisProcess() override;
+      virtual void resetFailedFromThisProcess() override;
 
-    private:
+    protected:
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    private:
       virtual bool isFromCurrentProcess() const override final;
     
   };
@@ -157,6 +158,11 @@ namespace edm {
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
     virtual bool unscheduledWasNotRun_() const override {return false;}
+    
+    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const;
+    virtual void resetProductData_(bool deleteEarly) override;
+
+    mutable WaitingTaskList m_waitingTasks;
   };
   
   class UnscheduledProductResolver : public ProducedProductResolver {

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -134,6 +134,8 @@ namespace edm {
     public:
       ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus) : DataManagingProductResolver(bd, iDefaultStatus) {assert(bd->produced());}
 
+    virtual void resetFailedFromThisProcess() override;
+
     private:
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
       virtual bool isFromCurrentProcess() const override final;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -943,7 +943,15 @@ namespace edm {
     assert(iStreamID<streamSchedules_.size());
     streamSchedules_[iStreamID]->endStream();
   }
-
+  
+  void Schedule::processOneEvent(unsigned int iStreamID,
+                                 EventPrincipal& ep,
+                                 EventSetup const& es,
+                                 bool cleaningUpAfterException) {
+    assert(iStreamID<streamSchedules_.size());
+    streamSchedules_[iStreamID]->processOneEvent(ep,es,cleaningUpAfterException);
+  }
+  
   void Schedule::preForkReleaseResources() {
     using std::placeholders::_1;
     for_all(allWorkers(), std::bind(&Worker::preForkReleaseResources, _1));

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -540,6 +540,72 @@ namespace edm {
     }
     return result;
   }
+  
+  void StreamSchedule::processOneEvent(EventPrincipal& ep,
+                                       EventSetup const& es,
+                                       bool cleaningUpAfterException) {
+    this->resetAll();
+    for (int empty_trig_path : empty_trig_paths_) {
+      results_->at(empty_trig_path) = HLTPathStatus(hlt::Pass, 0);
+    }
+    
+    using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
+    
+    Traits::setStreamContext(streamContext_, ep);
+    StreamScheduleSignalSentry<Traits> sentry(actReg_.get(), &streamContext_);
+    
+    SendTerminationSignalIfException terminationSentry(actReg_.get(), &streamContext_);
+    // This call takes care of the unscheduled processing.
+    workerManager_.processOneOccurrence<Traits>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
+    
+    ++total_events_;
+    try {
+      convertException::wrap([&]() {
+        try {
+          if (runTriggerPaths<Traits>(ep, es, &streamContext_)) {
+            ++total_passed_;
+          }
+        }
+        catch(cms::Exception& e) {
+          exception_actions::ActionCodes action = actionTable().find(e.category());
+          assert (action != exception_actions::IgnoreCompletely);
+          assert (action != exception_actions::FailPath);
+          if (action == exception_actions::SkipEvent) {
+            edm::printCmsExceptionWarning("SkipEvent", e);
+          } else {
+            throw;
+          }
+        }
+        
+        try {
+          ParentContext parentContext(&streamContext_);
+          if (results_inserter_.get()) results_inserter_->doWork<Traits>(ep, es, streamID_, parentContext, &streamContext_);
+        }
+        catch (cms::Exception & ex) {
+          ex.addContext("Calling produce method for module TriggerResultInserter");
+          std::ostringstream ost;
+          ost << "Processing " << ep.id();
+          ex.addContext(ost.str());
+          throw;
+        }
+        
+        if (endpathsAreActive_) runEndPaths<Traits>(ep, es, &streamContext_);
+        resetEarlyDelete();
+      });
+    }
+    catch(cms::Exception& ex) {
+      if (ex.context().empty()) {
+        addContextAndPrintException("Calling function StreamSchedule::processOneEvent", ex, cleaningUpAfterException);
+      } else {
+        addContextAndPrintException("", ex, cleaningUpAfterException);
+      }
+      throw;
+    }
+    terminationSentry.completedSuccessfully();
+    
+    //If we got here no other exception has happened so we can propogate any Service related exceptions
+    sentry.allowThrow();
+  }
 
   void
   StreamSchedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -362,6 +362,7 @@ namespace edm {
     StreamID                streamID_;
     StreamContext           streamContext_;
     volatile bool           endpathsAreActive_;
+    std::atomic<bool>       skippingEvent_;
   };
 
   void

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -167,8 +167,7 @@ namespace edm {
     
     StreamSchedule(StreamSchedule const&) = delete;
 
-    template <typename T>
-    void processOneEvent(typename T::MyPrincipal& principal,
+    void processOneEvent( EventPrincipal& principal,
                          EventSetup const& eventSetup,
                          bool cleaningUpAfterException = false);
 
@@ -370,73 +369,6 @@ namespace edm {
   StreamSchedule::reportSkipped(EventPrincipal const& ep) const {
     Service<JobReport> reportSvc;
     reportSvc->reportSkippedEvent(ep.id().run(), ep.id().event());
-  }
-
-  template <typename T>
-  void StreamSchedule::processOneEvent(typename T::MyPrincipal& ep,
-                                 EventSetup const& es,
-                                 bool cleaningUpAfterException) {
-    this->resetAll();
-    for (int empty_trig_path : empty_trig_paths_) {
-      results_->at(empty_trig_path) = HLTPathStatus(hlt::Pass, 0);
-    }
-
-    T::setStreamContext(streamContext_, ep);
-    StreamScheduleSignalSentry<T> sentry(actReg_.get(), &streamContext_);
-
-    SendTerminationSignalIfException terminationSentry(actReg_.get(), &streamContext_);
-    // This call takes care of the unscheduled processing.
-    workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
-
-    ++total_events_;
-    try {
-      convertException::wrap([&]() {
-        try {
-          if (runTriggerPaths<T>(ep, es, &streamContext_)) {
-            ++total_passed_;
-          }
-        }
-        catch(cms::Exception& e) {
-          exception_actions::ActionCodes action = actionTable().find(e.category());
-          assert (action != exception_actions::IgnoreCompletely);
-          assert (action != exception_actions::FailPath);
-          if (action == exception_actions::SkipEvent) {
-            edm::printCmsExceptionWarning("SkipEvent", e);
-          } else {
-            throw;
-          }
-        }
-
-        try {
-          ParentContext parentContext(&streamContext_);
-          if (results_inserter_.get()) results_inserter_->doWork<T>(ep, es, streamID_, parentContext, &streamContext_);
-        }
-        catch (cms::Exception & ex) {
-          if (T::isEvent_) {
-            ex.addContext("Calling produce method for module TriggerResultInserter");
-          }
-          std::ostringstream ost;
-          ost << "Processing " << ep.id();
-          ex.addContext(ost.str());
-          throw;
-        }
-
-        if (endpathsAreActive_) runEndPaths<T>(ep, es, &streamContext_);
-        resetEarlyDelete();
-      });
-    }
-    catch(cms::Exception& ex) {
-      if (ex.context().empty()) {
-        addContextAndPrintException("Calling function StreamSchedule::processOneEvent", ex, cleaningUpAfterException);
-      } else {
-        addContextAndPrintException("", ex, cleaningUpAfterException);
-      }
-      throw;
-    }
-    terminationSentry.completedSuccessfully();
-    
-    //If we got here no other exception has happened so we can propogate any Service related exceptions
-    sentry.allowThrow();
   }
 
   template <typename T>

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -368,8 +368,7 @@ namespace edm {
                           principal.reader());
     ep.setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());
     propagateProducts(InEvent, principal, ep);
-    typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Traits;
-    schedule_->processOneEvent<Traits>(ep.streamID().value(),ep, esp_->eventSetup());
+    schedule_->processOneEvent(ep.streamID().value(),ep, esp_->eventSetup());
     if(hasSubProcesses()) {
       for(auto& subProcess : *subProcesses_) {
         subProcess.doEvent(ep);

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -77,6 +77,8 @@ private:
     timesFailed_(),
     timesExcept_(),
     state_(Ready),
+    numberOfPathsOn_(0),
+    numberOfPathsLeftToRun_(0),
     moduleCallingContext_(&iMD),
     actions_(iActions),
     cached_exception_(),
@@ -303,6 +305,15 @@ private:
       ost << "Calling endStream for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
       ex.addContext(ost.str());
       throw;
+    }
+  }
+  
+  void Worker::skipOnPath(EventPrincipal const& iPrincipal) {
+    if( 0 == --numberOfPathsLeftToRun_) {
+      for(auto index : itemsShouldPutInEvent()) {
+        auto resolver = iPrincipal.getProductResolverByIndex(index);
+        resolver->putProduct(std::unique_ptr<WrapperBase>());
+      }
     }
   }
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -55,6 +55,7 @@ the worker is reset().
 #include <string>
 #include <vector>
 #include <exception>
+#include <unordered_map>
 
 namespace edm {
   class EventPrincipal;
@@ -126,6 +127,8 @@ namespace edm {
     //Used to make EDGetToken work
     virtual void updateLookup(BranchType iBranchType,
                       ProductResolverIndexHelper const&) = 0;
+    virtual void resolvePutIndicies(BranchType iBranchType,
+                                    std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) = 0;
 
     virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                                  ProductRegistry const& preg,

--- a/FWCore/Framework/src/WorkerInPath.cc
+++ b/FWCore/Framework/src/WorkerInPath.cc
@@ -12,6 +12,7 @@ namespace edm {
     worker_(w),
     placeInPathContext_(placeInPath)
   {
+    w->addedToPath();
   }
 
 }

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -31,6 +31,12 @@ namespace edm {
 		   StreamID streamID,
                    typename T::Context const* context);
 
+    void skipWorker(EventPrincipal const& iPrincipal) {
+      worker_->skipOnPath(iPrincipal);
+    }
+    void skipWorker(RunPrincipal const&) {}
+    void skipWorker(LuminosityBlockPrincipal const&) {}
+    
     void clearCounters() {
       timesVisited_ = timesPassed_ = timesFailed_ = timesExcept_ = 0;
     }

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -19,6 +19,7 @@ namespace edm {
 
   class PathContext;
   class StreamID;
+  class WaitingTask;
 
   class WorkerInPath {
   public:
@@ -28,9 +29,18 @@ namespace edm {
 
     template <typename T>
     bool runWorker(typename T::MyPrincipal const&, EventSetup const&,
-		   StreamID streamID,
+                   StreamID streamID,
                    typename T::Context const* context);
 
+    template <typename T>
+    void runWorkerAsync(WaitingTask* iTask,
+                        typename T::MyPrincipal const&, EventSetup const&,
+                        StreamID streamID,
+                        typename T::Context const* context);
+
+    
+    bool checkResultsOfRunWorker(bool wasEvent);
+    
     void skipWorker(EventPrincipal const& iPrincipal) {
       worker_->skipOnPath(iPrincipal);
     }
@@ -62,7 +72,65 @@ namespace edm {
 
     PlaceInPathContext placeInPathContext_;
   };
+  
+  inline bool WorkerInPath::checkResultsOfRunWorker(bool wasEvent) {
+    if(not wasEvent) {
+      return true;
+    }
+    auto state = worker_->state();
+    bool rc = true;
+    switch (state) {
+      case Worker::Fail:
+      {
+        ++timesFailed_;
+        rc = false;
+        break;
+      }
+      case Worker::Pass:
+        break;
+      case Worker::Exception:
+      {
+        ++timesExcept_;
+        return true;
+      }
+        
+      default:
+        assert(false);
+    }
+    
+    if(Ignore == filterAction()) {
+      rc = true;
+    } else if(Veto == filterAction()) {
+      rc = !rc;
+    }
+    
+    if(rc) {
+      ++timesPassed_;
+    } else {
+      ++timesFailed_;
+    }
+    return rc;
+    
+  }
 
+  template <typename T>
+  void WorkerInPath::runWorkerAsync(WaitingTask* iTask,
+                                    typename T::MyPrincipal const& ep, EventSetup const & es,
+                                    StreamID streamID,
+                                    typename T::Context const* context) {
+    if (T::isEvent_) {
+      ++timesVisited_;
+    }
+    
+    if(T::isEvent_) {
+      ParentContext parentContext(&placeInPathContext_);
+      worker_->doWorkAsync<T>(iTask,ep, es,streamID, parentContext, context);
+    } else {
+      ParentContext parentContext(context);
+      worker_->doWorkAsync<T>(iTask,ep, es,streamID, parentContext, context);
+    }
+  }
+  
   template <typename T>
   bool WorkerInPath::runWorker(typename T::MyPrincipal const& ep, EventSetup const & es,
                                StreamID streamID,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -454,6 +454,24 @@ namespace edm{
       iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
     }
 
+    std::vector<ProductResolverIndex> s_emptyIndexList;
+    
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(void const*) {
+      return s_emptyIndexList;
+    }
+    
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(ProducerBase const* iProd) {
+      return iProd->indiciesForPutProducts(edm::InEvent);
+    }
+
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(edm::stream::EDProducerAdaptorBase const* iProd) {
+      return iProd->indiciesForPutProducts(edm::InEvent);
+    }
+
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(edm::stream::EDFilterAdaptorBase const* iProd) {
+      return iProd->indiciesForPutProducts(edm::InEvent);
+    }
+
   }
   
   template<typename T>
@@ -461,6 +479,14 @@ namespace edm{
                                       std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) {
     resolvePutIndiciesImpl(&module(), iBranchType,iIndicies, description().moduleLabel());
   }
+  
+
+  template<typename T>
+  std::vector<ProductResolverIndex> const&
+  WorkerT<T>::itemsShouldPutInEvent() const {
+    return itemsShouldPutInEventImpl(&module());
+  }
+
 
   template<>
   Worker::Types WorkerT<EDAnalyzer>::moduleType() const { return Worker::kAnalyzer;}

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -425,6 +425,42 @@ namespace edm{
                                 ProductResolverIndexHelper const& iHelper) {
     module_->updateLookup(iBranchType,iHelper,mustPrefetchMayGet<T>());
   }
+  
+  namespace {
+    void resolvePutIndiciesImpl(void*,
+                            BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& iModuleLabel) {
+      //Do nothing
+    }
+
+    void resolvePutIndiciesImpl(ProducerBase* iProd,
+                            BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& iModuleLabel) {
+      iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
+    }
+
+    void resolvePutIndiciesImpl(edm::stream::EDProducerAdaptorBase* iProd,
+                            BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& iModuleLabel) {
+      iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
+    }
+    void resolvePutIndiciesImpl(edm::stream::EDFilterAdaptorBase* iProd,
+                            BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& iModuleLabel) {
+      iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
+    }
+
+  }
+  
+  template<typename T>
+  void WorkerT<T>::resolvePutIndicies(BranchType iBranchType,
+                                      std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) {
+    resolvePutIndiciesImpl(&module(), iBranchType,iIndicies, description().moduleLabel());
+  }
 
   template<>
   Worker::Types WorkerT<EDAnalyzer>::moduleType() const { return Worker::kAnalyzer;}

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -129,6 +129,9 @@ namespace edm {
     }
 
     virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const override { return module_->itemsToGetFromEvent(); }
+    
+    virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
+
 
     edm::propagate_const<std::shared_ptr<T>> module_;
   };

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -46,7 +46,8 @@ namespace edm {
 
     virtual void updateLookup(BranchType iBranchType,
                               ProductResolverIndexHelper const&) override;
-
+    virtual void resolvePutIndicies(BranchType iBranchType,
+                                    std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) override;
 
     template<typename D>
     void callWorkerBeginStream(D, StreamID);

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -133,6 +133,21 @@ namespace edm {
 
     template< typename T>
     void
+    ProducingModuleAdaptorBase<T>::resolvePutIndicies(BranchType iBranchType,
+                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            std::string const& moduleLabel) {
+      m_streamModules[0]->resolvePutIndicies(iBranchType,iIndicies,moduleLabel);
+    }
+
+
+    template< typename T>
+    std::vector<edm::ProductResolverIndex> const&
+    ProducingModuleAdaptorBase<T>::indiciesForPutProducts(BranchType iBranchType) const {
+      return m_streamModules[0]->indiciesForPutProducts(iBranchType);
+    }
+
+    template< typename T>
+    void
     ProducingModuleAdaptorBase<T>::doBeginJob() {
       
     }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -58,7 +58,7 @@ using namespace edm;
 namespace edm {
   class ProducerBase {
   public:
-    static void commitEvent(Event& e) { e.commit_(); }
+    static void commitEvent(Event& e) { e.commit_(std::vector<ProductResolverIndex>()); }
 
   };
 }

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -161,7 +161,7 @@ void testEventGetRefBeforePut::getRefTest() {
 
     refToProd = event.getRefBeforePut<edmtest::IntProduct>(productInstanceName);
     event.put(std::move(pr),productInstanceName);
-    event.commit_();
+    event.commit_(std::vector<edm::ProductResolverIndex>());
   }
   catch (cms::Exception& x) {
     std::cerr << x.explainSelf()<< std::endl;

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -37,7 +37,7 @@ Test of GenericHandle class.
 namespace edm {
    class ProducerBase {
       public:
-         static void commitEvent(Event& e) { e.commit_(); }
+         static void commitEvent(Event& e) { e.commit_(std::vector<ProductResolverIndex>()); }
    };
 }
 

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -72,6 +72,26 @@ namespace edmtest {
 
   //--------------------------------------------------------------------
   //
+  class IntConsumingAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    IntConsumingAnalyzer(edm::ParameterSet const& iPSet)
+     {
+      consumes<IntProduct>(iPSet.getUntrackedParameter<edm::InputTag>("getFromModule"));
+    }
+    
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override {}
+    
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<edm::InputTag>("getFromModule");
+      descriptions.add("consumeInt", desc);
+
+    }
+
+    
+  };
+  //--------------------------------------------------------------------
+  //
   class ConsumingStreamAnalyzer : public edm::stream::EDAnalyzer<> {
   public:
     ConsumingStreamAnalyzer(edm::ParameterSet const& iPSet) :
@@ -224,12 +244,14 @@ namespace edmtest {
 
 using edmtest::NonAnalyzer;
 using edmtest::IntTestAnalyzer;
+using edmtest::IntConsumingAnalyzer;
 using edmtest::ConsumingStreamAnalyzer;
 using edmtest::ConsumingOneSharedResourceAnalyzer;
 using edmtest::SCSimpleAnalyzer;
 using edmtest::DSVAnalyzer;
 DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
+DEFINE_FWK_MODULE(IntConsumingAnalyzer);
 DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);
 DEFINE_FWK_MODULE(ConsumingOneSharedResourceAnalyzer);
 DEFINE_FWK_MODULE(SCSimpleAnalyzer);

--- a/FWCore/Framework/test/test_multiPathEarlyDelete_cfg.py
+++ b/FWCore/Framework/test/test_multiPathEarlyDelete_cfg.py
@@ -31,7 +31,14 @@ onlyOne = cms.untracked.bool(True),
 acceptValue = cms.untracked.int32(3)
 )
 
+process.p1Done = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.waitTillP1Done = cms.EDAnalyzer("IntConsumingAnalyzer",
+                                        getFromModule = cms.untracked.InputTag("p1Done"))
 
-process.p1 = cms.Path(process.maker+process.f2+process.reader+process.tester)
-process.p2 = cms.Path(process.maker+process.p2PreTester+process.f3+process.reader+process.tester)
-process.p3 = cms.Path(process.tester)
+process.p2Done = cms.EDProducer("IntProducer", ivalue = cms.int32(2))
+process.waitTillP2Done = cms.EDAnalyzer("IntConsumingAnalyzer",
+                                        getFromModule = cms.untracked.InputTag("p2Done"))
+
+process.p1 = cms.Path(process.maker+process.f2+process.reader+process.tester+process.p1Done)
+process.p2 = cms.Path(process.waitTillP1Done+process.maker+process.p2PreTester+process.f3+process.reader+process.tester+process.p2Done)
+process.p3 = cms.Path(process.waitTillP2Done+process.tester)

--- a/FWCore/Framework/test/test_multiPathMultiModuleEarlyDelete_cfg.py
+++ b/FWCore/Framework/test/test_multiPathMultiModuleEarlyDelete_cfg.py
@@ -39,7 +39,15 @@ onlyOne = cms.untracked.bool(True),
 acceptValue = cms.untracked.int32(3)
 )
 
+process.p1Done = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.waitTillP1Done = cms.EDAnalyzer("IntConsumingAnalyzer",
+                                        getFromModule = cms.untracked.InputTag("p1Done"))
 
-process.p1 = cms.Path(process.maker+process.f2+process.reader1+process.tester1)
-process.p2 = cms.Path(process.maker+process.p2PreTester+process.f3+process.reader2+process.tester2)
-process.p3 = cms.Path(process.tester3)
+process.p2Done = cms.EDProducer("IntProducer", ivalue = cms.int32(2))
+process.waitTillP2Done = cms.EDAnalyzer("IntConsumingAnalyzer",
+                                        getFromModule = cms.untracked.InputTag("p2Done"))
+
+
+process.p1 = cms.Path(process.maker+process.f2+process.reader1+process.tester1+process.p1Done)
+process.p2 = cms.Path(process.waitTillP1Done+process.maker+process.p2PreTester+process.f3+process.reader2+process.tester2+process.p2Done)
+process.p3 = cms.Path(process.waitTillP2Done+process.tester3)

--- a/FWCore/Integration/test/testSkipEvent_cfg.py
+++ b/FWCore/Integration/test/testSkipEvent_cfg.py
@@ -75,6 +75,11 @@ process.onEndPath = cms.EDAnalyzer('RunLumiEventAnalyzer',
 # No particular reason that I selected these two modules
 process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
 
+process.p1Done = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.waitTillP1Done = cms.EDAnalyzer("IntConsumingAnalyzer",
+                                        getFromModule = cms.untracked.InputTag("p1Done"))
+
+
 process.f1 = cms.EDFilter("TestFilterModule",
     acceptValue = cms.untracked.int32(98),
     onlyOne = cms.untracked.bool(False)
@@ -91,8 +96,8 @@ process.p1 = cms.Path(process.beforeException *
                       process.testThrow *
                       process.afterException *
                       process.thingWithMergeProducer *
-                      process.f1)
+                      process.f1+process.p1Done)
 
-process.p2 = cms.Path(process.afterException)
+process.p2 = cms.Path(process.waitTillP1Done+process.afterException)
 
 process.e = cms.EndPath(process.out * process.onEndPath)

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -391,14 +391,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -419,8 +421,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -433,14 +433,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -449,8 +453,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -459,8 +461,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -477,14 +477,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -493,8 +497,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -503,8 +505,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -527,14 +527,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -555,8 +557,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -569,14 +569,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -585,8 +589,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -595,8 +597,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -613,14 +613,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -629,8 +633,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -639,8 +641,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -663,14 +663,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -691,8 +693,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -705,14 +705,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -721,8 +725,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -731,8 +733,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -749,14 +749,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -765,8 +769,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -775,8 +777,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -799,14 +799,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -827,8 +829,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -841,14 +841,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -857,8 +861,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -867,8 +869,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -885,14 +885,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -901,8 +905,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -911,8 +913,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1165,14 +1165,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -1193,8 +1195,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -1207,14 +1207,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -1223,8 +1227,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -1233,8 +1235,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -1251,14 +1251,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -1267,8 +1271,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -1277,8 +1279,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1301,14 +1301,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -1329,8 +1331,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -1343,14 +1343,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -1359,8 +1363,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -1369,8 +1371,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -1387,14 +1387,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -1403,8 +1407,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -1413,8 +1415,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1437,14 +1437,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -1465,8 +1467,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -1479,14 +1479,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -1495,8 +1499,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -1505,8 +1507,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -1523,14 +1523,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -1539,8 +1543,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -1549,8 +1551,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1573,14 +1573,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -1601,8 +1603,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -1615,14 +1615,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -1631,8 +1635,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -1641,8 +1643,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -1659,14 +1659,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -1675,8 +1679,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -1685,8 +1687,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1939,14 +1939,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -1967,8 +1969,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -1981,14 +1981,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -1997,8 +2001,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -2007,8 +2009,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -2025,14 +2025,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -2041,8 +2045,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -2051,8 +2053,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2075,14 +2075,16 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -2103,8 +2105,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -2117,14 +2117,18 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -2133,8 +2137,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -2143,8 +2145,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -2161,14 +2161,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -2177,8 +2181,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -2187,8 +2189,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2671,14 +2671,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -2699,8 +2701,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -2713,14 +2713,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -2729,8 +2733,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -2739,8 +2741,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -2757,14 +2757,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -2773,8 +2777,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -2783,8 +2785,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2807,14 +2807,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -2835,8 +2837,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -2849,14 +2849,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -2865,8 +2869,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -2875,8 +2877,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -2893,14 +2893,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -2909,8 +2913,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -2919,8 +2921,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2943,14 +2943,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -2971,8 +2973,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -2985,14 +2985,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3001,8 +3005,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3011,8 +3013,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3029,14 +3029,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3045,8 +3049,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3055,8 +3057,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3079,14 +3079,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -3107,8 +3109,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -3121,14 +3121,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3137,8 +3141,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3147,8 +3149,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3165,14 +3165,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3181,8 +3185,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3191,8 +3193,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3445,14 +3445,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -3473,8 +3475,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -3487,14 +3487,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3503,8 +3507,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3513,8 +3515,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3531,14 +3531,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3547,8 +3551,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3557,8 +3559,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3581,14 +3581,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -3609,8 +3611,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -3623,14 +3623,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3639,8 +3643,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3649,8 +3651,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3667,14 +3667,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3683,8 +3687,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3693,8 +3695,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3717,14 +3717,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -3745,8 +3747,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -3759,14 +3759,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3775,8 +3779,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3785,8 +3787,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3803,14 +3803,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3819,8 +3823,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3829,8 +3831,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3853,14 +3853,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -3881,8 +3883,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -3895,14 +3895,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -3911,8 +3915,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -3921,8 +3923,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -3939,14 +3939,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -3955,8 +3959,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -3965,8 +3967,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4219,14 +4219,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -4247,8 +4249,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -4261,14 +4261,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -4277,8 +4281,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -4287,8 +4289,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -4305,14 +4305,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -4321,8 +4325,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -4331,8 +4333,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4355,14 +4355,16 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -4383,8 +4385,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -4397,14 +4397,18 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -4413,8 +4417,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -4423,8 +4425,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -4441,14 +4441,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -4457,8 +4461,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -4467,8 +4469,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4951,14 +4951,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -4979,8 +4981,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -4993,14 +4993,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5009,8 +5013,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5019,8 +5021,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5037,14 +5037,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5053,8 +5057,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5063,8 +5065,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5087,14 +5087,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -5115,8 +5117,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -5129,14 +5129,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5145,8 +5149,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5155,8 +5157,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5173,14 +5173,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5189,8 +5193,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5199,8 +5201,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5223,14 +5223,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -5251,8 +5253,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -5265,14 +5265,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5281,8 +5285,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5291,8 +5293,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5309,14 +5309,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5325,8 +5329,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5335,8 +5337,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5359,14 +5359,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -5387,8 +5389,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -5401,14 +5401,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5417,8 +5421,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5427,8 +5429,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5445,14 +5445,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5461,8 +5465,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5471,8 +5473,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5725,14 +5725,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -5753,8 +5755,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -5767,14 +5767,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5783,8 +5787,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5793,8 +5795,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5811,14 +5811,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5827,8 +5831,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5837,8 +5839,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5861,14 +5861,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -5889,8 +5891,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -5903,14 +5903,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -5919,8 +5923,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -5929,8 +5931,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -5947,14 +5947,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -5963,8 +5967,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -5973,8 +5975,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5997,14 +5997,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -6025,8 +6027,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -6039,14 +6039,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -6055,8 +6059,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -6065,8 +6067,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -6083,14 +6083,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -6099,8 +6103,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -6109,8 +6111,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6133,14 +6133,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -6161,8 +6163,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -6175,14 +6175,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -6191,8 +6195,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -6201,8 +6203,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -6219,14 +6219,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -6235,8 +6239,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -6245,8 +6247,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6499,14 +6499,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -6527,8 +6529,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -6541,14 +6541,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -6557,8 +6561,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -6567,8 +6569,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -6585,14 +6585,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -6601,8 +6605,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -6611,8 +6613,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6635,14 +6635,16 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
@@ -6663,8 +6665,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
@@ -6677,14 +6677,18 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
@@ -6693,8 +6697,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
@@ -6703,8 +6705,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
@@ -6721,14 +6721,18 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ finished: processing path 'path1' : stream = 0
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
@@ -6737,8 +6741,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: processing path 'path2' : stream = 0
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
@@ -6747,8 +6749,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: processing path 'path3' : stream = 0
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -64,7 +64,7 @@ namespace edm {
     eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
     Event e(eventPrincipal, moduleDescription(), nullptr);
     produce(e);
-    e.commit_();
+    e.commit_(std::vector<ProductResolverIndex>());
     resetEventCached();
   }
 

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -120,6 +120,7 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   registry.watchPostSourceEvent(    this, & FastTimerService::postSourceEvent );
   registry.watchPreEvent(           this, & FastTimerService::preEvent );
   registry.watchPostEvent(          this, & FastTimerService::postEvent );
+  /* Disable until can handle more than one thread per event
   // watch per-path events
   registry.watchPrePathEvent(       this, & FastTimerService::prePathEvent );
   registry.watchPostPathEvent(      this, & FastTimerService::postPathEvent );
@@ -130,6 +131,7 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
     registry.watchPreModuleEventDelayedGet(  this, & FastTimerService::preModuleEventDelayedGet );
     registry.watchPostModuleEventDelayedGet( this, & FastTimerService::postModuleEventDelayedGet );
   }
+  */
 
   // if requested, reserve plots for timing vs. lumisection
   // there is no need to store the id, as it wil always be 0
@@ -1318,7 +1320,7 @@ double FastTimerService::queryModuleTime(edm::StreamID sid, const edm::ModuleDes
   if (module.id() < m_stream[sid].fast_modules.size()) {
     return m_stream[sid].fast_modules[module.id()]->time_active;
   } else {
-    edm::LogError("FastTimerService") << "FastTimerService::queryModuleTime: unexpected module " << module.moduleLabel();
+    //edm::LogError("FastTimerService") << "FastTimerService::queryModuleTime: unexpected module " << module.moduleLabel();
     return 0.;
   }
 }
@@ -1328,7 +1330,7 @@ double FastTimerService::queryModuleTime(edm::StreamID sid, unsigned int id) con
   if (id < m_stream[sid].fast_modules.size()) {
     return m_stream[sid].fast_modules[id]->time_active;
   } else {
-    edm::LogError("FastTimerService") << "FastTimerService::queryModuleTime: unexpected module id " << id;
+    //edm::LogError("FastTimerService") << "FastTimerService::queryModuleTime: unexpected module id " << id;
     return 0.;
   }
 }
@@ -1340,7 +1342,7 @@ double FastTimerService::queryModuleTimeByLabel(edm::StreamID sid, const std::st
     return keyval->second.time_active;
   } else {
     // module not found
-    edm::LogError("FastTimerService") << "FastTimerService::queryModuleTimeByLabel: unexpected module " << label;
+    //edm::LogError("FastTimerService") << "FastTimerService::queryModuleTimeByLabel: unexpected module " << label;
     return 0.;
   }
 }
@@ -1352,7 +1354,7 @@ double FastTimerService::queryModuleTimeByType(edm::StreamID sid, const std::str
     return keyval->second.time_active;
   } else {
     // module not found
-    edm::LogError("FastTimerService") << "FastTimerService::queryModuleTimeByType: unexpected module type " << type;
+    //edm::LogError("FastTimerService") << "FastTimerService::queryModuleTimeByType: unexpected module type " << type;
     return 0.;
   }
 }


### PR DESCRIPTION
Allow Paths and EndPaths to run concurrently within one Event.
This change properly handles dependencies between modules on different paths (a module on one path will wait until a module on another path has finished). In addition unscheduled modules can now safely depend on scheduled modules.
