### PR TITLE
Remove unused functionality from SeedComparitor

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -20,15 +20,11 @@ class LowPtClusterShapeSeedComparitor : public SeedComparitor
   virtual ~LowPtClusterShapeSeedComparitor(){}
   virtual void init(const edm::Event& e, const edm::EventSetup& es) ;
   virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const ;
-  virtual bool compatible(const TrajectorySeed &seed) const { return true; }
   virtual bool compatible(const TrajectoryStateOnSurface &,  
                           SeedingHitSet::ConstRecHitPointer hit) const { return true; }
   virtual bool compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
                           const FastHelix                  &helix,
-                          const TrackingRegion & region) const { return true; }
-  virtual bool compatible(const SeedingHitSet  &hits, 
-                          const GlobalTrajectoryParameters &straightLineStateAtVertex,
                           const TrackingRegion & region) const { return true; }
 
  private:

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -19,13 +19,12 @@ class LowPtClusterShapeSeedComparitor : public SeedComparitor
   LowPtClusterShapeSeedComparitor(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
   virtual ~LowPtClusterShapeSeedComparitor(){}
   virtual void init(const edm::Event& e, const edm::EventSetup& es) ;
-  virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const ;
+  virtual bool compatible(const SeedingHitSet  &hits) const ;
   virtual bool compatible(const TrajectoryStateOnSurface &,  
                           SeedingHitSet::ConstRecHitPointer hit) const { return true; }
   virtual bool compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
-                          const FastHelix                  &helix,
-                          const TrackingRegion & region) const { return true; }
+                          const FastHelix                  &helix) const { return true; }
 
  private:
    /// something

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -102,8 +102,8 @@ class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, pub
         // implemented
         virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const ;
         // not implemented 
-        virtual bool compatible(const SeedingHitSet &hits, const TrackingRegion & region) const { return true; }
-        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix, const TrackingRegion & region) const ;
+        virtual bool compatible(const SeedingHitSet &hits) const { return true; }
+        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const ;
 
     protected:
         bool filterAtHelixStage_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -103,9 +103,7 @@ class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, pub
         virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const ;
         // not implemented 
         virtual bool compatible(const SeedingHitSet &hits, const TrackingRegion & region) const { return true; }
-        virtual bool compatible(const TrajectorySeed &seed) const { return true; }
         virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix, const TrackingRegion & region) const ;
-        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &straightLineStateAtVertex, const TrackingRegion & region) const { return true; }
 
     protected:
         bool filterAtHelixStage_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
@@ -28,15 +28,11 @@ class PixelClusterShapeSeedComparitor : public SeedComparitor {
         virtual ~PixelClusterShapeSeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
         virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override { return true; }
-        virtual bool compatible(const TrajectorySeed &seed) const override { return true; }
         virtual bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix,
-                const TrackingRegion & region) const override ;
-        virtual bool compatible(const SeedingHitSet  &hits, 
-                const GlobalTrajectoryParameters &straightLineStateAtVertex,
                 const TrackingRegion & region) const override ;
 
     private:
@@ -85,14 +81,6 @@ PixelClusterShapeSeedComparitor::compatible(const TrajectoryStateOnSurface &tsos
     if (filterAtHelixStage_) return true;
     assert(hit->isValid() && tsos.isValid());
     return compatibleHit(*hit, tsos.globalDirection());
-}
-
-bool
-PixelClusterShapeSeedComparitor::compatible(const SeedingHitSet  &hits, 
-        const GlobalTrajectoryParameters &straightLineStateAtVertex,
-        const TrackingRegion & region) const 
-{ 
-    return true; 
 }
 
 bool

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
@@ -27,13 +27,12 @@ class PixelClusterShapeSeedComparitor : public SeedComparitor {
         PixelClusterShapeSeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
         virtual ~PixelClusterShapeSeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
-        virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override { return true; }
+        virtual bool compatible(const SeedingHitSet  &hits) const override { return true; }
         virtual bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
-                const FastHelix                  &helix,
-                const TrackingRegion & region) const override ;
+                const FastHelix                  &helix) const override ;
 
     private:
         bool compatibleHit(const TrackingRecHit &hit, const GlobalVector &direction) const ;
@@ -86,8 +85,7 @@ PixelClusterShapeSeedComparitor::compatible(const TrajectoryStateOnSurface &tsos
 bool
 PixelClusterShapeSeedComparitor::compatible(const SeedingHitSet  &hits, 
         const GlobalTrajectoryParameters &helixStateAtVertex,
-        const FastHelix                  &helix,
-        const TrackingRegion & region) const 
+        const FastHelix                  &helix) const
 { 
     if (!filterAtHelixStage_) return true;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
@@ -117,7 +117,7 @@ void LowPtClusterShapeSeedComparitor::init(const edm::Event& e, const edm::Event
   e.getByToken(thePixelClusterShapeCacheToken, thePixelClusterShapeCache);
 }
 
-bool LowPtClusterShapeSeedComparitor::compatible(const SeedingHitSet &hits, const TrackingRegion &) const
+bool LowPtClusterShapeSeedComparitor::compatible(const SeedingHitSet &hits) const
 //(const reco::Track* track, const vector<const TrackingRecHit *> & recHits) const
 {
   assert(hits.size()==3);

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -365,7 +365,7 @@ bool StripSubClusterShapeSeedFilter::compatible
 }
 
 bool StripSubClusterShapeSeedFilter::compatible
-    (const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix, const TrackingRegion & region) const 
+    (const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const
 { 
    if (!filterAtHelixStage_) return true;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -201,7 +201,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
       SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
 
 
-      if (!theComparitor->compatible(tmpTriplet, region) )
+      if (!theComparitor->compatible(tmpTriplet) )
       {
         continue;
       }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -231,7 +231,7 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 
 		if (theComparitor)
 		{
-			if (!theComparitor->compatible(tmpTriplet, region))
+			if (!theComparitor->compatible(tmpTriplet))
 			{
 
 				continue;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -201,7 +201,7 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
         // accept quadruplets.
         if(theComparitor) {
           SeedingHitSet tmpTriplet(triplet.inner(), triplet.outer(), hit);
-          if(!theComparitor->compatible(tmpTriplet, region)) {
+          if(!theComparitor->compatible(tmpTriplet)) {
             continue;
           }
         }

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -309,7 +309,7 @@ void PixelTripletHLTGenerator::hitTriplets(
 	  if (checkPhiInRange(p3_phi, rangeRPhi.first*ir-phiErr, rangeRPhi.second*ir+phiErr,maxPhiErr)) {
 	    // insert here check with comparitor
 	    OrderedHitTriplet hittriplet( doublets.hit(ip,HitDoublets::inner), doublets.hit(ip,HitDoublets::outer), hits.theHits[KDdata].hit());
-	    if (!theComparitor  || theComparitor->compatible(hittriplet,region) ) {
+	    if (!theComparitor  || theComparitor->compatible(hittriplet) ) {
 	      result.push_back( hittriplet );
 	    } else {
 	      LogDebug("RejectedTriplet") << "rejected triplet from comparitor ";

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
@@ -476,8 +476,8 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
 		  FastHelix mhelix(mtth2->globalPosition(), mtth1->globalPosition(), vertexPos, nomField,&*bfield, vertexPos);
 		  mkine = mhelix.stateAtVertex();
 
-		  if(theComparitor&&!theComparitor->compatible(phits, pkine, phelix, region)) { return 0; }
-		  if(theComparitor&&!theComparitor->compatible(mhits, mkine, mhelix, region)) { return 0; }
+		  if(theComparitor&&!theComparitor->compatible(phits, pkine, phelix)) { return 0; }
+		  if(theComparitor&&!theComparitor->compatible(mhits, mkine, mhelix)) { return 0; }
     }
 
 

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicSeedCreator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicSeedCreator.cc
@@ -131,10 +131,7 @@ void CosmicSeedCreator::makeSeed(TrajectorySeedCollection & seedCollection,
     
     
     PTrajectoryStateOnDet const & PTraj = trajectoryStateTransform::persistentState(tsos, usedHit->hit()->geographicalId().rawId());
-    TrajectorySeed seed(PTraj,seedHits,seedDirection);
-    if (filter == 0 || filter->compatible(seed)) {
-        seedCollection.push_back(seed);
-    }
+    seedCollection.emplace_back(PTraj,seedHits,seedDirection);
     
   }//end charge loop
   

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -119,7 +119,7 @@ bool SeedFromConsecutiveHitsCreator::initialKinematic(GlobalTrajectoryParameters
 					kine.charge(),
 					&*bfield);
   }
-  return (filter ? filter->compatible(hits, kine, helix, *region) : true); 
+  return (filter ? filter->compatible(hits, kine, helix) : true); 
 }
 
 
@@ -202,6 +202,6 @@ SeedFromConsecutiveHitsCreator::checkHit(
       const TrajectoryStateOnSurface &tsos,
       SeedingHitSet::ConstRecHitPointer hit) const 
 { 
-    return (filter ? filter->compatible(tsos,hit) : true); 
+    return (filter ? filter->compatible(tsos,hit) : true);
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -186,8 +186,7 @@ void SeedFromConsecutiveHitsCreator::buildSeed(
   
   PTrajectoryStateOnDet const & PTraj = 
     trajectoryStateTransform::persistentState(updatedState, hit->geographicalId().rawId());
-  TrajectorySeed seed(PTraj,std::move(seedHits),alongMomentum); 
-  if ( !filter || filter->compatible(seed)) seedCollection.push_back(std::move(seed));
+  seedCollection.emplace_back(PTraj,std::move(seedHits),alongMomentum);
 
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.cc
@@ -19,7 +19,7 @@ bool SeedFromConsecutiveHitsStraightLineCreator::initialKinematic(GlobalTrajecto
   TrackCharge q = 1; // irrelevant, since infinite momentum
   kine = GlobalTrajectoryParameters(vertexPos, initMomentum, q, &*bfield);
 
-  return (filter ? filter->compatible(hits, kine, *region) : true); 
+  return true;
 
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
@@ -30,7 +30,7 @@ bool SeedFromConsecutiveHitsTripletOnlyCreator::initialKinematic(GlobalTrajector
 					kine.charge(),
 					&*bfield);
     }
-    return (filter ? filter->compatible(hits, kine, helix, *region) : true); 
+    return (filter ? filter->compatible(hits, kine, helix) : true); 
   } 
   
   const GlobalPoint& vertexPos = region->origin();
@@ -50,5 +50,5 @@ bool SeedFromConsecutiveHitsTripletOnlyCreator::initialKinematic(GlobalTrajector
 					kine.charge(),
 					&*bfield);
   }
-  return (filter ? filter->compatible(hits, kine, helix, *region) : true); 
+  return (filter ? filter->compatible(hits, kine, helix) : true);
 }

--- a/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
@@ -28,7 +28,7 @@ void SeedGeneratorFromRegionHits::run(TrajectorySeedCollection & seedCollection,
   //                                                            // as it will cause N re-allocations instead of the normal log(N)/log(2)
   for (unsigned int iHits = 0; iHits < nHitss; ++iHits) { 
     const SeedingHitSet & hits =  hitss[iHits];
-    if (!theComparitor || theComparitor->compatible(hits, region) ) {
+    if (!theComparitor || theComparitor->compatible(hits) ) {
       theSeedCreator->makeSeed(seedCollection, hits);
     }
   }

--- a/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
@@ -24,15 +24,11 @@ class SeedComparitor {
   virtual ~SeedComparitor() {}
   virtual void init(const edm::Event& ev, const edm::EventSetup& es) = 0;
   virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const = 0;
-  virtual bool compatible(const TrajectorySeed &seed) const = 0;
   virtual bool compatible(const TrajectoryStateOnSurface &,  
                           SeedingHitSet::ConstRecHitPointer hit) const = 0;
   virtual bool compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
                           const FastHelix                  &helix,
-                          const TrackingRegion & region) const = 0;
-  virtual bool compatible(const SeedingHitSet  &hits, 
-                          const GlobalTrajectoryParameters &straightLineStateAtVertex,
                           const TrackingRegion & region) const = 0;
 };
 

--- a/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedComparitor.h
@@ -23,13 +23,12 @@ class SeedComparitor {
  public:
   virtual ~SeedComparitor() {}
   virtual void init(const edm::Event& ev, const edm::EventSetup& es) = 0;
-  virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const = 0;
+  virtual bool compatible(const SeedingHitSet  &hits) const = 0;
   virtual bool compatible(const TrajectoryStateOnSurface &,  
                           SeedingHitSet::ConstRecHitPointer hit) const = 0;
   virtual bool compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
-                          const FastHelix                  &helix,
-                          const TrackingRegion & region) const = 0;
+                          const FastHelix                  &helix) const = 0;
 };
 
 #endif

--- a/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
@@ -11,15 +11,11 @@ class CombinedSeedComparitor : public SeedComparitor {
         virtual ~CombinedSeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
         virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override ;
-        virtual bool compatible(const TrajectorySeed &seed) const override ;
         virtual bool compatible(const TrajectoryStateOnSurface &,  
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix,
-                const TrackingRegion & region) const override ;
-        virtual bool compatible(const SeedingHitSet  &hits, 
-                const GlobalTrajectoryParameters &straightLineStateAtVertex,
                 const TrackingRegion & region) const override ;
 
     private:
@@ -67,17 +63,6 @@ CombinedSeedComparitor::compatible(const SeedingHitSet  &hits, const TrackingReg
 }
 
 bool
-CombinedSeedComparitor::compatible(const TrajectorySeed &seed) const
-{
-    typedef boost::ptr_vector<SeedComparitor>::const_iterator ITC;
-    for (ITC it = comparitors_.begin(), ed = comparitors_.end(); it != ed; ++it) {
-        bool pass = it->compatible(seed);
-        if (isAnd_ != pass) return pass; // break on failures if doing an AND, and on successes if doing an OR
-    }
-    return isAnd_; // if we arrive here, we have no successes for OR, and no failures for AND
-}
-
-bool
 CombinedSeedComparitor::compatible(const TrajectoryStateOnSurface &tsos,
 				   SeedingHitSet::ConstRecHitPointer hit) const
 {
@@ -98,19 +83,6 @@ CombinedSeedComparitor::compatible(const SeedingHitSet  &hits,
     typedef boost::ptr_vector<SeedComparitor>::const_iterator ITC;
     for (ITC it = comparitors_.begin(), ed = comparitors_.end(); it != ed; ++it) {
         bool pass = it->compatible(hits, helixStateAtVertex, helix, region);
-        if (isAnd_ != pass) return pass; // break on failures if doing an AND, and on successes if doing an OR
-    }
-    return isAnd_; // if we arrive here, we have no successes for OR, and no failures for AND
-}
-
-bool
-CombinedSeedComparitor::compatible(const SeedingHitSet  &hits,
-                          const GlobalTrajectoryParameters &straightLineStateAtVertex,
-                          const TrackingRegion & region) const
-{
-    typedef boost::ptr_vector<SeedComparitor>::const_iterator ITC;
-    for (ITC it = comparitors_.begin(), ed = comparitors_.end(); it != ed; ++it) {
-        bool pass = it->compatible(hits, straightLineStateAtVertex, region);
         if (isAnd_ != pass) return pass; // break on failures if doing an AND, and on successes if doing an OR
     }
     return isAnd_; // if we arrive here, we have no successes for OR, and no failures for AND

--- a/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
@@ -10,13 +10,12 @@ class CombinedSeedComparitor : public SeedComparitor {
         CombinedSeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
         virtual ~CombinedSeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
-        virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override ;
+        virtual bool compatible(const SeedingHitSet  &hits) const override ;
         virtual bool compatible(const TrajectoryStateOnSurface &,  
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
-                const FastHelix                  &helix,
-                const TrackingRegion & region) const override ;
+                const FastHelix                  &helix) const override ;
 
     private:
         boost::ptr_vector<SeedComparitor> comparitors_;
@@ -52,11 +51,11 @@ CombinedSeedComparitor::init(const edm::Event& ev, const edm::EventSetup& es) {
 }
 
 bool
-CombinedSeedComparitor::compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const
+CombinedSeedComparitor::compatible(const SeedingHitSet  &hits) const
 {
     typedef boost::ptr_vector<SeedComparitor>::const_iterator ITC;
     for (ITC it = comparitors_.begin(), ed = comparitors_.end(); it != ed; ++it) {
-        bool pass = it->compatible(hits, region);
+        bool pass = it->compatible(hits);
         if (isAnd_ != pass) return pass; // break on failures if doing an AND, and on successes if doing an OR
     }
     return isAnd_; // if we arrive here, we have no successes for OR, and no failures for AND
@@ -77,12 +76,11 @@ CombinedSeedComparitor::compatible(const TrajectoryStateOnSurface &tsos,
 bool
 CombinedSeedComparitor::compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
-                          const FastHelix                  &helix,
-                          const TrackingRegion & region) const
+                          const FastHelix                  &helix) const
 {
     typedef boost::ptr_vector<SeedComparitor>::const_iterator ITC;
     for (ITC it = comparitors_.begin(), ed = comparitors_.end(); it != ed; ++it) {
-        bool pass = it->compatible(hits, helixStateAtVertex, helix, region);
+        bool pass = it->compatible(hits, helixStateAtVertex, helix);
         if (isAnd_ != pass) return pass; // break on failures if doing an AND, and on successes if doing an OR
     }
     return isAnd_; // if we arrive here, we have no successes for OR, and no failures for AND

--- a/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
@@ -9,13 +9,12 @@ class SimpleClusterProbabilitySeedComparitor : public SeedComparitor {
         SimpleClusterProbabilitySeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
         virtual ~SimpleClusterProbabilitySeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override {}
-        virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override { return true; }
+        virtual bool compatible(const SeedingHitSet  &hits) const override { return true; }
         virtual bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
-                const FastHelix                  &helix,
-                const TrackingRegion & region) const override { return true; }
+                const FastHelix                  &helix) const override { return true; }
 
 
     private:

--- a/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
@@ -10,15 +10,11 @@ class SimpleClusterProbabilitySeedComparitor : public SeedComparitor {
         virtual ~SimpleClusterProbabilitySeedComparitor() ; 
         virtual void init(const edm::Event& ev, const edm::EventSetup& es) override {}
         virtual bool compatible(const SeedingHitSet  &hits, const TrackingRegion & region) const override { return true; }
-        virtual bool compatible(const TrajectorySeed &seed) const override { return true; }
         virtual bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
         virtual bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix,
-                const TrackingRegion & region) const override { return true; }
-        virtual bool compatible(const SeedingHitSet  &hits, 
-                const GlobalTrajectoryParameters &straightLineStateAtVertex,
                 const TrackingRegion & region) const override { return true; }
 
 


### PR DESCRIPTION
While trying to understand where and why we use `TrackingRegion` in seeding (for planning of efficient regional CA), I removed two methods of `SeedComparitor` that had only trivial (`return true`) implementations, and removed the `TrackingRegion` parameters as they were not used by any implementation.

It turned out, however, that these changed will not help in any way the development towards regional CA (`TrackingRegion` will be needed for other reasons), so these changes are not needed for that. But since I already had committed them, I though it would still be worth of the effort to ask the question: do we have any foreseen use case in `SeedComparitor`s for either the removed methods, or for TrackingRegion? ~~(hence "RFC")~~ Apparently not.

Personally I would eventually revamp the whole `SeedComparitor` infrastructure as its internals are currently very confusing (and there are implementations only for pixel/strip cluster shape cuts, but with total of 4 of them...).

What do people think? Seems to be acceptable.

Tested in CMSSW_8_1_0_pre12, no changes expected anywhere.

@rovere @VinInn @felicepantaleo 
