### PR TITLE
[80X] Temporary fix for multi-IOV input in MillePede

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
@@ -34,6 +34,7 @@ SiPixelAliPedeAlignmentProducer.tjTkAssociationMapTag = 'TrackRefitter2'
 
 SiPixelAliPedeAlignmentProducer.algoConfig = MillePedeAlignmentAlgorithm
 SiPixelAliPedeAlignmentProducer.algoConfig.mode = 'pede'
+SiPixelAliPedeAlignmentProducer.algoConfig.runAtPCL = True
 SiPixelAliPedeAlignmentProducer.algoConfig.mergeBinaryFiles = [SiPixelAliMilleFileExtractor.outputBinaryFile.value()]
 SiPixelAliPedeAlignmentProducer.algoConfig.binaryFile = ''
 SiPixelAliPedeAlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -37,6 +37,7 @@ SiPixelAliPedeAlignmentProducer.tjTkAssociationMapTag = 'TrackRefitter2'
 
 SiPixelAliPedeAlignmentProducer.algoConfig = MillePedeAlignmentAlgorithm
 SiPixelAliPedeAlignmentProducer.algoConfig.mode = 'pede'
+SiPixelAliPedeAlignmentProducer.algoConfig.runAtPCL = True
 SiPixelAliPedeAlignmentProducer.algoConfig.mergeBinaryFiles = [SiPixelAliMilleFileExtractor.outputBinaryFile.value()]
 SiPixelAliPedeAlignmentProducer.algoConfig.binaryFile = ''
 SiPixelAliPedeAlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -71,7 +71,6 @@ typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer;
 typedef TrajectoryFactoryBase::ReferenceTrajectoryCollection RefTrajColl;
 
 // Includes for PXB survey
-#include <iostream>
 #include "Alignment/SurveyAnalysis/interface/SurveyPxbImage.h"
 #include "Alignment/SurveyAnalysis/interface/SurveyPxbImageLocalFit.h"
 #include "Alignment/SurveyAnalysis/interface/SurveyPxbImageReader.h"
@@ -674,7 +673,9 @@ int MillePedeAlignmentAlgorithm::addGlobalData(const edm::EventSetup &setup, con
         theDoubleBufferX.push_back(iValuesInd->first.first);
         theDoubleBufferY.push_back(iValuesInd->first.second);
       } else {
-        std::cerr << "MillePedeAlignmentAlgorithm::addGlobalData: Invalid label " << globalLabel << " <= 0 or > 2147483647" << std::endl;
+	edm::LogError("Alignment")
+	  << "@SUB=MillePedeAlignmentAlgorithm::addGlobalData"
+	  << "Invalid label " << globalLabel << " <= 0 or > 2147483647";
       }
     }
   }
@@ -794,7 +795,9 @@ bool MillePedeAlignmentAlgorithm
           globalDerivativesX.push_back(derivs[iSel][kLocalX] / thePedeSteer->cmsToPedeFactor(iSel));
           globalDerivativesY.push_back(derivs[iSel][kLocalY] / thePedeSteer->cmsToPedeFactor(iSel));
         } else {
-          std::cerr << "MillePedeAlignmentAlgorithm::globalDerivativesHierarchy: Invalid label " << globalLabel << " <= 0 or > 2147483647" << std::endl;
+	  edm::LogError("Alignment")
+	    << "@SUB=MillePedeAlignmentAlgorithm::globalDerivativesHierarchy"
+	    << "Invalid label " << globalLabel << " <= 0 or > 2147483647";
         }
       }
     }
@@ -1440,7 +1443,12 @@ void MillePedeAlignmentAlgorithm::addPxbSurvey(const edm::ParameterSet &pxbSurve
 {
 	// do some printing, if requested
 	const bool doOutputOnStdout(pxbSurveyCfg.getParameter<bool>("doOutputOnStdout"));
-	if (doOutputOnStdout) std::cout << "# Output from addPxbSurvey follows below because doOutputOnStdout is set to True" << std::endl;
+	if (doOutputOnStdout) {
+	  edm::LogInfo("Alignment")
+	    << "@SUB=MillePedeAlignmentAlgorithm::addPxbSurvey"
+	    << "# Output from addPxbSurvey follows below because "
+	    << "doOutputOnStdout is set to True";
+	}
 
 	// instantiate a dicer object
 	SurveyPxbDicer dicer(pxbSurveyCfg.getParameter<std::vector<edm::ParameterSet> >("toySurveyParameters"), pxbSurveyCfg.getParameter<unsigned int>("toySurveySeed"));
@@ -1454,7 +1462,11 @@ void MillePedeAlignmentAlgorithm::addPxbSurvey(const edm::ParameterSet &pxbSurve
 	// loop over photographs (=measurements) and perform the fit
 	for(std::vector<SurveyPxbImageLocalFit>::size_type i=0; i!=measurements.size(); i++)
 	{
-		if (doOutputOnStdout) std::cout << "Module " << i << ": ";
+                if (doOutputOnStdout) {
+                  edm::LogInfo("Alignment")
+                    << "@SUB=MillePedeAlignmentAlgorithm::addPxbSurvey"
+                    << "Module " << i << ": ";
+                }
 
 		// get the Alignables and their surfaces
 		AlignableDetOrUnitPtr mod1(theAlignableNavigator->alignableFromDetId(measurements[i].getIdFirst()));
@@ -1498,10 +1510,12 @@ void MillePedeAlignmentAlgorithm::addPxbSurvey(const edm::ParameterSet &pxbSurve
 		// do some reporting, if requested
 		if (doOutputOnStdout)
 		{
-		  std::cout << "a: " << a[0] << ", " << a[1]  << ", " << a[2] << ", " << a[3]
-			<< " S= " << sqrt(a[2]*a[2]+a[3]*a[3])
-			<< " phi= " << atan(a[3]/a[2])
-			<< " chi2= " << chi2 << std::endl;
+                  edm::LogInfo("Alignment")
+                    << "@SUB=MillePedeAlignmentAlgorithm::addPxbSurvey"
+                    << "a: " << a[0] << ", " << a[1]  << ", " << a[2] << ", " << a[3]
+                    << " S= " << sqrt(a[2]*a[2]+a[3]*a[3])
+                    << " phi= " << atan(a[3]/a[2])
+                    << " chi2= " << chi2 << std::endl;
 		}
 		if (theMonitor) 
 		{

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
@@ -46,7 +46,7 @@ def create_single_iov_db(global_tag, run_number, output_db):
                           "tag": "_".join([tag["name"], tag["since"]])}
         cmd = ("conddb_import",
                "-f", "frontier://PromptProd/cms_conditions",
-               "-c", "sqlite:"+output_db,
+               "-c", result[record]["connect"],
                "-i", tag["name"],
                "-t", result[record]["tag"],
                "-b", str(run_number),

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import subprocess
+import CondCore.Utilities.CondDBFW.shell as shell
+
+
+def create_single_iov_db(global_tag, run_number, output_db):
+    """Create an sqlite file with single-IOV tags for alignment payloads.
+
+    Arguments:
+    - `global_tag`: global tag from which to extract the payloads
+    - `run_number`: run for which the IOVs are selected
+    - `output_db`: name of the output sqlite file
+    """
+
+    con = shell.connect()
+    tags = con.global_tag_map(global_tag_name = global_tag,
+                              record = ["TrackerAlignmentRcd",
+                                        "TrackerSurfaceDeformationRcd",
+                                        "TrackerAlignmentErrorExtendedRcd"])
+    con.close_session()
+
+    tags = {item["record"]: {"name": item["tag_name"]}
+            for item in tags.as_dicts()}
+
+    for record,tag in tags.iteritems():
+        iovs = con.tag(name = tag["name"]).iovs().as_dicts()
+        run_is_covered = False
+        for iov in reversed(iovs):
+            if iov["since"] <= run_number:
+                tag["since"] = str(iov["since"])
+                run_is_covered = True
+                break
+        if not run_is_covered:
+            msg = ("Run number {0:d} is not covered in '{1:s}' ({2:s}) from"
+                   " '{3:s}'.".format(run_number, tag["name"], record,
+                                      global_tag))
+            print msg
+            print "Aborting..."
+            sys.exit(1)
+
+    result = {}
+    if os.path.exists(output_db): os.remove(output_db)
+    for record,tag in tags.iteritems():
+        result[record] = {"connect": "sqlite_file:"+output_db,
+                          "tag": "_".join([tag["name"], tag["since"]])}
+        cmd = ("conddb_import",
+               "-f", "frontier://PromptProd/cms_conditions",
+               "-c", "sqlite:"+output_db,
+               "-i", tag["name"],
+               "-t", result[record]["tag"],
+               "-b", str(run_number),
+               "-e", str(run_number))
+        run_checked(cmd)
+    run_checked(["sqlite3", output_db, "update iov set since=1"])
+
+    return result
+
+
+def run_checked(cmd):
+    """Run `cmd` and exit in case of failures.
+
+    Arguments:
+    - `cmd`: list containing the strings of the command
+    """
+
+    try:
+        with open(os.devnull, "w") as devnull:
+            subprocess.check_call(cmd, stdout = devnull)
+    except subprocess.CalledProcessError as e:
+        print "Problem in running the following command:"
+        print " ".join(e.cmd)
+        sys.exit(1)

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
+
+################################################################################
+def main(argv = None):
+    """Main routine of the script.
+
+    Arguments:
+    - `argv`: arguments passed to the main routine
+    """
+
+    if argv == None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description="Prepare input db file for MillePede workflow.")
+    parser.add_argument("-g", "--global-tag", dest="global_tag", required=True,
+                        metavar="TAG",
+                        help="global tag to extract the alignment payloads")
+    parser.add_argument("-r", "--run-number", dest="run_number", required=True,
+                        metavar="INTEGER", type=int,
+                        help="run number to select IOV")
+    parser.add_argument("-o", "--output-db", dest="output_db",
+                        default="alignment_input.db", metavar="PATH",
+                        help="name of the output file (default: '%(default)s')")
+    args = parser.parse_args(argv)
+
+    mps_tools.create_single_iov_db(args.global_tag,
+                                   args.run_number,
+                                   args.output_db)
+
+
+################################################################################
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -29,6 +29,7 @@ pedeMem        = 32000
 datasetdir     = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/datasetfiles
 configTemplate = universalConfigTemplate.py
 globaltag      = auto:run2_data
+FirstRunForStartGeometry = 0  ; set this to the run from where you want to start
 
 ;####################################################################
 ;## datasets


### PR DESCRIPTION
Backport of #16135

Adds a protection against multi-IOV input for MillePede to prevent issues like reported in the [Tracker Alignment HN](https://hypernews.cern.ch/HyperNews/CMS/get/tk-alignment/1639.html).

This is meant to be a temporary fix to quickly protect against this problem. The mid-term solution which is in preparation will properly handle multi-IOV input instead of prohibiting them.
