### PR TITLE
Remove support for Event::put(auto_ptr) FINALLY!!!

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -118,17 +118,9 @@ namespace edm {
     ///Put a new product.
     template<typename PROD>
     OrphanHandle<PROD>
-    put(std::auto_ptr<PROD> product) {return put<PROD>(product, std::string());}
-
-    template<typename PROD>
-    OrphanHandle<PROD>
     put(std::unique_ptr<PROD> product) {return put<PROD>(std::move(product), std::string());}
 
     ///Put a new product with a 'product instance name'
-    template<typename PROD>
-    OrphanHandle<PROD>
-    put(std::auto_ptr<PROD> product, std::string const& productInstanceName);
-
     template<typename PROD>
     OrphanHandle<PROD>
     put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
@@ -367,11 +359,6 @@ namespace edm {
       return true;
   }
 
-  template<typename PROD>
-  OrphanHandle<PROD>
-  Event::put(std::auto_ptr<PROD> product, std::string const& productInstanceName) {
-    return put(std::unique_ptr<PROD>(product.release()),productInstanceName);
-  }
   template<typename PROD>
   OrphanHandle<PROD>
   Event::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -106,17 +106,9 @@ namespace edm {
     ///Put a new product.
     template <typename PROD>
     void
-    put(std::auto_ptr<PROD> product) {put<PROD>(product, std::string());}
-
-    template <typename PROD>
-    void
     put(std::unique_ptr<PROD> product) {put<PROD>(std::move(product), std::string());}
 
     ///Put a new product with a 'product instance name'
-    template <typename PROD>
-    void
-    put(std::auto_ptr<PROD> product, std::string const& productInstanceName);
-
     template <typename PROD>
     void
     put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
@@ -167,12 +159,6 @@ namespace edm {
 
     static const std::string emptyString_;
   };
-
-  template <typename PROD>
-  void
-  LuminosityBlock::put(std::auto_ptr<PROD> product, std::string const& productInstanceName) {
-    put(std::unique_ptr<PROD>(product.release()),productInstanceName);
-  }
 
   template <typename PROD>
   void

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -108,17 +108,9 @@ namespace edm {
     ///Put a new product.
     template <typename PROD>
     void
-    put(std::auto_ptr<PROD> product) {put<PROD>(product, std::string());}
-
-    template <typename PROD>
-    void
     put(std::unique_ptr<PROD> product) {put<PROD>(std::move(product), std::string());}
 
     ///Put a new product with a 'product instance name'
-    template <typename PROD>
-    void
-    put(std::auto_ptr<PROD> product, std::string const& productInstanceName);
-
     template <typename PROD>
     void
     put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
@@ -179,12 +171,6 @@ namespace edm {
     static const std::string emptyString_;
   };
 
-  template <typename PROD>
-  void
-  Run::put(std::auto_ptr<PROD> product, std::string const& productInstanceName) {
-    put(std::unique_ptr<PROD>(product.release()),productInstanceName);
-  }
-  
   template <typename PROD>
   void
   Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -37,7 +37,7 @@ namespace edm {
 	std::string const& productInstanceName) {
       throw Exception(errors::NullPointerError)
 	<< principalType
-	<< "::put: A null auto_ptr or unique_ptr was passed to 'put'.\n"
+	<< "::put: A null unique_ptr was passed to 'put'.\n"
 	<< "The pointer is of type "
 	<< productType
         << ".\nThe specified productInstanceName was '"


### PR DESCRIPTION
This PR removes the last use of auto_ptr in the CMS framework, namely its use as an argument in Event:put(). (also put() for run and lumi) All calls to put() in CMSSW have now been converted to use unique_ptr instead of auto_ptr.
This PR will cause many packages to rebuild, but, unless someone adds a new call to put(auto_ptr) before this PR is merged, there should be no issues.
