### PR TITLE
Add stage2 L1 trigger matching + other features 81X

### DIFF
--- a/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
+++ b/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
@@ -13,11 +13,13 @@
 
 
 #include <cmath>
+#include <type_traits>
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
@@ -70,10 +72,13 @@ class L1MuonMatcherAlgo {
             return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
         }
 
-
         /// Try to match one track to one L1. Return true if succeeded (and update deltaR, deltaPhi accordingly)
         /// The preselection cut on L1, if specified in the config, is applied before the match
         bool match(TrajectoryStateOnSurface & propagated, const l1extra::L1MuonParticle &l1, float &deltaR, float &deltaPhi) const ;
+
+
+
+	// Methods to match with vectors of legacy L1 muon trigger objects
 
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
         /// Returns -1 if the match fails
@@ -99,12 +104,48 @@ class L1MuonMatcherAlgo {
             return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
         }
 
-
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi accordingly)
         /// Returns -1 if the match fails
         /// The preselection cut on L1, if specified in the config, is applied before the match
         int match(TrajectoryStateOnSurface &propagated, const std::vector<l1extra::L1MuonParticle> &l1, float &deltaR, float &deltaPhi) const ;
 
+
+
+
+	// Methods to match with vectors of stage2 L1 muon trigger objects
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage2 L1, if specified in the config, is applied before the match
+        int match(const reco::Track &tk, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(tk);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage2 L1, if specified in the config, is applied before the match
+        int match(const reco::Candidate &c, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(c);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage2 L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage 2 L1, if specified in the config, is applied before the match
+        int match(const SimTrack &tk, const edm::SimVertexContainer &vtxs, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi, TrajectoryStateOnSurface &propagated) const {
+            propagated = extrapolate(tk, vtxs);
+            return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+        }
+
+        /// Find the best match to stage 2 L1, and return its index in the vector (and update deltaR, deltaPhi accordingly)
+        /// Returns -1 if the match fails
+        /// The preselection cut on stage 2 L1, if specified in the config, is applied before the match
+        int match(TrajectoryStateOnSurface &propagated, const std::vector<l1t::Muon> &l1, float &deltaR, float &deltaPhi) const ;
+
+
+
+	// Generic matching
 
         /// Find the best match to L1, and return its index in the vector (and update deltaR, deltaPhi and propagated TSOS accordingly)
         /// Returns -1 if the match fails
@@ -133,14 +174,18 @@ class L1MuonMatcherAlgo {
         template<typename Collection, typename Selector>
         int matchGeneric(TrajectoryStateOnSurface &propagated, const Collection &l1, const Selector &sel, float &deltaR, float &deltaPhi) const ;
 
-
         /// Add this offset to the L1 phi before doing the match, to correct for different scales in L1 vs offline
         void setL1PhiOffset(double l1PhiOffset) { l1PhiOffset_ = l1PhiOffset; }
 
     private:
+
+	template<class T> int genericQuality(const T & cand) const;
+
         PropagateToMuon prop_;
 
-        typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
+	bool useStage2L1_;
+
+        typedef StringCutObjectSelector<reco::Candidate,true> L1Selector;
         /// Preselection cut to apply to L1 candidates before matching
         L1Selector preselectionCut_;
 
@@ -148,22 +193,45 @@ class L1MuonMatcherAlgo {
         double deltaR2_, deltaPhi_, deltaEta_;
 
         /// Sort by deltaPhi or deltaEta instead of deltaR
-        enum SortBy { SortByDeltaR, SortByDeltaPhi, SortByDeltaEta, SortByPt };
+        enum SortBy { SortByDeltaR = 0, SortByDeltaPhi, SortByDeltaEta, SortByPt, SortByQual};
         SortBy sortBy_;
 
         /// offset to be added to the L1 phi before the match
         double l1PhiOffset_;
+
 };
+
+template<>
+inline int L1MuonMatcherAlgo::genericQuality<l1extra::L1MuonParticle>(const l1extra::L1MuonParticle & cand) const
+{
+  return cand.gmtMuonCand().rank();
+}
+
+template<>
+inline int L1MuonMatcherAlgo::genericQuality<l1t::Muon>(const l1t::Muon & cand) const
+{
+  return cand.hwQual();
+}
+
+template<class T>
+inline int L1MuonMatcherAlgo::genericQuality(const T & cand) const
+{
+    return 0;
+}
+
+
 
 template<typename Collection, typename Selector>
 int 
 L1MuonMatcherAlgo::matchGeneric(TrajectoryStateOnSurface &propagated, const Collection &l1s, const Selector &sel, float &deltaR, float &deltaPhi) const {
-    typedef typename Collection::value_type obj;
+    typedef typename Collection::value_type obj;    
+
     int match = -1;
     double minDeltaPhi = deltaPhi_;
     double minDeltaEta = deltaEta_;
     double minDeltaR2  = deltaR2_;
-    double minPt       = -1.0;
+    double maxPt       = -1.0;
+    int maxQual        = 0;
     GlobalPoint pos = propagated.globalPosition();
     for (int i = 0, n = l1s.size(); i < n; ++i) {
         const obj &l1 = l1s[i];
@@ -171,14 +239,17 @@ L1MuonMatcherAlgo::matchGeneric(TrajectoryStateOnSurface &propagated, const Coll
             double thisDeltaPhi = ::deltaPhi(double(pos.phi()),  l1.phi()+l1PhiOffset_);
             double thisDeltaEta = pos.eta() - l1.eta();
             double thisDeltaR2  = ::deltaR2(double(pos.eta()), double(pos.phi()), l1.eta(), l1.phi()+l1PhiOffset_);
+            int    thisQual     = genericQuality<obj>(l1);
             double thisPt       = l1.pt();
             if ((fabs(thisDeltaPhi) < deltaPhi_) && (fabs(thisDeltaEta) < deltaEta_) && (thisDeltaR2 < deltaR2_)) { // check all
                 bool betterMatch = (match == -1);
-                switch (sortBy_) {
+		switch (sortBy_) {
                     case SortByDeltaR:   betterMatch = (thisDeltaR2        < minDeltaR2);        break;
                     case SortByDeltaEta: betterMatch = (fabs(thisDeltaEta) < fabs(minDeltaEta)); break;
                     case SortByDeltaPhi: betterMatch = (fabs(thisDeltaPhi) < fabs(minDeltaPhi)); break;
-                    case SortByPt:       betterMatch = (thisPt             > minPt);             break;
+		    case SortByPt:       betterMatch = (thisPt             > maxPt);             break;
+		    // Quality is an int, adding sorting by pT in case of identical qualities
+		    case SortByQual:     betterMatch = (thisQual > maxQual || ((thisQual == maxQual) && (thisPt > maxPt)));  break;
                 }
                 if (betterMatch) { // sort on one
                     match = i;
@@ -187,7 +258,8 @@ L1MuonMatcherAlgo::matchGeneric(TrajectoryStateOnSurface &propagated, const Coll
                     minDeltaR2  = thisDeltaR2;
                     minDeltaEta = thisDeltaEta;
                     minDeltaPhi = thisDeltaPhi;
-                    minPt       = thisPt;
+                    maxQual     = thisQual;
+                    maxPt       = thisPt;
                 }
             }
         }

--- a/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
+++ b/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
@@ -70,6 +70,8 @@ class PropagateToMuon {
         /// for cosmics, some things change: the along-opposite is not in-out, nor the innermost/outermost states are in-out really
         bool cosmicPropagation_;
 
+	bool useMB2InOverlap_;
+
         // needed services for track propagation
         edm::ESHandle<MagneticField> magfield_;
         edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;

--- a/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
+++ b/MuonAnalysis/MuonAssociators/python/muonL1Match_cfi.py
@@ -8,10 +8,14 @@ from math import pi
 
 muonL1MatcherParameters = cms.PSet(
     # Choice of matching algorithm
-    useTrack = cms.string("tracker"),  # 'none' to use Candidate P4; or 'tracker', 'muon', 'global'
-    useState = cms.string("atVertex"), # 'innermost' and 'outermost' require the TrackExtra
-    useSimpleGeometry = cms.bool(True), # just use a cylinder plus two disks.
-    fallbackToME1 = cms.bool(False),    # If propagation to ME2 fails, propagate to ME1
+    useTrack = cms.string("tracker"),   # 'none' to use Candidate P4; or 'tracker', 'muon', 'global'
+    useState = cms.string("atVertex"),  # 'innermost' and 'outermost' require the TrackExtra
+    useSimpleGeometry = cms.bool(True),  # just use a cylinder plus two disks.
+    fallbackToME1 = cms.bool(False),     # If propagation to ME2 fails, propagate to ME1
+
+    useMB2InOverlap =  cms.bool(False),  # propagate to MB2 in overlap region (according to L1 experts OMTF uses MB2 as RF in all its coverage) 
+    useStage2L1 = cms.bool(False),       # Use stage2 L1 instead of legacy one
+
     sortBy = cms.string("pt"),          # among compatible candidates, pick the highest pt one
 
     # Matching Criteria
@@ -39,4 +43,9 @@ muonL1Match = cms.EDProducer("L1MuonMatcher",
 
     # Write extra ValueMaps
     writeExtraInfo = cms.bool(True),
+
+    # Min and Max BXs from l1t::BxVector (applies to stage 2 only)
+    firstBX = cms.int32(0),
+    lastBX  = cms.int32(0),
+
 )

--- a/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
+++ b/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
@@ -4,41 +4,49 @@
 
 L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet & iConfig) :
     prop_(iConfig),
-    preselectionCut_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection") : ""),
+    useStage2L1_(iConfig.existsAs<bool>("useStage2L1") ? iConfig.getParameter<bool>("useStage2L1") : false),
+    preselectionCut_((iConfig.existsAs<std::string>("preselection")) ? iConfig.getParameter<std::string>("preselection") : ""),
     deltaR2_(std::pow(iConfig.getParameter<double>("maxDeltaR"),2)),
     deltaPhi_(iConfig.existsAs<double>("maxDeltaPhi") ? iConfig.getParameter<double>("maxDeltaPhi") : 10),
     deltaEta_(iConfig.existsAs<double>("maxDeltaEta") ? iConfig.getParameter<double>("maxDeltaEta") : 10),
     l1PhiOffset_(iConfig.existsAs<double>("l1PhiOffset") ? iConfig.getParameter<double>("l1PhiOffset") : 0)
 {
-    bool reqPhi = iConfig.existsAs<bool>("sortByDeltaPhi") && iConfig.getParameter<bool>("sortByDeltaPhi");
-    bool reqEta = iConfig.existsAs<bool>("sortByDeltaEta") && iConfig.getParameter<bool>("sortByDeltaEta");
-    bool reqPt  = iConfig.existsAs<bool>("sortByPt")       && iConfig.getParameter<bool>("sortByPt");
+    bool reqQual = iConfig.existsAs<bool>("sortByQual")     && iConfig.getParameter<bool>("sortByQual");
+    bool reqPhi  = iConfig.existsAs<bool>("sortByDeltaPhi") && iConfig.getParameter<bool>("sortByDeltaPhi");
+    bool reqEta  = iConfig.existsAs<bool>("sortByDeltaEta") && iConfig.getParameter<bool>("sortByDeltaEta");
+    bool reqPt   = iConfig.existsAs<bool>("sortByPt")       && iConfig.getParameter<bool>("sortByPt");
     std::string sortBy = iConfig.existsAs<std::string>("sortBy") ? iConfig.getParameter<std::string>("sortBy") : "";
-    if (reqPhi + reqEta + reqPt > 1) throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set more than one 'sortBy<XXX>' parameter to True.\n";
+    if (reqPhi + reqEta + reqPt + reqQual > 1) throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set more than one 'sortBy<XXX>' parameter to True.\n";
     if (sortBy == "deltaPhi") { 
-        if (reqEta || reqPt) 
+        if (reqEta || reqPt || reqQual) 
             throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set sortBy = 'deltaPhi' and set also another 'sortBy<XXX>' parameter to True.\n";
         else reqPhi = true;
     }
     if (sortBy == "deltaEta") {
-	 if(reqPhi || reqPt)
+	 if(reqPhi || reqPt || reqQual)
             throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set sortBy = 'deltaEta' and set also another 'sortBy<XXX>' parameter to True.\n";
          else reqEta = true;
     }
     if (sortBy == "pt") {
-	 if(reqPhi || reqEta) 
+	 if(reqPhi || reqEta || reqQual) 
             throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set sortBy = 'pt' and set also another 'sortBy<XXX>' parameter to True.\n";
         else reqPt = true;
     }
+    if (sortBy == "quality") {
+	 if(reqPhi || reqEta || reqPt) 
+            throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set sortBy = 'quality' and set also another 'sortBy<XXX>' parameter to True.\n";
+        else reqQual = true;
+    }
     if (sortBy == "deltaR") {
-	 if(reqPhi || reqEta || reqPt)
+	 if(reqPhi || reqEta || reqPt || reqQual)
             throw cms::Exception("Configuration") << "L1MuonMatcherAlgo: Can't set sortBy = 'deltaR' and set also another 'sortBy<XXX>' parameter to True.\n";
     }
     // so, if we're here there's no ambiguity in what the user may want. either everything is false, or exactly one req is true.
-    if      (reqEta) sortBy_ = SortByDeltaEta;
-    else if (reqPhi) sortBy_ = SortByDeltaPhi;
-    else if (reqPt)  sortBy_ = SortByPt;
-    else             sortBy_ = SortByDeltaR;
+    if      (reqEta)  sortBy_ = SortByDeltaEta;
+    else if (reqPhi)  sortBy_ = SortByDeltaPhi;
+    else if (reqQual) sortBy_ = SortByQual;
+    else if (reqPt)   sortBy_ = SortByPt;
+    else              sortBy_ = SortByDeltaR;
 }
 
 
@@ -67,6 +75,11 @@ L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const l1extra::L
 
 int
 L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1extra::L1MuonParticle> &l1s, float &deltaR, float &deltaPhi) const {
+    return matchGeneric(propagated, l1s, preselectionCut_, deltaR, deltaPhi);
+}
+
+int
+L1MuonMatcherAlgo::match(TrajectoryStateOnSurface & propagated, const std::vector<l1t::Muon> &l1s, float &deltaR, float &deltaPhi) const {
     return matchGeneric(propagated, l1s, preselectionCut_, deltaR, deltaPhi);
 }
 

--- a/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
+++ b/MuonAnalysis/MuonAssociators/src/PropagateToMuon.cc
@@ -19,7 +19,9 @@ PropagateToMuon::PropagateToMuon(const edm::ParameterSet & iConfig) :
   useMB2_(iConfig.existsAs<bool>("useStation2") ? iConfig.getParameter<bool>("useStation2") : true),
   fallbackToME1_(iConfig.existsAs<bool>("fallbackToME1") ? iConfig.getParameter<bool>("fallbackToME1") : false),
   whichTrack_(None), whichState_(AtVertex),
-  cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis") ? iConfig.getParameter<bool>("cosmicPropagationHypothesis") : false)
+  cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis") ? iConfig.getParameter<bool>("cosmicPropagationHypothesis") : false),
+  useMB2InOverlap_(iConfig.existsAs<bool>("useMB2InOverlap") ? iConfig.getParameter<bool>("useMB2InOverlap") : false)
+
 {
     std::string whichTrack = iConfig.getParameter<std::string>("useTrack");
     if      (whichTrack == "none")    { whichTrack_ = None; }
@@ -62,6 +64,10 @@ PropagateToMuon::init(const edm::EventSetup & iSetup) {
         endcapRadii_[i] = std::make_pair(endcapDiskPos_[i]->innerRadius(), endcapDiskPos_[i]->outerRadius());
         //std::cout << "L1MuonMatcher: endcap " << i << " Z = " << endcapDiskPos_[i]->position().z() << ", radii = " << endcapRadii_[i].first << "," << endcapRadii_[i].second << std::endl;
     }
+
+    if (useMB2_ && useMB2InOverlap_)
+      barrelHalfLength_ = endcapDiskPos_[2]->position().z();
+
 }
 
 FreeTrajectoryState 


### PR DESCRIPTION
This PR extends the offline muon -> L1 muon matching functionalities with the following features:
1. Allows matching with stage 2 L1 muon candidates
2. Implements a "by quality" sorting logic in the matching code
3. Adds further output that simplifies the computation of results for trigger efficiency and SFs,  given the issues described in [[1](https://indico.cern.ch/event/560227/contributions/2283979/attachments/1327133/1992714/2016_08_25_EMTF_WGM.pdf),[2](https://indico.cern.ch/event/568217/contributions/2296959/attachments/1333069/2004449/TnP_Trigger_SWunsch_07092016.pdf)]

the main user of the updated classes is Muon POG tag and probe.
