### PR TITLE
PA Common Alignment Producers 81X

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -93,7 +93,7 @@ def getSequence(process, collection,
     #########################################
     isCosmics = False
 
-    if collection == "ALCARECOTkAlMinBias" or collection == "generalTracks":
+    if collection == "ALCARECOTkAlMinBias" or collection == "generalTracks" or collection == "ALCARECOTkAlMinBiasHI" or collection == "hiGeneralTracks":
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,
@@ -124,7 +124,7 @@ def getSequence(process, collection,
                 "applyMultiplicityFilter": True,
                 "maxMultiplicity": 1
                 })
-    elif collection == "ALCARECOTkAlMuonIsolated":
+    elif collection == "ALCARECOTkAlMuonIsolated" or collection == "ALCARECOTkAlMuonIsolatedHI" or collection == "ALCARECOTkAlMuonIsolatedPA":
         options["TrackSelector"]["Alignment"].update({
                 ("minHitsPerSubDet", "inPIXEL"): 1,
                 "ptMin": 5.0,
@@ -132,7 +132,7 @@ def getSequence(process, collection,
                 "applyMultiplicityFilter": True,
                 "maxMultiplicity": 1,
                 })
-    elif collection == "ALCARECOTkAlZMuMu":
+    elif collection == "ALCARECOTkAlZMuMu" or collection == "ALCARECOTkAlZMuMuHI" or collection == "ALCARECOTkAlZMuMuPA":
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 15.0,
                 "etaMin": -3.0,

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using JpsiMuMu events
+# AlCaReco for track based alignment using Jpsi->mumu events in heavy ion (PbPb) data
 OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlJpsiMuMuHI')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_cff.py
@@ -1,4 +1,4 @@
-# AlCaReco for track based alignment using Jpsi->mumu events in heavy ion data
+# AlCaReco for track based alignment using Jpsi->mumu events in heavy ion (PbPb) data
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import *
@@ -17,4 +17,8 @@ ALCARECOTkAlJpsiMuMuHI = ALCARECOTkAlJpsiMuMu.clone(
 
 ALCARECOTkAlJpsiMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlJpsiMuMuHIGoodMuons'
 
-seqALCARECOTkAlJpsiMuMuHI = cms.Sequence(ALCARECOTkAlJpsiMuMuHIHLT+ALCARECOTkAlJpsiMuMuHIDCSFilter+ALCARECOTkAlJpsiMuMuHIGoodMuons+ALCARECOTkAlJpsiMuMuHI)
+seqALCARECOTkAlJpsiMuMuHI = cms.Sequence(ALCARECOTkAlJpsiMuMuHIHLT
+                                         +ALCARECOTkAlJpsiMuMuHIDCSFilter
+                                         +ALCARECOTkAlJpsiMuMuHIGoodMuons
+                                         +ALCARECOTkAlJpsiMuMuHI
+                                         )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using MuonIsolated events
+# AlCaReco for track based alignment using MuonIsolated events for heavy ion (PbPb) data
 OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolatedHI')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_cff.py
@@ -1,27 +1,21 @@
-# AlCaReco for track based alignment using isolated muon tracks
+# AlCaReco for track based alignment using isolated muon tracks - relaxed cuts for PbPb collisions
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import *
 
 ALCARECOTkAlMuonIsolatedHIHLT = ALCARECOTkAlMuonIsolatedHLT.clone(
-    eventSetupPathsKey = 'TkAlMuonIsolated'
+    eventSetupPathsKey = 'TkAlMuonIsolatedHI'
     )
 
 ALCARECOTkAlMuonIsolatedHIDCSFilter = ALCARECOTkAlMuonIsolatedDCSFilter.clone()
-
-ALCARECOTkAlMuonIsolatedHIGoodMuons = ALCARECOTkAlMuonIsolatedGoodMuons.clone()
-ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons = ALCARECOTkAlMuonIsolatedRelCombIsoMuons.clone(
-    src = 'ALCARECOTkAlMuonIsolatedHIGoodMuons'
-)
 
 ALCARECOTkAlMuonIsolatedHI = ALCARECOTkAlMuonIsolated.clone(
     src = 'hiGeneralTracks'
 )
 
-ALCARECOTkAlMuonIsolatedHI.GlobalSelector.muonSource = 'ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons'
 # Isolation is shifted to the muon preselection, and then applied intrinsically if applyGlobalMuonFilter = True
 ALCARECOTkAlMuonIsolatedHI.GlobalSelector.applyIsolationtest = False
-ALCARECOTkAlMuonIsolatedHI.GlobalSelector.minJetDeltaR = 0.1
+ALCARECOTkAlMuonIsolatedHI.GlobalSelector.minJetDeltaR = 0.0 #pp version has 0.1
 ALCARECOTkAlMuonIsolatedHI.GlobalSelector.applyGlobalMuonFilter = True
 ALCARECOTkAlMuonIsolatedHI.GlobalSelector.jetIsoSource = cms.InputTag("iterativeConePu5CaloJets")
 ALCARECOTkAlMuonIsolatedHI.GlobalSelector.jetCountSource = cms.InputTag("iterativeConePu5CaloJets")
@@ -30,4 +24,7 @@ ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyMassrangeFilter = False
 ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyChargeFilter = False
 ALCARECOTkAlMuonIsolatedHI.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 
-seqALCARECOTkAlMuonIsolatedHI = cms.Sequence(ALCARECOTkAlMuonIsolatedHIHLT+ALCARECOTkAlMuonIsolatedHIDCSFilter+ALCARECOTkAlMuonIsolatedHIGoodMuons+ALCARECOTkAlMuonIsolatedHIRelCombIsoMuons+ALCARECOTkAlMuonIsolatedHI)
+seqALCARECOTkAlMuonIsolatedHI = cms.Sequence(ALCARECOTkAlMuonIsolatedHIHLT
+                                             +ALCARECOTkAlMuonIsolatedHIDCSFilter
+                                             +ALCARECOTkAlMuonIsolatedHI
+                                             )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using MuonIsolated events
+# AlCaReco for track based alignment using MuonIsolated events for heavy ion (PA) data
 OutALCARECOTkAlMuonIsolatedPA_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolatedPA')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using UpsilonMuMu events
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion (PbPb) data 
 OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuHI')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_cff.py
@@ -1,4 +1,4 @@
-# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion data
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion (PbPb) data
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
@@ -10,14 +10,14 @@ ALCARECOTkAlUpsilonMuMuHIHLT = ALCARECOTkAlUpsilonMuMuHLT.clone(
 ALCARECOTkAlUpsilonMuMuHIDCSFilter = ALCARECOTkAlUpsilonMuMuDCSFilter.clone()
 
 ALCARECOTkAlUpsilonMuMuHIGoodMuons = ALCARECOTkAlUpsilonMuMuGoodMuons.clone()
-#ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons = ALCARECOTkAlUpsilonMuMuRelCombIsoMuons.clone()
-#ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons.src = 'ALCARECOTkAlUpsilonMuMuHIGoodMuons'
-#ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons.cut = '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.3'
 
 ALCARECOTkAlUpsilonMuMuHI = ALCARECOTkAlUpsilonMuMu.clone(
      src = 'hiGeneralTracks'
 )
 ALCARECOTkAlUpsilonMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlUpsilonMuMuHIGoodMuons'
 
-#seqALCARECOTkAlUpsilonMuMuHI = cms.Sequence(ALCARECOTkAlUpsilonMuMuHIHLT+ALCARECOTkAlUpsilonMuMuHIDCSFilter+ALCARECOTkAlUpsilonMuMuHIGoodMuons+ALCARECOTkAlUpsilonMuMuHIRelCombIsoMuons+ALCARECOTkAlUpsilonMuMuHI)
-seqALCARECOTkAlUpsilonMuMuHI = cms.Sequence(ALCARECOTkAlUpsilonMuMuHIHLT+ALCARECOTkAlUpsilonMuMuHIDCSFilter+ALCARECOTkAlUpsilonMuMuHIGoodMuons+ALCARECOTkAlUpsilonMuMuHI)
+seqALCARECOTkAlUpsilonMuMuHI = cms.Sequence(ALCARECOTkAlUpsilonMuMuHIHLT
+                                            +ALCARECOTkAlUpsilonMuMuHIDCSFilter
+                                            +ALCARECOTkAlUpsilonMuMuHIGoodMuons
+                                            +ALCARECOTkAlUpsilonMuMuHI
+                                            )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using UpsilonMuMu events
+OutALCARECOTkAlUpsilonMuMuPA_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuPA')
+    ),
+    outputCommands = cms.untracked.vstring( 
+        'keep *_ALCARECOTkAlUpsilonMuMuPA_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_offlinePrimaryVertices_*_*')
+)
+
+import copy
+OutALCARECOTkAlUpsilonMuMuPA = copy.deepcopy(OutALCARECOTkAlUpsilonMuMuPA_noDrop)
+OutALCARECOTkAlUpsilonMuMuPA.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using UpsilonMuMu events
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion (PA) data 
 OutALCARECOTkAlUpsilonMuMuPA_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuPA')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_cff.py
@@ -1,4 +1,4 @@
-# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion data
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion (PA) data
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
@@ -10,16 +10,12 @@ ALCARECOTkAlUpsilonMuMuPAHLT = ALCARECOTkAlUpsilonMuMuHLT.clone(
 ALCARECOTkAlUpsilonMuMuPADCSFilter = ALCARECOTkAlUpsilonMuMuDCSFilter.clone()
 
 ALCARECOTkAlUpsilonMuMuPAGoodMuons = ALCARECOTkAlUpsilonMuMuGoodMuons.clone()
-#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons = ALCARECOTkAlUpsilonMuMuRelCombIsoMuons.clone()
-#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons.src = 'ALCARECOTkAlUpsilonMuMuPAGoodMuons'
-#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons.cut = '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.3'
 
 ALCARECOTkAlUpsilonMuMuPA = ALCARECOTkAlUpsilonMuMu.clone(
      src = 'generalTracks'
 )
 ALCARECOTkAlUpsilonMuMuPA.GlobalSelector.muonSource = 'ALCARECOTkAlUpsilonMuMuPAGoodMuons'
 
-#seqALCARECOTkAlUpsilonMuMuPA = cms.Sequence(ALCARECOTkAlUpsilonMuMuPAHLT+ALCARECOTkAlUpsilonMuMuPADCSFilter+ALCARECOTkAlUpsilonMuMuPAGoodMuons+ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons+ALCARECOTkAlUpsilonMuMuPA)
 seqALCARECOTkAlUpsilonMuMuPA = cms.Sequence(ALCARECOTkAlUpsilonMuMuPAHLT
                                             +ALCARECOTkAlUpsilonMuMuPADCSFilter
                                             +ALCARECOTkAlUpsilonMuMuPAGoodMuons

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_cff.py
@@ -1,0 +1,27 @@
+# AlCaReco for track based alignment using Upsilon->mumu events in heavy ion data
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
+
+ALCARECOTkAlUpsilonMuMuPAHLT = ALCARECOTkAlUpsilonMuMuHLT.clone(
+    eventSetupPathsKey = 'TkAlUpsilonMuMu'
+)
+
+ALCARECOTkAlUpsilonMuMuPADCSFilter = ALCARECOTkAlUpsilonMuMuDCSFilter.clone()
+
+ALCARECOTkAlUpsilonMuMuPAGoodMuons = ALCARECOTkAlUpsilonMuMuGoodMuons.clone()
+#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons = ALCARECOTkAlUpsilonMuMuRelCombIsoMuons.clone()
+#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons.src = 'ALCARECOTkAlUpsilonMuMuPAGoodMuons'
+#ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons.cut = '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.3'
+
+ALCARECOTkAlUpsilonMuMuPA = ALCARECOTkAlUpsilonMuMu.clone(
+     src = 'generalTracks'
+)
+ALCARECOTkAlUpsilonMuMuPA.GlobalSelector.muonSource = 'ALCARECOTkAlUpsilonMuMuPAGoodMuons'
+
+#seqALCARECOTkAlUpsilonMuMuPA = cms.Sequence(ALCARECOTkAlUpsilonMuMuPAHLT+ALCARECOTkAlUpsilonMuMuPADCSFilter+ALCARECOTkAlUpsilonMuMuPAGoodMuons+ALCARECOTkAlUpsilonMuMuPARelCombIsoMuons+ALCARECOTkAlUpsilonMuMuPA)
+seqALCARECOTkAlUpsilonMuMuPA = cms.Sequence(ALCARECOTkAlUpsilonMuMuPAHLT
+                                            +ALCARECOTkAlUpsilonMuMuPADCSFilter
+                                            +ALCARECOTkAlUpsilonMuMuPAGoodMuons
+                                            +ALCARECOTkAlUpsilonMuMuPA
+                                            )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using ZMuMu events
+# AlCaReco for track based alignment using Z->mumu events in heavy ion (PbPb) data
 OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuHI')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_cff.py
@@ -1,4 +1,4 @@
-# AlCaReco for track based alignment using Z->mumu events in heavy ion data
+# AlCaReco for track based alignment using Z->mumu events in heavy ion (PbPb) data
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
@@ -10,13 +10,14 @@ ALCARECOTkAlZMuMuHIHLT = ALCARECOTkAlZMuMuHLT.clone(
 ALCARECOTkAlZMuMuHIDCSFilter = ALCARECOTkAlZMuMuDCSFilter.clone()
 
 ALCARECOTkAlZMuMuHIGoodMuons = ALCARECOTkAlZMuMuGoodMuons.clone()
-#ALCARECOTkAlZMuMuHIRelCombIsoMuons = ALCARECOTkAlZMuMuRelCombIsoMuons.clone()
-#ALCARECOTkAlZMuMuHIRelCombIsoMuons.src = 'ALCARECOTkAlZMuMuHIGoodMuons'
 
 ALCARECOTkAlZMuMuHI = ALCARECOTkAlZMuMu.clone(
      src = 'hiGeneralTracks'
 )
 ALCARECOTkAlZMuMuHI.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuHIGoodMuons'
 
-#seqALCARECOTkAlZMuMuHI = cms.Sequence(ALCARECOTkAlZMuMuHIHLT+ALCARECOTkAlZMuMuHIDCSFilter+ALCARECOTkAlZMuMuHIGoodMuons+ALCARECOTkAlZMuMuHIRelCombIsoMuons+ALCARECOTkAlZMuMuHI)
-seqALCARECOTkAlZMuMuHI = cms.Sequence(ALCARECOTkAlZMuMuHIHLT+ALCARECOTkAlZMuMuHIDCSFilter+ALCARECOTkAlZMuMuHIGoodMuons+ALCARECOTkAlZMuMuHI)
+seqALCARECOTkAlZMuMuHI = cms.Sequence(ALCARECOTkAlZMuMuHIHLT
+                                      +ALCARECOTkAlZMuMuHIDCSFilter
+                                      +ALCARECOTkAlZMuMuHIGoodMuons
+                                      +ALCARECOTkAlZMuMuHI
+                                      )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# AlCaReco for track based alignment using ZMuMu events
+# AlCaReco for track based alignment using Z->mumu events in heavy ion (PA) data 
 OutALCARECOTkAlZMuMuPA_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuPA')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using ZMuMu events
+OutALCARECOTkAlZMuMuPA_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuPA')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_ALCARECOTkAlZMuMuPA_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+	'keep *_offlinePrimaryVertices_*_*')
+)
+
+import copy
+OutALCARECOTkAlZMuMuPA = copy.deepcopy(OutALCARECOTkAlZMuMuPA_noDrop)
+OutALCARECOTkAlZMuMuPA.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
@@ -1,0 +1,26 @@
+# AlCaReco for track based alignment using Z->mumu events in heavy ion data
+import FWCore.ParameterSet.Config as cms
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
+
+ALCARECOTkAlZMuMuPAHLT = ALCARECOTkAlZMuMuHLT.clone(
+    eventSetupPathsKey = 'TkAlZMuMu'
+)
+
+ALCARECOTkAlZMuMuPADCSFilter = ALCARECOTkAlZMuMuDCSFilter.clone()
+
+ALCARECOTkAlZMuMuPAGoodMuons = ALCARECOTkAlZMuMuGoodMuons.clone()
+#ALCARECOTkAlZMuMuPARelCombIsoMuons = ALCARECOTkAlZMuMuRelCombIsoMuons.clone()
+#ALCARECOTkAlZMuMuPARelCombIsoMuons.src = 'ALCARECOTkAlZMuMuPAGoodMuons'
+
+ALCARECOTkAlZMuMuPA = ALCARECOTkAlZMuMu.clone(
+     src = 'generalTracks'
+)
+ALCARECOTkAlZMuMuPA.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuPAGoodMuons'
+
+#seqALCARECOTkAlZMuMuPA = cms.Sequence(ALCARECOTkAlZMuMuPAHLT+ALCARECOTkAlZMuMuPADCSFilter+ALCARECOTkAlZMuMuPAGoodMuons+ALCARECOTkAlZMuMuPARelCombIsoMuons+ALCARECOTkAlZMuMuPA)
+seqALCARECOTkAlZMuMuPA = cms.Sequence(ALCARECOTkAlZMuMuPAHLT
+                                      +ALCARECOTkAlZMuMuPADCSFilter
+                                      +ALCARECOTkAlZMuMuPAGoodMuons
+                                      +ALCARECOTkAlZMuMuPA
+                                      )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
@@ -1,4 +1,4 @@
-# AlCaReco for track based alignment using Z->mumu events in heavy ion data
+# AlCaReco for track based alignment using Z->mumu events in heavy ion (PA) data
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
@@ -10,15 +10,12 @@ ALCARECOTkAlZMuMuPAHLT = ALCARECOTkAlZMuMuHLT.clone(
 ALCARECOTkAlZMuMuPADCSFilter = ALCARECOTkAlZMuMuDCSFilter.clone()
 
 ALCARECOTkAlZMuMuPAGoodMuons = ALCARECOTkAlZMuMuGoodMuons.clone()
-#ALCARECOTkAlZMuMuPARelCombIsoMuons = ALCARECOTkAlZMuMuRelCombIsoMuons.clone()
-#ALCARECOTkAlZMuMuPARelCombIsoMuons.src = 'ALCARECOTkAlZMuMuPAGoodMuons'
 
 ALCARECOTkAlZMuMuPA = ALCARECOTkAlZMuMu.clone(
      src = 'generalTracks'
 )
 ALCARECOTkAlZMuMuPA.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuPAGoodMuons'
 
-#seqALCARECOTkAlZMuMuPA = cms.Sequence(ALCARECOTkAlZMuMuPAHLT+ALCARECOTkAlZMuMuPADCSFilter+ALCARECOTkAlZMuMuPAGoodMuons+ALCARECOTkAlZMuMuPARelCombIsoMuons+ALCARECOTkAlZMuMuPA)
 seqALCARECOTkAlZMuMuPA = cms.Sequence(ALCARECOTkAlZMuMuPAHLT
                                       +ALCARECOTkAlZMuMuPADCSFilter
                                       +ALCARECOTkAlZMuMuPAGoodMuons

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
@@ -34,7 +34,7 @@ def setConfiguration(process, collection, mode, monitorFile, binaryFile,
     ## Tracktype specific ##
     ########################
 
-    if collection == "ALCARECOTkAlZMuMu":
+    if collection == "ALCARECOTkAlZMuMu" or collection == "ALCARECOTkAlZMuMuHI" or collection == "ALCARECOTkAlZMuMuPA":
         process.AlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(
              process.TwoBodyDecayTrajectoryFactory
         )

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -6,6 +6,7 @@ import FWCore.ParameterSet.Config as cms
 # AlCaReco for track based alignment using ZMuMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuPA_Output_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics_Output_cff import *
@@ -17,7 +18,6 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlLAS_Output_cff import *
 # AlCaReco for track based alignment using isoMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_Output_cff import *
-# AlCaReco for track based alignment using isoMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_Output_cff import *
 # AlCaReco for track based alignment using J/Psi events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_Output_cff import *
@@ -25,6 +25,7 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMuHI_Output_cff import 
 # AlCaReco for track based alignment using Upsilon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_Output_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_Output_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_Output_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBiasHI_Output_cff import *

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -5,7 +5,9 @@ import FWCore.ParameterSet.Config as cms
 ###############################################################
 # AlCaReco for track based alignment using ZMuMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuPA_Output_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_Output_cff import *
@@ -17,17 +19,23 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_Output_cff impor
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlLAS_Output_cff import *
 # AlCaReco for track based alignment using isoMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_Output_cff import *
 # AlCaReco for track based alignment using J/Psi events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMuHI_Output_cff import *
 # AlCaReco for track based alignment using Upsilon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_Output_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_Output_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBiasHI_Output_cff import *
 
 # AlCaReco for pixel calibration using muons

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -336,3 +336,6 @@ workflows[145] = ['',['HydjetQ_MinBias_5020GeV','DIGIHI','RECOHI','HARVESTHI']]
 
 ### pPb test ###
 workflows[280]= ['',['AMPT_PPb_5020GeV_MinimumBias','DIGI','RECO','HARVEST']]
+
+### pPb Run2 ###
+workflows[281]= ['',['EPOS_PPb_8160GeV_MinimumBias','DIGIUP15_PPb','RECOUP15_PPb','HARVESTUP15_PPb']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1168,7 +1168,7 @@ steps['RECOUP15_trackingOnlyLowPU']=merge([step3_trackingLowPU, step3Up2015Defau
 steps['RECOUP15_HIPM']=merge([step3_HIPM,step3Up2015Defaults]) # todo: remove UP from label
 
 # for Run2 PPb workflows
-steps['RECOUP15_PPb']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,VALIDATION,DQM','--conditions':'auto:run2_mc_pa','--customise':'RecoHI/Configuration/customise_PPwithHI.customisePPrecoforPPb','--datatier':'AODSIM,DQMIO','--eventcontent':'AODSIM,DQM'}, steps['RECOUP15']])
+steps['RECOUP15_PPb']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:TkAlMinBias+TkAlMuonIsolatedPA+TkAlUpsilonMuMuPA+TkAlZMuMuPA,EI,VALIDATION,DQM','--conditions':'auto:run2_mc_pa','--customise':'RecoHI/Configuration/customise_PPwithHI.customisePPrecoforPPb','--datatier':'AODSIM,DQMIO','--eventcontent':'AODSIM,DQM'}, steps['RECOUP15']])
 
 #steps['RECOUP15PROD1']=merge([{ '-s' : 'RAW2DIGI,L1Reco,RECO,EI,DQM:DQMOfflinePOGMC', '--datatier' : 'AODSIM,DQMIO', '--eventcontent' : 'AODSIM,DQM'},step3Up2015Defaults])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -550,14 +550,13 @@ steps['LM9p']=genS('LM9p_8TeV_cff',Kby(25,100))
 steps['QCD_Pt_20_30']=genS('QCD_Pt_20_30_8TeV_TuneCUETP8M1_cfi',Kby(25,100))
 steps['QCD_Pt_170_230']=genS('QCD_Pt_170_230_8TeV_TuneCUETP8M1_cfi',Kby(25,100))
 
-
-
-
 ## pPb tests
 step1PPbDefaults={'--beamspot':'Realistic8TeVCollision'}
 steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AMPT_PPb_5020GeV_MinimumBias_cfi',Kby(9,100))])
-# GF to be uncommented when GEN-SIM becomes available
-# steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[4],),location='STD')}
+
+## pPb Run2
+step1PPbDefaultsUp15={'--beamspot':'Run2PPbBoost','--conditions':'auto:run2_mc_pa','--eventcontent':'RAWSIM'}
+steps['EPOS_PPb_8160GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaultsUp15,gen2015('ReggeGribovPartonMC_EposLHC_4080_4080GeV_pPb_cfi',Kby(9,100))])
 
 ## heavy ions tests
 U2000by1={'--relval': '2000,1'}
@@ -918,6 +917,8 @@ steps['DIGIUP15PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2016','--eventc
 steps['DIGIUP15_PU25']=merge([PU25,step2Upg2015Defaults])
 steps['DIGIUP15_PU50']=merge([PU50,step2Upg2015Defaults50ns])
 
+# for Run2 PPb workflows (NOTE: using HLT:@fake for the moment)
+steps['DIGIUP15_PPb']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake','--conditions':'auto:run2_mc_pa'}, steps['DIGIUP15']])
 
 # PU25 for high stats workflows
 steps['DIGIUP15_PU25HS']=merge([PU25HS,step2Upg2015Defaults])
@@ -1165,6 +1166,9 @@ steps['RECOUP15_trackingOnly']=merge([step3Up2015Defaults_trackingOnly]) # todo:
 steps['RECOUP15_trackingLowPU']=merge([step3_trackingLowPU, step3Up2015Defaults]) # todo: remove UP from label
 steps['RECOUP15_trackingOnlyLowPU']=merge([step3_trackingLowPU, step3Up2015Defaults_trackingOnly]) # todo: remove UP from label
 steps['RECOUP15_HIPM']=merge([step3_HIPM,step3Up2015Defaults]) # todo: remove UP from label
+
+# for Run2 PPb workflows
+steps['RECOUP15_PPb']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,VALIDATION,DQM','--conditions':'auto:run2_mc_pa','--customise':'RecoHI/Configuration/customise_PPwithHI.customisePPrecoforPPb','--datatier':'AODSIM,DQMIO','--eventcontent':'AODSIM,DQM'}, steps['RECOUP15']])
 
 #steps['RECOUP15PROD1']=merge([{ '-s' : 'RAW2DIGI,L1Reco,RECO,EI,DQM:DQMOfflinePOGMC', '--datatier' : 'AODSIM,DQMIO', '--eventcontent' : 'AODSIM,DQM'},step3Up2015Defaults])
 
@@ -1482,6 +1486,9 @@ steps['HARVESTUP15_PU25']=steps['HARVESTUP15']
 steps['HARVESTUP15_PU50']=merge([{'-s':'HARVESTING:@standardValidation+@standardDQMFakeHLT+@miniAODValidation+@miniAODDQM','--era' : 'Run2_50ns'},steps['HARVESTUP15']])
 
 steps['HARVESTUP15_trackingOnly']=merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, steps['HARVESTUP15']])
+
+# for Run2 PPb workflows
+steps['HARVESTUP15_PPb']=merge([{'--conditions':'auto:run2_mc_pa',}, steps['HARVESTMINUP15']])
 
 # unSchHarvestOverrides={'-s':'HARVESTING:@standardValidation+@standardDQM+@miniAODValidation+@miniAODDQM'}
 # steps['HARVESTmAODUP15']=merge([unSchHarvestOverrides,steps['HARVESTUP15']])

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -9,6 +9,7 @@ import FWCore.ParameterSet.Config as cms
 ###############################################################
 # AlCaReco for track based alignment using ZMuMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuPA_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics_cff import *
@@ -17,12 +18,12 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0T_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_cff import *
 # AlCaReco for track based alignment using isoMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import *
-# AlCaReco for track based alignment using isoMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_cff import *
 # AlCaReco for track based alignment using J/Psi events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import *
 # AlCaReco for track based alignment using Upsilon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_cff import *
 
@@ -138,10 +139,12 @@ from DQMOffline.Configuration.AlCaRecoDQM_cff import *
 # AlCaReco path definitions:
 
 pathALCARECOTkAlZMuMu = cms.Path(seqALCARECOTkAlZMuMu*ALCARECOTkAlZMuMuDQM)
+pathALCARECOTkAlZMuMuPA = cms.Path(seqALCARECOTkAlZMuMuPA*ALCARECOTkAlZMuMuPADQM)
 pathALCARECOTkAlMuonIsolated = cms.Path(seqALCARECOTkAlMuonIsolated*ALCARECOTkAlMuonIsolatedDQM)
-pathALCARECOTkAlMuonIsolatedPA = cms.Path(seqALCARECOTkAlMuonIsolatedPA)
+pathALCARECOTkAlMuonIsolatedPA = cms.Path(seqALCARECOTkAlMuonIsolatedPA*ALCARECOTkAlMuonIsolatedPADQM)
 pathALCARECOTkAlJpsiMuMu = cms.Path(seqALCARECOTkAlJpsiMuMu*ALCARECOTkAlJpsiMuMuDQM)
 pathALCARECOTkAlUpsilonMuMu = cms.Path(seqALCARECOTkAlUpsilonMuMu*ALCARECOTkAlUpsilonMuMuDQM)
+pathALCARECOTkAlUpsilonMuMuPA = cms.Path(seqALCARECOTkAlUpsilonMuMuPA*ALCARECOTkAlUpsilonMuMuPADQM)
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
@@ -272,6 +275,15 @@ ALCARECOStreamTkAlZMuMu = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
+ALCARECOStreamTkAlZMuMuPA = cms.FilteredStream(
+        responsible = 'James Castle',
+        name = 'TkAlZMuMuPA',
+        paths  = (pathALCARECOTkAlZMuMuPA),
+        content = OutALCARECOTkAlZMuMuPA.outputCommands,
+        selectEvents = OutALCARECOTkAlZMuMuPA.SelectEvents,
+        dataTier = cms.untracked.string('ALCARECO')
+        )
+
 ALCARECOStreamTkAlJpsiMuMu = cms.FilteredStream(
 	responsible = 'Andreas Mussgiller',
 	name = 'TkAlJpsiMuMu',
@@ -289,6 +301,15 @@ ALCARECOStreamTkAlUpsilonMuMu = cms.FilteredStream(
 	selectEvents = OutALCARECOTkAlUpsilonMuMu.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
+
+ALCARECOStreamTkAlUpsilonMuMuPA = cms.FilteredStream(
+        responsible = 'James Castle',
+        name = 'TkAlUpsilonMuMuPA',
+        paths  = (pathALCARECOTkAlUpsilonMuMuPA),
+        content = OutALCARECOTkAlUpsilonMuMuPA.outputCommands,
+        selectEvents = OutALCARECOTkAlUpsilonMuMuPA.SelectEvents,
+        dataTier = cms.untracked.string('ALCARECO')
+        )
 
 ALCARECOStreamSiPixelLorentzAngle = cms.FilteredStream(
 	responsible = 'Lotte Wilke',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -9,6 +9,7 @@ import FWCore.ParameterSet.Config as cms
 ###############################################################
 # AlCaReco for track based alignment using ZMuMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff import *
+# AlCaReco for track based alignment using ZMuMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuPA_cff import *
 # AlCaReco for track based alignment using Cosmic muon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmicsInCollisions_cff import *
@@ -18,11 +19,13 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0T_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_cff import *
 # AlCaReco for track based alignment using isoMu events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolated_cff import *
+# AlCaReco for track based alignment using isoMu events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_cff import *
 # AlCaReco for track based alignment using J/Psi events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlJpsiMuMu_cff import *
 # AlCaReco for track based alignment using Upsilon events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
+# AlCaReco for track based alignment using Upsilon events for PA data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_cff import *
@@ -258,7 +261,7 @@ ALCARECOStreamTkAlMuonIsolated = cms.FilteredStream(
 	)
 
 ALCARECOStreamTkAlMuonIsolatedPA = cms.FilteredStream(
-	responsible = 'Gero Flucke',
+	responsible = 'James Castle',
 	name = 'TkAlMuonIsolatedPA',
 	paths  = (pathALCARECOTkAlMuonIsolatedPA),
 	content = OutALCARECOTkAlMuonIsolatedPA.outputCommands,

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -92,6 +92,36 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_cff import ALCARECOTk
 ALCARECOTkAlZMuMuHIDQM = cms.Sequence( ALCARECOTkAlZMuMuHITrackingDQM + ALCARECOTkAlZMuMuHITkAlDQM )
 
 #########################################################
+#############---  TkAlZMuMuPA ---########################
+#########################################################
+__selectionName = 'TkAlZMuMuPA'
+ALCARECOTkAlZMuMuPATrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot"
+)
+
+ALCARECOTkAlZMuMuPATkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuPA_cff import ALCARECOTkAlZMuMuPAHLT
+#ALCARECOTkAlZMuMuHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*Mu.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlZMuMuHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlZMuMuDQM = cms.Sequence( ALCARECOTkAlZMuMuTrackingDQM + ALCARECOTkAlZMuMuTkAlDQM + ALCARECOTkAlZMuMuHLTDQM)
+ALCARECOTkAlZMuMuPADQM = cms.Sequence( ALCARECOTkAlZMuMuPATrackingDQM + ALCARECOTkAlZMuMuPATkAlDQM )
+
+#########################################################
 #############---  TkAlJpsiMuMu ---#######################
 #########################################################
 __selectionName = 'TkAlJpsiMuMu'
@@ -239,6 +269,42 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuHI_cff import ALCA
 
 #ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuHLTDQM)
 ALCARECOTkAlUpsilonMuMuHIDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuHITrackingDQM + ALCARECOTkAlUpsilonMuMuHITkAlDQM )
+
+############################################################
+#############---  TkAlUpsilonMuMuPA ---#####################
+############################################################
+__selectionName = 'TkAlUpsilonMuMuPA'
+ALCARECOTkAlUpsilonMuMuPATrackingDQM = ALCARECOTkAlUpsilonMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+# margins and settings
+    TrackPtMax = 50
+)
+
+ALCARECOTkAlUpsilonMuMuPATkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+# margins and settings
+    MassMin = 8.,
+    MassMax = 10,
+    TrackPtMax = 50
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_cff import ALCARECOTkAlUpsilonMuMuPAHLT
+#ALCARECOTkAlUpsilonMuMuHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*Mu.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlUpsilonMuMuHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuHLTDQM)
+ALCARECOTkAlUpsilonMuMuPADQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuPATrackingDQM + ALCARECOTkAlUpsilonMuMuPATkAlDQM )
 
 #########################################################
 #############---  TkAlBeamHalo ---#######################
@@ -428,6 +494,38 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_cff import ALC
 
 #ALCARECOTkAlMuonIsolatedHIDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedHITrackingDQM + ALCARECOTkAlMuonIsolatedHITkAlDQM+ALCARECOTkAlMuonIsolatedHIHLTDQM)
 ALCARECOTkAlMuonIsolatedHIDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedHITrackingDQM + ALCARECOTkAlMuonIsolatedHITkAlDQM )
+
+#############################################################
+#############---  TkAlMuonIsolatedPA ---#####################
+#############################################################
+__selectionName = 'TkAlMuonIsolatedPA'
+ALCARECOTkAlMuonIsolatedPATrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+#names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+# margins and settings
+    TkSizeBin = 16,
+    TkSizeMin = -0.5,
+    TkSizeMax = 15.5
+)
+ALCARECOTkAlMuonIsolatedPATkAlDQM = ALCARECOTkAlMinBiasTkAlDQM.clone(
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName
+)
+
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedPA_cff import ALCARECOTkAlMuonIsolatedPAHLT
+#ALCARECOTkAlMuonIsolatedPAHLTDQM = hltMonBitSummary.clone(
+#    directory = "AlCaReco/"+__selectionName+"/HLTSummary",
+#    histLabel = __selectionName,
+#    HLTPaths = ["HLT_.*L1.*"],
+#    eventSetupPathsKey =  ALCARECOTkAlMuonIsolatedPAHLT.eventSetupPathsKey.value()
+#)
+
+#ALCARECOTkAlMuonIsolatedPADQM = cms.Sequence( ALCARECOTkAlMuonIsolatedPATrackingDQM + ALCARECOTkAlMuonIsolatedPATkAlDQM+ALCARECOTkAlMuonIsolatedPAHLTDQM)
+ALCARECOTkAlMuonIsolatedPADQM = cms.Sequence( ALCARECOTkAlMuonIsolatedPATrackingDQM + ALCARECOTkAlMuonIsolatedPATkAlDQM )
 
 ####################################################
 #############---  TkAlLAS ---#######################


### PR DESCRIPTION
Adds in new PA-specific common alignment producers for muon-based tracker alignment collections.  In pA and AA collisions, the yields of isoMus and Z's are strongly suppressed by the *RelCombIsoMuons step.  Studies on 2013 pPb data show improvement in alignment yields using producers where this step has been removed as outlined in the following presentation at the tracker alignment weekly meeting:

https://indico.cern.ch/event/536888/contributions/2326743/attachments/1348506/2034547/10_5_16_Alignment.pdf

Additional edits were made to the new Millepede configuration files to include these new track collections in the standard workflows.
