### PR TITLE
Add to phase-I queues updated version of SiPixelFedCablingMap for 48-channel feds, and update HCal QIEdata to version 2017_v2.0

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,11 +36,11 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '81X_upgrade2017_design_v12',
+    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_05_11_42_10',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v14',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_05_11_41_20',
     # Global Tag for MC production with development HCAL conditions for Phase1 2017 detector
-    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_v3',
+    'phase1_2017_hcaldev'  : '81X_upgrade2017_HCALdev_Candidate_2016_10_05_11_20_17',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
This PR is meant as a bridge towards wrapping up the phase-I workflows (in PR #15994) to let people finish development work.
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_Candidate_2016_10_05_11_41_20](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_Candidate_2016_10_05_11_41_20) as [81X_upgrade2017_realistic_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v14) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_Candidate_2016_10_05_11_41_20/81X_upgrade2017_realistic_v14): 
  - updated version of SiPixelFedCablingMap for 48-channel feds
- **PhaseI design scenario** : [81X_upgrade2017_design_Candidate_2016_10_05_11_42_10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_Candidate_2016_10_05_11_42_10) as [81X_upgrade2017_design_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_Candidate_2016_10_05_11_42_10/81X_upgrade2017_design_v12): 
  - updated version of SiPixelFedCablingMap for 48-channel feds
- **PhaseI HcalDev scenario** : [81X_upgrade2017_HCALdev_Candidate_2016_10_05_11_20_17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_Candidate_2016_10_05_11_20_17) as [81X_upgrade2017_HCALdev_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_HCALdev_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_HCALdev_Candidate_2016_10_05_11_20_17/81X_upgrade2017_HCALdev_v3): 
  - updated version of SiPixelFedCablingMap for 48-channel feds
  - update HCal QIEdata to version 2017_v2.0

@dkotlins @abdoulline 
