### PR TITLE
Modify vertex validation to use timing when possible.

### DIFF
--- a/SimTracker/VertexAssociation/interface/VertexAssociatorByPositionAndTracks.h
+++ b/SimTracker/VertexAssociation/interface/VertexAssociatorByPositionAndTracks.h
@@ -19,6 +19,17 @@ public:
                                       double absZ,
                                       double sigmaZ,
                                       double maxRecoZ,
+				      double absT,
+				      double sigmaT,
+				      double maxRecoT,
+                                      double sharedTrackFraction,
+                                      const reco::RecoToSimCollection *trackRecoToSimAssociation,
+                                      const reco::SimToRecoCollection *trackSimToRecoAssociation);
+
+  VertexAssociatorByPositionAndTracks(const edm::EDProductGetter *productGetter,
+                                      double absZ,
+                                      double sigmaZ,
+                                      double maxRecoZ,
                                       double sharedTrackFraction,
                                       const reco::RecoToSimCollection *trackRecoToSimAssociation,
                                       const reco::SimToRecoCollection *trackSimToRecoAssociation);
@@ -39,6 +50,9 @@ private:
   const double absZ_;
   const double sigmaZ_;
   const double maxRecoZ_;
+  const double absT_;
+  const double sigmaT_;
+  const double maxRecoT_;
   const double sharedTrackFraction_;
 
   const reco::RecoToSimCollection *trackRecoToSimAssociation_;

--- a/SimTracker/VertexAssociation/plugins/VertexAssociatorByPositionAndTracksProducer.cc
+++ b/SimTracker/VertexAssociation/plugins/VertexAssociatorByPositionAndTracksProducer.cc
@@ -27,6 +27,9 @@ private:
   const double absZ_;
   const double sigmaZ_;
   const double maxRecoZ_;
+  const double absT_;
+  const double sigmaT_;
+  const double maxRecoT_;
   const double sharedTrackFraction_;
 
   edm::EDGetTokenT<reco::RecoToSimCollection> trackRecoToSimAssociationToken_;
@@ -37,6 +40,9 @@ VertexAssociatorByPositionAndTracksProducer::VertexAssociatorByPositionAndTracks
   absZ_(config.getParameter<double>("absZ")),
   sigmaZ_(config.getParameter<double>("sigmaZ")),
   maxRecoZ_(config.getParameter<double>("maxRecoZ")),
+  absT_(config.getParameter<double>("absT")),
+  sigmaT_(config.getParameter<double>("sigmaT")),
+  maxRecoT_(config.getParameter<double>("maxRecoT")),
   sharedTrackFraction_(config.getParameter<double>("sharedTrackFraction")),
   trackRecoToSimAssociationToken_(consumes<reco::RecoToSimCollection>(config.getParameter<edm::InputTag>("trackAssociation"))),
   trackSimToRecoAssociationToken_(consumes<reco::SimToRecoCollection>(config.getParameter<edm::InputTag>("trackAssociation")))
@@ -53,6 +59,9 @@ void VertexAssociatorByPositionAndTracksProducer::fillDescriptions(edm::Configur
   desc.add<double>("absZ", 0.1);
   desc.add<double>("sigmaZ", 3.0);
   desc.add<double>("maxRecoZ", 1000.0);
+  desc.add<double>("absT", -1.0);
+  desc.add<double>("sigmaT", -1.0);
+  desc.add<double>("maxRecoT", -1.0);
   desc.add<double>("sharedTrackFraction", -1.0);
 
   // Track-TrackingParticle association
@@ -68,13 +77,27 @@ void VertexAssociatorByPositionAndTracksProducer::produce(edm::StreamID, edm::Ev
   edm::Handle<reco::SimToRecoCollection > simtorecoCollectionH;
   iEvent.getByToken(trackSimToRecoAssociationToken_, simtorecoCollectionH);
 
-  auto impl = std::make_unique<VertexAssociatorByPositionAndTracks>(&(iEvent.productGetter()),
-                                                                    absZ_,
-                                                                    sigmaZ_,
-                                                                    maxRecoZ_,
-                                                                    sharedTrackFraction_,
-                                                                    recotosimCollectionH.product(),
-                                                                    simtorecoCollectionH.product());
+  std::unique_ptr<VertexAssociatorByPositionAndTracks> impl;
+  if( sigmaT_ < 0.0 ) {
+    impl = std::make_unique<VertexAssociatorByPositionAndTracks>(&(iEvent.productGetter()),
+								 absZ_,
+								 sigmaZ_,
+								 maxRecoZ_,
+								 sharedTrackFraction_,
+								 recotosimCollectionH.product(),
+								 simtorecoCollectionH.product());
+  } else {
+    impl = std::make_unique<VertexAssociatorByPositionAndTracks>(&(iEvent.productGetter()),
+                                                                 absZ_,
+                                                                 sigmaZ_,
+                                                                 maxRecoZ_,
+								 absT_,
+                                                                 sigmaT_,
+                                                                 maxRecoT_,
+                                                                 sharedTrackFraction_,
+                                                                 recotosimCollectionH.product(),
+                                                                 simtorecoCollectionH.product());
+  }
 
   auto toPut = std::make_unique<reco::VertexToTrackingVertexAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));

--- a/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
+++ b/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
@@ -1,5 +1,6 @@
 #include "SimTracker/VertexAssociation/interface/VertexAssociatorByPositionAndTracks.h"
 #include "SimTracker/VertexAssociation/interface/calculateVertexSharedTracks.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -81,12 +82,21 @@ reco::VertexRecoToSimCollection VertexAssociatorByPositionAndTracks::associateRe
 
       LogTrace("VertexAssociation") << "  Considering TrackingVertex at Z " << simVertex.position().z();
 
+      //  recoVertex.t() == 0.  is a special value
+      // need to change this to std::numeric_limits<double>::max() or something more clear
+      const bool useTiming = ( absT_ != std::numeric_limits<double>::max() && recoVertex.t() != 0. );
+      if( useTiming ) {
+	LogTrace("VertexAssociation") << " and T " << recoVertex.t()*CLHEP::second << std::endl;
+      }
+
+      const double tdiff = std::abs(recoVertex.t() - simVertex.position().t()*CLHEP::second);
       const double zdiff = std::abs(recoVertex.z() - simVertex.position().z());
-      if(zdiff < absZ_ && zdiff / recoVertex.zError() < sigmaZ_) {
+      if( zdiff < absZ_ && zdiff / recoVertex.zError() < sigmaZ_ &&
+	  ( !useTiming || ( tdiff < absT_ && tdiff / recoVertex.tError() < sigmaT_ ) ) ) {
         auto sharedTracks = calculateVertexSharedTracks(recoVertex, simVertex, *trackRecoToSimAssociation_);
         auto fraction = double(sharedTracks)/recoVertex.tracksSize();
         if(sharedTrackFraction_ < 0 || fraction > sharedTrackFraction_) {
-          LogTrace("VertexAssociation") << "   Matched with significance " << zdiff/recoVertex.zError()
+          LogTrace("VertexAssociation") << "   Matched with significance " << zdiff/recoVertex.zError() << " " << tdiff/recoVertex.tError()
                                         << " shared tracks " << sharedTracks << " reco Tracks " << recoVertex.tracksSize() << " TrackingParticles " << simVertex.nDaughterTracks();
 
           ret.insert(reco::VertexBaseRef(vCH, iReco), std::make_pair(TrackingVertexRef(tVCH, iSim), sharedTracks));
@@ -136,13 +146,19 @@ reco::VertexSimToRecoCollection VertexAssociatorByPositionAndTracks::associateSi
         continue;
 
       LogTrace("VertexAssociation") << "  Considering reco::Vertex at Z " << recoVertex.z();
+      const bool useTiming = ( absT_ != std::numeric_limits<double>::max() && recoVertex.t() != 0. );
+      if( useTiming ) {
+	LogTrace("VertexAssociation") << " and T " << recoVertex.t()*CLHEP::second << std::endl;
+      }
 
+      const double tdiff = std::abs(recoVertex.t() - simVertex.position().t()*CLHEP::second);
       const double zdiff = std::abs(recoVertex.z() - simVertex.position().z());
-      if(zdiff < absZ_ && zdiff / recoVertex.zError() < sigmaZ_) {
+      if( zdiff < absZ_ && zdiff / recoVertex.zError() < sigmaZ_ &&
+	  ( !useTiming || ( tdiff < absT_ && tdiff / recoVertex.tError() < sigmaT_ ) ) ) {
         auto sharedTracks = calculateVertexSharedTracks(simVertex, recoVertex, *trackSimToRecoAssociation_);
         auto fraction = double(sharedTracks)/recoVertex.tracksSize();
         if(sharedTrackFraction_ < 0 || fraction > sharedTrackFraction_) {
-          LogTrace("VertexAssociation") << "   Matched with significance " << zdiff/recoVertex.zError()
+          LogTrace("VertexAssociation") << "   Matched with significance " << zdiff/recoVertex.zError() << " " << tdiff/recoVertex.tError()
                                         << " shared tracks " << sharedTracks << " reco Tracks " << recoVertex.tracksSize() << " TrackingParticles " << simVertex.nDaughterTracks();
 
           ret.insert(TrackingVertexRef(tVCH, iSim), std::make_pair(reco::VertexBaseRef(vCH, iReco), sharedTracks));

--- a/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
+++ b/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
@@ -7,6 +7,9 @@ VertexAssociatorByPositionAndTracks::VertexAssociatorByPositionAndTracks(const e
                                                                          double absZ,
                                                                          double sigmaZ,
                                                                          double maxRecoZ,
+									 double absT,
+                                                                         double sigmaT,
+                                                                         double maxRecoT,
                                                                          double sharedTrackFraction,
                                                                          const reco::RecoToSimCollection *trackRecoToSimAssociation,
                                                                          const reco::SimToRecoCollection *trackSimToRecoAssociation):
@@ -14,6 +17,28 @@ VertexAssociatorByPositionAndTracks::VertexAssociatorByPositionAndTracks(const e
   absZ_(absZ),
   sigmaZ_(sigmaZ),
   maxRecoZ_(maxRecoZ),
+  absT_(absT),
+  sigmaT_(sigmaT),
+  maxRecoT_(maxRecoT),
+  sharedTrackFraction_(sharedTrackFraction),
+  trackRecoToSimAssociation_(trackRecoToSimAssociation),
+  trackSimToRecoAssociation_(trackSimToRecoAssociation)
+{}
+
+VertexAssociatorByPositionAndTracks::VertexAssociatorByPositionAndTracks(const edm::EDProductGetter *productGetter,
+                                                                         double absZ,
+                                                                         double sigmaZ,
+                                                                         double maxRecoZ,
+                                                                         double sharedTrackFraction,
+                                                                         const reco::RecoToSimCollection *trackRecoToSimAssociation,
+                                                                         const reco::SimToRecoCollection *trackSimToRecoAssociation):
+  productGetter_(productGetter),
+  absZ_(absZ),
+  sigmaZ_(sigmaZ),
+  maxRecoZ_(maxRecoZ),
+  absT_(std::numeric_limits<double>::max()),
+  sigmaT_(std::numeric_limits<double>::max()),
+  maxRecoT_(std::numeric_limits<double>::max()),
   sharedTrackFraction_(sharedTrackFraction),
   trackRecoToSimAssociation_(trackRecoToSimAssociation),
   trackSimToRecoAssociation_(trackSimToRecoAssociation)


### PR DESCRIPTION
This PR modifies the vertex matching to take advantage of timing information if it is available.

Examples (red is 4D vertexing, blue is 3D):
<img width="957" alt="screen shot 2016-10-09 at 17 20 43" src="https://cloud.githubusercontent.com/assets/1068089/19319338/23d2adb2-9072-11e6-94f4-fb252f237556.png">
<img width="956" alt="screen shot 2016-10-09 at 17 24 47" src="https://cloud.githubusercontent.com/assets/1068089/19319355/2c9e7d90-9072-11e6-98b8-bd2d7bfd9aa4.png">
