### PR TITLE
added cluster position plot in the AlCa DQM application (81X version) 

### DIFF
--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -73,7 +73,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
     MonitorElement* LayerNumberOfClusterProfile = 0;
     MonitorElement* LayerClusterWidthProfile = 0;
     MonitorElement* LayerClusWidthVsAmpTH2 = 0;
-
+    MonitorElement* LayerClusterPosition = 0;
   };
 
   struct SubDetMEs{ // MEs for Subdetector Level

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
@@ -47,7 +47,7 @@ SiStripCalZeroBiasMonitorCluster.TH1ClusterPos = cms.PSet(
     Nbinx          = cms.int32(768),
     xmin           = cms.double(-0.5),
     xmax           = cms.double(767.5),
-    layerswitchon  = cms.bool(False),
+    layerswitchon  = cms.bool(True),
     moduleswitchon = cms.bool(False)
 )
 SiStripCalZeroBiasMonitorCluster.TH1ClusterDigiPos = cms.PSet(

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -1097,6 +1097,7 @@ void SiStripMonitorCluster::createLayerMEs(std::string label, int ndets , DQMSto
   layerMEs.LayerNumberOfClusterProfile = 0;
   layerMEs.LayerClusterWidthProfile = 0;
   layerMEs.LayerClusWidthVsAmpTH2 = 0;
+  layerMEs.LayerClusterPosition = 0;
 
   //Cluster Width
   if(layerswitchcluswidthon) {
@@ -1149,6 +1150,11 @@ void SiStripMonitorCluster::createLayerMEs(std::string label, int ndets , DQMSto
     layerMEs.LayerClusWidthVsAmpTH2=bookME2D("ClusWidthVsAmpTH2", hidmanager.createHistoLayer("ClusterWidths_vs_Amplitudes","layer",label,"").c_str() , ibooker );
   }
 
+  // Cluster Position
+  if (layerswitchclusposon)  {
+    std::string hid = hidmanager.createHistoLayer("ClusterPosition","layer",label,"");
+    layerMEs.LayerClusterPosition=ibooker.book1D(hid, hid, 128*6, 0.5, 128*6+0.5);
+  }
 
   LayerMEsMap[label]=layerMEs;
 }
@@ -1366,6 +1372,10 @@ void SiStripMonitorCluster::fillLayerMEs(LayerMEs& layerMEs, ClusterProperties& 
 
   if( layer_clusterWidth_vs_amplitude_on ) {
 	fillME(layerMEs.LayerClusWidthVsAmpTH2, cluster.charge, cluster.width);
+  }
+
+  if (layerswitchclusposon)  {
+    fillME(layerMEs.LayerClusterPosition,cluster.position);
   }
 }
 //------------------------------------------------------------------------------------------


### PR DESCRIPTION
added cluster position plot (1 plot per layer) in SiStrip AlCa DQM application

Somehow the exact equivalent PR #15268  for 80X  has been merged some time ago, without a 81X version  - this PR is to re-establish the synch between 81X and 80X
