### PR TITLE
Use database objects to set MSB in LUTs for HCAL 2017 HE TP

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -425,7 +425,7 @@ HcaluLUTTPGCoder::lookupMSB(const QIE11DataFrame& df, std::vector<std::bitset<2>
    int lutId = getLUTId(HcalDetId(df.id()));
    const Lut& lut = upgradeQIE11LUT_.at(lutId);
    for (int i = 0; i < df.samples(); ++i) {
-      msb[0] = lut.at(df[i].adc()) & QIE11_LUT_MSB0;
-      msb[1] = lut.at(df[i].adc()) & QIE11_LUT_MSB1;
+      msb[i][0] = lut.at(df[i].adc()) & QIE11_LUT_MSB0;
+      msb[i][1] = lut.at(df[i].adc()) & QIE11_LUT_MSB1;
    }
 }

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -236,8 +236,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
   HcalSubdetector subdets[] = {HcalBarrel, HcalEndcap, HcalForward};
   for (int isub = 0; isub < 3; ++isub){
     HcalSubdetector subdet = subdets[isub];
-    for (int ieta = -HcalDetId::kHcalEtaMask2; 
-	 ieta <= HcalDetId::kHcalEtaMask2; ++ieta) {
+    for (int ieta = -HcalDetId::kHcalEtaMask2; ieta <= HcalDetId::kHcalEtaMask2; ++ieta) {
       for (int iphi = 0; iphi <= HcalDetId::kHcalPhiMask2; ++iphi) {
 	for (int depth = 1; depth < HcalDetId::kHcalDepthMask2; ++depth) {
 	  HcalDetId cell(subdet, ieta, iphi, depth);
@@ -265,8 +264,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 	    //Get Channel Quality
 	    const HcalChannelStatus* channelStatus = conditions.getHcalChannelStatus(cell);
 	    status = channelStatus->getValue();
-	  }
-	  else {
+	  } else {
 	    const HcalL1TriggerObject* myL1TObj = conditions.getHcalL1TriggerObject(cell);
 	    ped = myL1TObj->getPedestal();
 	    gain = myL1TObj->getRespGain();


### PR DESCRIPTION
Companion to #15945.

Use information from the `HcalTPChannelParameter` object to set two MSB in the linearization LUTs.

Posting separately as it is self-contained and only affects one package.
