### PR TITLE
Fixes for HCAL premixing

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -39,7 +39,9 @@ run2_HCAL_2017.toModify( hcalRawDataVME,
     HF = cms.untracked.InputTag(""),
 )
 run2_HCAL_2017.toModify( hcalRawDatauHTR,
-    HBHE = cms.untracked.InputTag("DMHcalDigis"),
-    HF = cms.untracked.InputTag("DMHcalDigis")
+    HBHEqie8 = cms.InputTag("DMHcalDigis"),
+    HFqie8 = cms.InputTag("DMHcalDigis"),
+    QIE10 = cms.InputTag("DMHcalDigis","HFQIE10DigiCollection"),
+    QIE11 = cms.InputTag("DMHcalDigis","HBHEQIE11DigiCollection"),
 )
 

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -114,8 +114,8 @@ class HcalUHTRData {
   inline uint32_t crateId() const { return uint32_t(m_raw64[1])&0xFF; }
   /** \brief Get the board slot */
   inline uint32_t slot() const { return uint32_t(m_raw64[1]>>8)&0xF; }
-  /** \brief Get the presamples */
-  inline uint32_t presamples() const { return uint32_t(m_raw64[1]>>12)&0xF; }
+  /** \brief Get the presamples, clearing last bit */
+  inline uint32_t presamples() const { return uint32_t((m_raw64[1]&~0x8000)>>12)&0xF; }
 
   /** \brief Was this channel passed as part of Mark&Pass ZS?*/
   bool wasMarkAndPassZS(int fiber, int fiberchan) const;
@@ -127,6 +127,8 @@ class HcalUHTRData {
   /** \brief Get the HTR firmware flavor */
   int getFirmwareFlavor() const { return uint32_t(m_raw64[1]>>32)&0xFF; }
 
+  //** \brief Check for simulated HTR with flag word kept */
+  bool wasSimulatedHTR() const { return (((m_raw64[1]&0x8000)>>15)&0x1)==1; }
 
 protected:
   int m_formatVersion;

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -114,6 +114,8 @@ class HcalUHTRData {
   inline uint32_t crateId() const { return uint32_t(m_raw64[1])&0xFF; }
   /** \brief Get the board slot */
   inline uint32_t slot() const { return uint32_t(m_raw64[1]>>8)&0xF; }
+  /** \brief Get the presamples */
+  inline uint32_t presamples() const { return uint32_t(m_raw64[1]>>12)&0xF; }
 
   /** \brief Was this channel passed as part of Mark&Pass ZS?*/
   bool wasMarkAndPassZS(int fiber, int fiberchan) const;

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -151,7 +151,8 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int presamples = qiedf.presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-	uhtrs.newUHTR( uhtrIndex , presamples );
+        //special setting to keep flag word for QIE11 premixing
+        uhtrs.newUHTR( uhtrIndex , presamples , true );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -121,6 +121,7 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int crateId = eid.crateId();
       int slotId = eid.slot();
       int uhtrIndex = ((slotId&0xF)<<8) | (crateId&0xFF);
+      int presamples = qiedf.presamples();
 
       /* Defining a custom index that will encode only
 	 the information about the crate and slot of a 
@@ -128,7 +129,7 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 	 slot:  bits 8-12 */
 
       if( ! uhtrs.exist( uhtrIndex ) ){
-	uhtrs.newUHTR( uhtrIndex );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }
@@ -147,9 +148,10 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int crateId = eid.crateId();
       int slotId = eid.slot();
       int uhtrIndex = ((slotId&0xF)<<8) | (crateId&0xFF);
+      int presamples = qiedf.presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-	uhtrs.newUHTR( uhtrIndex );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }
@@ -167,9 +169,10 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int crateId = eid.crateId();
       int slotId = eid.slot();
       int uhtrIndex = (crateId&0xFF) | ((slotId&0xF)<<8) ; 
+      int presamples = qiedf->presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-	uhtrs.newUHTR( uhtrIndex );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }
@@ -187,9 +190,10 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int crateId = eid.crateId();
       int slotId = eid.slot();
       int uhtrIndex = (crateId&0xFF) | ((slotId&0xF)<<8) ; 
+      int presamples = qiedf->presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-	uhtrs.newUHTR( uhtrIndex );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }
@@ -210,9 +214,10 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int ilink = eid.fiberIndex();
       int itower = eid.fiberChanId();
       int channelid = (itower&0xF) | ((ilink&0xF)<<4);
+      int presamples = qiedf->presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-	uhtrs.newUHTR( uhtrIndex );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,channelid,_verbosity);
     }

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <vector>
 #include <map>
+#include <cmath>
 
 namespace CDFHeaderSpec{
   static const int OFFSET_H = 0; 
@@ -394,13 +395,13 @@ public:
      return header;
   }
 
-  uhtrData* newUHTR( int uhtrIndex , int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
+  uhtrData* newUHTR( int uhtrIndex , int ps = 0, int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
     
     // initialize vector of 16-bit words
     uhtrs[uhtrIndex] = uhtrData(8);
     // build header -- some information will be updated at the end    
     
-    uint64_t presamples    = 10;
+    uint64_t presamples    = std::max(ps,0);
     uint64_t uhtrCrate     = uhtrIndex&0xFF;
     uint64_t uhtrSlot      = (uhtrIndex&0xF00)>>8; 
 // From Jeremy:

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -396,7 +396,7 @@ public:
      return header;
   }
 
-  uhtrData* newUHTR( int uhtrIndex , int ps = 0, bool specialSimPremixBit = false, int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
+  uhtrData* newUHTR( int uhtrIndex , int ps, bool specialSimPremixBit = false, int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
     
     // initialize vector of 16-bit words
     uhtrs[uhtrIndex] = uhtrData(8);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -622,6 +622,8 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           for (++i; i != iend && !i.isHeader(); ++i) {
               ns++;
           }
+          //account for packed flag word from simulation
+          if(uhtr.wasSimulatedHTR()) ns--;
           // Check QEI11 container exists
           if (colls.qie11 == 0) {
               colls.qie11 = new QIE11DigiCollection(ns);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -595,6 +595,8 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
         printf("%04d %04x\n",iw,uhtr.getRawData16()[iw]);
 #endif
 
+    //use uhtr presamples since amc header not properly packed in simulation
+    nps = uhtr.presamples();
     HcalUHTRData::const_iterator i=uhtr.begin(), iend=uhtr.end();
     while (i!=iend) {
 #ifdef DebugLog

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -28,7 +28,7 @@ class HcalSiPMHitResponse : public CaloHitResponse {
 
 public:
   HcalSiPMHitResponse(const CaloVSimParameterMap * parameterMap, 
-		      const CaloShapes * shapes);
+		      const CaloShapes * shapes, bool PreMix1 = false);
 
   virtual ~HcalSiPMHitResponse();
 
@@ -68,7 +68,7 @@ private:
   float const Y11RANGE;
   float const Y11MAX;
   float const Y11TIMETORISE;
-  float theDiffNorm;
+  bool PreMixDigis;
 
   photonTimeMap precisionTimedPhotons;
   HcalTDCParameters theTDCParams;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -19,9 +19,9 @@
 #include <list>
 
 HcalSiPMHitResponse::HcalSiPMHitResponse(const CaloVSimParameterMap * parameterMap,
-					 const CaloShapes * shapes) :
+					 const CaloShapes * shapes, bool PreMix1) :
   CaloHitResponse(parameterMap, shapes), theSiPM(), theRecoveryTime(250.), 
-  TIMEMULT(1), Y11RANGE(80.), Y11MAX(0.04), Y11TIMETORISE(16.65) {
+  TIMEMULT(1), Y11RANGE(80.), Y11MAX(0.04), Y11TIMETORISE(16.65), PreMixDigis(PreMix1) {
   theSiPM = new HcalSiPM(2500);
 }
 
@@ -35,7 +35,8 @@ void HcalSiPMHitResponse::initializeHits() {
 }
 
 void HcalSiPMHitResponse::finalizeHits(CLHEP::HepRandomEngine* engine) {
-  addPEnoise(engine);
+  //do not add PE noise for initial premix
+  if(!PreMixDigis) addPEnoise(engine);
 
   photonTimeMap::iterator channelPhotons;
   for (channelPhotons = precisionTimedPhotons.begin();

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -43,7 +43,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theParameterMap(new HcalSimParameterMap(ps)),
   theShapes(new HcalShapes()),
   theHBHEResponse(new CaloHitResponse(theParameterMap, theShapes)),
-  theHBHESiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes)),
+  theHBHESiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes, ps.getParameter<bool>("HcalPreMixStage1"))),
   theHOResponse(new CaloHitResponse(theParameterMap, theShapes)),   
   theHOSiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes)),
   theHFResponse(new CaloHitResponse(theParameterMap, theShapes)),


### PR DESCRIPTION
The first two commits in this PR fix regressions that were unknowingly introduced before pre12 (which prevent premixing from running at all):
1) Premixing config for new packer
2) Packing and unpacking presamples value for QIE8 in new packer

The second two commits fix known issues specifically for QIE11 premixing:
3) Packing and unpacking QIE11 flag word (used for premixing error bits)
4) Disabling SiPM dark current noise during premixing step 1

The following plots compare the QIE11 ADC distribution with standard mixing (blue) vs. premixing (red).

After commits 1,2:
![adc](http://kjplanet.com/pr/adc_standard_vs_premix_pre12_fix1,2.png)

After commits 1,2,3: (better agreement at high ADC where error bits are used)
![adc](http://kjplanet.com/pr/adc_standard_vs_premix_pre12_fix1,2,3.png)

After commits 1,2,3,4: (better agreement at low ADC where single pe noise was previously duplicated)
![adc](http://kjplanet.com/pr/adc_standard_vs_premix_pre12_fix1,2,3,4.png)

attn: @jmmans, @lihux25, @mdhildreth 
