### PR TITLE
Allow shared_ptr and unique_ptr in top level data products

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -48,6 +48,8 @@ namespace edm {
     static boost::regex const reUnsigned("unsigned ");
     static boost::regex const reLong("long ");
     static boost::regex const reVector("std::vector");
+    static boost::regex const reSharedPtr("std::shared_ptr");
+    static boost::regex const reUniquePtr("std::unique_ptr");
     static boost::regex const reAIKR(", *edm::helper::AssociationIdenticalKeyReference"); //this is a default so can replaced with empty
     //force first argument to also be the argument to edm::ClonePolicy so that if OwnVector is within
     // a template it will not eat all the remaining '>'s
@@ -67,6 +69,7 @@ namespace edm {
     static boost::regex const reToRefs2("edm::RefVector< *(.*) *, *(.*) *, *edm::refhelper::FindUsingAdvance< *\\1, *\\2 *> *>");
     static boost::regex const reToRefsAssoc("edm::RefVector< *Association(.*) *, *edm::helper(.*), *Association(.*)::Find>");
     
+    
     std::string standardRenames(std::string const& iIn) {
        using boost::regex_replace;
        using boost::regex;
@@ -80,6 +83,8 @@ namespace edm {
        name = regex_replace(name,reUnsigned,"u");
        name = regex_replace(name,reLong,"l");
        name = regex_replace(name,reVector,"s");
+       name = regex_replace(name,reSharedPtr,"SharedPtr");
+       name = regex_replace(name,reUniquePtr,"UniquePtr");
        name = regex_replace(name,reOwnVector,"sOwned<$1>");
        name = regex_replace(name,reToVector,"AssociationVector<$1,To,$2>");
        name = regex_replace(name,reOneToOne,"Association<$1,ToOne,$2>");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -38,6 +38,12 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("bar::Foo","barFoo") );
   classToFriendly.insert( Values("std::vector<Foo>","Foos") );
   classToFriendly.insert( Values("std::vector<bar::Foo>","barFoos") );
+  classToFriendly.insert( Values("std::shared_ptr<Foo>","FooSharedPtr"));
+  classToFriendly.insert( Values("std::shared_ptr<bar::Foo>","barFooSharedPtr"));
+  classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
+  classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
+  classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));
+  classToFriendly.insert( Values("std::vector<std::unique_ptr<bar::Foo>>","barFooUniquePtrs"));
   classToFriendly.insert( Values("V<A,B>","ABV") );
   classToFriendly.insert( Values("edm::ExtCollection<std::vector<reco::SuperCluster>,reco::SuperClusterRefProds>","recoSuperClustersrecoSuperClusterRefProdsedmExtCollection") );
   classToFriendly.insert( Values("edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >","EcalUncalibratedRecHitsSorted") );


### PR DESCRIPTION
Added special cases to the friendly name generator to handle
std::shared_ptr and std::unique_ptr as items being held by
collections which are used as data products. This avoids having
an extra underscore be in friendly class name which is not allowed.
