### PR TITLE
Use database objects for HCAL 2017 TP

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -24,13 +24,6 @@ class IntegerCaloSamples;
 
 class HcalTriggerPrimitiveAlgo {
 public:
-   struct TPParameters {
-      uint32_t hbhe_fg_version;
-      uint64_t hf_tdc_mask;
-      uint32_t hf_adc_threshold;
-      uint32_t hf_fg_threshold;
-   };
-
   HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, int latency,
                            uint32_t FG_threshold, uint32_t FG_HF_threshold, uint32_t ZS_threshold,
                            int numberOfSamples,   int numberOfPresamples,
@@ -77,10 +70,7 @@ public:
   void setRCTScaleShift(int);
 
   void setUpgradeFlags(bool hb, bool he, bool hf);
-  void overrideParameters(unsigned int hbhe_fg_version,
-                          unsigned int hf_tdc_mask,
-                          unsigned int hf_adc_threshold,
-                          unsigned int hf_fg_threshold);
+  void overrideParameters(const edm::ParameterSet& ps) { override_parameters_ = ps; };
 
  private:
 
@@ -196,7 +186,7 @@ public:
   bool upgrade_he_ = false;
   bool upgrade_hf_ = false;
 
-  std::unique_ptr<const TPParameters> override_parameters_;
+  edm::ParameterSet override_parameters_;
 
   static const int HBHE_OVERLAP_TOWER = 16;
   static const int LAST_FINEGRAIN_DEPTH = 6;
@@ -237,8 +227,8 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
 
    // Prepare the fine-grain calculation algorithm for HB/HE
    int version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
-   if (override_parameters_)
-      version = override_parameters_->hbhe_fg_version;
+   if (override_parameters_.exists("FGVersionHBHE"))
+      version = override_parameters_.getParameter<uint32_t>("FGVersionHBHE");
    HcalFinegrainBit fg_algo(version);
 
    // VME produces additional bits on the front used by lumi but not the

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -226,7 +226,9 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    addDigis(digis...);
 
    // Prepare the fine-grain calculation algorithm for HB/HE
-   int version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
+   int version = 0;
+   if (upgrade_he_ or upgrade_hb_)
+      version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
    if (override_parameters_.exists("FGVersionHBHE"))
       version = override_parameters_.getParameter<uint32_t>("FGVersionHBHE");
    HcalFinegrainBit fg_algo(version);

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -521,7 +521,7 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
    if (override_parameters_.exists("ADCThresholdHF"))
       adc_threshold = override_parameters_.getParameter<uint32_t>("ADCThresholdHF");
    if (override_parameters_.exists("TDCMaskHF"))
-      adc_threshold = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
+      tdc_mask = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
 
    if (digi[ts].adc() < adc_threshold)
       return true;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -526,7 +526,7 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
    if (digi[ts].adc() < adc_threshold)
       return true;
 
-   return (1ul << (digi[ts].le_tdc() - 1)) & tdc_mask;
+   return (1ul << digi[ts].le_tdc()) & tdc_mask;
 }
 
 void HcalTriggerPrimitiveAlgo::analyzeHF2017(

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -1,16 +1,22 @@
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
-#include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
+
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
-#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"//cuts based on short and long energy deposited.
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 #include <iostream>
+
 using namespace std;
 
 HcalTriggerPrimitiveAlgo::HcalTriggerPrimitiveAlgo( bool pf, const std::vector<double>& w, int latency,
@@ -57,11 +63,13 @@ HcalTriggerPrimitiveAlgo::setUpgradeFlags(bool hb, bool he, bool hf)
 
 
 void
-HcalTriggerPrimitiveAlgo::overrideParameters(unsigned int hf_tdc_mask,
+HcalTriggerPrimitiveAlgo::overrideParameters(unsigned int hbhe_fg_version,
+                                             unsigned int hf_tdc_mask,
                                              unsigned int hf_adc_threshold,
                                              unsigned int hf_fg_threshold)
 {
    auto parameters = new TPParameters();
+   parameters->hbhe_fg_version = hbhe_fg_version;
    parameters->hf_tdc_mask = hf_tdc_mask;
    parameters->hf_adc_threshold = hf_adc_threshold;
    parameters->hf_fg_threshold = hf_fg_threshold;
@@ -513,6 +521,28 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2016(
     
 }
 
+bool
+HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
+{
+   auto mask = conditions_->getHcalTPChannelParameter(HcalDetId(digi.id()))->getMask();
+   if (mask)
+      return false;
+
+   auto parameters = conditions_->getHcalTPParameters();
+   auto adc_threshold = parameters->getADCThresholdHF();
+   auto tdc_mask = parameters->getTDCMaskHF();
+
+   if (override_parameters_) {
+      adc_threshold = override_parameters_->hf_adc_threshold;
+      tdc_mask = override_parameters_->hf_tdc_mask;
+   }
+
+   if (digi[ts].adc() < adc_threshold)
+      return true;
+
+   return (1ul << (digi[ts].le_tdc() - 1)) & tdc_mask;
+}
+
 void HcalTriggerPrimitiveAlgo::analyzeHF2017(
         const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result,
         const int hf_lumi_shift, const HcalFeatureBit* hcalfem)
@@ -550,8 +580,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
 
             for (auto i: {0, 2}) {
                if (idx < details[i].samples.size()) {
-                  if ((unsigned int) details[i].digi[idx].adc() < override_parameters_->hf_adc_threshold
-                        or (1ul << (details[i].digi[idx].le_tdc() - 1)) & override_parameters_->hf_tdc_mask) {
+                  if (validChannel(details[i].digi, idx)) {
                      long_fiber_val += details[i].samples[idx];
                      saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
                      ++long_fiber_count;
@@ -560,8 +589,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             }
             for (auto i: {1, 3}) {
                if (idx < details[i].samples.size()) {
-                  if ((unsigned int) details[i].digi[idx].adc() < override_parameters_->hf_adc_threshold
-                        or (1ul << (details[i].digi[idx].le_tdc() - 1)) & override_parameters_->hf_tdc_mask) {
+                  if (validChannel(details[i].digi, idx)) {
                      short_fiber_val += details[i].samples[idx];
                      saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
                      ++short_fiber_count;

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -29,14 +29,13 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     upgradeHB = cms.bool(False),
     upgradeHE = cms.bool(False),
 
-    parameters = cms.untracked.PSet(
-        TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
-        ADCThreshold=cms.uint32(0),
-        FGThreshold=cms.uint32(12)
-    ),
-    
-    
-#
+    # parameters = cms.untracked.PSet(
+    #     FGVersionHBHE=cms.uint32(0),
+    #     TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
+    #     ADCThreshold=cms.uint32(0),
+    #     FGThreshold=cms.uint32(12)
+    # ),
+
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo
     # Input digi label (_must_ be without zero-suppression!)
     inputLabel = cms.VInputTag(cms.InputTag('simHcalUnsuppressedDigis'),

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -52,10 +52,7 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    if (ps.exists("parameters")) {
       auto pset = ps.getUntrackedParameter<edm::ParameterSet>("parameters");
-      theAlgo_.overrideParameters(pset.getParameter<unsigned int>("FGVersionHBHE"),
-                                  pset.getParameter<unsigned long long>("TDCMask"),
-                                  pset.getParameter<unsigned int>("ADCThreshold"),
-                                  pset.getParameter<unsigned int>("FGThreshold"));
+      theAlgo_.overrideParameters(ps);
    }
    theAlgo_.setUpgradeFlags(upgrades[0], upgrades[1], upgrades[2]);
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -52,7 +52,8 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    if (ps.exists("parameters")) {
       auto pset = ps.getUntrackedParameter<edm::ParameterSet>("parameters");
-      theAlgo_.overrideParameters(pset.getParameter<unsigned long long>("TDCMask"),
+      theAlgo_.overrideParameters(pset.getParameter<unsigned int>("FGVersionHBHE"),
+                                  pset.getParameter<unsigned long long>("TDCMask"),
                                   pset.getParameter<unsigned int>("ADCThreshold"),
                                   pset.getParameter<unsigned int>("FGThreshold"));
    }
@@ -196,13 +197,13 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
   // Step C: Invoke the algorithm, passing in inputs and getting back outputs.
   if (legacy_ and not upgrade_) {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheDigis, *hfDigis);
   } else if (legacy_ and upgrade_) {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheDigis, *hfDigis, *hbheUpDigis, *hfUpDigis);
   } else {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheUpDigis, *hfUpDigis);
   }
 


### PR DESCRIPTION
Uses the database objects from #15646, #15521.

Allows to override single parameters instead of the whole set, using a PSet for the TP producer.
