### PR TITLE
HBHE: siPM M2 reco fixes 

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
+++ b/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
@@ -19,11 +19,12 @@ public:
     static const unsigned MAXSAMPLES = 10;
 
     inline HBHEChannelInfo()
-      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, riseTime_{0.f}, adc_{0},
+      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.},
+	  darkCurrent_{0.}, fcByPE_{0.}, lambda_{0.}, riseTime_{0.f}, adc_{0},
           hasTimeInfo_(false) {clear();}
 
     inline explicit HBHEChannelInfo(const bool hasTimeFromTDC)
-      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, riseTime_{0.f}, adc_{0},
+      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, darkCurrent_{0.}, fcByPE_{0.}, lambda_{0.}, riseTime_{0.f}, adc_{0},
           hasTimeInfo_(hasTimeFromTDC) {clear();}
 
     inline void clear()
@@ -59,12 +60,16 @@ public:
     // For speed, the "setSample" function does not perform bounds checking
     inline void setSample(const unsigned ts, const uint8_t rawADC,
                           const double q, const double ped, const double pedWidth,
+			  const double darkCurrent, const double fcByPE, const double lambda,
                           const double g, const float t)
     {
         rawCharge_[ts] = q;
         pedestal_[ts] = ped;
         pedestalWidth_[ts] = pedWidth;
         gain_[ts] = g;
+	darkCurrent_[ts] = darkCurrent;
+	fcByPE_[ts] = fcByPE;
+	lambda_[ts] = lambda,
         riseTime_[ts] = t;
         adc_[ts] = rawADC;
     }
@@ -88,6 +93,9 @@ public:
     inline const double* pedestal() const {return pedestal_;}
     inline const double* pedestalWidth() const {return pedestalWidth_;}
     inline const double* gain() const {return gain_;}
+    inline const double* darkCurrent() const {return darkCurrent_;}
+    inline const double* fcByPE() const {return fcByPE_;}
+    inline const double* lambda() const {return lambda_;}
     inline const uint8_t* adc() const {return adc_;}
     inline const float* riseTime() const
         {if (hasTimeInfo_) return riseTime_; else return nullptr;}
@@ -101,6 +109,9 @@ public:
     inline double tsEnergy(const unsigned ts) const
         {return (rawCharge_[ts] - pedestal_[ts])*gain_[ts];}
     inline double tsGain(const unsigned ts) const {return gain_[ts];}
+    inline double darkCurrent(const unsigned ts) const {return darkCurrent_[ts];}
+    inline double fcByPE(const unsigned ts) const {return fcByPE_[ts];}
+    inline double lambda(const unsigned ts) const {return lambda_[ts];}
     inline uint8_t tsAdc(const unsigned ts) const {return adc_[ts];}
     inline float tsRiseTime(const unsigned ts) const
         {return hasTimeInfo_ ? riseTime_[ts] : HcalSpecialTimes::UNKNOWN_T_NOTDC;}
@@ -194,6 +205,11 @@ private:
 
     // fC to GeV conversion factor (can depend on CAPID)
     double gain_[MAXSAMPLES];
+
+    // needed for the dark current
+    double darkCurrent_[MAXSAMPLES];
+    double fcByPE_[MAXSAMPLES];
+    double lambda_[MAXSAMPLES];
 
     // Signal rise time from TDC in ns (if provided)
     float riseTime_[MAXSAMPLES];

--- a/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
+++ b/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
@@ -19,12 +19,11 @@ public:
     static const unsigned MAXSAMPLES = 10;
 
     inline HBHEChannelInfo()
-      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, gainWidth_{0.},
-	  darkCurrent_{0.}, fcByPE_{0.}, lambda_{0.}, riseTime_{0.f}, adc_{0},
+      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, gainWidth_{0.}, riseTime_{0.f}, adc_{0},
           hasTimeInfo_(false) {clear();}
 
     inline explicit HBHEChannelInfo(const bool hasTimeFromTDC)
-      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, darkCurrent_{0.}, fcByPE_{0.}, lambda_{0.}, riseTime_{0.f}, adc_{0},
+      : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.}, gain_{0.}, gainWidth_{0.}, riseTime_{0.f}, adc_{0},
           hasTimeInfo_(hasTimeFromTDC) {clear();}
 
     inline void clear()

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -23,7 +23,7 @@
    <class name="HBHEChannelInfo" ClassVersion="5">
     <version ClassVersion="3" checksum="184305963"/>
     <version ClassVersion="4" checksum="1052948187"/>
-    <version ClassVersion="5" checksum="2522740764"/>
+    <version ClassVersion="5" checksum="1980420663"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3957655113"/>

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -20,9 +20,10 @@
    <class name="HFPreRecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="224636588"/>
    </class>
-   <class name="HBHEChannelInfo" ClassVersion="4">
+   <class name="HBHEChannelInfo" ClassVersion="5">
     <version ClassVersion="3" checksum="184305963"/>
     <version ClassVersion="4" checksum="1052948187"/>
+    <version ClassVersion="5" checksum="2522740764"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3957655113"/>

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -23,7 +23,7 @@
    <class name="HBHEChannelInfo" ClassVersion="5">
     <version ClassVersion="3" checksum="184305963"/>
     <version ClassVersion="4" checksum="1052948187"/>
-    <version ClassVersion="5" checksum="1980420663"/>
+    <version ClassVersion="5" checksum="2422402317"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3957655113"/>

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -50,6 +50,7 @@ namespace FitterFuncs{
      void setpsFitslew (double *slew  ){ for(int i=0; i<HcalConst::maxSamples; ++i) {psFit_slew [i] = slew [i]; } }
      double sigmaHPDQIE8(double ifC);
      double sigmaSiPMQIE10(double ifC);
+     double getSiPMDarkCurrent(double darkCurrent, double fcByPE, double lambda);
 
      double singlePulseShapeFunc( const double *x );
      double doublePulseShapeFunc( const double *x );

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -56,8 +56,8 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   for(unsigned int ip=0; ip<channelData.nSamples(); ip++){
 
     double charge = channelData.tsRawCharge(ip);
-    double ped = channelData.tsPedestal(ip); // ped and gain are not function of the timeslices but of the det ?
-    double gain = channelData.tsGain(ip);
+    double ped = channelData.pedestal(); 
+    double gain = channelData.gain();
 
     gainCorr = gain;
     inputCharge.push_back(charge);

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -56,8 +56,8 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   for(unsigned int ip=0; ip<channelData.nSamples(); ip++){
 
     double charge = channelData.tsRawCharge(ip);
-    double ped = channelData.pedestal(); 
-    double gain = channelData.gain();
+    double ped = channelData.tsPedestal(ip); 
+    double gain = channelData.tsGain(ip);
 
     gainCorr = gain;
     inputCharge.push_back(charge);

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -270,7 +270,8 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
 }
 
 void PulseShapeFitOOTPileupCorrection::setPulseShapeTemplate(const HcalPulseShapes::Shape& ps, bool isHPD) {
-  // comment this otherwise he siPM is not correctly initialized
+  // initialize for every hit now to avoid incorrect settings for different channel types (HPD vs SiPM)
+  // FIXME: keep this as a reminder to improve and reduce CPU use
   //  if( cntsetPulseShape ) return;
 
    // set the M2 parameters before defining the shape

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -195,8 +195,8 @@ namespace FitterFuncs{
    }
 
    double PulseShapeFunctor::sigmaSiPMQIE10(double ifC) {
-     // to be implemented
-     return 0;
+     if(ifC < 200) return (0.7416 + 0.0358*ifC)/3.;
+     return (15.225  + 0.0268*ifC + 9e-8*ifC*ifC)/3.;
    }
   
 }
@@ -270,7 +270,8 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
 }
 
 void PulseShapeFitOOTPileupCorrection::setPulseShapeTemplate(const HcalPulseShapes::Shape& ps, bool isHPD) {
-   if( cntsetPulseShape ) return;
+  // comment this otherwise he siPM is not correctly initialized
+  //  if( cntsetPulseShape ) return;
 
    // set the M2 parameters before defining the shape
    setChi2Term(isHPD);

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -194,6 +194,7 @@ namespace FitterFuncs{
       return (2.75  + 0.0373*ifC + 3e-6*ifC*ifC)/3.; 
    }
 
+  //https://indico.cern.ch/event/563410/contributions/2277004/attachments/1324249/2063825/ADCgranularity.pdf
    double PulseShapeFunctor::sigmaSiPMQIE10(double ifC) {
      if(ifC < 200) return (0.7416 + 0.0358*ifC)/3.;
      return (15.225  + 0.0268*ifC + 9e-8*ifC*ifC)/3.;

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -225,6 +225,7 @@ PulseShapeFitOOTPileupCorrection::~PulseShapeFitOOTPileupCorrection() {
 
 void PulseShapeFitOOTPileupCorrection::setChi2Term( bool isHPD ) {
 
+  // FIXME: pedSig_ should be the pedestalWidth from database
   if(isHPD) {
     timeSig_            = timeSigHPD_;
     pedSig_             = pedSigHPD_;
@@ -533,8 +534,8 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
 
     //      const int capid = channelData.capid(); // not needed
     double charge = channelData.tsRawCharge(ip);
-    double ped = channelData.tsPedestal(ip); // ped and gain are not function of the timeslices but of the det ?
-    double gain = channelData.tsGain(ip);
+    double ped = channelData.pedestal();
+    double gain = channelData.gain();
 
     double energy = charge*gain;
     double peden = ped*gain;
@@ -548,7 +549,9 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
 
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;
-    if(channelData.hasTimeInfo() && (charge-ped)>channelData.tsPedestalWidth(ip)) noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(ip),channelData.fcByPE(ip),channelData.lambda(ip));
+    if(channelData.hasTimeInfo() && (charge-ped)>channelData.pedestalWidth()) {
+      noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
+    }
 
     noiseArr[ip]= noiseADCArr[ip] + noiseDCArr[ip];
 

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -534,8 +534,8 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
 
     //      const int capid = channelData.capid(); // not needed
     double charge = channelData.tsRawCharge(ip);
-    double ped = channelData.pedestal();
-    double gain = channelData.gain();
+    double ped = channelData.tsPedestal(ip);
+    double gain = channelData.tsGain(ip);
 
     double energy = charge*gain;
     double peden = ped*gain;
@@ -549,7 +549,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
 
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;
-    if(channelData.hasTimeInfo() && (charge-ped)>channelData.pedestalWidth()) {
+    if(channelData.hasTimeInfo() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
       noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
     }
 

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
@@ -16,9 +16,9 @@ m2Parameters = cms.PSet(
     timeSigmaSiPM         = cms.double(2.5),  #ns
     meanPed               = cms.double(0.),   #GeV
     pedSigmaHPD           = cms.double(0.5),  #GeV
-    pedSigmaSiPM          = cms.double(1.5),  #GeV # placeholder for siPM
+    pedSigmaSiPM          = cms.double(0.00043),  #GeV # this correspond roughtly to 1.5 fC for a gain of 3500
     noiseHPD              = cms.double(1),    #fC
-    noiseSiPM             = cms.double(2),    #fC
+    noiseSiPM             = cms.double(1),    #fC
     ###
     timeMin               = cms.double(-12.5),#ns
     timeMax               = cms.double(12.5), #ns

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -367,7 +367,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
 
 	// needed for the dark current in the M2
 	double darkCurrent = cond.getHcalSiPMParameter(cell)->getDarkCurrent();
-	double FCByPE = cond.getHcalSiPMParameter(cell)->getFCByPE();
+	double fcByPE = cond.getHcalSiPMParameter(cell)->getFCByPE();
 	double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(cond.getHcalSiPMParameter(cell)->getType());
 
         // ADC to fC conversion
@@ -385,19 +385,22 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         {
             auto s(frame[ts]);
             const int capid = s.capid();
-            const double pedestal = calib.pedestal(capid);
-	    const double pedestalWidth = calibWidth.pedestal(capid);
-            const double gain = calib.respcorrgain(capid);
             const double rawCharge = getRawChargeFromSample(s, cs[ts], calib);
+	    const double pedestal = calib.pedestal(capid);
+	    const double pedestalWidth = calibWidth.pedestal(capid);
+	    const double gain = calib.respcorrgain(capid);
+	    const double gainWidth = calib.respcorrgain(capid);
             const float t = getTDCTimeFromSample(s);
-            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, darkCurrent, FCByPE, lambda, gain, t);
+            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, gain, gainWidth, t);
             if (ts == soi)
                 soiCapid = capid;
         }
 
+
         // Fill the overall channel info items
         const std::pair<bool,bool> hwerr = findHWErrors(frame, maxTS);
         channelInfo->setChannelInfo(cell, pulseShapeID, maxTS, soi, soiCapid,
+				    darkCurrent, fcByPE, lambda,
                                     hwerr.first, hwerr.second,
                                     taggedBadByDb || dropByZS);
 

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -409,9 +409,10 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         const RawChargeFromSample<DFrame> rcfs(cond, cell);
 
 	// needed for the dark current in the M2
-	double darkCurrent = cond.getHcalSiPMParameter(cell)->getDarkCurrent();
-	double fcByPE = cond.getHcalSiPMParameter(cell)->getFCByPE();
-	double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(cond.getHcalSiPMParameter(cell)->getType());
+	const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
+	const double darkCurrent = siPMParameter.getDarkCurrent();
+	const double fcByPE = siPMParameter.getFCByPE();
+	const double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
 
         // ADC to fC conversion
         CaloSamples cs;
@@ -431,7 +432,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
             const double pedestal = calib.pedestal(capid);
             const double pedestalWidth = calibWidth.pedestal(capid);
             const double gain = calib.respcorrgain(capid);
-            const double gainWidth = calib.respcorrgain(capid);
+	    const double gainWidth = calibWidth.gain(capid);
             const double rawCharge = rcfs.getRawCharge(cs[ts], pedestal);
             const float t = getTDCTimeFromSample(s);
             channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, gain, gainWidth, t);

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -365,6 +365,11 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
 
 	int pulseShapeID=paramTS_->getValues(cell.rawId())->pulseShapeID();
 
+	// needed for the dark current in the M2
+	double darkCurrent = cond.getHcalSiPMParameter(cell)->getDarkCurrent();
+	double FCByPE = cond.getHcalSiPMParameter(cell)->getFCByPE();
+	double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(cond.getHcalSiPMParameter(cell)->getType());
+
         // ADC to fC conversion
         CaloSamples cs;
         coder.adc2fC(frame, cs);
@@ -385,7 +390,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
             const double gain = calib.respcorrgain(capid);
             const double rawCharge = getRawChargeFromSample(s, cs[ts], calib);
             const float t = getTDCTimeFromSample(s);
-            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, gain, t);
+            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, darkCurrent, FCByPE, lambda, gain, t);
             if (ts == soi)
                 soiCapid = capid;
         }


### PR DESCRIPTION
1) FIX the initialization of the siPM pulse (Run2-phase1). 
Before the M2 siPM fits was done with the HPD pulse and parameters.
The  save 20% of CPU time on single particle no PU
2) Add extra features: add the ADC granularity or siPM (phase1)
3) fix the dark current term in the noise term of the M2-chi2
(http://dalfonso.web.cern.ch/dalfonso/DarkCurrentOnSiPM_PR15959.pdf)

This PR discuss also a possible move the initial time of the M2 fit to 2ns (Run2-phase1 ), but this is removed from the list of commit.
The save an extra 20% of CPU time on single particle no PU

Some reference slide
https://indico.cern.ch/event/570231/contributions/2306435/attachments/1341696/2021200/PR15959.pdf
