### PR TITLE
Remove AlcaRecos from 2017 trackingOnly workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -38,6 +38,8 @@ def _trackingOnly(stepList):
         s = step
         if 'RecoFull' in step or 'HARVESTFull' in step:
             s = s.replace('Full', 'Full_trackingOnly')
+        if 'ALCA' in s:
+            continue
         res.append(s)
     return res
 def _trackingRun2(stepList):
@@ -49,6 +51,8 @@ def _trackingRun2(stepList):
                 s = s.replace('Only', 'OnlyRun2')
             else:
                 s = s.replace('Full', 'Full_trackingRun2')
+        if 'ALCA' in s:
+            continue
         res.append(s)
     return res
 def _trackingPhase1PU70(stepList):
@@ -60,6 +64,8 @@ def _trackingPhase1PU70(stepList):
                 s = s.replace('Only', 'OnlyPhase1PU70')
             else:
                 s = s.replace('Full', 'Full_trackingPhase1PU70')
+        if 'ALCA' in s:
+            continue
         res.append(s)
     return res
 


### PR DESCRIPTION
This PR fixes the workflows 10024.1, 10024.3, and 10024.5 that are currently failing because of the AlcaReco step introduced in #16168. Thanks to @ebrondol for reporting the problem.

Tested in CMSSW_8_1_X_2016-10-12-2300, expected change is that the aforementioned workflows work again.

@rovere @VinInn @ebrondol 
