### PR TITLE
Update hardcoded LutMetadata for HCAL TP

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -580,5 +580,5 @@ void HcalDbHardcode::makeHardcodeTPParameters (HcalTPParameters& tppar) {
   // Parameters for a given TP algorithm:
   // FineGrain Algorithm Version for HBHE, ADC threshold fof TDC mask of HF,
   // TDC mask for HF, Self Trigger bits, auxiliary words
-  tppar.loadObject(0,0,0xFFFFFFFFFFFFFFF,0,0,0);
+  tppar.loadObject(0,0,0xFFFFFFFFFFFFFFFF,0,0,0);
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -600,6 +600,9 @@ std::unique_ptr<HcalLutMetadata> HcalHardcodeCalibrations::produceLutMetadata (c
     int threshold = 1;
 
     if (dbHardcode.useHEUpgrade() or dbHardcode.useHFUpgrade()) {
+       // Use values from 2016 as starting conditions for 2017+.  These are
+       // averaged over the subdetectors, with the last two HE towers split
+       // off due to diverging correction values.
        switch (cell.genericSubdet()) {
           case HcalGenericDetId::HcalGenBarrel:
              rcalib = 1.128;


### PR DESCRIPTION
- Revert the gain that was changed in the 6XY series back to its original value
- Provide mores sensible RCalib values for running with Phase1 upgrades
- Adjust TDC mask to cover all allowed values for now (missing 4 highest bits)
