### PR TITLE
Adding a mode of operations in which all time slices are combined

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
@@ -10,13 +10,16 @@ class HcalCalibrations;
 class HFPreRecAlgo
 {
 public:
-    inline HFPreRecAlgo() {}
+    inline explicit HFPreRecAlgo(const bool sumAllTS) : sumAllTS_(sumAllTS) {}
+
     inline ~HFPreRecAlgo() {}
 
     HFQIE10Info reconstruct(const QIE10DataFrame& digi,
                             int tsToUse,
                             const HcalCoder& coder,
-                            const HcalCalibrations& calibs);
+                            const HcalCalibrations& calibs) const;
+private:
+    bool sumAllTS_;
 };
 
 #endif // RecoLocalCalo_HcalRecAlgos_HFPreRecAlgo_h_

--- a/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 hfprereco = cms.EDProducer("HFPreReconstructor",
     digiLabel = cms.InputTag("hcalDigis"),
     dropZSmarkedPassed = cms.bool(True),
-    tsFromDB = cms.bool(False)
+    tsFromDB = cms.bool(False),
+    sumAllTimeSlices = cms.bool(False)
 )

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -85,7 +85,8 @@ private:
 HFPreReconstructor::HFPreReconstructor(const edm::ParameterSet& conf)
     : inputLabel_(conf.getParameter<edm::InputTag>("digiLabel")),
       dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed")),
-      tsFromDB_(conf.getParameter<bool>("tsFromDB"))
+      tsFromDB_(conf.getParameter<bool>("tsFromDB")),
+      reco_(conf.getParameter<bool>("sumAllTimeSlices"))
 {
     // Describe consumed data
     tok_hfQIE10_ = consumes<QIE10DigiCollection>(inputLabel_);
@@ -290,6 +291,7 @@ HFPreReconstructor::fillDescriptions(edm::ConfigurationDescriptions& description
     desc.add<edm::InputTag>("digiLabel");
     desc.add<bool>("dropZSmarkedPassed");
     desc.add<bool>("tsFromDB");
+    desc.add<bool>("sumAllTimeSlices");
 
     descriptions.addDefault(desc);
 }


### PR DESCRIPTION
Introducing Phase 1 HF reco mode in which all time slices are combined. This is equivalent to what we did in Run 2 for cosmic runs. The timing information will be ignored.

This change is not supposed to modify any previous relvals.
