### PR TITLE
Update tracking validation

### DIFF
--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -56,7 +56,8 @@ class MTVHistoProducerAlgoForTracker {
 					   const reco::Track* track,
 					   int numVertices,
 					   double dR,
-					   const math::XYZPoint *pvPosition);
+					   const math::XYZPoint *pvPosition,
+                                           const TrackingVertex::LorentzVector *simPVPosition);
 
   void fill_recoAssociated_simTrack_histos(int count,
 					   const reco::GenParticle& tp,
@@ -71,6 +72,7 @@ class MTVHistoProducerAlgoForTracker {
                                      const TrackerTopology& ttopo,
 				     const math::XYZPoint& bsPosition,
 				     const math::XYZPoint *pvPosition,
+                                     const TrackingVertex::LorentzVector *simPVPosition,
 				     bool isMatched,
 				     bool isSigMatched,
 				     bool isChargeMatched,
@@ -147,6 +149,7 @@ class MTVHistoProducerAlgoForTracker {
   double minDeDx, maxDeDx;  int nintDeDx;
   double minVertcount, maxVertcount;  int nintVertcount;
   double minTracks, maxTracks; int nintTracks;
+  double minPVz, maxPVz; int nintPVz;
 
   const bool doSeedPlots_;
 
@@ -199,6 +202,7 @@ class MTVHistoProducerAlgoForTracker {
 
   std::vector<MonitorElement*> h_reco_dzpvcut_pt, h_assoc_dzpvcut_pt, h_assoc2_dzpvcut_pt, h_simul_dzpvcut_pt, h_simul2_dzpvcut_pt, h_pileup_dzpvcut_pt;
   std::vector<MonitorElement*> h_reco_dzpvsigcut_pt, h_assoc_dzpvsigcut_pt, h_assoc2_dzpvsigcut_pt, h_simul_dzpvsigcut_pt, h_simul2_dzpvsigcut_pt, h_pileup_dzpvsigcut_pt;
+  std::vector<MonitorElement*> h_reco_simpvz, h_assoc_simpvz, h_assoc2_simpvz, h_simul_simpvz, h_pileup_simpvz;
 
   std::vector<MonitorElement*> h_reco_seedingLayerSet, h_assoc2_seedingLayerSet, h_looper_seedingLayerSet, h_pileup_seedingLayerSet;
 

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -54,6 +54,7 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   std::string dirName_;
 
   bool useGsf;
+  const double simPVMaxZ_;
   // select tracking particles 
   //(i.e. "denominator" of the efficiency ratio)
   TrackingParticleSelector tpSelector;				      

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -693,7 +693,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
         int nSimLayers = nLayers_tPCeff[tpr];
         int nSimPixelLayers = nPixelLayers_tPCeff[tpr];
         int nSimStripMonoAndStereoLayers = nStripMonoAndStereoLayers_tPCeff[tpr];
-        histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,tp,momentumTP,vertexTP,dxySim,dzSim,dxyPVSim,dzPVSim,nSimHits,nSimLayers,nSimPixelLayers,nSimStripMonoAndStereoLayers,matchedTrackPointer,puinfo.getPU_NumInteractions(), dR, thePVposition);
+        histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,tp,momentumTP,vertexTP,dxySim,dzSim,dxyPVSim,dzPVSim,nSimHits,nSimLayers,nSimPixelLayers,nSimStripMonoAndStereoLayers,matchedTrackPointer,puinfo.getPU_NumInteractions(), dR, thePVposition, theSimPVPosition);
           sts++;
           if(matchedTrackPointer)
             asts++;
@@ -804,7 +804,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 	}
 
 	double dR=dR_trk[i];
-	histoProducerAlgo_->fill_generic_recoTrack_histos(w,*track, ttopo, bs.position(), thePVposition, isSimMatched,isSigSimMatched, isChargeMatched, numAssocRecoTracks, puinfo.getPU_NumInteractions(), nSimHits, sharedFraction, dR);
+	histoProducerAlgo_->fill_generic_recoTrack_histos(w,*track, ttopo, bs.position(), thePVposition, theSimPVPosition, isSimMatched,isSigSimMatched, isChargeMatched, numAssocRecoTracks, puinfo.getPU_NumInteractions(), nSimHits, sharedFraction, dR);
         if(doSummaryPlots_) {
           h_reco_coll[ww]->Fill(www);
           if(isSimMatched) {

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -52,7 +52,8 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset):
   doRecoTrackPlots_(pset.getUntrackedParameter<bool>("doRecoTrackPlots")),
   dodEdxPlots_(pset.getUntrackedParameter<bool>("dodEdxPlots")),
   doPVAssociationPlots_(pset.getUntrackedParameter<bool>("doPVAssociationPlots")),
-  doSeedPlots_(pset.getUntrackedParameter<bool>("doSeedPlots"))
+  doSeedPlots_(pset.getUntrackedParameter<bool>("doSeedPlots")),
+  simPVMaxZ_(pset.getUntrackedParameter<double>("simPVMaxZ"))
 {
   ParameterSet psetForHistoProducerAlgo = pset.getParameter<ParameterSet>("histoProducerAlgoBlock");
   histoProducerAlgo_ = std::make_unique<MTVHistoProducerAlgoForTracker>(psetForHistoProducerAlgo, doSeedPlots_, consumesCollector());
@@ -69,8 +70,8 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset):
     m_dEdx2Tag = consumes<edm::ValueMap<reco::DeDxData> >(pset.getParameter< edm::InputTag >("dEdx2Tag"));
   }
 
+  label_tv = consumes<TrackingVertexCollection>(pset.getParameter< edm::InputTag >("label_tv"));
   if(doPlotsOnlyForTruePV_ || doPVAssociationPlots_) {
-    label_tv = consumes<TrackingVertexCollection>(pset.getParameter< edm::InputTag >("label_tv"));
     recoVertexToken_ = consumes<edm::View<reco::Vertex> >(pset.getUntrackedParameter<edm::InputTag>("label_vertex"));
     vertexAssociatorToken_ = consumes<reco::VertexToTrackingVertexAssociator>(pset.getUntrackedParameter<edm::InputTag>("vertexAssociator"));
   }
@@ -331,10 +332,26 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   const reco::Vertex::Point *thePVposition = nullptr;
   const TrackingVertex::LorentzVector *theSimPVPosition = nullptr;
-  if(doPlotsOnlyForTruePV_ || doPVAssociationPlots_) {
-    edm::Handle<TrackingVertexCollection> htv;
-    event.getByToken(label_tv, htv);
+  // Find the sim PV and tak its position
+  edm::Handle<TrackingVertexCollection> htv;
+  event.getByToken(label_tv, htv);
+  {
+    const TrackingVertexCollection& tv = *htv;
+    for(size_t i=0; i<tv.size(); ++i) {
+      const TrackingVertex& simV = tv[i];
+      if(simV.eventId().bunchCrossing() != 0) continue; // remove OOTPU
+      if(simV.eventId().event() != 0) continue; // pick the PV of hard scatter
+      theSimPVPosition = &(simV.position());
+      break;
+    }
+  }
+  if(simPVMaxZ_ >= 0) {
+    if(!theSimPVPosition) return;
+    if(std::abs(theSimPVPosition->z()) > simPVMaxZ_) return;
+  }
 
+  // Check, when necessary, if reco PV matches to sim PV
+  if(doPlotsOnlyForTruePV_ || doPVAssociationPlots_) {
     edm::Handle<edm::View<reco::Vertex> > hvertex;
     event.getByToken(recoVertexToken_, hvertex);
 
@@ -346,19 +363,17 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
     if(!(pvPtr->isFake() || pvPtr->ndof() < 0)) { // skip junk vertices
       auto pvFound = v_r2s.find(pvPtr);
       if(pvFound != v_r2s.end()) {
-        int simPVindex = -1;
-        int i=0;
+        bool matchedToSimPV = false;
         for(const auto& vertexRefQuality: pvFound->val) {
           const TrackingVertex& tv = *(vertexRefQuality.first);
           if(tv.eventId().event() == 0 && tv.eventId().bunchCrossing() == 0) {
-            simPVindex = i;
+            matchedToSimPV = true;
+            break;
           }
-          ++i;
         }
-        if(simPVindex >= 0) {
+        if(matchedToSimPV) {
           if(doPVAssociationPlots_) {
             thePVposition = &(pvPtr->position());
-            theSimPVPosition = &(pvFound->val[simPVindex].first->position());
           }
         }
         else if(doPlotsOnlyForTruePV_)

--- a/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
@@ -348,7 +348,7 @@ void MultiTrackValidatorGenPs::analyze(const edm::Event& event, const edm::Event
       
       
       double dR=0;//fixme: plots vs dR not implemented for now
-      histoProducerAlgo_->fill_generic_recoTrack_histos(w,*track, ttopo, bs.position(), nullptr, isGenMatched,isSigGenMatched, isChargeMatched, numAssocRecoTracks, puinfo.getPU_NumInteractions(), nSimHits, sharedFraction,dR);
+      histoProducerAlgo_->fill_generic_recoTrack_histos(w,*track, ttopo, bs.position(), nullptr, nullptr, isGenMatched,isSigGenMatched, isChargeMatched, numAssocRecoTracks, puinfo.getPU_NumInteractions(), nSimHits, sharedFraction,dR);
       
       // dE/dx
       if (dodEdxPlots_) histoProducerAlgo_->fill_dedx_recoTrack_histos(w,track, v_dEdx);

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -273,7 +273,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 
 	double dR=0;//fixme: plots vs dR not implemented for now
 	histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,*tp,tp->momentum(),tp->vertex(),dxySim,dzSim,0,0,nSimHits,nSimLayers,nSimPixelLayers,nSimStripMonoAndStereoLayers,
-								matchedTrackPointer,puinfo.getPU_NumInteractions(),dR, nullptr);
+								matchedTrackPointer,puinfo.getPU_NumInteractions(),dR, nullptr, nullptr);
 
 	sts++;
 	if (matchedTrackPointer) asts++;
@@ -358,7 +358,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	}
 
 	double dR = 0.;//fixme: plots vs dR not implemented for now
-	histoProducerAlgo_->fill_generic_recoTrack_histos(w,*trackFromSeed, ttopo, bs.position(), nullptr, isSimMatched,isSigSimMatched,
+	histoProducerAlgo_->fill_generic_recoTrack_histos(w,*trackFromSeed, ttopo, bs.position(), nullptr, nullptr, isSimMatched,isSigSimMatched,
 							  isChargeMatched, numAssocSeeds, 
 							  puinfo.getPU_NumInteractions(),
 							  nSimHits, sharedFraction, dR);

--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -90,6 +90,12 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
     minTracks = cms.double(0),
     maxTracks = cms.double(2000),
     nintTracks = cms.int32(100),
+
+    # PV z coordinate (to be kept in synch with PrimaryVertexAnalyzer4PUSlimmed)
+    minPVz = cms.double(-60),
+    maxPVz = cms.double(60),
+    nintPVz = cms.int32(120),
+
     #
     #parameters for resolution plots
     ptRes_rangeMin = cms.double(-0.1),

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -81,6 +81,8 @@ multiTrackValidator = cms.EDAnalyzer(
     label_vertex = cms.untracked.InputTag("offlinePrimaryVertices"),
     vertexAssociator = cms.untracked.InputTag("VertexAssociatorByPositionAndTracks"),
 
+    simPVMaxZ = cms.untracked.double(-1),
+
     ### Allow switching off particular histograms
     doSummaryPlots = cms.untracked.bool(True),
     doSimPlots = cms.untracked.bool(True),

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -115,6 +115,10 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
     "effic_vs_dzpvsigcut2_pt 'Fraction of true p_{T} carried by recoed TPs from PV (tracking eff factorized out) vs. dz(PV)/dzError' num_assoc(simToReco)_dzpvsigcut_pt num_simul2_dzpvsigcut_pt",
     "fakerate_vs_dzpvsigcut_pt 'Fraction of fake p_{T} carried by tracks from PV vs. dz(PV)/dzError' num_assoc(recoToSim)_dzpvsigcut_pt num_reco_dzpvsigcut_pt fake",
     "pileuprate_dzpvsigcut_pt 'Fraction of pileup p_{T} carried by tracks from PV vs. dz(PV)/dzError' num_pileup_dzpvsigcut_pt num_reco_dzpvsigcut_pt",
+
+    "effic_vs_simpvz 'Efficiency vs. sim PV z' num_assoc(simToReco)_simpvz num_simul_simpvz",
+    "fakerate_vs_simpvz 'Fake rate vs. sim PV z' num_assoc(recoToSim)_simpvz num_reco_simpvz fake",
+    "pileuprate_simpvz 'Pileup rate vs. sim PV z' num_pileup_simpvz num_reco_simpvz",
     ),
     resolution = cms.vstring(
                              "cotThetares_vs_eta '#sigma(cot(#theta)) vs #eta' cotThetares_vs_eta",

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -45,6 +45,12 @@ _fromPVName = "Tracks from PV"
 _fromPVAllTPName = "Tracks from PV (all TPs)"
 _conversionName = "Tracks for conversions"
 _gsfName = "Electron GSF tracks"
+def _toHP(s):
+    return "High purity "+_lowerFirst(s)
+def _allToHP(s):
+    return s.replace("All", "High purity")
+def _ptCut(s):
+    return s.replace("Tracks", "Tracks pT &gt; 0.9 GeV").replace("tracks", "tracks pT &gt; 0.9 GeV")
 _trackQualityNameOrder = collections.OrderedDict([
     ("seeding_seeds", "Seeds"),
     ("seeding_seedsa", "Seeds A"),
@@ -54,8 +60,8 @@ _trackQualityNameOrder = collections.OrderedDict([
     ("building_", "Built tracks"),
     ("", "All tracks"),
     ("highPurity", "High purity tracks"),
-    ("Pt", "Tracks pT &gt; 0.9 GeV"),
-    ("highPurityPt", "High purity tracks pT &gt; 0.9 GeV"),
+    ("Pt09", "Tracks pT &gt; 0.9 GeV"),
+    ("highPurityPt09", "High purity tracks pT &gt; 0.9 GeV"),
     ("ByOriginalAlgo", "All tracks by originalAlgo"),
     ("highPurityByOriginalAlgo", "High purity tracks by originalAlgo"),
     ("ByAlgoMask", "All tracks by algoMask"),
@@ -63,17 +69,19 @@ _trackQualityNameOrder = collections.OrderedDict([
     ("btvLike", "BTV-like"),
     ("ak4PFJets", "AK4 PF jets"),
     ("allTPEffic_", _allTPEfficName),
-    ("allTPEffic_highPurity", _allTPEfficName.replace("All", "High purity")),
+    ("allTPEffic_highPurity", _allToHP(_allTPEfficName)),
     ("fromPV_", _fromPVName),
-    ("fromPV_highPurity", "High purity "+_lowerFirst(_fromPVName)),
+    ("fromPV_highPurity", _toHP(_fromPVName)),
+    ("fromPV_Pt09", _ptCut(_fromPVName)),
+    ("fromPV_highPurityPt09", _toHP(_ptCut(_fromPVName))),
     ("fromPVAllTP_", _fromPVAllTPName),
-    ("fromPVAllTP_highPurity", "High purity "+_lowerFirst(_fromPVAllTPName)),
-    ("fromPVAllTP_Pt", _fromPVAllTPName.replace("Tracks", "Tracks pT &gt; 0.9 GeV")),
-    ("fromPVAllTP_highPurityPt", "High purity "+_lowerFirst(_fromPVAllTPName).replace("tracks", "tracks pT &gt; 0.9 GeV")),
+    ("fromPVAllTP_highPurity", _toHP(_fromPVAllTPName)),
+    ("fromPVAllTP_Pt09", _ptCut(_fromPVAllTPName)),
+    ("fromPVAllTP_highPurityPt09", _toHP(_ptCut(_fromPVAllTPName))),
     ("fromPVAllTP2_", _fromPVAllTPName.replace("PV", "PV v2")),
     ("fromPVAllTP2_highPurity", "High purity "+_lowerFirst(_fromPVAllTPName).replace("PV", "PV v2")),
-    ("fromPVAllTP2_Pt", _fromPVAllTPName.replace("Tracks", "Tracks pT &gt; 0.9 GeV").replace("PV", "PV v2")),
-    ("fromPVAllTP2_highPurityPt", "High purity "+_lowerFirst(_fromPVAllTPName).replace("tracks", "tracks pT &gt; 0.9 GeV").replace("PV", "PV v2")),
+    ("fromPVAllTP2_Pt09", _fromPVAllTPName.replace("Tracks", "Tracks pT &gt; 0.9 GeV").replace("PV", "PV v2")),
+    ("fromPVAllTP2_highPurityPt09", _toHP(_ptCut(_fromPVAllTPName)).replace("PV", "PV v2")),
     ("conversion_", _conversionName),
     ("gsf_", _gsfName),
 ])
@@ -166,10 +174,11 @@ _sectionNameMapOrder = collections.OrderedDict([
 ])
 _allTPEfficLegend = "All tracks, efficiency denominator contains all TrackingParticles"
 _fromPVLegend = "Tracks from reco PV vs. TrackingParticles from gen PV (fake rate includes pileup tracks)"
+_fromPVPtLegend = "Tracks (pT &gt; 0.9 GeV) from reco PV vs. TrackingParticles from gen PV (fake rate includes pileup tracks)"
 _fromPVAllTPLegend = "Tracks from reco PV, fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
-_fromPVAllTPPtLegend = "Tracks (pT &gt 0.9 GeV) from reco PV, fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
+_fromPVAllTPPtLegend = "Tracks (pT &gt; 0.9 GeV) from reco PV, fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
 _fromPVAllTP2Legend = "Tracks from reco PV (another method), fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
-_fromPVAllTPPt2Legend = "Tracks (pT &gt 0.9 GeV) from reco PV (another method), fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
+_fromPVAllTPPt2Legend = "Tracks (pT &gt; 0.9 GeV) from reco PV (another method), fake rate numerator contains all TrackingParticles (separates fake tracks from pileup tracks)"
 
 def _sectionNameLegend():
     return {
@@ -177,19 +186,21 @@ def _sectionNameLegend():
         "ak4PFJets": "Tracks from AK4 PF jets (jet corrected pT &gt; 10 GeV)",
         "allTPEffic": _allTPEfficLegend,
         "allTPEffic_": _allTPEfficLegend,
-        "allTPEffic_highPurity": _allTPEfficLegend.replace("All", "High purity"),
+        "allTPEffic_highPurity": _allToHP(_allTPEfficLegend),
         "fromPV": _fromPVLegend,
         "fromPV_": _fromPVLegend,
-        "fromPV_highPurity": "High purity "+_lowerFirst(_fromPVLegend),
+        "fromPV_highPurity": _toHP(_fromPVLegend),
+        "fromPV_Pt09": _fromPVPtLegend,
+        "fromPV_highPurity_Pt09": _toHP(_fromPVPtLegend),
         "fromPVAllTP": _fromPVAllTPLegend,
         "fromPVAllTP_": _fromPVAllTPLegend,
-        "fromPVAllTP_highPurity": "High purity "+_lowerFirst(_fromPVAllTPLegend),
-        "fromPVAllTP_Pt": _fromPVAllTPPtLegend,
-        "fromPVAllTP_highPurityPt": "High purity "+_lowerFirst(_fromPVAllTPPtLegend),
+        "fromPVAllTP_highPurity": _toHP(_fromPVAllTPLegend),
+        "fromPVAllTP_Pt09": _fromPVAllTPPtLegend,
+        "fromPVAllTP_highPurityPt09": _toHP(_fromPVAllTPPtLegend),
         "fromPVAllTP2_": _fromPVAllTP2Legend,
-        "fromPVAllTP2_highPurity": "High purity "+_lowerFirst(_fromPVAllTP2Legend),
-        "fromPVAllTP2_Pt": _fromPVAllTPPt2Legend,
-        "fromPVAllTP2_highPurityPt": "High purity "+_lowerFirst(_fromPVAllTPPt2Legend),
+        "fromPVAllTP2_highPurity": _toHP(_fromPVAllTP2Legend),
+        "fromPVAllTP2_Pt09": _fromPVAllTPPt2Legend,
+        "fromPVAllTP2_highPurityPt09": _toHP(_fromPVAllTPPt2Legend),
     }
 
 class Table:

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -9,10 +9,15 @@ import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
 class LimitTrackAlgo:
-    def __init__(self, algos):
+    def __init__(self, algos, includePtCut):
         self._algos = algos
+        self._includePtCut = includePtCut
     def __call__(self, algo, quality):
-        return algo in self._algos
+        if algo not in self._algos:
+            return False
+        if not self._includePtCut and "Pt09" in quality:
+            return False
+        return True
 
 def limitRelVal(algo, quality):
     return quality in ["", "highPurity"]
@@ -37,7 +42,7 @@ def main(opts):
     kwargs_tracking = {}
     kwargs_tracking.update(kwargs)
     if opts.limit_tracking_algo is not None:
-        limitProcessing = LimitTrackAlgo(opts.limit_tracking_algo)
+        limitProcessing = LimitTrackAlgo(opts.limit_tracking_algo, includePtCut=opts.ptcut)
         kwargs_tracking["limitSubFoldersOnlyTo"] = {
             "": limitProcessing,
             "allTPEffic": limitProcessing,
@@ -89,6 +94,8 @@ if __name__ == "__main__":
                         help="Comma separated list of tracking algos to limit to. (default: all algos; conflicts with --limit-relval)")
     parser.add_argument("--limit-relval", action="store_true",
                         help="Limit set of plots to those in release validation (almost). (default: all plots in the DQM files; conflicts with --limit-tracking-algo)")
+    parser.add_argument("--ptcut", action="store_true",
+                        help="Include plots with pT > 0.9 GeV cut")
     parser.add_argument("--extended", action="store_true",
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
     parser.add_argument("--no-html", action="store_true",

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -754,8 +754,6 @@ void MTVHistoProducerAlgoForTracker::fill_recoAssociated_simTrack_histos(int cou
       h_simul_dzpvcut_pt[count]->Fill(0, pt);
       h_simul_dzpvsigcut_pt[count]->Fill(0, pt);
 
-      const auto simpvz = simPVPosition->z();
-      h_simul_simpvz[count]->Fill(simpvz);
       if(isMatched) {
         fillPlotNoFlow(h_assocdzpv[count], dzPVSim);
 
@@ -769,6 +767,12 @@ void MTVHistoProducerAlgoForTracker::fill_recoAssociated_simTrack_histos(int cou
         h_assoc_dzpvsigcut[count]->Fill(dzpvsigcut);
         h_assoc_dzpvcut_pt[count]->Fill(dzpvcut, pt);
         h_assoc_dzpvsigcut_pt[count]->Fill(dzpvsigcut, pt);
+      }
+    }
+    if(simPVPosition) {
+      const auto simpvz = simPVPosition->z();
+      h_simul_simpvz[count]->Fill(simpvz);
+      if(isMatched) {
         h_assoc_simpvz[count]->Fill(simpvz);
       }
     }
@@ -853,6 +857,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
       h_reco_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
       h_reco_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
       h_reco_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+    }
+    if(simPVPosition) {
       h_reco_simpvz[count]->Fill(simpvz);
     }
   }
@@ -883,6 +889,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
         h_assoc2_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
         h_assoc2_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
         h_assoc2_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+      }
+      if(simPVPosition) {
         h_assoc2_simpvz[count]->Fill(simpvz);
       }
     }
@@ -956,6 +964,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
           h_pileup_dzpvsigcut[count]->Fill(std::abs(dzpvsig));
           h_pileup_dzpvcut_pt[count]->Fill(std::abs(dzpv), pt);
           h_pileup_dzpvsigcut_pt[count]->Fill(std::abs(dzpvsig), pt);
+        }
+        if(simPVPosition) {
           h_pileup_simpvz[count]->Fill(simpvz);
         }
       }

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -848,7 +848,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
     fillPlotNoFlow(h_recovertpos[count], vertxy);
     fillPlotNoFlow(h_recozpos[count], vertz);
     h_recodr[count]->Fill(deltar);
-  if(fillSeedingLayerSets) h_reco_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+    if(fillSeedingLayerSets) h_reco_seedingLayerSet[count]->Fill(seedingLayerSetBin);
     if(pvPosition) {
       fillPlotNoFlow(h_recodxypv[count], dxypv);
       fillPlotNoFlow(h_recodzpv[count], dzpv);
@@ -880,7 +880,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
       fillPlotNoFlow(h_assoc2vertpos[count], vertxy);
       fillPlotNoFlow(h_assoc2zpos[count], vertz);
       h_assoc2dr[count]->Fill(deltar);
-    if(fillSeedingLayerSets) h_assoc2_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+      if(fillSeedingLayerSets) h_assoc2_seedingLayerSet[count]->Fill(seedingLayerSetBin);
       if(pvPosition) {
         fillPlotNoFlow(h_assoc2dxypv[count], dxypv);
         fillPlotNoFlow(h_assoc2dzpv[count], dzpv);
@@ -932,7 +932,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
         fillPlotNoFlow(h_loopervertpos[count], vertxy);
         fillPlotNoFlow(h_looperzpos[count], vertz);
         h_looperdr[count]->Fill(deltar);
-      if(fillSeedingLayerSets) h_looper_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+        if(fillSeedingLayerSets) h_looper_seedingLayerSet[count]->Fill(seedingLayerSetBin);
         if(pvPosition) {
           fillPlotNoFlow(h_looperdxypv[count], dxypv);
           fillPlotNoFlow(h_looperdzpv[count], dzpv);
@@ -955,7 +955,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
         fillPlotNoFlow(h_pileupvertpos[count], vertxy);
         fillPlotNoFlow(h_pileupzpos[count], vertz);
         h_pileupdr[count]->Fill(deltar);
-      if(fillSeedingLayerSets) h_pileup_seedingLayerSet[count]->Fill(seedingLayerSetBin);
+        if(fillSeedingLayerSets) h_pileup_seedingLayerSet[count]->Fill(seedingLayerSetBin);
         if(pvPosition) {
           fillPlotNoFlow(h_pileupdxypv[count], dxypv);
           fillPlotNoFlow(h_pileupdzpv[count], dzpv);

--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PUSlimmed.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PUSlimmed.h
@@ -151,6 +151,9 @@ class PrimaryVertexAnalyzer4PUSlimmed : public DQMEDAnalyzer {
   //                                      const simPrimaryVertex &v);
   void fillRecoAssociatedGenVertexHistograms(const std::string &,
                                              const simPrimaryVertex &v);
+  void fillRecoAssociatedGenPVHistograms(const std::string& label,
+                                         const PrimaryVertexAnalyzer4PUSlimmed::simPrimaryVertex& v,
+                                         bool genPVMatchedToRecoPV);
   void fillGenAssociatedRecoVertexHistograms(const std::string &,
                                              int,
                                              recoPrimaryVertex &v);

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
@@ -38,7 +38,9 @@ postProcessorVertex = cms.EDAnalyzer("DQMGenericClient",
                                          "duplicate_vs_R 'Duplicate vs R' RecoAllAssoc2MultiMatchedGen_R RecoAllAssoc2Gen_R",
                                          "duplicate_vs_Pt2 'Duplicate vs Sum p_{T}^{2}' RecoAllAssoc2MultiMatchedGen_Pt2 RecoAllAssoc2Gen_Pt2",
                                          "duplicate_vs_NumTracks 'Duplicate vs NumTracks' RecoAllAssoc2MultiMatchedGen_NumTracks RecoAllAssoc2Gen_NumTracks",
-                                         "duplicate_vs_ClosestVertexInZ 'Duplicate vs ClosestsVtx In Z' RecoAllAssoc2MultiMatchedGen_ClosestDistanceZ RecoAllAssoc2Gen_ClosestDistanceZ"
+                                         "duplicate_vs_ClosestVertexInZ 'Duplicate vs ClosestsVtx In Z' RecoAllAssoc2MultiMatchedGen_ClosestDistanceZ RecoAllAssoc2Gen_ClosestDistanceZ",
+
+                                         "PV_effic_vs_Z 'PV reco+tag efficiency vs Z' GenPVAssoc2RecoPVMatched_Z GenPVAssoc2RecoPV_Z",
                                      ),
                                      resolution = cms.vstring(
                                          "RecoAllAssoc2GenMatched_ResolX_vs_PU '#sigma(x) vs PU' RecoAllAssoc2GenMatched_ResolX_vs_PU",

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -171,6 +171,26 @@ void PrimaryVertexAnalyzer4PUSlimmed::bookHistograms(
     std::string current_folder = root_folder_ + "/" + label;
     i.setCurrentFolder(current_folder);
 
+    auto book1d = [&](const char *name, int bins, double min, double max) {
+      mes_[label][name] = i.book1D(name, name, bins, min, max);
+    };
+    auto book1dlogx = [&](const char *name, int bins, const float *xbinedges) {
+      mes_[label][name] = i.book1D(name, name, bins, xbinedges);
+    };
+    auto book2d = [&](const char *name,
+                      int xbins, double xmin, double xmax,
+                      int ybins, double ymin, double ymax) {
+      mes_[label][name] = i.book2D(name, name, xbins,xmin,xmax, ybins,ymin,ymax);
+    };
+    auto book2dlogx = [&](const char *name,
+                          int xbins, const float *xbinedges,
+                          int ybins, double ymin, double ymax) {
+      auto me = i.book2D(name, name, xbins,xbinedges[0],xbinedges[xbins], ybins,ymin,ymax);
+      me->getTH2F()->GetXaxis()->Set(xbins, xbinedges);
+      mes_[label][name] = me;
+    };
+
+
     mes_[label]["RecoVtx_vs_GenVtx"] = i.bookProfile(
         "RecoVtx_vs_GenVtx", "RecoVtx_vs_GenVtx", 125, 0., 250., 250, 0., 250.);
     mes_[label]["MatchedRecoVtx_vs_GenVtx"] =
@@ -287,6 +307,9 @@ void PrimaryVertexAnalyzer4PUSlimmed::bookHistograms(
     mes_[label]["GenAllAssoc2Reco_ClosestDistanceZ"] =
         i.book1D("GenAllAssoc2Reco_ClosestDistanceZ",
                  "GeneratedAllAssoc2Reco_ClosestDistanceZ", 30, &log_bins[0]);
+    book1d("GenPVAssoc2RecoPV_X", 120, -0.6, 0.6);
+    book1d("GenPVAssoc2RecoPV_Y", 120, -0.6, 0.6);
+    book1d("GenPVAssoc2RecoPV_Z", 120, -60,  60);
 
     // All Generated Vertices Matched to a Reconstructed vertex. Used
     // for Efficiency plots
@@ -314,6 +337,9 @@ void PrimaryVertexAnalyzer4PUSlimmed::bookHistograms(
     mes_[label]["GenAllAssoc2RecoMatched_ClosestDistanceZ"] = i.book1D(
         "GenAllAssoc2RecoMatched_ClosestDistanceZ",
         "GeneratedAllAssoc2RecoMatched_ClosestDistanceZ", 30, &log_bins[0]);
+    book1d("GenPVAssoc2RecoPVMatched_X", 120, -0.6, 0.6);
+    book1d("GenPVAssoc2RecoPVMatched_Y", 120, -0.6, 0.6);
+    book1d("GenPVAssoc2RecoPVMatched_Z", 120, -60,  60);
 
     // All Generated Vertices Multi-Matched to a Reconstructed vertex. Used
     // for Duplicate rate plots
@@ -484,25 +510,6 @@ void PrimaryVertexAnalyzer4PUSlimmed::bookHistograms(
 
 
     // Resolution and pull histograms
-    auto book1d = [&](const char *name, int bins, double min, double max) {
-      mes_[label][name] = i.book1D(name, name, bins, min, max);
-    };
-    auto book1dlogx = [&](const char *name, int bins, const float *xbinedges) {
-      mes_[label][name] = i.book1D(name, name, bins, xbinedges);
-    };
-    auto book2d = [&](const char *name,
-                      int xbins, double xmin, double xmax,
-                      int ybins, double ymin, double ymax) {
-      mes_[label][name] = i.book2D(name, name, xbins,xmin,xmax, ybins,ymin,ymax);
-    };
-    auto book2dlogx = [&](const char *name,
-                          int xbins, const float *xbinedges,
-                          int ybins, double ymin, double ymax) {
-      auto me = i.book2D(name, name, xbins,xbinedges[0],xbinedges[xbins], ybins,ymin,ymax);
-      me->getTH2F()->GetXaxis()->Set(xbins, xbinedges);
-      mes_[label][name] = me;
-    };
-
     const double resolx = 0.1;
     const double resoly = 0.1;
     const double resolz = 0.1;
@@ -662,6 +669,20 @@ void PrimaryVertexAnalyzer4PUSlimmed::fillRecoAssociatedGenVertexHistograms(
     if (v.closest_vertex_distance_z > 0.)
       mes_[label]["GenAllAssoc2RecoMultiMatched_ClosestDistanceZ"]
           ->Fill(v.closest_vertex_distance_z);
+  }
+}
+
+void PrimaryVertexAnalyzer4PUSlimmed::fillRecoAssociatedGenPVHistograms(
+    const std::string& label,
+    const PrimaryVertexAnalyzer4PUSlimmed::simPrimaryVertex& v,
+    bool genPVMatchedToRecoPV) {
+  mes_[label]["GenPVAssoc2RecoPV_X"]->Fill(v.x);
+  mes_[label]["GenPVAssoc2RecoPV_Y"]->Fill(v.y);
+  mes_[label]["GenPVAssoc2RecoPV_Z"]->Fill(v.z);
+  if (genPVMatchedToRecoPV) {
+    mes_[label]["GenPVAssoc2RecoPVMatched_X"]->Fill(v.x);
+    mes_[label]["GenPVAssoc2RecoPVMatched_Y"]->Fill(v.y);
+    mes_[label]["GenPVAssoc2RecoPVMatched_Z"]->Fill(v.z);
   }
 }
 
@@ -923,6 +944,7 @@ PrimaryVertexAnalyzer4PUSlimmed::getSimPVs(
         std::cout << *gv << std::endl;
       }
       std::cout << "----------" << std::endl;
+
     }  // end of verbose_ session
 
     // I'd rather change this and select only vertices that come from
@@ -1395,8 +1417,9 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
                         &(*iv)) != v.rec_vertices.end()) {
             mes_[label]["TruePVLocationIndex"]
                 ->Fill(pv_position_in_reco_collection);
+            const bool genPVMatchedToRecoPV = (pv_position_in_reco_collection == 0);
             mes_[label]["TruePVLocationIndexCumulative"]
-                ->Fill(pv_position_in_reco_collection > 0 ? 1 : 0);
+                ->Fill(genPVMatchedToRecoPV ? 0 : 1);
 
             if (signal_is_highest_pt) {
               mes_[label]["TruePVLocationIndexSignalIsHighest"]
@@ -1406,6 +1429,7 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
                 ->Fill(pv_position_in_reco_collection);
             }
 
+            fillRecoAssociatedGenPVHistograms(label, v, genPVMatchedToRecoPV);
             genpv_position_in_reco_collection = pv_position_in_reco_collection;
             break;
           }


### PR DESCRIPTION
This PR adds the following plots to track/vertex validation
- PV reco+ID efficiency vs. vertex z
- track efficiency, fake rate, and pileup rate vs. sim PV z
- tracks with pT>0.9 GeV as separate track collections (but `makeTrackValidationPlots.py` does not plot them by default)

Tested in CMSSW_8_1_X_2016-10-13-1100, expecting only new histograms, no changes to existing ones.

@rovere @VinInn @ebrondol @lgray 
