### PR TITLE
Fix memory leak in L1Trigger/L1TMuonBarrel/src/L1MuBMEUX

### DIFF
--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMEUX.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMEUX.cc
@@ -105,6 +105,7 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
 
   if ( m_start == 0 || m_target == 0 ) {
     if ( L1MuBMTFConfig::Debug(4) ) cout << "Error: EUX has no data loaded" << endl;
+    delete theExtLUTs;
     return;
   }
 
@@ -140,8 +141,10 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
   if ( m_seu.ext() == EX24 ) qcut = pars.get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
   if ( m_seu.ext() == EX34 ) qcut = pars.get_soc_qcut_st4(m_sp.id().wheel(), m_sp.id().sector());
 
-  if ( m_start->quality() < qcut ) return;
-
+  if ( m_start->quality() < qcut ) {     
+    delete theExtLUTs;
+    return;
+  }
   // calculate bit shift
   int sh_phi  = 12 - nbit_phi;
   int sh_phib = 10 - nbit_phib;
@@ -168,9 +171,14 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
   int phi_offset = phi_target - offset;
   if ( ( lut_idx == EX34 ) || ( lut_idx == EX21 ) )
     phi_offset = phi_start + offset;
-  if ( phi_offset >= (1 << (nbit_phi-1)) -1 ) return;
-  if ( phi_offset < -(1 << (nbit_phi-1)) +1 ) return;
-
+  if ( phi_offset >= (1 << (nbit_phi-1)) -1 ) {
+        delete theExtLUTs;
+	return;
+  }
+  if ( phi_offset < -(1 << (nbit_phi-1)) +1 ) {
+    delete theExtLUTs;
+    return;
+  }
   // is phi-difference within the extrapolation window?
   bool openlut = pars.get_soc_openlut_extr(m_sp.id().wheel(), m_sp.id().sector());
   if (( diff >= low && diff <= high ) || L1MuBMTFConfig::getopenLUTs() || openlut ) {


### PR DESCRIPTION
from the way the code is structured, I would guess its a mistake that these luts are initialized every call to this function. But I leave that for the experts.
