### PR TITLE
Disable anode timing measurement in case energy measurement is disabled

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
@@ -134,7 +134,7 @@ HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
         for (unsigned ianode=0; ianode<2; ++ianode)
         {
             const HFQIE10Info* anodeInfo = prehit.getHFQIE10Info(ianode);
-            if (anodeInfo)
+            if (anodeInfo && weights[ianode] > 0.f)
             {
                 const float weightedEnergy = weights[ianode]*anodeInfo->energy();
                 energy += weightedEnergy;


### PR DESCRIPTION
Minor fix -- this change discards the TDC time contribution from a PMT anode into a rechit if its energy measurement has been discarded. In the previous version of the code, it would potentially be possible to pick up timing measurement from the anode without using the energy (nor a logical thing to do).
