### PR TITLE
PR 81x v86.1 tsg-9.2 post O2O PR merge - part Muon

### DIFF
--- a/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
+++ b/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
@@ -19,7 +19,7 @@ gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     topCfgXmlFile = cms.string('L1Trigger/L1TMuon/data/o2o/ugmt/ugmt_top_config_p5.xml'),
     xmlCfgKey = cms.string('TestKey1'),
     # get configuration from DB and ignore values below this one
-    configFromXml = cms.bool(True),
+    configFromXml = cms.bool(False),
 
     #fwVersion = cms.uint32(1),
     fwVersion = cms.uint32(0x2020000),


### PR DESCRIPTION
This PR is addendum on the already merged PR #15974, now concerning emulation of L1T muons

DONE: Bit-wise agreement for muon objects after configuring L1TMuonGlobalParamsESProducer to
not use Xml files.
