### PR TITLE
New version of backup paths for inclusive high ET electrons (81X)

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Ele150_CaloIdVT_GsfTrkIdT_v",
+        "HLT_Ele145_CaloIdVT_GsfTrkIdT_v",
         "HLT_Ele200_CaloIdVT_GsfTrkIdT_v",
         "HLT_Ele105_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
         "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu


### PR DESCRIPTION
Requested by https://its.cern.ch/jira/browse/CMSHLT-1032
