### PR TITLE
L1Trigger/L1THGCal : Fix for clang compiler error undefined reference to HGCalDetId::kHGCalCellMask

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <fstream>
 
+const int HGCalDetId::kHGCalCellMask;
 
 class HGCalTriggerGeometryHexImp1 : public HGCalTriggerGeometryGenericMapping
 {


### PR DESCRIPTION
Clang requires the declaration of static const variables in the  .cc file where they are used.

> > Building edm plugin tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/libL1TriggerL1THGCalPlugins_geometries.so
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/3.8.0-dpekbn/bin/clang++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/HGCalTriggerGeometryHexImp2.o tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/TrivialGeometry.o tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/NullGeometry.o tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/HGCalTriggerGeometryHexImp1.o tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/HGCalTriggerGeometryImp1.o -o tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/libL1TriggerL1THGCalPlugins_geometries.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/lib/slc6_amd64_gcc530 -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/external/slc6_amd64_gcc530/lib -lL1TriggerL1THGCal -lGeometryHGCalGeometry -lGeometryCaloTopology -lGeometryCaloGeometry -lDataFormatsCaloTowers -lFWCoreFramework -lGeometryHcalCommonData -lDataFormatsCandidate -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lFWCoreServiceRegistry -lDataFormatsDetId -lDataFormatsMath -lFWCoreCommon -lFWCorePythonParameterSet -lGeometryHGCalCommonData -lDataFormatsCommon -lDetectorDescriptionCore -lFWCoreParameterSet -lDataFormatsProvenance -lDetectorDescriptionExprAlgo -lDetectorDescriptionBase -lFWCoreMessageLogger -lFWCorePluginManager -lDataFormatsStdDictionaries -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lGenVector -lMathMore -lTree -lNet -lThread -lMathCore -lRIO -lboost_filesystem -lCore -lboost_python -lboost_regex -lboost_system -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -lCLHEP -lgsl -lgslcblas -luuid -lpython2.7 -ltbb -lxerces-c -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/geometries/HGCalTriggerGeometryHexImp1.o: In function `HGCalTriggerGeometryHexImp1::fillMaps(HGCalTriggerGeometryBase::es_info const&)':
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/src/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc:(.text+0x17a2): undefined reference to`HGCalDetId::kHGCalCellMask'
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/src/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc:(.text+0x1d88): undefined reference to `HGCalDetId::kHGCalCellMask'
> > clang-3.8: error: linker command failed with exit code 1 (use -v to see invocation)
> >   gmake: **\* [tmp/slc6_amd64_gcc530/src/L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_geometries/libL1TriggerL1THGCalPlugins_geometries.so] Error 1
> >  Leaving library rule at src/L1Trigger/L1THGCal/plugins
