### PR TITLE
Phase1 Pixel DQM Online, Raw Data, and Bugfix

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -99,6 +99,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
 process.load("DQM.SiPixelCommon.SiPixelP5DQM_source_cff")
 process.load("DQM.SiPixelCommon.SiPixelP5DQM_client_cff")
 
+process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_cff")
+
 process.qTester = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath(QTestfile),
     prescaleFactor = cms.untracked.int32(1),
@@ -143,7 +145,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 else:
     process.Reco = cms.Sequence(process.siPixelDigis*process.siPixelClusters)
 
-process.p = cms.Path(process.Reco*process.DQMmodules*process.SiPixelRawDataErrorSource*process.SiPixelDigiSource*process.SiPixelClusterSource*process.PixelP5DQMClientWithDataCertification)
+process.p = cms.Path(process.Reco*process.DQMmodules*process.SiPixelRawDataErrorSource*process.SiPixelDigiSource*process.SiPixelClusterSource*process.PixelP5DQMClientWithDataCertification*process.siPixelPhase1OnlineDQM_source*process.siPixelPhase1OnlineDQM_harvesting)
     
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -28,7 +28,6 @@
 #include "DQM/SiPixelPhase1Common/interface/GeometryInterface.h"
 #include "DQM/SiPixelPhase1Common/interface/AbstractHistogram.h"
 
-// TODO: Should we use a namespace, and if yes, which?
 class HistogramManager {
 public:
   explicit HistogramManager(const edm::ParameterSet& iConfig, GeometryInterface& geo);
@@ -47,9 +46,9 @@ public:
   void book(DQMStore::IBooker& iBooker, edm::EventSetup const& iSetup);
 
   // These functions perform step2, for online (per lumisection) or offline (endRun) respectively.
-  // TODO: we need a EventSetup in offline as well. we'll see.
-  void executeHarvestingOnline(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::EventSetup const& iSetup);
-  void executeHarvestingOffline(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
+  // Note that the EventSetup from PerLumi is used in offline as well, so PerLumi always has to be called first.
+  void executePerLumiHarvesting(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::EventSetup const& iSetup);
+  void executeHarvesting(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
 
   typedef std::map<GeometryInterface::Values, AbstractHistogram> Table;
   // Set a handler to be called when a custom() step is hit. This can do 
@@ -84,6 +83,7 @@ private:
 
 public: // these are available in config as is, and may be used in harvesting.
   bool enabled;
+  bool perLumiHarvesting;
   bool bookUndefined;
   std::string top_folder_name;
   std::string default_grouping;

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -35,8 +35,14 @@ PerLumisection = cms.PSet(enabled = cms.bool(True)) # trend profiles
 DefaultHisto = cms.PSet(
   # Setting this to False hides all plots of this HistogramManager. It does not even record any data.
   enabled = cms.bool(True),
+
+  # a.k.a. online harvesting. Might be useful in offline for custom harvesting,
+  # but the main purpose is online, where this is on by default.
+  perLumiHarvesting = cms.bool(False),
+
   # If False, no histograms are booked for DetIds where any column is undefined.
   bookUndefined = cms.bool(True),
+
   # where the plots should go.
   topFolderName = cms.string("PixelPhase1"),
 

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -332,9 +332,20 @@ void GeometryInterface::loadFEDCabling(edm::EventSetup const& iSetup, const edm:
 
   addExtractor(intern("FED"),
     [fedmap] (InterestingQuantities const& iq) {
+      if (iq.sourceModule == 0xFFFFFFFF)
+        return iq.col; // hijacked for the raw data plugin
       auto it = fedmap.find(iq.sourceModule);
       if (it == fedmap.end()) return GeometryInterface::UNDEFINED;
       return it->second;
     }
+  );
+  addExtractor(intern("FEDChannel"),
+    [] (InterestingQuantities const& iq) {
+      // TODO: we also should be able to compute the channel from the ROC.
+      // But for raw data, we only need this hack.
+      //if (iq.sourceModule == 0xFFFFFFFF)
+      return iq.row; // hijacked for the raw data plugin
+    },
+    0, 39 // TODO: real range
   );
 }

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -495,9 +495,10 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
         h.me = iBooker.bookProfile(h.name, (h.title + ";" + h.xlabel + ";" + h.ylabel).c_str(),
                        h.range_x_nbins, h.range_x_min, h.range_x_max, -(1./0.), 1./0.);
       } else if (h.kind == MonitorElement::DQM_KIND_TPROFILE2D) {
-        h.me = iBooker.book2D(h.name, (h.title + ";" + h.xlabel + ";" + h.ylabel).c_str(),
+        h.me = iBooker.bookProfile2D(h.name, (h.title + ";" + h.xlabel + ";" + h.ylabel).c_str(),
                        h.range_x_nbins, h.range_x_min, h.range_x_max,
-                       h.range_y_nbins, h.range_y_min, h.range_y_max);
+                       h.range_y_nbins, h.range_y_min, h.range_y_max,
+                       0.0, 0.0); // Z range is ignored if min==max
       } else if (h.kind == MonitorElement::DQM_KIND_INT) {
         // counter, nothing to do
         continue; // avoid the getTH1 below

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -20,6 +20,7 @@ HistogramManager::HistogramManager(const edm::ParameterSet& iconfig,
     : iConfig(iconfig),
       geometryInterface(geo),
       enabled(iconfig.getParameter<bool>("enabled")),
+      perLumiHarvesting(iconfig.getParameter<bool>("perLumiHarvesting")),
       bookUndefined(iconfig.getParameter<bool>("bookUndefined")),
       top_folder_name(iconfig.getParameter<std::string>("topFolderName")),
       name(iconfig.getParameter<std::string>("name")),
@@ -509,14 +510,17 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
   }
 }
 
-void HistogramManager::executeHarvestingOnline(DQMStore::IBooker& iBooker,
-                                               DQMStore::IGetter& iGetter,
-                                               edm::EventSetup const& iSetup) {
+void HistogramManager::executePerLumiHarvesting(DQMStore::IBooker& iBooker,
+                                                DQMStore::IGetter& iGetter,
+                                                edm::EventSetup const& iSetup) {
   if (!enabled) return;
   // this should also give us the GeometryInterface for offline, though it is a
   // bit dirty and might explode.
   if (!geometryInterface.loaded()) {
     geometryInterface.load(iSetup);
+  }
+  if (perLumiHarvesting) {
+    executeHarvesting(iBooker, iGetter);
   }
 }
 
@@ -524,6 +528,7 @@ void HistogramManager::loadFromDQMStore(SummationSpecification& s, Table& t,
                                         DQMStore::IGetter& iGetter) {
   // This is essentially the booking code of step1, to reconstruct the ME names.
   // Once we have a name we load the ME and put it into the table.
+  t.clear();
   for (auto iq : geometryInterface.allModules()) {
     std::string name = this->name;
     GeometryInterface::Values significantvalues;
@@ -570,7 +575,7 @@ void HistogramManager::loadFromDQMStore(SummationSpecification& s, Table& t,
         edm::LogError("HistogramManager") << "ME " << path << " not found\n";
       // else this will happen quite often
     } else {
-      // only touch the able if a me is added. Empty items are illegal.
+      // only touch the table if a me is added. Empty items are illegal.
       AbstractHistogram& histo = t[significantvalues];
       histo.me = me;
       histo.th1 = histo.me->getTH1();
@@ -747,7 +752,7 @@ void HistogramManager::executeExtend(SummationStep& step, Table& t, bool isX) {
     if (new_histo.th1->GetDimension() == 1) {	
         for (int i = 1; i <= th1->GetXaxis()->GetNbins(); i++) {
         new_histo.th1->SetBinContent(new_histo.count, th1->GetBinContent(i));
-	new_histo.th1->SetBinError(new_histo.count, th1->GetBinError(i));
+        new_histo.th1->SetBinError(new_histo.count, th1->GetBinError(i));
         new_histo.count += 1;
       }
     } else {
@@ -758,7 +763,7 @@ void HistogramManager::executeExtend(SummationStep& step, Table& t, bool isX) {
             // TODO Error etc.?
             new_histo.th1->SetBinContent(new_histo.count, j,
                                          th1->GetBinContent(i, j));
-	    new_histo.th1->SetBinError   (new_histo.count, j, th1->GetBinError(i, j));
+            new_histo.th1->SetBinError   (new_histo.count, j, th1->GetBinError(i, j));
           }
           new_histo.count += 1;
         }
@@ -768,7 +773,7 @@ void HistogramManager::executeExtend(SummationStep& step, Table& t, bool isX) {
             // TODO Error etc.?
             new_histo.th1->SetBinContent(i, new_histo.count,
                                          th1->GetBinContent(i, j));
-	    new_histo.th1->SetBinError   (i, new_histo.count, th1->GetBinError(i, j));
+            new_histo.th1->SetBinError   (i, new_histo.count, th1->GetBinError(i, j));
           }
           new_histo.count += 1;
         }
@@ -778,8 +783,8 @@ void HistogramManager::executeExtend(SummationStep& step, Table& t, bool isX) {
   t.swap(out);
 }
 
-void HistogramManager::executeHarvestingOffline(DQMStore::IBooker& iBooker,
-                                                DQMStore::IGetter& iGetter) {
+void HistogramManager::executeHarvesting(DQMStore::IBooker& iBooker,
+                                         DQMStore::IGetter& iGetter) {
   if (!enabled) return;
   // edm::LogTrace("HistogramManager") << "HistogramManager: Step2 offline\n";
   // Debug output

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
@@ -6,9 +6,9 @@
 
 void SiPixelPhase1Harvester::dqmEndLuminosityBlock(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup) {
   for (HistogramManager& histoman : histo)
-    histoman.executeHarvestingOnline(iBooker, iGetter, eSetup);
+    histoman.executePerLumiHarvesting(iBooker, iGetter, eSetup);
 };
 void SiPixelPhase1Harvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {
   for (HistogramManager& histoman : histo)
-    histoman.executeHarvestingOffline(iBooker, iGetter);
+    histoman.executeHarvesting(iBooker, iGetter);
 };

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -5,6 +5,11 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 # Configure Phase1 DQM for Phase0 data
 SiPixelPhase1Geometry.n_inner_ring_blades = 24 # no outer ring
 
+# Turn on 'online' harvesting. This has to be set before other configs are 
+# loaded (due to how the DefaultHisto PSet is later cloned), therefore it is
+# here and not in the harvestng config.
+DefaultHisto.perLumiHarvesting = True
+
 # Pixel Digi Monitoring
 from DQM.SiPixelPhase1Digis.SiPixelPhase1Digis_cfi import *
 SiPixelPhase1DigisAnalyzer.src = cms.InputTag("siPixelDigis") # adapt for real data

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -17,12 +17,17 @@ SiPixelPhase1DigisAnalyzer.src = cms.InputTag("siPixelDigis") # adapt for real d
 # Cluster (track-independent) monitoring
 from DQM.SiPixelPhase1Clusters.SiPixelPhase1Clusters_cfi import *
 
+# Raw data errors
+from DQM.SiPixelPhase1RawData.SiPixelPhase1RawData_cfi import *
+
 PerModule.enabled = True
 
 siPixelPhase1OnlineDQM_source = cms.Sequence(SiPixelPhase1DigisAnalyzer
                                             + SiPixelPhase1ClustersAnalyzer
+                                            + SiPixelPhase1RawDataAnalyzer
                                             )
 
 siPixelPhase1OnlineDQM_harvesting = cms.Sequence(SiPixelPhase1DigisHarvester 
                                                 + SiPixelPhase1ClustersHarvester
+                                                + SiPixelPhase1RawDataHarvester
                                                 )

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+# Configure Phase1 DQM for Phase0 data
+SiPixelPhase1Geometry.n_inner_ring_blades = 24 # no outer ring
+
+# Pixel Digi Monitoring
+from DQM.SiPixelPhase1Digis.SiPixelPhase1Digis_cfi import *
+SiPixelPhase1DigisAnalyzer.src = cms.InputTag("siPixelDigis") # adapt for real data
+
+# Cluster (track-independent) monitoring
+from DQM.SiPixelPhase1Clusters.SiPixelPhase1Clusters_cfi import *
+
+PerModule.enabled = True
+
+siPixelPhase1OnlineDQM_source = cms.Sequence(SiPixelPhase1DigisAnalyzer
+                                            + SiPixelPhase1ClustersAnalyzer
+                                            )
+
+siPixelPhase1OnlineDQM_harvesting = cms.Sequence(SiPixelPhase1DigisHarvester 
+                                                + SiPixelPhase1ClustersHarvester
+                                                )

--- a/DQM/SiPixelPhase1RawData/BuildFile.xml
+++ b/DQM/SiPixelPhase1RawData/BuildFile.xml
@@ -1,0 +1,3 @@
+<use   name="DQM/SiPixelPhase1Common"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<flags   EDM_PLUGIN="1"/>

--- a/DQM/SiPixelPhase1RawData/interface/SiPixelPhase1RawData.h
+++ b/DQM/SiPixelPhase1RawData/interface/SiPixelPhase1RawData.h
@@ -1,0 +1,34 @@
+#ifndef SiPixelPhase1RawData_h 
+#define SiPixelPhase1RawData_h 
+// -*- C++ -*-
+// 
+// Package:     SiPixelPhase1RawData
+// Class  :     SiPixelPhase1RawData
+//
+
+// Original Author: Marcel Schneider
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+
+using edm::DetSetVector;
+
+class SiPixelPhase1RawData : public SiPixelPhase1Base {
+  enum {
+    NERRORS,
+    FIFOFULL,
+    TBMMESSAGE,
+    TBMTYPE,
+    TYPE_NERRORS
+  };
+
+  public:
+  explicit SiPixelPhase1RawData(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private:
+  edm::EDGetTokenT<DetSetVector<SiPixelRawDataError>> srcToken_;
+};
+
+#endif

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -1,0 +1,85 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+
+SiPixelPhase1RawDataNErrors = DefaultHisto.clone(
+  name = "errors",
+  title = "Errors",
+  xlabel = "errors",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  dimensions = 0,
+  specs = cms.VPSet(
+    Specification().groupBy("FED/Event")
+                   .reduce("COUNT")
+                   .groupBy("FED").save(),
+    Specification().groupBy("FED/FEDChannel")
+                   .groupBy("FED", "EXTEND_X")
+                   .save()
+                   .groupBy("", "EXTEND_Y")
+                   .save()
+  )
+)
+
+SiPixelPhase1RawDataFIFOFull = DefaultHisto.clone(
+  name = "fifofull",
+  title = "Type of FIFO full",
+  xlabel = "FIFO (data bit #)",
+  range_min = -0.5, range_max = 7.5, range_nbins = 8,
+  dimensions = 1,
+  specs = cms.VPSet(
+    Specification().groupBy("FED").save(),
+  )
+)
+
+SiPixelPhase1RawDataTBMMessage = DefaultHisto.clone(
+  name = "tbmmessage",
+  title = "TBM trailer message",
+  xlabel = "TBM message (data bit #)",
+  range_min = -0.5, range_max = 7.5, range_nbins = 8,
+  dimensions = 1,
+  specs = cms.VPSet(
+    Specification().groupBy("FED").save(),
+  )
+)
+
+SiPixelPhase1RawDataTBMType = DefaultHisto.clone(
+  name = "tbmtype",
+  title = "Type of TBM trailer",
+  xlabel = "TBM type",
+  range_min = -0.5, range_max = 4.5, range_nbins = 4,
+  dimensions = 1,
+  specs = cms.VPSet(
+    Specification().groupBy("FED").save(),
+  )
+)
+
+SiPixelPhase1RawDataTypeNErrors = DefaultHisto.clone(
+  name = "nerrors_per_type",
+  title = "Number of Errors per Type",
+  xlabel = "Error Type",
+  range_min = 0, range_max = 50, range_nbins = 51,#TODO: proper range here
+  dimensions = 1,
+  specs = cms.VPSet(
+    Specification().groupBy("FED").save()
+                   .groupBy("", "EXTEND_Y").save(),
+  )
+)
+
+SiPixelPhase1RawDataConf = cms.VPSet(
+  SiPixelPhase1RawDataNErrors,
+  SiPixelPhase1RawDataFIFOFull,
+  SiPixelPhase1RawDataTBMMessage,
+  SiPixelPhase1RawDataTBMType,
+  SiPixelPhase1RawDataTypeNErrors,
+)
+
+SiPixelPhase1RawDataAnalyzer = cms.EDAnalyzer("SiPixelPhase1RawData",
+        src = cms.InputTag("siPixelDigis"),
+        histograms = SiPixelPhase1RawDataConf,
+        geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1RawDataHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1RawDataConf,
+        geometry = SiPixelPhase1Geometry
+)

--- a/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
+++ b/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
@@ -1,0 +1,86 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1RawData
+// Class:       SiPixelPhase1RawData
+//
+
+// Original Author: Marcel Schneider
+
+#include "DQM/SiPixelPhase1RawData/interface/SiPixelPhase1RawData.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+
+SiPixelPhase1RawData::SiPixelPhase1RawData(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig) 
+{
+  srcToken_ = consumes<DetSetVector<SiPixelRawDataError>>(iConfig.getParameter<edm::InputTag>("src"));
+}
+
+
+void SiPixelPhase1RawData::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<DetSetVector<SiPixelRawDataError>> input;
+  iEvent.getByToken(srcToken_, input);
+  if (!input.isValid()) return;
+
+  for (auto it = input->begin(); it != input->end(); ++it) {
+    for (auto& siPixelRawDataError : *it) { 
+      int fed = siPixelRawDataError.getFedId();
+      int type = siPixelRawDataError.getType();
+      DetId id = it->detId();
+      
+      const uint32_t LINK_bits = 6;
+      const uint32_t LINK_shift = 26;
+      const uint64_t LINK_mask = (1 << LINK_bits) - 1;
+
+      uint64_t errorWord = 0;
+      if (type == 32 || type == 33 || type == 34) {
+        errorWord = siPixelRawDataError.getWord64();
+      } else {
+        errorWord = siPixelRawDataError.getWord32();
+      }
+
+      int32_t chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+      if (type == 29) chanNmbr = -1; // TODO: different formula needed.
+
+      uint32_t error_data = errorWord & 0xFF;
+
+      if (type == 28) { // overflow.
+        for (uint32_t i = 0; i < 8; i++) {
+          if (error_data  & (1 << i)) histo[FIFOFULL].fill(i, id, &iEvent, fed, chanNmbr);
+        }
+      }
+
+      if (type == 30) { // TBM stuff.
+        uint32_t statemachine_state = errorWord >> 8 & 0xF; // next 4 bits after data
+        const uint32_t tbm_types[16] = { 
+          0, 1, 2, 4,
+          2, 4, 2, 4,
+          3, 1, 4, 4,
+          4, 4, 4, 4
+        };
+
+        histo[TBMTYPE].fill(tbm_types[statemachine_state], id, &iEvent, fed, chanNmbr);
+
+        for (uint32_t i = 0; i < 8; i++) {
+          if (error_data  & (1 << i)) histo[TBMMESSAGE].fill(i, id, &iEvent, fed, chanNmbr);
+        }
+        continue; // we don't really consider these as errors.
+      }
+
+      // note that a DetId of 0xFFFFFFFF can mean 'no DetId'.
+      // We hijack column and row for FED and chan in this case,
+      // the GeometryInterface does understand that.
+
+      histo[NERRORS].fill(id, &iEvent, fed, chanNmbr);
+      histo[TYPE_NERRORS].fill(type, id, &iEvent, fed, chanNmbr); 
+    }
+  }
+
+  histo[NERRORS].executePerEventHarvesting();
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1RawData);
+

--- a/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
+++ b/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
@@ -31,11 +31,14 @@ void SiPixelPhase1RawData::analyze(const edm::Event& iEvent, const edm::EventSet
       int type = siPixelRawDataError.getType();
       DetId id = it->detId();
       
+      // encoding of the channel number within the FED error word
       const uint32_t LINK_bits = 6;
       const uint32_t LINK_shift = 26;
       const uint64_t LINK_mask = (1 << LINK_bits) - 1;
 
       uint64_t errorWord = 0;
+      // use 64bit word for some error types
+      // invalid header, invalid trailer, size mismatch
       if (type == 32 || type == 33 || type == 34) {
         errorWord = siPixelRawDataError.getWord64();
       } else {
@@ -43,6 +46,7 @@ void SiPixelPhase1RawData::analyze(const edm::Event& iEvent, const edm::EventSet
       }
 
       int32_t chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+      // timeout
       if (type == 29) chanNmbr = -1; // TODO: different formula needed.
 
       uint32_t error_data = errorWord & 0xFF;


### PR DESCRIPTION
As the title says, this PR adds 3 things to the Phase1 DQM:
- The pixel online configuration is modified to run the relevant Phase1 plugins as well. Doing this on the live config should be fine, since 8_1_0 should never go into online production, and for 2017 the new plugins are needed (and the old ones should be removed).
- Along with this come improvements to make the Phase1 DQM actually work in online. This includes harvesting running in online and configuring the Phase1 DQM to run on Phase0 data (there is no Phase1 online yet... -- the changes only affect online). 
- The Phase1-on-Phase0 config allows testing and using the Phase1 Raw Data monitoring, so I added it here. This is really only designed and tested for Phase0, since we don't have enough information about Phase1 yet. It can already run in Phase1 offline (the records are present) but obviously there is nothing to monitor in MC.
- There is a fairly critical bugfix for the Phase1 DQM framework. A c&p mistake in the last PR made all 2D profiles actually TH2s which is incorrect.

Still to be done are specific  plots and settings for online. There might also be a memory leak in the Phase1 harvesting code which would become a problem in online, but this is hard to tell at the moment (involves `new`ed TH1s and `TH1::add`).
