### PR TITLE
Microstate monitoring update (DAQ) 81X

### DIFF
--- a/EventFilter/Utilities/interface/AuxiliaryMakers.h
+++ b/EventFilter/Utilities/interface/AuxiliaryMakers.h
@@ -9,7 +9,8 @@ namespace evf{
     edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record, 
 					   unsigned int runNumber,
 					   unsigned int lumiSection,
-					   std::string const &processGUID);
+					   std::string const &processGUID,
+                                           bool verifyLumiSection);
   }
 }
 #endif

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -251,6 +251,7 @@ namespace evf{
       unsigned int lastGlobalLumi_;
       std::queue<unsigned int> lastGlobalLumisClosed_;
       bool isGlobalLumiTransition_;
+      bool isInitTransition_;
       unsigned int lumiFromSource_;
 
       //global state

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -21,7 +21,7 @@ namespace evf{
 
     enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inNewLumiBusyEndingLS, inNewLumiIdleEndingLS, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived,
                       inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest, inNoRequestWithIdleThreads,
-                      inNoRequestWithIdleAndEoLThreads, inNoRequestWithGlobalEoL, inNoRequestWithAllEoLThreads, inNoRequestWithEoLThreads,
+                      inNoRequestWithGlobalEoL, inNoRequestWithEoLThreads,
                       //supervisor thread and worker threads state
                       inSupFileLimit, inSupWaitFreeChunk, inSupWaitFreeChunkCopying, inSupWaitFreeThread, inSupWaitFreeThreadCopying, inSupBusy, inSupLockPolling,
                       inSupLockPollingCopying,inSupNoFile,inSupNewFile,inSupNewFileWaitThreadCopying,inSupNewFileWaitThread,

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -19,7 +19,7 @@ namespace evf{
     enum Macrostate { sInit = 0, sJobReady, sRunGiven, sRunning, sStopping,
 		      sShuttingDown, sDone, sJobEnded, sError, sErrorEnded, sEnd, sInvalid,MCOUNT}; 
 
-    enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived, 
+    enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inNewLumiBusyEndingLS, inNewLumiIdleEndingLS, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived,
                       inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest, inNoRequestWithIdleThreads,
                       inNoRequestWithIdleAndEoLThreads, inNoRequestWithGlobalEoL, inNoRequestWithAllEoLThreads, inNoRequestWithEoLThreads,
                       //supervisor thread and worker threads state

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -106,6 +106,8 @@ private:
 
   const bool fileListMode_;
   unsigned int fileListIndex_ = 0;
+  const bool fileListLoopMode_;
+  unsigned int loopModeIterationInc_ = 0;
 
   edm::RunNumber_t runNumber_;
   std::string fuOutputDir_;

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -9,7 +9,8 @@ namespace evf{
       edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record,
 					     unsigned int runNumber,
                                              unsigned int lumiSection,
-					     std::string const &processGUID){
+					     std::string const &processGUID,
+                                             bool verifyLumiSection){
 	edm::EventID eventId(runNumber, // check that runnumber from record is consistent
 			     //record->getHeader().getData().header.lumiSection,//+1
                              lumiSection,
@@ -27,7 +28,7 @@ namespace evf{
 	uint64_t orbitnr = (((uint64_t)record->getHeader().getData().header.orbitHigh) << 16) + record->getHeader().getData().header.orbitLow;
         uint32_t recordLumiSection = record->getHeader().getData().header.lumiSection;
 
-        if (recordLumiSection != lumiSection) 
+        if (verifyLumiSection && recordLumiSection != lumiSection) 
           edm::LogWarning("AuxiliaryMakers") << "Lumisection mismatch, external : "<<lumiSection << ", record : " << recordLumiSection; 
         if ((orbitnr >> 18) + 1 != recordLumiSection)
           edm::LogWarning("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -765,11 +765,11 @@ namespace evf{
     }
     else {
       if (isGlobalLumiTransition_)
-      for (unsigned int i=0;i<nStreams_;i++) {
-        if (microstate_[i]==&reservedMicroStateNames[mFwkEoL]) {
-          microstate_[i]=&reservedMicroStateNames[mGlobEoL];
+        for (unsigned int i=0;i<nStreams_;i++) {
+          if (microstate_[i]==&reservedMicroStateNames[mFwkEoL]) {
+            microstate_[i]=&reservedMicroStateNames[mGlobEoL];
+          }
         }
-      }
     }
 
     for (unsigned int i=0;i<nStreams_;i++) {

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -773,12 +773,10 @@ namespace evf{
     }
 
     for (unsigned int i=0;i<nStreams_;i++) {
-       fmt_.m_data.ministateEncoded_[i] = encPath_[i].encode(ministate_[i]);
-       fmt_.m_data.microstateEncoded_[i] = encModule_.encode(microstate_[i]);
+      fmt_.m_data.ministateEncoded_[i] = encPath_[i].encode(ministate_[i]);
+      fmt_.m_data.microstateEncoded_[i] = encModule_.encode(microstate_[i]);
     }
 
-    //else return;
-    //capture latest mini/microstate of streams
     bool inputStatePerThread=false;
 
     if (inputState_==FastMonitoringThread::inWaitInput) {


### PR DESCRIPTION
Fixes to microstate monitoring in DAQ EvF:
- Global EoL microstate state should not be set in initialization stage.
- GlobalEoL should only be set for thread/stream after postStreamEndLumi
- Per thread/stream breakdown of some states for input state monitoring (to analyze the effective impact of limitations imposed by the multithreading model).
- Two states removed, two new input states added

PR also includes new test mode for FedRawDataSource used to fill ramdisk in fakeBU mode looping over events from raw files.
