### PR TITLE
Add EPOS gen fragment for pPb relval

### DIFF
--- a/Configuration/Generator/python/ReggeGribovPartonMC_EposLHC_4080_4080GeV_pPb_cfi.py
+++ b/Configuration/Generator/python/ReggeGribovPartonMC_EposLHC_4080_4080GeV_pPb_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("ReggeGribovPartonMCGeneratorFilter",
+
+                          bmin = cms.double(0), #impact parameter min in fm
+                          bmax = cms.double(10000),#impact parameter max in fm
+                          paramFileName = cms.untracked.string("Configuration/Generator/data/ReggeGribovPartonMC.param"), #file with more parameters specific to crmc interface
+                          skipNuclFrag = cms.bool(True), #in HI collisions nuclear fragments with pt=0 can be in the hep event. to skip those activate this option
+                          beammomentum = cms.double(4080),
+                          targetmomentum = cms.double(-4080),
+                          beamid = cms.int32(208),
+                          targetid = cms.int32(1),
+                          model = cms.int32(0),
+                          )


### PR DESCRIPTION
This generator fragment will be used for the pPb relval workflow (280) as agreed with @fabozzi
This workflow is currently still configured for Run 1, but will be updated shortly for Run 2.
The update to the configBuilder will come in a subsequent PR.
This is the 80X version of the 81X PR #16016 
