### PR TITLE
add HCAL to 2023 validation/DQM

### DIFF
--- a/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
+++ b/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
@@ -33,3 +33,7 @@ _phase1_hcalOfflineSourceSequence.insert(0,digiPhase1Task)
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hcalOfflineSourceSequence, _phase1_hcalOfflineSourceSequence )
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+_phase2_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copyAndExclude([digiTask,tpTask,rawTask])
+phase2_hcal.toReplaceWith(hcalOfflineSourceSequence, _phase2_hcalOfflineSourceSequence)

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -49,7 +49,7 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
                           'dqmHarvesting']
             }
 
-_phase2_allowed = ['trackingOnlyDQM','muon']
+_phase2_allowed = ['trackingOnlyDQM','muon','hcal']
 autoDQM['phase2'] = ['','','']
 for i in range(0,3):
     autoDQM['phase2'][i] = '+'.join([autoDQM[m][i] for m in _phase2_allowed])

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -4,12 +4,13 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
                    'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'],
                    'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
+                   'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'],
                    'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
                    'miniAODValidation' : ['prevalidationMiniAOD','validationMiniAOD','validationHarvestingMiniAOD'],
                    'standardValidation' : ['prevalidation','validation','validationHarvesting']
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation','hcalOnlyValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([autoValidation[m][i] for m in _phase2_allowed])

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -140,6 +140,15 @@ globalPrevalidationJetMETOnly = cms.Sequence(
 				  +metPreValidSeq
 )
 
+globalPrevalidationHCAL = cms.Sequence()
+
+globalValidationHCAL = cms.Sequence(
+      hcalSimHitsValidationSequence
+    + hcaldigisValidationSequence
+    + hcalSimHitStudy
+    + hcalRecHitsValidationSequence
+)
+
 globalPrevalidationMuons = cms.Sequence(
       gemSimValid
     + me0SimValid

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -82,6 +82,12 @@ postValidation_muons = cms.Sequence(
 postValidation_JetMET = cms.Sequence(
     METPostProcessor
 )
+
+postValidation_HCAL = cms.Sequence(
+      hcalSimHitsPostProcessor
+    + hcaldigisPostProcessor
+    + hcalrechitsPostProcessor
+)
  
 postValidation_gen = cms.Sequence(
     EventGeneratorPostProcessor

--- a/Validation/HcalDigis/interface/HcalDigisValidation.h
+++ b/Validation/HcalDigis/interface/HcalDigisValidation.h
@@ -147,6 +147,7 @@ private:
     int maxDepth_[5]; // 0:any, 1:HB, 2:HE, 3:HF
     int nChannels_[5]; // 0:any, 1:HB, 2:HE, 
 
+    bool skipDataTPs;
 };
 
 #endif

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -16,3 +16,5 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():
     hcaldigisAnalyzer.simHits = cms.untracked.InputTag("famosSimHits","HcalHits")
     
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(hcaldigisAnalyzer, dataTPs = cms.InputTag(""))

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -43,8 +43,12 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
     tok_ho_ = consumes< HODigiCollection >(inputTag_);
     tok_hf_ = consumes< HFDigiCollection >(inputTag_);
     tok_emulTPs_ = consumes<HcalTrigPrimDigiCollection>(emulTPsTag_);
-    tok_dataTPs_ = consumes<HcalTrigPrimDigiCollection>(dataTPsTag_);
-    
+    if(dataTPsTag_==edm::InputTag("")) skipDataTPs = true;
+    else {
+        skipDataTPs = false;
+        tok_dataTPs_ = consumes<HcalTrigPrimDigiCollection>(dataTPsTag_);
+    }
+
     tok_qie10_hf_ = consumes< QIE10DigiCollection >(edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
     tok_qie11_hbhe_ = consumes< QIE11DigiCollection >(edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
 
@@ -121,6 +125,7 @@ void HcalDigisValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &
         booking(ib,subdet_, 0, bmc);
     }
 
+    if(skipDataTPs) return;
     
     HistLim tp_hl_et(260, -10, 250);
     HistLim tp_hl_ntp(640, -20, 3180);
@@ -392,7 +397,7 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     iEvent.getByToken(tok_emulTPs_, emulTPs);
 
     edm::Handle<HcalTrigPrimDigiCollection> dataTPs;
-    iEvent.getByToken(tok_dataTPs_, dataTPs);
+    if(!skipDataTPs) iEvent.getByToken(tok_dataTPs_, dataTPs);
     //iEvent.getByLabel("hcalDigis", dataTPs);
 
     //~TP Code
@@ -447,6 +452,8 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
    //TP Code
    //Counters
    int c = 0, cv0 = 0, cv1 = 0, chb = 0, che = 0, chf = 0, chfv0 = 0, chfv1 = 0;
+
+   if(skipDataTPs) return;
 
    for (HcalTrigPrimDigiCollection::const_iterator itr = dataTPs->begin(); itr != dataTPs->end(); ++itr) {
      int ieta  = itr->id().ieta();

--- a/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
+++ b/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
@@ -13,3 +13,7 @@ hcalRecHitsValidationSequence = cms.Sequence(NoiseRatesValidation*RecHitsValidat
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():
     hcalRecHitsValidationSequence.remove(NoiseRatesValidation)
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+_phase2_hcalRecHitsValidationSequence = hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation])
+phase2_hcal.toReplaceWith(hcalRecHitsValidationSequence, _phase2_hcalRecHitsValidationSequence)


### PR DESCRIPTION
After #15714, the HCAL validation sequence is sufficiently flexible to run with any topology. The digi-related plots will not be filled (because in phase2 we still use `HcalUpgradeDataFrames` instead of `QIE10/11DataFrames`, until the 2017 HCAL reco is finished - hopefully soon), but we get the SimHit and RecHit plots.

attn: @kencall, @hatakeyamak, @lihux25 
