### PR TITLE
Third part of the migration to era for phase2 tracking

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -820,3 +820,6 @@ if fastSim.isChosen():
     for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent,RAWAODSIMEventContent]:
         fastSimEC.dropSimDigis(_entry.outputCommands)
     
+if eras.phase2_tracker.isChosen():
+    for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
+        eras.phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -822,4 +822,4 @@ if fastSim.isChosen():
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
-  phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])
+  phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_mix_*_*'])

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -819,7 +819,8 @@ RAWAODSIMEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 if fastSim.isChosen():
     for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent,RAWAODSIMEventContent]:
         fastSimEC.dropSimDigis(_entry.outputCommands)
-    
-if eras.phase2_tracker.isChosen():
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+if phase2_tracker.isChosen():
     for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
-        eras.phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])
+        phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -821,6 +821,5 @@ if fastSim.isChosen():
         fastSimEC.dropSimDigis(_entry.outputCommands)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-if phase2_tracker.isChosen():
-    for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
-        phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])
+for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
+  phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + ['keep Phase2TrackerDigiedmDetSetVector_*_*_*'])

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -36,6 +36,7 @@ eras.phase1Pixel.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawDa
 # same for phase2 tracker
 eras.phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,rpcpacker])) # FIXME
 
-if eras.fastSim.isChosen() :
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+if fastSim.isChosen() :
     for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:
         DigiToRaw.remove(_entry)

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -35,7 +35,7 @@ phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_muon
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([rpcpacker]))
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -34,7 +34,7 @@ phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
 # Remove siPixelRawData until we have phase1 pixel digis
 eras.phase1Pixel.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
 # same for phase2 tracker
-eras.phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData],[rpcpacker])) # FIXME
+eras.phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,rpcpacker])) # FIXME
 
 if eras.fastSim.isChosen() :
     for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -32,9 +32,8 @@ from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
 
 # Remove siPixelRawData until we have phase1 pixel digis
-eras.phase1Pixel.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
-# same for phase2 tracker
-eras.phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,rpcpacker])) # FIXME
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,rpcpacker])) # FIXME
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen() :

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -33,7 +33,10 @@ phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
 
 # Remove siPixelRawData until we have phase1 pixel digis
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,rpcpacker])) # FIXME
+phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_muon
+phase2_muon.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([rpcpacker]))
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen() :

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -31,7 +31,11 @@ phase2_common.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([castorRawData])
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
 
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen() :
+# Remove siPixelRawData until we have phase1 pixel digis
+eras.phase1Pixel.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
+# same for phase2 tracker
+eras.phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData],[rpcpacker])) # FIXME
+
+if eras.fastSim.isChosen() :
     for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:
         DigiToRaw.remove(_entry)

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -84,8 +84,10 @@ phase2_common.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([castorDigis]))
 # until we have hcal raw data for phase 2...
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([hcalDigis]))
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 # Remove siPixelDigis until we have phase1 pixel digis
-eras.phase2_tracker.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([siPixelDigis])) # FIXME
+phase2_tracker.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([siPixelDigis])) # FIXME
 
 
 # add CTPPS 2016 raw-to-digi modules

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -81,9 +81,12 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([castorDigis]))
 
+<<<<<<< HEAD
 # until we have hcal raw data for phase 2...
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([hcalDigis]))
+# Remove siPixelDigis until we have phase1 pixel digis
+eras.phase2_tracker.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([siPixelDigis])) # FIXME
 
 
 # add CTPPS 2016 raw-to-digi modules

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -81,7 +81,6 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([castorDigis]))
 
-<<<<<<< HEAD
 # until we have hcal raw data for phase 2...
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([hcalDigis]))

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -103,7 +103,7 @@ lowPtQuadStepTrajectoryFilterBase = _lowPtQuadStepTrajectoryFilterBase.clone(
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 trackingPhase1PU70.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
-eras.trackingPhase2PU140.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
+trackingPhase2PU140.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 # Composite filter

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -103,6 +103,7 @@ lowPtQuadStepTrajectoryFilterBase = _lowPtQuadStepTrajectoryFilterBase.clone(
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 trackingPhase1PU70.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
+eras.trackingPhase2PU140.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 # Composite filter

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -78,7 +78,7 @@ def customise_Validation(process,pileup):
         process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
 
-    if hasattr(process,'trackingParticleNumberOfLayersProducer'):
+      if hasattr(process,'trackingParticleNumberOfLayersProducer'):
         process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
                                                                cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -1,13 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-#import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
 
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Flat version of the Phase2 Tracker !!!"
-    if hasattr(process,'DigiToRaw'):
-        process=customise_DigiToRaw(process)
-    if hasattr(process,'RawToDigi'):
-        process=customise_RawToDigi(process)
     n=0
     if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
         if hasattr(process,'mix'):
@@ -17,33 +12,12 @@ def customise(process):
             print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
             print 'Please provide one!'
             sys.exit(1)
-    if hasattr(process,'reconstruction'):
-        process=customise_Reco(process,float(n))
-    if hasattr(process,'digitisation_step'):
-        process=customise_Digi(process)
-    if hasattr(process,'validation_step'):
-        process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
 
     return process
 
-def customise_Digi(process):
-    return process
-
-
-def customise_DigiToRaw(process):
-    return process
-
-def customise_RawToDigi(process):
-    return process
-
-def customise_Reco(process,pileup):
-    return process
-
 def customise_condOverRides(process):
+    # this is a custom specific for tilted/flat .. how do we want to deal with it?
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkFlat_cff')
     return process
 
-
-def customise_Validation(process,pileup):
-    return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+#import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
 from Configuration.StandardSequences.Eras import eras
 
 #GEN-SIM so far...

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-#import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
+from Configuration.StandardSequences.Eras import eras
 
 #GEN-SIM so far...
 def customise(process):
@@ -28,42 +28,16 @@ def customise(process):
     return process
 
 def customise_Digi(process):
-    process.digitisation_step.remove(process.mix.digitizers.pixel)
-    process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
-    process.mix.digitizers.pixel=process.phase2TrackerDigitizer
-    process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
-                         'g4SimHitsTrackerHitsPixelEndcapLowTof')
-    #Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
-    if hasattr(process.mix.digitizers,"mergedtruth") :
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
-
-    # keep new digis
-    alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
-    for a in alist:
-        b=a+'output'
-        if hasattr(process,b):
-            getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
     return process
 
 
 def customise_DigiToRaw(process):
-    process.digi2raw_step.remove(process.siPixelRawData)
-    process.digi2raw_step.remove(process.rpcpacker)
     return process
 
 def customise_RawToDigi(process):
-    process.raw2digi_step.remove(process.siPixelDigis)
     return process
 
 def customise_Reco(process,pileup):
-
     return process
 
 def customise_condOverRides(process):
@@ -72,14 +46,4 @@ def customise_condOverRides(process):
 
 
 def customise_Validation(process,pileup):
-
-    process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
-    if hasattr(process,'simHitTPAssocProducer'):
-        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
-      if hasattr(process,'trackingParticleNumberOfLayersProducer'):
-        process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -3,17 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Flat version of the Phase2 Tracker !!!"
-    n=0
-    if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
-        if hasattr(process,'mix'):
-            if hasattr(process.mix,'input'):
-                n=process.mix.input.nbPileupEvents.averageNumber.value()
-        else:
-            print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
-            print 'Please provide one!'
-            sys.exit(1)
     process=customise_condOverRides(process)
-
     return process
 
 def customise_condOverRides(process):

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkFlat.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 #import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
-from Configuration.StandardSequences.Eras import eras
 
 #GEN-SIM so far...
 def customise(process):

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -1,14 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-#import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
-from Configuration.StandardSequences.Eras import eras
 
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Tilted version of the Phase2 Tracker !!!"
-    if hasattr(process,'DigiToRaw'):
-        process=customise_DigiToRaw(process)
-    if hasattr(process,'RawToDigi'):
-        process=customise_RawToDigi(process)
     n=0
     if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
         if hasattr(process,'mix'):
@@ -18,56 +12,8 @@ def customise(process):
             print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
             print 'Please provide one!'
             sys.exit(1)
-    if hasattr(process,'reconstruction'):
-        process=customise_Reco(process,float(n))
-    if hasattr(process,'digitisation_step'):
-        process=customise_Digi(process)
-    if hasattr(process,'validation_step'):
-        process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
 
-    return process
-
-def customise_Digi(process):
-
-    if not eras.trackingPhase2PU140.isChosen():
-      process.digitisation_step.remove(process.mix.digitizers.pixel)
-      process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
-      process.mix.digitizers.pixel=process.phase2TrackerDigitizer
-      process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
-                       'g4SimHitsTrackerHitsPixelEndcapLowTof')
-      #Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
-      if hasattr(process.mix.digitizers,"mergedtruth") :
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
-          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
-
-      # keep new digis
-      alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
-      for a in alist:
-          b=a+'output'
-          if hasattr(process,b):
-              getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
-    return process
-
-
-def customise_DigiToRaw(process):
-    if not eras.trackingPhase2PU140.isChosen():
-      process.digi2raw_step.remove(process.siPixelRawData)
-      process.digi2raw_step.remove(process.rpcpacker)
-    return process
-
-def customise_RawToDigi(process):
-    if not eras.trackingPhase2PU140.isChosen():
-      process.raw2digi_step.remove(process.siPixelDigis)
-    return process
-
-def customise_Reco(process,pileup):
     return process
 
 def customise_condOverRides(process):
@@ -75,16 +21,3 @@ def customise_condOverRides(process):
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted_cff')
     return process
 
-
-def customise_Validation(process,pileup):
-    if not eras.trackingPhase2PU140.isChosen():
-      process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
-      if hasattr(process,'simHitTPAssocProducer'):
-        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
-      if hasattr(process,'trackingParticleNumberOfLayersProducer'):
-        process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
-    return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -29,21 +29,22 @@ def customise(process):
 
 def customise_Digi(process):
 
-    process.digitisation_step.remove(process.mix.digitizers.pixel)
-    process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
-    process.mix.digitizers.pixel=process.phase2TrackerDigitizer
-    process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
-                         'g4SimHitsTrackerHitsPixelEndcapLowTof')
-    #Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
-    if hasattr(process.mix.digitizers,"mergedtruth") :
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
+    if not eras.trackingPhase2PU140.isChosen():
+      process.digitisation_step.remove(process.mix.digitizers.pixel)
+      process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
+      process.mix.digitizers.pixel=process.phase2TrackerDigitizer
+      process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
+                       'g4SimHitsTrackerHitsPixelEndcapLowTof')
+      #Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
+      if hasattr(process.mix.digitizers,"mergedtruth") :
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
+          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
 
     # keep new digis
     alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
@@ -61,13 +62,15 @@ def customise_DigiToRaw(process):
     return process
 
 def customise_RawToDigi(process):
-    process.raw2digi_step.remove(process.siPixelDigis)
+    if not eras.trackingPhase2PU140.isChosen():
+      process.raw2digi_step.remove(process.siPixelDigis)
     return process
 
 def customise_Reco(process,pileup):
     return process
 
 def customise_condOverRides(process):
+    # this is a custom specific for tilted/flat .. how do we want to deal with it?
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted_cff')
     return process
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 #import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
+from Configuration.StandardSequences.Eras import eras
 
 #GEN-SIM so far...
 def customise(process):
@@ -76,9 +77,9 @@ def customise_condOverRides(process):
 
 
 def customise_Validation(process,pileup):
-
-    process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
-    if hasattr(process,'simHitTPAssocProducer'):
+    if not eras.trackingPhase2PU140.isChosen():
+      process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
+      if hasattr(process,'simHitTPAssocProducer'):
         process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -28,6 +28,7 @@ def customise(process):
     return process
 
 def customise_Digi(process):
+
     process.digitisation_step.remove(process.mix.digitizers.pixel)
     process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
     process.mix.digitizers.pixel=process.phase2TrackerDigitizer
@@ -54,8 +55,9 @@ def customise_Digi(process):
 
 
 def customise_DigiToRaw(process):
-    process.digi2raw_step.remove(process.siPixelRawData)
-    process.digi2raw_step.remove(process.rpcpacker)
+    if not eras.trackingPhase2PU140.isChosen():
+      process.digi2raw_step.remove(process.siPixelRawData)
+      process.digi2raw_step.remove(process.rpcpacker)
     return process
 
 def customise_RawToDigi(process):

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -46,12 +46,12 @@ def customise_Digi(process):
           process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
           process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
 
-    # keep new digis
-    alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
-    for a in alist:
-        b=a+'output'
-        if hasattr(process,b):
-            getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
+      # keep new digis
+      alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
+      for a in alist:
+          b=a+'output'
+          if hasattr(process,b):
+              getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -77,7 +77,7 @@ def customise_Validation(process,pileup):
         process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
 
-    if hasattr(process,'trackingParticleNumberOfLayersProducer'):
+      if hasattr(process,'trackingParticleNumberOfLayersProducer'):
         process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
                                                                cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
 

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted.py
@@ -3,17 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Tilted version of the Phase2 Tracker !!!"
-    n=0
-    if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
-        if hasattr(process,'mix'):
-            if hasattr(process.mix,'input'):
-                n=process.mix.input.nbPileupEvents.averageNumber.value()
-        else:
-            print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
-            print 'Please provide one!'
-            sys.exit(1)
     process=customise_condOverRides(process)
-
     return process
 
 def customise_condOverRides(process):

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted4021.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted4021.py
@@ -1,13 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-#import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
 
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Tilted version of the Phase2 Tracker !!!"
-    if hasattr(process,'DigiToRaw'):
-        process=customise_DigiToRaw(process)
-    if hasattr(process,'RawToDigi'):
-        process=customise_RawToDigi(process)
     n=0
     if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
         if hasattr(process,'mix'):
@@ -17,69 +12,12 @@ def customise(process):
             print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
             print 'Please provide one!'
             sys.exit(1)
-    if hasattr(process,'reconstruction'):
-        process=customise_Reco(process,float(n))
-    if hasattr(process,'digitisation_step'):
-        process=customise_Digi(process)
-    if hasattr(process,'validation_step'):
-        process=customise_Validation(process,float(n))
     process=customise_condOverRides(process)
 
     return process
 
-def customise_Digi(process):
-    process.digitisation_step.remove(process.mix.digitizers.pixel)
-    process.load('SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi')
-    process.mix.digitizers.pixel=process.phase2TrackerDigitizer
-    process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
-                         'g4SimHitsTrackerHitsPixelEndcapLowTof')
-    #Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
-    if hasattr(process.mix.digitizers,"mergedtruth") :
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
-        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
-
-    # keep new digis
-    alist=['FEVTDEBUG','FEVTDEBUGHLT','FEVT']
-    for a in alist:
-        b=a+'output'
-        if hasattr(process,b):
-            getattr(process,b).outputCommands.append('keep Phase2TrackerDigiedmDetSetVector_*_*_*')
-    return process
-
-
-def customise_DigiToRaw(process):
-    process.digi2raw_step.remove(process.siPixelRawData)
-    process.digi2raw_step.remove(process.rpcpacker)
-    return process
-
-def customise_RawToDigi(process):
-    process.raw2digi_step.remove(process.siPixelDigis)
-    return process
-
-def customise_Reco(process,pileup):
-
-    return process
-
 def customise_condOverRides(process):
+    # this is a custom specific for tilted/flat .. how do we want to deal with it?
     process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted4021_cff')
     return process
 
-
-def customise_Validation(process,pileup):
-
-    process.pixelDigisValid.src = cms.InputTag('simSiPixelDigis', "Pixel")
-    if hasattr(process,'simHitTPAssocProducer'):
-        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
-    if hasattr(process,'trackingParticleNumberOfLayersProducer'):
-        process.trackingParticleNumberOfLayersProducer.simHits=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                               cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-
-    return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted4021.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkTilted4021.py
@@ -3,17 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #GEN-SIM so far...
 def customise(process):
     print "!!!You are using the SUPPORTED Tilted version of the Phase2 Tracker !!!"
-    n=0
-    if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
-        if hasattr(process,'mix'):
-            if hasattr(process.mix,'input'):
-                n=process.mix.input.nbPileupEvents.averageNumber.value()
-        else:
-            print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
-            print 'Please provide one!'
-            sys.exit(1)
     process=customise_condOverRides(process)
-
     return process
 
 def customise_condOverRides(process):

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -9,7 +9,7 @@ pixelDigitizer = cms.PSet(
     makeDigiSimLinks = cms.untracked.bool(True)
 )
 
-from Configuration.StandardSequences.Eras import eras
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer
-eras.phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
 

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
-from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import *
 
 pixelDigitizer = cms.PSet(
     SiPixelSimBlock,
@@ -11,6 +10,6 @@ pixelDigitizer = cms.PSet(
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_tracker.toModify( pixelDigitizer, 
-                              pixel = phase2TrackerDigitizer)
+from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer
+eras.phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
 

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
+from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import *
 
 pixelDigitizer = cms.PSet(
     SiPixelSimBlock,
@@ -8,4 +9,8 @@ pixelDigitizer = cms.PSet(
     hitsProducer = cms.string('g4SimHits'),
     makeDigiSimLinks = cms.untracked.bool(True)
 )
+
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_tracker.toModify( pixelDigitizer, 
+                              pixel = phase2TrackerDigitizer)
 

--- a/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
@@ -10,8 +10,8 @@ stripDigitizer = cms.PSet(
     makeDigiSimLinks = cms.untracked.bool(True)
     )
 
-from Configuration.StandardSequences.Eras import eras
-eras.phase2_tracker.toModify( stripDigitizer, ROUList = ["g4SimHitsTrackerHitsPixelBarrelLowTof",
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( stripDigitizer, ROUList = ["g4SimHitsTrackerHitsPixelBarrelLowTof",
                                                          "g4SimHitsTrackerHitsPixelEndcapLowTof"]
 )
 

--- a/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
@@ -10,3 +10,8 @@ stripDigitizer = cms.PSet(
     makeDigiSimLinks = cms.untracked.bool(True)
     )
 
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_tracker.toModify( stripDigitizer, ROUList = ["g4SimHitsTrackerHitsPixelBarrelLowTof",
+                                                         "g4SimHitsTrackerHitsPixelEndcapLowTof"]
+)
+

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -58,3 +58,5 @@ run3_GEM.toModify(trackingParticles, simHitCollections = dict(
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))
+
+eras.phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -59,4 +59,5 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))
 
-eras.phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -60,4 +60,14 @@ phase2_muon.toModify( trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+#      if hasattr(process.mix.digitizers,"mergedtruth") :
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
+#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
+
 phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -60,14 +60,4 @@ phase2_muon.toModify( trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-#      if hasattr(process.mix.digitizers,"mergedtruth") :
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
-#          process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
-
 phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -19,8 +19,12 @@ simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
   trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth')
 )
 
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+from Configuration.StandardSequences.Eras import eras
+eras.trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                                                   cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+)
+
+if eras.fastSim.isChosen():
     simHitTPAssocProducer.simHitSrc = cms.VInputTag(cms.InputTag('famosSimHits','TrackerHits'),
                                                     cms.InputTag("MuonSimHits","MuonCSCHits"),
                                                     cms.InputTag("MuonSimHits","MuonDTHits"),

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -19,8 +19,8 @@ simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
   trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth')
 )
 
-from Configuration.StandardSequences.Eras import eras
-eras.trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -20,9 +20,7 @@ simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                                                   cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-)
+eras.trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
 
 if eras.fastSim.isChosen():
     simHitTPAssocProducer.simHitSrc = cms.VInputTag(cms.InputTag('famosSimHits','TrackerHits'),

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -19,8 +19,8 @@ simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
   trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth')
 )
 
-from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -22,7 +22,8 @@ simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
 from Configuration.StandardSequences.Eras import eras
 eras.trackingPhase2PU140.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
 
-if eras.fastSim.isChosen():
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+if fastSim.isChosen():
     simHitTPAssocProducer.simHitSrc = cms.VInputTag(cms.InputTag('famosSimHits','TrackerHits'),
                                                     cms.InputTag("MuonSimHits","MuonCSCHits"),
                                                     cms.InputTag("MuonSimHits","MuonDTHits"),

--- a/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
+++ b/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
@@ -1,4 +1,5 @@
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cfi import *
-from Configuration.StandardSequences.Eras import eras
-eras.fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
-eras.trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])

--- a/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
+++ b/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
@@ -1,6 +1,4 @@
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cfi import *
 from Configuration.StandardSequences.Eras import eras
 eras.fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
-eras.trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
-                                                                                                  cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
-)
+eras.trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])

--- a/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
+++ b/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
@@ -1,3 +1,6 @@
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cfi import *
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
+from Configuration.StandardSequences.Eras import eras
+eras.fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
+eras.trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                                                                  cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+)

--- a/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
+++ b/SimGeneral/TrackingAnalysis/python/trackingParticleNumberOfLayersProducer_cff.py
@@ -1,5 +1,5 @@
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cfi import *
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(trackingParticleNumberOfLayersProducer, simHits=['famosSimHits:TrackerHits'])
-from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(trackingParticleNumberOfLayersProducer, simHits = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(trackingParticleNumberOfLayersProducer, simHits = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -75,7 +75,7 @@ void ClusterTPAssociationProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("simTrackSrc",     edm::InputTag("g4SimHits"));
   desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis"));
   desc.add<edm::InputTag>("stripSimLinkSrc", edm::InputTag("simSiStripDigis"));
-  desc.add<edm::InputTag>("phase2OTSimLinkSrc", edm::InputTag("simPh2OTDigis"));
+  desc.add<edm::InputTag>("phase2OTSimLinkSrc", edm::InputTag("simSiPixelDigis","Tracker"));
   desc.add<edm::InputTag>("pixelClusterSrc", edm::InputTag("siPixelClusters"));
   desc.add<edm::InputTag>("stripClusterSrc", edm::InputTag("siStripClusters"));
   desc.add<edm::InputTag>("phase2OTClusterSrc", edm::InputTag("siPhase2Clusters"));

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -393,7 +393,7 @@ tracksValidationTruth = cms.Sequence(
     VertexAssociatorByPositionAndTracks +
     trackingParticleNumberOfLayersProducer
 )
-eras.fastSim.toModify(tracksValidationTruth, lambda x: x.remove(tpClusterProducer))
+fastSim.toModify(tracksValidationTruth, lambda x: x.remove(tpClusterProducer))
 
 tracksPreValidation = cms.Sequence(
     tracksValidationSelectors +

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -12,6 +12,7 @@ from Validation.RecoTrack.PostProcessorTracker_cfi import *
 import cutsRecoTracks_cfi
 
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
+eras.trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = "simSiPixelDigis:Pixel")
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 from CommonTools.RecoAlgos.trackingParticleConversionRefSelector_cfi import trackingParticleConversionRefSelector as _trackingParticleConversionRefSelector
@@ -393,7 +394,6 @@ tracksValidationTruth = cms.Sequence(
     trackingParticleNumberOfLayersProducer
 )
 eras.fastSim.toModify(tracksValidationTruth, lambda x: x.remove(tpClusterProducer))
-eras.trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"))
 
 tracksPreValidation = cms.Sequence(
     tracksValidationSelectors +

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -12,8 +12,6 @@ from Validation.RecoTrack.PostProcessorTracker_cfi import *
 import cutsRecoTracks_cfi
 
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
-from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = "simSiPixelDigis:Pixel")
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 from CommonTools.RecoAlgos.trackingParticleConversionRefSelector_cfi import trackingParticleConversionRefSelector as _trackingParticleConversionRefSelector

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -392,7 +392,8 @@ tracksValidationTruth = cms.Sequence(
     VertexAssociatorByPositionAndTracks +
     trackingParticleNumberOfLayersProducer
 )
-fastSim.toModify(tracksValidationTruth, lambda x: x.remove(tpClusterProducer))
+eras.fastSim.toModify(tracksValidationTruth, lambda x: x.remove(tpClusterProducer))
+eras.trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"))
 
 tracksPreValidation = cms.Sequence(
     tracksValidationSelectors +

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -12,7 +12,8 @@ from Validation.RecoTrack.PostProcessorTracker_cfi import *
 import cutsRecoTracks_cfi
 
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
-eras.trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = "simSiPixelDigis:Pixel")
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase2PU140.toModify(tpClusterProducer, pixelSimLinkSrc = "simSiPixelDigis:Pixel")
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 from CommonTools.RecoAlgos.trackingParticleConversionRefSelector_cfi import trackingParticleConversionRefSelector as _trackingParticleConversionRefSelector

--- a/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
+++ b/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
@@ -8,5 +8,5 @@ pixelDigisValid = cms.EDAnalyzer("SiPixelDigiValid",
 
 # This customization will be removed once we have phase2 pixel digis
 from Configuration.StandardSequences.Eras import eras
-eras.phase2_tracker.toModify(pixelDigisValid, src = cms.InputTag('simSiPixelDigis', "Pixel"))
+eras.phase2_tracker.toModify(pixelDigisValid, src = 'simSiPixelDigis:Pixel')
 

--- a/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
+++ b/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
@@ -6,5 +6,7 @@ pixelDigisValid = cms.EDAnalyzer("SiPixelDigiValid",
     runStandalone = cms.bool(False)
 )
 
-
+# This customization will be removed once we have phase2 pixel digis
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_tracker.toModify(pixelDigisValid, src = cms.InputTag('simSiPixelDigis', "Pixel"))
 

--- a/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
+++ b/Validation/TrackerDigis/python/pixelDigisValidation_cfi.py
@@ -7,6 +7,6 @@ pixelDigisValid = cms.EDAnalyzer("SiPixelDigiValid",
 )
 
 # This customization will be removed once we have phase2 pixel digis
-from Configuration.StandardSequences.Eras import eras
-eras.phase2_tracker.toModify(pixelDigisValid, src = 'simSiPixelDigis:Pixel')
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(pixelDigisValid, src = 'simSiPixelDigis:Pixel')
 


### PR DESCRIPTION
Following PRs #15183 and #15417, this is the third (and almost last) PR to migrate phase2 tracker/tracking from custom to era. Only one part is missing - further discussion with @boudoul and @kpedro88 is might needed.
Extended discussion with @makortel [here](https://github.com/makortel/cmssw/pull/4/files).

No difference are expected in any part of the reconstruction.
Here there are already some results for [D1 workflow](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/MovingToEra/20161011_D1/plots_summary/summary.pdf) and for [D2 workflow](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/MovingToEra/20161011_D2/plots_summary/summary.pdf).
@VinInn @rovere  
