### PR TITLE
Proper use of eras for L1Reco and a fastSim fix

### DIFF
--- a/L1Trigger/Configuration/python/L1TReco_cff.py
+++ b/L1Trigger/Configuration/python/L1TReco_cff.py
@@ -12,22 +12,6 @@ import FWCore.ParameterSet.Config as cms
 # These might be more widely useful...  L1T_customs?
 #
 
-
-def config_L1ExtraForStage1Raw(coll):
-    coll.isolatedEmSource      = cms.InputTag("caloStage1LegacyFormatDigis","isoEm")
-    coll.nonIsolatedEmSource   = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm")    
-    coll.forwardJetSource      = cms.InputTag("caloStage1LegacyFormatDigis","forJets")
-    coll.centralJetSource      = cms.InputTag("caloStage1LegacyFormatDigis","cenJets")
-    coll.tauJetSource          = cms.InputTag("caloStage1LegacyFormatDigis","tauJets")
-    coll.isoTauJetSource       = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets")
-    coll.etTotalSource         = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.etHadSource           = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.etMissSource          = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.htMissSource          = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.hfRingEtSumsSource    = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis")
-    coll.muonSource            = cms.InputTag("gtDigis")
-    
 def config_L1ExtraForStage2Sim(coll):
     coll.isolatedEmSource      = cms.InputTag("simCaloStage1LegacyFormatDigis","isoEm")
     coll.nonIsolatedEmSource   = cms.InputTag("simCaloStage1LegacyFormatDigis","nonIsoEm")    
@@ -44,47 +28,40 @@ def config_L1ExtraForStage2Sim(coll):
     coll.muonSource            = cms.InputTag("simGmtDigis")
     
 
+from L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi import l1extraParticles
+
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    print "L1TReco Sequence configured for Run1 (Legacy) trigger. "
-    from L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi import *
-    l1extraParticles.centralBxOnly = False
-    from EventFilter.L1GlobalTriggerRawToDigi.l1GtRecord_cfi import *
-    from EventFilter.L1GlobalTriggerRawToDigi.l1GtTriggerMenuLite_cfi import *
-    import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi
-    conditionsInEdm = EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi.conditionDumperInEdm.clone()
-    from L1Trigger.GlobalTrigger.convertObjectMapRecord_cfi import *
-    l1L1GtObjectMap = convertObjectMapRecord.clone()
-    L1Reco_L1Extra = cms.Sequence(l1extraParticles)
-    L1Reco_L1Extra_L1GtRecord = cms.Sequence(l1extraParticles+l1GtRecord)
-    L1Reco = cms.Sequence(l1extraParticles+l1GtTriggerMenuLite+conditionsInEdm+l1L1GtObjectMap)
-
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtRecord_cfi import l1GtRecord
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtTriggerMenuLite_cfi import l1GtTriggerMenuLite
+import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi
+conditionsInEdm = EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi.conditionDumperInEdm.clone()
+import L1Trigger.GlobalTrigger.convertObjectMapRecord_cfi as _converterModule
+l1L1GtObjectMap = _converterModule.convertObjectMapRecord.clone()
+L1Reco_L1Extra = cms.Sequence(l1extraParticles)
+L1Reco_L1Extra_L1GtRecord = cms.Sequence(l1extraParticles+l1GtRecord)
+L1Reco = cms.Sequence(l1extraParticles+l1GtTriggerMenuLite+conditionsInEdm+l1L1GtObjectMap)
 
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    print "L1TReco Sequence configured for Stage-1 (2015) trigger. "    
-    from L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi import *
-    config_L1ExtraForStage1Raw(l1extraParticles)
-    L1Reco = cms.Sequence(l1extraParticles)
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+stage1L1Trigger.toReplaceWith(L1Reco_L1Extra,cms.Sequence())
+stage1L1Trigger.toReplaceWith(L1Reco_L1Extra_L1GtRecord,cms.Sequence())
+stage1L1Trigger.toReplaceWith(L1Reco, cms.Sequence(l1extraParticles))
 
 #
 # Stage-2 Trigger:  fow now, reco Stage-1 as before:
 #
-if stage2L1Trigger.isChosen():
-    print "L1TReco Sequence configured for Stage-2 (2016) trigger. "    
-    from L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi import *
-    config_L1ExtraForStage1Raw(l1extraParticles)
-    L1Reco = cms.Sequence(l1extraParticles)
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toReplaceWith(L1Reco_L1Extra,cms.Sequence())
+stage2L1Trigger.toReplaceWith(L1Reco_L1Extra_L1GtRecord,cms.Sequence())
+stage2L1Trigger.toReplaceWith(L1Reco, cms.Sequence(l1extraParticles))
 
+#
+# l1L1GtObjectMap does not work properly with fastsim
+#
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    # fastsim runs L1Reco and HLT in one step
-    # this requires to set :
-    from L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi import *
-    l1extraParticles.centralBxOnly = True
+_L1Reco_modified = L1Reco.copyAndExclude([l1L1GtObjectMap])
+fastSim.toReplaceWith(L1Reco, _L1Reco_modified)

--- a/L1Trigger/L1ExtraFromDigis/python/l1extraParticles_cfi.py
+++ b/L1Trigger/L1ExtraFromDigis/python/l1extraParticles_cfi.py
@@ -16,23 +16,36 @@ l1extraParticles = cms.EDProducer("L1ExtraParticlesProd",
     etHadSource = cms.InputTag("gctDigis"),
     hfRingEtSumsSource = cms.InputTag("gctDigis"),
     hfRingBitCountsSource = cms.InputTag("gctDigis"),
-    centralBxOnly = cms.bool(True),
+    centralBxOnly = cms.bool(False),
     ignoreHtMiss = cms.bool(False)
 )
 
 #
-# Modify for running with the Stage 1 trigger
+# Modify for running with the Stage 1 or Stage 2 trigger
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-stage1L1Trigger.toModify( l1extraParticles, etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis") )
-stage1L1Trigger.toModify( l1extraParticles, nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm") )
-stage1L1Trigger.toModify( l1extraParticles, etMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
-stage1L1Trigger.toModify( l1extraParticles, htMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
-stage1L1Trigger.toModify( l1extraParticles, forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets") )
-stage1L1Trigger.toModify( l1extraParticles, centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets") )
-stage1L1Trigger.toModify( l1extraParticles, tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets") )
-stage1L1Trigger.toModify( l1extraParticles, isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets") )
-stage1L1Trigger.toModify( l1extraParticles, isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm") )
-stage1L1Trigger.toModify( l1extraParticles, etHadSource = cms.InputTag("caloStage1LegacyFormatDigis") )
-stage1L1Trigger.toModify( l1extraParticles, hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis") )
-stage1L1Trigger.toModify( l1extraParticles, hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger 
+_caloStage1LegacyFormatDigis = "caloStage1LegacyFormatDigis"
+_params = dict(
+    etTotalSource         = cms.InputTag(_caloStage1LegacyFormatDigis),
+    nonIsolatedEmSource   = cms.InputTag(_caloStage1LegacyFormatDigis,"nonIsoEm"),
+    etMissSource          = cms.InputTag(_caloStage1LegacyFormatDigis),
+    htMissSource          = cms.InputTag(_caloStage1LegacyFormatDigis),
+    forwardJetSource      = cms.InputTag(_caloStage1LegacyFormatDigis,"forJets"),
+    centralJetSource      = cms.InputTag(_caloStage1LegacyFormatDigis,"cenJets"),
+    tauJetSource          = cms.InputTag(_caloStage1LegacyFormatDigis,"tauJets"),
+    isoTauJetSource       = cms.InputTag(_caloStage1LegacyFormatDigis,"isoTauJets"),
+    isolatedEmSource      = cms.InputTag(_caloStage1LegacyFormatDigis,"isoEm"),
+    etHadSource           = cms.InputTag(_caloStage1LegacyFormatDigis),
+    hfRingEtSumsSource    = cms.InputTag(_caloStage1LegacyFormatDigis),
+    hfRingBitCountsSource = cms.InputTag(_caloStage1LegacyFormatDigis),
+    muonSource            = cms.InputTag("gtDigis"),
+    centralBxOnly         = True)
+
+stage1L1Trigger.toModify( l1extraParticles, **_params)
+stage2L1Trigger.toModify( l1extraParticles, **_params)
+
+# fastsim runs L1Reco and HLT in one step
+# this requires to set :
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(l1extraParticles, centralBxOnly = True)


### PR DESCRIPTION
The tests in CMSSW_8_1_DEVEL_X are failing because of an unrunnable schedule when using fastSim with the legacy L1 trigger. Although it would have been possible to fix just that problem, the L1TReco_cff file was not using the modern recommended practice for eras. Therefore I also updated the use of eras.
