### PR TITLE
81x L1T - TEST - fix crash at endJob in test workflow 136.7321 

### DIFF
--- a/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
+++ b/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
@@ -61,7 +61,7 @@ class XMLConfigReader{
 			  unsigned int index=0,
 			  unsigned int aGPNumber=999);
   
-  xercesc::XercesDOMParser *parser;
+  std::unique_ptr<xercesc::XercesDOMParser> parser;
   xercesc::DOMDocument* doc;
 
   ///Cache with GPs read.

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -38,12 +38,11 @@ inline XMLCh*  _toDOMS(std::string temp) {
 }
 ////////////////////////////////////
 ////////////////////////////////////
-XMLConfigReader::XMLConfigReader(){
+XMLConfigReader::XMLConfigReader():parser(new xercesc::XercesDOMParser()) {
 
   XMLPlatformUtils::Initialize();
   
   ///Initialise XML parser  
-  parser = new XercesDOMParser(); 
   parser->setValidationScheme(XercesDOMParser::Val_Auto);
   parser->setDoNamespaces(false);
 
@@ -52,7 +51,6 @@ XMLConfigReader::XMLConfigReader(){
 
 XMLConfigReader::~XMLConfigReader()
 {
-  delete parser;
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -53,7 +53,6 @@ XMLConfigReader::XMLConfigReader(){
 XMLConfigReader::~XMLConfigReader()
 {
   delete parser;
-  XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////


### PR DESCRIPTION
This PR is to test only and help understand the reason for crash.

Fix crash in endJob of IB test job 136.7321 reported with CMSSW_8_1_X_2016-10-07-1100

The crash is reported to be in XmlConfigReader used by L1TMuonBarrelParamsESProducer.

<pre>
#5  0x00007fc8b8c83f6c in xercesc_3_1::IGXMLScanner::cleanUp (this=0x7fc8849fb408) at xercesc/internal/IGXMLScanner.cpp:559
#6  0x00007fc8b8c841d7 in xercesc_3_1::IGXMLScanner::~IGXMLScanner (this=0x7fc8849fb408, __in_chrg=<optimized out>) at xercesc/internal/IGXMLScanner.cpp:162
#7  0x00007fc8b8c84209 in xercesc_3_1::IGXMLScanner::~IGXMLScanner (this=0x7fc8849fb408, __in_chrg=<optimized out>) at xercesc/internal/IGXMLScanner.cpp:163
#8  0x00007fc8b8cce46f in xercesc_3_1::AbstractDOMParser::cleanUp (this=this@entry=0x7fc89d7ef268) at xercesc/parsers/AbstractDOMParser.cpp:160
#9  0x00007fc8b8cd27e2 in xercesc_3_1::AbstractDOMParser::~AbstractDOMParser (this=0x7fc89d7ef268, __in_chrg=<optimized out>) at xercesc/parsers/AbstractDOMParser.cpp:130
#10 0x00007fc8b8ce1419 in xercesc_3_1::XercesDOMParser::~XercesDOMParser (this=0x7fc89d7ef268, __in_chrg=<optimized out>) at xercesc/parsers/XercesDOMParser.cpp:66
#11 0x00007fc89d28d96a in l1t::XmlConfigReader::~XmlConfigReader() () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/libL1TriggerL1TCommon.so
#12 0x00007fc89d278117 in l1t::TrigSystem::~TrigSystem() () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/libL1TriggerL1TCommon.so
#13 0x00007fc88471eadf in L1TMuonBarrelParamsESProducer::~L1TMuonBarrelParamsESProducer() () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/pluginL1TriggerL1TMuonBarrelPlugins.so
</pre>


However, there is another XML reader, namely XMLConfigReader in L1TMuonOverlap, which was recently edited in PR #16088.

Making the following changes mitigates the crash in the workflow test job 136.7321
- Remove XMLPlatformUtils::Terminate() from destructor of OMTF XMLConfigReader.
