### PR TITLE
Do not reset rechit flag inside the module

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -554,7 +554,8 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	auxflag+=((i->sample(fTS2).capid())<<28);
 	(rec->back()).setAuxHBHE(auxflag);
 
-	(rec->back()).setFlags(0);  // this sets all flag bits to 0
+	// (rec->back()).setFlags(0);  Don't want to do this because the algorithm
+        //                             can already set some flags
 	// Set presample flag
 	if (fTS>0)
 	  (rec->back()).setFlagField((i->sample(fTS-1).adc()), HcalCaloFlagLabels::PresampleADC,7);
@@ -660,7 +661,8 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	// bits 28 and 29 are reserved for capid of the first time slice saved in aux
 	auxflag+=((i->sample(fTS).capid())<<28);
 	(rec->back()).setAux(auxflag);
-	(rec->back()).setFlags(0);
+	// (rec->back()).setFlags(0);  Don't want to do this because the algorithm
+        //                             can already set some flags
 	// Fill Presample ADC flag
 	if (fTS>0)
 	  (rec->back()).setFlagField((i->sample(fTS-1).adc()), HcalCaloFlagLabels::PresampleADC,7);
@@ -759,8 +761,8 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
 	auxflag+=((i->sample(fTS).capid())<<28);
 	(rec->back()).setAux(auxflag);
 
-	// Clear flags
-	(rec->back()).setFlags(0);
+	// (rec->back()).setFlags(0);  Don't want to do this because the algorithm
+        //                             can already set some flags
 
 	// Fill Presample ADC flag
 	if (fTS>0)


### PR DESCRIPTION
Bug fix: do not reset rechit flag inside the HcalHitReconstructor module. The flag may be already set. In particular, 1 or 3 pulse fit flag is set for "Method 2" by the algorithm creating the rechit.
