### PR TITLE
Added 2-D histogram of trigger tower flags vs Et.

### DIFF
--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -149,6 +149,26 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('DCC'),
             description = cms.untracked.string('Distribution of the trigger tower flags.')
         ),
+        TTFlagsVsEt = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sSelectiveReadoutTask/%(prefix)sSRT TT Flags vs Et%(suffix)s'),
+            kind = cms.untracked.string('TH2F'),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(7.5),
+                nbins = cms.untracked.int32(8),
+                low = cms.untracked.double(-0.5),
+                title = cms.untracked.string('TT flag'),
+                labels = cms.untracked.vstring(map(str, range(0, 8)))
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(50.0),
+                nbins = cms.untracked.int32(100),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('TP Et')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.')
+        ),
         TTFlags4 = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TTF4 Occupancy%(suffix)s'),
             kind = cms.untracked.string('TH2F'),

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -189,6 +189,7 @@ namespace ecaldqm
     MESet& meMedIntMap(MEs_.at("MedIntMap"));
     MESet& meHighIntMap(MEs_.at("HighIntMap"));
     MESet& meTTFlags(MEs_.at("TTFlags"));
+    MESet& meTTFlagsVsEt(MEs_.at("TTFlagsVsEt"));
     MESet& meTTFlags4( MEs_.at("TTFlags4") );
     MESet& meTTFMismatch(MEs_.at("TTFMismatch"));
     MESet& meOccVsBx(MEs_.at("OccVsBx"));
@@ -235,6 +236,7 @@ namespace ecaldqm
       // Fill TT Flag MEs
       float ttF( tpItr->ttFlag() );
       meTTFlags.fill( ttid, ttF );
+      meTTFlagsVsEt.fill(ttid, et, ttF);
       // Monitor occupancy of TTF=4
       // which contains info about TT auto-masking
       if ( ttF == 4. )


### PR DESCRIPTION
We introduce a new 2-D histogram to show the correlation between TT flags and Et deposited in a given trigger tower.

Companion to 8_0_X PR: CMSSW PR#16205 (https://github.com/cms-sw/cmssw/pull/16205)
