### PR TITLE
Phase I Pixel Barrel Geometry and Material Budget changes for pre12

### DIFF
--- a/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
+++ b/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
@@ -677,8 +677,8 @@ o Phase I Pixel Barrel module cables
 * 2 "Aluminium"             "Aluminium"                       0.85   1   CAB
 
 # "Phase I BPIX module cables L1"   "micro_twisted_boundle_1"      146   -1.
-* 1 "Signal Cable"                "Copper"                       0.123  18  CAB
-* 2 "Power Cable"                 "micro_twisted_power_cable"    0.877  128 CAB
+* 1 "Signal Cable"                "Copper"                       0.386  18  CAB
+* 2 "Power Cable"                 "micro_twisted_power_cable"    0.614  128 CAB
 
 # "Phase I BPIX module cables L2-4"   "micro_twisted_boundle_2"      110   -1.
 * 1 "Signal Cable"                "Copper"                        0.127  14  CAB

--- a/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
+++ b/Geometry/TrackerCommonData/data/Materials/pixel_bar.in
@@ -677,8 +677,8 @@ o Phase I Pixel Barrel module cables
 * 2 "Aluminium"             "Aluminium"                       0.85   1   CAB
 
 # "Phase I BPIX module cables L1"   "micro_twisted_boundle_1"      146   -1.
-* 1 "Signal Cable"                "Copper"                       0.386  18  CAB
-* 2 "Power Cable"                 "micro_twisted_power_cable"    0.614  128 CAB
+* 1 "Signal Cable"                "Copper"                       0.123  18  CAB
+* 2 "Power Cable"                 "micro_twisted_power_cable"    0.877  128 CAB
 
 # "Phase I BPIX module cables L2-4"   "micro_twisted_boundle_2"      110   -1.
 * 1 "Signal Cable"                "Copper"                        0.127  14  CAB

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -86,8 +86,8 @@
  <Constant name="CableSignal1Z3"          value="[CableSignal1Z1]+[CableSignal1T2]"/>
 
  <Constant name="CablePower1Rin"          value="3.00*cm"/>
- <Constant name="CablePower1T1"           value="0.0098*cm"/>
- <Constant name="CablePower1T2"           value="0.0611*cm"/>
+ <Constant name="CablePower1T1"           value="0.0130*cm"/>
+ <Constant name="CablePower1T2"           value="0.0812*cm"/>
  <Constant name="CablePower2Rin"          value="6.800*cm"/>
  <Constant name="CablePower2T1"           value="0.0334*cm"/>
  <Constant name="CablePower2T2"           value="0.09185*cm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -55,8 +55,8 @@
  <Constant name="FlangeHCT"         value="0.528*cm"/>
 
  <Constant name="CableSignal1Rin"          value="3.00*cm"/>
- <Constant name="CableSignal1T1"           value="0.00335*cm"/>
- <Constant name="CableSignal1T2"           value="0.02088*cm"/>
+ <Constant name="CableSignal1T1"           value="0.00445*cm"/>
+ <Constant name="CableSignal1T2"           value="0.02777*cm"/>
  <Constant name="CableSignal2Rin"          value="6.800*cm"/>
  <Constant name="CableSignal2T1"           value="0.0114*cm"/>
  <Constant name="CableSignal2T2"           value="0.03135*cm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -539,7 +539,7 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelConn3" category="unspecified">
   <rSolid name="PixelBarrelConn3"/>
-  <rMaterial name="pixbarmaterial:SupplyTubeConn3_3Disks"/>
+  <rMaterial name="pixbarmaterial:SupplyTubeConn3_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelConn4" category="unspecified">
   <rSolid name="PixelBarrelConn4"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
@@ -28,6 +28,7 @@
  <Constant name="Cable3Dz"          value="[Cable3Length]+[CableDzOverModule]"/>
  <Constant name="Cable4Dz"          value="[Cable4Length]+[CableDzOverModule]"/>
  <Constant name="CableBoundleDiameter"     value="1.5*mm"/> 
+ <Constant name="CableBoundleDiameter1"    value="1.5*mm * sqrt((128+18)/(96+14))"/> <!-- take into account the different composition of the layer1 cables -->
  <Constant name="CableBoxThick"     value="[CableBoundleDiameter]"/> 
  <Constant name="CapacitorZ"        value="2.80*cm"/> 
  <Constant name="CapacitorThick"    value="1.50*mm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
@@ -28,8 +28,9 @@
  <Constant name="Cable3Dz"          value="[Cable3Length]+[CableDzOverModule]"/>
  <Constant name="Cable4Dz"          value="[Cable4Length]+[CableDzOverModule]"/>
  <Constant name="CableBoundleDiameter"     value="1.5*mm"/> 
- <Constant name="CableBoundleDiameter1"    value="1.5*mm * sqrt((128+18)/(96+14))"/> <!-- take into account the different composition of the layer1 cables -->
+ <Constant name="CableBoundleDiameter1"    value="2.0*mm"/> <!-- take into account the different composition of the layer1 cables -->
  <Constant name="CableBoxThick"     value="[CableBoundleDiameter]"/> 
+ <Constant name="CableBoxThick1"     value="[CableBoundleDiameter1]"/> 
  <Constant name="CapacitorZ"        value="2.80*cm"/> 
  <Constant name="CapacitorThick"    value="1.50*mm"/>
  <Constant name="CapacitorDx"       value="3.20*mm"/>
@@ -51,10 +52,10 @@
  
  <Constant name="ModuleDz"          value="[Length]/[Modules]"/>
  <Constant name="ModuleZ"           value="-([Length]-[ModuleDz])/2"/>
- <Constant name="Cable1BoundleX"           value="-([pixbarladder:CableBoundleDiameter]+[pixbarladder:CableBoundleDiameter]/2)"/> 
- <Constant name="Cable2BoundleX"           value="-([pixbarladder:CableBoundleDiameter]/2)"/> 
- <Constant name="Cable3BoundleX"           value="([pixbarladder:CableBoundleDiameter]/2)"/> 
- <Constant name="Cable4BoundleX"           value="([pixbarladder:CableBoundleDiameter]+[pixbarladder:CableBoundleDiameter]/2)"/> 
+ <Constant name="Cable1BoundleX"           value="-([pixbarladder:CableBoundleDiameter1]+[pixbarladder:CableBoundleDiameter1]/2)"/> 
+ <Constant name="Cable2BoundleX"           value="-([pixbarladder:CableBoundleDiameter1]/2)"/> 
+ <Constant name="Cable3BoundleX"           value="([pixbarladder:CableBoundleDiameter1]/2)"/> 
+ <Constant name="Cable4BoundleX"           value="([pixbarladder:CableBoundleDiameter1]+[pixbarladder:CableBoundleDiameter1]/2)"/> 
 
  <Constant name="Cable1Z"           value="([ExternalLength]-[Cable1Dz])/2"/>
  <Constant name="Cable2Z"           value="([ExternalLength]-[Cable2Dz])/2"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
@@ -28,9 +28,10 @@
  <Constant name="Cable3Dz"          value="[Cable3Length]+[CableDzOverModule]"/>
  <Constant name="Cable4Dz"          value="[Cable4Length]+[CableDzOverModule]"/>
  <Constant name="CableBoundleDiameter"     value="1.5*mm"/> 
- <Constant name="CableBoundleDiameter1"    value="2.0*mm"/> <!-- take into account the different composition of the layer1 cables -->
- <Constant name="CableBoxThick"     value="[CableBoundleDiameter]"/> 
- <Constant name="CableBoxThick1"     value="[CableBoundleDiameter1]"/> 
+ <Constant name="CableBoundleXLayer1"      value="3.0*mm"/> <!-- take into account the different composition of the layer1 cables -->
+ <Constant name="CableBoundleYLayer1"      value="1.32*mm"/>
+ <Constant name="CableBoxThick"            value="[CableBoundleDiameter]"/> 
+ <Constant name="CableBoxThickLayer1"      value="[CableBoundleYLayer1]"/> 
  <Constant name="CapacitorZ"        value="2.80*cm"/> 
  <Constant name="CapacitorThick"    value="1.50*mm"/>
  <Constant name="CapacitorDx"       value="3.20*mm"/>
@@ -52,10 +53,14 @@
  
  <Constant name="ModuleDz"          value="[Length]/[Modules]"/>
  <Constant name="ModuleZ"           value="-([Length]-[ModuleDz])/2"/>
- <Constant name="Cable1BoundleX"           value="-([pixbarladder:CableBoundleDiameter1]+[pixbarladder:CableBoundleDiameter1]/2)"/> 
- <Constant name="Cable2BoundleX"           value="-([pixbarladder:CableBoundleDiameter1]/2)"/> 
- <Constant name="Cable3BoundleX"           value="([pixbarladder:CableBoundleDiameter1]/2)"/> 
- <Constant name="Cable4BoundleX"           value="([pixbarladder:CableBoundleDiameter1]+[pixbarladder:CableBoundleDiameter1]/2)"/> 
+ <Constant name="Cable1BoundleX"           value="-([pixbarladder:CableBoundleDiameter]+[pixbarladder:CableBoundleDiameter]/2)"/> 
+ <Constant name="Cable2BoundleX"           value="-([pixbarladder:CableBoundleDiameter]/2)"/> 
+ <Constant name="Cable3BoundleX"           value="([pixbarladder:CableBoundleDiameter]/2)"/> 
+ <Constant name="Cable4BoundleX"           value="([pixbarladder:CableBoundleDiameter]+[pixbarladder:CableBoundleDiameter]/2)"/> 
+ <Constant name="Cable1BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> 
+ <Constant name="Cable2BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]/2)"/> 
+ <Constant name="Cable3BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]/2)"/> 
+ <Constant name="Cable4BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> 
 
  <Constant name="Cable1Z"           value="([ExternalLength]-[Cable1Dz])/2"/>
  <Constant name="Cable2Z"           value="([ExternalLength]-[Cable2Dz])/2"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
@@ -27,11 +27,11 @@
  <Constant name="Cable2Dz"          value="[Cable2Length]+[CableDzOverModule]"/>
  <Constant name="Cable3Dz"          value="[Cable3Length]+[CableDzOverModule]"/>
  <Constant name="Cable4Dz"          value="[Cable4Length]+[CableDzOverModule]"/>
- <Constant name="CableBoundleDiameter"     value="1.5*mm"/> 
- <Constant name="CableBoundleXLayer1"      value="3.0*mm"/> <!-- take into account the different composition of the layer1 cables -->
- <Constant name="CableBoundleYLayer1"      value="1.32*mm"/>
+ <Constant name="CableBoundleDiameter"     value="1.3*mm"/> 
+<!-- <Constant name="CableBoundleXLayer1"      value="3.0*mm"/>-->
+<!-- <Constant name="CableBoundleYLayer1"      value="1.32*mm"/>-->
  <Constant name="CableBoxThick"            value="[CableBoundleDiameter]"/> 
- <Constant name="CableBoxThickLayer1"      value="[CableBoundleYLayer1]"/> 
+<!-- <Constant name="CableBoxThickLayer1"      value="[CableBoundleYLayer1]"/> -->
  <Constant name="CapacitorZ"        value="2.80*cm"/> 
  <Constant name="CapacitorThick"    value="1.50*mm"/>
  <Constant name="CapacitorDx"       value="3.20*mm"/>
@@ -57,10 +57,10 @@
  <Constant name="Cable2BoundleX"           value="-([pixbarladder:CableBoundleDiameter]/2)"/> 
  <Constant name="Cable3BoundleX"           value="([pixbarladder:CableBoundleDiameter]/2)"/> 
  <Constant name="Cable4BoundleX"           value="([pixbarladder:CableBoundleDiameter]+[pixbarladder:CableBoundleDiameter]/2)"/> 
- <Constant name="Cable1BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> 
- <Constant name="Cable2BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]/2)"/> 
- <Constant name="Cable3BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]/2)"/> 
- <Constant name="Cable4BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> 
+<!-- <Constant name="Cable1BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> -->
+<!-- <Constant name="Cable2BoundleXLayer1"     value="-([pixbarladder:CableBoundleXLayer1]/2)"/> -->
+<!-- <Constant name="Cable3BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]/2)"/> -->
+<!-- <Constant name="Cable4BoundleXLayer1"     value="([pixbarladder:CableBoundleXLayer1]+[pixbarladder:CableBoundleXLayer1]/2)"/> -->
 
  <Constant name="Cable1Z"           value="([ExternalLength]-[Cable1Dz])/2"/>
  <Constant name="Cable2Z"           value="([ExternalLength]-[Cable2Dz])/2"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -32,11 +32,11 @@
            2*[pixbarladder:SensorEdge]"/>
  <Constant name="LadderWidth"       value="[CFStripWidth]"/>
  <Constant name="LadderThick"       value="[CFStripThick]+
-           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThick1]"/>
+           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThickLayer1]"/>
  <Constant name="CableBoxY"         value="([LadderThick]-
-           [pixbarladder:CableBoxThick1])/2"/>
+           [pixbarladder:CableBoxThickLayer1])/2"/>
  <Constant name="ModuleBoxY"        value="[CableBoxY]-
-           ([pixbarladder:CableBoxThick1]+[pixbarladder:Module0Thick])/2"/>
+           ([pixbarladder:CableBoxThickLayer1]+[pixbarladder:Module0Thick])/2"/>
  <Constant name="CFStripY"          value="[ModuleBoxY]-
            ([pixbarladder:Module0Thick]+[CFStripThick])/2"/>
 <!-- <Constant name="BaseY"             value="-([pixbarladder:Module0Thick]-
@@ -75,7 +75,7 @@
  <Box name="PixelBarrelCFStripFull"      dx="[pixbarladderfull0:CFStripWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" dz="[pixbarladder:Length]/2"/>
  <Box name="PixelBarrelCableBoxFull"     dx="[pixbarladderfull0:LadderWidth]/2"
-      dy="[pixbarladder:CableBoxThick1]/2"   dz="[pixbarladder:ExternalLength]/2"/>
+      dy="[pixbarladder:CableBoxThickLayer1]/2"   dz="[pixbarladder:ExternalLength]/2"/>
  <Box name="PixelBarrelModuleFull"       dx="[pixbarladderfull0:LadderWidth]/2"
       dy="[pixbarladder:Module0Thick]/2"     dz="[pixbarladder:ModuleDz]/2"/>
 <!--
@@ -90,14 +90,14 @@
       dy="[pixbarladder:ActiveDz]/2"        dz="[pixbarladder:SensorThick]/2"/>
  <Box name="PixelBarrelHybridFull"       dx="[pixbarladderfull0:HybridWidth]/2"
       dy="[pixbarladder:HybridThick]/2"     dz="[pixbarladder:HybridDz]/2"/>
- <Tubs name="PixelBarrelCableBoundle1" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
-       dz="[pixbarladder:Cable1Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle2" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
-       dz="[pixbarladder:Cable2Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle3" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
-       dz="[pixbarladder:Cable3Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle4" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
-       dz="[pixbarladder:Cable4Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
+ <EllipticalTube name="PixelBarrelCableBoundle1" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
+       zHeight="[pixbarladder:Cable1Dz]/2"/>
+ <EllipticalTube name="PixelBarrelCableBoundle2" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
+       zHeight="[pixbarladder:Cable2Dz]/2"/>
+ <EllipticalTube name="PixelBarrelCableBoundle3" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
+       zHeight="[pixbarladder:Cable3Dz]/2"/>
+ <EllipticalTube name="PixelBarrelCableBoundle4" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
+       zHeight="[pixbarladder:Cable4Dz]/2"/>
  <Box name="PixelBarrelCFStripHoleFull"  dx="[pixbarladderfull0:CFHoleWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" 
       dz="[pixbarladderfull0:CFHoleDz]/2"/>
@@ -291,49 +291,49 @@
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <Translation x="[pixbarladder:Cable1BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable1BoundleXLayer1]" y="[zero]" 
                z="[pixbarladder:Cable1Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <Translation x="[pixbarladder:Cable1BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable1BoundleXLayer1]" y="[zero]" 
                z="-[pixbarladder:Cable1Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <Translation x="[pixbarladder:Cable2BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable2BoundleXLayer1]" y="[zero]" 
                z="[pixbarladder:Cable2Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <Translation x="[pixbarladder:Cable2BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable2BoundleXLayer1]" y="[zero]" 
                z="-[pixbarladder:Cable2Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <Translation x="[pixbarladder:Cable3BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable3BoundleXLayer1]" y="[zero]" 
                z="[pixbarladder:Cable3Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <Translation x="[pixbarladder:Cable3BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable3BoundleXLayer1]" y="[zero]" 
                z="-[pixbarladder:Cable3Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <Translation x="[pixbarladder:Cable4BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable4BoundleXLayer1]" y="[zero]" 
                z="[pixbarladder:Cable4Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <Translation x="[pixbarladder:Cable4BoundleX]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable4BoundleXLayer1]" y="[zero]" 
                z="-[pixbarladder:Cable4Z]" />
  </PosPart>
  <!--

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -32,11 +32,11 @@
            2*[pixbarladder:SensorEdge]"/>
  <Constant name="LadderWidth"       value="[CFStripWidth]"/>
  <Constant name="LadderThick"       value="[CFStripThick]+
-           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThick]"/>
+           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThick1]"/>
  <Constant name="CableBoxY"         value="([LadderThick]-
-           [pixbarladder:CableBoxThick])/2"/>
+           [pixbarladder:CableBoxThick1])/2"/>
  <Constant name="ModuleBoxY"        value="[CableBoxY]-
-           ([pixbarladder:CableBoxThick]+[pixbarladder:Module0Thick])/2"/>
+           ([pixbarladder:CableBoxThick1]+[pixbarladder:Module0Thick])/2"/>
  <Constant name="CFStripY"          value="[ModuleBoxY]-
            ([pixbarladder:Module0Thick]+[CFStripThick])/2"/>
 <!-- <Constant name="BaseY"             value="-([pixbarladder:Module0Thick]-
@@ -75,7 +75,7 @@
  <Box name="PixelBarrelCFStripFull"      dx="[pixbarladderfull0:CFStripWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" dz="[pixbarladder:Length]/2"/>
  <Box name="PixelBarrelCableBoxFull"     dx="[pixbarladderfull0:LadderWidth]/2"
-      dy="[pixbarladder:CableBoxThick]/2"   dz="[pixbarladder:ExternalLength]/2"/>
+      dy="[pixbarladder:CableBoxThick1]/2"   dz="[pixbarladder:ExternalLength]/2"/>
  <Box name="PixelBarrelModuleFull"       dx="[pixbarladderfull0:LadderWidth]/2"
       dy="[pixbarladder:Module0Thick]/2"     dz="[pixbarladder:ModuleDz]/2"/>
 <!--

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -178,19 +178,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle_1"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer1_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle_1"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer1_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle_1"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer1_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle_1"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer1_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull0:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -32,11 +32,11 @@
            2*[pixbarladder:SensorEdge]"/>
  <Constant name="LadderWidth"       value="[CFStripWidth]"/>
  <Constant name="LadderThick"       value="[CFStripThick]+
-           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThickLayer1]"/>
+           [pixbarladder:Module0Thick]+[pixbarladder:CableBoxThick]"/>
  <Constant name="CableBoxY"         value="([LadderThick]-
-           [pixbarladder:CableBoxThickLayer1])/2"/>
+           [pixbarladder:CableBoxThick])/2"/>
  <Constant name="ModuleBoxY"        value="[CableBoxY]-
-           ([pixbarladder:CableBoxThickLayer1]+[pixbarladder:Module0Thick])/2"/>
+           ([pixbarladder:CableBoxThick]+[pixbarladder:Module0Thick])/2"/>
  <Constant name="CFStripY"          value="[ModuleBoxY]-
            ([pixbarladder:Module0Thick]+[CFStripThick])/2"/>
 <!-- <Constant name="BaseY"             value="-([pixbarladder:Module0Thick]-
@@ -75,7 +75,7 @@
  <Box name="PixelBarrelCFStripFull"      dx="[pixbarladderfull0:CFStripWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" dz="[pixbarladder:Length]/2"/>
  <Box name="PixelBarrelCableBoxFull"     dx="[pixbarladderfull0:LadderWidth]/2"
-      dy="[pixbarladder:CableBoxThickLayer1]/2"   dz="[pixbarladder:ExternalLength]/2"/>
+      dy="[pixbarladder:CableBoxThick]/2"   dz="[pixbarladder:ExternalLength]/2"/>
  <Box name="PixelBarrelModuleFull"       dx="[pixbarladderfull0:LadderWidth]/2"
       dy="[pixbarladder:Module0Thick]/2"     dz="[pixbarladder:ModuleDz]/2"/>
 <!--
@@ -90,14 +90,22 @@
       dy="[pixbarladder:ActiveDz]/2"        dz="[pixbarladder:SensorThick]/2"/>
  <Box name="PixelBarrelHybridFull"       dx="[pixbarladderfull0:HybridWidth]/2"
       dy="[pixbarladder:HybridThick]/2"     dz="[pixbarladder:HybridDz]/2"/>
- <EllipticalTube name="PixelBarrelCableBoundle1" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
-       zHeight="[pixbarladder:Cable1Dz]/2"/>
- <EllipticalTube name="PixelBarrelCableBoundle2" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
-       zHeight="[pixbarladder:Cable2Dz]/2"/>
- <EllipticalTube name="PixelBarrelCableBoundle3" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
-       zHeight="[pixbarladder:Cable3Dz]/2"/>
- <EllipticalTube name="PixelBarrelCableBoundle4" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"
-       zHeight="[pixbarladder:Cable4Dz]/2"/>
+ <Tubs name="PixelBarrelCableBoundle1" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+       dz="[pixbarladder:Cable1Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
+ <Tubs name="PixelBarrelCableBoundle2" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+       dz="[pixbarladder:Cable2Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
+ <Tubs name="PixelBarrelCableBoundle3" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+       dz="[pixbarladder:Cable3Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
+ <Tubs name="PixelBarrelCableBoundle4" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+       dz="[pixbarladder:Cable4Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
+<!-- <EllipticalTube name="PixelBarrelCableBoundle1" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"-->
+<!--       zHeight="[pixbarladder:Cable1Dz]/2"/>-->
+<!-- <EllipticalTube name="PixelBarrelCableBoundle2" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"-->
+<!--       zHeight="[pixbarladder:Cable2Dz]/2"/>-->
+<!-- <EllipticalTube name="PixelBarrelCableBoundle3" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"-->
+<!--       zHeight="[pixbarladder:Cable3Dz]/2"/>-->
+<!-- <EllipticalTube name="PixelBarrelCableBoundle4" xSemiAxis="[pixbarladder:CableBoundleXLayer1]/2" ySemiAxis="[pixbarladder:CableBoundleYLayer1]/2"-->
+<!--       zHeight="[pixbarladder:Cable4Dz]/2"/>-->
  <Box name="PixelBarrelCFStripHoleFull"  dx="[pixbarladderfull0:CFHoleWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" 
       dz="[pixbarladderfull0:CFHoleDz]/2"/>
@@ -291,49 +299,49 @@
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <Translation x="[pixbarladder:Cable1BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable1BoundleX]" y="[zero]" 
                z="[pixbarladder:Cable1Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle1"/>
-  <Translation x="[pixbarladder:Cable1BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable1BoundleX]" y="[zero]" 
                z="-[pixbarladder:Cable1Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <Translation x="[pixbarladder:Cable2BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable2BoundleX]" y="[zero]" 
                z="[pixbarladder:Cable2Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle2"/>
-  <Translation x="[pixbarladder:Cable2BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable2BoundleX]" y="[zero]" 
                z="-[pixbarladder:Cable2Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <Translation x="[pixbarladder:Cable3BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable3BoundleX]" y="[zero]" 
                z="[pixbarladder:Cable3Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle3"/>
-  <Translation x="[pixbarladder:Cable3BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable3BoundleX]" y="[zero]" 
                z="-[pixbarladder:Cable3Z]" />
  </PosPart>
   <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <Translation x="[pixbarladder:Cable4BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable4BoundleX]" y="[zero]" 
                z="[pixbarladder:Cable4Z]" />
  </PosPart>
  <PosPart copyNumber="2">
    <rParent name="pixbarladderfull0:PixelBarrelCableBoxFull"/>
    <rChild name="pixbarladderfull0:PixelBarrelCableBoundle4"/>
-  <Translation x="[pixbarladder:Cable4BoundleXLayer1]" y="[zero]" 
+  <Translation x="[pixbarladder:Cable4BoundleX]" y="[zero]" 
                z="-[pixbarladder:Cable4Z]" />
  </PosPart>
  <!--

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -90,13 +90,13 @@
       dy="[pixbarladder:ActiveDz]/2"        dz="[pixbarladder:SensorThick]/2"/>
  <Box name="PixelBarrelHybridFull"       dx="[pixbarladderfull0:HybridWidth]/2"
       dy="[pixbarladder:HybridThick]/2"     dz="[pixbarladder:HybridDz]/2"/>
- <Tubs name="PixelBarrelCableBoundle1" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+ <Tubs name="PixelBarrelCableBoundle1" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
        dz="[pixbarladder:Cable1Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle2" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+ <Tubs name="PixelBarrelCableBoundle2" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
        dz="[pixbarladder:Cable2Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle3" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+ <Tubs name="PixelBarrelCableBoundle3" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
        dz="[pixbarladder:Cable3Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
- <Tubs name="PixelBarrelCableBoundle4" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter]/2"
+ <Tubs name="PixelBarrelCableBoundle4" rMin="[zero]"    rMax="[pixbarladder:CableBoundleDiameter1]/2"
        dz="[pixbarladder:Cable4Dz]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
  <Box name="PixelBarrelCFStripHoleFull"  dx="[pixbarladderfull0:CFHoleWidth]/2"
       dy="[pixbarladderfull0:CFStripThick]/2" 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
@@ -163,19 +163,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull1:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
@@ -153,19 +153,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull2:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
@@ -152,19 +152,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle1" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle1"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle2" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle2"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle3" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle3"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCableBoundle4" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCableBoundle4"/>
-  <rMaterial name="materials:micro_twisted_boundle_2"/>
+  <rMaterial name="pixbarmaterial:Pix_Bar_Cable_Layer234_Upgrade"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
   <rSolid name="pixbarladderfull3:PixelBarrelCFStripHoleFull"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer.xml
@@ -5,7 +5,7 @@
  <Constant name="LayerDz"           value="54.00*cm"/> <!--55.40 -->
  <Constant name="CoolDz"            value="54.00*cm"/> <!--55.40 -->
  <Constant name="CoolSide"          value="0.40*cm"/>
- <Constant name="CoolThick"         value="0.01*cm"/>
+ <Constant name="CoolThick"         value="0.005*cm"/>
 </ConstantsSection>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
@@ -10,6 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.16*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="-0.917*deg"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.04651*cm"/>
+ <Constant name="InnerOffsetFineTune"    value="-0.01201*cm"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
@@ -5,10 +5,11 @@
  <Constant name="Ladders"           value="12"/>
  <Constant name="CoolDist"          value="3.03*cm"/>
  <Constant name="CoolRadius"        value="0.0900*cm"/>
- <Constant name="LadderOffset"        value="0.225*cm"/> 
+ <Constant name="LadderOffset"        value="0.220*cm"/> 
  <Constant name="Cool1Offset"        value="0.83*cm"/>
  <Constant name="Cool2Offset"        value="-0.16*cm"/>
  <Constant name="OuterFirst"        value="1"/>
+ <Constant name="PitchFineTune"     value="-0.917*deg"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">
@@ -30,6 +31,9 @@
   <Numeric name="LadderOffset"      value="[pixbarlayer0:LadderOffset]"/>
   <Numeric name="ActiveWidth"      value="[pixbarladderfull0:ActiveWidth]"/>
   <Numeric name="OuterFirst"       value="[pixbarlayer0:OuterFirst]"/>
+  <Numeric name="PitchFineTune"       value="[pixbarlayer0:PitchFineTune]"/>
+  <Numeric name="OuterOffsetFineTune"       value="[pixbarlayer0:OuterOffsetFineTune]"/>
+  <Numeric name="InnerOffsetFineTune"       value="[pixbarlayer0:InnerOffsetFineTune]"/>
 </Algorithm>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
@@ -10,8 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.16*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="-0.917*deg"/>
- <Constant name="OuterOffsetFineTune"    value="-0.04651*cm"/>
- <Constant name="InnerOffsetFineTune"    value="-0.01201*cm"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.0467*cm+[pixbarladder:SensorThick]/2"/>
+ <Constant name="InnerOffsetFineTune"    value="-0.0120*cm-[pixbarladder:SensorThick]/2"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
@@ -10,6 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="-0.9435*deg"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.02799*cm"/>
+ <Constant name="InnerOffsetFineTune"    value="0.02651*cm"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
@@ -5,10 +5,11 @@
  <Constant name="Ladders"           value="28"/>
  <Constant name="CoolDist"          value="6.8*cm"/>
  <Constant name="CoolRadius"        value="0.0900*cm"/>
- <Constant name="LadderOffset"        value="0.225*cm"/>
+ <Constant name="LadderOffset"        value="0.270*cm"/>
  <Constant name="Cool1Offset"        value="0.9*cm"/>
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
+ <Constant name="PitchFineTune"     value="-0.9435*deg"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">
@@ -29,7 +30,9 @@
   <Numeric name="LadderThick"      value="[pixbarladderfull1:LadderThick]"/>
   <Numeric name="LadderOffset"      value="[pixbarlayer1:LadderOffset]"/>
   <Numeric name="OuterFirst"       value="[pixbarlayer1:OuterFirst]"/>
-
+  <Numeric name="PitchFineTune"       value="[pixbarlayer1:PitchFineTune]"/>
+  <Numeric name="OuterOffsetFineTune"       value="[pixbarlayer1:OuterOffsetFineTune]"/>
+  <Numeric name="InnerOffsetFineTune"       value="[pixbarlayer1:InnerOffsetFineTune]"/>
 </Algorithm>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
@@ -10,8 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="-0.9435*deg"/>
- <Constant name="OuterOffsetFineTune"    value="-0.02799*cm"/>
- <Constant name="InnerOffsetFineTune"    value="0.02651*cm"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.0281*cm+[pixbarladder:SensorThick]/2"/>
+ <Constant name="InnerOffsetFineTune"    value="0.0263*cm-[pixbarladder:SensorThick]/2"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
@@ -5,10 +5,11 @@
  <Constant name="Ladders"           value="44"/>
  <Constant name="CoolDist"          value="10.9*cm"/>
  <Constant name="CoolRadius"        value="0.0900*cm"/>
- <Constant name="LadderOffset"        value="0.225*cm"/>
+ <Constant name="LadderOffset"        value="0.270*cm"/>
  <Constant name="Cool1Offset"        value="0.9*cm"/>
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
+ <Constant name="PitchFineTune"     value="0.118*deg"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">
@@ -29,7 +30,9 @@
   <Numeric name="LadderThick"      value="[pixbarladderfull2:LadderThick]"/>
   <Numeric name="LadderOffset"      value="[pixbarlayer2:LadderOffset]"/>
   <Numeric name="OuterFirst"       value="[pixbarlayer2:OuterFirst]"/>
-
+  <Numeric name="PitchFineTune"       value="[pixbarlayer2:PitchFineTune]"/>
+  <Numeric name="OuterOffsetFineTune"       value="[pixbarlayer2:OuterOffsetFineTune]"/>
+  <Numeric name="InnerOffsetFineTune"       value="[pixbarlayer2:InnerOffsetFineTune]"/>
 </Algorithm>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
@@ -10,8 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="0.118*deg"/>
- <Constant name="OuterOffsetFineTune"    value="-0.041*cm"/>
- <Constant name="InnerOffsetFineTune"    value="0.0415*cm"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.0413*cm+[pixbarladder:SensorThick]/2"/>
+ <Constant name="InnerOffsetFineTune"    value="0.0413*cm-[pixbarladder:SensorThick]/2"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
@@ -10,6 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="0.118*deg"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.041*cm"/>
+ <Constant name="InnerOffsetFineTune"    value="0.0415*cm"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
@@ -10,6 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="0.0535*deg"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.0405*cm"/>
+ <Constant name="InnerOffsetFineTune"    value="0.04*cm"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
@@ -10,8 +10,8 @@
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
  <Constant name="PitchFineTune"     value="0.0535*deg"/>
- <Constant name="OuterOffsetFineTune"    value="-0.0405*cm"/>
- <Constant name="InnerOffsetFineTune"    value="0.04*cm"/>
+ <Constant name="OuterOffsetFineTune"    value="-0.0405*cm+[pixbarladder:SensorThick]/2"/>
+ <Constant name="InnerOffsetFineTune"    value="0.0405*cm-[pixbarladder:SensorThick]/2"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
@@ -5,10 +5,11 @@
  <Constant name="Ladders"           value="64"/> 
  <Constant name="CoolDist"          value="16.0*cm"/>
  <Constant name="CoolRadius"        value="0.0900*cm"/>
- <Constant name="LadderOffset"        value="0.225*cm"/>
+ <Constant name="LadderOffset"        value="0.270*cm"/>
  <Constant name="Cool1Offset"        value="0.9*cm"/>
  <Constant name="Cool2Offset"        value="-0.1*cm"/>
  <Constant name="OuterFirst"        value="1"/>
+ <Constant name="PitchFineTune"     value="0.0535*deg"/>
 </ConstantsSection>
 
 <Algorithm name="track:DDPixBarLayerUpgradeAlgo">
@@ -29,7 +30,9 @@
   <Numeric name="LadderThick"      value="[pixbarladderfull3:LadderThick]"/>
   <Numeric name="LadderOffset"      value="[pixbarlayer3:LadderOffset]"/>
   <Numeric name="OuterFirst"       value="[pixbarlayer3:OuterFirst]"/>
-
+  <Numeric name="PitchFineTune"       value="[pixbarlayer3:PitchFineTune]"/>
+  <Numeric name="OuterOffsetFineTune"       value="[pixbarlayer3:OuterOffsetFineTune]"/>
+  <Numeric name="InnerOffsetFineTune"       value="[pixbarlayer3:InnerOffsetFineTune]"/>
 </Algorithm>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -557,7 +557,7 @@
 
  <CompositeMaterial name="SectorA" density="0.3136*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.10443">
-      <rMaterial name="materials:C6F14_F2_-10C"/>
+      <rMaterial name="materials:Bpix_CO2_-20C"/>
     </MaterialFraction>
     <MaterialFraction fraction="0.00283">
       <rMaterial name="pixbarmaterial:Polyoxymethylene"/>
@@ -643,7 +643,7 @@
 
   <CompositeMaterial name="SectorC" density="0.7928*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.14778">
-      <rMaterial name="materials:C6F14_F2_-10C"/>
+      <rMaterial name="materials:Bpix_CO2_-20C"/>
     </MaterialFraction>
     <MaterialFraction fraction="0.0139">
       <rMaterial name="pixbarmaterial:Polyoxymethylene"/>
@@ -699,7 +699,7 @@
 
   <CompositeMaterial name="PixelBarrelSupTubCables" density="2.25064*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.09162">
-      <rMaterial name="materials:C6F14_F2_-10C"/>
+      <rMaterial name="materials:Bpix_CO2_-20C"/>
     </MaterialFraction>
     <MaterialFraction fraction="0.14907">
       <rMaterial name="materials:Steel-008"/>
@@ -715,7 +715,7 @@
 
  <CompositeMaterial name="PixelBarrelSupTubCables2" density="0.4152*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.09162">
-      <rMaterial name="materials:C6F14_F2_-10C"/>
+      <rMaterial name="materials:Bpix_CO2_-20C"/>
     </MaterialFraction>
     <MaterialFraction fraction="0.14907">
       <rMaterial name="materials:Steel-008"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -713,7 +713,7 @@
   </CompositeMaterial>
 
 
- <CompositeMaterial name="PixelBarrelSupTubCables2" density="0.61235*g/cm3" symbol=" " method="mixture by weight">
+ <CompositeMaterial name="PixelBarrelSupTubCables2" density="0.4152*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.09162">
       <rMaterial name="materials:C6F14_F2_-10C"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -555,7 +555,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
- <CompositeMaterial name="SectorA" density="0.47813*g/cm3" symbol=" " method="mixture by weight">
+ <CompositeMaterial name="SectorA" density="0.3136*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.10443">
       <rMaterial name="materials:C6F14_F2_-10C"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -362,6 +362,23 @@
     </MaterialFraction>
   </CompositeMaterial>
 
+  <CompositeMaterial name="Pix_Bar_Cable_Layer1_Upgrade" density="5.72*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.46">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.54">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Pix_Bar_Cable_Layer234_Upgrade" density="4.31*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.46">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.54">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
   
   <CompositeMaterial name="Flange_with_Manifold_Layer1" density="5.00093*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.1636">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -329,7 +329,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-    <CompositeMaterial name="Pix_Bar_CableSignal_Upgrade" density="0.500*g/cm3" symbol=" " method="mixture by weight">
+    <CompositeMaterial name="Pix_Bar_CableSignal_Upgrade" density="3.650*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.249079">
       <rMaterial name="materials:T_Kapton"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -3,9 +3,12 @@
 
 <MaterialSection label="pixbarmaterial.xml">
 <!--  Upgrade-->
-    <CompositeMaterial name="SupplyTubeConn3_Upgrade" density="0.2710*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="1.00000000">
+    <CompositeMaterial name="SupplyTubeConn3_Upgrade" density="0.424*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.640">
       <rMaterial name="materials:micro_twisted_boundle"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.360">
+      <rMaterial name="materials:CFK"/>
     </MaterialFraction>
   </CompositeMaterial>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -329,7 +329,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-    <CompositeMaterial name="Pix_Bar_CableSignal_Upgrade" density="3.650*g/cm3" symbol=" " method="mixture by weight">
+    <CompositeMaterial name="Pix_Bar_CableSignal_Upgrade" density="0.925*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.249079">
       <rMaterial name="materials:T_Kapton"/>
     </MaterialFraction>
@@ -341,7 +341,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-     <CompositeMaterial name="Pix_Bar_CablePower_Upgrade" density="0.500*g/cm3" symbol=" " method="mixture by weight">
+     <CompositeMaterial name="Pix_Bar_CablePower_Upgrade" density="0.925*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.110505">
       <rMaterial name="materials:T_Kapton"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -2,6 +2,12 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
 
 <MaterialSection label="pixbarmaterial.xml">
+<!--  Upgrade-->
+    <CompositeMaterial name="SupplyTubeConn3_Upgrade" density="0.2710*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="materials:micro_twisted_boundle"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 
 <!-- New materials -->
   <CompositeMaterial name="SupplyTubeConn3" density="0.3556*g/cm3" symbol=" " method="mixture by weight">   <!--Supply tube material in Conn3 volume (no fpix contribution and 150/180 deg sectors)-->

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -641,7 +641,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="SectorC" density="0.98261*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="SectorC" density="0.7928*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.14778">
       <rMaterial name="materials:C6F14_F2_-10C"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -74,8 +74,10 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
 
   double dphi = CLHEP::twopi/number;
   double x2   = coolDist*sin(0.5*dphi);
-  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick;
+  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick);
   double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset);
+//  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick+fabs(rInnerFineTune));
+//  double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset+rOuterFineTune);
   double rtmx = sqrt(rmxh*rmxh+ladderWidth*ladderWidth/4);
   DDSolid solid = DDSolidFactory::tubs(DDName(idName, idNameSpace),0.5*layerDz,
                                        rtmi, rtmx, 0, CLHEP::twopi);
@@ -149,16 +151,15 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
 			  << rot;
     copy++;
     rrr  = coolDist*cos(0.5*dphi);
-    tran = DDTranslation(rrr*cos(phi)-x2*sin(phi), 
-			 rrr*sin(phi)+x2*cos(phi), 0);
     rots = idName + std::to_string(i+100);
     phix = phi + 90.*CLHEP::deg;
     if(iup < 0) phix += dphi;
-//    if (iup > 0 || (i==1) || (i==number/2+1)) phix -= 0.5*dphi;
+    rrr += coolRadius/2.;
     phiy = phix+90.*CLHEP::deg;
     LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: Creating a new "
 			  << "rotation: " << rots << "\t90., " << phix/CLHEP::deg 
 			  << ", 90.," << phiy/CLHEP::deg << ", 0, 0";
+    tran = DDTranslation(rrr*cos(phi)-x2*sin(phi), rrr*sin(phi)+x2*cos(phi), 0);
     rot = DDrot(DDName(rots,idNameSpace), 90*CLHEP::deg, phix, 90*CLHEP::deg, phiy, 0.,0.);
     cpv.position (coolTube, layer, i+1, tran, rot);
     if ((i==1)||(i==number/2+1)){

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -74,7 +74,7 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
 
   double dphi = CLHEP::twopi/number;
   double x2   = coolDist*sin(0.5*dphi);
-  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick);
+  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick;
   double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset);
   double rtmx = sqrt(rmxh*rmxh+ladderWidth*ladderWidth/4);
   DDSolid solid = DDSolidFactory::tubs(DDName(idName, idNameSpace),0.5*layerDz,
@@ -90,7 +90,7 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
 
   std::string name = idName + "CoolTube";
   solid = DDSolidFactory::tubs(DDName(name,idNameSpace), 0.5*coolDz,
-			       0, coolRadius, 0, CLHEP::twopi);
+			       0, coolRadius, 0, CLHEP::pi);
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " <<solid.name() 
 			<< " Tubs made of " << tubeMat << " from 0 to " <<
 			CLHEP::twopi/CLHEP::deg << " with Rout " << coolRadius <<
@@ -100,7 +100,7 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
 
   name = idName + "Coolant";
   solid = DDSolidFactory::tubs(DDName(name,idNameSpace), 0.5*coolDz,
-			       0, coolRadius-coolThick, 0, CLHEP::twopi);
+			       0, coolRadius-coolThick, 0, CLHEP::pi);
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " <<solid.name() 
 			<< " Tubs made of " << tubeMat << " from 0 to " <<
 			CLHEP::twopi/CLHEP::deg << " with Rout " << coolRadius-coolThick <<
@@ -152,8 +152,9 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
     tran = DDTranslation(rrr*cos(phi)-x2*sin(phi), 
 			 rrr*sin(phi)+x2*cos(phi), 0);
     rots = idName + std::to_string(i+100);
-    phix = phi+0.5*dphi;
-    if (iup > 0) phix += 180*CLHEP::deg;
+    phix = phi + 90.*CLHEP::deg;
+    if(iup < 0) phix += dphi;
+//    if (iup > 0 || (i==1) || (i==number/2+1)) phix -= 0.5*dphi;
     phiy = phix+90.*CLHEP::deg;
     LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: Creating a new "
 			  << "rotation: " << rots << "\t90., " << phix/CLHEP::deg 
@@ -161,16 +162,16 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
     rot = DDrot(DDName(rots,idNameSpace), 90*CLHEP::deg, phix, 90*CLHEP::deg, phiy, 0.,0.);
     cpv.position (coolTube, layer, i+1, tran, rot);
     if ((i==1)||(i==number/2+1)){
-    	rrroffset = coolDist*cos(0.5*dphi)+iup*ladderOffset;
-	tran = DDTranslation(rrroffset*cos(phi)-cool1Offset*sin(phi), 
-		rrroffset*sin(phi)+cool1Offset*cos(phi), 0);
+    	rrroffset = coolDist*cos(0.5*dphi)+iup*ladderOffset + rOuterFineTune;
+	    tran = DDTranslation(rrroffset*cos(phi)-cool1Offset*sin(phi), 
+		  rrroffset*sin(phi)+cool1Offset*cos(phi), 0);
     	cpv.position (coolTube, layer, copyoffset, tran, DDRotation());
-	copyoffset++;
-	tran = DDTranslation(rrroffset*cos(phi)-cool2Offset*sin(phi), 
-		rrroffset*sin(phi)+cool2Offset*cos(phi), 0);
+      copyoffset++;
+	    tran = DDTranslation(rrroffset*cos(phi)-cool2Offset*sin(phi), 
+	    rrroffset*sin(phi)+cool2Offset*cos(phi), 0);
     	cpv.position (coolTube, layer, copyoffset, tran, DDRotation());
-	copyoffset++;
-	} 
+	    copyoffset++;
+	  } 
    LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " << coolTube.name() 
 			  << " number " << i+1 << " positioned in " 
 			  << layer.name() << " at " << tran << " with "<< rot;

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -72,13 +72,10 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
   DDName      mother = parent().name();
   std::string idName = DDSplit(mother).first;
   
-  double maxoff = std::max(fabs(rInnerFineTune), fabs(rOuterFineTune));
   double dphi = CLHEP::twopi/number;
   double x2   = coolDist*sin(0.5*dphi);
-  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick+maxoff);
-  double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset+maxoff);
-//  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick+fabs(rInnerFineTune));
-//  double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset+rOuterFineTune);
+  double rtmi = coolDist*cos(0.5*dphi)-(coolRadius+ladderThick)+rInnerFineTune;
+  double rmxh = coolDist*cos(0.5*dphi)+(coolRadius+ladderThick+ladderOffset)+rOuterFineTune;
   double rtmx = sqrt(rmxh*rmxh+ladderWidth*ladderWidth/4);
   DDSolid solid = DDSolidFactory::tubs(DDName(idName, idNameSpace),0.5*layerDz,
                                        rtmi, rtmx, 0, CLHEP::twopi);

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -44,6 +44,8 @@ void DDPixBarLayerUpgradeAlgo::initialize(const DDNumericArguments & nArgs,
   coolMat   = sArgs["CoolMaterial"];
   tubeMat   = sArgs["CoolTubeMaterial"];
   phiFineTune = nArgs["PitchFineTune"];
+  rOuterFineTune = nArgs["OuterOffsetFineTune"];
+  rInnerFineTune = nArgs["InnerOffsetFineTune"];
 
 
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo debug: Parent " << parentName 
@@ -127,9 +129,9 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
       dr=coolRadius+0.5*ladderThick;
     }
     if(i % 2 == 1) {
-      rrr = coolDist*cos(0.5*dphi)+iup*dr;
+      rrr = coolDist*cos(0.5*dphi)+iup*dr+rOuterFineTune;
     } else {
-      rrr = coolDist*cos(0.5*dphi)+iup*dr;
+      rrr = coolDist*cos(0.5*dphi)+iup*dr+rInnerFineTune;
     }
     tran = DDTranslation(rrr*cos(phi), rrr*sin(phi), 0);
     rots = idName + std::to_string(copy);

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -43,6 +43,7 @@ void DDPixBarLayerUpgradeAlgo::initialize(const DDNumericArguments & nArgs,
   cool2Offset = nArgs["Cool2Offset"];
   coolMat   = sArgs["CoolMaterial"];
   tubeMat   = sArgs["CoolTubeMaterial"];
+  phiFineTune = nArgs["PitchFineTune"];
 
 
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo debug: Parent " << parentName 
@@ -113,19 +114,23 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
   int  copy=1, iup=(-1)*outerFirst;
   int copyoffset=number+2;
   for (int i=1; i<number+1; i++) {
-    double phi = i*dphi+90*CLHEP::deg-0.5*dphi; //to start with the interface ladder
+    double phi = i*dphi+90*CLHEP::deg-0.5*dphi+phiFineTune; //to start with the interface ladder
     double phix, phiy, rrr, rrroffset;
     std::string rots;
     DDTranslation tran;
     DDRotation rot;
     iup  =-iup;
     double dr;
-    if ((i==1)||(i==number/2+1)){
-	dr=coolRadius+0.5*ladderThick+ladderOffset; //interface ladder offset
-	}else{
-	dr=coolRadius+0.5*ladderThick;
-	}
-    rrr = coolDist*cos(0.5*dphi)+iup*dr;
+    if ((i==1)||(i==number/2+1)) {
+      dr=coolRadius+0.5*ladderThick+ladderOffset; //interface ladder offset
+    } else {
+      dr=coolRadius+0.5*ladderThick;
+    }
+    if(i % 2 == 1) {
+      rrr = coolDist*cos(0.5*dphi)+iup*dr+rOuterFineTune;
+    } else {
+      rrr = coolDist*cos(0.5*dphi)+iup*dr+rInnerFineTune;
+    }
     tran = DDTranslation(rrr*cos(phi), rrr*sin(phi), 0);
     rots = idName + std::to_string(copy);
     if (iup > 0) phix = phi-90*CLHEP::deg;

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -127,9 +127,9 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
       dr=coolRadius+0.5*ladderThick;
     }
     if(i % 2 == 1) {
-      rrr = coolDist*cos(0.5*dphi)+iup*dr+rOuterFineTune;
+      rrr = coolDist*cos(0.5*dphi)+iup*dr;
     } else {
-      rrr = coolDist*cos(0.5*dphi)+iup*dr+rInnerFineTune;
+      rrr = coolDist*cos(0.5*dphi)+iup*dr;
     }
     tran = DDTranslation(rrr*cos(phi), rrr*sin(phi), 0);
     rots = idName + std::to_string(copy);

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
@@ -41,6 +41,8 @@ private:
   double                   ladderOffset; //ladder dispacement at interface 
   int                      outerFirst;  //Controller of the placement of ladder
   double                   phiFineTune; //Fine-tuning pitch of first ladder
+  double                   rOuterFineTune; //Fine-tuning r offset for outer ladders
+  double                   rInnerFineTune; //Fine-tuning r offset for inner ladders
 };
 
 #endif

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
@@ -40,6 +40,7 @@ private:
   double                   ladderThick; //Thicknes of ladder 
   double                   ladderOffset; //ladder dispacement at interface 
   int                      outerFirst;  //Controller of the placement of ladder
+  double                   phiFineTune; //Fine-tuning pitch of first ladder
 };
 
 #endif


### PR DESCRIPTION
This pull request includes several updates for the Phase I Pixel Barrel geometry and material budget. The main changes are:
- added offset to the pixel barrel ladder positions (in r and phi) to match the pixel barrel blueprints
- updated geometry and material for cooling tubes
- signal and power cable material for BPix including Supply Tubes is updated according form the latest information
- adjusted material density for conn3 and conn4, pixel barrel service, and SupTubesCables solids

@veszpv and @schneiml may want to be informed or comment about this pull request.
