### PR TITLE
Add HGCAL L1 trigger in SimL1Emulator and event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -115,7 +115,7 @@ stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendStage2Digis)
 # adding HGCal L1 trigger digis
 def _appendHGCalDigis(obj):
     l1HGCalDigis = [
-        'keep *_hgcalTriggerPrimitiveDigiProducer_*_*',
+        'keep *_hgcalTriggerPrimitiveDigiProducer__*',
         ]
     obj.outputCommands += l1HGCalDigis
 

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -111,3 +111,13 @@ stage2L1Trigger.toModify(L1TriggerRAWDEBUG, func=_appendStage2Digis)
 stage2L1Trigger.toModify(L1TriggerRECO, func=_appendStage2Digis)
 stage2L1Trigger.toModify(L1TriggerAOD, func=_appendStage2Digis)
 stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendStage2Digis)
+
+# adding HGCal L1 trigger digis
+def _appendHGCalDigis(obj):
+    l1HGCalDigis = [
+        'keep *_hgcalTriggerPrimitiveDigiProducer_*_*',
+        ]
+    obj.outputCommands += l1HGCalDigis
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify(L1TriggerFEVTDEBUG, func=_appendHGCalDigis)

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -52,3 +52,12 @@ SimL1Emulator = cms.Sequence( SimL1EmulatorCore )
 from L1Trigger.L1TCalorimeter.hackConditions_cff import *
 from L1Trigger.L1TMuon.hackConditions_cff import *
 from L1Trigger.L1TGlobal.hackConditions_cff import *
+
+
+# Customisation for the phase2_hgcal era. Includes the HGCAL L1 trigger
+from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
+_phase2_siml1emulator = SimL1Emulator.copy()
+_phase2_siml1emulator += hgcalTriggerPrimitives
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_hgcal.toReplaceWith( SimL1Emulator , _phase2_siml1emulator )

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -59,5 +59,5 @@ from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
 _phase2_siml1emulator = SimL1Emulator.copy()
 _phase2_siml1emulator += hgcalTriggerPrimitives
 
-from Configuration.StandardSequences.Eras import eras
-eras.phase2_hgcal.toReplaceWith( SimL1Emulator , _phase2_siml1emulator )
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toReplaceWith( SimL1Emulator , _phase2_siml1emulator )


### PR DESCRIPTION
For the `phase2_hgcal` era:
- Add the HGCAL L1 trigger simulation in the `SimL1Emulator` sequence
- Add the HGCAL trigger cell digis in the `L1TriggerFEVTDEBUG` event content

The processing time increase is a bit more than 1s/event for 200PU events. The output collection size is about 400kB/event for 200PU events.
