### PR TITLE
clang compilation error  undefined reference to HcaluLUTTPGCoder::QIE*_LUT_BITMASK

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -28,6 +28,11 @@
 
 const float HcaluLUTTPGCoder::lsb_=1./16;
 
+const int HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
+const int HcaluLUTTPGCoder::QIE10_LUT_BITMASK;
+const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK;
+
+
 HcaluLUTTPGCoder::HcaluLUTTPGCoder(const HcalTopology* top) : topo_(top), LUTGenerationMode_(true), bitToMask_(0) {
   firstHBEta_ = topo_->firstHBRing();      
   lastHBEta_  = topo_->lastHBRing();


### PR DESCRIPTION
Fix for these clang compilation errors:

> > Building shared library tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/libCalibCalorimetryHcalTPGAlgos.so
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/3.8.0-giojec/bin/clang++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/XMLDOMBlock.o tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/XMLProcessor.o tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/LutXml.o tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/HcalEmap.o tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/HcaluLUTTPGCoder.o -o tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/libCalibCalorimetryHcalTPGAlgos.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/lib/slc6_amd64_gcc530 -L/build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/external/slc6_amd64_gcc530/lib -lCalibCalorimetryHcalAlgos -lCalibFormatsHcalObjects -lCondFormatsDataRecord -lCondFormatsHcalObjects -lGeometryHcalTowerAlgo -lGeometryCaloTopology -lGeometryRecords -lCondFormatsAlignmentRecord -lCondFormatsCommon -lGeometryCaloGeometry -lDataFormatsCaloTowers -lDataFormatsHcalDigi -lFWCoreFramework -lGeometryHcalCommonData -lCalibFormatsCaloObjects -lDataFormatsCandidate -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lFWCoreServiceRegistry -lDataFormatsDetId -lDataFormatsMath -lFWCoreCommon -lFWCorePythonParameterSet -lGeometryHGCalCommonData -lDataFormatsCommon -lDetectorDescriptionCore -lFWCoreParameterSet -lDataFormatsProvenance -lDetectorDescriptionExprAlgo -lDetectorDescriptionBase -lFWCoreMessageLogger -lFWCorePluginManager -lCondFormatsSerialization -lDataFormatsStdDictionaries -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lThread -lMathCore -lRIO -lboost_filesystem -lCore -lboost_python -lboost_regex -lboost_serialization -lboost_system -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -lCLHEP -lgsl -lgslcblas -luuid -lpython2.7 -ltbb -lxerces-c -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > tmp/slc6_amd64_gcc530/src/CalibCalorimetry/HcalTPGAlgos/src/CalibCalorimetryHcalTPGAlgos/HcaluLUTTPGCoder.o: In function `HcaluLUTTPGCoder::update(HcalDbService const&)':
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/src/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc:(.text+0x2364): undefined reference to`HcaluLUTTPGCoder::QIE8_LUT_BITMASK'
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/src/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc:(.text+0x2374): undefined reference to `HcaluLUTTPGCoder::QIE11_LUT_BITMASK'
> > /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/86f7302e2fcfe09cffbe98f72c4e9e89/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-09-28-1100/src/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc:(.text+0x2384): undefined reference to`HcaluLUTTPGCoder::QIE10_LUT_BITMASK'
> > clang-3.8: error: linker command failed with exit code 1 (use -v to see invocation)
