### PR TITLE
Fix to CA seeding customize functions

### DIFF
--- a/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsByCellularAutomaton.py
@@ -36,5 +36,5 @@ def customiseForQuadrupletsByCellularAutomaton(process):
         )
 
         if hasattr(quadruplets.GeneratorPSet, "SeedComparitorPSet"):
-            pset.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
+            module.OrderedHitsFactoryPSet.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
     return process

--- a/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForQuadrupletsHLTPixelTracksByCellularAutomaton.py
@@ -41,5 +41,5 @@ def customiseForQuadrupletsHLTPixelTracksByCellularAutomaton(process):
         )
 
         if hasattr(quadruplets.GeneratorPSet, "SeedComparitorPSet"):
-            pset.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
+            module.OrderedHitsFactoryPSet.SeedComparitorPSet = quadruplets.GeneratorPSet.SeedComparitorPSet
     return process

--- a/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsByCellularAutomaton.py
@@ -34,5 +34,5 @@ def customiseForTripletsByCellularAutomaton(process):
         )
 
         if hasattr(Triplets.GeneratorPSet, "SeedComparitorPSet"):
-            pset.SeedComparitorPSet = Triplets.GeneratorPSet.SeedComparitorPSet
+            module.OrderedHitsFactoryPSet.SeedComparitorPSet = Triplets.GeneratorPSet.SeedComparitorPSet
     return process

--- a/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
+++ b/RecoTracker/Configuration/python/customiseForTripletsHLTPixelTracksByCellularAutomaton.py
@@ -37,5 +37,5 @@ def customiseForTripletsHLTPixelTracksByCellularAutomaton(process):
         )
 
         if hasattr(triplets.GeneratorPSet, "SeedComparitorPSet"):
-            pset.SeedComparitorPSet = triplets.GeneratorPSet.SeedComparitorPSet
+            module.OrderedHitsFactoryPSet.SeedComparitorPSet = triplets.GeneratorPSet.SeedComparitorPSet
     return process


### PR DESCRIPTION
The `SeedComparitorPSet` was not properly propagated in the CA seeding/pixel tracking customize functions.

Tested in CMSSW_8_1_0_pre12, no changes expected in standard workflows.

@rovere @VinInn @felicepantaleo 
