### PR TITLE
Fix for Puppi MET and MET significance compatibility between AOD and miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -188,7 +188,7 @@ PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& 
   JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(iSetup, jetSFType_);
 
   //Compute the covariance matrix and fill it
-  reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, *inputCands,
+  reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, inputCands,
 						       *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
 
   return cov;

--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
@@ -50,7 +50,8 @@ void RecoMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
 
   std::vector<reco::MET> *metCol = new std::vector<reco::MET>();
   
-  reco::MET met(src->front().corP4(corLevel_), src->front().vertex() );
+  reco::MET met(src->front().corSumEt(corLevel_), src->front().corP4(corLevel_), src->front().vertex() );
+  
   metCol->push_back( met );
   
   std::unique_ptr<std::vector<reco::MET> > recoMETs(metCol);

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -49,7 +49,7 @@ patMETs = cms.EDProducer("PATMETProducer",
     computeMETSignificance  = cms.bool(False),
     # significance computation parameters, not used
     # if the significance is not computed
-    srcJets = cms.InputTag("selectedPatJets"),
+    srcJets = cms.InputTag("cleanedPatJets"),
     srcPFCands =  cms.InputTag("particleFlow"),
     srcLeptons = cms.VInputTag("selectedPatElectrons", "selectedPatMuons", "selectedPatPhotons"),
     srcJetSF = cms.string('AK4PFchs'),

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -30,6 +30,7 @@ def makePuppies( process ):
 def makePuppiesFromMiniAOD( process ):
     process.load('CommonTools.PileupAlgos.Puppi_cff')
     process.puppi.candName = cms.InputTag('packedPFCandidates')
+    process.puppi.clonePackedCands = cms.bool(True)
     process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
     process.pfNoLepPUPPI = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut =  cms.string("abs(pdgId) != 13 && abs(pdgId) != 11 && abs(pdgId) != 15"))
     process.pfLeptonsPUPPET   = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("abs(pdgId) == 13 || abs(pdgId) == 11 || abs(pdgId) == 15"))
@@ -41,9 +42,9 @@ def makePuppiesFromMiniAOD( process ):
     process.puppiForMET = process.puppiPhoton.clone()
     setupPuppiPhotonMiniAOD(process)
     #Line below doesn't work because of an issue with references in MiniAOD without setting useRefs=>False and using delta R
-    #process.puppiForMET.puppiCandName    = 'puppiMerged'
-    #process.puppiForMET.useRefs          = False
+    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    process.puppiForMET.useRefs          = False
 
     #making a sequence for people running the MET tool in scheduled mode
-    puppiMETSequence = cms.Sequence(process.puppi*process.puppiForMET)
+    puppiMETSequence = cms.Sequence(process.puppi*process.pfLeptonsPUPPET*process.pfNoLepPUPPI*process.puppiNoLep*process.puppiMerged*process.puppiForMET)
     setattr(process, "puppiMETSequence", puppiMETSequence)

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -44,3 +44,6 @@ def makePuppiesFromMiniAOD( process ):
     #process.puppiForMET.puppiCandName    = 'puppiMerged'
     #process.puppiForMET.useRefs          = False
 
+    #making a sequence for people running the MET tool in scheduled mode
+    puppiMETSequence = cms.Sequence(process.puppi*process.puppiForMET)
+    setattr(process, "puppiMETSequence", puppiMETSequence)

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -27,7 +27,7 @@ def makePuppies( process ):
     process.puppiForMET.puppiCandName    = 'puppiMerged'
 
 
-def makePuppiesFromMiniAOD( process ):
+def makePuppiesFromMiniAOD( process, createScheduledSequence=False ):
     process.load('CommonTools.PileupAlgos.Puppi_cff')
     process.puppi.candName = cms.InputTag('packedPFCandidates')
     process.puppi.clonePackedCands = cms.bool(True)
@@ -46,5 +46,6 @@ def makePuppiesFromMiniAOD( process ):
     process.puppiForMET.useRefs          = False
 
     #making a sequence for people running the MET tool in scheduled mode
-    puppiMETSequence = cms.Sequence(process.puppi*process.pfLeptonsPUPPET*process.pfNoLepPUPPI*process.puppiNoLep*process.puppiMerged*process.puppiForMET)
-    setattr(process, "puppiMETSequence", puppiMETSequence)
+    if createScheduledSequence:
+        puppiMETSequence = cms.Sequence(process.puppi*process.pfLeptonsPUPPET*process.pfNoLepPUPPI*process.puppiNoLep*process.puppiMerged*process.puppiForMET)
+        setattr(process, "puppiMETSequence", puppiMETSequence)

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -75,9 +75,9 @@ if usePrivateSQlite:
 ### =====================================================================================================
 # Define the input source
 if runOnData:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre10/DoubleEG/MINIAOD/81X_dataRun2_relval_v4_RelVal_doubEG2015D-v1/00000/88859857-6168-E611-9E79-0025905A60AA.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre11/DoubleEG/MINIAOD/81X_dataRun2_relval_v6_resub_RelVal_doubEG2015D-v1/00000/1CF62687-8374-E611-A98B-0025905A6090.root'
 else:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbar_13/MINIAODSIM/81X_mcRun2_asymptotic_v5_recycle-v1/00000/B49E8325-6E67-E611-BFE7-0025905A60D0.root'
+  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre11/RelValTTbar_13/MINIAODSIM/81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55-v1/00000/7836FEC5-6C74-E611-97C0-0CC47A745250.root'
 
 # Define the input source
 process.source = cms.Source("PoolSource", 

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -27,7 +27,7 @@ process.maxEvents = cms.untracked.PSet(
 
 #configurable options =======================================================================
 runOnData=False #data/MC switch
-usePrivateSQlite=False #use external JECs (sqlite file)
+usePrivateSQlite=True #use external JECs (sqlite file)
 useHFCandidates=True #create an additionnal NoHF slimmed MET collection if the option is set to false
 redoPuppi=True # rebuild puppiMET
 #===================================================================
@@ -45,16 +45,22 @@ if runOnData:
 else:
   process.GlobalTag.globaltag = autoCond['run2_mc']
 
+
+#Summer16_25nsV1_MC.db
+
 if usePrivateSQlite:
     from CondCore.DBCommon.CondDBSetup_cfi import *
     import os
     if runOnData:
       era="Summer15_25nsV6_DATA"
     else:
-      era="Summer15_25nsV6_MC"
+      era="Summer16_25nsV1_MC"
+
+    #process.jec.connect = cms.string('sqlite:'+era+'.db')
+    #connect = cms.string( "frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS"),
       
     process.jec = cms.ESSource("PoolDBESSource",CondDBSetup,
-                               connect = cms.string( "frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS"),
+                               connect = cms.string('sqlite:'+era+'.db'),
                                toGet =  cms.VPSet(
             cms.PSet(
                 record = cms.string("JetCorrectionsRecord"),
@@ -71,13 +77,12 @@ if usePrivateSQlite:
     process.es_prefer_jec = cms.ESPrefer("PoolDBESSource",'jec')
 
 
-
 ### =====================================================================================================
 # Define the input source
 if runOnData:
   fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre11/DoubleEG/MINIAOD/81X_dataRun2_relval_v6_resub_RelVal_doubEG2015D-v1/00000/1CF62687-8374-E611-A98B-0025905A6090.root'
 else:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre11/RelValTTbar_13/MINIAODSIM/81X_mcRun2_asymptotic_Candidate_2016_08_30_11_31_55-v1/00000/7836FEC5-6C74-E611-97C0-0CC47A745250.root'
+  fname = '/store/relval/CMSSW_8_0_20/RelValZMM_13/MINIAODSIM/80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1/00000/64F9C946-C57A-E611-AA05-0CC47A74527A.root'
 
 # Define the input source
 process.source = cms.Source("PoolSource", 
@@ -133,7 +138,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     compressionLevel = cms.untracked.int32(4),
     compressionAlgorithm = cms.untracked.string('LZMA'),
     eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
-    outputCommands = cms.untracked.vstring( "keep *_slimmedMETs_*_RERUN",
+    outputCommands = cms.untracked.vstring( "keep *_slimmedMETs_*_*",
                                             "keep *_slimmedMETsNoHF_*_*",
                                             "keep *_patPFMet_*_*",
                                             "keep *_patPFMetT1_*_*",

--- a/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
+++ b/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py
@@ -27,7 +27,7 @@ process.maxEvents = cms.untracked.PSet(
 
 #configurable options =======================================================================
 runOnData=False #data/MC switch
-usePrivateSQlite=True #use external JECs (sqlite file)
+usePrivateSQlite=False #use external JECs (sqlite file)
 useHFCandidates=True #create an additionnal NoHF slimmed MET collection if the option is set to false
 redoPuppi=True # rebuild puppiMET
 #===================================================================
@@ -54,13 +54,11 @@ if usePrivateSQlite:
     if runOnData:
       era="Summer15_25nsV6_DATA"
     else:
-      era="Summer16_25nsV1_MC"
+      era="Summer15_25nsV6_MC"
 
-    #process.jec.connect = cms.string('sqlite:'+era+'.db')
-    #connect = cms.string( "frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS"),
-      
     process.jec = cms.ESSource("PoolDBESSource",CondDBSetup,
-                               connect = cms.string('sqlite:'+era+'.db'),
+                               connect = cms.string( "frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS"),
+                               #connect = cms.string('sqlite:'+era+'.db'),
                                toGet =  cms.VPSet(
             cms.PSet(
                 record = cms.string("JetCorrectionsRecord"),
@@ -80,7 +78,7 @@ if usePrivateSQlite:
 ### =====================================================================================================
 # Define the input source
 if runOnData:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_1_0_pre11/DoubleEG/MINIAOD/81X_dataRun2_relval_v6_resub_RelVal_doubEG2015D-v1/00000/1CF62687-8374-E611-A98B-0025905A6090.root'
+  fname = '/store/relval/CMSSW_8_0_20/MET/MINIAOD/80X_dataRun2_relval_Candidate_2016_09_02_10_27_40_RelVal_met2016B-v1/00000/2E6B9138-1C7A-E611-AE72-0025905A60DE.root' 
 else:
   fname = '/store/relval/CMSSW_8_0_20/RelValZMM_13/MINIAODSIM/80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1/00000/64F9C946-C57A-E611-AA05-0CC47A74527A.root'
 

--- a/PhysicsTools/PatAlgos/test/produceMETFromAOD.py
+++ b/PhysicsTools/PatAlgos/test/produceMETFromAOD.py
@@ -10,7 +10,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #configurable options =======================================================================
-runOnData=False #data/MC switch
 usePrivateSQlite=False #use external JECs (sqlite file)
 useHFCandidates=True #create an additionnal NoHF slimmed MET collection if the option is set to false
 redoPuppi=False # rebuild puppiMET
@@ -54,10 +53,7 @@ if usePrivateSQlite:
 
 ### =====================================================================================================
 # Define the input source
-if runOnData:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_0_0_pre4/SinglePhoton/MINIAOD/80X_dataRun2_v0_RelVal_sigPh2015D-v1/00000/600919D1-51AA-E511-8E4C-0025905B855C.root'
-else:
-  fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_0_3/RelValTTbar_13/MINIAODSIM/PU25ns_80X_mcRun2_asymptotic_2016_v3_gs7120p2NewGTv3-v1/00000/36E82F31-D6EF-E511-A22B-0025905B8574.root'
+fname = 'root://eoscms.cern.ch//store/relval/CMSSW_8_0_20/RelValTTbar_13/GEN-SIM-RECO/80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1/00000/1E399A96-C47A-E611-A718-0025905B8572.root'
 
 # Define the input source
 process.source = cms.Source("PoolSource", 
@@ -79,6 +75,8 @@ if not useHFCandidates:
 
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMETCorrectionsAndUncertainties
 
+process.load("PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff")
+process.load("PhysicsTools.PatAlgos.selectionLayer1.jetSelector_cfi")
 #default configuration for miniAOD reprocessing, change the isData flag to run on data
 #for a full met computation, remove the pfCandColl input
 runMETCorrectionsAndUncertainties(process,
@@ -112,9 +110,7 @@ if runOnData:
   runOnData( process )
 
 
-process.out.outputCommands = cms.untracked.vstring( "keep *_slimmedMETs_*_*",
-                                                    "keep *_slimmedMETsNoHF_*_*",
-                                                    "keep *_slimmedMETsPuppi_*_*",
+process.out.outputCommands = cms.untracked.vstring( "keep *_patPFMet*_*_*",
                                                     )
 process.out.fileName = cms.untracked.string('corMETMiniAOD.root')
   

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -559,6 +559,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if postfix=="NoHF":
                 getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
             if self._parameters["runOnData"].value:
+                from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams_Data
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
             if self._parameters["Puppi"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')
@@ -1404,9 +1405,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, jetColName).doAreaFastjet = True
             
             #puppi
-            #if "Puppi" in postfix:
-            #    getattr(process, jetColName).doAreaFastjet = cms.bool(True)
-            #    getattr(process, jetColName).src = cms.InputTag("puppiNoLep")
+            if self._parameters["Puppi"].value:
+                getattr(process, jetColName).src = cms.InputTag("puppi")
 
             patMetModuleSequence += getattr(process, jetColName)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1292,7 +1292,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
     def extractMET(self, process, correctionLevel, patMetModuleSequence, postfix):
         pfMet = cms.EDProducer("RecoMETExtractor",
-                               metSource= cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess()),
+                               metSource= cms.InputTag("slimmedMETs" if not self_.parameters["Puppi"].value else "slimmedMETsPuppi",processName=cms.InputTag.skipCurrentProcess()),
                                correctionLevel = cms.string(correctionLevel)
                                )
         if(correctionLevel=="raw"):

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -314,6 +314,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if onMiniAOD:
             if not reclusterJets and reapplyJEC:
                 jetCollectionUnskimmed = self.updateJECs(process, jetCollectionUnskimmed, patMetModuleSequence, postfix)
+                    
 
         #getting the jet collection that will be used for corrections 
         #and uncertainty computation
@@ -323,6 +324,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                             autoJetCleaning,
                                                             patMetModuleSequence,
                                                             postfix)
+
+        #pre-preparation to run over miniAOD 
+        if onMiniAOD:
+            self.miniAODConfigurationPre(process, patMetModuleSequence, postfix)
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
@@ -557,7 +562,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
             if self._parameters["Puppi"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')
-                getattr(process, "pat"+metType+"Met"+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
+                getattr(process, "pat"+metType+"Met"+postfix).srcJets = cms.InputTag('cleanedPatJets'+postfix)
                 getattr(process, "pat"+metType+"Met"+postfix).srcJetSF = cms.string('AK4PFPuppi')
                 getattr(process, "pat"+metType+"Met"+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
                 getattr(process, "pat"+metType+"Met"+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
@@ -1265,7 +1270,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"patMETCorrections"), postfix)
                   
             #T1 pfMet for AOD to mAOD only
-            if not onMiniAOD or self._parameters["Puppi"].value:
+            if not onMiniAOD: #or self._parameters["Puppi"].value:
                 #correction duplication needed
                 getattr(process, "pfMetT1"+postfix).src = cms.InputTag("pfMet"+postfix)
                 patMetModuleSequence += getattr(process, "pfMetT1"+postfix)
@@ -1278,7 +1283,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
                 if self._parameters["Puppi"].value:
                     getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
-                    getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('selectedPatJets'+postfix)
+                    getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('cleanedPatJets'+postfix)
                     getattr(process, 'patMETs'+postfix).srcJetSF = cms.string('AK4PFPuppi')
                     getattr(process, 'patMETs'+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
                     getattr(process, 'patMETs'+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
@@ -1385,6 +1390,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             
             if not hasattr(process, "pfCHS"+postfix):
                 setattr(process,"pfCHS"+postfix,pfCHS)
+                patMetModuleSequence += getattr(process, "pfCHS"+postfix)
             pfCandColl = cms.InputTag("pfCHS"+postfix)
                    
 
@@ -1430,10 +1436,23 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"patJetCorrFactors"+postfix).primaryVertices= cms.InputTag("offlineSlimmedPrimaryVertices")
             if self._parameters["Puppi"].value:
                 getattr(process,"patJetCorrFactors"+postfix).payload=cms.string('AK4PFPuppi')
+            patMetModuleSequence += getattr(process, "patJetCorrFactors"+postfix)
+            patMetModuleSequence += getattr(process, "patJets"+postfix)
 
         return cms.InputTag("patJets"+postfix)
         
 
+
+    def miniAODConfigurationPre(self, process, patMetModuleSequence, postfix):
+        
+            #extractor for caloMET === temporary for the beginning of the data taking
+            self.extractMET(process,"rawCalo",patMetModuleSequence,postfix)
+            from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+            addMETCollection(process,
+                             labelName = "patCaloMet",
+                             metSource = "metrawCalo"+postfix if not self._parameters["Puppi"].value else "metrawCalo" 
+                             )
+            getattr(process,"patCaloMet").addGenMET = False
 
     def miniAODConfigurationPost(self, process, postfix):
 
@@ -1487,14 +1506,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"slimmedMETs"+postfix).runningOnMiniAOD = True
             getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess())
          
-            #extractor for caloMET === temporary for the beginning of the data taking
-            self.extractMET(process,"rawCalo",patMetModuleSequence,postfix)
-            from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
-            addMETCollection(process,
-                             labelName = "patCaloMet",
-                             metSource = "metrawCalo"+postfix
-                             )
-            getattr(process,"patCaloMet").addGenMET = False
 
             #smearing and type0 variations not yet supported in reprocessing
             #del getattr(process,"slimmedMETs"+postfix).t1SmearedVarsAndUncs

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -34,7 +34,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.addParameter(self._defaultParameters, 'electronCollection', cms.InputTag('selectedPatElectrons'),
 	                  "Input electron collection", Type=cms.InputTag, acceptNoneValue=True)
 #  empty default InputTag for photons to avoid double-counting wrt. cleanPatElectrons collection
-	self.addParameter(self._defaultParameters, 'photonCollection', None,
+	self.addParameter(self._defaultParameters, 'photonCollection', cms.InputTag('selectedPatPhotons'),
 	                  "Input photon collection", Type=cms.InputTag, acceptNoneValue=True)
 	self.addParameter(self._defaultParameters, 'muonCollection', cms.InputTag('selectedPatMuons'),
                           "Input muon collection", Type=cms.InputTag, acceptNoneValue=True)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1292,7 +1292,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
     def extractMET(self, process, correctionLevel, patMetModuleSequence, postfix):
         pfMet = cms.EDProducer("RecoMETExtractor",
-                               metSource= cms.InputTag("slimmedMETs" if not self_.parameters["Puppi"].value else "slimmedMETsPuppi",processName=cms.InputTag.skipCurrentProcess()),
+                               metSource= cms.InputTag("slimmedMETs" if not self._parameters["Puppi"].value else "slimmedMETsPuppi",processName=cms.InputTag.skipCurrentProcess()),
                                correctionLevel = cms.string(correctionLevel)
                                )
         if(correctionLevel=="raw"):
@@ -1314,7 +1314,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
         
         patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
-            src = cms.InputTag("slimmedJets"),
+            src = cms.InputTag("slimmedJets" if not self._parameters["Puppi"].value else "slimmedJetsPuppi"),
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
@@ -1325,10 +1325,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
         patJetsReapplyJEC = updatedPatJets.clone(
-            jetSource = cms.InputTag("slimmedJets"),
+            jetSource = cms.InputTag("slimmedJets" if not self._parameters["Puppi"].value else "slimmedJetsPuppi"),
             jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"+postfix))
             )
-        
+
         setattr(process,"patJetCorrFactorsReapplyJEC"+postfix,patJetCorrFactorsReapplyJEC)
         setattr(process,"patJetsReapplyJEC"+postfix,patJetsReapplyJEC.clone())
         patMetModuleSequence += getattr(process,"patJetCorrFactorsReapplyJEC"+postfix)
@@ -1504,7 +1504,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process,"slimmedMETs"+postfix).tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxy"+postfix)
 
             getattr(process,"slimmedMETs"+postfix).runningOnMiniAOD = True
-            getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess())
+            getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs" if not self._parameters["Puppi"].value else "slimmedMETsPuppi",processName=cms.InputTag.skipCurrentProcess())
          
 
             #smearing and type0 variations not yet supported in reprocessing

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -215,6 +215,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('addToPatDefaultSequence',addToPatDefaultSequence),
         self.setParameter('jetSelection',jetSelection),
         self.setParameter('recoMetFromPFCs',recoMetFromPFCs),
+        self.setParameter('reapplyJEC',reapplyJEC),
         self.setParameter('runOnData',runOnData),
         self.setParameter('onMiniAOD',onMiniAOD),
         self.setParameter('postfix',postfix),
@@ -309,7 +310,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if reclusterJets:
             jetCollectionUnskimmed = self.ak4JetReclustering(process, pfCandCollection, 
                                                              patMetModuleSequence, postfix)
-
+        
         # or reapplication of jecs
         if onMiniAOD:
             if not reclusterJets and reapplyJEC:
@@ -558,7 +559,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
-            getattr(process, "pat"+metType+"Met"+postfix).srcPFCands =  cms.InputTag("packedPFCandidates")
+            getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
             if postfix=="NoHF":
                 getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
             if self._parameters["runOnData"].value:
@@ -1720,6 +1721,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                jetCorLabelRes="ak4PFCHSL1FastL2L3ResidualCorrector",
 ##                               jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",
                                CHS=False,
+                               reapplyJEC=True,
                                jecUncFile="",
                                postfix=""):
 
@@ -1739,6 +1741,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       runOnData=isData,
                                       onMiniAOD=True,
+                                      reapplyJEC=reapplyJEC,
                                       reclusterJets=reclusterJets,
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,
@@ -1766,6 +1769,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       runOnData=isData,
                                       onMiniAOD=True,
+                                      reapplyJEC=reapplyJEC,
                                       reclusterJets=reclusterJets,
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,
@@ -1792,6 +1796,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       pfCandCollection =pfCandColl,
                                       runOnData=isData,
                                       onMiniAOD=True,
+                                      reapplyJEC=reapplyJEC,
                                       reclusterJets=reclusterJets,
                                       jetSelection=jetSelection,
                                       recoMetFromPFCs=recoMetFromPFCs,

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -369,7 +369,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         patMetUncertaintySequence = cms.Sequence()
         tmpUncSequence =cms.Sequence()
         if not hasattr(process, "patMetUncertaintySequence"+postfix):
-            patMetUncertaintySequence=cms.Sequence(getattr(process, "ak4PFCHSL1FastL2L3CorrectorChain")+getattr(process, "ak4PFCHSL1FastL2L3ResidualCorrectorChain"))
+            if self._parameters["Puppi"].value:
+                patMetUncertaintySequence=cms.Sequence(getattr(process, "ak4PFPuppiL1FastL2L3CorrectorChain")+getattr(process, "ak4PFPuppiL1FastL2L3ResidualCorrectorChain"))
+            else:
+                patMetUncertaintySequence=cms.Sequence(getattr(process, "ak4PFCHSL1FastL2L3CorrectorChain")+getattr(process, "ak4PFCHSL1FastL2L3ResidualCorrectorChain"))
         patShiftedModuleSequence = cms.Sequence()
         if computeUncertainties:
             tmpUncSequence,patShiftedModuleSequence =  self.getMETUncertainties(process, metType, metModName,
@@ -588,7 +591,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabel = cms.InputTag("ak4PFPuppiL1FastL2L3Corrector")
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabelRes = cms.InputTag("ak4PFPuppiL1FastL2L3ResidualCorrector")
             getattr(process, "corrPfMetType1"+postfix).offsetCorrLabel = cms.InputTag("ak4PFPuppiL1FastjetCorrector")
-            getattr(process, "basicJetsForMet"+postfix).offsetCorrLabel = cms.InputTag("ak4PFPuppiL1FastjetCorrector")
+            getattr(process, "basicJetsForMet"+postfix).offsetCorrLabel = cms.InputTag("L1FastJet")
 
         if "T1" in correctionLevel and self._parameters["CHS"].value and self._parameters["reclusterJets"].value:
             getattr(process, "corrPfMetType1"+postfix).src =  cms.InputTag("ak4PFJetsCHS"+postfix)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -768,7 +768,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #photon projection ==
             pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
-                                              veto = tauCollection
+                                              veto = photonCollection
                                               )
             setattr(process, "pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -39,7 +39,7 @@ namespace metsig {
 
          reco::METCovMatrix getCovariance(const edm::View<reco::Jet>& jets,
 					  const std::vector< edm::Handle<reco::CandidateView> >& leptons,
-					  const edm::View<reco::Candidate>& pfCandidates,
+					  const edm::Handle<edm::View<reco::Candidate> >& pfCandidates,
 					  double rho,
 					  JME::JetResolution & resPtObj,
 					  JME::JetResolution & resPhiObj,

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -58,9 +58,10 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
          lep_i != leptons.end(); ++lep_i ) {
       for( reco::CandidateView::const_iterator lep = (*lep_i)->begin(); lep != (*lep_i)->end(); lep++ ){
          if( lep->pt() > 10 ){
-            for( unsigned int n=0; n < lep->numberOfSourceCandidatePtrs(); n++ ){
-               if( lep->sourceCandidatePtr(n).isNonnull() and lep->sourceCandidatePtr(n).isAvailable() ){
-                  footprint.push_back(lep->sourceCandidatePtr(n));
+	   for( unsigned int n=0; n < lep->numberOfSourceCandidatePtrs(); n++ ){
+	     if( lep->sourceCandidatePtr(n).isNonnull() and lep->sourceCandidatePtr(n).isAvailable() ){
+	       footprint.push_back(lep->sourceCandidatePtr(n));
+	       
                } 
             }
          }
@@ -73,7 +74,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
       if(!cleanJet(*jet, leptons) ) continue;
 
       for( unsigned int n=0; n < jet->numberOfSourceCandidatePtrs(); n++){
-         if( jet->sourceCandidatePtr(n).isNonnull() and jet->sourceCandidatePtr(n).isAvailable() ){
+	if( jet->sourceCandidatePtr(n).isNonnull() and jet->sourceCandidatePtr(n).isAvailable() ){
             footprint.push_back(jet->sourceCandidatePtr(n));
          }
       }
@@ -88,13 +89,15 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
       // check if candidate exists in a lepton or jet
       bool cleancand = true;
       for(unsigned int i=0; i < footprint.size(); i++){
-         if( footprint[i]->p4() == cand->p4() ){
+
+	if( (footprint[i]->p4()-cand->p4()).Rho()<0.001 ){
             cleancand = false;
+	    break;
          }
       }
       // if not, add to sumPt
       if( cleancand ){
-         sumPt += cand->pt();
+	sumPt += cand->pt();
       }
 
    }
@@ -147,7 +150,6 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
       }
 
    }
-
 
    //protection against unphysical events
    if(sumPt<0) sumPt=0;

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -39,12 +39,15 @@ metsig::METSignificance::~METSignificance() {
 reco::METCovMatrix
 metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 				       const std::vector< edm::Handle<reco::CandidateView> >& leptons,
-				       const edm::Handle<edm::View<reco::Candidate> >& pfCandidates,
+				       const edm::Handle<edm::View<reco::Candidate> >& pfCandidatesH,
 				       double rho,
 				       JME::JetResolution& resPtObj,
 				       JME::JetResolution& resPhiObj,
 				       JME::JetResolutionScaleFactor& resSFObj,
 				       bool isRealData) {
+
+  //pfcandidates
+  const edm::View<reco::Candidate>* pfCandidates=pfCandidatesH.product();
 
    // metsig covariance
    double cov_xx = 0;

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -82,7 +82,6 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 
    // calculate sumPt
    double sumPt = 0;
-   int nFootPrint=0, nCand=0;
    for(size_t i = 0; i< pfCandidates->size();  ++i) {
      
      // check if candidate exists in a lepton or jet
@@ -93,21 +92,16 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
        for( std::set<reco::CandidatePtr>::const_iterator it=footprint.begin();it!=footprint.end();it++) {
 	 if( ((*it)->p4()-(*pfCandidates)[i].p4()).Rho()<0.005 ){
 	   cleancand = false;
-	   nFootPrint++;
 	   break;
 	 }
        }
        // if not, add to sumPt
        if( cleancand ){
 	 sumPt += (*pfCandidates)[i].pt();
-	 nCand++;
        }
      }
-     else {
-       nFootPrint++;
-     }
    }
-   //std::cout<<" pfcands "<<sumPt<<" / nCands "<<nCand<<" / nFootPrint "<<nFootPrint<<" / total "<<pfCandidates->size()<<std::endl;
+   
    // add jets to metsig covariance matrix and subtract them from sumPt
    for(edm::View<reco::Jet>::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
      

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -1,3 +1,4 @@
+
 // -*- C++ -*-
 //
 // Package:    METAlgorithms
@@ -90,7 +91,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 
        //dP4 recovery
        for( std::set<reco::CandidatePtr>::const_iterator it=footprint.begin();it!=footprint.end();it++) {
-	 if( ((*it)->p4()-(*pfCandidates)[i].p4()).Rho()<0.005 ){
+	 if( ((*it)->p4()-(*pfCandidates)[i].p4()).Et2()<0.000025 ){
 	   cleancand = false;
 	   break;
 	 }

--- a/RecoMET/METProducers/interface/PFMETProducer.h
+++ b/RecoMET/METProducers/interface/PFMETProducer.h
@@ -67,7 +67,7 @@ namespace cms
     private:
 
       reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup&, 
-					 const edm::View<reco::Candidate>& input) const;
+					 const edm::Handle<edm::View<reco::Candidate> >& input) const;
 
 
       edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -89,7 +89,7 @@ namespace cms
    //
    // compute the significance
    //
-   const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, *pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
+   const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
    double sig  = metSigAlgo_->getSignificance(cov, met);
 
    auto significance = std::make_unique<double>();

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -58,7 +58,7 @@ namespace cms
 
     if(calculateSignificance_)
       {
-	reco::METCovMatrix sigcov = getMETCovMatrix(event, setup, *input);
+	reco::METCovMatrix sigcov = getMETCovMatrix(event, setup, input);
 	pfmet.setSignificanceMatrix(sigcov);
       }
 
@@ -70,7 +70,7 @@ namespace cms
 
 
 
-  reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& setup, const edm::View<reco::Candidate>& candInput) const {
+  reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& setup, const edm::Handle<edm::View<reco::Candidate> >& candInput) const {
 
 	// leptons
 	std::vector< edm::Handle<reco::CandidateView> > leptons;


### PR DESCRIPTION
This PR improves the coherence between what is done for Puppi MET and the MET significance calculation at the miniAOD production level and recomputation on top of miniAODs.

Packages touched : 
- PhysicsTools/PatAlgos
- PhysicsTools/PatUtils
- RecoMET/METAlgorithms
- RecoMET/METProducers

Changes : 
- fix scheduled mode (do not affect unscheduled mode)
- change the constructor of MET in the RecoMET extractor to copy properly the sumET from the slimmedMET collection when updating a miniAOD
- MET significance computation at the AOD level updated to match the miniAOD level
- Update of the test cfg files
- fix the puppi JEC and the use of slimmedJetPuppi when recomputing the puppiMET from miniAOD
- modify the MET signifiance code to match by reference the pfCandidates to the jets/lepton constituents + use of an extra recovery by delta"4Vector" matching when reference matching is failing

Expected changes in data file contents :
- small changes in the mET signifiance when producing miniAOD
- puppi MET values when rerunning on miniAOD
- storage of the sumEt when recomputing MET on top of miniAOD
