### PR TITLE
Various improvements for O2O jobs management

### DIFF
--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -146,7 +146,7 @@ namespace cond {
       std::string dummy;
       if(!m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, m_data->synchronizationType,
 						    m_data->endOfValidity, dummy, m_data->lastValidatedTime ) ){
-	throwException( "Tag \""+tag+"\" has not been found in the database.","IOVProxy::load");
+	throwException( "Tag \""+tag+"\" has not been found in the database "+m_session->connectionString,"IOVProxy::load");
       }
       m_data->tag = tag;
 

--- a/CondCore/Utilities/python/credentials.py
+++ b/CondCore/Utilities/python/credentials.py
@@ -1,0 +1,14 @@
+import netrc
+import os
+
+def get_credentials_from_file( service, authFile=None ):
+    creds = netrc.netrc( authFile ).authenticators(service)
+    return creds
+
+def get_credentials( authPathEnvVar, service, authFile=None ):
+    if authFile is None:
+        if authPathEnvVar in os.environ:
+            authPath = os.environ[authPathEnvVar]
+            authFile = os.path.join(authPath,'.netrc')
+    return get_credentials_from_file( service, authFile )
+

--- a/CondCore/Utilities/python/o2o.py
+++ b/CondCore/Utilities/python/o2o.py
@@ -6,16 +6,19 @@ import subprocess
 from datetime import datetime
 import os
 import sys
-import netrc
 import logging
+import string
+
+import CondCore.Utilities.credentials as auth
 
 prod_db_service = ['cms_orcon_prod','o2o_prod']
 dev_db_service = ['cms_orcoff_prep','o2o_dev']
 schema_name = 'CMS_CONDITIONS'
-oracle_tpl = 'oracle://%s:%s@%s'
+sqlalchemy_tpl = 'oracle://%s:%s@%s'
+coral_tpl = 'oracle://%s/%s'
 private_db = 'sqlite:///o2o_jobs.db'
 startStatus = -1
-authPathEnvVar = 'O2O_AUTH_PATH'
+authPathEnvVar = 'COND_AUTH_PATH'
 messageLevelEnvVar = 'O2O_LOG_LEVEL'
 logFolderEnvVar = 'O2O_LOG_FOLDER'
 
@@ -47,13 +50,7 @@ class O2ORun(_Base):
     log                = sqlalchemy.Column(sqlalchemy.CLOB,           nullable=True)
 
 def get_db_credentials( db_service, authFile ):
-    pwd = None
-    if authFile is None:
-       if authPathEnvVar in os.environ:
-            authPath = os.environ[authPathEnvVar]
-            authFile = os.path.join(authPath,'.netrc')
-            logging.debug('Retrieving credentials from file %s' %authFile )
-    (username, account, pwd) = netrc.netrc( authFile ).authenticators(db_service[1])
+    (username, account, pwd) = auth.get_credentials( authPathEnvVar, db_service[1], authFile )
     return username,pwd
 
 
@@ -82,9 +79,9 @@ class O2OMgr(object):
                 username = None
                 pwd = None
             if username is None:
-                logging.error('Credentials for service %s are not available',db_service[0])
+                logging.error('Credentials for service %s (machine=%s) are not available' %(db_service[0],db_service[1]))
                 return None
-            url = oracle_tpl %(username,pwd,db_service[0])
+            url = sqlalchemy_tpl %(username,pwd,db_service[0])
         session = None
         try:
             self.eng = sqlalchemy.create_engine( url )
@@ -137,6 +134,8 @@ class O2ORunMgr(O2OMgr):
         self.job_name = None
         self.start = None
         self.end = None
+        self.tag_name = None
+        self.db_connection = None
 
     def log( self, level, message ):
         consoleLog = getattr(O2OMgr.logger( self ),level)
@@ -151,6 +150,7 @@ class O2ORunMgr(O2OMgr):
         if self.session is None:
             return False
         else:
+            self.db_connection = coral_tpl %(service[0],schema_name)
             return True
 
     def startJob( self, job_name ):
@@ -158,10 +158,11 @@ class O2ORunMgr(O2OMgr):
         exists = None
         enabled = None
         try:
-            res = self.session.query(O2OJob.enabled).filter_by(name=job_name)
+            res = self.session.query(O2OJob.enabled,O2OJob.tag_name).filter_by(name=job_name)
             for r in res:
                 exists = True
                 enabled = int(r[0])
+                self.tag_name = str(r[1]) 
             if exists is None:
                 exists = False
                 enabled = False
@@ -187,7 +188,9 @@ class O2ORunMgr(O2OMgr):
         except sqlalchemy.exc.SQLAlchemyError as dberror:
             O2OMgr.logger( self ).error( str(dberror) )
 
-    def executeJob( self, job_name, command ):
+    def executeJob( self, args ):
+        job_name = args.name
+        command = args.executable
         logFolder = os.getcwd()
         if logFolderEnvVar in os.environ:
             logFolder = os.environ[logFolderEnvVar]
@@ -197,13 +200,22 @@ class O2ORunMgr(O2OMgr):
         exists, enabled = self.startJob( job_name )
         if exists is None:
             return 3
-        if enabled is None:
+        if not exists:
             O2OMgr.logger( self).error( 'The job %s is unknown.', job_name )
             return 2
         else:
             if enabled == 0:
                 O2OMgr.logger( self).info( 'The job %s has been disabled.', job_name )
                 return 5
+        if args.inputFromDb:
+            try:
+                O2OMgr.logger( self ).info('Setting db input parameters...') 
+                input_params = {'db':self.db_connection,'tag':self.tag_name }
+                commandTpl = string.Template( command )
+                command = commandTpl.substitute( input_params )
+            except KeyError as exc:
+                O2OMgr.logger( self).error( str(exc)+': Unknown template key in the command.' )
+        O2OMgr.logger( self ).info('O2O Command: "%s"', command )
         try:
             O2OMgr.logger( self ).info('Executing job %s', job_name )
             pipe = subprocess.Popen( command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )

--- a/CondCore/Utilities/python/popcon2dropbox.py
+++ b/CondCore/Utilities/python/popcon2dropbox.py
@@ -14,6 +14,7 @@ errorInUploadFileFolder = 'upload_errors'
 dateformatForFolder = "%y-%m-%d-%H-%M-%S"
 dateformatForLabel = "%y-%m-%d %H:%M:%S"
 
+"""
 import upload_popcon
 
 class CondMetaData(object):
@@ -62,66 +63,26 @@ class CondMetaData(object):
       with open( '%s.txt' %fileNameForDropBox, 'wb') as jf:
          jf.write( json.dumps( uploadMd, sort_keys=True, indent = 2 ) )
          jf.write('\n')
+def dumpMetadataForUpload( destDb, destTag, comment ):
+    uploadMd = {}
+    uploadMd['destinationDatabase'] = destDb
+    tags = {}
+    tagInfo = {}
+    tags[ destTag ] = tagInfo
+    uploadMd['destinationTags'] = tags
+    uploadMd['inputTag'] = destTag
+    uploadMd['since'] = None
+    datef = datetime.now() 
+    #datelabel = datef.strftime(dateformatForLabel)
+    uploadMd['userText'] = '%s : %s' %(datelabel,comment)
+    with open( '%s.txt' %fileNameForDropBox, 'wb') as jf:
+       jf.write( json.dumps( uploadMd, sort_keys=True, indent = 2 ) )
+       jf.write('\n')
+"""
    
-def runO2O( cmsswdir, releasepath, release, arch, jobfilename, logfilename, *p ):
-    # first remove any existing metadata file...
-    if os.path.exists( '%s.db' %fileNameForDropBox ):
-       print "Removing files with name %s" %fileNameForDropBox
-       os.remove( '%s.db' %fileNameForDropBox )
-    if os.path.exists( '%s.txt' %fileNameForDropBox ):
-       os.remove( '%s.txt' %fileNameForDropBox )
-    command = 'export SCRAM_ARCH=%s;' %arch
-    command += 'CMSSWDIR=%s;' %cmsswdir
-    command += 'source ${CMSSWDIR}/cmsset_default.sh;'
-    command += 'cd %s/%s/src;' %(releasepath,release)
-    command += 'eval `scramv1 runtime -sh`;'
-    command += 'cd -;'
-    command += 'pwd;'
-    command += 'cmsRun %s ' %jobfilename
-    command += ' '.join(p)
-    command += ' 2>&1'
-    pipe = subprocess.Popen( command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
-    stdout_val = pipe.communicate()[0]
-    return stdout_val
-
-def upload_to_dropbox( backend ):
-
-    md = CondMetaData(confFileName) 
-    # check if the expected input file is there...
-    if not os.path.exists( dbFileForDropBox ):
-       print 'The input sqlite file has not been produced.'
-       return False
-    # first remove any existing metadata file...
-    if os.path.exists( '%s.txt' %fileNameForDropBox ):
-       os.remove( '%s.txt' %fileNameForDropBox )
-    try:
-       dropBox = upload_popcon.ConditionsUploader(upload_popcon.defaultHostname, upload_popcon.defaultUrlTemplate)
-       # Try to find the netrc entry
-       try:
-          (username, account, password) = netrc.netrc().authenticators(upload_popcon.defaultNetrcHost)
-       except Exception:
-          print 'Netrc entry "%s" not found.' %upload_popcon.defaultNetrcHost
-          return False
-       dropBox.signIn(username, password)
-       ret = True
-       for k,v in  md.records().items():
-          destTag = v.get("destinationTag")
-          inputTag = v.get("sqliteTag")
-          if inputTag == None:
-             inputTag = destTag
-          comment = v.get("comment")
-          metadata = md.dumpMetadataForUpload( inputTag, destTag, comment )
-          ret &= dropBox.uploadFile(dbFileForDropBox, backend, upload_popcon.defaultTemporaryFile)
-       dropBox.signOut()
-       if ret:
-          print 'File %s successfully uploaded.' %dbFileForDropBox
-       return ret
-    except upload_popcon.HTTPError as e:
-       print e
-       return False
-
-def upload( cfileName, authPath ):
-    md = CondMetaData(cfileName)
+def upload( destDb, destTag, comment, authPath ):
+    #md = CondMetaData(cfileName)
+    datef = datetime.now()
 
     # check if the expected input file is there...                                                                                                                              
     if not os.path.exists( dbFileForDropBox ):
@@ -148,52 +109,62 @@ def upload( cfileName, authPath ):
     if os.path.exists( '%s.txt' %fileNameForDropBox ):
        os.remove( '%s.txt' %fileNameForDropBox )
     
-    # loop over the records to process...
     ret = 0
-    for k,v in  md.records().items():
-       destTag = v.get("destinationTag")
-       inputTag = v.get("sqliteTag")
-       if inputTag == None:
-          inputTag = destTag
-       comment = v.get("comment")
-       metadata = md.dumpMetadataForUpload( inputTag, destTag, comment )
-       uploadCommand = 'uploadConditions.py %s' %fileNameForDropBox
-       if not authPath is None:
-          uploadCommand += ' -a %s' %authPath
-       try:
-          pipe = subprocess.Popen( uploadCommand, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
-          stdout = pipe.communicate()[0]
-          print stdout
-          retCode = pipe.returncode
-          if retCode != 0:
-             # save a copy of the files in case of upload failure...
-             leafFolderName = md.datef.strftime(dateformatForFolder)
-             fileFolder = os.path.join( errorInUploadFileFolder, leafFolderName)
-             if not os.path.exists(fileFolder):
-                os.makedirs(fileFolder)
-             df= '%s.db' %fileNameForDropBox
-             mf= '%s.txt' %fileNameForDropBox
-             dataDestFile = os.path.join( fileFolder, df)
-             if not os.path.exists(dataDestFile):
-                shutil.copy2(df, dataDestFile)
-             shutil.copy2(mf,os.path.join(fileFolder,mf))
-             print "Upload failed. Data file and metadata saved in folder '%s'" %os.path.abspath(fileFolder)
-          ret |= retCode
-       except Exception as e:
-          ret |= 1
-          print e
+    # dump Metadata for the Upload
+    uploadMd = {}
+    uploadMd['destinationDatabase'] = destDb
+    tags = {}
+    tagInfo = {}
+    tags[ destTag ] = tagInfo
+    uploadMd['destinationTags'] = tags
+    uploadMd['inputTag'] = destTag
+    uploadMd['since'] = None
+    datelabel = datef.strftime(dateformatForLabel)
+    commentStr = ''
+    if not comment is None:
+       commentStr = comment
+    uploadMd['userText'] = '%s : %s' %(datelabel,commentStr)
+    with open( '%s.txt' %fileNameForDropBox, 'wb') as jf:
+       jf.write( json.dumps( uploadMd, sort_keys=True, indent = 2 ) )
+       jf.write('\n')
+
+    # run the upload
+    uploadCommand = 'uploadConditions.py %s' %fileNameForDropBox
+    if not authPath is None:
+       uploadCommand += ' -a %s' %authPath
+    try:
+       pipe = subprocess.Popen( uploadCommand, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
+       stdout = pipe.communicate()[0]
+       print stdout
+       retCode = pipe.returncode
+       if retCode != 0:
+          # save a copy of the files in case of upload failure...
+          leafFolderName = datef.strftime(dateformatForFolder)
+          fileFolder = os.path.join( errorInUploadFileFolder, leafFolderName)
+          if not os.path.exists(fileFolder):
+             os.makedirs(fileFolder)
+          df= '%s.db' %fileNameForDropBox
+          mf= '%s.txt' %fileNameForDropBox
+          dataDestFile = os.path.join( fileFolder, df)
+          if not os.path.exists(dataDestFile):
+             shutil.copy2(df, dataDestFile)
+          shutil.copy2(mf,os.path.join(fileFolder,mf))
+          print "Upload failed. Data file and metadata saved in folder '%s'" %os.path.abspath(fileFolder)
+       ret |= retCode
+    except Exception as e:
+       ret |= 1
+       print e
     return ret
 
-def run( jobfilename, authPath ):
-    fns = os.path.splitext( jobfilename )
-    confFile = '%s.json' %fns[0]
+def run( args ):
     if os.path.exists( '%s.db' %fileNameForDropBox ):
        print "Removing files with name %s" %fileNameForDropBox
        os.remove( '%s.db' %fileNameForDropBox )
     if os.path.exists( '%s.txt' %fileNameForDropBox ):
        os.remove( '%s.txt' %fileNameForDropBox )
-    command = 'cmsRun %s ' %jobfilename
-    command += ' popconConfigFileName=%s' %confFile
+    command = 'cmsRun %s ' %args.job_file
+    command += ' destinationDatabase=%s' %args.destDb
+    command += ' destinationTag=%s' %args.destTag
     command += ' 2>&1'
     pipe = subprocess.Popen( command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
     stdout = pipe.communicate()[0]
@@ -203,4 +174,4 @@ def run( jobfilename, authPath ):
     if retCode!=0:
        print 'O2O job failed. Skipping upload.'
        return retCode
-    return upload( confFile, authPath )
+    return upload( args.destDb, args.destTag, args.comment, args.auth )

--- a/CondCore/Utilities/scripts/o2oRun.py
+++ b/CondCore/Utilities/scripts/o2oRun.py
@@ -14,8 +14,8 @@ def main( argv ):
     parser = argparse.ArgumentParser()
     parser.add_argument("executable", type=str, help="wrapper for O2O jobs")
     parser.add_argument("-n","--name", type=str, help="the O2O job name" )
+    parser.add_argument("-i","--inputFromDb", action="store_true", help="get input params from the db ( labels: '$db' for the database connection string; '$tag' for the destination tag name")
     parser.add_argument("-d","--dev", action="store_true", help="bookkeeping in dev database")
-    parser.add_argument("-p","--private", action="store_true", help="bookkeeping in private database")
     parser.add_argument("-a","--auth", type=str,  help="path of the authentication file")
     parser.add_argument("-v","--verbose", action="store_true", help="job output mirrored to screen (default=logfile only)")
     args = parser.parse_args()  
@@ -23,18 +23,13 @@ def main( argv ):
     if not args.name:
         parser.error("Job name not given.")
 
-    command = args.executable
-
-    db_service = None
-    if not args.private:
-        if args.dev:
-            db_service = o2olib.dev_db_service
-        else:
-            db_service = o2olib.prod_db_service
+    db_service = o2olib.prod_db_service
+    if args.dev:
+        db_service = o2olib.dev_db_service
     runMgr = o2olib.O2ORunMgr()
     ret = -1
     if runMgr.connect( db_service, args ):
-        ret = runMgr.executeJob( args.name, command )
+        ret = runMgr.executeJob( args )
     return ret
 
 if __name__ == '__main__':

--- a/CondCore/Utilities/scripts/o2oSetup.py
+++ b/CondCore/Utilities/scripts/o2oSetup.py
@@ -20,19 +20,15 @@ def main( argv ):
     parser.add_argument("-t","--tag", type=str, help="the CondDB Tag name")
     parser.add_argument("-i","--interval", type=str, help="the chron job interval")
     parser.add_argument("-d","--dev", action="store_true", help="bookkeeping in dev database")
-    parser.add_argument("-p","--private", action="store_true", help="bookkeeping in private database")
     parser.add_argument("-a","--auth", type=str,  help="path of the authentication file")
     args = parser.parse_args()  
 
     if not args.create and not args.enable and not args.disable:
         parser.error("Command not given. Possible choices: create, enable, disable")
 
-    db_service = None
-    if not args.private:
-        if args.dev:
-            db_service = o2olib.dev_db_service
-        else:
-            db_service = o2olib.prod_db_service
+    db_service = o2olib.prod_db_service
+    if args.dev:
+        db_service = o2olib.dev_db_service
     mgr = o2olib.O2OJobMgr()
     ret = -1
     if mgr.connect( db_service, args.auth ):

--- a/CondCore/Utilities/scripts/popconRun
+++ b/CondCore/Utilities/scripts/popconRun
@@ -12,7 +12,10 @@ def main( argv ):
 
     parser = argparse.ArgumentParser()
     parser.add_argument("job_file", type=str, help="wrapper for popcon jobs")
+    parser.add_argument("-d","--destDb", type=str, help="destination database")
+    parser.add_argument("-t","--destTag", type=str, help="destination database")
     parser.add_argument("-a","--auth", type=str,  help="authentication path (for conddb key and .netrc files)")
+    parser.add_argument("-x","--comment", type=str, help="user comment for the upload")
     args = parser.parse_args()  
 
     if args.job_file is None:
@@ -21,13 +24,21 @@ def main( argv ):
     if not os.path.exists( args.job_file ):
         print 'ERROR: the specified cfg file %s has not been found in the execution directory' %args.job_file
         return -2
-    fns = os.path.splitext( args.job_file )
-    confFile = '%s.json' %fns[0]
-    if not os.path.exists( confFile ):
-        print 'ERROR: the metadata file %s has not been found in the execution directory' %confFile
-        return -3
+    if args.destDb is None:
+        print 'ERROR: the destination database has not been provided.'
+        return -1        
+    if args.destTag is None:
+        print 'ERROR: the destination tag has not been provided.'
+        return -1        
     
-    return popcon2dropbox.run( args.job_file, args.auth )
+    #fns = os.path.splitext( args.job_file )
+    #confFile = '%s.json' %fns[0]
+    #if not os.path.exists( confFile ):
+    #    print 'ERROR: the metadata file %s has not been found in the execution directory' %confFile
+    #    return -3
+    
+    #return popcon2dropbox.run( args.job_file, args.auth )
+    return popcon2dropbox.run( args )
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/CondTools/Ecal/python/EcalDAQ_popcon.py
+++ b/CondTools/Ecal/python/EcalDAQ_popcon.py
@@ -1,0 +1,43 @@
+from CondCore.Utilities.popcon2dropbox_job_conf import options, psetForRecord, setup_popcon
+import CondTools.Ecal.db_credentials as auth
+
+recordName = "EcalDAQTowerStatusRcd"
+tagTimeType = "runnumber"
+
+process = setup_popcon( recordName, tagTimeType )
+
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.essource = cms.ESSource("PoolDBESSource",
+                                connect = cms.string( str(options.destinationDatabase) ),
+                                DumpStat=cms.untracked.bool(True),
+                                toGet = cms.VPSet( psetForRecord( recordName ) )
+)
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
+
+process.conf_o2o = cms.EDAnalyzer("ExTestEcalDAQAnalyzer",
+    SinceAppendMode = cms.bool(True),
+    record = cms.string( recordName ),
+    loggingOn = cms.untracked.bool(True),
+    Source = cms.PSet(
+        firstRun = cms.string('121756'),
+        lastRun = cms.string('100000000'),
+        OnlineDBUser = cms.string(db_user),
+        debug = cms.bool(False),
+        OnlineDBPassword = cms.string(db_pwd),
+        OnlineDBSID = cms.string(db_service),
+        location = cms.string('P5_Co'),
+#        runtype = cms.string('Cosmic'), 
+        runtype = cms.string('BEAM'), 
+        gentag = cms.string('GLOBAL')
+    ),
+    targetDBConnectionString = cms.untracked.string(str(options.destinationDatabase))
+)
+
+process.p = cms.Path(process.conf_o2o)
+

--- a/CondTools/Ecal/python/EcalDCS_popcon.py
+++ b/CondTools/Ecal/python/EcalDCS_popcon.py
@@ -1,0 +1,40 @@
+from CondCore.Utilities.popcon2dropbox_job_conf import options, psetForRecord, setup_popcon
+import CondTools.Ecal.db_credentials as auth
+
+recordName = "EcalDCSTowerStatusRcd"
+tagTimeType = "runnumber"
+
+process = setup_popcon( recordName, tagTimeType )
+
+
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.essource = cms.ESSource("PoolDBESSource",
+                                connect = cms.string( str(options.destinationDatabase) ),
+                                DumpStat=cms.untracked.bool(True),
+                                toGet = cms.VPSet( psetForRec )
+)
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
+
+process.conf_o2o = cms.EDAnalyzer("ExTestEcalDCSAnalyzer",
+    SinceAppendMode = cms.bool(True),
+    record = cms.string(recordName),
+    loggingOn = cms.untracked.bool(True),
+    Source = cms.PSet(
+        firstRun = cms.string('210000'),
+        lastRun = cms.string('100000000'),
+        OnlineDBUser = cms.string(db_user),
+        debug = cms.bool(True),
+        OnlineDBPassword = cms.string(db_pwd),
+        OnlineDBSID = cms.string(db_service)
+    ),
+    targetDBConnectionString = cms.untracked.string(str(options.destinationDatabase))
+)
+
+process.p = cms.Path(process.conf_o2o)
+

--- a/CondTools/Ecal/python/EcalLaser_express_popcon.py
+++ b/CondTools/Ecal/python/EcalLaser_express_popcon.py
@@ -1,0 +1,44 @@
+from CondCore.Utilities.popcon2dropbox_job_conf import options, psetForRecord, setup_popcon
+import CondTools.Ecal.db_credentials as auth
+
+recordName = "EcalLaserAPDPNRatiosRcd"
+tagTimeType = "timestamp"
+
+process = setup_popcon( recordName, tagTimeType )
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.essource = cms.ESSource("PoolDBESSource",
+                                connect = cms.string( str(options.destinationDatabase)),
+                                DumpStat=cms.untracked.bool(True),
+                                toGet = cms.VPSet( psetForRecord( recordName ) )
+)
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
+
+process.conf_o2o = cms.EDAnalyzer("ExTestEcalLaserAnalyzer",
+    SinceAppendMode = cms.bool(True),
+    record = cms.string( recordName ),
+    loggingOn = cms.untracked.bool(True),
+    Source = cms.PSet(
+  # maxtime is mandatory
+  # it can be expressed either as an absolute time with format YYYY-MM-DD HH24:MI:SS
+  # or as a relative time w.r.t. now, using -N, where N is expressed in units of hours
+      maxtime = cms.string("-1"),
+      sequences = cms.string("20"),  
+      OnlineDBUser = cms.string(db_user),
+    # debug must be False for production
+      debug = cms.bool(False),
+    # if fake is True, no insertion in the db is performed
+      fake = cms.bool(False),
+      OnlineDBPassword = cms.string(db_pwd),
+      OnlineDBSID = cms.string(db_service)    
+    ),
+    targetDBConnectionString = cms.untracked.string(str(options.destinationDatabase))
+)
+
+process.p = cms.Path(process.conf_o2o)
+

--- a/CondTools/Ecal/python/EcalLaser_prompt_popcon.py
+++ b/CondTools/Ecal/python/EcalLaser_prompt_popcon.py
@@ -1,0 +1,44 @@
+from CondCore.Utilities.popcon2dropbox_job_conf import options, psetForRecord, setup_popcon
+import CondTools.Ecal.db_credentials as auth
+
+recordName = "EcalLaserAPDPNRatiosRcd"
+tagTimeType = "timestamp"
+
+process = setup_popcon( recordName, tagTimeType )
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.essource = cms.ESSource("PoolDBESSource",
+                                connect = cms.string( str(options.destinationDatabase)),
+                                DumpStat=cms.untracked.bool(True),
+                                toGet = cms.VPSet( psetForRecord( recordName ) )
+)
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
+
+process.conf_o2o = cms.EDAnalyzer("ExTestEcalLaserAnalyzer",
+    SinceAppendMode = cms.bool(True),
+    record = cms.string( recordName ),
+    loggingOn = cms.untracked.bool(True),
+    Source = cms.PSet(
+  # maxtime is mandatory
+  # it can be expressed either as an absolute time with format YYYY-MM-DD HH24:MI:SS
+  # or as a relative time w.r.t. now, using -N, where N is expressed in units of hours
+      maxtime = cms.string("-30"),
+      sequences = cms.string("20"),  
+      OnlineDBUser = cms.string(db_user),
+    # debug must be False for production
+      debug = cms.bool(False),
+    # if fake is True, no insertion in the db is performed
+      fake = cms.bool(False),
+      OnlineDBPassword = cms.string(db_pwd),
+      OnlineDBSID = cms.string(db_service)    
+    ),
+    targetDBConnectionString = cms.untracked.string(str(options.destinationDatabase))
+)
+
+process.p = cms.Path(process.conf_o2o)
+

--- a/CondTools/Ecal/python/conddb_init.py
+++ b/CondTools/Ecal/python/conddb_init.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("ProcessOne")
+
+options = VarParsing.VarParsing()
+options.register('destinationDatabase',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the destination database connection string")
+options.register('destinationTag',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the destination tag name")
+options.parseArguments()

--- a/CondTools/Ecal/python/copyBadStrip_cfg.py
+++ b/CondTools/Ecal/python/copyBadStrip_cfg.py
@@ -1,17 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto" #default value
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -30,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGStripStatus_v3_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGStripStatusRcd'),
-        tag = cms.string('EcalTPGStripStatus_v3_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadStripAnalyzer",
     record = cms.string('EcalTPGStripStatusRcd'),
@@ -52,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadStripAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyBadTT_cfg.py
+++ b/CondTools/Ecal/python/copyBadTT_cfg.py
@@ -1,17 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -30,19 +21,19 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGTowerStatus_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGTowerStatusRcd'),
-        tag = cms.string('EcalTPGTowerStatus_hlt')
-    ))
+        tag = cms.string(conddb_init.options.destinationTag)
+        )
+    )
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadTTAnalyzer",
     record = cms.string('EcalTPGTowerStatusRcd'),
@@ -52,10 +43,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadTTAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyBadXT_cfg.py
+++ b/CondTools/Ecal/python/copyBadXT_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGCrystalStatus_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGCrystalStatusRcd'),
-        tag = cms.string('EcalTPGCrystalStatus_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadXTAnalyzer",
     record = cms.string('EcalTPGCrystalStatusRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGBadXTAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyFgrGroup_cfg.py
+++ b/CondTools/Ecal/python/copyFgrGroup_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainEBGroup_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGFineGrainEBGroupRcd'),
-        tag = cms.string('EcalTPGFineGrainEBGroup_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainEBGroupAnalyzer",
     record = cms.string('EcalTPGFineGrainEBGroupRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainEBGroupAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyFgrIdMap_cfg.py
+++ b/CondTools/Ecal/python/copyFgrIdMap_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainEBIdMap_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGFineGrainEBIdMapRcd'),
-        tag = cms.string('EcalTPGFineGrainEBIdMap_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainEBIdMapAnalyzer",
     record = cms.string('EcalTPGFineGrainEBIdMapRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainEBIdMapAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyFgrStripEE_cfg.py
+++ b/CondTools/Ecal/python/copyFgrStripEE_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainStripEE_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGFineGrainStripEERcd'),
-        tag = cms.string('EcalTPGFineGrainStripEE_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainStripEEAnalyzer",
     record = cms.string('EcalTPGFineGrainStripEERcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainStripEEAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyFgrTowerEE_cfg.py
+++ b/CondTools/Ecal/python/copyFgrTowerEE_cfg.py
@@ -1,16 +1,9 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
+
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +22,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainTowerEE_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGFineGrainTowerEERcd'),
-        tag = cms.string('EcalTPGFineGrainTowerEE_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainTowerEEAnalyzer",
     record = cms.string('EcalTPGFineGrainTowerEERcd'),
@@ -51,10 +43,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGFineGrainTowerEEAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyLin_cfg.py
+++ b/CondTools/Ecal/python/copyLin_cfg.py
@@ -1,18 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
-process.MessageLogger = cms.Service("MessageLogger",
+rocess.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGLinearizationConst_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGLinearizationConstRcd'),
-        tag = cms.string('EcalTPGLinearizationConst_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLinConstAnalyzer",
     record = cms.string('EcalTPGLinearizationConstRcd'),
@@ -51,10 +42,10 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLinConstAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
+     OnlineDBSID = cms.string(db_service),
 #     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyLutGroup_cfg.py
+++ b/CondTools/Ecal/python/copyLutGroup_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGLutGroup_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGLutGroupRcd'),
-        tag = cms.string('EcalTPGLutGroup_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLutGroupAnalyzer",
     record = cms.string('EcalTPGLutGroupRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLutGroupAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyLutIdMap_cfg.py
+++ b/CondTools/Ecal/python/copyLutIdMap_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,20 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGLutIdMap_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGLutIdMapRcd'),
-        tag = cms.string('EcalTPGLutIdMap_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
 
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLutIdMapAnalyzer",
     record = cms.string('EcalTPGLutIdMapRcd'),
@@ -52,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGLutIdMapAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyPed_cfg.py
+++ b/CondTools/Ecal/python/copyPed_cfg.py
@@ -1,18 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
-process.MessageLogger = cms.Service("MessageLogger",
+rocess.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGPedestals_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGPedestalsRcd'),
-        tag = cms.string('EcalTPGPedestals_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGPedestalsAnalyzer",
     record = cms.string('EcalTPGPedestalsRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGPedestalsAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyPhysConst_cfg.py
+++ b/CondTools/Ecal/python/copyPhysConst_cfg.py
@@ -1,18 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
-process.MessageLogger = cms.Service("MessageLogger",
+rocess.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGPhysicsConst_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGPhysicsConstRcd'),
-        tag = cms.string('EcalTPGPhysicsConst_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGPhysicsConstAnalyzer",
     record = cms.string('EcalTPGPhysicsConstRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGPhysicsConstAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copySli_cfg.py
+++ b/CondTools/Ecal/python/copySli_cfg.py
@@ -1,25 +1,16 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
-process.MessageLogger = cms.Service("MessageLogger",
+rocess.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')
     ),
     destinations = cms.untracked.vstring('cout')
 )
-
 
 process.source = cms.Source("EmptyIOVSource",
     lastValue = cms.uint64(100000000),
@@ -30,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGSlidingWindow_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGSlidingWindowRcd'),
-        tag = cms.string('EcalTPGSlidingWindow_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGSlidingWindowAnalyzer",
     record = cms.string('EcalTPGSlidingWindowRcd'),
@@ -52,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGSlidingWindowAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copySpikeTh_cfg.py
+++ b/CondTools/Ecal/python/copySpikeTh_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -29,19 +21,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGSpike_v3_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGSpikeRcd'),
-        tag = cms.string('EcalTPGSpike_v3_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGSpikeAnalyzer",
     record = cms.string('EcalTPGSpikeRcd'),
@@ -51,10 +42,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGSpikeAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('100000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyWGroup_cfg.py
+++ b/CondTools/Ecal/python/copyWGroup_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -30,20 +22,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGWeightGroup_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGWeightGroupRcd'),
-        tag = cms.string('EcalTPGWeightGroup_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
 
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGWeightGroupAnalyzer",
     record = cms.string('EcalTPGWeightGroupRcd'),
@@ -53,10 +43,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGWeightGroupAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/copyWIdMap_cfg.py
+++ b/CondTools/Ecal/python/copyWIdMap_cfg.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -30,20 +22,18 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-#process.CondDB.connect = 'sqlite_file:EcalTPGWeightIdMap_v2_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 process.CondDB.DBParameters.authenticationPath = ''
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalTPGWeightIdMapRcd'),
-        tag = cms.string('EcalTPGWeightIdMap_v2_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
 
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalTPGWeightIdMapAnalyzer",
     record = cms.string('EcalTPGWeightIdMapRcd'),
@@ -53,10 +43,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalTPGWeightIdMapAnalyzer",
     Source=cms.PSet(
      firstRun = cms.string('200000'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/db_credentials.py
+++ b/CondTools/Ecal/python/db_credentials.py
@@ -1,0 +1,17 @@
+import CondCore.Utilities.credentials as credentials
+import socket
+
+authPathEnvVar = 'COND_AUTH_PATH'
+db_service = 'cms_omds_adg'
+if socket.getfqdn().strip().endswith('.cms'):
+    db_service = 'cms_omds_lb'
+db_machine = db_service + '/CMS_ECAL_R' 
+
+
+def get_readOnly_db_credentials():
+    creds = credentials.get_credentials( authPathEnvVar, db_machine )
+    if not creds is None:
+        (username, account, pwd) = creds
+        return db_service, username, pwd
+    else:
+        raise Exception('Entry for service %s not found in .netrc' %db_machine )

--- a/CondTools/Ecal/python/updateADCToGeV_express.py
+++ b/CondTools/Ecal/python/updateADCToGeV_express.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -31,17 +23,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 
 process.CondDB.DBParameters.authenticationPath = ''
 
-#process.CondDB.connect = 'sqlite_file:EcalADCToGeVConstant_V1_express.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
+process.CondDB.connect = conddb_init.options.destinationDatabase
 
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
         toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalADCToGeVConstantRcd'),
-        tag = cms.string('EcalADCToGeVConstant_V1_express')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
 
@@ -57,10 +46,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalADCToGeVAnalyzer",
 #     FileHighField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/ADCToGeV_express_current_BON.xml'),
      firstRun = cms.string('207149'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/updateADCToGeV_hlt.py
+++ b/CondTools/Ecal/python/updateADCToGeV_hlt.py
@@ -1,16 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -30,20 +22,17 @@ process.source = cms.Source("EmptyIOVSource",
 process.load("CondCore.CondDB.CondDB_cfi")
 
 process.CondDB.DBParameters.authenticationPath = ''
-
-#process.CondDB.connect = 'sqlite_file:EcalADCToGeVConstant_V1_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
-
+process.CondDB.connect = conddb_init.options.destinationDatabase
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
         toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalADCToGeVConstantRcd'),
-        tag = cms.string('EcalADCToGeVConstant_V1_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalADCToGeVAnalyzer",
     record = cms.string('EcalADCToGeVConstantRcd'),
@@ -57,10 +46,9 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalADCToGeVAnalyzer",
 #     FileHighField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/ADCToGeV_hlt_current_BON.xml'),
      firstRun = cms.string('207149'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/updateIntercali_express.py
+++ b/CondTools/Ecal/python/updateIntercali_express.py
@@ -1,17 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -31,20 +22,17 @@ process.source = cms.Source("EmptyIOVSource",
 process.load("CondCore.CondDB.CondDB_cfi")
 
 process.CondDB.DBParameters.authenticationPath = ''
-
-#process.CondDB.connect = 'sqlite_file:EcalIntercalibConstants_V1_express.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
-
+process.CondDB.connect = conddb_init.options.destinationDatabase
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalIntercalibConstantsRcd'),
-        tag = cms.string('EcalIntercalibConstants_V1_express')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalIntercalibAnalyzer",
     record = cms.string('EcalIntercalibConstantsRcd'),
@@ -52,17 +40,14 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalIntercalibAnalyzer",
     IsDestDbCheckedInQueryLog=cms.untracked.bool(True),
     SinceAppendMode=cms.bool(True),
     Source=cms.PSet(
-     FileLowField = cms.string('/data/O2O/Ecal/TPG/Intercalib_Boff.xml'),
-     FileHighField = cms.string('/data/O2O/Ecal/TPG/Intercalib_Bon.xml'),
-#     FileLowField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/Intercalib_express_current_BOFF.xml'),
-#     FileHighField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/Intercalib_express_current_BON.xml'),
-     Value_Bon = cms.untracked.double(0.76724),
+     FileLowField = cms.string('Intercalib_Boff.xml'),
+     FileHighField = cms.string('Intercalib_Bon.xml'),
+     Value_Bon = cms.untracked.double(0.7041),
      firstRun = cms.string('207149'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),

--- a/CondTools/Ecal/python/updateIntercali_hlt.py
+++ b/CondTools/Ecal/python/updateIntercali_hlt.py
@@ -1,17 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
+import CondTools.Ecal.conddb_init as conddb_init
+import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
-
-options = VarParsing.VarParsing()
-options.register( "password"
-                , "myToto"
-                , VarParsing.VarParsing.multiplicity.singleton
-                , VarParsing.VarParsing.varType.string
-                , "the password"
-                  )
-options.parseArguments()
-
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
@@ -31,20 +22,17 @@ process.source = cms.Source("EmptyIOVSource",
 process.load("CondCore.CondDB.CondDB_cfi")
 
 process.CondDB.DBParameters.authenticationPath = ''
-
-#process.CondDB.connect = 'sqlite_file:EcalIntercalibConstants_V1_hlt.db'
-process.CondDB.connect = 'oracle://cms_orcon_prod/CMS_CONDITIONS'
-
+process.CondDB.connect = conddb_init.options.destinationDatabase
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB, 
-#    logconnect = cms.untracked.string('oracle://cms_orcon_prod/CMS_COND_31X_POPCONLOG'),
-   logconnect = cms.untracked.string('sqlite_file:log.db'),   
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('EcalIntercalibConstantsRcd'),
-        tag = cms.string('EcalIntercalibConstants_V1_hlt')
+        tag = cms.string(conddb_init.options.destinationTag)
     ))
 )
+
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 
 process.Test1 = cms.EDAnalyzer("ExTestEcalIntercalibAnalyzer",
     record = cms.string('EcalIntercalibConstantsRcd'),
@@ -52,17 +40,14 @@ process.Test1 = cms.EDAnalyzer("ExTestEcalIntercalibAnalyzer",
     IsDestDbCheckedInQueryLog=cms.untracked.bool(True),
     SinceAppendMode=cms.bool(True),
     Source=cms.PSet(
-    FileLowField = cms.string('/data/O2O/Ecal/TPG/Intercalib_Boff.xml'),
-    FileHighField = cms.string('/data/O2O/Ecal/TPG/Intercalib_Bon.xml'),
-#     FileLowField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/Intercalib_hlt_current_BOFF.xml'),
-#     FileHighField = cms.string('/afs/cern.ch/work/d/depasse/cmssw/CMSSW_8_0_1/src/CondTools/Ecal/python/Intercalib_hlt_current_BON.xml'),
-     Value_Bon = cms.untracked.double(0.76724),
+     FileLowField = cms.string('Intercalib_Boff.xml'),
+     FileHighField = cms.string('Intercalib_Bon.xml'),
+     Value_Bon = cms.untracked.double(0.7041),
      firstRun = cms.string('207149'),
      lastRun = cms.string('10000000'),
-     OnlineDBSID = cms.string('cms_omds_lb'),
-#     OnlineDBSID = cms.string('cms_orcon_adg'),  test on lxplus
-     OnlineDBUser = cms.string('cms_ecal_r'),
-     OnlineDBPassword = cms.string( options.password ),
+     OnlineDBSID = cms.string(db_service),
+     OnlineDBUser = cms.string(db_user),
+     OnlineDBPassword = cms.string( db_pwd ),
      LocationSource = cms.string('P5'),
      Location = cms.string('P5_Co'),
      GenTag = cms.string('GLOBAL'),


### PR DESCRIPTION
In this PR:
- o2o commands share the  path for the authentication file with the rest of Conddb applications
- o2oRun supports implicit resolution of the destination db/tag 
- popconRun does no longer require an input json file
- Ecal O2O scripts are modified to use the above features
