### PR TITLE
Compression level 1 for PB files (80X)

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -408,8 +408,10 @@ void DQMStore::mergeAndResetMEsRunSummaryCache(uint32_t run,
 	      std::cout << "mergeAndResetMEsRunSummaryCache: Failed to merge DQM element "<<me->getFullname();
 	    }
 	  }
-	  else
-	    me->getTH1()->Add(i->getTH1());
+	  else {
+            if (i->getTH1()->GetEntries())
+	      me->getTH1()->Add(i->getTH1());
+          }
 	}
     } else {
       if (verbose_ > 1)
@@ -474,8 +476,10 @@ void DQMStore::mergeAndResetMEsLuminositySummaryCache(uint32_t run,
 	      std::cout << "mergeAndResetMEsLuminositySummaryCache: Failed to merge DQM element "<<me->getFullname();
 	    }
 	  }
-	  else
-	    me->getTH1()->Add(i->getTH1());
+	  else {
+            if (i->getTH1()->GetEntries())
+	      me->getTH1()->Add(i->getTH1());
+          }
 	}
     } else {
       if (verbose_ > 1)
@@ -2606,7 +2610,7 @@ void DQMStore::savePB(const std::string &filename,
   FileOutputStream file_stream(filedescriptor);
   GzipOutputStream::Options options;
   options.format = GzipOutputStream::GZIP;
-  options.compression_level = 6;
+  options.compression_level = 1;
   GzipOutputStream gzip_stream(&file_stream,
                                options);
   dqmstore_message.SerializeToZeroCopyStream(&gzip_stream);


### PR DESCRIPTION
DQM changes seen to improve DAQ/HLT performance in timing benchmarks:
- compression level 1 for PB files (performance improvement for online)
- before adding check if histogram has been filled (better performance in case of many histograms not filled in a lumisection)

(same as #15903 for 81X)
