### PR TITLE
add AlCaReco matrix for 2016 reprocessing

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -31,6 +31,29 @@ AlCaRecoMatrix = {"AlCaLumiPixels" : "LumiPixels",
                   # 'TestEnablesEcalHcal' : 'HcalCalPedestal'
                   }
 
+AlCaRecoMatrixRereco = {'AlCaLumiPixels' : 'LumiPixels',
+                        'Charmonium'     : 'TkAlJpsiMuMu',
+                        'Commissioning'  : 'TkAlMinBias+SiStripCalMinBias+HcalCalIsoTrk+HcalCalIsolatedBunchSelector',
+                        'Cosmics'        : 'TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics',
+                        'DoubleEG'       : 'EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter',
+                        'DoubleElectron' : 'EcalUncalZElectron+HcalCalIsoTrkFilter',
+                        'DoubleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu+MuAlZMuMu+TkAlZMuMu+TkAlJpsiMuMu+TkAlUpsilonMuMu+HcalCalIsoTrkFilter',
+                        'DoubleMuon'     : 'TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+DtCalib',
+                        'DoubleMuParked' : 'MuAlCalIsolatedMu+MuAlOverlaps+DtCalib+TkAlZMuMu',
+                        'HLTPhysics'     : 'SiStripCalMinBias+TkAlMinBias+HcalCalIsoTrkFilter',
+                        'JetHT'          : 'HcalCalDijets+HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter',
+                        'NoBPTX'         : 'TkAlCosmicsInCollisions',
+                        'MET'            : 'HcalCalNoise',
+                        'MinimumBias'    : 'SiStripCalMinBias+TkAlMinBias',
+                        'MuOnia'         : 'TkAlUpsilonMuMu',
+                        'SingleElectron' : 'EcalUncalWElectron+EcalUncalZElectron+EcalESAlign+HcalCalIterativePhiSym+HcalCalIsoTrkFilter',
+                        'SingleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+DtCalib+MuAlZMuMu+HcalCalHO',
+                        'SingleMuon'     : 'TkAlMuonIsolated+DtCalib+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalIterativePhiSym+HcalCalHO',
+                        'SinglePhoton'   : 'HcalCalGammaJet',
+                        'ZeroBias'       : 'SiStripCalZeroBias+TkAlMinBias+LumiPixelsMinBias+SiStripCalMinBias',
+                        'HcalNZS'        : 'HcalCalMinBias'
+                        }
+
 def buildList(pdList, matrix):
     """Takes a list of primary datasets (PDs) and the AlCaRecoMatrix (a dictinary) and returns a string with all the AlCaRecos for the selected PDs separated by the '+' character without duplicates."""
     alCaRecoList = []


### PR DESCRIPTION
add AlCaReco matrix for 2016September reprocessing,
which is all what is run at T0 and less than it's currently in the matrix.
For documentation and future reference.
