### PR TITLE
Phase I Pixel Barrel supply tubes material

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -543,15 +543,15 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelConn4" category="unspecified">
   <rSolid name="PixelBarrelConn4"/>
-  <rMaterial name="pixbarmaterial:SectorC_3Disks"/>
+  <rMaterial name="pixbarmaterial:SectorBC"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelService" category="unspecified">
   <rSolid name="PixelBarrelService"/>
-  <rMaterial name="pixbarmaterial:SectorA_3Disks"/>
+  <rMaterial name="pixbarmaterial:SectorA"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelSupTubCables" category="unspecified">
   <rSolid name="PixelBarrelSupTubCables"/>
-  <rMaterial name="pixbarmaterial:PixelBarrelSupTubCables2_3Disks"/>
+  <rMaterial name="pixbarmaterial:PixelBarrelSupTubCables"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -681,8 +681,26 @@
       <rMaterial name="trackermaterial:T_Nomex"/>
     </MaterialFraction>
   </CompositeMaterial>
+
+  <CompositeMaterial name="SectorBC" density="0.9875*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.265">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.115">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.052">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.006">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.562">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
   
- <CompositeMaterial name="SectorC_3Disks" density="0.8068*1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+ <CompositeMaterial name="SectorC_3Disks" density="1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
     <MaterialFraction fraction="1.000000">
       <rMaterial name="pixbarmaterial:SectorC"/>
     </MaterialFraction>
@@ -699,7 +717,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="PixelBarrelSupTubCables" density="2.25064*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="PixelBarrelSupTubCables" density="0.6510*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.09162">
       <rMaterial name="materials:Bpix_CO2_-20C"/>
     </MaterialFraction>
@@ -730,7 +748,7 @@
     </MaterialFraction>
   </CompositeMaterial>
   
-  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.6780*0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
     <MaterialFraction fraction="1.00000000">
       <rMaterial name="PixelBarrelSupTubCables2"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -584,45 +584,18 @@
     </MaterialFraction>
   </CompositeMaterial>
 
- <CompositeMaterial name="SectorA" density="0.3136*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.10443">
-      <rMaterial name="materials:Bpix_CO2_-20C"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.00283">
-      <rMaterial name="pixbarmaterial:Polyoxymethylene"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.20588">
+ <CompositeMaterial name="SectorA" density="0.3661*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.329">
       <rMaterial name="trackermaterial:T_FR4"/>
     </MaterialFraction>
-    <MaterialFraction fraction="0.08188">
-      <rMaterial name="materials:Acrylate"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.11064">
-      <rMaterial name="materials:Steel-008"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.0145">
-      <rMaterial name="materials:Brass"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.10724">
-      <rMaterial name="materials:Epoxy"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.00283">
-      <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.01613">
-      <rMaterial name="trackermaterial:T_Copper"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.19232">
+    <MaterialFraction fraction="0.333">
       <rMaterial name="trackermaterial:T_Aluminium"/>
     </MaterialFraction>
-    <MaterialFraction fraction="0.1272">
-      <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+    <MaterialFraction fraction="0.320">
+      <rMaterial name="trackermaterial:T_Copper"/>
     </MaterialFraction>
-    <MaterialFraction fraction="0.009">
-      <rMaterial name="materials:Polyvinylchloride"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.02513">
-      <rMaterial name="trackermaterial:T_Nomex"/>
+    <MaterialFraction fraction="0.018">
+      <rMaterial name="materials:Steel-008"/>
     </MaterialFraction>
   </CompositeMaterial>
   
@@ -709,7 +682,7 @@
     </MaterialFraction>
   </CompositeMaterial>
   
- <CompositeMaterial name="SectorC_3Disks" density="1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+ <CompositeMaterial name="SectorC_3Disks" density="0.8068*1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
     <MaterialFraction fraction="1.000000">
       <rMaterial name="pixbarmaterial:SectorC"/>
     </MaterialFraction>
@@ -757,7 +730,7 @@
     </MaterialFraction>
   </CompositeMaterial>
   
-  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.6780*0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
     <MaterialFraction fraction="1.00000000">
       <rMaterial name="PixelBarrelSupTubCables2"/>
     </MaterialFraction>


### PR DESCRIPTION
This PR adds some modifications to the Phase I Pixel Barrel supply tubes material composition. The weight and the fraction of the different materials have been estimated from the measured weight of the individual components supposed to be built on the supply tubes. Also the materials are now correctly recognized by the MaterialBudget macros.

This PR does _not_ change the Pixel Barrel Geometry.
