### PR TITLE
Making averageDigiOccupancy threadsafe in offline. 

### DIFF
--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -73,7 +73,7 @@ class SiPixelActionExecutor {
                                     bool                           hiRes);
  void createOccupancy(    	    DQMStore::IBooker            & iBooker,
 				    DQMStore::IGetter  		 & iGetter);
- void normaliseROCcupancy(	    DQMStore::IBooker		 & iBooker,
+ void normaliseAvDigiOcc(	    DQMStore::IBooker		 & iBooker,
 				    DQMStore::IGetter		 & iGetter);
  bool readConfiguration(	    int 			 & tkmap_freq, 
                         	    int 			 & sum_barrel_freq, 

--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -73,6 +73,8 @@ class SiPixelActionExecutor {
                                     bool                           hiRes);
  void createOccupancy(    	    DQMStore::IBooker            & iBooker,
 				    DQMStore::IGetter  		 & iGetter);
+ void normaliseROCcupancy(	    DQMStore::IBooker		 & iBooker,
+				    DQMStore::IGetter		 & iGetter);
  bool readConfiguration(	    int 			 & tkmap_freq, 
                         	    int 			 & sum_barrel_freq, 
 				    int 			 & sum_endcap_freq, 

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -1573,6 +1573,7 @@ void SiPixelActionExecutor::createOccupancy(DQMStore::IBooker & iBooker, DQMStor
   fillOccupancy(iBooker,iGetter, false);
   iBooker.cd();
   iGetter.cd();
+
   //std::cout<<"leaving SiPixelActionExecutor::createOccupancy..."<<std::endl;
 }
 
@@ -1625,6 +1626,32 @@ void SiPixelActionExecutor::fillOccupancy(DQMStore::IBooker & iBooker, DQMStore:
 	
   //occupancyprinting cout<<"leaving SiPixelActionExecutor::fillOccupancy..."<<std::endl;
 	
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutor::normaliseROCcupancy(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter){
+  //occupancyprinting cout<<"entering SiPixelActionExecutor::normaliseROCcupancy..."<<std::endl;
+  
+  iGetter.cd();
+
+  MonitorElement * roccupancyPlot = iGetter.get("Pixel/averageDigiOccupancy");
+  
+  float totalDigisBPIX = 0.;
+  float totalDigisFPIX = 0.;
+  for (int i = 1; i !=41; i++){
+    if (i < 33) totalDigisBPIX += roccupancyPlot->getBinContent(i);
+    else totalDigisFPIX += roccupancyPlot->getBinContent(i);
+  } 
+  float averageBPIXOcc = totalDigisBPIX/32.;
+  float averageFPIXOcc = totalDigisFPIX/8.;
+  for (int i = 1; i !=41; i++){
+    if (i < 33) roccupancyPlot->setBinContent(i,roccupancyPlot->getBinContent(i)/averageBPIXOcc);
+    else roccupancyPlot->setBinContent(i,roccupancyPlot->getBinContent(i)/averageFPIXOcc);
+  }
+  
+  iGetter.setCurrentFolder(iBooker.pwd());
+  
 }
 
 //=============================================================================================================

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -1630,8 +1630,8 @@ void SiPixelActionExecutor::fillOccupancy(DQMStore::IBooker & iBooker, DQMStore:
 
 //=============================================================================================================
 
-void SiPixelActionExecutor::normaliseROCcupancy(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter){
-  //occupancyprinting cout<<"entering SiPixelActionExecutor::normaliseROCcupancy..."<<std::endl;
+void SiPixelActionExecutor::normaliseAvDigiOcc(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter){
+  //occupancyprinting cout<<"entering SiPixelActionExecutor::normaliseAvDigiOcc..."<<std::endl;
   
   iGetter.cd();
 

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -244,6 +244,8 @@ void SiPixelEDAClient::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGetter 
 
     sipixelActionExecutor_->createOccupancy(iBooker,iGetter);
 
+    if(Tier0Flag_) sipixelActionExecutor_->normaliseROCcupancy(iBooker,iGetter);
+
     iBooker.cd();
     iGetter.cd();
     bool init=true;

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -244,7 +244,7 @@ void SiPixelEDAClient::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGetter 
 
     sipixelActionExecutor_->createOccupancy(iBooker,iGetter);
 
-    if(Tier0Flag_) sipixelActionExecutor_->normaliseROCcupancy(iBooker,iGetter);
+    if(Tier0Flag_) sipixelActionExecutor_->normaliseAvDigiOcc(iBooker,iGetter);
 
     iBooker.cd();
     iGetter.cd();

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -135,7 +135,7 @@ SiPixelDigiSource::endLuminosityBlock(const edm::LuminosityBlock& lb, edm::Event
 	  if(averageFPIXFed>0.) averageOcc = nDigisPerFed[i]/averageFPIXFed;
 	}
 	if (!modOn){
-	  averageDigiOccupancy->Fill(i,averageOcc);
+	  averageDigiOccupancy->Fill(i,nDigisPerFed[i]); //In offline we fill all digis and normalise at the end of the run for thread safe behaviour.
 	}        
 	if ( modOn ){
 	  if (thisls % 10 == 0)
@@ -691,12 +691,15 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker, const edm::EventSet
   char title6[80];  sprintf(title6, "Number of Low-Efficiency Endcap ROCs;LumiSection;N_{LO EFF} Endcap ROCs");
   loOccROCsEndcap = iBooker.book1D("loOccROCsEndcap",title6,500,0.,5000.);
   char title7[80];  sprintf(title7, "Average digi occupancy per FED;FED;NDigis/<NDigis>");
-  averageDigiOccupancy = iBooker.bookProfile("averageDigiOccupancy",title7,40,-0.5,39.5,0.,3.);
-  averageDigiOccupancy->setLumiFlag();
-  if(modOn){
+  if (modOn){
+    averageDigiOccupancy = iBooker.bookProfile("averageDigiOccupancy",title7,40,-0.5,39.5,0.,3.);
+    averageDigiOccupancy->setLumiFlag();
     char title4[80]; sprintf(title4, "FED Digi Occupancy (NDigis/<NDigis>) vs LumiSections;Lumi Section;FED");
     avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title4, 640,0., 3200., 40, -0.5, 39.5);
-  }  
+  }
+  if (!modOn){
+    averageDigiOccupancy = iBooker.book1D("averageDigiOccupancy",title7,40,-0.5,39.5); //Book as TH1 for offline to ensure thread-safe behaviour
+  }
   std::map<uint32_t,SiPixelDigiModule*>::iterator struct_iter;
  
   SiPixelFolderOrganizer theSiPixelFolder(false);


### PR DESCRIPTION
It is now (in offine only) a TH1 that is normalised in the dqmEndJob step of the SiPixelEDAClient. These changes do not affect online implementation.
