### PR TITLE
Fixing HBHEStatusBitSetter

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h
@@ -20,7 +20,6 @@ public:
 
   void SetFrontEndMap(const HcalFrontEndMap* m); 
   void Clear();
-  void setTopo(const HcalTopology* topo);
   void SetFlagsFromDigi(HBHERecHit& hbhe, const HBHEDataFrame& digi,
                         const HcalCoder& coder, const HcalCalibrations& calib);
   void rememberHit(const HBHERecHit& hbhe);

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -68,7 +68,7 @@ hbheprereco = cms.EDProducer(
 
     # Turn rechit status bit setters on/off
     setNegativeFlags = cms.bool(False),
-    setNoiseFlagsQIE8 = cms.bool(False), # Set to "True" when the topology map is fixed
+    setNoiseFlagsQIE8 = cms.bool(True),
     setNoiseFlagsQIE11 = cms.bool(False),
     setPulseShapeFlagsQIE8 = cms.bool(True),
     setPulseShapeFlagsQIE11 = cms.bool(False),

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -582,12 +582,21 @@ HBHEPhase1Reconstructor::beginRun(edm::Run const& r, edm::EventSetup const& es)
                 << std::endl;
     }
 
-    edm::ESHandle<HcalTopology> htopo;
-    es.get<HcalRecNumberingRecord>().get(htopo);
-    if (setNoiseFlagsQIE8_)
-        hbheFlagSetterQIE8_->setTopo(htopo.product());
-    if (setNoiseFlagsQIE11_)
-        hbheFlagSetterQIE11_->setTopo(htopo.product());
+    if (setNoiseFlagsQIE8_ || setNoiseFlagsQIE11_)
+    {
+        edm::ESHandle<HcalFrontEndMap> hfemap;
+        es.get<HcalFrontEndMapRcd>().get(hfemap);
+        if (hfemap.isValid())
+        {
+            if (setNoiseFlagsQIE8_)
+                hbheFlagSetterQIE8_->SetFrontEndMap(hfemap.product());
+            if (setNoiseFlagsQIE11_)
+                hbheFlagSetterQIE11_->SetFrontEndMap(hfemap.product());
+        }
+        else
+            edm::LogWarning("EventSetup") <<
+                "HBHEPhase1Reconstructor failed to get HcalFrontEndMap!" << std::endl;
+    }
 
     reco_->beginRun(r, es);
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -343,7 +343,6 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
     }
 
   if (hbheFlagSetter_) {
-    hbheFlagSetter_->setTopo(htopo.product());
     edm::ESHandle<HcalFrontEndMap> hfemap;
     es.get<HcalFrontEndMapRcd>().get(hfemap);
     if (hfemap.isValid()) {


### PR DESCRIPTION
Properly fixing HBHEStatusBitSetter following the conversion from HcalLogicalMap to HcalFrontEndMap in the PR #15382 

This PR removes "setTopo" method of the HBHEStatusBitSetter class, clears hpdMultiplicity_ vector every time HcalFrontEndMap is set (bug fix) and enables HBHEStatusBitSetter for QIE8 readouts in the HBHEPhase1Reconstructor config.
