### PR TITLE
Use unique_ptr, not auto_ptr in RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/Configuration/plugins/HepMCCopy.cc
+++ b/RecoParticleFlow/Configuration/plugins/HepMCCopy.cc
@@ -19,11 +19,11 @@ void HepMCCopy::produce(edm::Event & iEvent, const edm::EventSetup & es)
   edm::Handle<edm::HepMCProduct> theHepMCProduct;
   bool source = iEvent.getByLabel("generatorSmeared",theHepMCProduct);
   if ( !source ) { 
-    std::auto_ptr<edm::HepMCProduct> pu_product(new edm::HepMCProduct());  
-    iEvent.put(pu_product);
+    auto pu_product = std::make_unique<edm::HepMCProduct>();  
+    iEvent.put(std::move(pu_product));
   } else { 
-    std::auto_ptr<edm::HepMCProduct> pu_product(new edm::HepMCProduct(*theHepMCProduct));  
-    iEvent.put(pu_product);
+    auto pu_product = std::make_unique<edm::HepMCProduct>(*theHepMCProduct);  
+    iEvent.put(std::move(pu_product));
   }
 
 }

--- a/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
@@ -65,7 +65,7 @@ class HGCRecHitNavigator : public PFRecHitNavigatorBase {
     if( nullptr != hebNav_ ) hebNav_->beginEvent(iSetup);
   }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
+  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
     switch( DetId(hit.detId()).subdetId() ) {
     case D1:
       if( nullptr != eeNav_ )  eeNav_->associateNeighbours(hit,hits,refProd);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -66,7 +66,7 @@ class PFECALHashNavigator : public PFRecHitNavigatorBase {
 
   }
 
-  void associateNeighbours(reco::PFRecHit& rh,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refprod) {
+  void associateNeighbours(reco::PFRecHit& rh,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refprod) {
 
 
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
@@ -33,7 +33,7 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
       recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       beginEvent(iEvent,iSetup);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
@@ -33,7 +33,7 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
       recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       beginEvent(iEvent,iSetup);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -25,7 +25,7 @@ class PFHBHERecHitCreator :  public  PFRecHitCreatorBase {
       recHitToken_ = iC.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       beginEvent(iEvent,iSetup);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -43,7 +43,7 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
   }
 
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       beginEvent(iEvent,iSetup);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -39,7 +39,7 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
 
 
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
 
       reco::PFRecHitCollection tmpOut;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -30,7 +30,7 @@ template <typename DET,PFLayer::Layer Layer,ForwardSubdetector subdet>
       geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       for (unsigned int i=0;i<qualityTests_.size();++i) {
 	qualityTests_.at(i)->beginEvent(iEvent,iSetup);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -27,7 +27,7 @@ template <typename Digi, typename Geometry,PFLayer::Layer Layer,int Detector>
       recHitToken_ = iC.consumes<edm::SortedCollection<Digi>  >(iConfig.getParameter<edm::InputTag>("src"));
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
 
       beginEvent(iEvent,iSetup);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -33,7 +33,7 @@ class PFPSRecHitCreator final :  public  PFRecHitCreatorBase {
       recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     }
 
-    void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       beginEvent(iEvent,iSetup);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
@@ -27,7 +27,7 @@ class PFRecHitCaloNavigator : public PFRecHitNavigatorBase {
 
  virtual ~PFRecHitCaloNavigator() { if(!ownsTopo) { topology_.release(); } }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
+  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
       DetId detid( hit.detId() );
       
       CaloNavigator<DET> navigator(detid, topology_.get());

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -36,7 +36,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
  virtual ~PFRecHitCaloNavigatorWithTime() { if(!ownsTopo) { topology_.release(); } }
 
 
-  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
+  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
       DetId detid( hit.detId() );
       
       CaloNavigator<D> navigator(detid, topology_.get());
@@ -116,7 +116,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalc;
 
 
-  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi) {
+  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi) {
     double sigma2=10000.0;
     
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
@@ -36,7 +36,7 @@ class PFRecHitCreatorBase {
   }
 
 
-  virtual void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&,std::auto_ptr<reco::PFRecHitCollection>& ,const edm::Event&,const edm::EventSetup&)=0;
+  virtual void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&,std::unique_ptr<reco::PFRecHitCollection>& ,const edm::Event&,const edm::EventSetup&)=0;
 
  protected:
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
@@ -26,7 +26,7 @@ class PFRecHitDualNavigator : public PFRecHitNavigatorBase {
 
   }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
+  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
       if (hit.layer() ==  D1)
 	barrelNav_->associateNeighbours(hit,hits,refProd);
       else if (hit.layer() ==  D2)

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitFakeNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitFakeNavigator.h
@@ -27,7 +27,7 @@ class PFRecHitFakeNavigator : public PFRecHitNavigatorBase {
 
  virtual ~PFRecHitFakeNavigator() {  }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) { }
+  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) { }
 
 
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -33,12 +33,12 @@ class PFRecHitNavigatorBase {
   virtual ~PFRecHitNavigatorBase() {}
 
   virtual void beginEvent(const edm::EventSetup&)=0;
-  virtual void associateNeighbours(reco::PFRecHit&,std::auto_ptr<reco::PFRecHitCollection>&,edm::RefProd<reco::PFRecHitCollection>&)=0;
+  virtual void associateNeighbours(reco::PFRecHit&,std::unique_ptr<reco::PFRecHitCollection>&,edm::RefProd<reco::PFRecHitCollection>&)=0;
 
 
  protected:
 
-  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi,short depth) {
+  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi,short depth) {
     auto found_hit = std::lower_bound(hits->begin(),hits->end(),
 				      id,
 				      [](const reco::PFRecHit& a, 

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -72,8 +72,8 @@ DEFINE_FWK_MODULE(CorrectedECALPFClusterProducer);
 
 void CorrectedECALPFClusterProducer::
 produce(edm::Event& e, const edm::EventSetup& es) {
-  std::unique_ptr<reco::PFClusterCollection> clusters_out(new reco::PFClusterCollection);    
-  std::unique_ptr<reco::PFCluster::EEtoPSAssociation> association_out(new reco::PFCluster::EEtoPSAssociation);
+  auto clusters_out = std::make_unique<reco::PFClusterCollection>();
+  auto association_out = std::make_unique<reco::PFCluster::EEtoPSAssociation>();
   
   edm::Handle<reco::PFClusterCollection> handleECAL;
   e.getByToken(_inputECAL,handleECAL);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
@@ -142,10 +142,10 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
   const HcalSeverityLevelComputer* hcalSevLvlComputer = hcalSevLvlComputerHndl.product();
 
 
-  auto_ptr< vector<reco::PFRecHit> > rechits( new vector<reco::PFRecHit> ); 
-  auto_ptr< vector<reco::PFRecHit> > rechitsCleaned( new vector<reco::PFRecHit> ); 
-  auto_ptr< vector<reco::PFRecHit> > HFHADRecHits( new vector<reco::PFRecHit> ); 
-  auto_ptr< vector<reco::PFRecHit> > HFEMRecHits( new vector<reco::PFRecHit> ); 
+  auto rechits = std::make_unique<std::vector<reco::PFRecHit>>(); 
+  auto rechitsCleaned = std::make_unique<std::vector<reco::PFRecHit>>(); 
+  auto HFHADRecHits = std::make_unique<std::vector<reco::PFRecHit>>(); 
+  auto HFEMRecHits = std::make_unique<std::vector<reco::PFRecHit>>(); 
 
   edm::Handle<CaloTowerCollection> caloTowers; 
   iEvent.getByToken(towersToken_,caloTowers);
@@ -812,10 +812,10 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
       }
     }
 
-  iEvent.put( rechits,"" );	
-  iEvent.put( rechitsCleaned,"Cleaned" );	
-  iEvent.put( HFEMRecHits,"HFEM" );	
-  iEvent.put( HFHADRecHits,"HFHAD" );	
+  iEvent.put(std::move(rechits),"");
+  iEvent.put(std::move(rechitsCleaned),"Cleaned");
+  iEvent.put(std::move(HFEMRecHits),"HFEM");
+  iEvent.put(std::move(HFHADRecHits),"HFHAD");
 
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
@@ -25,14 +25,13 @@ public:
   }
 
   virtual void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const {
-    std::auto_ptr<reco::PFClusterCollection> output;
-    output.reset(new reco::PFClusterCollection);
+    auto output = std::make_unique<reco::PFClusterCollection>();
     for( const auto& input : _inputs ) {
       edm::Handle<reco::PFClusterCollection> handle;
       e.getByToken(input,handle);
       output->insert(output->end(),handle->begin(),handle->end());
     }
-    e.put(output);
+    e.put(std::move(output));
   }
 private:
   std::vector<edm::EDGetTokenT<reco::PFClusterCollection> > _inputs;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -101,15 +101,14 @@ void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
 
 
-  std::auto_ptr<reco::PFClusterCollection> initialClusters;
-  initialClusters.reset(new reco::PFClusterCollection);
+  auto initialClusters = std::make_unique<reco::PFClusterCollection>();
   _initialClustering->buildClusters(rechits, mask, seedable, *initialClusters);
   LOGVERB("PFClusterProducer::produce()") << *_initialClustering;
 
 
 
 
-  std::auto_ptr<reco::PFClusterCollection> pfClusters;
+  auto pfClusters = std::make_unique<reco::PFClusterCollection>();
   pfClusters.reset(new reco::PFClusterCollection);
   if( _pfClusterBuilder ) { // if we've defined a re-clustering step execute it
     _pfClusterBuilder->buildClusters(*initialClusters, seedable, *pfClusters);
@@ -130,6 +129,6 @@ void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     _energyCorrector->correctEnergies(*pfClusters);
   }
 
-  if( _prodInitClusters ) e.put(initialClusters,"initialClusters");
-  e.put(pfClusters);
+  if( _prodInitClusters ) e.put(std::move(initialClusters),"initialClusters");
+  e.put(std::move(pfClusters));
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
@@ -37,8 +37,8 @@ void PFClusterTimeSelector::produce(edm::Event& iEvent,
 
   edm::Handle<reco::PFClusterCollection> clusters; 
   iEvent.getByToken(clusters_,clusters);
-  std::auto_ptr<reco::PFClusterCollection> out(new reco::PFClusterCollection);
-  std::auto_ptr<reco::PFClusterCollection> outOOT(new reco::PFClusterCollection);
+  auto out = std::make_unique<reco::PFClusterCollection>();
+  auto outOOT = std::make_unique<reco::PFClusterCollection>();
 
   for(const auto& cluster : *clusters ) {    
     const double energy = cluster.energy();
@@ -67,8 +67,8 @@ void PFClusterTimeSelector::produce(edm::Event& iEvent,
 
 
 
-  iEvent.put( out);
-  iEvent.put( outOOT,"OOT");
+  iEvent.put(std::move(out));
+  iEvent.put(std::move(outOOT),"OOT");
 
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -48,14 +48,13 @@ void PFMultiDepthClusterProducer::produce(edm::Event& e, const edm::EventSetup& 
   
   std::vector<bool> seedable;
 
-  std::auto_ptr<reco::PFClusterCollection> pfClusters;
-  pfClusters.reset(new reco::PFClusterCollection);
+  auto pfClusters = std::make_unique<reco::PFClusterCollection>();
   _pfClusterBuilder->buildClusters(*inputClusters, seedable, *pfClusters);
   LOGVERB("PFMultiDepthClusterProducer::produce()") << *_pfClusterBuilder;
 
   if( _energyCorrector ) {
     _energyCorrector->correctEnergies(*pfClusters);
   }
-  e.put(pfClusters);
+  e.put(std::move(pfClusters));
 
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -47,8 +47,8 @@ void
  PFRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    using namespace edm;
-   std::auto_ptr<reco::PFRecHitCollection> out(new reco::PFRecHitCollection );
-   std::auto_ptr<reco::PFRecHitCollection> cleaned(new reco::PFRecHitCollection );
+   auto out = std::make_unique<reco::PFRecHitCollection>();
+   auto cleaned = std::make_unique<reco::PFRecHitCollection>();
 
    navigator_->beginEvent(iSetup);
 
@@ -71,8 +71,8 @@ void
      navigator_->associateNeighbours(pfrechit,out,refProd);
    }
 
-   iEvent.put(out,"");
-   iEvent.put(cleaned,"Cleaned");
+   iEvent.put(std::move(out),"");
+   iEvent.put(std::move(cleaned),"Cleaned");
 
 }
 

--- a/RecoParticleFlow/PFClusterShapeProducer/plugins/PFClusterShapeProducer.cc
+++ b/RecoParticleFlow/PFClusterShapeProducer/plugins/PFClusterShapeProducer.cc
@@ -49,21 +49,21 @@ void PFClusterShapeProducer::produce(edm::Event & evt, const edm::EventSetup & e
   const CaloSubdetectorGeometry * endcapGeo_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   const CaloSubdetectorTopology * endcapTop_p = new EcalEndcapTopology(geoHandle);
 
-  std::auto_ptr<reco::ClusterShapeCollection> 
+  std::unique_ptr<reco::ClusterShapeCollection>
     csCollection_ap(csAlgo_p->makeClusterShapes(clusterHandle, rechitHandle, 
 						barrelGeo_p, barrelTop_p,
 						endcapGeo_p, endcapTop_p));
   
-  edm::OrphanHandle<reco::ClusterShapeCollection> shape_h = evt.put(csCollection_ap, shapesLabel_);
+  edm::OrphanHandle<reco::ClusterShapeCollection> shape_h = evt.put(std::move(csCollection_ap), shapesLabel_);
   
-  std::auto_ptr<reco::PFClusterShapeAssociationCollection> association_ap(new reco::PFClusterShapeAssociationCollection);
+  auto association_ap = std::make_unique<reco::PFClusterShapeAssociationCollection>();
  
   for (unsigned int i = 0; i < clusterHandle->size(); i++){
     association_ap->insert(edm::Ref<reco::PFClusterCollection>(clusterHandle, i), 
 			   edm::Ref<reco::ClusterShapeCollection>(shape_h, i));
   } 
   
-  evt.put(association_ap, shapesLabel_);
+  evt.put(std::move(association_ap), shapesLabel_);
 
   delete barrelTop_p;
   delete endcapTop_p;

--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -193,40 +193,40 @@ class PFAlgo {
   void setPhotonExtraRef(const edm::OrphanHandle<reco::PFCandidatePhotonExtraCollection >& pf_extrah);	
 
   /// \return collection of candidates
-  const std::auto_ptr< reco::PFCandidateCollection >& pfCandidates() const {
+  const std::unique_ptr<reco::PFCandidateCollection>& pfCandidates() const {
     return pfCandidates_;
   }
 
   /// \return the unfiltered electron collection
-  std::auto_ptr< reco::PFCandidateCollection> transferElectronCandidates()  {
-    return pfElectronCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferElectronCandidates() {
+    return std::move(pfElectronCandidates_);
   }
 
   /// \return the unfiltered electron extra collection
-  // done this way because the pfElectronExtra is needed later in the code to create the Refs and with an auto_ptr, it would be destroyed
-  std::auto_ptr< reco::PFCandidateElectronExtraCollection> transferElectronExtra()  {
-    std::auto_ptr< reco::PFCandidateElectronExtraCollection> result(new reco::PFCandidateElectronExtraCollection);
+  // done this way because the pfElectronExtra is needed later in the code to create the Refs and with a unique_ptr, it would be destroyed
+  std::unique_ptr<reco::PFCandidateElectronExtraCollection> transferElectronExtra() {
+    auto result = std::make_unique<reco::PFCandidateElectronExtraCollection>();
     result->insert(result->end(),pfElectronExtra_.begin(),pfElectronExtra_.end());
     return result;
   }
 
 
   /// \return the unfiltered photon extra collection
-  // done this way because the pfPhotonExtra is needed later in the code to create the Refs and with an auto_ptr, it would be destroyed
-  std::auto_ptr< reco::PFCandidatePhotonExtraCollection> transferPhotonExtra()  {
-    std::auto_ptr< reco::PFCandidatePhotonExtraCollection> result(new reco::PFCandidatePhotonExtraCollection);
+  // done this way because the pfPhotonExtra is needed later in the code to create the Refs and with a unique_ptr, it would be destroyed
+  std::unique_ptr< reco::PFCandidatePhotonExtraCollection> transferPhotonExtra()  {
+    auto result = std::make_unique<reco::PFCandidatePhotonExtraCollection>();
     result->insert(result->end(),pfPhotonExtra_.begin(),pfPhotonExtra_.end());
     return result;
   }
 
 
   /// \return collection of cleaned HF candidates
-  std::auto_ptr< reco::PFCandidateCollection >& transferCleanedCandidates() {
-    return pfCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferCleanedCandidates() {
+    return std::move(pfCleanedCandidates_);
   }
   
-    /// \return auto_ptr to the collection of candidates (transfers ownership)
-  std::auto_ptr< reco::PFCandidateCollection >  transferCandidates() {
+    /// \return unique_ptr to the collection of candidates (transfers ownership)
+  std::unique_ptr< reco::PFCandidateCollection> transferCandidates() {
     return connector_.connect(pfCandidates_);
   }
   
@@ -281,13 +281,13 @@ class PFAlgo {
   double nSigmaHCAL( double clusterEnergy, 
 		     double clusterEta ) const;
 
-  std::auto_ptr< reco::PFCandidateCollection >    pfCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection>    pfCandidates_;
   /// the unfiltered electron collection 
-  std::auto_ptr< reco::PFCandidateCollection >    pfElectronCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection>    pfElectronCandidates_;
   /// the unfiltered photon collection 
-  std::auto_ptr< reco::PFCandidateCollection >    pfPhotonCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection>    pfPhotonCandidates_;
   // the post-HF-cleaned candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection>    pfCleanedCandidates_;
 
   /// the unfiltered electron collection 
   reco::PFCandidateElectronExtraCollection    pfElectronExtra_;

--- a/RecoParticleFlow/PFProducer/interface/PFCandConnector.h
+++ b/RecoParticleFlow/PFProducer/interface/PFCandConnector.h
@@ -18,7 +18,7 @@ class PFCandConnector {
     public :
        
        PFCandConnector( ) { 
-	 pfC_ = std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection); 
+	 pfC_ = std::make_unique<reco::PFCandidateCollection>(); 
 	 debug_ = false;
 	 bCorrect_ = false;
 	 bCalibPrimary_ =  false;
@@ -65,17 +65,17 @@ class PFCandConnector {
 
        
 
-       std::auto_ptr<reco::PFCandidateCollection> connect(std::auto_ptr<reco::PFCandidateCollection>& pfCand);
+       std::unique_ptr<reco::PFCandidateCollection> connect(std::unique_ptr<reco::PFCandidateCollection>& pfCand);
 
        
  
     private :
 
        /// Analyse nuclear interactions where a primary or merged track is present
-       void analyseNuclearWPrim(std::auto_ptr<reco::PFCandidateCollection>&, unsigned int);
+       void analyseNuclearWPrim(std::unique_ptr<reco::PFCandidateCollection>&, unsigned int);
 
        /// Analyse nuclear interactions where a secondary track is present
-       void analyseNuclearWSec(std::auto_ptr<reco::PFCandidateCollection>&, unsigned int);
+       void analyseNuclearWSec(std::unique_ptr<reco::PFCandidateCollection>&, unsigned int);
 
        bool isPrimaryNucl( const reco::PFCandidate& pf ) const;
 
@@ -85,7 +85,7 @@ class PFCandConnector {
        double rescaleFactor( const double pt, const double cFrac ) const;
 
        /// Collection of primary PFCandidates to be transmitted to the Event
-       std::auto_ptr<reco::PFCandidateCollection> pfC_;
+       std::unique_ptr<reco::PFCandidateCollection> pfC_;
        /// A mask to define the candidates which shall not be transmitted
        std::vector<bool> bMask_;
 

--- a/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
@@ -83,28 +83,28 @@ class PFMuonAlgo {
   void postClean(reco::PFCandidateCollection *);
   void addMissingMuons(edm::Handle<reco::MuonCollection>, reco::PFCandidateCollection* cands);
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferCleanedCosmicCandidates() {
-    return pfCosmicsMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferCleanedCosmicCandidates() {
+    return std::move(pfCosmicsMuonCleanedCandidates_);
   }
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferCleanedTrackerAndGlobalCandidates() {
-    return pfCleanedTrackerAndGlobalMuonCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferCleanedTrackerAndGlobalCandidates() {
+    return std::move(pfCleanedTrackerAndGlobalMuonCandidates_);
   }
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferCleanedFakeCandidates() {
-    return pfFakeMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferCleanedFakeCandidates() {
+    return std::move(pfFakeMuonCleanedCandidates_);
   }
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferPunchThroughCleanedMuonCandidates() {
-    return pfPunchThroughMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferPunchThroughCleanedMuonCandidates() {
+    return std::move(pfPunchThroughMuonCleanedCandidates_);
   }
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferPunchThroughCleanedHadronCandidates() {
-    return pfPunchThroughHadronCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferPunchThroughCleanedHadronCandidates() {
+    return std::move(pfPunchThroughHadronCleanedCandidates_);
   }
 
-  std::auto_ptr<reco::PFCandidateCollection>& transferAddedMuonCandidates() {
-    return pfAddedMuonCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> transferAddedMuonCandidates() {
+    return std::move(pfAddedMuonCandidates_);
   }
 
  private:
@@ -135,17 +135,17 @@ class PFMuonAlgo {
 
   //Output collections for post cleaning
   /// the collection of  cosmics cleaned muon candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfCosmicsMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfCosmicsMuonCleanedCandidates_;
   /// the collection of  tracker/global cleaned muon candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfCleanedTrackerAndGlobalMuonCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfCleanedTrackerAndGlobalMuonCandidates_;
   /// the collection of  fake cleaned muon candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfFakeMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfFakeMuonCleanedCandidates_;
   /// the collection of  punch-through cleaned muon candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfPunchThroughMuonCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfPunchThroughMuonCleanedCandidates_;
   /// the collection of  punch-through cleaned neutral hadron candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfPunchThroughHadronCleanedCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfPunchThroughHadronCleanedCandidates_;
   /// the collection of  added muon candidates
-  std::auto_ptr< reco::PFCandidateCollection >    pfAddedMuonCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfAddedMuonCandidates_;
   
   std::vector<unsigned int > maskedIndices_;
 

--- a/RecoParticleFlow/PFProducer/interface/PFPhotonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFPhotonAlgo.h
@@ -81,7 +81,7 @@ class PFPhotonAlgo {
   //check candidate validity
   bool isPhotonValidCandidate(const reco::PFBlockRef&  blockRef,
 			      std::vector< bool >&  active,
-			      std::auto_ptr< reco::PFCandidateCollection > &pfPhotonCandidates,
+			      std::unique_ptr< reco::PFCandidateCollection > &pfPhotonCandidates,
 			      std::vector<reco::PFCandidatePhotonExtra>& pfPhotonExtraCandidates,
 			      std::vector<reco::PFCandidate>& 
 			      tempElectronCandidates
@@ -198,10 +198,10 @@ private:
   void RunPFPhoton(const reco::PFBlockRef&  blockRef,
 		   std::vector< bool >& active,
 
-		   std::auto_ptr< reco::PFCandidateCollection > &pfPhotonCandidates,
+		   std::unique_ptr<reco::PFCandidateCollection> &pfPhotonCandidates,
 		   std::vector<reco::PFCandidatePhotonExtra>& 
 		   pfPhotonExtraCandidates,
-		   //  std::auto_ptr< reco::PFCandidateCollection > 
+		   //  std::unique_ptr<reco::PFCandidateCollection> 
 		   //&pfElectronCandidates_
 		   std::vector<reco::PFCandidate>& 
 		   tempElectronCandidates

--- a/RecoParticleFlow/PFProducer/plugins/PFConcretePFCandidateProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFConcretePFCandidateProducer.cc
@@ -19,7 +19,7 @@ void PFConcretePFCandidateProducer::produce(edm::Event& iEvent,
     // nothing ... I guess we prefer to send an exception in the next lines
    }
 
-  std::auto_ptr< reco::PFCandidateCollection > outputColl(new reco::PFCandidateCollection());
+  auto outputColl = std::make_unique<reco::PFCandidateCollection>();
   outputColl->resize(inputColl->size());
   
   for (unsigned int iCopy=0;iCopy!=inputColl->size();++iCopy){
@@ -30,5 +30,5 @@ void PFConcretePFCandidateProducer::produce(edm::Event& iEvent,
     //math::XYZPoint(pf.vx(),pf.vy(),pf.vz()));
   }
   
-  iEvent.put(outputColl);
+  iEvent.put(std::move(outputColl));
 }

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -248,9 +248,9 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   
 
   // reset output collection  
-  egCandidates_.reset( new reco::PFCandidateCollection );   
-  egExtra_.reset( new reco::PFCandidateEGammaExtraCollection ); 
-  sClusters_.reset( new reco::SuperClusterCollection );      
+  egCandidates_ = std::make_unique<reco::PFCandidateCollection>();
+  egExtra_ = std::make_unique<reco::PFCandidateEGammaExtraCollection>();
+  sClusters_ = std::make_unique<reco::SuperClusterCollection>();
     
   // Get the EE-PS associations
   edm::Handle<reco::PFCluster::EEtoPSAssociation> eetops;
@@ -435,8 +435,8 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   }
   
   //build collections of output CaloClusters from the used PFClusters
-  std::auto_ptr<reco::CaloClusterCollection> caloClustersEBEE(new reco::CaloClusterCollection);
-  std::auto_ptr<reco::CaloClusterCollection> caloClustersES(new reco::CaloClusterCollection);
+  auto caloClustersEBEE = std::make_unique<reco::CaloClusterCollection>();
+  auto caloClustersES = std::make_unique<reco::CaloClusterCollection>();
   
   std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapEBEE; //maps of pfclusters to caloclusters 
   std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapES;  
@@ -469,8 +469,8 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   }
   
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEBEE = iEvent.put(caloClustersEBEE,ebeeClustersCollection_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleES = iEvent.put(caloClustersES,esClustersCollection_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEBEE = iEvent.put(std::move(caloClustersEBEE),ebeeClustersCollection_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleES = iEvent.put(std::move(caloClustersES),esClustersCollection_);
   
   //relink superclusters to output caloclusters
   for( auto& sc : *sClusters_ ) {
@@ -494,14 +494,14 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   
   //create and fill references to single leg conversions
   edm::RefProd<reco::ConversionCollection> convProd = iEvent.getRefBeforePut<reco::ConversionCollection>();
-  singleLegConv_.reset(new reco::ConversionCollection);  
+  singleLegConv_ = std::make_unique<reco::ConversionCollection>();  
   createSingleLegConversions(*egExtra_, *singleLegConv_, convProd);
   
   // release our demonspawn into the wild to cause havoc
-  iEvent.put(sClusters_);
-  iEvent.put(egExtra_);  
-  iEvent.put(singleLegConv_);
-  iEvent.put(egCandidates_); 
+  iEvent.put(std::move(sClusters_));
+  iEvent.put(std::move(egExtra_));
+  iEvent.put(std::move(singleLegConv_));
+  iEvent.put(std::move(egCandidates_));
 }
 
 //PFEGammaAlgo: a new method added to set the parameters for electron and photon reconstruction. 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
@@ -126,10 +126,10 @@ class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<pfEGHel
   
   reco::Vertex       primaryVertex_;
   
-  std::auto_ptr< reco::PFCandidateCollection >          egCandidates_;
-  std::auto_ptr<reco::PFCandidateEGammaExtraCollection> egExtra_;
-  std::auto_ptr<reco::ConversionCollection>             singleLegConv_;
-  std::auto_ptr< reco::SuperClusterCollection >         sClusters_;  
+  std::unique_ptr<reco::PFCandidateCollection> egCandidates_;
+  std::unique_ptr<reco::PFCandidateEGammaExtraCollection> egExtra_;
+  std::unique_ptr<reco::ConversionCollection> singleLegConv_;
+  std::unique_ptr<reco::SuperClusterCollection> sClusters_;  
 
   /// the unfiltered electron collection 
     

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -74,26 +74,20 @@ PFElectronTranslator::~PFElectronTranslator() {}
 void PFElectronTranslator::produce(edm::Event& iEvent,  
 				    const edm::EventSetup& iSetup) { 
   
-  std::auto_ptr<reco::GsfElectronCoreCollection>
-    gsfElectronCores_p(new reco::GsfElectronCoreCollection);
+  auto gsfElectronCores_p = std::make_unique<reco::GsfElectronCoreCollection>();
 
-  std::auto_ptr<reco::GsfElectronCollection>
-    gsfElectrons_p(new reco::GsfElectronCollection);
+  auto gsfElectrons_p = std::make_unique<reco::GsfElectronCollection>();
 
-  std::auto_ptr<reco::SuperClusterCollection> 
-    superClusters_p(new reco::SuperClusterCollection);
+  auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
 
-  std::auto_ptr<reco::BasicClusterCollection> 
-    basicClusters_p(new reco::BasicClusterCollection);
+  auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
 
-  std::auto_ptr<reco::PreshowerClusterCollection>
-    psClusters_p(new reco::PreshowerClusterCollection);
+  auto psClusters_p = std::make_unique<reco::PreshowerClusterCollection>();
   
-  std::auto_ptr<edm::ValueMap<float> > mvaMap_p(new edm::ValueMap<float>());
+  auto mvaMap_p = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler mvaFiller(*mvaMap_p);
 
-  std::auto_ptr<edm::ValueMap<reco::SuperClusterRef> > 
-    scMap_p(new edm::ValueMap<reco::SuperClusterRef>());
+  auto scMap_p = std::make_unique<edm::ValueMap<reco::SuperClusterRef>>();
   edm::ValueMap<reco::SuperClusterRef>::Filler scRefFiller(*scMap_p);
   
 
@@ -206,11 +200,11 @@ void PFElectronTranslator::produce(edm::Event& iEvent,
    //Save the basic clusters and get an handle as to be able to create valid Refs (thanks to Claude)
   //  std::cout << " Number of basic clusters " << basicClusters_p->size() << std::endl;
   const edm::OrphanHandle<reco::BasicClusterCollection> bcRefProd = 
-    iEvent.put(basicClusters_p,PFBasicClusterCollection_);
+    iEvent.put(std::move(basicClusters_p),PFBasicClusterCollection_);
 
   //preshower clusters
   const edm::OrphanHandle<reco::PreshowerClusterCollection> psRefProd = 
-    iEvent.put(psClusters_p,PFPreshowerClusterCollection_);
+    iEvent.put(std::move(psClusters_p),PFPreshowerClusterCollection_);
 
   // now that the Basic clusters are in the event, the Ref can be created
   createBasicClusterPtrs(bcRefProd);
@@ -221,7 +215,7 @@ void PFElectronTranslator::produce(edm::Event& iEvent,
   if(status) createSuperClusters(*pfCandidates,*superClusters_p);
   
   // Let's put the super clusters in the event
-  const edm::OrphanHandle<reco::SuperClusterCollection> scRefProd = iEvent.put(superClusters_p,PFSuperClusterCollection_); 
+  const edm::OrphanHandle<reco::SuperClusterCollection> scRefProd = iEvent.put(std::move(superClusters_p),PFSuperClusterCollection_); 
   // create the super cluster Ref
   createSuperClusterGsfMapRefs(scRefProd);
 
@@ -229,14 +223,14 @@ void PFElectronTranslator::produce(edm::Event& iEvent,
   createGsfElectronCores(*gsfElectronCores_p);
   // Put them in the as to get to be able to build a Ref
   const edm::OrphanHandle<reco::GsfElectronCoreCollection> gsfElectronCoreRefProd = 
-    iEvent.put(gsfElectronCores_p,GsfElectronCoreCollection_);
+    iEvent.put(std::move(gsfElectronCores_p),GsfElectronCoreCollection_);
 
   // now create the Refs 
   createGsfElectronCoreRefs(gsfElectronCoreRefProd);
 
   // now make the GsfElectron
   createGsfElectrons(*pfCandidates,isolationValues,*gsfElectrons_p);
-  iEvent.put(gsfElectrons_p,GsfElectronCollection_);
+  iEvent.put(std::move(gsfElectrons_p),GsfElectronCollection_);
 
   fillMVAValueMap(iEvent,mvaFiller);
   mvaFiller.fill();
@@ -245,9 +239,9 @@ void PFElectronTranslator::produce(edm::Event& iEvent,
   scRefFiller.fill();
 
   // MVA map
-  iEvent.put(mvaMap_p,PFMVAValueMap_);
+  iEvent.put(std::move(mvaMap_p),PFMVAValueMap_);
   // Gsf-SC map
-  iEvent.put(scMap_p,PFSCValueMap_);
+  iEvent.put(std::move(scMap_p),PFSCValueMap_);
 
 
   

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -61,8 +61,7 @@ PFLinker::~PFLinker() {;}
 
 void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   
-  std::auto_ptr<reco::PFCandidateCollection>
-    pfCandidates_p(new reco::PFCandidateCollection);
+  auto pfCandidates_p = std::make_unique<reco::PFCandidateCollection>();
   
   edm::Handle<reco::GsfElectronCollection> gsfElectrons;
   iEvent.getByToken(inputTagGsfElectrons_,gsfElectrons);
@@ -154,7 +153,7 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }      
     // save the PFCandidates and get a valid handle
   }
-  const edm::OrphanHandle<reco::PFCandidateCollection> pfCandidateRefProd = (producePFCandidates_) ? iEvent.put(pfCandidates_p,nameOutputPF_) :
+  const edm::OrphanHandle<reco::PFCandidateCollection> pfCandidateRefProd = (producePFCandidates_) ? iEvent.put(std::move(pfCandidates_p),nameOutputPF_) :
     edm::OrphanHandle<reco::PFCandidateCollection>();
   
   
@@ -186,15 +185,14 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 						    pfCandidateRefProd);
   }
   
-  std::auto_ptr<edm::ValueMap<reco::PFCandidatePtr> > 
-    pfMapMerged(new edm::ValueMap<reco::PFCandidatePtr>());
+  auto pfMapMerged = std::make_unique<edm::ValueMap<reco::PFCandidatePtr>>();
   edm::ValueMap<reco::PFCandidatePtr>::Filler pfMapMergedFiller(*pfMapMerged);
   
   *pfMapMerged                   += pfMapGsfElectrons;
   *pfMapMerged                   += pfMapPhotons;
   if(fillMuonRefs_) *pfMapMerged += pfMapMuons;
   
-  iEvent.put(pfMapMerged,nameOutputMergedPF_);
+  iEvent.put(std::move(pfMapMerged),nameOutputMergedPF_);
 }
 
 
@@ -206,7 +204,7 @@ edm::ValueMap<reco::PFCandidatePtr>  PFLinker::fillValueMap(edm::Event & event,
 							    const std::map<edm::Ref<TYPE>, reco::PFCandidatePtr> & mapToTheCandidate,
 							    const edm::OrphanHandle<reco::PFCandidateCollection> & newPFCandColl) const {
   
-  std::auto_ptr<edm::ValueMap<reco::PFCandidatePtr> > pfMap_p(new edm::ValueMap<reco::PFCandidatePtr>());
+  auto pfMap_p = std::make_unique<edm::ValueMap<reco::PFCandidatePtr>>();
   edm::ValueMap<reco::PFCandidatePtr>::Filler filler(*pfMap_p);
   
   typedef typename std::map<edm::Ref<TYPE>, reco::PFCandidatePtr>::const_iterator MapTYPE_it; 
@@ -230,6 +228,6 @@ edm::ValueMap<reco::PFCandidatePtr>  PFLinker::fillValueMap(edm::Event & event,
   filler.insert(inputObjCollection,values.begin(),values.end());
   filler.fill();
   edm::ValueMap<reco::PFCandidatePtr> returnValue = *pfMap_p;
-  event.put(pfMap_p,label);
+  event.put(std::move(pfMap_p),label);
   return returnValue;
 }

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
@@ -109,15 +109,12 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
 
   //cout << "NEW EVENT"<<endl;
 
-  std::auto_ptr<reco::BasicClusterCollection> 
-    basicClusters_p(new reco::BasicClusterCollection);
+  auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
 
-  std::auto_ptr<reco::PreshowerClusterCollection>
-    psClusters_p(new reco::PreshowerClusterCollection);
+  auto psClusters_p = std::make_unique<reco::PreshowerClusterCollection>();
 
   /*
-  std::auto_ptr<reco::ConversionCollection>
-    SingleLeg_p(new reco::ConversionCollection);
+  auto SingleLeg_p = std::make_unique<reco::ConversionCollection>();
   */
 
   reco::SuperClusterCollection outputSuperClusterCollection;
@@ -308,11 +305,11 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
    //Save the basic clusters and get an handle as to be able to create valid Refs (thanks to Claude)
   //  std::cout << " Number of basic clusters " << basicClusters_p->size() << std::endl;
   const edm::OrphanHandle<reco::BasicClusterCollection> bcRefProd = 
-    iEvent.put(basicClusters_p,PFBasicClusterCollection_);
+    iEvent.put(std::move(basicClusters_p),PFBasicClusterCollection_);
 
   //preshower clusters
   const edm::OrphanHandle<reco::PreshowerClusterCollection> psRefProd = 
-    iEvent.put(psClusters_p,PFPreshowerClusterCollection_);
+    iEvent.put(std::move(psClusters_p),PFPreshowerClusterCollection_);
   
   // now that the Basic clusters are in the event, the Ref can be created
   createBasicClusterPtrs(bcRefProd);
@@ -326,8 +323,8 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
   //std::cout << "nb superclusters in collection : "<<outputSuperClusterCollection.size()<<std::endl;
 
   // Let's put the super clusters in the event
-  std::auto_ptr<reco::SuperClusterCollection> superClusters_p(new reco::SuperClusterCollection(outputSuperClusterCollection));  
-  const edm::OrphanHandle<reco::SuperClusterCollection> scRefProd = iEvent.put(superClusters_p,PFSuperClusterCollection_); 
+  auto superClusters_p = std::make_unique<reco::SuperClusterCollection>(outputSuperClusterCollection);  
+  const edm::OrphanHandle<reco::SuperClusterCollection> scRefProd = iEvent.put(std::move(superClusters_p),PFSuperClusterCollection_); 
 
 
   /*
@@ -345,8 +342,8 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
   if (status) createOneLegConversions(scRefProd, outputOneLegConversionCollection);
 
 
-  std::auto_ptr<reco::ConversionCollection> SingleLeg_p(new reco::ConversionCollection(outputOneLegConversionCollection));  
-  const edm::OrphanHandle<reco::ConversionCollection> ConvRefProd = iEvent.put(SingleLeg_p,PFConversionCollection_);
+  auto SingleLeg_p = std::make_unique<reco::ConversionCollection>(outputOneLegConversionCollection);  
+  const edm::OrphanHandle<reco::ConversionCollection> ConvRefProd = iEvent.put(std::move(SingleLeg_p),PFConversionCollection_);
   /*
   int iconv = 0;
   for (reco::ConversionCollection::const_iterator convIter = ConvRefProd->begin(); convIter != ConvRefProd->end(); ++convIter){
@@ -368,9 +365,9 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
   //std::cout << "nb photoncores in collection : "<<outputPhotonCoreCollection.size()<<std::endl;
 
   // Put the photon cores in the event
-  std::auto_ptr<reco::PhotonCoreCollection> photonCores_p(new reco::PhotonCoreCollection(outputPhotonCoreCollection));  
-  //std::cout << "photon core collection put in auto_ptr"<<std::endl;
-  const edm::OrphanHandle<reco::PhotonCoreCollection> pcRefProd = iEvent.put(photonCores_p,PFPhotonCoreCollection_); 
+  auto photonCores_p = std::make_unique<reco::PhotonCoreCollection>(outputPhotonCoreCollection);  
+  //std::cout << "photon core collection put in unique_ptr"<<std::endl;
+  const edm::OrphanHandle<reco::PhotonCoreCollection> pcRefProd = iEvent.put(std::move(photonCores_p),PFPhotonCoreCollection_); 
   
   //std::cout << "photon core have been put in the event"<<std::endl;
   /*
@@ -449,9 +446,9 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
   if(status) createPhotons(vertexCollection, egPhotons, pcRefProd, isolationValues, outputPhotonCollection);
 
   // Put the photons in the event
-  std::auto_ptr<reco::PhotonCollection> photons_p(new reco::PhotonCollection(outputPhotonCollection));  
-  //std::cout << "photon collection put in auto_ptr"<<std::endl;
-  const edm::OrphanHandle<reco::PhotonCollection> photonRefProd = iEvent.put(photons_p,PFPhotonCollection_); 
+  auto photons_p = std::make_unique<reco::PhotonCollection>(outputPhotonCollection);  
+  //std::cout << "photon collection put in unique_ptr"<<std::endl;
+  const edm::OrphanHandle<reco::PhotonCollection> photonRefProd = iEvent.put(std::move(photons_p),PFPhotonCollection_); 
   //std::cout << "photons have been put in the event"<<std::endl;
   
   /*

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -572,42 +572,40 @@ PFProducer::produce(Event& iEvent,
   // Florian 5/01/2011
   // Save the PFElectron Extra Collection First as to be able to create valid References  
   if(usePFElectrons_)   {  
-    auto_ptr< reco::PFCandidateElectronExtraCollection >
-      pOutputElectronCandidateExtraCollection( pfAlgo_->transferElectronExtra() ); 
+    std::unique_ptr<reco::PFCandidateElectronExtraCollection> pOutputElectronCandidateExtraCollection( pfAlgo_->transferElectronExtra() ); 
 
     const edm::OrphanHandle<reco::PFCandidateElectronExtraCollection > electronExtraProd=
-      iEvent.put(pOutputElectronCandidateExtraCollection,electronExtraOutputCol_);      
+      iEvent.put(std::move(pOutputElectronCandidateExtraCollection),electronExtraOutputCol_);      
     pfAlgo_->setElectronExtraRef(electronExtraProd);
   }
 
   // Daniele 18/05/2011
   // Save the PFPhoton Extra Collection First as to be able to create valid References  
   if(usePFPhotons_)   {  
-    auto_ptr< reco::PFCandidatePhotonExtraCollection >
-      pOutputPhotonCandidateExtraCollection( pfAlgo_->transferPhotonExtra() ); 
+    std::unique_ptr<reco::PFCandidatePhotonExtraCollection> pOutputPhotonCandidateExtraCollection( pfAlgo_->transferPhotonExtra() ); 
 
     const edm::OrphanHandle<reco::PFCandidatePhotonExtraCollection > photonExtraProd=
-      iEvent.put(pOutputPhotonCandidateExtraCollection,photonExtraOutputCol_);      
+      iEvent.put(std::move(pOutputPhotonCandidateExtraCollection),photonExtraOutputCol_);      
     pfAlgo_->setPhotonExtraRef(photonExtraProd);
   }
 
    // Save cosmic cleaned muon candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pCosmicsMuonCleanedCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferCleanedCosmicCandidates() ); 
     // Save tracker/global cleaned muon candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pTrackerAndGlobalCleanedMuonCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferCleanedTrackerAndGlobalCandidates() ); 
     // Save fake cleaned muon candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pFakeCleanedMuonCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferCleanedFakeCandidates() ); 
     // Save punch-through cleaned muon candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pPunchThroughMuonCleanedCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferPunchThroughCleanedMuonCandidates() ); 
     // Save punch-through cleaned neutral hadron candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pPunchThroughHadronCleanedCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferPunchThroughCleanedHadronCandidates() ); 
     // Save added muon candidates
-    auto_ptr< reco::PFCandidateCollection > 
+    std::unique_ptr<reco::PFCandidateCollection> 
       pAddedMuonCandidateCollection( pfAlgo_->getPFMuonAlgo()->transferAddedMuonCandidates() ); 
 
   // Check HF overcleaning
@@ -625,13 +623,11 @@ PFProducer::produce(Event& iEvent,
     pfAlgo_->checkCleaning( hfCopy );
 
   // Save recovered HF candidates
-  auto_ptr< reco::PFCandidateCollection > 
-    pCleanedCandidateCollection( pfAlgo_->transferCleanedCandidates() ); 
+  std::unique_ptr<reco::PFCandidateCollection> pCleanedCandidateCollection( pfAlgo_->transferCleanedCandidates() ); 
 
   
   // Save the final PFCandidate collection
-  auto_ptr< reco::PFCandidateCollection > 
-    pOutputCandidateCollection( pfAlgo_->transferCandidates() ); 
+  std::unique_ptr<reco::PFCandidateCollection> pOutputCandidateCollection( pfAlgo_->transferCandidates() ); 
   
 
   
@@ -647,23 +643,23 @@ PFProducer::produce(Event& iEvent,
 
 
   // Write in the event
-  iEvent.put(pOutputCandidateCollection);
-  iEvent.put(pCleanedCandidateCollection,"CleanedHF");
+  iEvent.put(std::move(pOutputCandidateCollection));
+  iEvent.put(std::move(pCleanedCandidateCollection),"CleanedHF");
 
     if ( postMuonCleaning_ ) { 
-      iEvent.put(pCosmicsMuonCleanedCandidateCollection,"CleanedCosmicsMuons");
-      iEvent.put(pTrackerAndGlobalCleanedMuonCandidateCollection,"CleanedTrackerAndGlobalMuons");
-      iEvent.put(pFakeCleanedMuonCandidateCollection,"CleanedFakeMuons");
-      iEvent.put(pPunchThroughMuonCleanedCandidateCollection,"CleanedPunchThroughMuons");
-      iEvent.put(pPunchThroughHadronCleanedCandidateCollection,"CleanedPunchThroughNeutralHadrons");
-      iEvent.put(pAddedMuonCandidateCollection,"AddedMuonsAndHadrons");
+      iEvent.put(std::move(pCosmicsMuonCleanedCandidateCollection),"CleanedCosmicsMuons");
+      iEvent.put(std::move(pTrackerAndGlobalCleanedMuonCandidateCollection),"CleanedTrackerAndGlobalMuons");
+      iEvent.put(std::move(pFakeCleanedMuonCandidateCollection),"CleanedFakeMuons");
+      iEvent.put(std::move(pPunchThroughMuonCleanedCandidateCollection),"CleanedPunchThroughMuons");
+      iEvent.put(std::move(pPunchThroughHadronCleanedCandidateCollection),"CleanedPunchThroughNeutralHadrons");
+      iEvent.put(std::move(pAddedMuonCandidateCollection),"AddedMuonsAndHadrons");
     }
 
   if(usePFElectrons_)
     {
-      auto_ptr< reco::PFCandidateCollection >  
+      std::unique_ptr<reco::PFCandidateCollection>  
 	pOutputElectronCandidateCollection( pfAlgo_->transferElectronCandidates() ); 
-      iEvent.put(pOutputElectronCandidateCollection,electronOutputCol_);
+      iEvent.put(std::move(pOutputElectronCandidateCollection),electronOutputCol_);
 
     }
 }

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -444,7 +444,7 @@ void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks ) {
   else
     pfCleanedCandidates_.reset( new reco::PFCandidateCollection );
   
-  // not a auto_ptr; shout not be deleted after transfer
+  // not a unique_ptr; should not be deleted after transfer
   pfElectronExtra_.clear();
   pfPhotonExtra_.clear();
   
@@ -3330,8 +3330,7 @@ ostream& operator<<(ostream& out, const PFAlgo& algo) {
   out<<endl;
   out<<"reconstructed particles: "<<endl;
    
-  const std::auto_ptr< reco::PFCandidateCollection >& 
-    candidates = algo.pfCandidates(); 
+  const std::unique_ptr<reco::PFCandidateCollection>& candidates = algo.pfCandidates(); 
 
   if(!candidates.get() ) {
     out<<"candidates already transfered"<<endl;

--- a/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
+++ b/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
@@ -50,8 +50,8 @@ void PFCandConnector::setParameters(bool bCorrect, bool bCalibPrimary, double dp
 
 
 
-std::auto_ptr<reco::PFCandidateCollection>
-PFCandConnector::connect(std::auto_ptr<PFCandidateCollection>& pfCand) {
+std::unique_ptr<reco::PFCandidateCollection>
+PFCandConnector::connect(std::unique_ptr<PFCandidateCollection>& pfCand) {
    
   if(pfC_.get() ) pfC_->clear();
   else 
@@ -148,13 +148,13 @@ PFCandConnector::connect(std::auto_ptr<PFCandidateCollection>& pfCand) {
 
   if(debug_ && bCorrect_) cout << "==================== ------------------------------ ===============" << endl<< endl << endl;
    
-  return pfC_;
+  return std::move(pfC_);
 
 
 }
 
 void 
-PFCandConnector::analyseNuclearWPrim(std::auto_ptr<PFCandidateCollection>& pfCand, unsigned int ce1) {
+PFCandConnector::analyseNuclearWPrim(std::unique_ptr<PFCandidateCollection>& pfCand, unsigned int ce1) {
 
 
   PFDisplacedVertexRef ref1, ref2, ref1_bis;  
@@ -332,7 +332,7 @@ PFCandConnector::analyseNuclearWPrim(std::auto_ptr<PFCandidateCollection>& pfCan
 
 
 void 
-PFCandConnector::analyseNuclearWSec(std::auto_ptr<PFCandidateCollection>& pfCand, unsigned int ce1){
+PFCandConnector::analyseNuclearWSec(std::unique_ptr<PFCandidateCollection>& pfCand, unsigned int ce1){
 
   PFDisplacedVertexRef ref1, ref2;  
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -15,12 +15,12 @@ using namespace reco;
 using namespace boost;
 
 PFMuonAlgo::PFMuonAlgo() {
-  pfCosmicsMuonCleanedCandidates_ = std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-  pfCleanedTrackerAndGlobalMuonCandidates_= std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-  pfFakeMuonCleanedCandidates_= std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-  pfPunchThroughMuonCleanedCandidates_= std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-  pfPunchThroughHadronCleanedCandidates_= std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-  pfAddedMuonCandidates_= std::auto_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
+  pfCosmicsMuonCleanedCandidates_ = std::make_unique<reco::PFCandidateCollection>();
+  pfCleanedTrackerAndGlobalMuonCandidates_= std::make_unique<reco::PFCandidateCollection>();
+  pfFakeMuonCleanedCandidates_= std::make_unique<reco::PFCandidateCollection>();
+  pfPunchThroughMuonCleanedCandidates_= std::make_unique<reco::PFCandidateCollection>();
+  pfPunchThroughHadronCleanedCandidates_= std::make_unique<reco::PFCandidateCollection>();
+  pfAddedMuonCandidates_ = std::make_unique<reco::PFCandidateCollection>();
   
 }
 

--- a/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
@@ -86,7 +86,7 @@ PFPhotonAlgo::PFPhotonAlgo(std::string mvaweightfile,
 
 void PFPhotonAlgo::RunPFPhoton(const reco::PFBlockRef&  blockRef,
 			       std::vector<bool>& active,
-			       std::auto_ptr<PFCandidateCollection> &pfCandidates,
+			       std::unique_ptr<PFCandidateCollection> &pfCandidates,
 			       std::vector<reco::PFCandidatePhotonExtra>& pfPhotonExtraCandidates,
 			       std::vector<reco::PFCandidate> 
 			       &tempElectronCandidates

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -101,7 +101,7 @@ ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
 
   ///OUTPUT COLLECTION
-  std::auto_ptr<ConvBremSeedCollection> output(new ConvBremSeedCollection);
+  auto output = std::make_unique<ConvBremSeedCollection>();
 
 
   ///INITIALIZE
@@ -381,7 +381,7 @@ ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   } //END GSF TRACK COLLECTION LOOP 
   LogDebug("ConvBremSeedProducerProducer")<<"END";
-  iEvent.put(output);
+  iEvent.put(std::move(output));
     
 }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
@@ -68,11 +68,11 @@ namespace {
                      const edm::Handle<std::vector<reco::PFCluster> > & handle,
                      const std::vector<T> & values,
                      const std::string    & label) {
-    std::auto_ptr<edm::ValueMap<T> > valMap(new edm::ValueMap<T>());
+    auto valMap = std::make_unique<edm::ValueMap<T>>();
     typename edm::ValueMap<T>::Filler filler(*valMap);
     filler.insert(handle, values.begin(), values.end());
     filler.fill();
-    iEvent.put(valMap, label);
+    iEvent.put(std::move(valMap), label);
   }
 }
 
@@ -139,7 +139,7 @@ void EcalBarrelClusterFastTimer::produce(edm::StreamID sid, edm::Event& evt, con
     std::vector<std::pair<float,DetId> > smeared_times;
     resolutions.reserve(clusters.size());
     smeared_times.reserve(clusters.size());
-    std::auto_ptr<std::vector< std::vector<float> > > outP( new std::vector< std::vector<float> > );
+    auto outP = std::make_unique<std::vector< std::vector<float>>>();
     auto& out = *outP;
     
     // smear once then correct to multiple vertices
@@ -162,7 +162,7 @@ void EcalBarrelClusterFastTimer::produce(edm::StreamID sid, edm::Event& evt, con
       }
     }
 
-    evt.put(outP,name);
+    evt.put(std::move(outP),name);
     writeValueMap(evt,clustersH,resolutions,name+resolution);
   }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -219,8 +219,7 @@ void PFSimParticleProducer::produce(Event& iEvent,
   // deal with true particles 
   if( processParticles_) {
 
-    auto_ptr< reco::PFSimParticleCollection > 
-      pOutputPFSimParticleCollection(new reco::PFSimParticleCollection ); 
+    auto pOutputPFSimParticleCollection = std::make_unique<reco::PFSimParticleCollection>(); 
 
     Handle<vector<SimTrack> > simTracks;
     bool found = iEvent.getByToken(tokenSim_,simTracks);
@@ -517,7 +516,7 @@ void PFSimParticleProducer::produce(Event& iEvent,
       pOutputPFSimParticleCollection->push_back( particle );
     }
     
-    iEvent.put(pOutputPFSimParticleCollection);
+    iEvent.put(std::move(pOutputPFSimParticleCollection));
   }
 
   

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -163,8 +163,8 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
 
   // make blocks out of calo particles so we can have cluster references
   // likewise fill out superclusters
-  std::unique_ptr<reco::SuperClusterCollection> superclusters(new reco::SuperClusterCollection);
-  std::unique_ptr<reco::PFBlockCollection> blocks(new reco::PFBlockCollection);
+  auto superclusters = std::make_unique<reco::SuperClusterCollection>();
+  auto blocks = std::make_unique<reco::PFBlockCollection>();
   std::unordered_map<size_t,size_t> simCluster2Block;
   std::unordered_map<size_t,size_t> simCluster2BlockIndex;
   std::unordered_multimap<size_t,size_t> caloParticle2SimCluster;
@@ -185,7 +185,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
 	good_simclusters.push_back(isc);
 	etot += clusterRef->energy();
 	pttot += clusterRef->pt();	
-	std::unique_ptr<reco::PFBlockElementCluster> bec( new reco::PFBlockElementCluster(clusterRef,reco::PFBlockElement::HGCAL) );
+	auto bec = std::make_unique<reco::PFBlockElementCluster>(clusterRef,reco::PFBlockElement::HGCAL);
 	block.addElement(bec.get());
 	simCluster2Block[simc.key()] = icp;
 	simCluster2BlockIndex[simc.key()] = bec->index();
@@ -221,7 +221,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
                   //usedGsfTrack(GsfTrackCollection.size(),false), 
                     usedSimCluster(SimClusters.size(),false);
 
-  std::unique_ptr<reco::PFCandidateCollection> candidates(new reco::PFCandidateCollection);
+  auto candidates = std::make_unique<reco::PFCandidateCollection>();
   // in good particle flow fashion, start from the tracks and go out
   for( unsigned itk = 0; itk < TrackCollection.size(); ++itk ) {
     auto tkRef  = TrackCollection.refAt(itk);

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -50,7 +50,7 @@ void
 ElectronSeedMerger::produce(Event& iEvent, const EventSetup& iSetup)
 {
   //CREATE OUTPUT COLLECTION
-  auto_ptr<ElectronSeedCollection> output(new ElectronSeedCollection);
+  auto output = std::make_unique<ElectronSeedCollection>();
 
   //HANDLE THE INPUT SEED COLLECTIONS
   Handle<ElectronSeedCollection> EcalBasedSeeds;
@@ -124,6 +124,6 @@ ElectronSeedMerger::produce(Event& iEvent, const EventSetup& iSetup)
   }
   
   //PUT THE MERGED COLLECTION IN THE EVENT
-  iEvent.put(output);
+  iEvent.put(std::move(output));
   
 }

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -142,10 +142,10 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
   LogDebug("GoodSeedProducer")<<"START event: "<<iEvent.id().event()
 			      <<" in run "<<iEvent.id().run();
   //Create empty output collections
-  auto_ptr<ElectronSeedCollection> output_preid(new ElectronSeedCollection);
-  auto_ptr<TrajectorySeedCollection> output_nopre(new TrajectorySeedCollection);
-  auto_ptr<PreIdCollection> output_preidinfo(new PreIdCollection);
-  auto_ptr<edm::ValueMap<reco::PreIdRef> > preIdMap_p(new edm::ValueMap<reco::PreIdRef>);
+  auto output_preid = std::make_unique<ElectronSeedCollection>();
+  auto output_nopre = std::make_unique<TrajectorySeedCollection>();
+  auto output_preidinfo = std::make_unique<PreIdCollection>();
+  auto preIdMap_p = std::make_unique<edm::ValueMap<reco::PreIdRef>>();
   edm::ValueMap<reco::PreIdRef>::Filler mapFiller(*preIdMap_p);
 
   //Tracking Tools
@@ -458,12 +458,12 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
   } //end loop on the vector of track collections
   
   // no disablePreId_ switch, it is simpler to have an empty collection rather than no collection
-  iEvent.put(output_preid,preidgsf_);
+  iEvent.put(std::move(output_preid),preidgsf_);
   if (produceCkfseed_)
-    iEvent.put(output_nopre,preidckf_);
+    iEvent.put(std::move(output_nopre),preidckf_);
   if(producePreId_)
     {
-      const edm::OrphanHandle<reco::PreIdCollection> preIdRefProd = iEvent.put(output_preidinfo,preidname_);
+      const edm::OrphanHandle<reco::PreIdCollection> preIdRefProd = iEvent.put(std::move(output_preidinfo),preidname_);
       // now make the Value Map, but only if one input collection
       if(tracksContainers_.size()==1)
 	{
@@ -471,7 +471,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	  iEvent.getByToken(tracksContainers_[0],tkRefCollection);
 	  fillPreIdRefValueMap(tkRefCollection,preIdRefProd,mapFiller);
 	  mapFiller.fill();
-	  iEvent.put(preIdMap_p,preidname_);
+	  iEvent.put(std::move(preIdMap_p),preidname_);
 	}
     }
   // clear temporary maps

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -131,8 +131,8 @@ void HGCalTrackCollectionProducer::produce(edm::Event & evt, const edm::EventSet
   evt.getByToken(src_,trackHandle);
   const auto& tracks = *trackHandle;  
   
-  std::auto_ptr<reco::PFRecTrackCollection> outputInHGCal(new reco::PFRecTrackCollection);
-  std::auto_ptr<reco::PFRecTrackCollection> outputNotInHGCal(new reco::PFRecTrackCollection);
+  auto outputInHGCal = std::make_unique<reco::PFRecTrackCollection>();
+  auto outputNotInHGCal = std::make_unique<reco::PFRecTrackCollection>();
 
   for ( unsigned int i = 0 ; i < tracks.size() ; i++) {
     const auto track = tracks.ptrAt(i);
@@ -177,8 +177,8 @@ void HGCalTrackCollectionProducer::produce(edm::Event & evt, const edm::EventSet
     }
   } // track loop
 
-  evt.put(outputInHGCal,"TracksInHGCal");
-  evt.put(outputNotInHGCal,"TracksNotInHGCal");
+  evt.put(std::move(outputInHGCal),"TracksInHGCal");
+  evt.put(std::move(outputNotInHGCal),"TracksNotInHGCal");
 }
 
 DEFINE_FWK_MODULE(HGCalTrackCollectionProducer);

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -39,8 +39,7 @@ LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
 {
 
   //create the empty collections 
-  auto_ptr< reco::PFRecTrackCollection > 
-    PfTrColl (new reco::PFRecTrackCollection);
+  auto PfTrColl = std::make_unique<reco::PFRecTrackCollection>();
   
   for (unsigned int istr=0; istr<tracksContainers_.size();istr++){
     
@@ -63,7 +62,7 @@ LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
     }
   }
-  iEvent.put(PfTrColl);
+  iEvent.put(std::move(PfTrColl));
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -40,10 +40,8 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
 {
   
   //create the empty collections 
-  auto_ptr< reco::PFConversionCollection > 
-    pfConversionColl (new reco::PFConversionCollection);
-  auto_ptr< reco::PFRecTrackCollection > 
-    pfRecTrackColl (new reco::PFRecTrackCollection);
+  auto pfConversionColl = std::make_unique<reco::PFConversionCollection>();
+  auto pfRecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
   
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
@@ -174,8 +172,8 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
       reco::ConversionRef niRef(convCollH, collindex);
       pfConversionColl->push_back( reco::PFConversion( niRef, pfRecTkcoll ));
     }//end loop over collections
-  iEvent.put(pfRecTrackColl);
-  iEvent.put(pfConversionColl);    
+  iEvent.put(std::move(pfRecTrackColl));
+  iEvent.put(std::move(pfConversionColl));    
 }
   
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -31,10 +31,8 @@ PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& iSetu
 {
 
   //create the empty collections 
-  auto_ptr< reco::PFDisplacedTrackerVertexCollection > 
-    pfDisplacedTrackerVertexColl (new reco::PFDisplacedTrackerVertexCollection);
-  auto_ptr< reco::PFRecTrackCollection > 
-    pfRecTrackColl (new reco::PFRecTrackCollection);
+  auto pfDisplacedTrackerVertexColl = std::make_unique<reco::PFDisplacedTrackerVertexCollection>();
+  auto pfRecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
   
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
 
@@ -91,8 +89,8 @@ PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& iSetu
     pfDisplacedTrackerVertexColl->push_back( reco::PFDisplacedTrackerVertex( niRef, pfRecTkcoll ));
   }
  
-  iEvent.put(pfRecTrackColl);
-  iEvent.put(pfDisplacedTrackerVertexColl);
+  iEvent.put(std::move(pfRecTrackColl));
+  iEvent.put(std::move(pfDisplacedTrackerVertexColl));
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -101,12 +101,11 @@ PFDisplacedVertexCandidateProducer::produce(Event& iEvent,
   }    
 
 
-  auto_ptr< reco::PFDisplacedVertexCandidateCollection > 
-    pOutputDisplacedVertexCandidateCollection(
+  std::unique_ptr<reco::PFDisplacedVertexCandidateCollection> pOutputDisplacedVertexCandidateCollection(
       pfDisplacedVertexCandidateFinder_.transferVertexCandidates() ); 
   
   
-  iEvent.put(pOutputDisplacedVertexCandidateCollection);
+  iEvent.put(std::move(pOutputDisplacedVertexCandidateCollection));
  
   LogDebug("PFDisplacedVertexCandidateProducer")<<"STOP event: "<<iEvent.id().event()
 			     <<" in run "<<iEvent.id().run()<<endl;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -146,13 +146,13 @@ PFDisplacedVertexProducer::produce(Event& iEvent,
   }    
 
 
-  auto_ptr< reco::PFDisplacedVertexCollection > 
+  std::unique_ptr<reco::PFDisplacedVertexCollection>
     pOutputDisplacedVertexCollection( 
       pfDisplacedVertexFinder_.transferDisplacedVertices() ); 
 
 
   
-  iEvent.put(pOutputDisplacedVertexCollection);
+  iEvent.put(std::move(pOutputDisplacedVertexCollection));
  
   LogDebug("PFDisplacedVertexProducer")<<"STOP event: "<<iEvent.id().event()
 			     <<" in run "<<iEvent.id().run()<<endl;

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -113,12 +113,9 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
 
   //create the empty collections 
-  auto_ptr< GsfPFRecTrackCollection > 
-    gsfPFRecTrackCollection(new GsfPFRecTrackCollection);
-
+  auto gsfPFRecTrackCollection = std::make_unique<GsfPFRecTrackCollection>();
   
-  auto_ptr< GsfPFRecTrackCollection > 
-    gsfPFRecTrackCollectionSecondary(new GsfPFRecTrackCollection);
+  auto gsfPFRecTrackCollectionSecondary = std::make_unique<GsfPFRecTrackCollection>();
 
   //read collections of tracks
   Handle<GsfTrackCollection> gsftrackscoll;
@@ -350,7 +347,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   
   const edm::OrphanHandle<GsfPFRecTrackCollection> gsfPfRefProd = 
-    iEvent.put(gsfPFRecTrackCollectionSecondary,"Secondary");
+    iEvent.put(std::move(gsfPFRecTrackCollectionSecondary),"Secondary");
   
   
   //now the secondary GsfPFRecTracks are in the event, the Ref can be created
@@ -359,7 +356,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   for(unsigned int iGSF = 0; iGSF<primaryGsfPFRecTracks.size();iGSF++){
     gsfPFRecTrackCollection->push_back(primaryGsfPFRecTracks[iGSF]);
   }
-  iEvent.put(gsfPFRecTrackCollection);
+  iEvent.put(std::move(gsfPFRecTrackCollection));
 
   selGsfPFRecTracks.clear();
   GsfPFMap.clear();

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -34,10 +34,8 @@ PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup)
   typedef reco::NuclearInteraction::trackRef_iterator trackRef_iterator;
 
   //create the empty collections 
-  auto_ptr< reco::PFNuclearInteractionCollection > 
-    pfNuclearColl (new reco::PFNuclearInteractionCollection);
-  auto_ptr< reco::PFRecTrackCollection > 
-    pfNuclearRecTrackColl (new reco::PFRecTrackCollection);
+  auto pfNuclearColl = std::make_unique<reco::PFNuclearInteractionCollection>();
+  auto pfNuclearRecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
   
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
   int hid=0;
@@ -72,8 +70,8 @@ PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup)
       pfNuclearColl->push_back( reco::PFNuclearInteraction( niRef, pfRecTkcoll ));
     }
   }
-  iEvent.put(pfNuclearRecTrackColl);
-  iEvent.put(pfNuclearColl);
+  iEvent.put(std::move(pfNuclearRecTrackColl));
+  iEvent.put(std::move(pfNuclearColl));
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -59,8 +59,7 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
 {
   
   //create the empty collections 
-  auto_ptr< reco::PFRecTrackCollection > 
-    PfTrColl (new reco::PFRecTrackCollection);
+  auto PfTrColl = std::make_unique<reco::PFRecTrackCollection>();
   
   //read track collection
   Handle<GsfTrackCollection> gsftrackcoll;
@@ -220,7 +219,7 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
       }
     }
   }
-  iEvent.put(PfTrColl);
+  iEvent.put(std::move(PfTrColl));
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -36,9 +36,9 @@ PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup)
   LogDebug("PFV0Producer")<<"START event: "<<iEvent.id().event()
 			  <<" in run "<<iEvent.id().run();
   //create the empty collections 
-  auto_ptr< PFV0Collection > pfV0Coll (new PFV0Collection);
+  auto pfV0Coll = std::make_unique<PFV0Collection>();
 
-  auto_ptr<reco::PFRecTrackCollection> pfV0RecTrackColl(new reco::PFRecTrackCollection);
+  auto pfV0RecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
 
 
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
@@ -81,8 +81,8 @@ PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup)
   }
   
   
-  iEvent.put(pfV0Coll);
-  iEvent.put(pfV0RecTrackColl);
+  iEvent.put(std::move(pfV0Coll));
+  iEvent.put(std::move(pfV0RecTrackColl));
 }
 
 // ------------ method called once each job just before starting event loop  ------------


### PR DESCRIPTION
In preparation for removing framework support for deprecated auto_ptr arguments in put() calls, this pull request replaces the use of auto_ptr with unique_ptr in RecoParticleFlow packages. Also, std::make_unique is used when appropriate. 
