### PR TITLE
First round of fixes to static analyzer warnings in Alignment

### DIFF
--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -1441,10 +1441,6 @@ ApeEstimator::radialPositionAndError2(const LocalPoint& lP, const LocalError& lE
   float errY2(-999.F);
   
   x = phi*r_0;
-  // Cartesian y
-  y = lP.y();
-  // Trapezoidal y (symmetric around 0; length along strip)
-  y = measPos.y()*stripLength;
   // Radial y (not symmetric around 0; radial distance with minimum at middle strip at lower edge [0, yMax])
   const float l_0 = r_0 - topol.detHeight()/2;
   const float cosPhi(std::cos(phi));
@@ -1454,10 +1450,6 @@ ApeEstimator::radialPositionAndError2(const LocalPoint& lP, const LocalError& lE
   const float errPhi2(measErr.uu()*angularWidth2);
   
   errX2 = errPhi2*r_0*r_0;
-  // Cartesian y
-  errY2 = lE.yy();
-  // Trapezoidal y (symmetric around 0, length along strip)
-  errY2 = measErr.vv()*stripLength*stripLength;
   // Radial y (not symmetric around 0, real radial distance from intersection point)
   const float cosPhi4(std::pow(cosPhi,4)), sinPhi2(std::sin(phi)*std::sin(phi));
   const float helpSummand = l_0*l_0*(sinPhi2/cosPhi4*errPhi2);

--- a/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
@@ -520,14 +520,12 @@ ApeEstimatorSummary::calculateApe(){
        TF1 funcX_1("mygausX", "gaus", xMin, xMax);
        funcX_1.SetParameters(maximumX, meanX, rmsX);
        TString fitOpt("ILERQ"); //TString fitOpt("IMR"); ("IRLL"); ("IRQ");
-       Int_t fitResultX(0);
        if(integralX>minHitsPerInterval){
          if(mHists["norResX"]->Fit(&funcX_1, fitOpt)){
            edm::LogWarning("CalculateAPE")<<"Fit1 did not work: "<<mHists["norResX"]->Fit(&funcX_1, fitOpt);
            continue;
          }
-         fitResultX = mHists["norResX"]->Fit(&funcX_1, fitOpt);
-         std::cout<<"FitResult1\t"<<fitResultX<<"\n";
+         LogDebug("CalculateAPE")<<"FitResultX1\t"<<mHists["norResX"]->Fit(&funcX_1, fitOpt)<<"\n";
        }
        Double_t meanX_1  = funcX_1.GetParameter(1);
        Double_t sigmaX_1 = funcX_1.GetParameter(2);
@@ -541,7 +539,7 @@ ApeEstimatorSummary::calculateApe(){
            edm::LogWarning("CalculateAPE")<<"Fit2 did not work for x : "<<mHists["norResX"]->Fit(&funcX_2, fitOpt);
 	   continue;
          }
-         fitResultX = mHists["norResX"]->Fit(&funcX_2, fitOpt);
+         LogDebug("CalculateAPE")<<"FitResultX2\t"<<mHists["norResX"]->Fit(&funcX_2, fitOpt)<<"\n";
        }
        Double_t meanX_2  = funcX_2.GetParameter(1);
        Double_t sigmaX_2 = funcX_2.GetParameter(2);
@@ -573,14 +571,12 @@ ApeEstimatorSummary::calculateApe(){
 	 // First Gaus Fit
          TF1 funcY_1("mygausY", "gaus", yMin, yMax);
          funcY_1.SetParameters(maximumY, meanY, rmsY);
-         Int_t fitResultY(0);
          if(integralY>minHitsPerInterval){
            if(mHists["norResY"]->Fit(&funcY_1, fitOpt)){
              edm::LogWarning("CalculateAPE")<<"Fit1 did not work: "<<mHists["norResY"]->Fit(&funcY_1, fitOpt);
              continue;
            }
-            fitResultY = mHists["norResY"]->Fit(&funcY_1, fitOpt);
-	    std::cout<<"FitResult2\t"<<fitResultY<<"\n";
+            LogDebug("CalculateAPE")<<"FitResultY1\t"<<mHists["norResY"]->Fit(&funcY_1, fitOpt)<<"\n";
          }
          meanY_1  = funcY_1.GetParameter(1);
 	 sigmaY_1 = funcY_1.GetParameter(2);
@@ -593,7 +589,7 @@ ApeEstimatorSummary::calculateApe(){
              edm::LogWarning("CalculateAPE")<<"Fit2 did not work for y : "<<mHists["norResY"]->Fit(&funcY_2, fitOpt);
 	     continue;
            }
-            fitResultY = mHists["norResY"]->Fit(&funcY_2, fitOpt);
+            LogDebug("CalculateAPE")<<"FitResultY2\t"<<mHists["norResY"]->Fit(&funcY_2, fitOpt)<<"\n";
          }
          meanY_2  = funcY_2.GetParameter(1);
          sigmaY_2 = funcY_2.GetParameter(2);

--- a/Alignment/CocoaModel/src/DeviationsFromFileSensor2D.cc
+++ b/Alignment/CocoaModel/src/DeviationsFromFileSensor2D.cc
@@ -10,6 +10,7 @@
 #include "Alignment/CocoaUtilities/interface/ALIUtils.h"
 #include <cstdlib>
 #include <cmath>		// include floating-point std::abs functions
+#include <memory>
 
 enum directions{ xdir = 0, ydir = 1};
 
@@ -155,7 +156,7 @@ std::pair< ALIdouble, ALIdouble > DeviationsFromFileSensor2D::getDevis( ALIdoubl
   //---------- look which point in the deviation matrices correspond to intersX,Y
   //----- Look for each column, between which rows intersY is
   //assume first dir is Y
-  unsigned int* yrows = new unsigned int[ theNPoints ];
+  auto yrows = std::make_unique<unsigned int[]>(theNPoints);
 
   unsigned int ii = 0;
   ALIbool insideMatrix = 0;

--- a/Alignment/CocoaModel/src/OpticalObject.cc
+++ b/Alignment/CocoaModel/src/OpticalObject.cc
@@ -277,12 +277,12 @@ void OpticalObject::transformCylindrical2Cartesian()
 {
   ALIuint ii;
   ALIuint siz =  theCoordinateEntryVector.size();
-  ALIdouble newcoor[3];
   ALIdouble R = theCoordinateEntryVector[0]->value();
   ALIdouble phi = theCoordinateEntryVector[1]->value()/ALIUtils::LengthValueDimensionFactor()*ALIUtils::AngleValueDimensionFactor();
-  newcoor[0] = R*cos(phi);
-  newcoor[1] = R*sin(phi);
-  newcoor[2] = theCoordinateEntryVector[2]->value(); // Z
+  ALIdouble newcoor[] = { R*cos(phi),
+                          R*sin(phi),
+                          theCoordinateEntryVector[2]->value() // Z
+  };
   //-  std::cout << " phi " << phi << std::endl;
    //----- Name is filled from here to include 'centre' or 'angles'
 

--- a/Alignment/CocoaModel/src/OpticalObject.cc
+++ b/Alignment/CocoaModel/src/OpticalObject.cc
@@ -40,6 +40,7 @@
 #include "Alignment/CocoaDDLObjects/interface/CocoaSolidShapeBox.h"
 
 #include "CondFormats/OptAlignObjects/interface/OpticalAlignInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
@@ -1115,7 +1116,9 @@ void OpticalObject::displaceExtraEntry(const ALIuint entryNo, const ALIdouble di
 
   ALIdouble Pentry_orig_value = *(theExtraEntryValueOriginalVector.begin() + entryNo);
   Pentry_value = (Pentry_orig_value) + disp;
-  //  std::cout << " displaceExtraEntry " << Pentry_value << " <> " << Pentry_orig_value << std::endl;
+  LogDebug("OpticalObject::displaceExtraEntry")
+    << " displaceExtraEntry " << Pentry_value << " <> " << Pentry_orig_value
+    << std::endl;
   theExtraEntryValueVector[entryNo] = Pentry_value;
 }
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -255,7 +255,6 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
     tmpPresc_=prescale_;
   }
   if(trk_cnt!=ntracks)edm::LogError("AlignmentStats")<<"\nERROR! trk_cnt="<<trk_cnt<<"   ntracks="<<ntracks;
-  trk_cnt=0;
 
   return;
 }

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -814,7 +814,6 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	// which excludes current hit
 	
 	//////////Hit prescaling part 	 
-	bool skiphit = false; 	 
 	if (eventInfo.clusterValueMap()) { 	 
 	  // check from the PrescalingMap if the hit was taken. 	 
 	  // If not skip to the next TM 	 
@@ -872,16 +871,10 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	  } //end 'else' it is a pixel hit 	 
 	    // bool hitTaken=myflag.isTaken(); 	 
 	  if (!myflag.isTaken()) { 	 
-	    skiphit=true;
 	    continue;
 	  }
 	}//end if Prescaled Hits 	 
 	//////////////////////////////// 	 
-	if (skiphit) { 	 
-	  throw cms::Exception("LogicError")
-	    << "ERROR  in <HIPAlignmentAlgorithm::run>: this hit should have been skipped!"
-	    << std::endl;	 
-	}
 	
 	TrajectoryStateOnSurface tsos = tsoscomb.combine(meas.forwardPredictedState(),
 							 meas.backwardPredictedState());

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -879,8 +879,8 @@ bool MillePedeAlignmentAlgorithm::areEmptyParams(const std::vector<Alignable*> &
        iAli != alignables.end(); ++iAli) {
     const AlignmentParameters *params = (*iAli)->alignmentParameters();
     if (params) {
-      const AlgebraicVector &parVec(params->parameters());
-      const AlgebraicMatrix &parCov(params->covariance());
+      const auto& parVec(params->parameters());
+      const auto& parCov(params->covariance());
       for (int i = 0; i < parVec.num_row(); ++i) {
         if (parVec[i] != 0.) return false;
         for (int j = i; j < parCov.num_col(); ++j) {

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
@@ -167,8 +167,8 @@ void MuonGeometryArrange::endHist(){
 
    int size=_mgacollection.size();
    if(size<=0) return;	// nothing to do here.
-   float* xp = new float[size+1];
-   float* yp = new float[size+1];
+   std::vector<float> xp(size+1);
+   std::vector<float> yp(size+1);
    int i;
    float minV, maxV;
    int minI, maxI;
@@ -205,7 +205,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delX_vs_position", "Local #delta X vs position", 
-       "GdelX_vs_position","#delta x in cm", xp, yp, size);
+       "GdelX_vs_position","#delta x in cm", xp.data(), yp.data(), size);
 // Dy plot
    minV=99999999.; maxV=-minV;
    for(i=0; i<size; i++){
@@ -217,7 +217,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delY_vs_position", "Local #delta Y vs position", 
-       "GdelY_vs_position","#delta y in cm", xp, yp, size);
+       "GdelY_vs_position","#delta y in cm", xp.data(), yp.data(), size);
 
 // Dz plot
    minV=99999999.; maxV=-minV;
@@ -230,7 +230,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delZ_vs_position", "Local #delta Z vs position", 
-       "GdelZ_vs_position","#delta z in cm", xp, yp, size);
+       "GdelZ_vs_position","#delta z in cm", xp.data(), yp.data(), size);
 
 // Dphi plot
    minV=99999999.; maxV=-minV;
@@ -243,7 +243,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delphi_vs_position", "#delta #phi vs position", 
-       "Gdelphi_vs_position","#delta #phi in radians", xp, yp, size);
+       "Gdelphi_vs_position","#delta #phi in radians", xp.data(), yp.data(), size);
 
 // Dr plot
    minV=99999999.; maxV=-minV;
@@ -256,7 +256,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delR_vs_position", "#delta R vs position", 
-       "GdelR_vs_position","#delta R in cm", xp, yp, size);
+       "GdelR_vs_position","#delta R in cm", xp.data(), yp.data(), size);
 
 // Drphi plot
    minV=99999999.; maxV=-minV;
@@ -270,7 +270,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delRphi_vs_position", "R #delta #phi vs position", 
-       "GdelRphi_vs_position","R #delta #phi in cm", xp, yp, size);
+       "GdelRphi_vs_position","R #delta #phi in cm", xp.data(), yp.data(), size);
 
 // Dalpha plot
    minV=99999999.; maxV=-minV;
@@ -283,7 +283,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delalpha_vs_position", "#delta #alpha vs position", 
-       "Gdelalpha_vs_position","#delta #alpha in rad", xp, yp, size);
+       "Gdelalpha_vs_position","#delta #alpha in rad", xp.data(), yp.data(), size);
 
 // Dbeta plot
    minV=99999999.; maxV=-minV;
@@ -296,7 +296,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delbeta_vs_position", "#delta #beta vs position", 
-       "Gdelbeta_vs_position","#delta #beta in rad", xp, yp, size);
+       "Gdelbeta_vs_position","#delta #beta in rad", xp.data(), yp.data(), size);
 
 // Dgamma plot
    minV=99999999.; maxV=-minV;
@@ -309,7 +309,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delgamma_vs_position", "#delta #gamma vs position", 
-       "Gdelgamma_vs_position","#delta #gamma in rad", xp, yp, size);
+       "Gdelgamma_vs_position","#delta #gamma in rad", xp.data(), yp.data(), size);
 
 // Drotx plot
    minV=99999999.; maxV=-minV;
@@ -322,7 +322,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delrotX_vs_position", "#delta rotX vs position", 
-       "GdelrotX_vs_position","#delta rotX in rad", xp, yp, size);
+       "GdelrotX_vs_position","#delta rotX in rad", xp.data(), yp.data(), size);
 
 // Droty plot
    minV=99999999.; maxV=-minV;
@@ -335,7 +335,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delrotY_vs_position", "#delta rotY vs position", 
-       "GdelrotY_vs_position","#delta rotY in rad", xp, yp, size);
+       "GdelrotY_vs_position","#delta rotY in rad", xp.data(), yp.data(), size);
 
 // Drotz plot
    minV=99999999.; maxV=-minV;
@@ -348,7 +348,7 @@ void MuonGeometryArrange::endHist(){
    
    makeGraph(sizeI, smi, sma, minV, maxV,
        dxh, grx, "delrotZ_vs_position", "#delta rotZ vs position", 
-       "GdelrotZ_vs_position","#delta rotZ in rad", xp, yp, size);
+       "GdelrotZ_vs_position","#delta rotZ in rad", xp.data(), yp.data(), size);
 
 
 
@@ -409,7 +409,6 @@ void MuonGeometryArrange::endHist(){
    _theFile->Write();   
    _theFile->Close();
 
-   delete [] yp;  delete [] xp;
 
 }
 //////////////////////////////////////////////////
@@ -417,7 +416,7 @@ void MuonGeometryArrange::makeGraph(int sizeI, float smi, float sma,
 	float minV, float maxV,
 	TH2F* dxh, TGraph* grx, const char* name, const char* title, 
 	const char* titleg, const char* axis,
-	float* xp, float* yp, int size){
+	const float* xp, const float* yp, int size){
 
   if(minV>=maxV || smi>=sma || sizeI<=1 || xp==0x0 || yp==0x0) return;
   	// out of bounds, bail

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
@@ -76,9 +76,10 @@ private:
 	void fillTree(Alignable *refAli, const AlgebraicVector& diff);
 	//void createDBGeometry(const edm::EventSetup& iSetup);
 	void createROOTGeometry(const edm::EventSetup& iSetup);
-	void makeGraph(int sizeI, float smi, float sma, float minV,
-	  float maxV, TH2F* dxh, TGraph* grx, const char* name, const char* title,
-	  const char* titleg, const char* axis, float* xp, float* yp, int numEntries);
+        void makeGraph(int sizeI, float smi, float sma, float minV,
+                       float maxV, TH2F* dxh, TGraph* grx, const char* name,
+                       const char* title, const char* titleg, const char* axis,
+                       const float* xp, const float* yp, int numEntries);
 	
 	bool passIdCut( uint32_t );
 	bool checkChosen( Alignable* ali );	// Is ali one of wanted CSC?

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -27,6 +27,7 @@ XERCES_CPP_NAMESPACE_USE
 // user include files
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h"
 #include "Alignment/CommonAlignment/interface/StructureType.h"
+#include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "Alignment/CommonAlignment/interface/SurveyDet.h"
@@ -536,12 +537,9 @@ Alignable *MuonAlignmentInputXML::getDTnode(align::StructureType structureType, 
       ali = ali->mother();
 
       if (ali == NULL) {
-	 if (structureType == align::AlignableDTBarrel) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTBarrel" << std::endl;
-	 else if (structureType == align::AlignableDTWheel) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTWheel" << std::endl;
-	 else if (structureType == align::AlignableDTStation) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTStation" << std::endl;
-	 else if (structureType == align::AlignableDTChamber) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTChamber" << std::endl;
-	 else if (structureType == align::AlignableDTSuperLayer) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTSuperLayer" << std::endl;
-	 else if (structureType == align::AlignableDetUnit) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a DTLayer" << std::endl;
+        throw cms::Exception("XMLException")
+          << "rawId \"" << rawId << "\" is not a "
+          << AlignableObjectId::idToString(structureType) << std::endl;
       }
    }
    return ali;

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -627,11 +627,9 @@ Alignable *MuonAlignmentInputXML::getCSCnode(align::StructureType structureType,
       ali = ali->mother();
 
       if (ali == NULL) {
-	 if (structureType == align::AlignableCSCEndcap) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a CSCEndcap" << std::endl;
-	 else if (structureType == align::AlignableCSCStation) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a CSCStation" << std::endl;
-	 else if (structureType == align::AlignableCSCRing) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a CSCRing" << std::endl;
-	 else if (structureType == align::AlignableCSCChamber) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a CSCChamber" << std::endl;
-	 else if (structureType == align::AlignableDetUnit) throw cms::Exception("XMLException") << "rawId \"" << rawId << "\" is not a CSCLayer" << std::endl;
+        throw cms::Exception("XMLException")
+          << "rawId \"" << rawId << "\" is not a "
+          << AlignableObjectId::idToString(structureType) << std::endl;
       }
    }
    return ali;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
@@ -254,7 +254,9 @@
 	    //int   ndof = track->ndof();
 	    int   nhit  = track->numberOfValidHits();
 
-	    if (0) edm::LogInfo("Alignment") << "New track pt,eta,phi,chi2n,hits: " << pt <<","<< eta <<","<< phi <<","<< chi2n << ","<<nhit;
+	    LogDebug("Alignment")
+	      << "New track pt,eta,phi,chi2n,hits: "
+	      << pt << "," << eta << "," << phi << "," << chi2n << "," << nhit;
 
 	    //Accept or not accept the track
 	    if( pt > ptCut && chi2n < chi2nCut ) 

--- a/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
@@ -199,13 +199,6 @@ EopTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
      trackAssociator_.useDefaultPropagator();
      TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, trackAssociator_.getFreeTrajectoryState(iSetup, *track), parameters_);
-
-     trackemc1 = 0;
-     trackemc3 = 0;
-     trackemc5 = 0;
-     trackhac1 = 0;
-     trackhac3 = 0;
-     trackhac5 = 0;
      
      trackemc1 = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 0);
      trackemc3 = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
@@ -119,73 +119,73 @@ void SurveyDataConverter::applyAPEs( TrackerAlignment& tr_align ) {
     return;
   }
          
-  AlignableModifier* theModifier = new AlignableModifier();
+  AlignableModifier theModifier{};
   AlignableTracker* theAlignableTracker = tr_align.getAlignableTracker() ; 
   align::Alignables::const_iterator iter;
 
   // TIB
   const align::Alignables& theTIBhb = theAlignableTracker->innerHalfBarrels();
   for (iter = theTIBhb.begin(); iter != theTIBhb.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIBerrors.at(0), 
-                                                   TIBerrors.at(0), TIBerrors.at(0) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(0),
+                                                  TIBerrors.at(0), TIBerrors.at(0) ); }
   const align::Alignables& theTIBlayers = theAlignableTracker->innerBarrelLayers();
   for (iter = theTIBlayers.begin(); iter != theTIBlayers.end(); ++iter)
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIBerrors.at(1), 
-                                                   TIBerrors.at(1), TIBerrors.at(1) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(1),
+                                                  TIBerrors.at(1), TIBerrors.at(1) ); }
   const align::Alignables& theTIBgd = theAlignableTracker->innerBarrelGeomDets();
   for (iter = theTIBgd.begin(); iter != theTIBgd.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIBerrors.at(2), 
-                                                   TIBerrors.at(2), TIBerrors.at(2) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(2),
+                                                  TIBerrors.at(2), TIBerrors.at(2) ); }
 
   // TOB
   const align::Alignables& theTOBhb = theAlignableTracker->outerHalfBarrels();
   for (iter = theTOBhb.begin(); iter != theTOBhb.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TOBerrors.at(0), 
-                                                   TOBerrors.at(0), TOBerrors.at(1) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(0),
+                                                  TOBerrors.at(0), TOBerrors.at(1) ); }
   const align::Alignables& theTOBrods = theAlignableTracker->outerBarrelRods();
   for (iter = theTOBrods.begin(); iter != theTOBrods.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TOBerrors.at(2), 
-                                                   TOBerrors.at(2), TOBerrors.at(2) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(2),
+                                                  TOBerrors.at(2), TOBerrors.at(2) ); }
   const align::Alignables& theTOBgd = theAlignableTracker->outerBarrelGeomDets();
   for (iter = theTOBgd.begin(); iter != theTOBgd.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TOBerrors.at(3), 
-                                                   TOBerrors.at(3), TOBerrors.at(3) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(3),
+                                                  TOBerrors.at(3), TOBerrors.at(3) ); }
 
   // TID
   const align::Alignables& theTIDs = theAlignableTracker->TIDs();
   for (iter = theTIDs.begin(); iter != theTIDs.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIDerrors.at(0), 
-                                                   TIDerrors.at(0), TIDerrors.at(0) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(0),
+                                                  TIDerrors.at(0), TIDerrors.at(0) ); }
   const align::Alignables& theTIDdiscs = theAlignableTracker->TIDLayers();
   for (iter = theTIDdiscs.begin(); iter != theTIDdiscs.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIDerrors.at(1), 
-                                                   TIDerrors.at(1), TIDerrors.at(1) ); }
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(1),
+                                                  TIDerrors.at(1), TIDerrors.at(1) ); }
   const align::Alignables& theTIDrings = theAlignableTracker->TIDRings();
   for (iter = theTIDrings.begin(); iter != theTIDrings.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIDerrors.at(2), 
-                                                   TIDerrors.at(2), TIDerrors.at(2) ); } 
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(2),
+                                                  TIDerrors.at(2), TIDerrors.at(2) ); } 
   const align::Alignables& theTIDgd = theAlignableTracker->TIDGeomDets();
   for (iter = theTIDgd.begin(); iter != theTIDgd.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TIDerrors.at(3), 
-                                                   TIDerrors.at(3), TIDerrors.at(3) ); } 
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(3),
+                                                  TIDerrors.at(3), TIDerrors.at(3) ); } 
 
   // TEC
   const align::Alignables& theTECs = theAlignableTracker->endCaps();
   for (iter = theTECs.begin(); iter != theTECs.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TECerrors.at(0), 
-                                                   TECerrors.at(0), TECerrors.at(0) ); } 
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(0),
+                                                  TECerrors.at(0), TECerrors.at(0) ); } 
   const align::Alignables& theTECdiscs = theAlignableTracker->endcapLayers();
   for (iter = theTECdiscs.begin(); iter != theTECdiscs.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TECerrors.at(1), 
-                                                   TECerrors.at(1), TECerrors.at(1) ); } 
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(1),
+                                                  TECerrors.at(1), TECerrors.at(1) ); } 
   const align::Alignables& theTECpetals = theAlignableTracker->endcapPetals();
   for (iter = theTECpetals.begin(); iter != theTECpetals.end(); ++iter ) 
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TECerrors.at(2), 
-                                                   TECerrors.at(2), TECerrors.at(2) ); }   
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(2),
+                                                  TECerrors.at(2), TECerrors.at(2) ); }   
   const align::Alignables& theTECgd = theAlignableTracker->endcapGeomDets();
   for (iter = theTECgd.begin(); iter != theTECgd.end(); ++iter )
-    { theModifier->addAlignmentPositionErrorLocal( *iter, TECerrors.at(3), 
-                                                   TECerrors.at(3), TECerrors.at(3) ); }   
+    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(3),
+                                                  TECerrors.at(3), TECerrors.at(3) ); }   
 }
 
 DEFINE_FWK_MODULE(SurveyDataConverter);

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -426,13 +426,8 @@ void TrackerGeometryAnalyzer
     << "   max. number of ladders per layer:  " << pxbLadderIDs.size() << "\n"
     << "   max. number of layers  in PXB:     " << pxbLayerIDs.size();
 
-  int numPXBModules[pxbLayerIDs.size()][pxbLadderIDs.size()];
-
-  for (unsigned int i = 0; i < pxbLayerIDs.size(); ++i) {
-    for (unsigned int j = 0; j < pxbLadderIDs.size(); ++j) {
-      numPXBModules[i][j] = 0;
-    }
-  }
+  std::vector<std::vector<int> >
+    numPXBModules(pxbLayerIDs.size(), std::vector<int>(pxbLadderIDs.size(), 0));
 
   for (auto& det : trackerGeometry->dets()) {
     auto detId = det->geographicalId();
@@ -504,17 +499,15 @@ void TrackerGeometryAnalyzer
     << "   max. number of disks   per side:  " << pxeDiskIDs.size()   << "\n"
     << "   max. number of sides in PXE:      " << pxeSideIDs.size();
 
-  int numAlignablesPXE[pxeSideIDs.size()][pxeDiskIDs.size()][pxeBladeIDs.size()][pxePanelIDs.size()];
-
-  for (unsigned int i = 0; i < pxeSideIDs.size(); ++i) {
-    for (unsigned int j = 0; j < pxeDiskIDs.size(); ++j) {
-      for (unsigned int k = 0; k < pxeBladeIDs.size(); ++k) {
-        for (unsigned int l = 0; l < pxePanelIDs.size(); ++l) {
-          numAlignablesPXE[i][j][k][l] = 0;
-        }
-      }
-    }
-  }
+  std::vector<std::vector<std::vector<std::vector<int> > > >
+    numAlignablesPXE
+    (pxeSideIDs.size(), std::vector<std::vector<std::vector<int> > >
+     (pxeDiskIDs.size(), std::vector<std::vector<int> >
+      (pxeBladeIDs.size(), std::vector<int>
+       (pxePanelIDs.size(), 0)  // initialize everything with 0
+       )
+      )
+     );
 
   for (auto& det : trackerGeometry->dets()) {
     auto detId = det->geographicalId();


### PR DESCRIPTION
Fixes warnings detected by

```
scram build -f compile COMPILER=llvm-analyzer SCRAM_IGNORE_MISSING_COMPILERS=yes
```

Not all warnings are fixed in this PR because they are either false alarms or require quite some redesign as , e.g., in the Cocoa-related packages.
