### PR TITLE
Microstate monitoring update (DAQ) 80X

### DIFF
--- a/EventFilter/Utilities/interface/AuxiliaryMakers.h
+++ b/EventFilter/Utilities/interface/AuxiliaryMakers.h
@@ -9,7 +9,8 @@ namespace evf{
     edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record, 
 					   unsigned int runNumber,
 					   unsigned int lumiSection,
-					   std::string const &processGUID);
+					   std::string const &processGUID,
+                                           bool verifyLumiSection);
   }
 }
 #endif

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -251,6 +251,7 @@ namespace evf{
       unsigned int lastGlobalLumi_;
       std::queue<unsigned int> lastGlobalLumisClosed_;
       bool isGlobalLumiTransition_;
+      bool isInitTransition_;
       unsigned int lumiFromSource_;
 
       //global state

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -21,7 +21,7 @@ namespace evf{
 
     enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inNewLumiBusyEndingLS, inNewLumiIdleEndingLS, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived,
                       inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest, inNoRequestWithIdleThreads,
-                      inNoRequestWithIdleAndEoLThreads, inNoRequestWithGlobalEoL, inNoRequestWithAllEoLThreads, inNoRequestWithEoLThreads,
+                      inNoRequestWithGlobalEoL, inNoRequestWithEoLThreads,
                       //supervisor thread and worker threads state
                       inSupFileLimit, inSupWaitFreeChunk, inSupWaitFreeChunkCopying, inSupWaitFreeThread, inSupWaitFreeThreadCopying, inSupBusy, inSupLockPolling,
                       inSupLockPollingCopying,inSupNoFile,inSupNewFile,inSupNewFileWaitThreadCopying,inSupNewFileWaitThread,

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -19,7 +19,7 @@ namespace evf{
     enum Macrostate { sInit = 0, sJobReady, sRunGiven, sRunning, sStopping,
 		      sShuttingDown, sDone, sJobEnded, sError, sErrorEnded, sEnd, sInvalid,MCOUNT}; 
 
-    enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived, 
+    enum InputState { inIgnore = 0, inInit, inWaitInput, inNewLumi, inNewLumiBusyEndingLS, inNewLumiIdleEndingLS, inRunEnd, inProcessingFile, inWaitChunk , inChunkReceived,
                       inChecksumEvent, inCachedEvent, inReadEvent, inReadCleanup, inNoRequest, inNoRequestWithIdleThreads,
                       inNoRequestWithIdleAndEoLThreads, inNoRequestWithGlobalEoL, inNoRequestWithAllEoLThreads, inNoRequestWithEoLThreads,
                       //supervisor thread and worker threads state

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -106,6 +106,8 @@ private:
 
   const bool fileListMode_;
   unsigned int fileListIndex_ = 0;
+  const bool fileListLoopMode_;
+  unsigned int loopModeIterationInc_ = 0;
 
   edm::RunNumber_t runNumber_;
   std::string fuOutputDir_;

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -9,7 +9,8 @@ namespace evf{
       edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record,
 					     unsigned int runNumber,
                                              unsigned int lumiSection,
-					     std::string const &processGUID){
+					     std::string const &processGUID,
+                                             bool verifyLumiSection){
 	edm::EventID eventId(runNumber, // check that runnumber from record is consistent
 			     //record->getHeader().getData().header.lumiSection,//+1
                              lumiSection,
@@ -27,7 +28,7 @@ namespace evf{
 	uint64_t orbitnr = (((uint64_t)record->getHeader().getData().header.orbitHigh) << 16) + record->getHeader().getData().header.orbitLow;
         uint32_t recordLumiSection = record->getHeader().getData().header.lumiSection;
 
-        if (recordLumiSection != lumiSection) 
+        if (verifyLumiSection && recordLumiSection != lumiSection) 
           edm::LogWarning("AuxiliaryMakers") << "Lumisection mismatch, external : "<<lumiSection << ", record : " << recordLumiSection; 
         if ((orbitnr >> 18) + 1 != recordLumiSection)
           edm::LogWarning("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -765,11 +765,11 @@ namespace evf{
     }
     else {
       if (isGlobalLumiTransition_)
-      for (unsigned int i=0;i<nStreams_;i++) {
-        if (microstate_[i]==&reservedMicroStateNames[mFwkEoL]) {
-          microstate_[i]=&reservedMicroStateNames[mGlobEoL];
+        for (unsigned int i=0;i<nStreams_;i++) {
+          if (microstate_[i]==&reservedMicroStateNames[mFwkEoL]) {
+            microstate_[i]=&reservedMicroStateNames[mGlobEoL];
+          }
         }
-      }
     }
 
     for (unsigned int i=0;i<nStreams_;i++) {

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -773,12 +773,10 @@ namespace evf{
     }
 
     for (unsigned int i=0;i<nStreams_;i++) {
-       fmt_.m_data.ministateEncoded_[i] = encPath_[i].encode(ministate_[i]);
-       fmt_.m_data.microstateEncoded_[i] = encModule_.encode(microstate_[i]);
+      fmt_.m_data.ministateEncoded_[i] = encPath_[i].encode(ministate_[i]);
+      fmt_.m_data.microstateEncoded_[i] = encModule_.encode(microstate_[i]);
     }
 
-    //else return;
-    //capture latest mini/microstate of streams
     bool inputStatePerThread=false;
 
     if (inputState_==FastMonitoringThread::inWaitInput) {

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -65,6 +65,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   useL1EventID_(pset.getUntrackedParameter<bool> ("useL1EventID", false)),
   fileNames_(pset.getUntrackedParameter<std::vector<std::string>> ("fileNames",std::vector<std::string>())),
   fileListMode_(pset.getUntrackedParameter<bool> ("fileListMode", false)),
+  fileListLoopMode_(pset.getUntrackedParameter<bool> ("fileListLoopMode", false)),
   runNumber_(edm::Service<evf::EvFDaqDirector>()->getRunNumber()),
   fuOutputDir_(std::string()),
   daqProvenanceHelper_(edm::TypeID(typeid(FEDRawDataCollection))),
@@ -84,11 +85,13 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   long autoRunNumber = -1;
   if (fileListMode_)  {
     autoRunNumber = initFileList();
-    if (autoRunNumber<0)
-      throw cms::Exception("FedRawDataInputSource::FedRawDataInputSource") << "Run number not found from filename";
-    //override run number
-    runNumber_ = (edm::RunNumber_t)autoRunNumber;
-    edm::Service<evf::EvFDaqDirector>()->overrideRunNumber((unsigned int)autoRunNumber);
+    if (!fileListLoopMode_) {
+      if (autoRunNumber<0)
+        throw cms::Exception("FedRawDataInputSource::FedRawDataInputSource") << "Run number not found from filename";
+      //override run number
+      runNumber_ = (edm::RunNumber_t)autoRunNumber;
+      edm::Service<evf::EvFDaqDirector>()->overrideRunNumber((unsigned int)autoRunNumber);
+    }
   }
 
   processHistoryID_ = daqProvenanceHelper_.daqInit(productRegistryUpdate(), processHistoryRegistryForUpdate());
@@ -290,7 +293,10 @@ bool FedRawDataInputSource::checkNextEvent()
           maybeOpenNewLumiSection( event_->lumi() );
 	}
       }
-      eventRunNumber_=event_->run();
+      if (fileListLoopMode_)
+        eventRunNumber_=runNumber_;
+      else 
+        eventRunNumber_=event_->run();
       L1EventID_ = event_->event();
 
       setEventCached();
@@ -690,7 +696,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
     evf::evtn::TCDSRecord record((unsigned char *)(tcds_pointer_));
     edm::EventAuxiliary aux = evf::evtn::makeEventAuxiliary(&record,
 						 eventRunNumber_,currentLumiSection_,
-                                                 processGUID());
+                                                 processGUID(),!fileListLoopMode_);
     aux.setProcessHistoryID(processHistoryID_);
     makeEvent(eventPrincipal, aux);
   }
@@ -1447,12 +1453,25 @@ evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getFile(unsigned int& ls,
           std::string fileStem = fileName.stem().string();
           if (fileStem.find("ls")) fileStem = fileStem.substr(fileStem.find("ls")+2);
           if (fileStem.find("_")) fileStem = fileStem.substr(0,fileStem.find("_"));
-          ls = boost::lexical_cast<unsigned int>(fileStem);
+
+          if (!fileListLoopMode_)
+            ls = boost::lexical_cast<unsigned int>(fileStem);
+          else //always starting from LS 1 in loop mode
+            ls = 1 + loopModeIterationInc_;
+
           //fsize = 0;
           //lockWaitTime = 0;
           fileListIndex_++;
           return evf::EvFDaqDirector::newFile;
   }
-  else
-    return evf::EvFDaqDirector::runEnded;
+  else {
+    if (!fileListLoopMode_)
+      return evf::EvFDaqDirector::runEnded;
+    else {
+      //loop through files until interrupted
+      loopModeIterationInc_++;
+      fileListIndex_=0;
+      return getFile(ls,nextFile,fsize,lockWaitTime);
+    }
+  }
 }


### PR DESCRIPTION
Fixes to microstate monitoring in DAQ EvF:
- Global EoL microstate state should not be set in initialization stage.
- GlobalEoL should only be set for thread/stream after postStreamEndLumi
- Per thread/stream breakdown of some states for input state monitoring (to analyze the effective impact of limitations imposed by the multithreading model).
- Two states removed, two new input states added

PR also includes new test mode for FedRawDataSource used to fill ramdisk in fakeBU mode looping over events from raw files.

Backport of #15955
