### PR TITLE
Fix how the hf paramters are set when depth is extended to 4

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalSimParameterMap.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSimParameterMap.cc
@@ -86,7 +86,7 @@ const CaloSimParameters & HcalSimParameterMap::simParameters(const DetId & detId
        return theHOParameters;
      }
   } else { // HF
-    if(hcalDetId.depth() == 1) {
+    if(hcalDetId.depth() == 1 || hcalDetId.depth() == 3) {
       return theHFParameters1;
     } else {
       return theHFParameters2;


### PR DESCRIPTION
Before fixing, all depths other than 1 is set to use theHFParameters2 which is supposed to be used for short fiber. This is incorrect for depth 3 which is long fiber but one of the dual anode readout.
