### PR TITLE
clang compilation error undefined reference to Phase2ITPixelCluster::MAXSPAN

### DIFF
--- a/DataFormats/Phase2ITPixelCluster/src/Phase2ITPixelCluster.cc
+++ b/DataFormats/Phase2ITPixelCluster/src/Phase2ITPixelCluster.cc
@@ -14,6 +14,7 @@
 //!  \author Petar Maksimovic, JHU
 //---------------------------------------------------------------------------
 
+constexpr unsigned int Phase2ITPixelCluster::MAXSPAN;
 
 Phase2ITPixelCluster::Phase2ITPixelCluster( const Phase2ITPixelCluster::PixelPos& pix, uint32_t adc) :
   thePixelRow(pix.row()),


### PR DESCRIPTION
Fix for this clang compilation error:

> > Building shared library tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/libDataFormatsPhase2ITPixelCluster.so
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/3.8.0-giojec/bin/clang++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/a/DataFormatsPhase2ITPixelCluster_xr.o tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/Phase2ITPixelCluster.o tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/Phase2ITPixelClusterShapeCache.o -o tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/libDataFormatsPhase2ITPixelCluster.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/lib/slc6_amd64_gcc530 -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/external/slc6_amd64_gcc530/lib -lDataFormatsCommon -lDataFormatsProvenance -lFWCoreMessageLogger -lDataFormatsStdDictionaries -lFWCoreUtilities -lTree -lNet -lThread -lMathCore -lRIO -lboost_filesystem -lCore -lboost_regex -lboost_system -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -luuid -ltbb -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > tmp/slc6_amd64_gcc530/src/DataFormats/Phase2ITPixelCluster/src/DataFormatsPhase2ITPixelCluster/Phase2ITPixelCluster.o: In function `Phase2ITPixelCluster::add(Phase2ITPixelCluster::PixelPos const&, unsigned int)':
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/src/DataFormats/Phase2ITPixelCluster/src/Phase2ITPixelCluster.cc:(.text+0x9a6): undefined reference to`Phase2ITPixelCluster::MAXSPAN'
> > clang-3.8: error: linker command failed with exit code 1 (use -v to see invocation)
