### PR TITLE
Add timing workflow to short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -19,6 +19,7 @@ numWFIB = [20021.0,20024.0,20025.0,20026.0] #2023D1 scenario
 numWFIB.extend([20421.0,20424.0,20425.0,20426.0]) #2023D2
 numWFIB.extend([20821.0,20824.0,20825.0,20826.0]) #2023D3
 numWFIB.extend([21221.0,21224.0,21225.0,21226.0]) #2023D4
+numWFIB.extend([22424.0]) #2023D3Timing
 for i,key in enumerate(upgradeKeys[2023]):
     numWF=numWFStart+i*numWFSkip
     for frag in upgradeFragments:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10424.0, #2017 NewPix ttbar
                      20024.0, #2023D1 ttbar (Run2 calo)
-                     20824.0, #2023D3 ttbar (HGCal)
+                     22424.0, #2023D3Timing ttbar (HGCal + timing)
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC


### PR DESCRIPTION
Replace 20824.0 (TTbar D3) in short matrix with 22424.0 (TTbar D3Timing) so that new code is covered by regular testing in addition to the HGCal code.
