### PR TITLE
alignment validation bugfixes

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -251,10 +251,6 @@ class Dataset:
                     "chosen is greater than the upper time/runrange limit "
                     "('end'/'lastRun').")
             raise AllInOneError( msg )
-        if self.predefined() and (jsonPath or begin or end or firstRun or lastRun):
-            msg = ( "The parameters 'JSON', 'begin', 'end', 'firstRun', and 'lastRun'"
-                    "only work for official datasets, not predefined _cff.py files" )
-            raise AllInOneError( msg )
 
         lumiSecExtend = self.__lumiSelectionSnippet(jsonPath=jsonPath, firstRun=firstRun, lastRun=lastRun)
         lumiStr = goodLumiSecStr = ""
@@ -710,6 +706,10 @@ class Dataset:
 
     def datasetSnippet( self, jsonPath = None, begin = None, end = None,
                         firstRun = None, lastRun = None, crab = False, parent = False ):
+        if self.__predefined and (jsonPath or begin or end or firstRun or lastRun):
+            msg = ( "The parameters 'JSON', 'begin', 'end', 'firstRun', and 'lastRun' "
+                    "only work for official datasets, not predefined _cff.py files" )
+            raise AllInOneError( msg )
         if self.__predefined and parent:
                 with open(self.__filename) as f:
                     if "secFiles.extend" not in f.read():

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -350,6 +350,10 @@ def createMergeScript( path, validations ):
                                          repMap["mergeOfflineParJobsScriptPath"] )
         repMap["copyMergeScripts"] += ("cp .oO[Alignment/OfflineValidation]Oo./scripts/merge_TrackerOfflineValidation.C .\n"
                                        "rfcp %s .\n" % repMap["mergeOfflineParJobsScriptPath"])
+        repMap_offline = repMap.copy()
+        repMap_offline.update(PlottingOptions(config, "offline"))
+        repMap["copyMergeScripts"] = \
+            replaceByMap(repMap["copyMergeScripts"], repMap_offline)
 
     if anythingToMerge:
         # DownloadData is the section which merges output files from parallel jobs


### PR DESCRIPTION
- Error message was in a function that never got called, so it would just proceed silently and ignore firstRun and lastRun.  This bit several people.
- Also was missing .oO[Alignment/OfflineValidation]Oo. in creating the parallel jobs merge script repmap, need to apply PlottingOptions to get it.
