### PR TITLE
fix for root>=6.7.0: TMVA reader in root master keeps the ownership of reader method

### DIFF
--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -36,7 +36,9 @@ class TMVAEvaluator {
     std::string mMethod;
     mutable std::mutex m_mutex;
     [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVA::Reader> mReader;
+    #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     std::unique_ptr<TMVA::IMethod> mIMethod;
+    #endif
     std::shared_ptr<const GBRForest> mGBRForest;
 
     [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mVariables;

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -12,7 +12,6 @@ TMVAEvaluator::TMVAEvaluator() :
 {
 }
 
-
 void TMVAEvaluator::initialize(const std::string & options, const std::string & method, const std::string & weightFile,
                                const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useGBRForest, bool useAdaBoost)
 {
@@ -36,7 +35,11 @@ void TMVAEvaluator::initialize(const std::string & options, const std::string & 
   }
 
   // load the TMVA weights
+  #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   mIMethod = std::unique_ptr<TMVA::IMethod>( reco::details::loadTMVAWeights(mReader.get(), mMethod.c_str(), weightFile.c_str()) );
+  #else
+  reco::details::loadTMVAWeights(mReader.get(), mMethod.c_str(), weightFile.c_str());
+  #endif
 
   if (useGBRForest)
   {
@@ -44,7 +47,9 @@ void TMVAEvaluator::initialize(const std::string & options, const std::string & 
 
     // now can free some memory
     mReader.reset(nullptr);
+    #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     mIMethod.reset(nullptr);
+    #endif
 
     mUsingGBRForest = true;
     mUseAdaBoost = useAdaBoost;


### PR DESCRIPTION
Due to fix in TMVA Reader https://github.com/root-mirror/root/commit/e22060814e21266d24bd171b22cf45e56a809bc2#diff-e98c0e9377c09176d29f8bb937bb945d

Now Reader keeps the ownership. This PR should fix the following crashes we see in ROOT6 IBs

```
#6  0x00007f11ce011cc3 in TMVAEvaluator::initialize(std::string const&, std::string const&, std::string const&, std::vector<std::string, std::allocator<std::string> > const&, std::vector<std::string, std::allocator<std::string> > const&, bool, bool) () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-09-18-2300/lib/slc6_amd64_gcc530/libCommonToolsUtils.so
#7  0x00007f11cb6ad092 in CandidateChargeBTagComputer::initialize(JetTagComputerRecord const&) () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-09-18-2300/lib/slc6_amd64_gcc530/libRecoBTagCombined.so
#8  0x00007f11cc59a6bc in JetTagComputerESProducer<CandidateChargeBTagComputer>::produce(JetTagComputerRecord const&) () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-09-18-2300/lib/slc6_amd64_gcc530/pluginRecoBTagCombinedPlugins.so
#9  0x00007f11cc59ada4 in edm::eventsetup::CallbackProxy<edm::eventsetup::Callback<JetTagComputerESProducer<CandidateChargeBTagComputer>, std::shared_ptr<JetTagComputer>, JetTagComputerRecord, edm::eventsetup::CallbackSimpleDecorator<JetTagComputerRecord> >, JetTagComputerRecord, std::shared_ptr<JetTagComputer> >::getImpl(edm::eventsetup::EventSetupRecord const&, edm::eventsetup::DataKey const&) () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-09-18-2300/lib/slc6_amd64_gcc530/pluginRecoBTagCombinedPlugins.so
```

for normal IBs, where we have root 6.06.08 the behaviour is not changed.
