### PR TITLE
Fix material inclusion for D5 geometry

### DIFF
--- a/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D5XML_cfi.py
+++ b/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D5XML_cfi.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
     geomXMLFiles = cms.vstring(
-        'Geometry/CMSCommonData/data/PhaseII/materials.xml',
+        'Geometry/CMSCommonData/data/materials.xml',
         'Geometry/CMSCommonData/data/rotations.xml',
         'Geometry/CMSCommonData/data/extend/cmsextent.xml',
         'Geometry/CMSCommonData/data/PostLS2/cms.xml',


### PR DESCRIPTION
Follow up to #16081.

Wasn't caught in a previous PR  #16117 since the two PRs were done in parallel.

This fixes that oversight.

Tested with: `runTheMatrix.py -w upgrade -l 23224.0`
