### PR TITLE
Build in ECAL precision time to PFClusters in timing era

### DIFF
--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -178,5 +178,14 @@ eras.phase2_muon.toModify(RandomNumberGeneratorService, simMuonME0Digis = cms.PS
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('HepJamesRandom')) )
 
-eras.phase2_timing.toModify(RandomNumberGeneratorService,
-                            trackTimeValueMapProducer = cms.PSet(initialSeed = cms.untracked.uint32(1234567), engineName = cms.untracked.string('HepJamesRandom') ) )
+eras.phase2_timing.toModify(
+    RandomNumberGeneratorService,
+    trackTimeValueMapProducer = cms.PSet( 
+        initialSeed = cms.untracked.uint32(1234567), 
+        engineName = cms.untracked.string('HepJamesRandom') 
+        ),
+    ecalBarrelClusterFastTimer = cms.PSet(
+        initialSeed = cms.untracked.uint32(1234567),
+        engineName = cms.untracked.string('HepJamesRandom')
+        )
+)

--- a/RecoLocalCalo/EcalRecProducers/python/ecalDetailedTimeRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalDetailedTimeRecHit_cfi.py
@@ -11,8 +11,8 @@ ecalDetailedTimeRecHit = cms.EDProducer("EcalDetailedTimeRecHitProducer",
                                         EEDetailedTimeRecHitCollection = cms.string('EcalRecHitsEE'),
                                         EBTimeLayer = ecal_time_digi_parameters.timeLayerBarrel,
                                         EETimeLayer = ecal_time_digi_parameters.timeLayerEndcap,
-                                        correctForVertexZPosition=cms.bool(True),
-                                        useMCTruthVertex=cms.bool(True),
+                                        correctForVertexZPosition=cms.bool(False),
+                                        useMCTruthVertex=cms.bool(False),
                                         recoVertex = cms.InputTag("offlinePrimaryVerticesWithBS"),
                                         simVertex = cms.InputTag("g4SimHits")
                                         )

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -157,3 +157,19 @@ eras.phase2_hgcal.toModify( RecoParticleFlowFEVT, outputCommands = RecoParticleF
 eras.phase2_hgcal.toModify( RecoParticleFlowRECO, outputCommands = RecoParticleFlowRECO.outputCommands + [ 'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*', 'keep recoPFRecHits_particleFlowRecHitHGC_Cleaned_*', 'keep recoPFClusters_particleFlowClusterHGCal__*', 'keep recoPFBlocks_simPFProducer_*_*', 'keep recoSuperClusters_simPFProducer_*_*','keep *_particleFlowTmpBarrel_*_*' ] )
 eras.phase2_hgcal.toModify( RecoParticleFlowAOD,  outputCommands = RecoParticleFlowAOD.outputCommands + [ 'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*', 'keep recoPFRecHits_particleFlowRecHitHGC_Cleaned_*', 'keep recoPFClusters_particleFlowClusterHGCal__*', 'keep recoSuperClusters_simPFProducer_*_*' ] )
 
+#timing
+eras.phase2_timing.toModify( 
+    RecoParticleFlowFEVT, 
+    outputCommands = RecoParticleFlowFEVT.outputCommands + [
+        'keep *_ecalBarrelClusterFastTimer_*_*'
+        ])
+eras.phase2_timing.toModify( 
+    RecoParticleFlowRECO, 
+    outputCommands = RecoParticleFlowRECO.outputCommands + [
+        'keep *_ecalBarrelClusterFastTimer_*_*'
+        ])
+eras.phase2_timing.toModify( 
+    RecoParticleFlowAOD, 
+    outputCommands = RecoParticleFlowAOD.outputCommands + [
+        'keep *_ecalBarrelClusterFastTimer_*_*'
+        ])

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeAssigner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeAssigner.cc
@@ -1,0 +1,80 @@
+#ifndef __PFClusterTimeAssigner__
+#define __PFClusterTimeAssigner__
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+
+
+class PFClusterTimeAssigner : public edm::stream::EDProducer<> {
+public: 
+  PFClusterTimeAssigner(const edm::ParameterSet& conf) {
+    const edm::InputTag&  clusters = 
+      conf.getParameter<edm::InputTag>("src");    
+    clustersTok_ = consumes<reco::PFClusterCollection>( clusters );
+
+    const edm::InputTag& times = 
+      conf.getParameter<edm::InputTag>("timeSrc");
+    timesTok_ = consumes<edm::ValueMap<float> >( times );
+    
+    produces<reco::PFClusterCollection>();
+  }
+
+  virtual void produce(edm::Event& e, const edm::EventSetup& es);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:  
+  edm::EDGetTokenT<reco::PFClusterCollection> clustersTok_;
+  edm::EDGetTokenT<edm::ValueMap<float> > timesTok_;
+};
+
+DEFINE_FWK_MODULE(PFClusterTimeAssigner);
+
+void PFClusterTimeAssigner::
+produce(edm::Event& e, const edm::EventSetup& es) {
+  auto clusters_out = std::make_unique<reco::PFClusterCollection>();
+  
+  edm::Handle<reco::PFClusterCollection> clustersH;
+  e.getByToken(clustersTok_,clustersH);
+  edm::Handle<edm::ValueMap<float> > timesH;
+  e.getByToken(timesTok_,timesH);
+
+  auto const & clusters = *clustersH;
+  auto const & times = *timesH;
+  
+  clusters_out->reserve(clusters.size());
+  clusters_out->insert(clusters_out->end(),
+		       clusters.begin(),clusters.end());
+
+  //build the EE->PS association
+  auto& out = *clusters_out;
+  for( unsigned i = 0; i < out.size(); ++i ) {      
+    
+    edm::Ref<reco::PFClusterCollection> clusterRef(clustersH,i);
+    const float time = times[clusterRef];
+    out[i].setTime(time);
+    
+  }
+
+  e.put(std::move(clusters_out));
+}
+
+void PFClusterTimeAssigner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;  
+  desc.add<edm::InputTag>("src",edm::InputTag("particleFlowClusterECALUncorrected"));
+  desc.add<edm::InputTag>("timeSrc",edm::InputTag("ecalBarrelClusterFastTimer"));
+  descriptions.add("particleFlowClusterTimeAssignerDefault",desc);
+}
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterTimeAssigner_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterTimeAssigner_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterTimeAssignerDefault_cfi import *
+
+particleFlowTimeAssignerECAL = particleFlowClusterTimeAssignerDefault.clone()
+particleFlowTimeAssignerECAL.timeSrc = cms.InputTag('ecalBarrelClusterFastTimer:PerfectResolutionModel')
+
+

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -21,10 +21,11 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHO_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterPS_cfi import *
 
+particleFlowClusterECALSequence = cms.Sequence(particleFlowClusterECAL)
 
 pfClusteringECAL = cms.Sequence(particleFlowRecHitECAL*
                                 particleFlowClusterECALUncorrected *
-                                particleFlowClusterECAL)
+                                particleFlowClusterECALSequence)
 pfClusteringPS = cms.Sequence(particleFlowRecHitPS*particleFlowClusterPS)
 
 
@@ -51,8 +52,20 @@ particleFlowCluster = cms.Sequence(
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGC_cfi import particleFlowRecHitHGC
 pfClusteringHGCal = cms.Sequence(particleFlowRecHitHGC)
 
-_phase2_particleFlowCluster = particleFlowCluster.copy()
-_phase2_particleFlowCluster += pfClusteringHGCal
+_phase2_hgcal_particleFlowCluster = particleFlowCluster.copy()
+_phase2_hgcal_particleFlowCluster += pfClusteringHGCal
 
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_hgcal.toReplaceWith( particleFlowCluster, _phase2_particleFlowCluster )
+eras.phase2_hgcal.toReplaceWith( particleFlowCluster, _phase2_hgcal_particleFlowCluster )
+
+#timing
+
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterTimeAssigner_cfi import particleFlowTimeAssignerECAL
+from RecoParticleFlow.PFSimProducer.ecalBarrelClusterFastTimer_cfi import ecalBarrelClusterFastTimer
+_phase2_timing_particleFlowClusterECALSequence = cms.Sequence(ecalBarrelClusterFastTimer*
+                                                              particleFlowTimeAssignerECAL*
+                                                              particleFlowClusterECALSequence.copy())
+eras.phase2_timing.toReplaceWith(particleFlowClusterECALSequence, 
+                                 _phase2_timing_particleFlowClusterECALSequence)
+eras.phase2_timing.toModify(particleFlowClusterECAL,
+                            inputECAL = cms.InputTag('particleFlowTimeAssignerECAL'))

--- a/RecoParticleFlow/PFSimProducer/python/ecalBarrelClusterFastTimer_cfi.py
+++ b/RecoParticleFlow/PFSimProducer/python/ecalBarrelClusterFastTimer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 ecalBarrelClusterFastTimer = cms.EDProducer(
     'EcalBarrelClusterFastTimer',
     ebTimeHits = cms.InputTag('ecalDetailedTimeRecHit:EcalRecHitsEB'),
-    ebClusters = cms.InputTag('particleFlowClusterECAL'),
+    ebClusters = cms.InputTag('particleFlowClusterECALUncorrected'),
     timedVertices = cms.InputTag('offlinePrimaryVertices4D'),
     minFractionToConsider = cms.double(0.1),
     minEnergyToConsider = cms.double(0.0),


### PR DESCRIPTION
This PR uses the ECAL precision timing modules to assign times to ECAL PFClusters.

This overwrites the usual time() in ECAL PFClusters with the value derived from the precision time digitizer.

New data formats saved, and updated time all show up in wf22424.0.

@bendavid
