### PR TITLE
[81X] Add payloads for several new Hcal records in all Global Tags and update Hcal 2017dev tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,45 +2,45 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v2',
+    'run1_design'       :   '81X_mcRun1_design_v3',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v2',
+    'run1_mc'           :   '81X_mcRun1_realistic_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '81X_mcRun1_pA_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v7',
+    'run2_design'       :   '81X_mcRun2_design_v8',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v9',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v10',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v8',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v7',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v8',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v8',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v9',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v7',
+    'run1_data'         :   '81X_dataRun2_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v7',
+    'run2_data'         :   '81X_dataRun2_v8',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v1',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v4',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v1',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v11',
+    'phase1_2017_design' :  '81X_upgrade2017_design_v12',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v13',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v14',
     # Global Tag for MC production with development HCAL conditions for Phase1 2017 detector
-    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v2',
+    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunI simulation
- **RunI Ideal scenario** : [81X_mcRun1_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v3) as [81X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_design_v3/81X_mcRun1_design_v2): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
- **RunI Heavy Ions scenario** : [81X_mcRun1_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v3) as [81X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_HeavyIon_v3/81X_mcRun1_HeavyIon_v2): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
- **RunI Realistic scenario** : [81X_mcRun1_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v3) as [81X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_realistic_v3/81X_mcRun1_realistic_v2): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
- **RunI Proton-Lead scenario** : [81X_mcRun1_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v3) as [81X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_pA_v3/81X_mcRun1_pA_v2): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v8) as [81X_mcRun2_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v8/81X_mcRun2_design_v7): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v9) as [81X_mcRun2_asymptotic_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v9/81X_mcRun2_asymptotic_v8): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII Startup scenario** : [81X_mcRun2_startup_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v10) as [81X_mcRun2_startup_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v10/81X_mcRun2_startup_v9): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v3) as [81X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v3/81X_mcRun2_pA_v2): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v8) as [81X_mcRun2cosmics_startup_peak_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v8/81X_mcRun2cosmics_startup_peak_v7): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v9) as [81X_mcRun2_HeavyIon_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v9/81X_mcRun2_HeavyIon_v8): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v8) as [81X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v8/81X_dataRun2_v7): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII HLTHI processing** : [81X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v2) as [81X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v2/81X_dataRun2_HLTHI_frozen_v1): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v4) as [81X_dataRun2_HLT_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v4/81X_dataRun2_HLT_relval_v3): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII HLT processing** : [81X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v2) as [81X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v2/81X_dataRun2_HLT_frozen_v1): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **RunII Offline relval processing** : [81X_dataRun2_relval_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v10) as [81X_dataRun2_relval_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v10/81X_dataRun2_relval_v9): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v14) as [81X_upgrade2017_realistic_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v14/81X_upgrade2017_realistic_v13): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **PhaseI design scenario** : [81X_upgrade2017_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v12) as [81X_upgrade2017_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_v12/81X_upgrade2017_design_v11): 
  - added payload for `HcalSiPMsCharacteristics` 
  - added payload for `HcalSiPMParameters`
  - added payload for `HcalTPChannelParameters`
  - added payload for `HcalTPParameters` 
  - added payload for `HFPhase1PMTParams`
- **PhaseI Hcal development scenario** : [81X_upgrade2017_HCALdev_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_v3) as [81X_upgrade2017_HCALdev_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_HCALdev_v3/81X_upgrade2017_HCALdev_v2): 
  - updated version of `HcalLutMetadata`
  - updated version of `HcalSiPMCharacteristics`
  - updated version of `HcalSiPMParameters`
