### PR TITLE
Stop producing ECAL txt files

### DIFF
--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -19,7 +19,7 @@
 using namespace std;
 
 EcalSelectiveReadoutProducer::EcalSelectiveReadoutProducer(const edm::ParameterSet& params)
-  : params_(params),firstCallEB_(true),firstCallEE_(true),iEvent_(0)
+  : params_(params),firstCallEB_(true),firstCallEE_(true),iEvent_(1)
 {
   //settings:
   //  settings which are only in python config files:


### PR DESCRIPTION
This one-character change fixes a regression introduced in #15593, which caused three ECAL txt files to be produced whenever the DIGI step was run.
