### PR TITLE
explicitly depend on gcc-atomic

### DIFF
--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Services"/>
 <use   name="Utilities/StorageFactory"/>
+<use   name="gcc-atomic"/>
 <library   file="*.cc" name="FWCoreServicesPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
This should explicitly linked libatomic from gcc. It should fix the link error for CLANG IBs
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc530/CMSSW_8_1_CLANG_X_2016-10-04-1100/FWCore/Services
