### PR TITLE
StaticAnalyzer: copy the bloom.bin filter to the correct location in the source tree

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -36,3 +36,4 @@ sort -u getparam-dumper.txt.unsorted | awk '{print $0"\n"}' >getparam-dumper.txt
 cat classes.txt.inherits classes.txt.dumperft classes.txt.dumperct | grep -e"^class" | grep -v \'\' | sort -u >classes.txt
 rm *.txt.*unsorted
 classname-blmflt.py
+cp -pv $LOCALRT/tmp/bloom.bin $LOCALRT/src/Utilities/StaticAnalyzers/scripts/bloom.bin


### PR DESCRIPTION
The bloom.bin filter for data class names in the source tree has not been updated since Jan 2015. The bloom.bin file generated by run_class_dumper.sh needs to be copied into the source tree so the static analyzer has the most up to date data class list. 
