### PR TITLE
BugFix for PseudoTop construction in dilepton channel using proper lepton charges

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
@@ -283,17 +283,21 @@ void PseudoTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
       const auto t1LVec = w1LVec + bJet1.p4();
       const auto t2LVec = w2LVec + bJet2.p4();
 
+      // Recalculate lepton charges (needed due to initialization of leptons wrt sign of a charge)
+      const int lepQ1 = lepton1.charge();
+      const int lepQ2 = lepton2.charge();
+
       // Put all of them into candidate collection
-      reco::GenParticle t1(q1*2/3., t1LVec, genVertex_, q1*6, 3, false);
-      reco::GenParticle w1(q1, w1LVec, genVertex_, q1*24, 3, true);
-      reco::GenParticle b1(-q1/3., bJet1.p4(), genVertex_, q1*5, 1, true);
-      reco::GenParticle l1(q1, lepton1.p4(), genVertex_, lepton1.pdgId(), 1, true);
+      reco::GenParticle t1(lepQ1*2/3., t1LVec, genVertex_, lepQ1*6, 3, false);
+      reco::GenParticle w1(lepQ1, w1LVec, genVertex_, lepQ1*24, 3, true);
+      reco::GenParticle b1(-lepQ1/3., bJet1.p4(), genVertex_, lepQ1*5, 1, true);
+      reco::GenParticle l1(lepQ1, lepton1.p4(), genVertex_, lepton1.pdgId(), 1, true);
       reco::GenParticle n1(0, nu1.p4(), genVertex_, nu1.pdgId(), 1, true);
 
-      reco::GenParticle t2(q2*2/3., t2LVec, genVertex_, q2*6, 3, false);
-      reco::GenParticle w2(q2, w2LVec, genVertex_, q2*24, 3, true);
-      reco::GenParticle b2(-q2/3., bJet2.p4(), genVertex_, q2*5, 1, true);
-      reco::GenParticle l2(q2, lepton2.p4(), genVertex_, lepton2.pdgId(), 1, true);
+      reco::GenParticle t2(lepQ2*2/3., t2LVec, genVertex_, lepQ2*6, 3, false);
+      reco::GenParticle w2(lepQ2, w2LVec, genVertex_, lepQ2*24, 3, true);
+      reco::GenParticle b2(-lepQ2/3., bJet2.p4(), genVertex_, lepQ2*5, 1, true);
+      reco::GenParticle l2(lepQ2, lepton2.p4(), genVertex_, lepton2.pdgId(), 1, true);
       reco::GenParticle n2(0, nu2.p4(), genVertex_, nu2.pdgId(), 1, true);
 
       pseudoTop->push_back(t1);

--- a/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
@@ -292,7 +292,7 @@ void PseudoTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
 
       reco::GenParticle t2(q2*2/3., t2LVec, genVertex_, q2*6, 3, false);
       reco::GenParticle w2(q2, w2LVec, genVertex_, q2*24, 3, true);
-      reco::GenParticle b2(-q1/3., bJet2.p4(), genVertex_, q2*5, 1, true);
+      reco::GenParticle b2(-q2/3., bJet2.p4(), genVertex_, q2*5, 1, true);
       reco::GenParticle l2(q2, lepton2.p4(), genVertex_, lepton2.pdgId(), 1, true);
       reco::GenParticle n2(0, nu2.p4(), genVertex_, nu2.pdgId(), 1, true);
 


### PR DESCRIPTION
The bugfix needed to avoid cases, when Top Quark/ W-Plus / Anti-Lepton / B-jet are filled with charge/PdgIds corresponding to respective anti-particles (and vice versa), while keeping the original four-vectors (as associated to particular lepton). After the occurrence of such cases, an object collection (let's say, Anti-Leptons) actually is a mix of true Anti-Leptons and fakes from true Leptons (opposite for original Leptons collection). More detailed explanation of code's performance without bugfix is given in HN message "1" as indicated below, while message "2" leads to performance plots before/after bugfix.

Please check these messages on the HyperNews:
1. https://hypernews.cern.ch/HyperNews/CMS/get/top/2302/1/2/1.html
2. https://hypernews.cern.ch/HyperNews/CMS/get/top/2302/1/2/1/1.html
3. https://hypernews.cern.ch/HyperNews/CMS/get/top/2302/1/2/1/1/1.html
