### PR TITLE
Protect against invalide TSOS

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -74,7 +74,10 @@ void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface& tsos, DTRecSe
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
     DTLayerId layid((*it)->det()->geographicalId());
     TrajectoryStateOnSurface temp = propagator->propagate(tsos, theG->idToDet(layid)->surface());
-    if (temp.isValid()) tsos = updatorHandle->update(temp, **it);
+    if (temp.isValid()) {
+        TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
+        if (tempTsos.isValid() ) tsos = tempTsos;
+    }
   }
 }
 

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -91,7 +91,10 @@ void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface& tsos, CSCSeg
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
     const CSCLayer* cscLayer = cscGeom->layer((*it)->det()->geographicalId());
     TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());  
-    if (temp.isValid()) tsos = updatorHandle->update(temp, **it);
+    if (temp.isValid()) {
+      TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
+      if (tempTsos.isValid() ) tsos = tempTsos;
+    }
   }
 }
 


### PR DESCRIPTION
This PR is to solve a crash during the muon reconstruction.
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1477.html

Trajectory state after a propagation was invalid but the validity haven't been checked and fed into the next step of the propagation, caused crash.
We use the TSOS of the previous step if the propagation failed.

Changes are expected only for the problematic cases, so there should no difference in normal cases.
