### PR TITLE
Propagate the overthreshold / high charge bit to phase2 clusters

### DIFF
--- a/RecoLocalTracker/SiPhase2Clusterizer/interface/Phase2TrackerClusterizerArray.h
+++ b/RecoLocalTracker/SiPhase2Clusterizer/interface/Phase2TrackerClusterizerArray.h
@@ -10,11 +10,11 @@ class Phase2TrackerClusterizerArray {
         Phase2TrackerClusterizerArray();
         Phase2TrackerClusterizerArray(unsigned int, unsigned int);
         void setSize(unsigned int, unsigned int);
-        bool operator()(unsigned int, unsigned int) const;
+        int operator()(unsigned int, unsigned int) const;
         unsigned int rows() const;
         unsigned int columns() const;
         bool inside(unsigned int, unsigned int) const;
-        void set(unsigned int, unsigned int, bool);
+        void set(unsigned int, unsigned int, bool, bool);
         unsigned int size() const;
         unsigned int index(unsigned int, unsigned int) const;
 
@@ -22,6 +22,7 @@ class Phase2TrackerClusterizerArray {
 
         unsigned int nrows_, ncols_;
         std::vector< bool > matrix_;
+        std::vector< bool > hipmatrix_;
 
 };
 

--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizerAlgorithm.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizerAlgorithm.cc
@@ -33,6 +33,7 @@ void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< Pha
     Phase2TrackerDigi firstDigi;
     unsigned int sizeCluster(0);
     bool closeCluster(false); 
+    bool HIPbit(false); 
 
     // Loop over the Digis
     // for the S modules, 1 column = 1 strip, so adjacent digis are along the rows
@@ -56,13 +57,16 @@ void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< Pha
             // Otherwise check if we need to close a cluster (end of cluster)
             else closeCluster = ((sizeCluster != 0) ? true : false);
 
+	    // update the HIP bit
+	    HIPbit |= (matrix_(row, col)==2);
+
             // Always close a cluster if we reach the end of the loop
             if (sizeCluster != 0 and row == (nrows_ - 1)) closeCluster = true;
 
             // If we have to close a cluster, do it
             if (closeCluster) { 
                 // Add the cluster to the list
-                clusters.push_back(Phase2TrackerCluster1D(firstDigi, sizeCluster));
+                clusters.push_back(Phase2TrackerCluster1D(firstDigi, sizeCluster, HIPbit)); 
                 // Reset the variables
                 sizeCluster = 0;
                 // Increase the number of clusters
@@ -83,7 +87,7 @@ void Phase2TrackerClusterizerAlgorithm::clusterizeDetUnit(const edm::DetSet< Pha
  */
 
 void Phase2TrackerClusterizerAlgorithm::fillMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator begin, edm::DetSet< Phase2TrackerDigi >::const_iterator end) {
-    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), true);
+    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), true, di->overThreshold());
 }
 
 /*
@@ -91,6 +95,6 @@ void Phase2TrackerClusterizerAlgorithm::fillMatrix(edm::DetSet< Phase2TrackerDig
  */
 
 void Phase2TrackerClusterizerAlgorithm::clearMatrix(edm::DetSet< Phase2TrackerDigi >::const_iterator begin, edm::DetSet< Phase2TrackerDigi >::const_iterator end) {
-    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), false);
+    for (edm::DetSet< Phase2TrackerDigi >::const_iterator di(begin); di != end; ++di) matrix_.set(di->row(), di->column(), false, false);
 }
 

--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizerArray.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizerArray.cc
@@ -18,16 +18,23 @@ void Phase2TrackerClusterizerArray::setSize(unsigned int nrows, unsigned int nco
     nrows_ = nrows;
     ncols_ = ncols;
     matrix_.resize(nrows * ncols);
+    hipmatrix_.resize(nrows * ncols);
     for (std::vector< bool >::iterator it(matrix_.begin()); it != matrix_.end(); ++it) *it = false;
+    for (std::vector< bool >::iterator it(hipmatrix_.begin()); it != hipmatrix_.end(); ++it) *it = false;
 }
 
 /*
  * Return the value of an element in the Array
  */
 
-bool Phase2TrackerClusterizerArray::operator()(unsigned int row, unsigned int col) const {
-    if (inside(row, col)) return matrix_[index(row, col)];
-    else return false;
+int Phase2TrackerClusterizerArray::operator()(unsigned int row, unsigned int col) const {
+    if (inside(row, col)) {
+    	if (matrix_[index(row, col)]) {
+	   if (hipmatrix_[index(row, col)]) return 2;
+	   else return 1;
+	} else return 0;
+    }
+    else return 0;
 }
 
 /*
@@ -58,8 +65,9 @@ bool Phase2TrackerClusterizerArray::inside(unsigned int row, unsigned int col) c
  * Change the value of an element of the Array
  */
 
-void Phase2TrackerClusterizerArray::set(unsigned int row, unsigned int col, bool state) {
+void Phase2TrackerClusterizerArray::set(unsigned int row, unsigned int col, bool state, bool hip) {
     matrix_[index(row, col)] = state;
+    hipmatrix_[index(row, col)] = hip;
 }
 
 /*


### PR DESCRIPTION
Minimal change to propagate the over-threshold bit in digis from SSA chips to phase 2 tracker clusters.

This should have been done long ago and was somehow overlooked when the othr bit was added to digis. This is required for TDR studies of HSCP particles.

The cluster "high charge bit" is set as soon as one digi has that bit on. This corresponds to the expected behavior of the CIC chip. 

Tested with runTheMatrix.py --what upgrade -l 21200 in the last nightly. The output contains 7% of clusters with the bit set.

@boudoul @atricomi @thomaslenzi 
