### PR TITLE
Customise function to increase cluster number check and seeding limits (80X)

### DIFF
--- a/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
+++ b/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
@@ -7,6 +7,6 @@ def customiseClusterCheckForHighPileup(process):
                 module.ClusterCheckPSet.cut = "strip < 800000 && pixel < 80000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/7.)"
         if hasattr(module, "OrderedHitsFactoryPSet") and hasattr(module.OrderedHitsFactoryPSet, "GeneratorPSet"):
             if module.OrderedHitsFactoryPSet.GeneratorPSet.ComponentName.value() in ["PixelTripletLargeTipGenerator", "MultiHitGeneratorFromChi2"]:
-                module.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 500000
+                module.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 1000000
 
     return process

--- a/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
+++ b/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
@@ -4,7 +4,7 @@ def customiseClusterCheckForHighPileup(process):
             module.ClusterCheckPSet.MaxNumberOfPixelClusters = 400000
             # PhotonConversionTrajectorySeedProducerFromQuadruplets does not have "cut"...
             if hasattr(module.ClusterCheckPSet, "cut"):
-                module.ClusterCheckPSet.cut = "strip < 4000000 && pixel < 400000 && (strip < 500000 + 10*pixel) && (pixel < 50000 + 0.1*strip)"
+                module.ClusterCheckPSet.cut = "strip < 800000 && pixel < 80000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/7.)"
         if hasattr(module, "OrderedHitsFactoryPSet") and hasattr(module.OrderedHitsFactoryPSet, "GeneratorPSet"):
             if module.OrderedHitsFactoryPSet.GeneratorPSet.ComponentName.value() in ["PixelTripletLargeTipGenerator", "MultiHitGeneratorFromChi2"]:
                 module.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 500000

--- a/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
+++ b/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
@@ -1,0 +1,9 @@
+def customiseClusterCheckForHighPileup(process):
+    for module in process._Process__producers.values():
+        if hasattr(module, "ClusterCheckPSet"):
+            module.ClusterCheckPSet.MaxNumberOfPixelClusters = 400000
+            # PhotonConversionTrajectorySeedProducerFromQuadruplets does not have "cut"...
+            if hasattr(module.ClusterCheckPSet, "cut"):
+                module.ClusterCheckPSet.cut = "strip < 4000000 && pixel < 400000 && (strip < 500000 + 10*pixel) && (pixel < 50000 + 0.1*strip)"
+
+    return process

--- a/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
+++ b/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
@@ -1,7 +1,7 @@
 def customiseClusterCheckForHighPileup(process):
     for module in process._Process__producers.values():
         if hasattr(module, "ClusterCheckPSet"):
-            module.ClusterCheckPSet.MaxNumberOfPixelClusters = 400000
+            module.ClusterCheckPSet.MaxNumberOfPixelClusters = 80000
             # PhotonConversionTrajectorySeedProducerFromQuadruplets does not have "cut"...
             if hasattr(module.ClusterCheckPSet, "cut"):
                 module.ClusterCheckPSet.cut = "strip < 800000 && pixel < 80000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/7.)"

--- a/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
+++ b/RecoTracker/Configuration/python/customiseClusterCheckForHighPileup.py
@@ -5,5 +5,8 @@ def customiseClusterCheckForHighPileup(process):
             # PhotonConversionTrajectorySeedProducerFromQuadruplets does not have "cut"...
             if hasattr(module.ClusterCheckPSet, "cut"):
                 module.ClusterCheckPSet.cut = "strip < 4000000 && pixel < 400000 && (strip < 500000 + 10*pixel) && (pixel < 50000 + 0.1*strip)"
+        if hasattr(module, "OrderedHitsFactoryPSet") and hasattr(module.OrderedHitsFactoryPSet, "GeneratorPSet"):
+            if module.OrderedHitsFactoryPSet.GeneratorPSet.ComponentName.value() in ["PixelTripletLargeTipGenerator", "MultiHitGeneratorFromChi2"]:
+                module.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 500000
 
     return process


### PR DESCRIPTION
This PR adds a customise function to increase cluster number check limits by
- 2x for the "box"
- adjust coefficient for "pixel < N + k*strip" from k=1/10 to k=1/7

and `maxElement` for `PixelTripletLargeTipGenerator` and `MultiHitGeneratorFromChi2` by 5x. These should be sufficient to silence "TooManyClusters" and "TooManyTriplets" errors for the high pileup data.

Tested in 8_0_20 with

```
cmsDriver.py step3 --conditions 80X_dataRun2_Prompt_v14 -s RAW2DIGI,L1Reco,RECO \
  --runUnscheduled --process reRECO --data --era Run2_2016 --eventcontent RECO \
  --scenario pp --datatier RECO \
  --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016 \
  -n 5 --nThreads=5--fileout file:step3.root --filein <your-preferred-file> \
  --customise RecoTracker/Configuration/customiseClusterCheckForHighPileup.customiseClusterCheckForHighPileup
```

with a random file from ZeroBiasIsolatedBunch0 RAW.

@rovere @VinInn @mtosi 
