### PR TITLE
Improve readability of conddb console output

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -403,7 +403,7 @@ def output_table(args, table, headers, filters=None, output_file=None, no_first_
         filters = [None] * len(headers)
 
     def max_length_filter(s):
-        s = str(s).replace('\n', '\\n')
+        s = ' + '.join(str(s).splitlines())
         return '%s...' % s[:conddb.name_length] if ( len(s) > conddb.name_length and not no_max_length ) else s
 
     new_table = [[] for i in range(len(table))]


### PR DESCRIPTION
When a multi-line field is printed on the console, the output
is severely compromised, to the point of being non-readable.
The problem is due to the non correct handling of
line-breaks. This PR cures the problem using native str
methods. The special character '+' has been used to indicate
that the original field was a multi-line field. The choice
was completely arbitrary. Limited testing has been
performed, but on the pathological case, the correct
behaviour is restored. To test use, e.g.:
*
- conddb search SiStripDQMTrigger
  *
  before and after this patch.
