### PR TITLE
XMLConfigReader and XmlConfigReader cleanup in L1T 

### DIFF
--- a/L1Trigger/L1TCommon/interface/TrigSystem.h
+++ b/L1Trigger/L1TCommon/interface/TrigSystem.h
@@ -57,7 +57,7 @@ class TrigSystem
 
 		std::string* logText_;
 
-		XmlConfigReader _xmlRdr;
+		//XmlConfigReader _xmlRdr;
 
 		bool checkIdExistsAndSetSetting_(std::vector<Setting>& vec, const std::string& id, const std::string& value, const std::string& procRole);
 		bool checkIdExistsAndSetSetting_(std::vector<Setting>& vec, const std::string& id, const std::string& columns, const std::string& types,  const std::vector<std::string>& rows, const std::string& procRole, const std::string& delim);

--- a/L1Trigger/L1TCommon/src/TrigSystem.cc
+++ b/L1Trigger/L1TCommon/src/TrigSystem.cc
@@ -20,15 +20,19 @@ void TrigSystem::configureSystemFromFiles(const std::string& hwCfgFile, const st
 {
         // read hw description xml
         // this will set the sysId
-        _xmlRdr.readDOMFromFile(hwCfgFile);
-        _xmlRdr.readRootElement(*this);
-
-        // read configuration xml files
-        _xmlRdr.readDOMFromFile(topCfgFile);
-        _xmlRdr.buildGlobalDoc(key, topCfgFile);
-        _xmlRdr.readContexts(key, sysId_, *this);
-
-        isConfigured_ = true;
+  {  
+    XmlConfigReader xmlRdr;
+    xmlRdr.readDOMFromFile(hwCfgFile);
+    xmlRdr.readRootElement(*this);
+  }
+  // read configuration xml files
+  {
+    XmlConfigReader xmlRdr;
+    xmlRdr.readDOMFromFile(topCfgFile);
+    xmlRdr.buildGlobalDoc(key, topCfgFile);
+    xmlRdr.readContexts(key, sysId_, *this);
+  }
+  isConfigured_ = true;
 }
 
 

--- a/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
+++ b/L1Trigger/L1TMuonOverlap/interface/XMLConfigReader.h
@@ -61,8 +61,8 @@ class XMLConfigReader{
 			  unsigned int index=0,
 			  unsigned int aGPNumber=999);
   
-  xercesc::XercesDOMParser *parser;
-  xercesc::DOMDocument* doc;
+  //  xercesc::XercesDOMParser *parser;
+  //  xercesc::DOMDocument* doc;
 
   ///Cache with GPs read.
   std::vector<GoldenPattern*> aGPs;

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -40,20 +40,20 @@ inline XMLCh*  _toDOMS(std::string temp) {
 ////////////////////////////////////
 XMLConfigReader::XMLConfigReader(){
 
-  XMLPlatformUtils::Initialize();
+  //XMLPlatformUtils::Initialize();
   
   ///Initialise XML parser  
-  parser = new XercesDOMParser(); 
-  parser->setValidationScheme(XercesDOMParser::Val_Auto);
-  parser->setDoNamespaces(false);
+  //parser = new XercesDOMParser(); 
+  //parser->setValidationScheme(XercesDOMParser::Val_Auto);
+  //parser->setDoNamespaces(false);
 
-  doc = 0;  
+  //doc = 0;  
 }
 
 XMLConfigReader::~XMLConfigReader()
 {
-  delete parser;
-  XMLPlatformUtils::Terminate();
+  //  delete parser;
+  //XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
@@ -122,14 +122,22 @@ unsigned int XMLConfigReader::getPatternsVersion() const{
 
   if(!patternsFile.size()) return 0;
 
-  parser->parse(patternsFile.c_str()); 
-  xercesc::DOMDocument* doc = parser->getDocument();
+  XMLPlatformUtils::Initialize();
+
+  XercesDOMParser parser;
+  parser.setValidationScheme(XercesDOMParser::Val_Auto);
+  parser.setDoNamespaces(false);
+
+  parser.parse(patternsFile.c_str()); 
+  xercesc::DOMDocument* doc = parser.getDocument();
   assert(doc);
 
   DOMNode *aNode = doc->getElementsByTagName(_toDOMS("OMTF"))->item(0);
   DOMElement* aOMTFElement = static_cast<DOMElement *>(aNode);
 
   unsigned int version = std::stoul(_toString(aOMTFElement->getAttribute(_toDOMS("version"))), nullptr, 16);
+
+  XMLPlatformUtils::Terminate();
   
   return version;
 }
@@ -139,8 +147,15 @@ std::vector<GoldenPattern*> XMLConfigReader::readPatterns(const L1TMuonOverlapPa
 
   aGPs.clear();
   
-  parser->parse(patternsFile.c_str()); 
-  xercesc::DOMDocument* doc = parser->getDocument();
+  XMLPlatformUtils::Initialize();
+
+  XercesDOMParser parser;
+  parser.setValidationScheme(XercesDOMParser::Val_Auto);
+  parser.setDoNamespaces(false);
+
+
+  parser.parse(patternsFile.c_str()); 
+  xercesc::DOMDocument* doc = parser.getDocument();
   assert(doc);
 
   unsigned int nElem = doc->getElementsByTagName(_toDOMS("GP"))->getLength();
@@ -183,7 +198,9 @@ std::vector<GoldenPattern*> XMLConfigReader::readPatterns(const L1TMuonOverlapPa
   }
 
   // Reset the documents vector pool and release all the associated memory back to the system.
-  parser->resetDocumentPool();
+  //parser->resetDocumentPool();
+  parser.resetDocumentPool();
+  XMLPlatformUtils::Terminate();
 
   return aGPs;
 }
@@ -355,8 +372,15 @@ std::vector<std::vector<int> > XMLConfigReader::readEvent(unsigned int iEvent,
 //////////////////////////////////////////////////
 void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const{
 
- parser->parse(configFile.c_str()); 
-  xercesc::DOMDocument* doc = parser->getDocument();
+  XMLPlatformUtils::Initialize();
+
+  XercesDOMParser parser;
+  parser.setValidationScheme(XercesDOMParser::Val_Auto);
+  parser.setDoNamespaces(false);
+
+
+ parser.parse(configFile.c_str()); 
+  xercesc::DOMDocument* doc = parser.getDocument();
   assert(doc);
   unsigned int nElem = doc->getElementsByTagName(_toDOMS("OMTF"))->getLength();
   if(nElem!=1){
@@ -548,7 +572,11 @@ void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const{
   aConfig->setRefHitMap(aRefHitMapVec);
 
   // Reset the documents vector pool and release all the associated memory back to the system.
-  parser->resetDocumentPool();
+  parser.resetDocumentPool();
+  XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
+
+  //  xercesc::XercesDOMParser *parser;
+  //  xercesc::DOMDocument* doc;

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -122,21 +122,23 @@ unsigned int XMLConfigReader::getPatternsVersion() const{
 
   if(!patternsFile.size()) return 0;
 
+  unsigned int version=0;
   XMLPlatformUtils::Initialize();
-
-  XercesDOMParser parser;
-  parser.setValidationScheme(XercesDOMParser::Val_Auto);
-  parser.setDoNamespaces(false);
-
-  parser.parse(patternsFile.c_str()); 
-  xercesc::DOMDocument* doc = parser.getDocument();
-  assert(doc);
-
-  DOMNode *aNode = doc->getElementsByTagName(_toDOMS("OMTF"))->item(0);
-  DOMElement* aOMTFElement = static_cast<DOMElement *>(aNode);
-
-  unsigned int version = std::stoul(_toString(aOMTFElement->getAttribute(_toDOMS("version"))), nullptr, 16);
-
+  {
+    XercesDOMParser parser;
+    parser.setValidationScheme(XercesDOMParser::Val_Auto);
+    parser.setDoNamespaces(false);
+    
+    parser.parse(patternsFile.c_str()); 
+    xercesc::DOMDocument* doc = parser.getDocument();
+    assert(doc);
+    
+    DOMNode *aNode = doc->getElementsByTagName(_toDOMS("OMTF"))->item(0);
+    DOMElement* aOMTFElement = static_cast<DOMElement *>(aNode);
+    
+    version = std::stoul(_toString(aOMTFElement->getAttribute(_toDOMS("version"))), nullptr, 16);
+    
+  }
   XMLPlatformUtils::Terminate();
   
   return version;
@@ -148,58 +150,59 @@ std::vector<GoldenPattern*> XMLConfigReader::readPatterns(const L1TMuonOverlapPa
   aGPs.clear();
   
   XMLPlatformUtils::Initialize();
-
-  XercesDOMParser parser;
-  parser.setValidationScheme(XercesDOMParser::Val_Auto);
-  parser.setDoNamespaces(false);
-
-
-  parser.parse(patternsFile.c_str()); 
-  xercesc::DOMDocument* doc = parser.getDocument();
-  assert(doc);
-
-  unsigned int nElem = doc->getElementsByTagName(_toDOMS("GP"))->getLength();
-  if(nElem<1){
-    edm::LogError("critical")<<"Problem parsing XML file "<<patternsFile<<std::endl;
-    edm::LogError("critical")<<"No GoldenPattern items: GP found"<<std::endl;
-    return aGPs;
-  }
-
-  DOMNode *aNode = 0;
-  DOMElement* aGPElement = 0;
-  unsigned int iGPNumber=0;
-
-  for(unsigned int iItem=0;iItem<nElem;++iItem){
-    aNode = doc->getElementsByTagName(_toDOMS("GP"))->item(iItem);
-    aGPElement = static_cast<DOMElement *>(aNode);
-
-    std::ostringstream stringStr;
-    GoldenPattern *aGP;
-    for(unsigned int index = 1;index<5;++index){
-      stringStr.str("");
-      stringStr<<"iPt"<<index;
-      ///Patterns XML format backward compatibility. Can use both packed by 4, or by 1 XML files.      
-      if(aGPElement->getAttributeNode(_toDOMS(stringStr.str().c_str()))){
-	aGP = buildGP(aGPElement, aConfig, index, iGPNumber);
-	if(aGP){	  
-	  aGPs.push_back(aGP);
-	  iGPNumber++;
+  {
+    XercesDOMParser parser;
+    parser.setValidationScheme(XercesDOMParser::Val_Auto);
+    parser.setDoNamespaces(false);
+    
+    
+    parser.parse(patternsFile.c_str()); 
+    xercesc::DOMDocument* doc = parser.getDocument();
+    assert(doc);
+    
+    unsigned int nElem = doc->getElementsByTagName(_toDOMS("GP"))->getLength();
+    if(nElem<1){
+      edm::LogError("critical")<<"Problem parsing XML file "<<patternsFile<<std::endl;
+      edm::LogError("critical")<<"No GoldenPattern items: GP found"<<std::endl;
+      return aGPs;
+    }
+    
+    DOMNode *aNode = 0;
+    DOMElement* aGPElement = 0;
+    unsigned int iGPNumber=0;
+    
+    for(unsigned int iItem=0;iItem<nElem;++iItem){
+      aNode = doc->getElementsByTagName(_toDOMS("GP"))->item(iItem);
+      aGPElement = static_cast<DOMElement *>(aNode);
+      
+      std::ostringstream stringStr;
+      GoldenPattern *aGP;
+      for(unsigned int index = 1;index<5;++index){
+	stringStr.str("");
+	stringStr<<"iPt"<<index;
+	///Patterns XML format backward compatibility. Can use both packed by 4, or by 1 XML files.      
+	if(aGPElement->getAttributeNode(_toDOMS(stringStr.str().c_str()))){
+	  aGP = buildGP(aGPElement, aConfig, index, iGPNumber);
+	  if(aGP){	  
+	    aGPs.push_back(aGP);
+	    iGPNumber++;
+	  }
 	}
-      }
-      else{
-	aGP = buildGP(aGPElement, aConfig);
-	if(aGP){
-	  aGPs.push_back(aGP);
-	  iGPNumber++;
+	else{
+	  aGP = buildGP(aGPElement, aConfig);
+	  if(aGP){
+	    aGPs.push_back(aGP);
+	    iGPNumber++;
+	  }
+	  break;
 	}
-	break;
       }
     }
-  }
-
-  // Reset the documents vector pool and release all the associated memory back to the system.
+    
+    // Reset the documents vector pool and release all the associated memory back to the system.
   //parser->resetDocumentPool();
-  parser.resetDocumentPool();
+    parser.resetDocumentPool();
+  }
   XMLPlatformUtils::Terminate();
 
   return aGPs;
@@ -373,187 +376,187 @@ std::vector<std::vector<int> > XMLConfigReader::readEvent(unsigned int iEvent,
 void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const{
 
   XMLPlatformUtils::Initialize();
-
-  XercesDOMParser parser;
-  parser.setValidationScheme(XercesDOMParser::Val_Auto);
-  parser.setDoNamespaces(false);
-
-
- parser.parse(configFile.c_str()); 
-  xercesc::DOMDocument* doc = parser.getDocument();
-  assert(doc);
-  unsigned int nElem = doc->getElementsByTagName(_toDOMS("OMTF"))->getLength();
-  if(nElem!=1){
-    edm::LogError("critical")<<"Problem parsing XML file "<<configFile<<std::endl;
-    assert(nElem==1);
-  }
-  DOMNode *aNode = doc->getElementsByTagName(_toDOMS("OMTF"))->item(0);
-  DOMElement* aOMTFElement = static_cast<DOMElement *>(aNode);
-
-  unsigned int version = std::stoul(_toString(aOMTFElement->getAttribute(_toDOMS("version"))), nullptr, 16);
-  aConfig->setFwVersion(version);
-
-  ///Addresing bits numbers
-  nElem = aOMTFElement->getElementsByTagName(_toDOMS("GlobalData"))->getLength();
-  assert(nElem==1);
-  aNode = aOMTFElement->getElementsByTagName(_toDOMS("GlobalData"))->item(0);
-  DOMElement* aElement = static_cast<DOMElement *>(aNode); 
-
-  unsigned int nPdfAddrBits = std::atoi(_toString(aElement->getAttribute(_toDOMS("nPdfAddrBits"))).c_str()); 
-  unsigned int nPdfValBits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPdfValBits"))).c_str()); 
-  unsigned int nHitsPerLayer =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nHitsPerLayer"))).c_str()); 
-  unsigned int nPhiBits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPhiBits"))).c_str()); 
-  unsigned int nPhiBins =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPhiBins"))).c_str()); 
-  unsigned int nRefHits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nRefHits"))).c_str()); 
-  unsigned int nTestRefHits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nTestRefHits"))).c_str());
-  unsigned int nProcessors =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nProcessors"))).c_str());
-  unsigned int nLogicRegions =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nLogicRegions"))).c_str());
-  unsigned int nInputs =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nInputs"))).c_str());
-  unsigned int nLayers =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nLayers"))).c_str());
-  unsigned int nRefLayers =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nRefLayers"))).c_str());
-  unsigned int nGoldenPatterns =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nGoldenPatterns"))).c_str());
-
-  std::vector<int> paramsVec(L1TMuonOverlapParams::GENERAL_NCONFIG);
-  paramsVec[L1TMuonOverlapParams::GENERAL_ADDRBITS] = nPdfAddrBits;
-  paramsVec[L1TMuonOverlapParams::GENERAL_VALBITS] = nPdfValBits;
-  paramsVec[L1TMuonOverlapParams::GENERAL_HITSPERLAYER] = nHitsPerLayer;
-  paramsVec[L1TMuonOverlapParams::GENERAL_PHIBITS] = nPhiBits;
-  paramsVec[L1TMuonOverlapParams::GENERAL_PHIBINS] = nPhiBins;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NREFHITS] = nRefHits;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NTESTREFHITS] = nTestRefHits;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NPROCESSORS] = nProcessors;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NLOGIC_REGIONS] = nLogicRegions;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NINPUTS] = nInputs;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NLAYERS] = nLayers;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NREFLAYERS] = nRefLayers;
-  paramsVec[L1TMuonOverlapParams::GENERAL_NGOLDENPATTERNS] = nGoldenPatterns;
-  aConfig->setGeneralParams(paramsVec);
-
-  ///Chamber sectors connections to logic processros.
-  ///Start/End values for all processors, and chamber types are put into a single vector
-  std::vector<int> sectorsStart(3*nProcessors), sectorsEnd(3*nProcessors);
-  nElem = aOMTFElement->getElementsByTagName(_toDOMS("ConnectionMap"))->getLength();
-  DOMElement* aConnectionElement = 0;
-  for(unsigned int i=0;i<nElem;++i){
-    aNode = aOMTFElement->getElementsByTagName(_toDOMS("ConnectionMap"))->item(i);
-    aConnectionElement = static_cast<DOMElement *>(aNode);
-    unsigned int iProcessor = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("iProcessor"))).c_str());
-    unsigned int barrelMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("barrelMin"))).c_str());
-    unsigned int barrelMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("barrelMax"))).c_str());
-    unsigned int endcap10DegMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap10DegMin"))).c_str());
-    unsigned int endcap10DegMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap10DegMax"))).c_str());
-    unsigned int endcap20DegMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap20DegMin"))).c_str());
-    unsigned int endcap20DegMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap20DegMax"))).c_str());
-
-    sectorsStart[iProcessor] = barrelMin;
-    sectorsStart[iProcessor + nProcessors] = endcap10DegMin;
-    sectorsStart[iProcessor  + 2*nProcessors] = endcap20DegMin;
-
-    sectorsEnd[iProcessor] = barrelMax;
-    sectorsEnd[iProcessor + nProcessors] = endcap10DegMax;
-    sectorsEnd[iProcessor + 2*nProcessors] = endcap20DegMax;       
-  }  
-  aConfig->setConnectedSectorsStart(sectorsStart);
-  aConfig->setConnectedSectorsEnd(sectorsEnd);
-
+  {
+    XercesDOMParser parser;
+    parser.setValidationScheme(XercesDOMParser::Val_Auto);
+    parser.setDoNamespaces(false);
     
-  ///hw <-> logic numbering map
-  std::vector<L1TMuonOverlapParams::LayerMapNode> aLayerMapVec;
-  L1TMuonOverlapParams::LayerMapNode aLayerMapNode;
- 
-  nElem = aOMTFElement->getElementsByTagName(_toDOMS("LayerMap"))->getLength();
-  DOMElement* aLayerElement = 0;
-  for(unsigned int i=0;i<nElem;++i){
-    aNode = aOMTFElement->getElementsByTagName(_toDOMS("LayerMap"))->item(i);
-    aLayerElement = static_cast<DOMElement *>(aNode); 
-    unsigned int hwNumber = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("hwNumber"))).c_str());
-    unsigned int logicNumber = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("logicNumber"))).c_str());
-    unsigned int isBendingLayer = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("bendingLayer"))).c_str());
-    unsigned int iConnectedLayer = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("connectedToLayer"))).c_str());
-    aLayerMapNode.logicNumber = logicNumber;
-    aLayerMapNode.hwNumber = hwNumber;
-    aLayerMapNode.connectedToLayer = iConnectedLayer;
-    aLayerMapNode.bendingLayer = isBendingLayer;
-    aLayerMapVec.push_back(aLayerMapNode);
-  }
-  aConfig->setLayerMap(aLayerMapVec);
-
-  ///ref<->logic numberig map
-  std::vector<L1TMuonOverlapParams::RefLayerMapNode> aRefLayerMapVec;
-  L1TMuonOverlapParams::RefLayerMapNode aRefLayerNode;
-  
-  nElem = aOMTFElement->getElementsByTagName(_toDOMS("RefLayerMap"))->getLength();
-  DOMElement* aRefLayerElement = 0;
-  for(unsigned int i=0;i<nElem;++i){
-    aNode = aOMTFElement->getElementsByTagName(_toDOMS("RefLayerMap"))->item(i);
-    aRefLayerElement = static_cast<DOMElement *>(aNode); 
-    unsigned int refLayer = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("refLayer"))).c_str());
-    unsigned int logicNumber = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("logicNumber"))).c_str());
-    aRefLayerNode.refLayer = refLayer;
-    aRefLayerNode.logicNumber = logicNumber;
-    aRefLayerMapVec.push_back(aRefLayerNode);
-  }
-  aConfig->setRefLayerMap(aRefLayerMapVec);
-
-  std::vector<int> aGlobalPhiStartVec(nProcessors*nRefLayers);
-  
-  std::vector<L1TMuonOverlapParams::RefHitNode> aRefHitMapVec(nProcessors*nRefHits);
-  L1TMuonOverlapParams::RefHitNode aRefHitNode;
-  
-  std::vector<L1TMuonOverlapParams::LayerInputNode> aLayerInputMapVec(nProcessors*nLogicRegions*nLayers);  
-  L1TMuonOverlapParams::LayerInputNode aLayerInputNode;
-  
-  nElem = aOMTFElement->getElementsByTagName(_toDOMS("Processor"))->getLength();
-  assert(nElem==nProcessors);
-  DOMElement* aProcessorElement = 0;
-  for(unsigned int i=0;i<nElem;++i){
-    aNode = aOMTFElement->getElementsByTagName(_toDOMS("Processor"))->item(i);
-    aProcessorElement = static_cast<DOMElement *>(aNode); 
-    unsigned int iProcessor = std::atoi(_toString(aProcessorElement->getAttribute(_toDOMS("iProcessor"))).c_str());
-    unsigned int nElem1 = aProcessorElement->getElementsByTagName(_toDOMS("RefLayer"))->getLength();
-    assert(nElem1==nRefLayers);
+    
+    parser.parse(configFile.c_str()); 
+    xercesc::DOMDocument* doc = parser.getDocument();
+    assert(doc);
+    unsigned int nElem = doc->getElementsByTagName(_toDOMS("OMTF"))->getLength();
+    if(nElem!=1){
+      edm::LogError("critical")<<"Problem parsing XML file "<<configFile<<std::endl;
+      assert(nElem==1);
+    }
+    DOMNode *aNode = doc->getElementsByTagName(_toDOMS("OMTF"))->item(0);
+    DOMElement* aOMTFElement = static_cast<DOMElement *>(aNode);
+    
+    unsigned int version = std::stoul(_toString(aOMTFElement->getAttribute(_toDOMS("version"))), nullptr, 16);
+    aConfig->setFwVersion(version);
+    
+    ///Addresing bits numbers
+    nElem = aOMTFElement->getElementsByTagName(_toDOMS("GlobalData"))->getLength();
+    assert(nElem==1);
+    aNode = aOMTFElement->getElementsByTagName(_toDOMS("GlobalData"))->item(0);
+    DOMElement* aElement = static_cast<DOMElement *>(aNode); 
+    
+    unsigned int nPdfAddrBits = std::atoi(_toString(aElement->getAttribute(_toDOMS("nPdfAddrBits"))).c_str()); 
+    unsigned int nPdfValBits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPdfValBits"))).c_str()); 
+    unsigned int nHitsPerLayer =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nHitsPerLayer"))).c_str()); 
+    unsigned int nPhiBits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPhiBits"))).c_str()); 
+    unsigned int nPhiBins =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nPhiBins"))).c_str()); 
+    unsigned int nRefHits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nRefHits"))).c_str()); 
+    unsigned int nTestRefHits =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nTestRefHits"))).c_str());
+    unsigned int nProcessors =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nProcessors"))).c_str());
+    unsigned int nLogicRegions =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nLogicRegions"))).c_str());
+    unsigned int nInputs =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nInputs"))).c_str());
+    unsigned int nLayers =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nLayers"))).c_str());
+    unsigned int nRefLayers =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nRefLayers"))).c_str());
+    unsigned int nGoldenPatterns =  std::atoi(_toString(aElement->getAttribute(_toDOMS("nGoldenPatterns"))).c_str());
+    
+    std::vector<int> paramsVec(L1TMuonOverlapParams::GENERAL_NCONFIG);
+    paramsVec[L1TMuonOverlapParams::GENERAL_ADDRBITS] = nPdfAddrBits;
+    paramsVec[L1TMuonOverlapParams::GENERAL_VALBITS] = nPdfValBits;
+    paramsVec[L1TMuonOverlapParams::GENERAL_HITSPERLAYER] = nHitsPerLayer;
+    paramsVec[L1TMuonOverlapParams::GENERAL_PHIBITS] = nPhiBits;
+    paramsVec[L1TMuonOverlapParams::GENERAL_PHIBINS] = nPhiBins;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NREFHITS] = nRefHits;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NTESTREFHITS] = nTestRefHits;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NPROCESSORS] = nProcessors;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NLOGIC_REGIONS] = nLogicRegions;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NINPUTS] = nInputs;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NLAYERS] = nLayers;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NREFLAYERS] = nRefLayers;
+    paramsVec[L1TMuonOverlapParams::GENERAL_NGOLDENPATTERNS] = nGoldenPatterns;
+    aConfig->setGeneralParams(paramsVec);
+    
+    ///Chamber sectors connections to logic processros.
+    ///Start/End values for all processors, and chamber types are put into a single vector
+    std::vector<int> sectorsStart(3*nProcessors), sectorsEnd(3*nProcessors);
+    nElem = aOMTFElement->getElementsByTagName(_toDOMS("ConnectionMap"))->getLength();
+    DOMElement* aConnectionElement = 0;
+    for(unsigned int i=0;i<nElem;++i){
+      aNode = aOMTFElement->getElementsByTagName(_toDOMS("ConnectionMap"))->item(i);
+      aConnectionElement = static_cast<DOMElement *>(aNode);
+      unsigned int iProcessor = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("iProcessor"))).c_str());
+      unsigned int barrelMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("barrelMin"))).c_str());
+      unsigned int barrelMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("barrelMax"))).c_str());
+      unsigned int endcap10DegMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap10DegMin"))).c_str());
+      unsigned int endcap10DegMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap10DegMax"))).c_str());
+      unsigned int endcap20DegMin = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap20DegMin"))).c_str());
+      unsigned int endcap20DegMax = std::atoi(_toString(aConnectionElement->getAttribute(_toDOMS("endcap20DegMax"))).c_str());
+      
+      sectorsStart[iProcessor] = barrelMin;
+      sectorsStart[iProcessor + nProcessors] = endcap10DegMin;
+      sectorsStart[iProcessor  + 2*nProcessors] = endcap20DegMin;
+      
+      sectorsEnd[iProcessor] = barrelMax;
+      sectorsEnd[iProcessor + nProcessors] = endcap10DegMax;
+      sectorsEnd[iProcessor + 2*nProcessors] = endcap20DegMax;       
+    }  
+    aConfig->setConnectedSectorsStart(sectorsStart);
+    aConfig->setConnectedSectorsEnd(sectorsEnd);
+    
+    
+    ///hw <-> logic numbering map
+    std::vector<L1TMuonOverlapParams::LayerMapNode> aLayerMapVec;
+    L1TMuonOverlapParams::LayerMapNode aLayerMapNode;
+    
+    nElem = aOMTFElement->getElementsByTagName(_toDOMS("LayerMap"))->getLength();
+    DOMElement* aLayerElement = 0;
+    for(unsigned int i=0;i<nElem;++i){
+      aNode = aOMTFElement->getElementsByTagName(_toDOMS("LayerMap"))->item(i);
+      aLayerElement = static_cast<DOMElement *>(aNode); 
+      unsigned int hwNumber = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("hwNumber"))).c_str());
+      unsigned int logicNumber = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("logicNumber"))).c_str());
+      unsigned int isBendingLayer = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("bendingLayer"))).c_str());
+      unsigned int iConnectedLayer = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("connectedToLayer"))).c_str());
+      aLayerMapNode.logicNumber = logicNumber;
+      aLayerMapNode.hwNumber = hwNumber;
+      aLayerMapNode.connectedToLayer = iConnectedLayer;
+      aLayerMapNode.bendingLayer = isBendingLayer;
+      aLayerMapVec.push_back(aLayerMapNode);
+    }
+    aConfig->setLayerMap(aLayerMapVec);
+    
+    ///ref<->logic numberig map
+    std::vector<L1TMuonOverlapParams::RefLayerMapNode> aRefLayerMapVec;
+    L1TMuonOverlapParams::RefLayerMapNode aRefLayerNode;
+    
+    nElem = aOMTFElement->getElementsByTagName(_toDOMS("RefLayerMap"))->getLength();
     DOMElement* aRefLayerElement = 0;
-    for(unsigned int ii=0;ii<nElem1;++ii){
-      aNode = aProcessorElement->getElementsByTagName(_toDOMS("RefLayer"))->item(ii);
+    for(unsigned int i=0;i<nElem;++i){
+      aNode = aOMTFElement->getElementsByTagName(_toDOMS("RefLayerMap"))->item(i);
       aRefLayerElement = static_cast<DOMElement *>(aNode); 
-      unsigned int iRefLayer = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("iRefLayer"))).c_str());
-      int iPhi = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("iGlobalPhiStart"))).c_str());
-      aGlobalPhiStartVec[iRefLayer + iProcessor*nRefLayers] = iPhi;
+      unsigned int refLayer = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("refLayer"))).c_str());
+      unsigned int logicNumber = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("logicNumber"))).c_str());
+      aRefLayerNode.refLayer = refLayer;
+      aRefLayerNode.logicNumber = logicNumber;
+      aRefLayerMapVec.push_back(aRefLayerNode);
     }
-    ///////////
-    nElem1 = aProcessorElement->getElementsByTagName(_toDOMS("RefHit"))->getLength();
-    assert( (iProcessor==0 && nElem1==nRefHits) || (iProcessor!=0 && nElem1==0) );
-    DOMElement* aRefHitElement = 0;
-    for(unsigned int ii=0;ii<nElem1;++ii){
-      aNode = aProcessorElement->getElementsByTagName(_toDOMS("RefHit"))->item(ii);
-      aRefHitElement = static_cast<DOMElement *>(aNode); 
-      unsigned int iRefHit = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRefHit"))).c_str());
-      int iPhiMin = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iPhiMin"))).c_str());
-      int iPhiMax = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iPhiMax"))).c_str());
-      unsigned int iInput = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iInput"))).c_str());
-      unsigned int iRegion = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRegion"))).c_str());
-      unsigned int iRefLayer = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRefLayer"))).c_str());
-
-      aRefHitNode.iRefHit = iRefHit;
-      aRefHitNode.iPhiMin = iPhiMin;
-      aRefHitNode.iPhiMax = iPhiMax;
-      aRefHitNode.iInput = iInput;
-      aRefHitNode.iRegion = iRegion;
-      aRefHitNode.iRefLayer = iRefLayer;
-      for (unsigned int iProcessor=0; iProcessor<nProcessors; iProcessor++) aRefHitMapVec[iRefHit + iProcessor*nRefHits] = aRefHitNode;
-    }
-    ///////////
-    unsigned int nElem2 = aProcessorElement->getElementsByTagName(_toDOMS("LogicRegion"))->getLength();
-    assert( (iProcessor==0 && nElem2==nLogicRegions) || (iProcessor!=0 && nElem2==0) );
-    DOMElement* aRegionElement = 0;
-    for(unsigned int ii=0;ii<nElem2;++ii){
-      aNode = aProcessorElement->getElementsByTagName(_toDOMS("LogicRegion"))->item(ii);
-      aRegionElement = static_cast<DOMElement *>(aNode); 
-      unsigned int iRegion = std::atoi(_toString(aRegionElement->getAttribute(_toDOMS("iRegion"))).c_str());
-      unsigned int nElem3 = aRegionElement->getElementsByTagName(_toDOMS("Layer"))->getLength();
-      assert(nElem3==nLayers);
-      DOMElement* aLayerElement = 0;
-      for(unsigned int iii=0;iii<nElem3;++iii){
+    aConfig->setRefLayerMap(aRefLayerMapVec);
+    
+    std::vector<int> aGlobalPhiStartVec(nProcessors*nRefLayers);
+    
+    std::vector<L1TMuonOverlapParams::RefHitNode> aRefHitMapVec(nProcessors*nRefHits);
+    L1TMuonOverlapParams::RefHitNode aRefHitNode;
+    
+    std::vector<L1TMuonOverlapParams::LayerInputNode> aLayerInputMapVec(nProcessors*nLogicRegions*nLayers);  
+    L1TMuonOverlapParams::LayerInputNode aLayerInputNode;
+    
+    nElem = aOMTFElement->getElementsByTagName(_toDOMS("Processor"))->getLength();
+    assert(nElem==nProcessors);
+    DOMElement* aProcessorElement = 0;
+    for(unsigned int i=0;i<nElem;++i){
+      aNode = aOMTFElement->getElementsByTagName(_toDOMS("Processor"))->item(i);
+      aProcessorElement = static_cast<DOMElement *>(aNode); 
+      unsigned int iProcessor = std::atoi(_toString(aProcessorElement->getAttribute(_toDOMS("iProcessor"))).c_str());
+      unsigned int nElem1 = aProcessorElement->getElementsByTagName(_toDOMS("RefLayer"))->getLength();
+      assert(nElem1==nRefLayers);
+      DOMElement* aRefLayerElement = 0;
+      for(unsigned int ii=0;ii<nElem1;++ii){
+	aNode = aProcessorElement->getElementsByTagName(_toDOMS("RefLayer"))->item(ii);
+	aRefLayerElement = static_cast<DOMElement *>(aNode); 
+	unsigned int iRefLayer = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("iRefLayer"))).c_str());
+	int iPhi = std::atoi(_toString(aRefLayerElement->getAttribute(_toDOMS("iGlobalPhiStart"))).c_str());
+	aGlobalPhiStartVec[iRefLayer + iProcessor*nRefLayers] = iPhi;
+      }
+      ///////////
+      nElem1 = aProcessorElement->getElementsByTagName(_toDOMS("RefHit"))->getLength();
+      assert( (iProcessor==0 && nElem1==nRefHits) || (iProcessor!=0 && nElem1==0) );
+      DOMElement* aRefHitElement = 0;
+      for(unsigned int ii=0;ii<nElem1;++ii){
+	aNode = aProcessorElement->getElementsByTagName(_toDOMS("RefHit"))->item(ii);
+	aRefHitElement = static_cast<DOMElement *>(aNode); 
+	unsigned int iRefHit = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRefHit"))).c_str());
+	int iPhiMin = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iPhiMin"))).c_str());
+	int iPhiMax = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iPhiMax"))).c_str());
+	unsigned int iInput = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iInput"))).c_str());
+	unsigned int iRegion = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRegion"))).c_str());
+	unsigned int iRefLayer = std::atoi(_toString(aRefHitElement->getAttribute(_toDOMS("iRefLayer"))).c_str());
+	
+	aRefHitNode.iRefHit = iRefHit;
+	aRefHitNode.iPhiMin = iPhiMin;
+	aRefHitNode.iPhiMax = iPhiMax;
+	aRefHitNode.iInput = iInput;
+	aRefHitNode.iRegion = iRegion;
+	aRefHitNode.iRefLayer = iRefLayer;
+	for (unsigned int iProcessor=0; iProcessor<nProcessors; iProcessor++) aRefHitMapVec[iRefHit + iProcessor*nRefHits] = aRefHitNode;
+      }
+      ///////////
+      unsigned int nElem2 = aProcessorElement->getElementsByTagName(_toDOMS("LogicRegion"))->getLength();
+      assert( (iProcessor==0 && nElem2==nLogicRegions) || (iProcessor!=0 && nElem2==0) );
+      DOMElement* aRegionElement = 0;
+      for(unsigned int ii=0;ii<nElem2;++ii){
+	aNode = aProcessorElement->getElementsByTagName(_toDOMS("LogicRegion"))->item(ii);
+	aRegionElement = static_cast<DOMElement *>(aNode); 
+	unsigned int iRegion = std::atoi(_toString(aRegionElement->getAttribute(_toDOMS("iRegion"))).c_str());
+	unsigned int nElem3 = aRegionElement->getElementsByTagName(_toDOMS("Layer"))->getLength();
+	assert(nElem3==nLayers);
+	DOMElement* aLayerElement = 0;
+	for(unsigned int iii=0;iii<nElem3;++iii){
   	  aNode = aRegionElement->getElementsByTagName(_toDOMS("Layer"))->item(iii);
 	  aLayerElement = static_cast<DOMElement *>(aNode); 
 	  unsigned int iLayer = std::atoi(_toString(aLayerElement->getAttribute(_toDOMS("iLayer"))).c_str());
@@ -563,16 +566,17 @@ void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const{
 	  aLayerInputNode.iFirstInput = iFirstInput;
 	  aLayerInputNode.nInputs = nInputs;
 	  for (unsigned int iProcessor=0; iProcessor<nProcessors; ++iProcessor) aLayerInputMapVec[iLayer + iRegion*nLayers + iProcessor*nLayers*nLogicRegions] = aLayerInputNode;
-      }
-    }   
+	}
+      }   
+    }
+    
+    aConfig->setGlobalPhiStartMap(aGlobalPhiStartVec);
+    aConfig->setLayerInputMap(aLayerInputMapVec);
+    aConfig->setRefHitMap(aRefHitMapVec);
+    
+    // Reset the documents vector pool and release all the associated memory back to the system.
+    parser.resetDocumentPool();
   }
-
-  aConfig->setGlobalPhiStartMap(aGlobalPhiStartVec);
-  aConfig->setLayerInputMap(aLayerInputMapVec);
-  aConfig->setRefHitMap(aRefHitMapVec);
-
-  // Reset the documents vector pool and release all the associated memory back to the system.
-  parser.resetDocumentPool();
   XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////


### PR DESCRIPTION
rearrange xerces use in L1T packages to better handle memory management. Fixes errors in workflow 136.7321 currently in the IBs (hopefully doesn't cause others)
