### PR TITLE
Update the fall back express GT to be used by Event Display applications

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -4,7 +4,7 @@ GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serv
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.
-GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v14" )
+GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v15" )
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.


### PR DESCRIPTION
The Global tag for express processing used by Event Display applications as a fall-back in case the query to the Tier0 DataService API fails is updated to the latest version.
