### PR TITLE
Alignment/OfflineValidation : Fix for clang compiler error undefined reference to PrimaryVertexValidation::nMaxtracks_

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -62,6 +62,8 @@
 const int kBPIX = PixelSubdetector::PixelBarrel;
 const int kFPIX = PixelSubdetector::PixelEndcap;
 
+const int PrimaryVertexValidation::nMaxtracks_;
+
 // Constructor
 PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfig):
   storeNtuple_(iConfig.getParameter<bool>("storeNtuple")),


### PR DESCRIPTION
Clang requires the declaration of static const variables in the  .cc file where they are used.

> > Building edm plugin tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/libAlignmentOfflinevalidationPlugins.so
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/3.8.0-dpekbn/bin/clang++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/MuonAlignmentAnalyzer.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerOfflineValidation.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TkAlStyle.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/ResidualRefitting.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/ValidationMisalignedTracker.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerOfflineValidationSummary.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/Tracker_OldtoNewConverter.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerGeometryIntoNtuples.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerGeometryCompare.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/CosmicSplitterValidation.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/EopTreeWriter.o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/PrimaryVertexValidation.o -o tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/libAlignmentOfflinevalidationPlugins.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/lib/slc6_amd64_gcc530 -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/external/slc6_amd64_gcc530/lib -lRecoVertexPrimaryVertexProducer -lRecoMuonTrackingTools -lRecoVertexAdaptiveVertexFit -lRecoVertexTrimmedKalmanVertexFinder -lRecoVertexKalmanVertexFit -lRecoVertexLinearizationPointFinders -lTrackingToolsIPTools -lRecoVertexVertexTools -lAlignmentOfflineValidation -lRecoVertexVertexPrimitives -lTrackingToolsTrackRefitter -lRecoMuonNavigation -lTrackingToolsKalmanUpdators -lTrackingToolsTrackFitters -lTrackingToolsTransientTrack -lDataFormatsMuonReco -lRecoMuonDetLayers -lRecoTrackerTransientTrackingRecHit -lSimTrackerTrackAssociation -lTrackingToolsGsfTools -lTrackingToolsRecoGeometry -lTrackingToolsTrackAssociator -lDataFormatsParticleFlowCandidate -lRecoLocalTrackerPhase2TrackerRecHits -lRecoLocalTrackerSiStripRecHitConverter -lRecoTrackerRecord -lSimTrackerRecords -lTrackPropagationSteppingHelixPropagator -lTrackingToolsDetLayers -lTrackingToolsPatternTools -lDQMSiStripCommon -lDataFormatsEgammaCandidates -lRecoLocalTrackerClusterParameterEstimator -lRecoLocalTrackerSiPixelRecHits -lTrackingToolsGeomPropagators -lTrackingToolsRecords -lCalibTrackerSiPixelESProducers -lCommonToolsTrackerMap -lDataFormatsEgammaReco -lDataFormatsGsfTrackReco -lDataFormatsRecoCandidate -lDataFormatsVertexReco -lRecoLocalTrackerRecords -lRecoMuonTransientTrackingRecHit -lSimDataFormatsTrackingAnalysis -lSimTrackerTrackerHitAssociation -lTrackingToolsTrajectoryState -lAlignmentTrackerAlignment -lCalibFormatsSiStripObjects -lCalibTrackerRecords -lCommonToolsUtilAlgos -lDataFormatsTrackReco -lTrackingToolsTransientTrackingRecHit -lAlignmentCommonAlignment -lCalibTrackerSiStripCommon -lCommonToolsUtils -lCondFormatsSiPixelObjects -lDataFormatsGEMRecHit -lDataFormatsTrackCandidate -lDataFormatsTrackerRecHit2D -lMagneticFieldRecords -lRecoMuonRecords -lCondCoreDBOutputService -lCondFormatsDataRecord -lCondFormatsEgammaObjects -lDataFormatsCSCRecHit -lDataFormatsDTRecHit -lDataFormatsTrajectorySeed -lMagneticFieldVolumeBasedEngine -lCondCoreCondDB -lCondFormatsAlignment -lCondFormatsGeometryObjects -lCondFormatsPhysicsToolsObjects -lCondFormatsSiStripObjects -lDataFormatsTrackingRecHit -lGeometryCSCGeometry -lGeometryDTGeometry -lGeometryGEMGeometry -lGeometryRPCGeometry -lGeometryRecords -lGeometryTrackerGeometryBuilder -lMagneticFieldLayers -lCondFormatsAlignmentRecord -lCondFormatsCommon -lDQMServicesCore -lDataFormatsGeometryCommonDetAlgo -lGeometryCaloGeometry -lGeometryCommonDetUnit -lGeometryTrackerNumberingBuilder -lMagneticFieldVolumeGeometry -lSimDataFormatsCrossingFrame -lTrackingToolsAnalyticalJacobians -lCommonToolsStatistics -lCondFormatsCSCObjects -lDataFormatsCaloTowers -lDataFormatsDTDigi -lDataFormatsGeometrySurface -lDataFormatsHepMCCandidate -lDataFormatsSiPixelDigi -lDataFormatsTrackerCommon -lFWCoreFramework -lSimDataFormatsTrackingHit -lDataFormatsCLHEP -lDataFormatsCaloRecHit -lDataFormatsCandidate -lDataFormatsEcalDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lDataFormatsMuonDetId -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreServiceRegistry -lSimDataFormatsTrack -lSimDataFormatsVertex -lDataFormatsBeamSpot -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalTrigger -lDataFormatsMath -lDataFormatsPhase2TrackerCluster -lDataFormatsSiPixelCluster -lDataFormatsSiStripCluster -lDataFormatsSiStripCommon -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCorePythonParameterSet -lSimDataFormatsCaloHit -lSimDataFormatsGeneratorProducts -lSimDataFormatsTrackerDigiSimLink -lDataFormatsCommon -lDetectorDescriptionCore -lFWCoreParameterSet -lDataFormatsProvenance -lDetectorDescriptionExprAlgo -lGeometryCommonTopologies -lDetectorDescriptionBase -lFWCoreMessageLogger -lFWCorePluginManager -lMagneticFieldEngine -lTrackingToolsTrajectoryParametrization -lUtilitiesGeneral -lCalibFormatsSiPixelObjects -lCondFormatsSerialization -lDataFormatsStdDictionaries -lDataFormatsTrajectoryState -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lSimDataFormatsEncodedEventId -lUtilitiesBinningTools -llcg_CoralCommon -llcg_RelationalAccess -llcg_CoralKernel -llcg_CoralBase -lTMVA -lMLP -lTreePlayer -lGraf3d -lPostscript -lGui -lMinuit -lGpad -lGraf -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lThread -lMathCore -lRint -lRIO -lboost_filesystem -lclasslib -lCore -lboost_python -lboost_regex -lboost_serialization -lboost_system -lHepMCfio -lHepMC -lpng -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -lCLHEP -lgsl -lgslcblas -ljpeg -lturbojpeg -luuid -lssl -lcrypto -lprotobuf -lpython2.7 -lsigc-2.0 -ltbb -lxerces-c -llzma -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/PrimaryVertexValidation.o: In function `PrimaryVertexValidation::analyze(edm::Event const&, edm::EventSetup const&)':
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/a8cfa3cf46e2c655e9ea8aa18833b856/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_CLANG_X_2016-10-04-1100/src/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc:(.text+0x39fa): undefined reference to`PrimaryVertexValidation::nMaxtracks_'
> > clang-3.8: error: linker command failed with exit code 1 (use -v to see invocation)
> >   gmake: **\* [tmp/slc6_amd64_gcc530/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/libAlignmentOfflinevalidationPlugins.so] Error 1
> >  Leaving library rule at src/Alignment/OfflineValidation/plugins
