### PR TITLE
Remove Eras.py imports from tracking

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -48,7 +48,8 @@ validation = cms.Sequence(cms.SequencePlaceholder("mix")
 _validation_fastsim = validation.copy()
 for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze]:
     _validation_fastsim.remove(_entry)
-eras.fastSim.toReplaceWith(validation,_validation_fastsim)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validation,_validation_fastsim)
 
 validationLiteTracking = cms.Sequence( validation )
 validationLiteTracking.replace(globalValidation,globalValidationLiteTracking)

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -141,13 +141,3 @@ for era in _cfg.allEras():
     locals()["selectedIterTrackingStep"+pf] = _cfg.iterationAlgos(era)
 #selectedIterTrackingStep.append('muonSeededStepOutInDisplaced')
 
-# FIXME ::  this part will be removed when phase2 tracking is migrated to eras
-selectedIterTrackingStep_trackingPhase2PU140 = [
-    "initialStep",
-    "highPtTripletStep",
-    "lowPtQuadStep",
-    "lowPtTripletStep",
-    "detachedQuadStep",
-    "pixelPairStep",
-    "muonSeededStepInOut",
-]

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -136,8 +136,7 @@ clusterLabel     ['jetCoreRegionalStep'] = cms.vstring('Tot')
 clusterBin       ['jetCoreRegionalStep'] = cms.int32(500)
 clusterMax       ['jetCoreRegionalStep'] = cms.double(100000)
 
-for era in _cfg.allEras():
-    pf = _cfg.postfix(era)
-    locals()["selectedIterTrackingStep"+pf] = _cfg.iterationAlgos(era)
+for _eraName, _postfix, _era in _cfg.allEras():
+    locals()["selectedIterTrackingStep"+_postfix] = _cfg.iterationAlgos(_postfix)
 #selectedIterTrackingStep.append('muonSeededStepOutInDisplaced')
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -313,7 +313,7 @@ for tracks in selectedTracks :
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0 += locals()[label]
 # seeding monitoring
-for era in _cfg.allEras() + ["trackingPhase2PU140"]: # FIXME:: allEras() extension should be removed when phase2 tracking is migrated to eras
+for era in _cfg.allEras():
     postfix = _cfg.postfix(era)
     _seq = cms.Sequence()
     for step in locals()["selectedIterTrackingStep"+postfix]:

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -313,15 +313,14 @@ for tracks in selectedTracks :
     label = 'TrackerCollisionSelectedTrackMonCommon' + str(tracks)
     TrackingDQMSourceTier0 += locals()[label]
 # seeding monitoring
-for era in _cfg.allEras():
-    postfix = _cfg.postfix(era)
+for _eraName, _postfix, _era in _cfg.allEras():
     _seq = cms.Sequence()
-    for step in locals()["selectedIterTrackingStep"+postfix]:
+    for step in locals()["selectedIterTrackingStep"+_postfix]:
         _seq += locals()["TrackSeedMon"+step]
-    if era == "":
+    if _eraName == "":
         locals()["TrackSeedMonSequence"] = _seq
     else:
-        getattr(eras, era).toReplaceWith(TrackSeedMonSequence, _seq)
+        _era.toReplaceWith(TrackSeedMonSequence, _seq)
 TrackingDQMSourceTier0 += TrackSeedMonSequence
 # MessageLog
 for module in selectedModules :

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ###############################################
@@ -8,8 +7,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
 detachedQuadStepClusters = _cfg.clusterRemoverForIter("DetachedQuadStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(detachedQuadStepClusters, _cfg.clusterRemoverForIter("DetachedQuadStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(detachedQuadStepClusters, _cfg.clusterRemoverForIter("DetachedQuadStep", _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016 as _tracker_apv_vfp30_2016
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
@@ -9,8 +8,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
 detachedTripletStepClusters = _cfg.clusterRemoverForIter("DetachedTripletStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(detachedTripletStepClusters, _cfg.clusterRemoverForIter("DetachedTripletStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(detachedTripletStepClusters, _cfg.clusterRemoverForIter("DetachedTripletStep", _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ### high-pT triplets ###
 
 # NEW CLUSTERS (remove previously used clusters)
 highPtTripletStepClusters = _cfg.clusterRemoverForIter("HighPtTripletStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(highPtTripletStepClusters, _cfg.clusterRemoverForIter("HighPtTripletStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(highPtTripletStepClusters, _cfg.clusterRemoverForIter("HighPtTripletStep", _eraName, _postfix))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -1,11 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
 lowPtQuadStepClusters = _cfg.clusterRemoverForIter("LowPtQuadStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter("LowPtQuadStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter("LowPtQuadStep", _eraName, _postfix))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -1,12 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016 as _tracker_apv_vfp30_2016
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
 lowPtTripletStepClusters = _cfg.clusterRemoverForIter("LowPtTripletStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(lowPtTripletStepClusters, _cfg.clusterRemoverForIter("LowPtTripletStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(lowPtTripletStepClusters, _cfg.clusterRemoverForIter("LowPtTripletStep", _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ###############################################################
@@ -17,8 +16,8 @@ chargeCut2069Clusters =  cms.EDProducer("ClusterChargeMasker",
 mixedTripletStepClusters = _cfg.clusterRemoverForIter("MixedTripletStep")
 chargeCut2069Clusters.oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value()
 mixedTripletStepClusters.oldClusterRemovalInfo = "chargeCut2069Clusters"
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(mixedTripletStepClusters, _cfg.clusterRemoverForIter("MixedTripletStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(mixedTripletStepClusters, _cfg.clusterRemoverForIter("MixedTripletStep", _eraName, _postfix))
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(chargeCut2069Clusters, oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value())
 trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo="chargeCut2069Clusters")

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 ##########################################################################
@@ -7,8 +6,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 ##########################################################################
 
 pixelLessStepClusters = _cfg.clusterRemoverForIter("PixelLessStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter("PixelLessStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter("PixelLessStep", _eraName, _postfix))
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -5,8 +5,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 # NEW CLUSTERS (remove previously used clusters)
 pixelPairStepClusters = _cfg.clusterRemoverForIter("PixelPairStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter("PixelPairStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter("PixelPairStep", _eraName, _postfix))
 
 
 # SEEDING LAYERS

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
 #######################################################################
@@ -7,8 +6,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 #######################################################################
 
 tobTecStepClusters = _cfg.clusterRemoverForIter("TobTecStep")
-for era in _cfg.nonDefaultEras():
-    getattr(eras, era).toReplaceWith(tobTecStepClusters, _cfg.clusterRemoverForIter("TobTecStep", era))
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(tobTecStepClusters, _cfg.clusterRemoverForIter("TobTecStep", _eraName, _postfix))
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -3,9 +3,18 @@
 # InitialStepPreSplitting is not counted as an iteration.
 import FWCore.ParameterSet.Config as cms
 
-_defaultEra = ""
-_nonDefaultEras = ["trackingLowPU", "trackingPhase1", "trackingPhase1PU70", "trackingPhase2PU140"]
+_defaultEraName = ""
+_nonDefaultEraNames = ["trackingLowPU", "trackingPhase1", "trackingPhase1PU70", "trackingPhase2PU140"]
+
+# name, postfix, era
+_defaultEra = (_defaultEraName, "", None)
+_nonDefaultEras = [
+    (_name, "_"+_name, getattr(__import__('Configuration.Eras.Modifier_'+_name+'_cff',globals(),locals(),[_name],0),_name)) \
+    for _name in _nonDefaultEraNames
+]
+
 _allEras = [_defaultEra] + _nonDefaultEras
+
 
 _iterations = [
     "InitialStep",
@@ -103,9 +112,6 @@ _trackClusterRemoverBase_trackingPhase2PU140 = _phase2trackClusterRemover.clone(
     minNumberOfLayersWithMeasBeforeFiltering = 0,
 )
 
-def postfix(era):
-    return "_"+era if era != _defaultEra else era
-
 def _modulePrefix(iteration):
     return iteration[0].lower()+iteration[1:]
 
@@ -131,23 +137,21 @@ def allEras():
 def nonDefaultEras():
     return _nonDefaultEras
 
-def createEarlySequence(era, modDict):
-    pf = postfix(era)
+def createEarlySequence(eraName, postfix, modDict):
     seq = cms.Sequence()
-    for it in globals()["_iterations"+pf]:
+    for it in globals()["_iterations"+postfix]:
         seq += modDict[it]
     return seq
 
-def iterationAlgos(era):
-    muonVariable = "_iterations_muonSeeded"+postfix(era)
-    return [_modulePrefix(i) for i in globals()["_iterations"+postfix(era)] + globals().get(muonVariable, _iterations_muonSeeded)]
+def iterationAlgos(postfix):
+    muonVariable = "_iterations_muonSeeded"+postfix
+    return [_modulePrefix(i) for i in globals()["_iterations"+postfix] + globals().get(muonVariable, _iterations_muonSeeded)]
 
-def _seedOrTrackProducers(era, typ):
+def _seedOrTrackProducers(postfix, typ):
     ret = []
-    pf = postfix(era)
-    iters = globals()["_iterations"+pf]
+    iters = globals()["_iterations"+postfix]
     if typ == "Seeds":
-        multipleSeedProducers = globals()["_multipleSeedProducers"+pf]
+        multipleSeedProducers = globals()["_multipleSeedProducers"+postfix]
     else:
         multipleSeedProducers = None
     for i in iters:
@@ -157,25 +161,24 @@ def _seedOrTrackProducers(era, typ):
         else:
             ret.append(seeder)
 
-    for i in globals().get("_iterations_muonSeeded"+postfix(era), _iterations_muonSeeded):
+    for i in globals().get("_iterations_muonSeeded"+postfix, _iterations_muonSeeded):
         ret.append(_modulePrefix(i).replace("Step", typ))
 
     return ret
 
-def seedProducers(era):
-    return _seedOrTrackProducers(era, "Seeds")
+def seedProducers(postfix):
+    return _seedOrTrackProducers(postfix, "Seeds")
 
-def trackProducers(era):
-    return _seedOrTrackProducers(era, "Tracks")
+def trackProducers(postfix):
+    return _seedOrTrackProducers(postfix, "Tracks")
 
-def clusterRemoverForIter(iteration, era="", module=None):
+def clusterRemoverForIter(iteration, eraName="", postfix="", module=None):
     if module is None:
         module = _trackClusterRemoverBase.clone()
-    if era == "trackingPhase2PU140":
-        module = globals().get("_trackClusterRemoverBase"+postfix(era), _trackClusterRemoverBase)
+    if eraName == "trackingPhase2PU140":
+        module = globals().get("_trackClusterRemoverBase"+postfix, _trackClusterRemoverBase)
 
-    pf = postfix(era)
-    iters = globals()["_iterations"+pf]
+    iters = globals()["_iterations"+postfix]
     try:
         ind = iters.index(iteration)
     except ValueError:
@@ -183,16 +186,16 @@ def clusterRemoverForIter(iteration, era="", module=None):
         return module
 
     if ind == 0:
-        raise Exception("Iteration %s is the first iteration in era %s, asking cluster remover configuration does not make sense" % (iteration, era))
+        raise Exception("Iteration %s is the first iteration in era %s, asking cluster remover configuration does not make sense" % (iteration, eraName))
     prevIter = iters[ind-1]
 
     customize = dict(
         trajectories          = _tracks(prevIter),
         oldClusterRemovalInfo = _clusterRemover(prevIter) if ind >= 2 else "", # 1st iteration does not have cluster remover
     )
-    if era in ["trackingPhase1PU70", "trackingPhase2PU140"]:
+    if eraName in ["trackingPhase1PU70", "trackingPhase2PU140"]:
         customize["overrideTrkQuals"] = _classifier(prevIter, oldStyle=True) # old-style selector
-    elif era == "trackingLowPU":
+    elif eraName == "trackingLowPU":
         customize["overrideTrkQuals"] = _classifier(prevIter, oldStyle=True, oldStyleQualityMasks=True) # old-style selector with 'QualityMasks' instance label
     else:
         customize["trackClassifier"] = _classifier(prevIter)

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -25,9 +25,9 @@ from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
 
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 
-iterTrackingEarly = _cfg.createEarlySequence("", globals())
-for _era in _cfg.nonDefaultEras():
-    getattr(eras, _era).toReplaceWith(iterTrackingEarly, _cfg.createEarlySequence(_era, globals()))
+iterTrackingEarly = _cfg.createEarlySequence("", "", globals())
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toReplaceWith(iterTrackingEarly, _cfg.createEarlySequence(_eraName, _postfix, globals()))
 
 iterTracking = cms.Sequence(InitialStepPreSplitting*
                             iterTrackingEarly*


### PR DESCRIPTION
This PR is a follow-up to #16001 by removing all imports of `Eras.py` from tracking.

Tested in CMSSW_8_1_X_2016-10-02-2300, no changes expected. I checked with workflows `4.22,5.1,8.0,25.0,135.13,135.4,136.731,140.53,1000.0,1001.0,1325.0,1325.1,1325.2,1325.3,1325.4,1330.0,10021.0,10024.0,10024.1,10024.2,10024.3,10024.4,10024.5,10424.0,10624.0,10824.0,20024.0,20024.1,20424.1,22424.0` (those include all tracking-specific workflows) that there are no changes in the configuration dumps.

@rovere @VinInn @kpedro88 
