### PR TITLE
Fix thread-safety issue in edmNew::DetSetVector

### DIFF
--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -95,6 +95,7 @@
  <version ClassVersion="10" checksum="1132971359"/>
    <field name="m_filling" transient="true"/>
    <field name="m_getter" transient="true"/>
+   <field name="m_dataSize" transient="true"/>
 </class>
 <class name="edmNew::dstvdetails::DetSetVectorTrans::Item" ClassVersion="10">
  <version ClassVersion="10" checksum="1062438024"/>


### PR DESCRIPTION
The call to dataSize() can happen while the vector m_data is
having its size change. Therefore it is not thread safe to call
m_data.size() under that circumstance. Therefore when running onDemand
we need to use an std::atomic to control access to the value.
When reading back from a source, onDemand is always false so
we do not have to worry about initializing m_dataSize when
reading back from storage.
