### PR TITLE
Pr80x l1t memory fixes

### DIFF
--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMEUX.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMEUX.cc
@@ -105,6 +105,7 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
 
   if ( m_start == 0 || m_target == 0 ) {
     if ( L1MuBMTFConfig::Debug(4) ) cout << "Error: EUX has no data loaded" << endl;
+    delete theExtLUTs;
     return;
   }
 
@@ -140,8 +141,10 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
   if ( m_seu.ext() == EX24 ) qcut = pars.get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
   if ( m_seu.ext() == EX34 ) qcut = pars.get_soc_qcut_st4(m_sp.id().wheel(), m_sp.id().sector());
 
-  if ( m_start->quality() < qcut ) return;
-
+  if ( m_start->quality() < qcut ) {     
+    delete theExtLUTs;
+    return;
+  }
   // calculate bit shift
   int sh_phi  = 12 - nbit_phi;
   int sh_phib = 10 - nbit_phib;
@@ -168,9 +171,14 @@ void L1MuBMEUX::run(const edm::EventSetup& c) {
   int phi_offset = phi_target - offset;
   if ( ( lut_idx == EX34 ) || ( lut_idx == EX21 ) )
     phi_offset = phi_start + offset;
-  if ( phi_offset >= (1 << (nbit_phi-1)) -1 ) return;
-  if ( phi_offset < -(1 << (nbit_phi-1)) +1 ) return;
-
+  if ( phi_offset >= (1 << (nbit_phi-1)) -1 ) {
+        delete theExtLUTs;
+	return;
+  }
+  if ( phi_offset < -(1 << (nbit_phi-1)) +1 ) {
+    delete theExtLUTs;
+    return;
+  }
   // is phi-difference within the extrapolation window?
   bool openlut = pars.get_soc_openlut_extr(m_sp.id().wheel(), m_sp.id().sector());
   if (( diff >= low && diff <= high ) || L1MuBMTFConfig::getopenLUTs() || openlut ) {

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
@@ -35,7 +35,7 @@ void L1TMuonBarrelParamsHelper::configFromPy(std::map<std::string, int>& allInts
 
 	setAssLUTPath(AssLUTpath);
 	///Read Pt assignment Luts
-	std::vector<LUT> pta_lut(19);
+        std::vector<LUT> pta_lut(0); pta_lut.reserve(19);
 	std::vector<int> pta_threshold(10);
 	if ( load_pt(pta_lut,pta_threshold, allInts["PT_Assignment_nbits_Phi"], AssLUTpath) != 0 ) {
 	  cout << "Can not open files to load pt-assignment look-up tables for L1TMuonBarrelTrackProducer!" << endl;

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
@@ -36,7 +36,7 @@ void L1TMuonBarrelParamsHelper::configFromPy(std::map<std::string, int>& allInts
 	setAssLUTPath(AssLUTpath);
 	///Read Pt assignment Luts
 	std::vector<LUT> pta_lut(0); pta_lut.reserve(19);
-	std::vector<int> pta_threshold(6); pta_threshold.reserve(9);
+	std::vector<int> pta_threshold(6); pta_threshold.reserve(10);
 	if ( load_pt(pta_lut,pta_threshold, allInts["PT_Assignment_nbits_Phi"], AssLUTpath) != 0 ) {
 	  cout << "Can not open files to load pt-assignment look-up tables for L1TMuonBarrelTrackProducer!" << endl;
 	}

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
@@ -35,8 +35,8 @@ void L1TMuonBarrelParamsHelper::configFromPy(std::map<std::string, int>& allInts
 
 	setAssLUTPath(AssLUTpath);
 	///Read Pt assignment Luts
-	std::vector<LUT> pta_lut(0); pta_lut.reserve(19);
-	std::vector<int> pta_threshold(6); pta_threshold.reserve(10);
+	std::vector<LUT> pta_lut(19);
+	std::vector<int> pta_threshold(10);
 	if ( load_pt(pta_lut,pta_threshold, allInts["PT_Assignment_nbits_Phi"], AssLUTpath) != 0 ) {
 	  cout << "Can not open files to load pt-assignment look-up tables for L1TMuonBarrelTrackProducer!" << endl;
 	}

--- a/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
+++ b/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
@@ -28,6 +28,7 @@ class XMLConfigReader{
  public:
 
   XMLConfigReader();
+  ~XMLConfigReader();
 
   void readConfig(const std::string fName);
 
@@ -67,4 +68,5 @@ class XMLConfigReader{
   std::vector<GoldenPattern*> aGPs;
 
 };
+
 #endif

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -49,6 +49,12 @@ XMLConfigReader::XMLConfigReader(){
 
   doc = 0;  
 }
+
+XMLConfigReader::~XMLConfigReader()
+{
+  delete parser;
+  XMLPlatformUtils::Terminate();
+}
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigReader::readLUT(l1t::LUT *lut,const L1TMuonOverlapParams & aConfig, const std::string & type){
@@ -175,7 +181,9 @@ std::vector<GoldenPattern*> XMLConfigReader::readPatterns(const L1TMuonOverlapPa
       }
     }
   }
-  delete doc;
+
+  // Reset the documents vector pool and release all the associated memory back to the system.
+  parser->resetDocumentPool();
 
   return aGPs;
 }
@@ -539,8 +547,8 @@ void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const{
   aConfig->setLayerInputMap(aLayerInputMapVec);
   aConfig->setRefHitMap(aRefHitMapVec);
 
-  delete doc;
+  // Reset the documents vector pool and release all the associated memory back to the system.
+  parser->resetDocumentPool();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
-


### PR DESCRIPTION
This PR contains 3 types of fixes concerning memory management by L1Trigger:
- fix for **memory leak** in Muon Barell Extrapolater which was introduced with merging of O2O
  (free allocated memory before every return).  This is already provided in 81x #16061 by @davidlange6 
- fix for **repetitive memory allocation** in Muon Overlap XML Parser to reset DOM vector pool and release all the associated memory back to the system before re-using read methods.
- fix for **Invalid writes** in Muon Barell ParamsHelper class by reserving the correct vector size.
