### PR TITLE
clang compilation error undefined reference to HFQIE10Info::N_RAW_MAX

### DIFF
--- a/DataFormats/HcalRecHit/src/HFQIE10Info.cc
+++ b/DataFormats/HcalRecHit/src/HFQIE10Info.cc
@@ -1,6 +1,9 @@
 #include <algorithm>
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
 
+const unsigned HFQIE10Info::N_RAW_MAX;
+ 
+
 HFQIE10Info::HFQIE10Info()
     : charge_(0.f),
       energy_(0.f),

--- a/DataFormats/HcalRecHit/src/HFQIE10Info.cc
+++ b/DataFormats/HcalRecHit/src/HFQIE10Info.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
 
 const unsigned HFQIE10Info::N_RAW_MAX;
+const HFQIE10Info::raw_type HFQIE10Info::INVALID_RAW;
  
 
 HFQIE10Info::HFQIE10Info()


### PR DESCRIPTION
Fix for this clang compilation error:

> > Building shared library tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/libDataFormatsHcalRecHit.so
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/3.8.0-giojec/bin/clang++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/a/DataFormatsHcalRecHit_xr.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HcalCalibRecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HFRecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HFQIE10Info.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HcalSourcePositionData.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HFPreRecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/ZDCRecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/CastorRecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HORecHit.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HBHERecHit.o -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/libDataFormatsHcalRecHit.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/lib/slc6_amd64_gcc530 -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/external/slc6_amd64_gcc530/lib -lDataFormatsHcalDigi -lDataFormatsCaloRecHit -lDataFormatsHcalDetId -lDataFormatsDetId -lDataFormatsCommon -lDataFormatsProvenance -lFWCoreMessageLogger -lDataFormatsStdDictionaries -lFWCoreUtilities -lTree -lNet -lThread -lMathCore -lRIO -lboost_filesystem -lCore -lboost_regex -lboost_system -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -luuid -ltbb -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > tmp/slc6_amd64_gcc530/src/DataFormats/HcalRecHit/src/DataFormatsHcalRecHit/HFQIE10Info.o: In function `HFQIE10Info::HFQIE10Info(HcalDetId const&, float, float, float, float, unsigned int const*, unsigned int, unsigned int)':
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/src/DataFormats/HcalRecHit/src/HFQIE10Info.cc:(.text+0x7c): undefined reference to`HFQIE10Info::N_RAW_MAX'
> > clang-3.8: error: linker command failed with exit code 1 (use -v to see invocation)
