### PR TITLE
Use TTreeCache for RootEmbeddedFileSequence

### DIFF
--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -42,6 +42,7 @@ namespace edm {
     // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
     // and should be deleted from the code.
     initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
+    treeCacheSize_(pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize)),
     enablePrefetching_(false) {
 
     if(noFiles()) {
@@ -51,6 +52,9 @@ namespace edm {
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
     Service<SiteLocalConfig> pSLC;
     if(pSLC.isAvailable()) {
+      if(treeCacheSize_ != 0U && pSLC->sourceTTreeCacheSize()) {
+        treeCacheSize_ = *(pSLC->sourceTTreeCacheSize());
+      }
       enablePrefetching_ = pSLC->enablePrefetching();
     }
 
@@ -130,6 +134,7 @@ namespace edm {
           logicalFileName(),
           filePtr,
 	  input_.nStreams(),
+          treeCacheSize_,
           input_.treeMaxVirtualSize(),
           input_.runHelper(),
           input_.productSelectorRules(),
@@ -325,5 +330,7 @@ namespace edm {
                      "False: loopEvents() reads events regardless of lumi.");
     desc.addUntracked<unsigned int>("skipEvents", 0U)
         ->setComment("Skip the first 'skipEvents' events. Used only if 'sequential' is True and 'sameLumiBlock' is False");
+    desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
+        ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
   }
 }

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -63,6 +63,7 @@ namespace edm {
     bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*);
     int eventsRemainingInFile_;
     int initialNumberOfEventsToSkip_;
+    unsigned int treeCacheSize_;
     bool enablePrefetching_;
   }; // class RootEmbeddedFileSequence
 }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -126,6 +126,7 @@ namespace edm {
              std::string const& logicalFileName,
              std::shared_ptr<InputFile> filePtr,
              unsigned int nStreams,
+             unsigned int treeCacheSize,
              int treeMaxVirtualSize,
              RunHelperBase* runHelper,
              ProductSelectorRules const& productSelectorRules,
@@ -137,7 +138,7 @@ namespace edm {
              bool bypassVersionCheck,
              bool enablePrefetching) : RootFile(
                fileName, processConfiguration, logicalFileName, filePtr,
-               nullptr, false, -1, -1, nStreams, 0U, treeMaxVirtualSize,
+               nullptr, false, -1, -1, nStreams, treeCacheSize, treeMaxVirtualSize,
                InputSource::RunsLumisAndEvents, runHelper,
                false, productSelectorRules, inputType, nullptr, nullptr,
                nullptr, nullptr, false, processHistoryRegistry,  


### PR DESCRIPTION
This modifies RootEmbeddedFileSequence to have basically the same settings for the ROOT TTreeCache as the primary input file, defaulting to having the cache on.  RootEmbeddedFileSequence is only used by the MixingModule, so this change will turn on caching for the MixingModule inputs without affecting any other use cases.
