### PR TITLE
Feature Bits for 2017 HCAL HF TP

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
@@ -2,14 +2,28 @@
 #define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included 1
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDigi/interface/HFDataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 
 class HcalFeatureBit {
 	public:
 		HcalFeatureBit(){}
 		virtual ~HcalFeatureBit(){} //the virutal function is responcible for applying a cut based on a linear relationship of the energy
         //deposited in the short vers long fibers.
-		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const {return false;}
-		
+      virtual bool fineGrainbit(
+            const QIE10DataFrame& short1,
+            const QIE10DataFrame& short2,
+            const QIE10DataFrame& long1,
+            const QIE10DataFrame& long2,
+            bool validShort1,
+            bool validShort2,
+            bool validLong1,
+            bool validLong2,
+            int idx) const = 0;
+      virtual bool fineGrainbit(
+            const HFDataFrame& shortDigi,
+            const HFDataFrame& longDigi,
+            int idx) const = 0;
 };
 #endif
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -1,18 +1,20 @@
 #ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included
 #define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included 1
 
-
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
 class HcalFeatureHFEMBit : public HcalFeatureBit {
-public:    
-    HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
-    ~HcalFeatureHFEMBit();
-    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy 
-    //depoisted in the long and short fibers
-private:
-    double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
-    const HcalDbService& conditions_;
+   public:
+      HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
+      ~HcalFeatureHFEMBit();
+
+      // Provides FG bit based on energy cuts in long & short fibers.
+      virtual bool fineGrainbit(const HFDataFrame& shortDigi, const HFDataFrame& longDigi, int idx) const;
+   private:
+      float getE(const HFDataFrame& f, int idx) const;
+
+      double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
+      const HcalDbService& conditions_;
 };
 #endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -3,6 +3,7 @@
 
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 
 class HcalFeatureHFEMBit : public HcalFeatureBit {
    public:
@@ -10,11 +11,45 @@ class HcalFeatureHFEMBit : public HcalFeatureBit {
       ~HcalFeatureHFEMBit();
 
       // Provides FG bit based on energy cuts in long & short fibers.
-      virtual bool fineGrainbit(const HFDataFrame& shortDigi, const HFDataFrame& longDigi, int idx) const;
+      virtual bool fineGrainbit(
+            const QIE10DataFrame& short1,
+            const QIE10DataFrame& short2,
+            const QIE10DataFrame& long1,
+            const QIE10DataFrame& long2,
+            bool validShort1,
+            bool validShort2,
+            bool validLong1,
+            bool validLong2,
+            int idx) const override;
+      virtual bool fineGrainbit(
+            const HFDataFrame& shortDigi,
+            const HFDataFrame& longDigi,
+            int idx) const override;
    private:
-      float getE(const HFDataFrame& f, int idx) const;
+      template<typename T>
+      float getE(const T& f, int idx) const;
 
       double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
       const HcalDbService& conditions_;
 };
+
+template<typename T>
+float
+HcalFeatureHFEMBit::getE(const T& f, int idx) const
+{
+   const HcalDetId id(f.id());
+   const HcalCalibrations& calibrations = conditions_.getHcalCalibrations(id);
+   const auto* coder = conditions_.getHcalCoder(id);
+   const auto* shape = conditions_.getHcalShape(coder);
+
+   HcalCoderDb db(*coder, *shape);
+   CaloSamples samples;
+   db.adc2fC(f, samples);
+
+   auto ped = calibrations.pedestal(f[idx].capid());
+   auto corr = calibrations.respcorrgain(f[idx].capid());
+
+   return (samples[idx] - ped) * corr;
+}
+
 #endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -24,13 +24,6 @@ class IntegerCaloSamples;
 
 class HcalTriggerPrimitiveAlgo {
 public:
-   struct TPParameters {
-      uint32_t hbhe_fg_version;
-      uint64_t hf_tdc_mask;
-      uint32_t hf_adc_threshold;
-      uint32_t hf_fg_threshold;
-   };
-
   HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, int latency,
                            uint32_t FG_threshold, uint32_t FG_HF_threshold, uint32_t ZS_threshold,
                            int numberOfSamples,   int numberOfPresamples,
@@ -77,10 +70,7 @@ public:
   void setRCTScaleShift(int);
 
   void setUpgradeFlags(bool hb, bool he, bool hf);
-  void overrideParameters(unsigned int hbhe_fg_version,
-                          unsigned int hf_tdc_mask,
-                          unsigned int hf_adc_threshold,
-                          unsigned int hf_fg_threshold);
+  void overrideParameters(const edm::ParameterSet& ps) { override_parameters_ = ps; };
 
  private:
 
@@ -196,7 +186,7 @@ public:
   bool upgrade_he_ = false;
   bool upgrade_hf_ = false;
 
-  std::unique_ptr<const TPParameters> override_parameters_;
+  edm::ParameterSet override_parameters_;
 
   static const int HBHE_OVERLAP_TOWER = 16;
   static const int LAST_FINEGRAIN_DEPTH = 6;
@@ -237,8 +227,8 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
 
    // Prepare the fine-grain calculation algorithm for HB/HE
    int version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
-   if (override_parameters_)
-      version = override_parameters_->hbhe_fg_version;
+   if (override_parameters_.exists("FGVersionHBHE"))
+      version = override_parameters_.getParameter<uint32_t>("FGVersionHBHE");
    HcalFinegrainBit fg_algo(version);
 
    // VME produces additional bits on the front used by lumi but not the

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -226,7 +226,9 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    addDigis(digis...);
 
    // Prepare the fine-grain calculation algorithm for HB/HE
-   int version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
+   int version = 0;
+   if (upgrade_he_ or upgrade_hb_)
+      version = conditions_->getHcalTPParameters()->getFGVersionHBHE();
    if (override_parameters_.exists("FGVersionHBHE"))
       version = override_parameters_.getParameter<uint32_t>("FGVersionHBHE");
    HcalFinegrainBit fg_algo(version);

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -189,9 +189,13 @@ public:
 
   edm::ParameterSet override_parameters_;
 
+  // HE constants
   static const int HBHE_OVERLAP_TOWER = 16;
   static const int LAST_FINEGRAIN_DEPTH = 6;
   static const int LAST_FINEGRAIN_TOWER = 28;
+
+  // Fine-grain in HF ignores tower 29, and starts with 30
+  static const int FIRST_FINEGRAIN_TOWER = 30;
 
   static const int QIE8_LINEARIZATION_ET = HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
   static const int QIE10_LINEARIZATION_ET = HcaluLUTTPGCoder::QIE10_LUT_BITMASK;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -154,6 +154,7 @@ public:
   struct HFUpgradeDetails {
      IntegerCaloSamples samples;
      QIE10DataFrame digi;
+     std::vector<bool> validity;
   };
   typedef std::map<HcalTrigTowerDetId, std::map<uint32_t, std::array<HFUpgradeDetails, 4>>> HFUpgradeDetailMap;
   HFUpgradeDetailMap theHFUpgradeDetailMap;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -70,7 +70,7 @@ public:
   void setRCTScaleShift(int);
 
   void setUpgradeFlags(bool hb, bool he, bool hf);
-  void overrideParameters(const edm::ParameterSet& ps) { override_parameters_ = ps; };
+  void overrideParameters(const edm::ParameterSet& ps);
 
  private:
 
@@ -188,6 +188,11 @@ public:
   bool upgrade_hf_ = false;
 
   edm::ParameterSet override_parameters_;
+
+  bool override_adc_hf_ = false;
+  uint32_t override_adc_hf_value_;
+  bool override_tdc_hf_ = false;
+  unsigned long long override_tdc_hf_value_;
 
   // HE constants
   static const int HBHE_OVERLAP_TOWER = 16;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -521,7 +521,7 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
    if (override_parameters_.exists("ADCThresholdHF"))
       adc_threshold = override_parameters_.getParameter<uint32_t>("ADCThresholdHF");
    if (override_parameters_.exists("TDCMaskHF"))
-      adc_threshold = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
+      tdc_mask = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
 
    if (digi[ts].adc() < adc_threshold)
       return true;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -526,7 +526,7 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
    if (digi[ts].adc() < adc_threshold)
       return true;
 
-   return (1ul << (digi[ts].le_tdc() - 1)) & tdc_mask;
+   return (1ul << digi[ts].le_tdc()) & tdc_mask;
 }
 
 void HcalTriggerPrimitiveAlgo::analyzeHF2017(

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -1,16 +1,22 @@
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
+#include "CondFormats/HcalObjects/interface/HcalTPParameters.h"
+#include "CondFormats/HcalObjects/interface/HcalTPChannelParameters.h"
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
-#include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
+
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
-#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"//cuts based on short and long energy deposited.
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 #include <iostream>
+
 using namespace std;
 
 HcalTriggerPrimitiveAlgo::HcalTriggerPrimitiveAlgo( bool pf, const std::vector<double>& w, int latency,
@@ -57,11 +63,13 @@ HcalTriggerPrimitiveAlgo::setUpgradeFlags(bool hb, bool he, bool hf)
 
 
 void
-HcalTriggerPrimitiveAlgo::overrideParameters(unsigned int hf_tdc_mask,
+HcalTriggerPrimitiveAlgo::overrideParameters(unsigned int hbhe_fg_version,
+                                             unsigned int hf_tdc_mask,
                                              unsigned int hf_adc_threshold,
                                              unsigned int hf_fg_threshold)
 {
    auto parameters = new TPParameters();
+   parameters->hbhe_fg_version = hbhe_fg_version;
    parameters->hf_tdc_mask = hf_tdc_mask;
    parameters->hf_adc_threshold = hf_adc_threshold;
    parameters->hf_fg_threshold = hf_fg_threshold;
@@ -513,6 +521,28 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2016(
     
 }
 
+bool
+HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
+{
+   auto mask = conditions_->getHcalTPChannelParameter(HcalDetId(digi.id()))->getMask();
+   if (mask)
+      return false;
+
+   auto parameters = conditions_->getHcalTPParameters();
+   auto adc_threshold = parameters->getADCThresholdHF();
+   auto tdc_mask = parameters->getTDCMaskHF();
+
+   if (override_parameters_) {
+      adc_threshold = override_parameters_->hf_adc_threshold;
+      tdc_mask = override_parameters_->hf_tdc_mask;
+   }
+
+   if (digi[ts].adc() < adc_threshold)
+      return true;
+
+   return (1ul << (digi[ts].le_tdc() - 1)) & tdc_mask;
+}
+
 void HcalTriggerPrimitiveAlgo::analyzeHF2017(
         const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result,
         const int hf_lumi_shift, const HcalFeatureBit* hcalfem)
@@ -550,8 +580,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
 
             for (auto i: {0, 2}) {
                if (idx < details[i].samples.size()) {
-                  if ((unsigned int) details[i].digi[idx].adc() < override_parameters_->hf_adc_threshold
-                        or (1ul << (details[i].digi[idx].le_tdc() - 1)) & override_parameters_->hf_tdc_mask) {
+                  if (validChannel(details[i].digi, idx)) {
                      long_fiber_val += details[i].samples[idx];
                      saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
                      ++long_fiber_count;
@@ -560,8 +589,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             }
             for (auto i: {1, 3}) {
                if (idx < details[i].samples.size()) {
-                  if ((unsigned int) details[i].digi[idx].adc() < override_parameters_->hf_adc_threshold
-                        or (1ul << (details[i].digi[idx].le_tdc() - 1)) & override_parameters_->hf_tdc_mask) {
+                  if (validChannel(details[i].digi, idx)) {
                      short_fiber_val += details[i].samples[idx];
                      saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
                      ++short_fiber_count;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -202,6 +202,9 @@ HcalTriggerPrimitiveAlgo::addSignal(const QIE10DataFrame& frame)
       auto& details = theHFUpgradeDetailMap[id][fid.maskDepth()];
       details[fid.depth() - 1].samples = samples;
       details[fid.depth() - 1].digi = frame;
+      details[fid.depth() - 1].validity.resize(frame.samples());
+      for (int idx = 0; idx < frame.samples(); ++idx)
+         details[fid.depth() - 1].validity[idx] = validChannel(frame, idx);
    }
 }
 
@@ -565,21 +568,17 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             bool saturated = false;
 
             for (auto i: {0, 2}) {
-               if (idx < details[i].samples.size()) {
-                  if (validChannel(details[i].digi, idx)) {
-                     long_fiber_val += details[i].samples[idx];
-                     saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
-                     ++long_fiber_count;
-                  }
+               if (idx < details[i].samples.size() and details[i].validity[idx]) {
+                  long_fiber_val += details[i].samples[idx];
+                  saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
+                  ++long_fiber_count;
                }
             }
             for (auto i: {1, 3}) {
-               if (idx < details[i].samples.size()) {
-                  if (validChannel(details[i].digi, idx)) {
-                     short_fiber_val += details[i].samples[idx];
-                     saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
-                     ++short_fiber_count;
-                  }
+               if (idx < details[i].samples.size() and details[i].validity[idx]) {
+                  short_fiber_val += details[i].samples[idx];
+                  saturated = saturated || (details[i].samples[idx] == QIE10_LINEARIZATION_ET);
+                  ++short_fiber_count;
                }
             }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -64,6 +64,22 @@ HcalTriggerPrimitiveAlgo::setUpgradeFlags(bool hb, bool he, bool hf)
 }
 
 
+void
+HcalTriggerPrimitiveAlgo::overrideParameters(const edm::ParameterSet& ps)
+{
+   override_parameters_ = ps;
+
+   if (override_parameters_.exists("ADCThresholdHF")) {
+      override_adc_hf_ = true;
+      override_adc_hf_value_ = override_parameters_.getParameter<uint32_t>("ADCThresholdHF");
+   }
+   if (override_parameters_.exists("TDCMaskHF")) {
+      override_tdc_hf_ = true;
+      override_tdc_hf_value_ = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
+   }
+}
+
+
 void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame & frame) {
    // TODO: Need to add support for seperate 28, 29 in HE
    //Hack for 300_pre10, should be removed.
@@ -515,10 +531,10 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
    auto adc_threshold = parameters->getADCThresholdHF();
    auto tdc_mask = parameters->getTDCMaskHF();
 
-   if (override_parameters_.exists("ADCThresholdHF"))
-      adc_threshold = override_parameters_.getParameter<uint32_t>("ADCThresholdHF");
-   if (override_parameters_.exists("TDCMaskHF"))
-      tdc_mask = override_parameters_.getParameter<unsigned long long>("TDCMaskHF");
+   if (override_adc_hf_)
+      adc_threshold = override_adc_hf_value_;
+   if (override_tdc_hf_)
+      tdc_mask = override_tdc_hf_value_;
 
    if (digi[ts].adc() < adc_threshold)
       return true;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -486,10 +486,8 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2016(
             if (details.LongDigi.id().ietaAbs() != 29) {
                finegrain[ibin][1] = (ADCLong > FG_HF_threshold_ || ADCShort > FG_HF_threshold_);
 
-               if (HCALFEM != 0) {
-                  finegrain[ibin][0] = HCALFEM->fineGrainbit(details.ShortDigi, details.LongDigi, ibin)
-                  );
-               }
+               if (HCALFEM != 0)
+                  finegrain[ibin][0] = HCALFEM->fineGrainbit(details.ShortDigi, details.LongDigi, ibin);
             }
         }
     }
@@ -530,7 +528,7 @@ HcalTriggerPrimitiveAlgo::validChannel(const QIE10DataFrame& digi, int ts) const
 
 void HcalTriggerPrimitiveAlgo::analyzeHF2017(
         const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result,
-        const int hf_lumi_shift, const HcalFeatureBit* hcalfem)
+        const int hf_lumi_shift, const HcalFeatureBit* embit)
 {
     // Align digis and TP
     const int shift = samples.presamples() - numberOfPresamples_;
@@ -601,14 +599,15 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
                }
             }
 
-            // if (HCALFEM != 0) {
-            //    finegrain[ibin][0] = HCALFEM->fineGrainbit(
-            //          ADCShort, details.ShortDigi.id(),
-            //          details.ShortDigi[ibin].capid(),
-            //          ADCLong, details.LongDigi.id(),
-            //          details.LongDigi[ibin].capid()
-            //    );
-            // }
+            if (embit != 0) {
+               finegrain[ibin][0] = embit->fineGrainbit(
+                     details[1].digi, details[3].digi,
+                     details[0].digi, details[2].digi,
+                     details[1].validity[idx], details[3].validity[idx],
+                     details[0].validity[idx], details[2].validity[idx],
+                     idx
+               );
+            }
         }
     }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -487,11 +487,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2016(
                finegrain[ibin][1] = (ADCLong > FG_HF_threshold_ || ADCShort > FG_HF_threshold_);
 
                if (HCALFEM != 0) {
-                  finegrain[ibin][0] = HCALFEM->fineGrainbit(
-                        ADCShort, details.ShortDigi.id(),
-                        details.ShortDigi[ibin].capid(),
-                        ADCLong, details.LongDigi.id(),
-                        details.LongDigi[ibin].capid()
+                  finegrain[ibin][0] = HCALFEM->fineGrainbit(details.ShortDigi, details.LongDigi, ibin)
                   );
                }
             }

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -483,7 +483,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2016(
             uint32_t ADCLong = details.LongDigi[ibin].adc();
             uint32_t ADCShort = details.ShortDigi[ibin].adc();
 
-            if (details.LongDigi.id().ietaAbs() != 29) {
+            if (details.LongDigi.id().ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
                finegrain[ibin][1] = (ADCLong > FG_HF_threshold_ || ADCShort > FG_HF_threshold_);
 
                if (HCALFEM != 0)
@@ -594,7 +594,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             }
 
             for (const auto& detail: details) {
-               if (detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() != 29) {
+               if (detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
                   finegrain[ibin][1] = finegrain[ibin][1] or (detail.digi[idx].adc() > (int) FG_HF_threshold_);
                }
             }

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -29,14 +29,13 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     upgradeHB = cms.bool(False),
     upgradeHE = cms.bool(False),
 
-    parameters = cms.untracked.PSet(
-        TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
-        ADCThreshold=cms.uint32(0),
-        FGThreshold=cms.uint32(12)
-    ),
-    
-    
-#
+    # parameters = cms.untracked.PSet(
+    #     FGVersionHBHE=cms.uint32(0),
+    #     TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
+    #     ADCThreshold=cms.uint32(0),
+    #     FGThreshold=cms.uint32(12)
+    # ),
+
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo
     # Input digi label (_must_ be without zero-suppression!)
     inputLabel = cms.VInputTag(cms.InputTag('simHcalUnsuppressedDigis'),

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -52,10 +52,7 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    if (ps.exists("parameters")) {
       auto pset = ps.getUntrackedParameter<edm::ParameterSet>("parameters");
-      theAlgo_.overrideParameters(pset.getParameter<unsigned int>("FGVersionHBHE"),
-                                  pset.getParameter<unsigned long long>("TDCMask"),
-                                  pset.getParameter<unsigned int>("ADCThreshold"),
-                                  pset.getParameter<unsigned int>("FGThreshold"));
+      theAlgo_.overrideParameters(ps);
    }
    theAlgo_.setUpgradeFlags(upgrades[0], upgrades[1], upgrades[2]);
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -52,7 +52,8 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    if (ps.exists("parameters")) {
       auto pset = ps.getUntrackedParameter<edm::ParameterSet>("parameters");
-      theAlgo_.overrideParameters(pset.getParameter<unsigned long long>("TDCMask"),
+      theAlgo_.overrideParameters(pset.getParameter<unsigned int>("FGVersionHBHE"),
+                                  pset.getParameter<unsigned long long>("TDCMask"),
                                   pset.getParameter<unsigned int>("ADCThreshold"),
                                   pset.getParameter<unsigned int>("FGThreshold"));
    }
@@ -196,13 +197,13 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
   // Step C: Invoke the algorithm, passing in inputs and getting back outputs.
   if (legacy_ and not upgrade_) {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheDigis, *hfDigis);
   } else if (legacy_ and upgrade_) {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheDigis, *hfDigis, *hbheUpDigis, *hfUpDigis);
   } else {
-     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+     theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(), pSetup.product(),
            *result, &(*pG), rctlsb, hfembit, *hbheUpDigis, *hfUpDigis);
   }
 


### PR DESCRIPTION
Sits on top of #15945.
- Refactors the channel validity check to happen earlier
- Port of the 2016 MinBias feature bit
- Refactor the EM feature bit and hook it up to 2017 TP (if manually configured in the PSet)
