### PR TITLE
Explicitly set matplotlib.use to avoid incorrect defaults

### DIFF
--- a/FWCore/Concurrency/bin/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/bin/edmStreamStallGrapher.py
@@ -244,6 +244,9 @@ def printStalledModulesInOrder(stalledModules):
 
 
 def createPDFImage(processingSteps, numStreams, stalledModuleInfo):
+  #need to force display since problems with CMSSW matplotlib
+  import matplotlib
+  matplotlib.use("PDF")
   import matplotlib.pyplot as plt
   
   stalledModuleNames = set([ x for x in stalledModuleInfo.iterkeys()])


### PR DESCRIPTION
The matplotlib external for CMSSW does not have a usable default
for the renderer for matplotlib. To work around the problem one
can explicit set a renderer to use.
