### PR TITLE
Only get data products with labels beginning with 'hlt'

### DIFF
--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -53,6 +53,7 @@
 
 #include <functional>
 #include "tbb/concurrent_unordered_set.h"
+#include <regex>
 
 namespace edm {
   class EventSetup;
@@ -121,7 +122,8 @@ class TriggerSummaryProducerAOD : public edm::stream::EDProducer<edm::GlobalCach
   /// process name
   std::string pn_;
   /// module labels which should be avoided
-  const std::vector<std::string> moduleLabelsToSkip_;
+  std::vector<std::regex> moduleLabelPatternsToMatch_;
+  std::vector<std::regex> moduleLabelPatternsToSkip_;
 
   /// InputTag ordering class
   struct OrderInputTag {

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -120,6 +120,8 @@ class TriggerSummaryProducerAOD : public edm::stream::EDProducer<edm::GlobalCach
  private:
   /// process name
   std::string pn_;
+  /// module labels which should be avoided
+  const std::vector<std::string> moduleLabelsToSkip_;
 
   /// InputTag ordering class
   struct OrderInputTag {

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -57,6 +57,7 @@
 //
 TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps, const GlobalInputTags * gt) : 
   pn_(ps.getParameter<std::string>("processName")),
+  moduleLabelsToSkip_(ps.getParameter<std::vector<std::string>>("moduleLabelsToSkip")),
   filterTagsEvent_(pn_!="*"),
   filterTagsStream_(pn_!="*"),
   collectionTagsEvent_(pn_!="*"),
@@ -89,28 +90,46 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
 
   produces<trigger::TriggerEvent>();
 
-  getTriggerFilterObjectWithRefs_ = edm::GetterOfProducts<trigger::TriggerFilterObjectWithRefs>(edm::ProcessMatch(pn_), this);
-  getRecoEcalCandidateCollection_ = edm::GetterOfProducts<reco::RecoEcalCandidateCollection>(edm::ProcessMatch(pn_), this);
-  getElectronCollection_ = edm::GetterOfProducts<reco::ElectronCollection>(edm::ProcessMatch(pn_), this);
-  getRecoChargedCandidateCollection_ = edm::GetterOfProducts<reco::RecoChargedCandidateCollection>(edm::ProcessMatch(pn_), this);
-  getCaloJetCollection_ = edm::GetterOfProducts<reco::CaloJetCollection>(edm::ProcessMatch(pn_), this);
-  getCompositeCandidateCollection_ = edm::GetterOfProducts<reco::CompositeCandidateCollection>(edm::ProcessMatch(pn_), this);
-  getMETCollection_ = edm::GetterOfProducts<reco::METCollection>(edm::ProcessMatch(pn_), this);
-  getCaloMETCollection_ = edm::GetterOfProducts<reco::CaloMETCollection>(edm::ProcessMatch(pn_), this);
-  getIsolatedPixelTrackCandidateCollection_ = edm::GetterOfProducts<reco::IsolatedPixelTrackCandidateCollection>(edm::ProcessMatch(pn_), this);
-  getL1EmParticleCollection_ = edm::GetterOfProducts<l1extra::L1EmParticleCollection>(edm::ProcessMatch(pn_), this);
-  getL1MuonParticleCollection_ = edm::GetterOfProducts<l1extra::L1MuonParticleCollection>(edm::ProcessMatch(pn_), this);
-  getL1JetParticleCollection_ = edm::GetterOfProducts<l1extra::L1JetParticleCollection>(edm::ProcessMatch(pn_), this);
-  getL1EtMissParticleCollection_ = edm::GetterOfProducts<l1extra::L1EtMissParticleCollection>(edm::ProcessMatch(pn_), this);
-  getL1HFRingsCollection_ = edm::GetterOfProducts<l1extra::L1HFRingsCollection>(edm::ProcessMatch(pn_), this);
-  getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(edm::ProcessMatch(pn_), this);
-  getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(edm::ProcessMatch(pn_), this);
-  getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(edm::ProcessMatch(pn_), this);
-  getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(edm::ProcessMatch(pn_), this);
-  getL1TEtSumParticleCollection_ = edm::GetterOfProducts<l1t::EtSumBxCollection>(edm::ProcessMatch(pn_), this);
-  getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(edm::ProcessMatch(pn_), this);
-  getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(edm::ProcessMatch(pn_), this);
-  getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(edm::ProcessMatch(pn_), this);
+  auto const* pProcessName = &pn_;
+  auto const& moduleLabelsToSkip = moduleLabelsToSkip_;
+  auto productMatch = [pProcessName,&moduleLabelsToSkip](edm::BranchDescription const& iBranch) -> bool {
+    if(iBranch.processName() == *pProcessName || *pProcessName == "*") {
+      //require that the label begin with hlt to reduce the chance of
+      // picking up non HLT related data
+      if(0 == iBranch.moduleLabel().find("hlt")) {
+        for(auto const& shouldSkip : moduleLabelsToSkip) {
+          if(iBranch.moduleLabel() == shouldSkip) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+    return false;
+  };
+
+  getTriggerFilterObjectWithRefs_ = edm::GetterOfProducts<trigger::TriggerFilterObjectWithRefs>(productMatch, this);
+  getRecoEcalCandidateCollection_ = edm::GetterOfProducts<reco::RecoEcalCandidateCollection>(productMatch, this);
+  getElectronCollection_ = edm::GetterOfProducts<reco::ElectronCollection>(productMatch, this);
+  getRecoChargedCandidateCollection_ = edm::GetterOfProducts<reco::RecoChargedCandidateCollection>(productMatch, this);
+  getCaloJetCollection_ = edm::GetterOfProducts<reco::CaloJetCollection>(productMatch, this);
+  getCompositeCandidateCollection_ = edm::GetterOfProducts<reco::CompositeCandidateCollection>(productMatch, this);
+  getMETCollection_ = edm::GetterOfProducts<reco::METCollection>(productMatch, this);
+  getCaloMETCollection_ = edm::GetterOfProducts<reco::CaloMETCollection>(productMatch, this);
+  getIsolatedPixelTrackCandidateCollection_ = edm::GetterOfProducts<reco::IsolatedPixelTrackCandidateCollection>(productMatch, this);
+  getL1EmParticleCollection_ = edm::GetterOfProducts<l1extra::L1EmParticleCollection>(productMatch, this);
+  getL1MuonParticleCollection_ = edm::GetterOfProducts<l1extra::L1MuonParticleCollection>(productMatch, this);
+  getL1JetParticleCollection_ = edm::GetterOfProducts<l1extra::L1JetParticleCollection>(productMatch, this);
+  getL1EtMissParticleCollection_ = edm::GetterOfProducts<l1extra::L1EtMissParticleCollection>(productMatch, this);
+  getL1HFRingsCollection_ = edm::GetterOfProducts<l1extra::L1HFRingsCollection>(productMatch, this);
+  getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(productMatch, this);
+  getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(productMatch, this);
+  getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(productMatch, this);
+  getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(productMatch, this);
+  getL1TEtSumParticleCollection_ = edm::GetterOfProducts<l1t::EtSumBxCollection>(productMatch, this);
+  getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(productMatch, this);
+  getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(productMatch, this);
+  getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(productMatch, this);
 
   callWhenNewProductsRegistered([this](edm::BranchDescription const& bd){
     getTriggerFilterObjectWithRefs_(bd);
@@ -176,7 +195,8 @@ namespace {
 
 void TriggerSummaryProducerAOD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("processName","@");
+  desc.add<std::string>("processName","@")->setComment("Process name to use when getting data. The value of '@' is used to denote the current process name.");
+  desc.add<std::vector<std::string>>("moduleLabelsToSkip",std::vector<std::string>())->setComment("module labels for data products which should not be gotten.");
   descriptions.add("triggerSummaryProducerAOD", desc);
 }
 


### PR DESCRIPTION
When run in fastsim jobs, TriggerSummaryProducerAOD was requesting
data products for non HLT modules. Now it only accepts data products
from modules with labels beginning with 'hlt'. In addition, a new
parameter was added to the module to allow explicitly specifying
modules which should be avoided when choosing data products.
