### PR TITLE
adding DQM Offline histograms for BTV at HLT

### DIFF
--- a/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
@@ -59,11 +59,14 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
   std::string processname_;
   std::string pathname_;
   std::string filtername_; 
-  
+  std::string triggerPathPF_; 
+ 
   std::vector<std::pair<std::string, std::string> > custompathnamepairs_;
   
   edm::InputTag triggerSummaryLabel_;
   edm::InputTag triggerResultsLabel_;
+  edm::InputTag triggerFilterPFbfCSV_;
+  edm::InputTag triggerFilterPFafCSV_;
 
   edm::EDGetTokenT<reco::JetTagCollection> offlineCSVTokenPF_;
   edm::EDGetTokenT<reco::JetTagCollection> offlineCSVTokenCalo_;
@@ -101,10 +104,17 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
   public:
     void setHistos(
 		   MonitorElement* const CSV, MonitorElement* const Pt, MonitorElement* const Eta,
-		   MonitorElement* const CSV_RECOvsHLT, MonitorElement* const PVz, MonitorElement* const fastPVz,
+		   MonitorElement* const CSV_RECO, MonitorElement* const CSV_HLTMinusRECO, MonitorElement* const CSV_RECOvsHLT, 
+                   MonitorElement* const CSVbeforefilter_RECO, MonitorElement* const CSVafterfilter_RECO, 
+                   MonitorElement* const CSV_turnon, MonitorElement* const CSVratio_calofilter, MonitorElement* const CSVratio_PFfilter,
+                   MonitorElement* const PVz, MonitorElement* const fastPVz,
 		   MonitorElement* const PVz_HLTMinusRECO, MonitorElement* const fastPVz_HLTMinusRECO
 		   )
-    { CSV_ = CSV; Pt_ = Pt; Eta_ = Eta; CSV_RECOvsHLT_ = CSV_RECOvsHLT; PVz_ = PVz; fastPVz_ = fastPVz;
+    { CSV_ = CSV; Pt_ = Pt; Eta_ = Eta; 
+      CSV_RECO_ = CSV_RECO; ; CSV_HLTMinusRECO_ = CSV_HLTMinusRECO; CSV_RECOvsHLT_ = CSV_RECOvsHLT; 
+      CSVbeforefilter_RECO_ = CSVbeforefilter_RECO; CSVafterfilter_RECO_ = CSVafterfilter_RECO; 
+      CSV_turnon_ = CSV_turnon; CSVratio_calofilter_ = CSVratio_calofilter; CSVratio_PFfilter_ = CSVratio_PFfilter;
+      PVz_ = PVz; fastPVz_ = fastPVz;
       PVz_HLTMinusRECO_ = PVz_HLTMinusRECO; fastPVz_HLTMinusRECO_ = fastPVz_HLTMinusRECO;
     };
 
@@ -123,14 +133,21 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
       objectType_(type),
       triggerType_(triggerType){};
 
-      MonitorElement * getMEhisto_CSV()               { return CSV_;}
-      MonitorElement * getMEhisto_Pt()                { return Pt_; }
-      MonitorElement * getMEhisto_Eta()               { return Eta_;}
-      MonitorElement * getMEhisto_CSV_RECOvsHLT()     { return CSV_RECOvsHLT_;}
-      MonitorElement * getMEhisto_PVz()               { return PVz_;}
-      MonitorElement * getMEhisto_fastPVz()           { return fastPVz_;}
-      MonitorElement * getMEhisto_PVz_HLTMinusRECO()      { return PVz_HLTMinusRECO_;}
-      MonitorElement * getMEhisto_fastPVz_HLTMinusRECO()  { return fastPVz_HLTMinusRECO_;}
+      MonitorElement * getMEhisto_CSV()                        { return CSV_;                  }
+      MonitorElement * getMEhisto_Pt()                         { return Pt_;                   }
+      MonitorElement * getMEhisto_Eta()                        { return Eta_;                  }
+      MonitorElement * getMEhisto_CSV_RECO()                   { return CSV_RECO_;             }
+      MonitorElement * getMEhisto_CSV_HLTMinusRECO()           { return CSV_HLTMinusRECO_;     }
+      MonitorElement * getMEhisto_CSV_RECOvsHLT()              { return CSV_RECOvsHLT_;        }
+      MonitorElement * getMEhisto_CSVbeforefilter_RECO()       { return CSVbeforefilter_RECO_; }
+      MonitorElement * getMEhisto_CSVafterfilter_RECO()        { return CSVafterfilter_RECO_;  }
+      MonitorElement * getMEhisto_CSV_turnon()                 { return CSV_turnon_;           }
+      MonitorElement * getMEhisto_CSVratio_calofilter()        { return CSVratio_calofilter_;  }
+      MonitorElement * getMEhisto_CSVratio_PFfilter()          { return CSVratio_PFfilter_;    }
+      MonitorElement * getMEhisto_PVz()                        { return PVz_;                  }
+      MonitorElement * getMEhisto_fastPVz()                    { return fastPVz_;              }
+      MonitorElement * getMEhisto_PVz_HLTMinusRECO()           { return PVz_HLTMinusRECO_;     }
+      MonitorElement * getMEhisto_fastPVz_HLTMinusRECO()       { return fastPVz_HLTMinusRECO_; }
      
       const std::string getLabel(void ) const {
 	return filterName_;
@@ -175,7 +192,14 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
       MonitorElement*  CSV_;
       MonitorElement*  Pt_;
       MonitorElement*  Eta_;
-      MonitorElement*  CSV_RECOvsHLT_;   
+      MonitorElement*  CSV_RECO_;
+      MonitorElement*  CSV_HLTMinusRECO_;
+      MonitorElement*  CSV_RECOvsHLT_;
+      MonitorElement*  CSVbeforefilter_RECO_;
+      MonitorElement*  CSVafterfilter_RECO_;
+      MonitorElement*  CSV_turnon_;
+      MonitorElement*  CSVratio_calofilter_;
+      MonitorElement*  CSVratio_PFfilter_;
       MonitorElement*  PVz_;
       MonitorElement*  fastPVz_;
       MonitorElement*  PVz_HLTMinusRECO_;

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -7,14 +7,19 @@ BTVHLTOfflineSource = cms.EDAnalyzer(
     processname = cms.string("HLT"),  
     verbose = cms.untracked.bool(False),
     #
-    triggerSummaryLabel = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
-    triggerResultsLabel = cms.InputTag("TriggerResults","","HLT"),
-    offlineCSVLabelPF = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
+    triggerSummaryLabel    = cms.InputTag("hltTriggerSummaryAOD",                 "",    "HLT"),
+    triggerResultsLabel    = cms.InputTag("TriggerResults",                       "",    "HLT"),
+    triggerPathPF          = cms.string('HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460_v5'),
+    triggerFilterPFbfCSV   = cms.InputTag('hltBTagCaloCSVp022Single',             '',    'HLT'),
+    #triggerFilterPFbfCSV   = cms.InputTag('hltSelector6PFJets',                   '',    'HLT'),
+    triggerFilterPFafCSV   = cms.InputTag('hltBTagPFCSVp016SingleWithMatching',   '',    'HLT'),
+
+    offlineCSVLabelPF   = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
     offlineCSVLabelCalo = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-    hltFastPVLabel = cms.InputTag("hltFastPrimaryVertex"),
-    hltPFPVLabel = cms.InputTag("hltVerticesPFSelector"),
-    hltCaloPVLabel = cms.InputTag("hltVerticesL3"),    
-    offlinePVLabel = cms.InputTag("offlinePrimaryVertices"),    
+    hltFastPVLabel      = cms.InputTag("hltFastPrimaryVertex"),
+    hltPFPVLabel        = cms.InputTag("hltVerticesPFSelector"),
+    hltCaloPVLabel      = cms.InputTag("hltVerticesL3"),    
+    offlinePVLabel      = cms.InputTag("offlinePrimaryVertices"),    
     
     #
     pathPairs = cms.VPSet(

--- a/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
@@ -34,7 +34,9 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 using namespace trigger;
-  
+
+//test
+
 BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
 {
   LogDebug("BTVHLTOfflineSource") << "constructor....";

--- a/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
@@ -35,36 +35,39 @@ using namespace reco;
 using namespace std;
 using namespace trigger;
 
-//test
-
 BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
 {
-  LogDebug("BTVHLTOfflineSource") << "constructor....";
-  
-  dirname_                = iConfig.getUntrackedParameter("dirname",std::string("HLT/BTV/"));
-  processname_            = iConfig.getParameter<std::string>("processname");
-  verbose_                = iConfig.getUntrackedParameter< bool >("verbose", false);
-  triggerSummaryLabel_    = iConfig.getParameter<edm::InputTag>("triggerSummaryLabel");
-  triggerResultsLabel_    = iConfig.getParameter<edm::InputTag>("triggerResultsLabel");
-  triggerSummaryToken     = consumes <trigger::TriggerEvent> (triggerSummaryLabel_);
-  triggerResultsToken     = consumes <edm::TriggerResults>   (triggerResultsLabel_);
-  triggerSummaryFUToken   = consumes <trigger::TriggerEvent> (edm::InputTag(triggerSummaryLabel_.label(),triggerSummaryLabel_.instance(),std::string("FU")));
-  triggerResultsFUToken   = consumes <edm::TriggerResults>   (edm::InputTag(triggerResultsLabel_.label(),triggerResultsLabel_.instance(),std::string("FU")));
-  csvCaloTagsToken_       = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
-  csvPfTagsToken_         = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsPF"));
-  offlineCSVTokenPF_      = consumes<reco::JetTagCollection> (iConfig.getParameter<edm::InputTag>("offlineCSVLabelPF"));
-  offlineCSVTokenCalo_    = consumes<reco::JetTagCollection> (iConfig.getParameter<edm::InputTag>("offlineCSVLabelCalo"));
-  hltFastPVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltFastPVLabel"));
-  hltPFPVToken_           = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltPFPVLabel"));
-  hltCaloPVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltCaloPVLabel"));
-  offlinePVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("offlinePVLabel"));
- 
-  std::vector<edm::ParameterSet> paths =  iConfig.getParameter<std::vector<edm::ParameterSet> >("pathPairs");
-  for(std::vector<edm::ParameterSet>::iterator pathconf = paths.begin() ; pathconf != paths.end();  pathconf++) { 
-    custompathnamepairs_.push_back(make_pair(
-					     pathconf->getParameter<std::string>("pathname"),
-					     pathconf->getParameter<std::string>("pathtype")
-					     ));}
+	LogDebug("BTVHLTOfflineSource") << "constructor....";
+
+	dirname_                = iConfig.getUntrackedParameter("dirname",std::string("HLT/BTV/"));
+	processname_            = iConfig.getParameter<std::string>("processname");
+	verbose_                = iConfig.getUntrackedParameter< bool >("verbose", false);
+	triggerSummaryLabel_    = iConfig.getParameter<edm::InputTag>("triggerSummaryLabel");
+	triggerResultsLabel_    = iConfig.getParameter<edm::InputTag>("triggerResultsLabel");
+	triggerSummaryToken     = consumes <trigger::TriggerEvent> (triggerSummaryLabel_);
+	triggerResultsToken     = consumes <edm::TriggerResults>   (triggerResultsLabel_);
+	triggerSummaryFUToken   = consumes <trigger::TriggerEvent> (edm::InputTag(triggerSummaryLabel_.label(),triggerSummaryLabel_.instance(),std::string("FU")));
+	triggerResultsFUToken   = consumes <edm::TriggerResults>   (edm::InputTag(triggerResultsLabel_.label(),triggerResultsLabel_.instance(),std::string("FU")));
+	csvCaloTagsToken_       = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
+	csvPfTagsToken_         = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsPF"));
+	offlineCSVTokenPF_      = consumes<reco::JetTagCollection> (iConfig.getParameter<edm::InputTag>("offlineCSVLabelPF"));
+	offlineCSVTokenCalo_    = consumes<reco::JetTagCollection> (iConfig.getParameter<edm::InputTag>("offlineCSVLabelCalo"));
+	hltFastPVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltFastPVLabel"));
+	hltPFPVToken_           = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltPFPVLabel"));
+	hltCaloPVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltCaloPVLabel"));
+	offlinePVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("offlinePVLabel"));
+
+        triggerFilterPFbfCSV_   = iConfig.getParameter<edm::InputTag>("triggerFilterPFbfCSV");
+        triggerFilterPFafCSV_   = iConfig.getParameter<edm::InputTag>("triggerFilterPFafCSV");        
+
+        triggerPathPF_          = iConfig.getParameter<std::string>("triggerPathPF");
+
+	std::vector<edm::ParameterSet> paths =  iConfig.getParameter<std::vector<edm::ParameterSet> >("pathPairs");
+	for(std::vector<edm::ParameterSet>::iterator pathconf = paths.begin() ; pathconf != paths.end();  pathconf++) { 
+		custompathnamepairs_.push_back(make_pair(
+					pathconf->getParameter<std::string>("pathname"),
+					pathconf->getParameter<std::string>("pathtype")
+					));}
 }
 
 BTVHLTOfflineSource::~BTVHLTOfflineSource()
@@ -73,206 +76,297 @@ BTVHLTOfflineSource::~BTVHLTOfflineSource()
 
 void BTVHLTOfflineSource::dqmBeginRun(const edm::Run& run, const edm::EventSetup& c)
 {
-    bool changed(true);
-    if (!hltConfig_.init(run, c, processname_, changed)) {
-    LogDebug("BTVHLTOfflineSource") << "HLTConfigProvider failed to initialize.";
-    }
-    
-  const unsigned int numberOfPaths(hltConfig_.size());
-  for(unsigned int i=0; i!=numberOfPaths; ++i){
-    pathname_      = hltConfig_.triggerName(i);
-    filtername_    = "dummy";
-    unsigned int usedPrescale = 1;
-    unsigned int objectType = 0;
-    std::string triggerType = "";
-    bool trigSelected = false;
-    
-    for (std::vector<std::pair<std::string, std::string> >::iterator custompathnamepair = custompathnamepairs_.begin(); 
-          custompathnamepair != custompathnamepairs_.end(); ++custompathnamepair){
-       if(pathname_.find(custompathnamepair->first)!=std::string::npos) { trigSelected = true; triggerType = custompathnamepair->second;}
-      }
-    
-    if (!trigSelected) continue;
-    
-    hltPathsAll_.push_back(PathInfo(usedPrescale, pathname_, "dummy", processname_, objectType, triggerType)); 
-   }
-  
+	bool changed(true);
+	if (!hltConfig_.init(run, c, processname_, changed)) {
+		LogDebug("BTVHLTOfflineSource") << "HLTConfigProvider failed to initialize.";
+	}
+
+	const unsigned int numberOfPaths(hltConfig_.size());
+	for(unsigned int i=0; i!=numberOfPaths; ++i){
+		pathname_      = hltConfig_.triggerName(i);
+		filtername_    = "dummy";
+		unsigned int usedPrescale = 1;
+		unsigned int objectType = 0;
+		std::string triggerType = "";
+		bool trigSelected = false;
+
+		for (std::vector<std::pair<std::string, std::string> >::iterator custompathnamepair = custompathnamepairs_.begin(); 
+				custompathnamepair != custompathnamepairs_.end(); ++custompathnamepair){
+			if(pathname_.find(custompathnamepair->first)!=std::string::npos) { trigSelected = true; triggerType = custompathnamepair->second;}
+		}
+
+		if (!trigSelected) continue;
+
+		hltPathsAll_.push_back(PathInfo(usedPrescale, pathname_, "dummy", processname_, objectType, triggerType)); 
+	}
+
 
 }
 
-void
+	void
 BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 { 
-  iEvent.getByToken(triggerResultsToken, triggerResults_);
-  if(!triggerResults_.isValid()) {
-    iEvent.getByToken(triggerResultsFUToken,triggerResults_);
-    if(!triggerResults_.isValid()) {
-      edm::LogInfo("BTVHLTOfflineSource") << "TriggerResults not found, "
-	"skipping event";
-      return;
-    }
-  }
-  
-  triggerNames_ = iEvent.triggerNames(*triggerResults_);
-  
-  iEvent.getByToken(triggerSummaryToken,triggerObj_);
-  if(!triggerObj_.isValid()) {
-    iEvent.getByToken(triggerSummaryFUToken,triggerObj_);
-    if(!triggerObj_.isValid()) {
-      edm::LogInfo("BTVHLTOfflineSource") << "TriggerEvent not found, "
-	"skipping event";
-      return;
-    }
-  } 
-  
-  iEvent.getByToken(csvCaloTagsToken_, csvCaloTags);
-  iEvent.getByToken(csvPfTagsToken_, csvPfTags);
-  
-  Handle<reco::VertexCollection> VertexHandler;
-  
-  Handle<reco::JetTagCollection> offlineJetTagHandlerPF;
-  iEvent.getByToken(offlineCSVTokenPF_, offlineJetTagHandlerPF);
-  
-  Handle<reco::JetTagCollection> offlineJetTagHandlerCalo;
-  iEvent.getByToken(offlineCSVTokenCalo_, offlineJetTagHandlerCalo);
-  
-  Handle<reco::VertexCollection> offlineVertexHandler;
-  iEvent.getByToken(offlinePVToken_, offlineVertexHandler);
-  
-  if(verbose_ && iEvent.id().event()%10000==0)
-    cout<<"Run = "<<iEvent.id().run()<<", LS = "<<iEvent.luminosityBlock()<<", Event = "<<iEvent.id().event()<<endl;  
-  
-  if(!triggerResults_.isValid()) return;
-   
-  for(PathInfoCollection::iterator v = hltPathsAll_.begin(); v!= hltPathsAll_.end(); ++v ){
-    unsigned index = triggerNames_.triggerIndex(v->getPath()); 
-    if (index < triggerNames_.size() ){     
-     float DR  = 9999.;
-     if (csvPfTags.isValid() && v->getTriggerType() == "PF")
-     {
-      auto iter = csvPfTags->begin();
-      
-      float CSV_online = iter->second;
-      if (CSV_online<0) CSV_online = -0.05;
-    
-      v->getMEhisto_CSV()->Fill(CSV_online);  
-      v->getMEhisto_Pt()->Fill(iter->first->pt()); 
-      v->getMEhisto_Eta()->Fill(iter->first->eta());
-      
-      DR  = 9999.;
-      if(offlineJetTagHandlerPF.isValid()){
-          for ( reco::JetTagCollection::const_iterator iterO = offlineJetTagHandlerPF->begin(); iterO != offlineJetTagHandlerPF->end(); iterO++ ){ 
-            float CSV_offline = iterO->second;
-            if (CSV_offline<0) CSV_offline = -0.05;
-            DR = reco::deltaR(iterO->first->eta(),iterO->first->phi(),iter->first->eta(),iter->first->phi());
-            if (DR<0.3) {
-               v->getMEhisto_CSV_RECOvsHLT()->Fill(CSV_offline,CSV_online); continue;
-               }
-          }
-      }
-    
-      iEvent.getByToken(hltPFPVToken_, VertexHandler);
-      if (VertexHandler.isValid())
-      { 
-        v->getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
-        if (offlineVertexHandler.isValid()) v->getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
-        }
-      }
-      
-     if (csvCaloTags.isValid() && v->getTriggerType() == "Calo" && !csvCaloTags->empty()) 
-     { 
-      auto iter = csvCaloTags->begin();
-      
-      float CSV_online = iter->second;
-      if (CSV_online<0) CSV_online = -0.05;
-    
-      v->getMEhisto_CSV()->Fill(CSV_online);  
-      v->getMEhisto_Pt()->Fill(iter->first->pt()); 
-      v->getMEhisto_Eta()->Fill(iter->first->eta());
-      
-      DR  = 9999.;
-      if(offlineJetTagHandlerCalo.isValid()){
-          for ( reco::JetTagCollection::const_iterator iterO = offlineJetTagHandlerCalo->begin(); iterO != offlineJetTagHandlerCalo->end(); iterO++ )
-          {
-            float CSV_offline = iterO->second;
-            if (CSV_offline<0) CSV_offline = -0.05;
-            DR = reco::deltaR(iterO->first->eta(),iterO->first->phi(),iter->first->eta(),iter->first->phi());
-            if (DR<0.3) 
-            {
-                v->getMEhisto_CSV_RECOvsHLT()->Fill(CSV_offline,CSV_online); continue;
-            }  
-          }     
-      }
-      
-      iEvent.getByToken(hltFastPVToken_, VertexHandler);
-      if (VertexHandler.isValid()) 
-      {
-        v->getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
-	if (offlineVertexHandler.isValid()) v->getMEhisto_fastPVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
-       }
-      
-      iEvent.getByToken(hltCaloPVToken_, VertexHandler);
-      if (VertexHandler.isValid())
-      {
-        v->getMEhisto_fastPVz()->Fill(VertexHandler->begin()->z()); 
-	if (offlineVertexHandler.isValid()) v->getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
-       }
-       
-      }
-      
-      
-    }
-   }
-  
+	iEvent.getByToken(triggerResultsToken, triggerResults_);
+	if(!triggerResults_.isValid()) {
+		iEvent.getByToken(triggerResultsFUToken,triggerResults_);
+		if(!triggerResults_.isValid()) {
+			edm::LogInfo("BTVHLTOfflineSource") << "TriggerResults not found, "
+				"skipping event";
+			return;
+		}
+	}
+
+	triggerNames_ = iEvent.triggerNames(*triggerResults_);
+
+	iEvent.getByToken(triggerSummaryToken,triggerObj_);
+	if(!triggerObj_.isValid()) {
+		iEvent.getByToken(triggerSummaryFUToken,triggerObj_);
+		if(!triggerObj_.isValid()) {
+			edm::LogInfo("BTVHLTOfflineSource") << "TriggerEvent not found, "
+				"skipping event";
+			return;
+		}
+	} 
+
+	iEvent.getByToken(csvCaloTagsToken_, csvCaloTags);
+	iEvent.getByToken(csvPfTagsToken_, csvPfTags);
+
+	Handle<reco::VertexCollection> VertexHandler;
+
+	Handle<reco::JetTagCollection> offlineJetTagHandlerPF;
+	iEvent.getByToken(offlineCSVTokenPF_, offlineJetTagHandlerPF);
+
+	Handle<reco::JetTagCollection> offlineJetTagHandlerCalo;
+	iEvent.getByToken(offlineCSVTokenCalo_, offlineJetTagHandlerCalo);
+
+	Handle<reco::VertexCollection> offlineVertexHandler;
+	iEvent.getByToken(offlinePVToken_, offlineVertexHandler);
+
+	if(verbose_ && iEvent.id().event()%10000==0)
+		cout<<"Run = "<<iEvent.id().run()<<", LS = "<<iEvent.luminosityBlock()<<", Event = "<<iEvent.id().event()<<endl;  
+
+	if(!triggerResults_.isValid()) return;
+
+	for(PathInfoCollection::iterator v = hltPathsAll_.begin(); v!= hltPathsAll_.end(); ++v ){
+		unsigned index = triggerNames_.triggerIndex(v->getPath()); 
+		if (index < triggerNames_.size() ){     
+			
+                        // PARTICLE FLOW PATH
+                        float DR  = 9999.;
+			if (csvPfTags.isValid() && v->getTriggerType() == "PF")
+			{
+				auto iter = csvPfTags->begin();
+
+				float CSV_online = iter->second;
+				if (CSV_online<0) CSV_online = -0.05;
+
+				v->getMEhisto_CSV()->Fill(CSV_online);  
+				v->getMEhisto_Pt()->Fill(iter->first->pt()); 
+				v->getMEhisto_Eta()->Fill(iter->first->eta());
+
+				DR  = 9999.;
+				if(offlineJetTagHandlerPF.isValid()){
+					for ( reco::JetTagCollection::const_iterator iterO = offlineJetTagHandlerPF->begin(); iterO != offlineJetTagHandlerPF->end(); iterO++ ){ 
+						float CSV_offline = iterO->second;
+						if (CSV_offline<0) CSV_offline = -0.05;
+						DR = reco::deltaR(iterO->first->eta(),iterO->first->phi(),iter->first->eta(),iter->first->phi());
+						if (DR<0.3) {
+							v->getMEhisto_CSV_RECOvsHLT()->Fill(CSV_offline,CSV_online); 
+							v->getMEhisto_CSV_HLTMinusRECO()->Fill(CSV_online-CSV_offline);
+                                                        v->getMEhisto_CSV_RECO()->Fill(CSV_offline);
+
+                                                        //std::cout << "triggerPathPF_:        " << triggerPathPF_        << std::endl;
+                                                        //std::cout << "triggerFiltePFbfCSV_:  " << triggerFilterPFbfCSV_ << std::endl;
+                                                        //std::cout << "triggerFilterPFafCSV_: " << triggerFilterPFafCSV_ << std::endl;
+
+							//std::cout << "size filters : " << triggerObj_->sizeFilters() << std::endl;
+                                                        //for(int it = 0; it < triggerObj_->sizeFilters(); it++)
+                                                        //{   
+							//	std::cout << triggerObj_->filterLabel(it) << std::endl;
+                                                        //}
+							
+                                                        size_t filterIndex = triggerObj_->filterIndex( triggerFilterPFbfCSV_ );
+							if( !(filterIndex >= triggerObj_->sizeFilters()) )
+							{
+                                                                v->getMEhisto_CSVbeforefilter_RECO()->Fill(CSV_offline);
+							}
+                                                        
+							filterIndex = triggerObj_->filterIndex( triggerFilterPFafCSV_ );
+                                                        if( !(filterIndex >= triggerObj_->sizeFilters()) )
+                                                        {
+                                                                v->getMEhisto_CSVafterfilter_RECO()->Fill(CSV_offline);
+                                                        }
+								
+							continue;
+						}
+					}
+				}
+
+				iEvent.getByToken(hltPFPVToken_, VertexHandler);
+				if (VertexHandler.isValid())
+				{ 
+					v->getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
+					if (offlineVertexHandler.isValid()) v->getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
+				}
+			}
+
+                        // Produce turn-on...
+                        for (int i = 1; i < 55; i++)
+
+                        {
+                            float ratio = (v->getMEhisto_CSV_RECO()->getBinContent(i) != 0) ? v->getMEhisto_CSVbeforefilter_RECO()->getBinContent(i) / v->getMEhisto_CSV_RECO()->getBinContent(i) : 0 ;
+                            std::cout << "ratio 1: " << ratio << std::endl;
+                            v->getMEhisto_CSVratio_calofilter()->setBinContent(i, ratio);
+                        }
+
+
+                        for (int i = 1; i < 55; i++)
+                        {
+                            float ratio = (v->getMEhisto_CSV_RECO()->getBinContent(i) != 0) ? v->getMEhisto_CSVafterfilter_RECO()->getBinContent(i) / v->getMEhisto_CSV_RECO()->getBinContent(i) : 0 ;
+                            std::cout << "ratio 2: " << ratio << std::endl;
+                            v->getMEhisto_CSVratio_PFfilter()->setBinContent(i, ratio);
+                        }
+
+                        // CALO PATH
+			if (csvCaloTags.isValid() && v->getTriggerType() == "Calo" && !csvCaloTags->empty()) 
+			{ 
+				auto iter = csvCaloTags->begin();
+
+				float CSV_online = iter->second;
+				if (CSV_online<0) CSV_online = -0.05;
+
+				v->getMEhisto_CSV()->Fill(CSV_online);  
+				v->getMEhisto_Pt()->Fill(iter->first->pt()); 
+				v->getMEhisto_Eta()->Fill(iter->first->eta());
+
+				DR  = 9999.;
+				if(offlineJetTagHandlerCalo.isValid()){
+					for ( reco::JetTagCollection::const_iterator iterO = offlineJetTagHandlerCalo->begin(); iterO != offlineJetTagHandlerCalo->end(); iterO++ )
+					{
+						float CSV_offline = iterO->second;
+						if (CSV_offline<0) CSV_offline = -0.05;
+						DR = reco::deltaR(iterO->first->eta(),iterO->first->phi(),iter->first->eta(),iter->first->phi());
+						if (DR<0.3) 
+						{
+							v->getMEhisto_CSV_RECOvsHLT()->Fill(CSV_offline,CSV_online);
+							v->getMEhisto_CSV_HLTMinusRECO()->Fill(CSV_online-CSV_offline);
+							v->getMEhisto_CSV_RECO()->Fill(CSV_offline);
+                                                        v->getMEhisto_CSVafterfilter_RECO()->Fill(CSV_offline);
+							continue;
+						} 
+					}     
+				}
+
+				iEvent.getByToken(hltFastPVToken_, VertexHandler);
+				if (VertexHandler.isValid()) 
+				{
+					v->getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
+					if (offlineVertexHandler.isValid()) v->getMEhisto_fastPVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
+				}
+
+				iEvent.getByToken(hltCaloPVToken_, VertexHandler);
+				if (VertexHandler.isValid())
+				{
+					v->getMEhisto_fastPVz()->Fill(VertexHandler->begin()->z()); 
+					if (offlineVertexHandler.isValid()) v->getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
+				}
+			}
+
+                        // Produce turn-on...
+                        for (int i = 1; i < 55; i++)
+
+                        {   
+                            float ratio = (v->getMEhisto_CSV_RECO()->getBinContent(i) != 0) ? v->getMEhisto_CSVbeforefilter_RECO()->getBinContent(i) / v->getMEhisto_CSV_RECO()->getBinContent(i) : 0 ;
+                            std::cout << "ratio 1: " << ratio << std::endl;
+                            v->getMEhisto_CSVratio_calofilter()->setBinContent(i, ratio);
+                        }
+
+
+                        for (int i = 1; i < 55; i++)
+                        {   
+                            float ratio = (v->getMEhisto_CSV_RECO()->getBinContent(i) != 0) ? v->getMEhisto_CSVafterfilter_RECO()->getBinContent(i) / v->getMEhisto_CSV_RECO()->getBinContent(i) : 0 ;
+                            std::cout << "ratio 2: " << ratio << std::endl;
+                            v->getMEhisto_CSVratio_PFfilter()->setBinContent(i, ratio);
+                        }
+		}
+	}
 }
 
-void 
+	void 
 BTVHLTOfflineSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const & run, edm::EventSetup const & c)
 {
-  iBooker.setCurrentFolder(dirname_);
-   for(PathInfoCollection::iterator v = hltPathsAll_.begin(); v!= hltPathsAll_.end(); ++v ){
-     //
-     std::string trgPathName = HLTConfigProvider::removeVersion(v->getPath());
-     std::string subdirName  = dirname_ +"/"+ trgPathName;
-     std::string trigPath    = "("+trgPathName+")";
-     iBooker.setCurrentFolder(subdirName);  
+	iBooker.setCurrentFolder(dirname_);
+	for(PathInfoCollection::iterator v = hltPathsAll_.begin(); v!= hltPathsAll_.end(); ++v ){
+		//
+		std::string trgPathName = HLTConfigProvider::removeVersion(v->getPath());
+		std::string subdirName  = dirname_ +"/"+ trgPathName;
+		std::string trigPath    = "("+trgPathName+")";
+		iBooker.setCurrentFolder(subdirName);  
 
-     std::string labelname("HLT");
-     std::string histoname(labelname+"");
-     std::string title(labelname+"");
-      
-     histoname = labelname+"_CSV";
-     title = labelname+"_CSV "+trigPath;
-     MonitorElement * CSV =  iBooker.book1D(histoname.c_str(),title.c_str(),110,-0.1,1);
-     
-     histoname = labelname+"_Pt";
-     title = labelname+"_Pt "+trigPath;
-     MonitorElement * Pt =  iBooker.book1D(histoname.c_str(),title.c_str(),100,0,400);
-     
-     histoname = labelname+"_Eta";
-     title = labelname+"_Eta "+trigPath;
-     MonitorElement * Eta =  iBooker.book1D(histoname.c_str(),title.c_str(),60,-3.0,3.0);
-    
-     histoname = "RECOvsHLT_CSV";
-     title = "offline CSV vs online CSV "+trigPath;
-     MonitorElement * CSV_RECOvsHLT =  iBooker.book2D(histoname.c_str(),title.c_str(),110,-0.1,1,110,-0.1,1);
-    
-     histoname = labelname+"_PVz";
-     title = "online z(PV) "+trigPath;
-     MonitorElement * PVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
-     
-     histoname = labelname+"_fastPVz";
-     title = "online z(fastPV) "+trigPath;
-     MonitorElement * fastPVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
-     
-     histoname = "HLTMinusRECO_PVz";
-     title = "online z(PV) - offline z(PV) "+trigPath;
-     MonitorElement * PVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),200,-0.5,0.5);
-     
-     histoname = "HLTMinusRECO_fastPVz";
-     title = "online z(fastPV) - offline z(PV) "+trigPath;
-     MonitorElement * fastPVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),100,-2,2);
-    
-     v->setHistos(CSV,Pt,Eta,CSV_RECOvsHLT,PVz,fastPVz,PVz_HLTMinusRECO,fastPVz_HLTMinusRECO);  
-   }
+		std::string labelname("HLT");
+		std::string histoname(labelname+"");
+		std::string title(labelname+"");
+
+		histoname = labelname+"_CSV";
+		title = labelname+"_CSV "+trigPath;
+		MonitorElement * CSV =  iBooker.book1D(histoname.c_str(),title.c_str(),110,-0.1,1);
+
+		histoname = labelname+"_Pt";
+		title = labelname+"_Pt "+trigPath;
+		MonitorElement * Pt =  iBooker.book1D(histoname.c_str(),title.c_str(),100,0,400);
+
+		histoname = labelname+"_Eta";
+		title = labelname+"_Eta "+trigPath;
+		MonitorElement * Eta =  iBooker.book1D(histoname.c_str(),title.c_str(),60,-3.0,3.0);
+
+		histoname = "RECO_CSV";
+		title = "offline CSV "+trigPath;
+		MonitorElement * CSV_RECO = iBooker.book1D(histoname.c_str(),title.c_str(),55,-0.1,1);
+
+		histoname = "HLTMinusRECO_CSV";
+		title = "online CSV - offline CSV "+trigPath;
+		MonitorElement * CSV_HLTMinusRECO = iBooker.book1D(histoname.c_str(),title.c_str(),100,-2,2);
+
+		histoname = "RECOvsHLT_CSV";
+		title = "offline CSV vs online CSV "+trigPath;
+		MonitorElement * CSV_RECOvsHLT =  iBooker.book2D(histoname.c_str(),title.c_str(),110,-0.1,1,110,-0.1,1);
+
+                histoname = "RECO_CSVbeforefilter";
+                title = "offline before after filter "+trigPath;
+                MonitorElement * CSVbeforefilter_RECO = iBooker.book1D(histoname.c_str(),title.c_str(),55,-0.1,1);
+
+		histoname = "RECO_CSVafterfilter";
+		title = "offline CSV after filter "+trigPath;
+		MonitorElement * CSVafterfilter_RECO = iBooker.book1D(histoname.c_str(),title.c_str(),55,-0.1,1);
+
+                histoname = "CSVTurnON";
+                title = "turn on CSV "+trigPath;
+                MonitorElement * CSV_turnon = iBooker.book1D(histoname.c_str(),title.c_str(),110,-0.1,1);
+
+                histoname = "caloTurnON";
+                title = "ratio of offline CSV before and after calo b-tag filter"+trigPath;
+                MonitorElement * CSVratio_calofilter = iBooker.book1D(histoname.c_str(),title.c_str(),55,-0.1,1);
+
+                histoname = "PFTurnON";
+                title = "ratio of offline CSV before and after PF b-tag filter"+trigPath;
+                MonitorElement * CSVratio_PFfilter = iBooker.book1D(histoname.c_str(),title.c_str(),55,-0.1,1);
+
+		histoname = labelname+"_PVz";
+		title = "online z(PV) "+trigPath;
+		MonitorElement * PVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
+
+		histoname = labelname+"_fastPVz";
+		title = "online z(fastPV) "+trigPath;
+		MonitorElement * fastPVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
+
+		histoname = "HLTMinusRECO_PVz";
+		title = "online z(PV) - offline z(PV) "+trigPath;
+		MonitorElement * PVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),200,-0.5,0.5);
+
+		histoname = "HLTMinusRECO_fastPVz";
+		title = "online z(fastPV) - offline z(PV) "+trigPath;
+		MonitorElement * fastPVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),100,-2,2);
+
+		v->setHistos(CSV,Pt,Eta,CSV_RECO,CSV_HLTMinusRECO,CSV_RECOvsHLT,CSVbeforefilter_RECO,CSVafterfilter_RECO,CSV_turnon,CSVratio_calofilter,CSVratio_PFfilter,PVz,fastPVz,PVz_HLTMinusRECO,fastPVz_HLTMinusRECO);
+	}
 }

--- a/DQMOffline/Trigger/test/testTriggerBTV.py
+++ b/DQMOffline/Trigger/test/testTriggerBTV.py
@@ -4,7 +4,7 @@ process = cms.Process("DQM")
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMOffline.Trigger.BTVHLTOfflineSource_cfi")
 process.load( "Configuration.StandardSequences.FrontierConditions_GlobalTag_cff" )
-process.GlobalTag.globaltag = '74X_dataRun2_Prompt_v0'
+process.GlobalTag.globaltag = '81X_mcRun2_asymptotic_v5'
 process.prefer("GlobalTag")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
@@ -14,33 +14,20 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v2-v1/00000/3EC1C553-BF36-E511-9BF4-00259059649C.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v2-v1/00000/A2489ECC-BE36-E511-88CB-002618943900.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v2-v1/00000/B40AE4FD-B436-E511-A272-003048FFD7A2.root' 
-       'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-RECO/76X_mcRun2_asymptotic_v4-v1/00000/1A8546C9-5569-E511-A50B-0026189438F7.root',
-       'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-RECO/76X_mcRun2_asymptotic_v4-v1/00000/82BFCA1B-4669-E511-87AA-0025905A60B8.root',
-       'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-RECO/76X_mcRun2_asymptotic_v4-v1/00000/84BCCDC8-5569-E511-94EB-002618943854.root'
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-RECO/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/2AB0436C-AB6E-E611-9663-0CC47A4C8ECA.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-RECO/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/9695BFEF-AA6E-E611-8A07-0CC47A4D76B2.root' 
     ),
     secondaryFileNames = cms.untracked.vstring(
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/2ABA327E-2969-E511-A5A0-003048FFD736.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/46C054AB-2B69-E511-8CD3-0025905A60EE.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/5A3A6CFA-2769-E511-95AE-0025905B85A2.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/829C9381-3069-E511-943E-002590596484.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/84A3E212-3869-E511-A485-0025905938AA.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/8C278DF6-2769-E511-9A75-0025905A60BC.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/986B93AB-2B69-E511-8555-0025905A60EE.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/9A8902F8-2769-E511-A3AB-0025905B85EE.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/CE0D06A7-2B69-E511-A2F2-0025905964B4.root',
-       'file:///afs/cern.ch/user/s/sdonato/eos/cms/store/relval/CMSSW_7_6_0_pre6/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/76X_mcRun2_asymptotic_v4-v1/00000/D4F42F6F-2969-E511-AC2A-00261894390C.root' 
-       #       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/08BAC960-B436-E511-8306-0025905964C4.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/EA8F0E28-AA36-E511-9539-003048FFCBB0.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/483551C9-A936-E511-9A3E-002618943910.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/7603F5AF-B436-E511-AC18-0025905A610C.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/CE647DAD-B136-E511-BC87-0025905B8592.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/E2E857AB-B436-E511-A4EA-0025905A6138.root',
-#       '/store/relval/CMSSW_7_6_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW-HLTDEBUG/75X_mcRun2_asymptotic_v2-v1/00000/089CF124-AA36-E511-A05F-0025905A605E.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/20E851A4-A56E-E611-83E3-0CC47A78A4BA.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/366730AF-A46E-E611-90C3-0CC47A78A456.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/D63E50B3-A46E-E611-BCD8-0CC47A4D75F8.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/E2C277AB-A46E-E611-BF0C-0025905B8562.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/F26AFCAF-A46E-E611-906B-0CC47A745298.root',
+        'root://cms-xrd-global.cern.ch//store/relval/CMSSW_8_1_0_pre10/RelValTTbarLepton_13/GEN-SIM-DIGI-RAW-HLTDEBUG/81X_mcRun2_asymptotic_v5_hipoffHLT-v1/00000/F2899FA2-A46E-E611-B2A6-0CC47A4D769A.root'
     ),
 )
+
+print "File defined"
 
 process.p = cms.EndPath(
 process.BTVHLTOfflineSource + process.dqmEnv+process.dqmSaver


### PR DESCRIPTION
Adding few histograms for a better monitoring of b-tagging sequences at HLT.
New histograms include:
- difference in the value of the discriminant between online and offline
- offline value of the CSV before and after filter
- CSV of jets passing filters / CSV of all jets
  Few improvements still foreseen
