### PR TITLE
Make ContainerMask work with LazyGetter of DetSetVector

### DIFF
--- a/DataFormats/Common/interface/ContainerMask.h
+++ b/DataFormats/Common/interface/ContainerMask.h
@@ -41,8 +41,10 @@ namespace edm {
 
       // ---------- const member functions ---------------------
      	bool mask(unsigned int iIndex) const {
-         assert(iIndex<m_mask.size());
-         return m_mask[iIndex];
+          if(iIndex<m_mask.size()) {
+            return m_mask[iIndex];
+          }
+          return false;
      	}
      	bool mask(const typename ContainerMaskTraits<T>::value_type *);
      	void applyOrTo( std::vector<bool>&) const;
@@ -73,7 +75,7 @@ namespace edm {
    template<typename T>
    ContainerMask<T>::ContainerMask(const edm::RefProd<T>& iProd, const std::vector<bool>& iMask):
    m_prod(iProd), m_mask(iMask) {
-      assert(iMask.size() == ContainerMaskTraits<T>::size(m_prod.product()));
+      assert(iMask.size() <= ContainerMaskTraits<T>::size(m_prod.product()));
    }
    
    


### PR DESCRIPTION
edmNew::DetSetVector::dataSize can update as algorithms access the
cached values in edmNew::DetSetVector::dataSize. ContainerMask queries
that value to enforce that the mask it is given is compatible. Now
we just require that the mask be no longer than dataSize. If an
index beyond that range is requested, it returns false.
