### PR TITLE
Fix trackingOnly workflows for phase2_hcal sub-era

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -76,6 +76,7 @@ globalreco_tracking = cms.Sequence(offlineBeamSpot*
                           siPixelClusterShapeCachePreSplitting* # unclear where to put this
                           standalonemuontracking*
                           trackingGlobalReco*
+                          hcalGlobalRecoSequence*
                           vertexreco)
 _globalreco_tracking_LowPU_Phase1PU70 = globalreco_tracking.copy()
 _globalreco_tracking_LowPU_Phase1PU70.replace(trackingGlobalReco, recopixelvertexing+trackingGlobalReco)
@@ -87,7 +88,6 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 trackingPhase2PU140.toReplaceWith(globalreco_tracking, _globalreco_tracking_LowPU_Phase1PU70)
 
 globalreco = cms.Sequence(globalreco_tracking*
-                          hcalGlobalRecoSequence*
                           particleFlowCluster*
                           ecalClusters*
                           caloTowersRec*                          


### PR DESCRIPTION
This PR suggests a fix to an exception in e.g. 20824.1 workflow RECO step (phase2 D3, "trackingOnly" workflow). 

It appears that for `phase2_hcal` sub-era, `offlinePrimaryVertices` depends (via `ak4CaloJetsForTrk` and `caloTowerForTrk`) `hbhereco`, which is in `hcalGlobalRecoSequence` (by default the dependence is on `hbheprereco`). But `hcalGlobalRecoSequence` is not included in `globalreco_tracking` that is run in "trackingOnly" workflows (it is in `globalreco` sequence right after `globalreco_tracking`).

Simplest fix (proposed here) is to move `hcalGlobalRecoSequence` inside `globalreco_tracking` just before `vertexreco`. Limited matrix works, so I'd expect the change to not do any harm.

Tested in CMSSW_8_1_X_2016-10-09-2300, no changes expected in monitored quantities. Workflow 20824.1 works again.

@rovere @VinInn @ebrondol @kpedro88 
