### PR TITLE
Phase I Pixel Barrel cooling pipe and coolant density

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml
@@ -27,6 +27,8 @@
   <Numeric name="Cool2Offset"         value="[pixbarlayer0:Cool2Offset]"/>
   <String name="CoolMaterial"      value="materials:Bpix_CO2_-20C"/>
   <String name="CoolTubeMaterial"  value="materials:Bpix_Pipe_Steel"/>
+  <String name="CoolMaterialHalf"      value="pixbarmaterial:Bpix_CO2_-20C_Half"/>
+  <String name="CoolTubeMaterialHalf"  value="pixbarmaterial:Bpix_Pipe_Steel_Half"/>
   <String name="LadderName"        value="pixbarladderfull0:PixelBarrelLadderFull0"/> 
   <Numeric name="LadderWidth"      value="[pixbarladderfull0:LadderWidth]"/>
   <Numeric name="LadderThick"      value="[pixbarladderfull0:LadderThick]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml
@@ -27,6 +27,8 @@
   <Numeric name="Cool2Offset"         value="[pixbarlayer1:Cool2Offset]"/>
   <String name="CoolMaterial"      value="materials:Bpix_CO2_-20C"/>
   <String name="CoolTubeMaterial"  value="materials:Bpix_Pipe_Steel"/>
+  <String name="CoolMaterialHalf"      value="pixbarmaterial:Bpix_CO2_-20C_Half"/>
+  <String name="CoolTubeMaterialHalf"  value="pixbarmaterial:Bpix_Pipe_Steel_Half"/>
   <String name="LadderName"        value="pixbarladderfull1:PixelBarrelLadderFull1"/>
   <Numeric name="LadderWidth"      value="[pixbarladderfull1:LadderWidth]"/>
   <Numeric name="LadderThick"      value="[pixbarladderfull1:LadderThick]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml
@@ -27,6 +27,8 @@
   <Numeric name="Cool2Offset"         value="[pixbarlayer2:Cool2Offset]"/>
   <String name="CoolMaterial"      value="materials:Bpix_CO2_-20C"/>
   <String name="CoolTubeMaterial"  value="materials:Bpix_Pipe_Steel"/>
+  <String name="CoolMaterialHalf"      value="pixbarmaterial:Bpix_CO2_-20C_Half"/>
+  <String name="CoolTubeMaterialHalf"  value="pixbarmaterial:Bpix_Pipe_Steel_Half"/>
   <String name="LadderName"        value="pixbarladderfull2:PixelBarrelLadderFull2"/>
   <Numeric name="LadderWidth"      value="[pixbarladderfull2:LadderWidth]"/>
   <Numeric name="LadderThick"      value="[pixbarladderfull2:LadderThick]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml
@@ -27,6 +27,8 @@
   <Numeric name="Cool2Offset"         value="[pixbarlayer3:Cool2Offset]"/>
   <String name="CoolMaterial"      value="materials:Bpix_CO2_-20C"/>
   <String name="CoolTubeMaterial"  value="materials:Bpix_Pipe_Steel"/>
+  <String name="CoolMaterialHalf"      value="pixbarmaterial:Bpix_CO2_-20C_Half"/>
+  <String name="CoolTubeMaterialHalf"  value="pixbarmaterial:Bpix_Pipe_Steel_Half"/>
   <String name="LadderName"        value="pixbarladderfull3:PixelBarrelLadderFull3"/>
   <Numeric name="LadderWidth"      value="[pixbarladderfull3:LadderWidth]"/>
   <Numeric name="LadderThick"      value="[pixbarladderfull3:LadderThick]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -316,6 +316,18 @@
       <rMaterial name="trackermaterial:T_Aluminium"/>
     </MaterialFraction>
   </CompositeMaterial>
+  
+  <CompositeMaterial name="Bpix_CO2_-20C_Half" density="2.0654*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="materials:Bpix_CO2_-20C"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Bpix_Pipe_Steel_Half" density="16.04*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="materials:Bpix_Pipe_Steel"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 
   <CompositeMaterial name="Pix_Bar_Cable" density="1.67629*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.43796">

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -43,6 +43,8 @@ void DDPixBarLayerUpgradeAlgo::initialize(const DDNumericArguments & nArgs,
   cool2Offset = nArgs["Cool2Offset"];
   coolMat   = sArgs["CoolMaterial"];
   tubeMat   = sArgs["CoolTubeMaterial"];
+  coolMatHalf   = sArgs["CoolMaterialHalf"];
+  tubeMatHalf   = sArgs["CoolTubeMaterialHalf"];
   phiFineTune = nArgs["PitchFineTune"];
   rOuterFineTune = nArgs["OuterOffsetFineTune"];
   rInnerFineTune = nArgs["InnerOffsetFineTune"];
@@ -104,10 +106,10 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
   solid = DDSolidFactory::tubs(DDName(name,idNameSpace), 0.5*coolDz,
 			       0, coolRadius, 0, CLHEP::pi);
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " <<solid.name() 
-			<< " Tubs made of " << tubeMat << " from 0 to " <<
+			<< " Tubs made of " << tubeMatHalf << " from 0 to " <<
 			CLHEP::twopi/CLHEP::deg << " with Rout " << coolRadius <<
 			" ZHalf " << 0.5*coolDz;		
-  matter = DDMaterial(DDName(DDSplit(tubeMat).first, DDSplit(tubeMat).second));
+  matter = DDMaterial(DDName(DDSplit(tubeMatHalf).first, DDSplit(tubeMatHalf).second));
   DDLogicalPart coolTubeHalf(solid.ddname(), matter, solid);
   
   // Full Coolant
@@ -130,10 +132,10 @@ void DDPixBarLayerUpgradeAlgo::execute(DDCompactView& cpv) {
   solid = DDSolidFactory::tubs(DDName(name,idNameSpace), 0.5*coolDz,
 			       0, coolRadius-coolThick, 0, CLHEP::pi);
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " <<solid.name() 
-			<< " Tubs made of " << tubeMat << " from 0 to " <<
+			<< " Tubs made of " << tubeMatHalf << " from 0 to " <<
 			CLHEP::twopi/CLHEP::deg << " with Rout " << coolRadius-coolThick <<
 			" ZHalf " << 0.5*coolDz;		
-  matter = DDMaterial(DDName(DDSplit(coolMat).first, DDSplit(coolMat).second));
+  matter = DDMaterial(DDName(DDSplit(coolMatHalf).first, DDSplit(coolMatHalf).second));
   DDLogicalPart coolHalf(solid.ddname(), matter, solid);
   cpv.position (coolHalf, coolTubeHalf, 1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
   LogDebug("PixelGeom") << "DDPixBarLayerUpgradeAlgo test: " << cool.name() 

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
@@ -35,6 +35,8 @@ private:
   double                   cool2Offset;    //cooling pipe 2 offset for ladder at interface
   std::string              coolMat;     //Cooling fluid material name
   std::string              tubeMat;     //Cooling piece material name
+  std::string              coolMatHalf; //Cooling fluid material name
+  std::string              tubeMatHalf; //Cooling piece material name
   std::string              ladder;      //Name  of ladder
   double                   ladderWidth; //Width of ladder 
   double                   ladderThick; //Thicknes of ladder 


### PR DESCRIPTION
This PR contains a small correction not included in PR #15883 , recently merged.
The changes affect the density of the cooling fluid and pipes for the Pixel Barrel ladder cooling.
As in the other PR, @veszpv and @schneiml may want to comment and be informed of the developments.
