### PR TITLE
[81X] update phase-I geometry in all autoCond keys

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,11 +36,11 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v10',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v11',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v12',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v13',
     # Global Tag for MC production with development HCAL conditions for Phase1 2017 detector
-    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v1',
+    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v13) as [81X_upgrade2017_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v13/81X_upgrade2017_realistic_v12): 
  - updated version of geometry tags (`81YV7`) for phase-I; see [AlCa HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2628.html)
- **PhaseI design scenario** : [81X_upgrade2017_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v11) as [81X_upgrade2017_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v11/81X_upgrade2017_design_v10): 
  - updated version of geometry tags (`81YV7`) for phase-I; see [AlCa HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2628.html)
- **PhaseI HcalDev scenario** : [81X_upgrade2017_HCALdev_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_v2) as [81X_upgrade2017_HCALdev_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_HCALdev_v2/81X_upgrade2017_HCALdev_v1): 
  - updated version of geometry tags (`81YV8`) for phase-I; see [AlCa HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2627.html)
