### PR TITLE
Update the fall back express GT to be used by Event Display applications (80X)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -5,7 +5,7 @@ GlobalTag.pfnPrefix = cms.untracked.string("frontier://(proxyurl=http://localhos
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0.
-GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v14" )
+GlobalTag.globaltag = cms.string( "80X_dataRun2_Express_v15" )
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.


### PR DESCRIPTION
The Global tag for express processing used by Event Display applications as a fall-back in case the query to the Tier0 DataService API fails is updated to the latest version.

Back-port of #15965 
