### PR TITLE
change the raw format for 48-chan feds, back to the old one

### DIFF
--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -32,9 +32,11 @@ namespace {
 
   // Add phase1 constants 
   // For phase1  
-  constexpr int LINK_bits1 = 7;
-  constexpr int ROC_bits1  = 4;
-  // Special for layer 1 bpix rocs 6/9/16 d.k.
+  //GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT 
+  // 28/9/16 d.k.
+  constexpr int LINK_bits1 = 6; // 7;
+  constexpr int ROC_bits1  = 5; // 4;
+  // Special for layer 1 bpix rocs 6/9/16 d.k. THIS STAYS.
   constexpr int COL_bits1_l1 = 6;
   constexpr int ROW_bits1_l1 = 7;
 


### PR DESCRIPTION
Change back phase1 raw-fed format to what is used for phase0. 
With 48-channel FEDs we do not need the new format.
Needs the new (post 8_1_0_pre12) phase1 MC GTs.  
