### PR TITLE
[80X] updated MC and data Relval Global Tags with updated L1 menu for Post-TS2

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '80X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '80X_mcRun2_design_v19',
+    'run2_design'       :   '80X_mcRun2_design_v20',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '80X_mcRun2_startup_v18',
+    'run2_mc_50ns'      :   '80X_mcRun2_startup_v19',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '80X_mcRun2_asymptotic_v19',
+    'run2_mc'           :   '80X_mcRun2_asymptotic_v20',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v17',
+    'run2_mc_cosmics'   :   '80X_mcRun2cosmics_startup_peak_v18',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v12',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
@@ -26,19 +26,19 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '80X_dataRun2_Candidate_2016_09_02_10_26_48',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_Candidate_2016_09_02_10_27_40',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v17',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v12',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v13',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '80X_upgrade2017_design_v17',
+    'phase1_2017_design' :  '80X_upgrade2017_design_v18',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '80X_upgrade2017_realistic_v9',
+    'phase1_2017_realistic': '80X_upgrade2017_realistic_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [80X_mcRun2_design_v20](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v20) as [80X_mcRun2_design_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_design_v19) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_design_v20/80X_mcRun2_design_v19): 
  - updated postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
- **RunII CRAFT scenario** : [80X_mcRun2cosmics_startup_peak_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v18) as [80X_mcRun2cosmics_startup_peak_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2cosmics_startup_peak_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2cosmics_startup_peak_v18/80X_mcRun2cosmics_startup_peak_v17): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
- **RunII Asymptotic scenario** : [80X_mcRun2_asymptotic_v20](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v20) as [80X_mcRun2_asymptotic_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_asymptotic_v19) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_asymptotic_v20/80X_mcRun2_asymptotic_v19): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
- **RunII Startup scenario** : [80X_mcRun2_startup_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v19) as [80X_mcRun2_startup_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_startup_v18) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_startup_v19/80X_mcRun2_startup_v18): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
## RunII data
- **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v13) as [80X_dataRun2_HLT_relval_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v13/80X_dataRun2_HLT_relval_v12): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
- **RunII Offline relval processing** : [80X_dataRun2_relval_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v17) as [80X_dataRun2_relval_Candidate_2016_09_02_10_27_40](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_Candidate_2016_09_02_10_27_40) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v17/80X_dataRun2_relval_Candidate_2016_09_02_10_27_40): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
  - updated SiStrip DQM trigger bits for HIP monitoring (as standard data reprocessing Queue)
## Upgrade
- **PhaseI realistic scenario** : [80X_upgrade2017_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v10) as [80X_upgrade2017_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v10/80X_upgrade2017_design_v9): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
- **PhaseI design scenario** : [80X_upgrade2017_design_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v18) as [80X_upgrade2017_design_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_upgrade2017_design_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_upgrade2017_design_v18/80X_upgrade2017_design_v17): 
  - update postTS2 L1 menu (`L1Menu_Collisions2016_v6r5_ugt_1board_xml`)
  - use same HLT JECs as all others MC workflows (`JetCorrectorParametersCollection_HLT_BX25_V11_*`) for homogeneity
