### PR TITLE
ZDC - fixed typo to match backport

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc
@@ -21,7 +21,7 @@ ZdcSimpleReconstructor::ZdcSimpleReconstructor(edm::ParameterSet const& conf):
   dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed"))
 {
   tok_input_castor = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelcastor"));
-  tok_input_castor = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelhcal"));
+  tok_input_hcal = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelhcal"));
 
 
   std::string subd=conf.getParameter<std::string>("Subdetector");

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
@@ -32,8 +32,8 @@
       DetId::Detector det_;
       int subdet_;
       HcalOtherSubdetector subdetOther_;
-      edm::EDGetTokenT<ZDCDigiCollection> tok_input_castor;
       edm::EDGetTokenT<ZDCDigiCollection> tok_input_hcal;
+      edm::EDGetTokenT<ZDCDigiCollection> tok_input_castor;
 
       bool dropZSmarkedPassed_; // turn on/off dropping of zero suppression marked and passed digis
       


### PR DESCRIPTION
A few minor changes: 
-Bug fix in RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.cc. 
-Trivial line flip in RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
