### PR TITLE
Move LayerHitMapCache::clear() to very end in CA triplet and quadruplet generators

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -154,9 +154,6 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 	ca.findNtuplets(foundQuadruplets, numberOfHitsInNtuplet);
 
 
-	theLayerCache.clear();
-
-
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
   // re-used thoughout, need to be vectors because of RZLine interface
@@ -250,6 +247,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
   }
 
+  theLayerCache.clear();
 }
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -145,8 +145,6 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
 			caHardPtCut);
 
-	theLayerCache.clear();
-
 	unsigned int numberOfFoundTriplets = foundTriplets.size();
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
@@ -241,5 +239,6 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 		result.push_back(tmpTriplet);
 
 	}
+	theLayerCache.clear();
 }
 


### PR DESCRIPTION
In 810pre12 I get a segfault in step2 (HLT) with

```
runTheMatrix.py -i all -l 1325.0 --command "--customise RecoTracker/Configuration/customiseForTripletsByCellularAutomaton.customiseForTripletsByCellularAutomaton" 
```

It turns out that the `LayerHitMapCache` in `CAHitTripletGenerator` is currently cleared too early. `CACell::getInnerHit()` and `getOuterHit()` forward the calls to a `HitDoublets` object, which forwards the calls to a `RecHitsSortedInPhi` object owned by `LayerHitMapCache`. If the `LayerHitMapCache` is cleared, the `RecHitsSortedInPhi` objects are deleted, so the `clear()` must be done after all operations to `HitDoublets`. The `CAHitQuadrupletGenerator` is also affected.

With the fix here, the test above runs to completion (also a more thorough test

```
runTheMatrix.py -i all -l 1325.0,1325.1 --command "--customise RecoTracker/Configuration/customiseForTripletsByCellularAutomaton.customiseForTripletsByCellularAutomaton --customise RecoTracker/Configuration/customiseForTripletsHLTPixelTracksByCellularAutomaton.customiseForTripletsHLTPixelTracksByCellularAutomaton"
runTheMatrix.py -i all -l 10024.0,10024.1 --command "--customise RecoTracker/Configuration/customiseForQuadrupletsByCellularAutomaton.customiseForQuadrupletsByCellularAutomaton --customise RecoTracker/Configuration/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.customiseForQuadrupletsHLTPixelTracksByCellularAutomaton"
```

works)

Tested in 8_1_0_pre12, no changes expected in any matrix workflows.

@felicepantaleo @VinInn @rovere 
