### PR TITLE
Pr81x fix duplicate tracks EMTF on top l1t-tsg-v9.2-post-O2O-pr

### DIFF
--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockSP.cc
@@ -242,7 +242,7 @@ namespace l1t {
 	    if ( (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) && (res_hit->at(iHit)).Sector() == conv_vals_SP.at(1) &&
 		 (res_hit->at(iHit)).Subsector() == conv_vals_SP.at(2) && (res_hit->at(iHit)).Neighbor() == conv_vals_SP.at(3) &&
 		 (res_hit->at(iHit)).Station() == 1 && (res_hit->at(iHit)).Stub_num() == SP_.ME1_stub_num() &&
-		 (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
+		 (res_hit->at(iHit)).Endcap() == Track_.Endcap() && (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
 	      if (St_hits[0] == 0 ) Track_.push_Hit( res_hit->at(iHit) );
 	      St_hits[0] += 1; }
 	  }
@@ -260,7 +260,8 @@ namespace l1t {
 	    // if ( ( (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) || (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) + 3 ) && 
 	    // 	 (res_hit->at(iHit)).Sector() == conv_vals_SP.at(1) && 
 		 (res_hit->at(iHit)).Neighbor() == conv_vals_SP.at(3) && (res_hit->at(iHit)).Station() == 2 && 
-		 (res_hit->at(iHit)).Stub_num() == SP_.ME2_stub_num() && (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
+		 (res_hit->at(iHit)).Stub_num() == SP_.ME2_stub_num() && (res_hit->at(iHit)).Endcap() == Track_.Endcap() && 
+		 (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
 	      if (St_hits[1] == 0 ) Track_.push_Hit( res_hit->at(iHit) );
 	      St_hits[1] += 1; }
 	  }
@@ -278,7 +279,8 @@ namespace l1t {
 	    // if ( ( (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) || (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) + 3 ) && 
 	    // 	 (res_hit->at(iHit)).Sector() == conv_vals_SP.at(1) && 
 		 (res_hit->at(iHit)).Neighbor() == conv_vals_SP.at(3) && (res_hit->at(iHit)).Station() == 3 && 
-		 (res_hit->at(iHit)).Stub_num() == SP_.ME3_stub_num() && (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
+		 (res_hit->at(iHit)).Stub_num() == SP_.ME3_stub_num() && (res_hit->at(iHit)).Endcap() == Track_.Endcap() &&
+		 (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
 	      if (St_hits[2] == 0 ) Track_.push_Hit( res_hit->at(iHit) );
 	      St_hits[2] += 1; }
 	  }
@@ -296,7 +298,8 @@ namespace l1t {
 	    // if ( ( (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) || (res_hit->at(iHit)).CSC_ID() == conv_vals_SP.at(0) + 3 ) && 
 	    // 	 (res_hit->at(iHit)).Sector() == conv_vals_SP.at(1) && 
 		 (res_hit->at(iHit)).Neighbor() == conv_vals_SP.at(3) && (res_hit->at(iHit)).Station() == 4 && 
-		 (res_hit->at(iHit)).Stub_num() == SP_.ME4_stub_num() && (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
+		 (res_hit->at(iHit)).Stub_num() == SP_.ME4_stub_num() && (res_hit->at(iHit)).Endcap() == Track_.Endcap() && 
+		 (res_hit->at(iHit)).BX() - (SP_.TBIN() - 3) == dBX[iBX] ) {
 	      if (St_hits[3] == 0 ) Track_.push_Hit( res_hit->at(iHit) );
 	      St_hits[3] += 1; }
 	  }

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -65,12 +65,13 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   //fprintf (write,"12345\n"); //<-- part of printing text file to send verilog code, not needed if George's package is included
 
   //std::auto_ptr<L1TMuon::InternalTrackCollection> FoundTracks (new L1TMuon::InternalTrackCollection);
-  std::auto_ptr<l1t::RegionalMuonCandBxCollection > OutputCands (new l1t::RegionalMuonCandBxCollection);
-  std::auto_ptr<l1t::EMTFTrackCollection> OutTracks (new l1t::EMTFTrackCollection);
-  std::auto_ptr<l1t::EMTFHitCollection> OutHits (new l1t::EMTFHitCollection);
-  std::auto_ptr<l1t::EMTFTrackExtraCollection> OutputTracks (new l1t::EMTFTrackExtraCollection);
-  std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHits (new l1t::EMTFHitExtraCollection);
-  std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHitsRPC (new l1t::EMTFHitExtraCollection);
+  auto FoundTracks = std::make_unique<L1TMuon::InternalTrackCollection>();
+  auto OutputCands = std::make_unique<l1t::RegionalMuonCandBxCollection>();
+  auto OutTracks = std::make_unique<l1t::EMTFTrackCollection>();
+  auto OutHits = std::make_unique<l1t::EMTFHitCollection>();
+  auto OutputTracks = std::make_unique<l1t::EMTFTrackExtraCollection>();
+  auto OutputHits = std::make_unique<l1t::EMTFHitExtraCollection>();
+  auto OutputHitsRPC = std::make_unique<l1t::EMTFHitExtraCollection>();
 
   std::vector<BTrack> PTracks[NUM_SECTORS];
   std::vector<BTrack> PTracks_BX[NUM_SECTORS][3];
@@ -688,13 +689,13 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     }
   }
   
-  //ev.put( FoundTracks, "DataITC");
-  ev.put( OutputCands, "EMTF");
-  ev.put( OutHits, "");      // EMTFHitCollection
-  ev.put( OutTracks, "");    // EMTFTrackCollection
-  ev.put( OutputHits, "CSC");   // EMTFHitExtraCollection
-  ev.put( OutputHitsRPC, "RPC");   // EMTFHitExtraCollection
-  ev.put( OutputTracks, ""); // EMTFTrackExtraCollection
+  //ev.put(std::move(FoundTracks), "DataITC");
+  ev.put(std::move(OutputCands), "EMTF");
+  ev.put(std::move(OutHits), "");      // EMTFHitCollection
+  ev.put(std::move(OutTracks), "");    // EMTFTrackCollection
+  ev.put(std::move(OutputHits), "CSC");   // EMTFHitExtraCollection
+  ev.put(std::move(OutputHitsRPC), "RPC");   // EMTFHitExtraCollection
+  ev.put(std::move(OutputTracks), ""); // EMTFTrackExtraCollection
   
 }//analyzer
 

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -13,6 +13,7 @@
 
 #include "L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h"
+#include "L1Trigger/CSCTrackFinder/test/src/RefTrack.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,19 +64,19 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 
   //fprintf (write,"12345\n"); //<-- part of printing text file to send verilog code, not needed if George's package is included
 
-  auto FoundTracks = std::make_unique<L1TMuon::InternalTrackCollection>();
-  auto OutputCands = std::make_unique<l1t::RegionalMuonCandBxCollection>();
-  auto OutTracks = std::make_unique<l1t::EMTFTrackCollection>();
-  auto OutHits = std::make_unique<l1t::EMTFHitCollection>();
-  auto OutputTracks = std::make_unique<l1t::EMTFTrackExtraCollection>();
-  auto OutputHits = std::make_unique<l1t::EMTFHitExtraCollection>();
-  auto OutputHitsRPC = std::make_unique<l1t::EMTFHitExtraCollection>();
+  //std::auto_ptr<L1TMuon::InternalTrackCollection> FoundTracks (new L1TMuon::InternalTrackCollection);
+  std::auto_ptr<l1t::RegionalMuonCandBxCollection > OutputCands (new l1t::RegionalMuonCandBxCollection);
+  std::auto_ptr<l1t::EMTFTrackCollection> OutTracks (new l1t::EMTFTrackCollection);
+  std::auto_ptr<l1t::EMTFHitCollection> OutHits (new l1t::EMTFHitCollection);
+  std::auto_ptr<l1t::EMTFTrackExtraCollection> OutputTracks (new l1t::EMTFTrackExtraCollection);
+  std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHits (new l1t::EMTFHitExtraCollection);
+  std::auto_ptr<l1t::EMTFHitExtraCollection> OutputHitsRPC (new l1t::EMTFHitExtraCollection);
 
   std::vector<BTrack> PTracks[NUM_SECTORS];
   std::vector<BTrack> PTracks_BX[NUM_SECTORS][3];
 
-  std::vector<L1TMuon::TriggerPrimitive> tester;
-  std::vector<L1TMuon::TriggerPrimitive> tester_rpc;
+  std::vector<TriggerPrimitive> tester;
+  std::vector<TriggerPrimitive> tester_rpc;
   //std::vector<InternalTrack> FoundTracks;
 
   // Get the RPC geometry
@@ -95,8 +96,8 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
   edm::Handle<RPCDigiCollection> RDC;
   ev.getByToken(inputTokenRPC, RDC);
   
-  std::vector<L1TMuon::TriggerPrimitive> out;
-  std::vector<L1TMuon::TriggerPrimitive> out_rpc;
+  std::vector<TriggerPrimitive> out;
+  std::vector<TriggerPrimitive> out_rpc;
 
   auto chamber = MDC->begin();
   auto chend  = MDC->end();
@@ -106,7 +107,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     for( ; digi != dend; ++digi ) {
       CSCCorrelatedLCTDigi tmp_digi = *digi;
       tmp_digi.setBX( tmp_digi.getBX() + std::max(bxShiftCSC, -1*tmp_digi.getBX()) );
-      out.push_back(L1TMuon::TriggerPrimitive((*chamber).first,tmp_digi));
+      out.push_back(TriggerPrimitive((*chamber).first,tmp_digi));
       l1t::EMTFHitExtra thisHit;
       thisHit.ImportCSCDetId( (*chamber).first );
       thisHit.ImportCSCCorrelatedLCTDigi( tmp_digi );
@@ -128,19 +129,19 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     auto rdigi = (*rchamber).second.first;
     auto rdend = (*rchamber).second.second;
     for( ; rdigi != rdend; ++rdigi) {
-      out_rpc.push_back(L1TMuon::TriggerPrimitive( (*rchamber).first, rdigi->strip(), 0, rdigi->bx())); // Layer unset.  How to access? - AWB 03.06.16 
+      out_rpc.push_back(TriggerPrimitive( (*rchamber).first, rdigi->strip(), 0, rdigi->bx())); // Layer unset.  How to access? - AWB 03.06.16 
     }
   }
   
   
   //////////////////////////////////////////////
-  ///////// Get Trigger Primitives /////////////  Retrieve L1TMuon::TriggerPrimitives from the event record: Currently does nothing because we don't take RPC's
+  ///////// Get Trigger Primitives /////////////  Retrieve TriggerPrimitives from the event record: Currently does nothing because we don't take RPC's
   //////////////////////////////////////////////
   
   // auto tpsrc = _tpinputs.cbegin();
   //auto tpend = _tpinputs.cend();
   // for( ; tpsrc != tpend; ++tpsrc ) {
-  // edm::Handle<L1TMuon::TriggerPrimitiveCollection> tps;
+  // edm::Handle<TriggerPrimitiveCollection> tps;
   // ev.getByLabel(*tpsrc,tps);
   auto tp = out_rpc.cbegin();
   auto tpend = out_rpc.cend();
@@ -162,17 +163,17 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	   out[i1].getBX() == out[i2].getBX() && out[i1].Id() == out[i2].Id() &&
 	   out[i1].getStrip() != out[i2].getStrip() && out[i1].getWire() != out[i2].getWire() ) {
 	
-	L1TMuon::TriggerPrimitive NewWire1(out[i1],out[i2]);
-	L1TMuon::TriggerPrimitive NewWire2(out[i2],out[i1]);
+	TriggerPrimitive NewWire1(out[i1],out[i2]);
+	TriggerPrimitive NewWire2(out[i2],out[i1]);
 	tester.push_back(NewWire1);
 	tester.push_back(NewWire2);
       } 
     } // End loop: for(unsigned int i2=i1+1;i2<out.size();i2++)
   } // End loop: for(unsigned int i1=0;i1<out.size();i1++)
 
-  unsigned int nHits = OutputHits->size();
-  for (unsigned int iHit = 0; iHit < nHits; iHit++) {
-    for (unsigned int jHit = iHit+1; jHit < nHits; jHit++) {
+  uint nHits = OutputHits->size();
+  for (uint iHit = 0; iHit < nHits; iHit++) {
+    for (uint jHit = iHit+1; jHit < nHits; jHit++) {
       if ( OutputHits->at(iHit).Chamber() != OutputHits->at(jHit).Chamber() ) continue;
       if ( (OutputHits->at(iHit).Ring() % 3) != (OutputHits->at(jHit).Ring() % 3) ) continue;
       if ( OutputHits->at(iHit).Sector() != OutputHits->at(jHit).Sector() ) continue;
@@ -207,15 +208,15 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     CHits[SectIndex] = ConvHits;
 
     l1t::EMTFHitExtraCollection tmp_hits_rpc = primConvRPC_.convert(tester_rpc, SectIndex, _geom_rpc); 
-    for (unsigned int iHit = 0; iHit < tmp_hits_rpc.size(); iHit++) 
+    for (uint iHit = 0; iHit < tmp_hits_rpc.size(); iHit++) 
       OutputHitsRPC->push_back( tmp_hits_rpc.at(iHit) );
     std::vector<ConvertedHit> ConvHitsRPC = primConvRPC_.fillConvHits(tmp_hits_rpc);
     
     // Fill OutputHits with ConvertedHit information
-    for (unsigned int iCHit = 0; iCHit < ConvHits.size(); iCHit++) {
+    for (uint iCHit = 0; iCHit < ConvHits.size(); iCHit++) {
       // bool isMatched = false;
       
-      for (unsigned int iHit = 0; iHit < OutputHits->size(); iHit++) {
+      for (uint iHit = 0; iHit < OutputHits->size(); iHit++) {
 	if ( ConvHits.at(iCHit).Station()   == OutputHits->at(iHit).Station() &&
 	     ( ConvHits.at(iCHit).Id()      == OutputHits->at(iHit).CSC_ID()  ||
 	       ConvHits.at(iCHit).Id()      == ( (OutputHits->at(iHit).Ring() != 4) // Account for either ME1/1a 
@@ -223,7 +224,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 						 : OutputHits->at(iHit).CSC_ID() + 9 ) ) &&
 	     ConvHits.at(iCHit).Wire()       == OutputHits->at(iHit).Wire()    &&
 	     ConvHits.at(iCHit).Strip()      == OutputHits->at(iHit).Strip()   &&
-	     ConvHits.at(iCHit).BX() - 6     == OutputHits->at(iHit).BX()      &&  // switch from CSC convention (centered at +6) to  uGMT convention (centered at 0)
+	     ConvHits.at(iCHit).BX() - 6     == OutputHits->at(iHit).BX()      &&
 	     ConvHits.at(iCHit).IsNeighbor() == OutputHits->at(iHit).Neighbor() ) {
 	  // isMatched = true;
 	  OutputHits->at(iHit).set_neighbor    ( ConvHits.at(iCHit).IsNeighbor());
@@ -246,7 +247,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  
 	  OutHits->push_back( OutputHits->at(iHit).CreateEMTFHit() );
 	}
-      } // End loop: for (unsigned int iHit = 0; iHit < OutputHits->size(); iHit++)
+      } // End loop: for (uint iHit = 0; iHit < OutputHits->size(); iHit++)
 
       // if (isMatched == false) {
       //   std::cout << "***********************************************" << std::endl;
@@ -256,7 +257,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       // 	      << ", wire = " << ConvHits.at(iCHit).Wire() << ", strip = " << ConvHits.at(iCHit).Strip()
       // 	      << ", BX = " << ConvHits.at(iCHit).BX() << ", neighbor = " << ConvHits.at(iCHit).IsNeighbor() << std::endl;
       
-      //   for (unsigned int iHit = 0; iHit < OutputHits->size(); iHit++) {
+      //   for (uint iHit = 0; iHit < OutputHits->size(); iHit++) {
       //     std::cout << "EMTFHitExtra: station = " << OutputHits->at(iHit).Station() << ", CSC ID = " << OutputHits->at(iHit).CSC_ID()
       // 		<< ", sector index = " << OutputHits->at(iHit).Sector_index() << ", subsector = " << OutputHits->at(iHit).Subsector() 
       // 		<< ", wire = " << OutputHits->at(iHit).Wire() << ", strip = " << OutputHits->at(iHit).Strip()
@@ -266,7 +267,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
       //   }
       // }
       
-    } // End loop: for (unsigned int iCHit = 0; iCHit < ConvHits.size(); iCHit++)
+    } // End loop: for (uint iCHit = 0; iCHit < ConvHits.size(); iCHit++)
     
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -377,24 +378,37 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     }
   }
 
-  // Cancel out duplicate tracks
-  for (unsigned int i1=0; i1 < AllTracks_PreCancel.size(); i1++) {
+  // Cancel out tracks with identical hits
+  for (unsigned int i1 = 0; i1 < AllTracks_PreCancel.size(); i1++) {
     bool dup = false;
-    int ebx = 20, sindex = -1;
-    for (std::vector<ConvertedHit>::iterator A = AllTracks_PreCancel[i1].AHits.begin(); A != AllTracks_PreCancel[i1].AHits.end(); A++) {
-      if (A->TP().getCSCData().bx < ebx) ebx = A->TP().getCSCData().bx;
-      sindex = A->SectorIndex();
-    }
-    for (unsigned int i2 = i1+1; i2 < AllTracks_PreCancel.size(); i2++) {
-      int ebx2 = 20, sindex2 = -1;
-      for (std::vector<ConvertedHit>::iterator A2 = AllTracks_PreCancel[i1].AHits.begin(); A2 != AllTracks_PreCancel[i1].AHits.end(); A2++) {
-	if (A2->TP().getCSCData().bx < ebx2) ebx2 = A2->TP().getCSCData().bx;
-	sindex2 = A2->SectorIndex();
-      }
-      if (ebx == ebx2 && AllTracks_PreCancel[i1].theta == AllTracks_PreCancel[i2].theta && AllTracks_PreCancel[i1].phi == AllTracks_PreCancel[i2].phi && AllTracks_PreCancel[i1].winner.Rank() == AllTracks_PreCancel[i2].winner.Rank() && sindex == sindex2 && sindex != -1 && sindex2 != -1) dup = true;
-    }
-    if (!dup) AllTracks.push_back(AllTracks_PreCancel[i1]);
-  }
+    int rank1 = AllTracks_PreCancel[i1].winner.Rank();
+    int rank2 = -99;
+    int i1_dup = i1;
+    int i2_dup = -99;
+    for (unsigned int i2 = 0; i2 < AllTracks_PreCancel.size(); i2++) {
+      if (i1 == i2) continue;
+      for (std::vector<ConvertedHit>::iterator A1 = AllTracks_PreCancel[i1].AHits.begin(); A1 != AllTracks_PreCancel[i1].AHits.end(); A1++) {
+	CSCDetId D1 = A1->TP().detId<CSCDetId>();
+	TriggerPrimitive::CSCData C1 = A1->TP().getCSCData();
+	for (std::vector<ConvertedHit>::iterator A2 = AllTracks_PreCancel[i2].AHits.begin(); A2 != AllTracks_PreCancel[i2].AHits.end(); A2++) {
+	  CSCDetId D2 = A2->TP().detId<CSCDetId>();
+	  TriggerPrimitive::CSCData C2 = A2->TP().getCSCData();
+	  if ( A1->SectorIndex() == A2->SectorIndex() &&  D1.endcap() == D2.endcap() && D1.station() == D2.station() && 
+	       D1.ring() == D2.ring() && D1.triggerSector() == D2.triggerSector() && D1.chamber() == D2.chamber() &&
+	       C1.bx == C2.bx && C1.strip == C2.strip && C1.keywire == C2.keywire ) {
+	    dup = true;
+	    if (AllTracks_PreCancel[i2].winner.Rank() > rank2) {
+	      i2_dup = i2;
+	      rank2 = AllTracks_PreCancel[i2].winner.Rank();
+	    } // Find the highest-ranked duplicate track
+	  } // End if hits are identical
+	} // End loop over hits in track 2
+      } // End loop over hits in track 1
+    } // End second loop over tracks
+
+    // Only use ordering when ranks are equal.  Track order is not necessarily the same as FW. - AWB 21.09.16
+    if ( (!dup) || (rank1 > rank2) || (rank1 == rank2 && i1_dup < i2_dup) ) AllTracks.push_back(AllTracks_PreCancel[i1]);
+  } // End first loop over tracks
 
   
   ///////////////////////////////////
@@ -460,7 +474,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  l1t::EMTFHitExtra thisHit;
 	  // thisHit.ImportCSCDetId( A->TP().detId<CSCDetId>() );
 
-	  for (unsigned int iHit = 0; iHit < OutputHits->size(); iHit++) {
+	  for (uint iHit = 0; iHit < OutputHits->size(); iHit++) {
 	    if ( (A->TP().detId<CSCDetId>().endcap() == 1) == (OutputHits->at(iHit).Endcap() == 1) &&
 		 A->TP().detId<CSCDetId>().station()       == OutputHits->at(iHit).Station() &&
 		 A->TP().detId<CSCDetId>().triggerSector() == OutputHits->at(iHit).Sector()  &&
@@ -488,7 +502,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 		      << ", sector index " << A->SectorIndex() << ", subsector " << A->Sub()
 		      << ", wire " << A->Wire() << ", strip " << A->Strip() << ", BX " << A->TP().getCSCData().bx - 6 
 		      << ", neighbor " << A->IsNeighbor() << " has no match" << std::endl;
-	    for (unsigned int iHit = 0; iHit < OutputHits->size(); iHit++) 
+	    for (uint iHit = 0; iHit < OutputHits->size(); iHit++) 
 	      std::cout << "!@#$ Option " << iHit+1 << " with endcap " << OutputHits->at(iHit).Endcap() 
 			<< ", station " << OutputHits->at(iHit).Station() << ", CSC_ID " << OutputHits->at(iHit).CSC_ID() 
 			<< ", ring " << OutputHits->at(iHit).Ring() << ", chamber " << OutputHits->at(iHit).Chamber()
@@ -500,6 +514,10 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
 	  thisTrack.set_sector_index ( thisHit.Sector_index() );
 	  thisTrack.set_sector       ( l1t::calc_sector_from_index( thisHit.Sector_index() ) );
 	  thisTrack.set_sector_GMT   ( l1t::calc_sector_GMT( thisHit.Sector() ) );
+	  if ( thisHit.Neighbor() == 0 ) thisTrack.set_all_neighbor(0);
+	  if ( thisHit.Neighbor() == 1 ) thisTrack.set_has_neighbor(1);
+	  if ( thisHit.Neighbor() == 0 && thisTrack.Has_neighbor() == -999 ) thisTrack.set_has_neighbor(0);
+	  if ( thisHit.Neighbor() == 1 && thisTrack.All_neighbor() == -999 ) thisTrack.set_all_neighbor(0);
 	  
 	  int station = A->TP().detId<CSCDetId>().station();
 	  int id = A->TP().getCSCData().cscID;
@@ -670,13 +688,13 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& ev,
     }
   }
   
-  //ev.put(std::move(FoundTracks), "DataITC");
-  ev.put(std::move(OutputCands), "EMTF");
-  ev.put(std::move(OutHits), "");      // EMTFHitCollection
-  ev.put(std::move(OutTracks), "");    // EMTFTrackCollection
-  ev.put(std::move(OutputHits), "CSC");   // EMTFHitExtraCollection
-  ev.put(std::move(OutputHitsRPC), "RPC");   // EMTFHitExtraCollection
-  ev.put(std::move(OutputTracks), ""); // EMTFTrackExtraCollection
+  //ev.put( FoundTracks, "DataITC");
+  ev.put( OutputCands, "EMTF");
+  ev.put( OutHits, "");      // EMTFHitCollection
+  ev.put( OutTracks, "");    // EMTFTrackCollection
+  ev.put( OutputHits, "CSC");   // EMTFHitExtraCollection
+  ev.put( OutputHitsRPC, "RPC");   // EMTFHitExtraCollection
+  ev.put( OutputTracks, ""); // EMTFTrackExtraCollection
   
 }//analyzer
 


### PR DESCRIPTION
This is the 81x version of the 80x PR #15980.

Except that here in 81x, the l1t-tsg-9.2 has been fully merged, so what remains is only the fix in EMTF emulator to rid of duplicate tracks. Additional change from auto_ptr to unique_ptr is to sync with these changes made in 81x.
- STATUS: Pending blessing from L1T DPG.
