### PR TITLE
L1T - synchronise L1REPACK step FullSimTP for the underneath changed EMTF 

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -78,6 +78,7 @@ else:
     # simOmtfDigis.srcCSC              = cms.InputTag("simCscTriggerPrimitiveDigis")   # DEFAULT
 
     # EMTF
+    simEmtfDigis.RPCInput            = cms.InputTag('unpackRPC')
     simEmtfDigis.CSCInput            = cms.InputTag("unpackCsctf")
     # simEmtfDigis.CSCInput            = cms.InputTag("simCscTriggerPrimitiveDigis")     # DEFAULT
 


### PR DESCRIPTION
This is a missing simple, but needed, change in L1REPACK step FullSimTP step.

EMTF emulator has changed in l1t-tsg-v9 to now also take RPCs as input configuration.
That change is propagated here.

Tested successfully with 
runTheMatrix.py -l 136.7321 -i all
