### PR TITLE
Remove false dependency to TrackingTools/PatternTools.

### DIFF
--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,7 +1,5 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
-<use   name="TrackingTools/PatternTools"/>
-
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
I noticed this when building cmsShow tarball.
