### PR TITLE
Pr81x l1t  XmlConigReader with Rule of Three

### DIFF
--- a/L1Trigger/L1TCommon/interface/XmlConfigReader.h
+++ b/L1Trigger/L1TCommon/interface/XmlConfigReader.h
@@ -53,6 +53,13 @@ class XmlConfigReader {
   XmlConfigReader();
   XmlConfigReader(xercesc::DOMDocument* doc);
   ~XmlConfigReader();
+
+  XmlConfigReader(const XmlConfigReader &obj);
+
+  // assignment operator not needed, but provided respecting Rule of Three.
+  XmlConfigReader & operator= (XmlConfigReader obj);
+  void swap(XmlConfigReader &obj);
+
   void readDOMFromString(const std::string& str, xercesc::DOMDocument*& doc);
   void readDOMFromString(const std::string& str);
   void readDOMFromFile(const std::string& fName, xercesc::DOMDocument*& doc);

--- a/L1Trigger/L1TCommon/src/XmlConfigReader.cc
+++ b/L1Trigger/L1TCommon/src/XmlConfigReader.cc
@@ -151,6 +151,82 @@ XmlConfigReader::~XmlConfigReader()
   XMLPlatformUtils::Terminate();
 }
 
+XmlConfigReader::XmlConfigReader(const XmlConfigReader &obj) :
+  kTagHw          (obj.kTagHw),
+  kTagAlgo        (obj.kTagAlgo),
+  kTagRunSettings (obj.kTagRunSettings),
+  kTagDb          (obj.kTagDb),
+  kTagKey         (obj.kTagKey),
+  kTagLoad        (obj.kTagLoad),
+  kTagContext     (obj.kTagContext),
+  kTagParam       (obj.kTagParam),
+  kTagMask        (obj.kTagMask),
+  kTagDisable     (obj.kTagDisable),
+  kTagExclBoards  (obj.kTagExclBoards),
+  kTagExclude     (obj.kTagExclude),
+  kTagColumns     (obj.kTagColumns),
+  kTagTypes       (obj.kTagTypes),
+  kTagRow         (obj.kTagRow),
+  kTagProcessor   (obj.kTagProcessor),
+  kTagRole        (obj.kTagRole),
+  kTagCrate       (obj.kTagCrate),
+  kTagSlot        (obj.kTagSlot),
+  kTagDaqTtc      (obj.kTagDaqTtc),
+  kAttrId         (obj.kAttrId),
+  kAttrType       (obj.kAttrType),
+  kAttrDelim      (obj.kAttrDelim),
+  kAttrModule     (obj.kAttrModule),
+  kTypeTable      (obj.kTypeTable),
+  parser_         ( new XercesDOMParser()),
+  doc_            (obj.doc_)
+{
+  XMLPlatformUtils::Initialize();
+
+  parser_->setValidationScheme(XercesDOMParser::Val_Auto);
+  parser_->setDoNamespaces(false);
+
+}
+
+void XmlConfigReader::swap(XmlConfigReader & obj){
+ 
+  std::swap(kTagHw          , obj.kTagHw);
+  std::swap(kTagAlgo        , obj.kTagAlgo);
+  std::swap(kTagRunSettings , obj.kTagRunSettings);
+  std::swap(kTagDb          , obj.kTagDb);
+  std::swap(kTagKey         , obj.kTagKey);
+  std::swap(kTagLoad        , obj.kTagLoad);
+  std::swap(kTagContext     , obj.kTagContext);
+  std::swap(kTagParam       , obj.kTagParam);
+  std::swap(kTagMask        , obj.kTagMask);
+  std::swap(kTagDisable     , obj.kTagDisable);
+  std::swap(kTagExclBoards  , obj.kTagExclBoards);
+  std::swap(kTagExclude     , obj.kTagExclude);
+  std::swap(kTagColumns     , obj.kTagColumns);
+  std::swap(kTagTypes       , obj.kTagTypes);
+  std::swap(kTagRow         , obj.kTagRow);
+  std::swap(kTagProcessor   , obj.kTagProcessor);
+  std::swap(kTagRole        , obj.kTagRole);
+  std::swap(kTagCrate       , obj.kTagCrate);
+  std::swap(kTagSlot        , obj.kTagSlot);
+  std::swap(kTagDaqTtc      , obj.kTagDaqTtc);
+  std::swap(kAttrId         , obj.kAttrId);
+  std::swap(kAttrType       , obj.kAttrType);
+  std::swap(kAttrDelim      , obj.kAttrDelim);
+  std::swap(kAttrModule     , obj.kAttrModule);
+  std::swap(parser_         , obj.parser_);
+  std::swap(doc_            , obj.doc_);
+
+}
+
+XmlConfigReader &  XmlConfigReader::operator= (XmlConfigReader obj) {
+
+  swap(obj); 
+
+
+  return *this;
+
+}
+
 
 void XmlConfigReader::readDOMFromString(const std::string& str, DOMDocument*& doc)
 {

--- a/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
+++ b/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
@@ -30,6 +30,13 @@ class XMLConfigReader{
   XMLConfigReader();
   ~XMLConfigReader();
 
+  XMLConfigReader(const XMLConfigReader &obj);
+
+  // assignment operator not needed, but provided respecting Rule of Three.
+  XMLConfigReader & operator= (XMLConfigReader obj);
+  void swap(XMLConfigReader &obj);
+
+
   void readConfig(const std::string fName);
 
   void setConfigFile(const std::string & fName) {configFile = fName;}

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -55,6 +55,33 @@ XMLConfigReader::~XMLConfigReader()
   delete parser;
   XMLPlatformUtils::Terminate();
 }
+
+XMLConfigReader::XMLConfigReader(const XMLConfigReader &obj) :
+  parser         ( new XercesDOMParser()),
+  doc            (obj.doc)
+{
+
+  XMLPlatformUtils::Initialize();
+  parser->setValidationScheme(XercesDOMParser::Val_Auto);
+  parser->setDoNamespaces(false);
+
+}
+
+void XMLConfigReader::swap(XMLConfigReader & obj){
+ 
+  std::swap(parser         , obj.parser);
+  std::swap(doc            , obj.doc);
+
+}
+
+XMLConfigReader &  XMLConfigReader::operator= (XMLConfigReader obj) {
+
+  swap(obj); 
+
+  return *this;
+
+}
+
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigReader::readLUT(l1t::LUT *lut,const L1TMuonOverlapParams & aConfig, const std::string & type){


### PR DESCRIPTION
Now also add user-derined copy constructor and assignment operator to these two classes, 
since they already have user-defined destructors already defined previously:
- L1Trigger/L1TCommon/ XmlConfigReader
- L1Trigger/L1TMuonOverlap/ XMLConfigReader

This is a follow-up on @Dr15Jones  comment https://github.com/cms-sw/cmssw/pull/16088#issuecomment-252346616

However, the workflow 

<pre>
runTheMatrix.py -l 136.7321 -i all
</pre>

is still broken, with same errors and endJob

<pre>
#3  0x00007fc66d851078 in sig_dostack_then_abort () from /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc600/cms/cmssw/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007fc6785c4f6c in xercesc_3_1::IGXMLScanner::cleanUp (this=0x7fc63ddfa408) at xercesc/internal/IGXMLScanner.cpp:559
#6  0x00007fc6785c51d7 in xercesc_3_1::IGXMLScanner::~IGXMLScanner (this=0x7fc63ddfa408, __in_chrg=<optimized out>) at xercesc/internal/IGXMLScanner.cpp:162
#7  0x00007fc6785c5209 in xercesc_3_1::IGXMLScanner::~IGXMLScanner (this=0x7fc63ddfa408, __in_chrg=<optimized out>) at xercesc/internal/IGXMLScanner.cpp:163
#8  0x00007fc67860f46f in xercesc_3_1::AbstractDOMParser::cleanUp (this=this@entry=0x7fc657863ca8) at xercesc/parsers/AbstractDOMParser.cpp:160
#9  0x00007fc6786137e2 in xercesc_3_1::AbstractDOMParser::~AbstractDOMParser (this=0x7fc657863ca8, __in_chrg=<optimized out>) at xercesc/parsers/AbstractDOMParser.cpp:130
#10 0x00007fc678622419 in xercesc_3_1::XercesDOMParser::~XercesDOMParser (this=0x7fc657863ca8, __in_chrg=<optimized out>) at xercesc/parsers/XercesDOMParser.cpp:66
#11 0x00007fc65668ca8a in l1t::XmlConfigReader::~XmlConfigReader() () from /afs/cern.ch/work/r/rekovic/private/relaeses/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/libL1TriggerL1TCommon.so
#12 0x00007fc656677237 in l1t::TrigSystem::~TrigSystem() () from /afs/cern.ch/work/r/rekovic/private/relaeses/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/libL1TriggerL1TCommon.so
#13 0x00007fc63db1fadf in L1TMuonBarrelParamsESProducer::~L1TMuonBarrelParamsESProducer() () from /afs/cern.ch/work/r/rekovic/private/relaeses/CMSSW_8_1_X_2016-10-07-1100/lib/slc6_amd64_gcc600/pluginL1TriggerL1TMuonBarrelPlugins.so
</pre>


The crash above does not happen if the following call to `XMLPlatformUtils::Terminate();` is`  commented out [here](https://github.com/cms-l1t-offline/cmssw/blob/3c73f0d5f507b17a3b158d2f402b969f576baa50/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc#L56).
