### PR TITLE
Backported fix for correct handling of stop of run in SIM producer

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -10,7 +10,6 @@
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include <memory>
 
@@ -26,6 +25,7 @@ namespace sim {
 class PrimaryTransformer;
 class Generator;
 class PhysicsList;
+class CustomUIsession;
 
 class SimWatcher;
 class SimProducer;
@@ -62,7 +62,7 @@ class RunManagerMT
   friend class RunManagerMTWorker;
 
 public:
-  RunManagerMT(edm::ParameterSet const & p);
+  explicit RunManagerMT(edm::ParameterSet const & p);
   ~RunManagerMT();
 
   void initG4(const DDCompactView *pDD, const MagneticField *pMF, const HepPDT::ParticleDataTable *fPDGTable);
@@ -75,34 +75,32 @@ public:
 
   // Keep this to keep ExceptionHandler to compile, probably removed
   // later (or functionality moved to RunManagerMTWorker)
-  void abortRun(bool softAbort=false) {}
+  inline void abortRun(bool softAbort=false) {}
 
-  const DDDWorld& world() const {
+  inline const DDDWorld& world() const {
     return *m_world;
   }
 
-  const SensitiveDetectorCatalog& catalog() const {
+  inline const SensitiveDetectorCatalog& catalog() const {
     return m_catalog;
   }
 
-  const std::vector<std::string>& G4Commands() const {
+  inline const std::vector<std::string>& G4Commands() const {
     return m_G4Commands;
   }
 
   // In order to share the physics list with the worker threads, we
   // need a non-const pointer. Thread-safety is handled inside Geant4
-  // with TLS. Should we consider a friend declaration here in order
-  // to avoid misuse?
-  PhysicsList *physicsListForWorker() const {
+  // with TLS. 
+  inline PhysicsList *physicsListForWorker() const {
     return m_physicsList.get();
   }
 
   // In order to share the ChordFinderSetter (for
   // G4MonopoleTransportation) with the worker threads, we need a
   // non-const pointer. Thread-safety is handled inside
-  // ChordFinderStter with TLS. Should we consider a friend
-  // declaration here in order to avoid misuse?
-  sim::ChordFinderSetter *chordFinderSetterForWorker() const {
+  // ChordFinderStter with TLS. 
+  inline sim::ChordFinderSetter *chordFinderSetterForWorker() const {
     return m_chordFinderSetter.get();
   }
 
@@ -112,6 +110,7 @@ private:
 
   G4MTRunManagerKernel * m_kernel;
     
+  std::unique_ptr<CustomUIsession> m_UIsession;
   std::unique_ptr<PhysicsList> m_physicsList;
   bool m_managerInitialized;
   bool m_runTerminated;
@@ -129,13 +128,14 @@ private:
   edm::ParameterSet m_pRunAction;      
   edm::ParameterSet m_g4overlap;
   std::vector<std::string> m_G4Commands;
+  edm::ParameterSet m_p;
 
   std::unique_ptr<DDDWorld> m_world;
   std::unique_ptr<DDG4ProductionCuts> m_prodCuts;
   SimActivityRegistry m_registry;
   SensitiveDetectorCatalog m_catalog;
     
-  sim::FieldBuilder             *m_fieldBuilder;
+  sim::FieldBuilder  *m_fieldBuilder;
   std::unique_ptr<sim::ChordFinderSetter> m_chordFinderSetter;
     
   std::string m_FieldFile;

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -5,6 +5,7 @@
 #include "SimG4Core/Application/interface/SimTrackManager.h"
 #include "SimG4Core/Application/interface/G4SimEvent.h"
 #include "SimG4Core/Application/interface/ParametrisedEMPhysics.h"
+#include "SimG4Core/Application/interface/CustomUIsession.h"
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
@@ -20,7 +21,6 @@
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "SimG4Core/Notification/interface/CurrentG4Track.h"
 #include "SimG4Core/Application/interface/G4RegionReporter.h"
@@ -70,9 +70,10 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_pRunAction(p.getParameter<edm::ParameterSet>("RunAction")),
       m_g4overlap(p.getParameter<edm::ParameterSet>("G4CheckOverlap")),
       m_G4Commands(p.getParameter<std::vector<std::string> >("G4Commands")),
-      m_fieldBuilder(nullptr)
+      m_p(p),m_fieldBuilder(nullptr)
 {    
   m_currentRun = nullptr;
+  m_UIsession.reset(new CustomUIsession());
   m_kernel = new G4MTRunManagerKernel();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
@@ -127,15 +128,17 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   std::unique_ptr<PhysicsListMakerBase>
     physicsMaker(PhysicsListFactory::get()->create(
       m_pPhysics.getParameter<std::string> ("type")));
-  if (physicsMaker.get()==0) {
-    throw SimG4Exception("Unable to find the Physics list requested");
+  if (physicsMaker.get()==nullptr) {
+    throw edm::Exception( edm::errors::Configuration ) 
+      << "Unable to find the Physics list requested";
   }
   m_physicsList = 
     physicsMaker->make(map_,fPDGTable,m_chordFinderSetter.get(),m_pPhysics,m_registry);
 
   PhysicsList* phys = m_physicsList.get(); 
-  if (phys==0) { 
-    throw SimG4Exception("Physics list construction failed!"); 
+  if (phys==nullptr) { 
+    throw edm::Exception( edm::errors::Configuration,
+			  "Physics list construction failed!"); 
   }
 
   // adding GFlash, Russian Roulette for eletrons and gamma, 
@@ -149,7 +152,9 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   edm::LogInfo("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of PhysicsList for master";
 
-  int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
+  int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),
+		      m_p.getParameter<int>("SteppingVerbosity"));
+
   m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   m_physicsList->SetCutsWithDefault();
   m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
@@ -169,7 +174,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   if (m_kernel->RunInitialization()) { m_managerInitialized = true; }
   else { 
-    throw SimG4Exception("G4RunManagerKernel initialization failed!"); 
+    throw edm::Exception( edm::errors::LogicError, 
+			  "G4RunManagerKernel initialization failed!"); 
   }
 
   if (m_StorePhysicsTables) {
@@ -236,13 +242,15 @@ void RunManagerMT::stopG4()
 }
 
 void RunManagerMT::terminateRun() {
-  m_userRunAction->EndOfRunAction(m_currentRun);
-  delete m_userRunAction;
-  m_userRunAction = 0;
+  if(m_userRunAction) {
+    m_userRunAction->EndOfRunAction(m_currentRun);
+    delete m_userRunAction;
+    m_userRunAction = nullptr;
+  }
   if(m_kernel && !m_runTerminated) {
     m_kernel->RunTermination();
-    m_runTerminated = true;
   }
+  m_runTerminated = true;
 }
 
 void RunManagerMT::DumpMagneticField(const G4Field* field) const

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -152,8 +152,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   edm::LogInfo("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of PhysicsList for master";
 
-  int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),
-		      m_p.getParameter<int>("SteppingVerbosity"));
+  int verb = m_pPhysics.getUntrackedParameter<int>("Verbosity",0);
 
   m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   m_physicsList->SetCutsWithDefault();


### PR DESCRIPTION
In the case of a fail at initialisation of other producers OscarMTProducer wrongly abort the run, which shadows the real problem. In this PR two classes are backported from 8_1_X providing the fix. 
