### PR TITLE
Make BasicTrajectoryState thread safe

### DIFF
--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -72,7 +72,7 @@ class BasicTrajectoryState {
 public:
 
   // default constructor : to make root happy
-  BasicTrajectoryState() : theValid(false), theWeight(0){}
+ BasicTrajectoryState() : theWeight(0), theValid(false){}
 
  /// construct invalid trajectory state (without parameters)
   explicit BasicTrajectoryState(const SurfaceType& aSurface);
@@ -140,12 +140,14 @@ public:
   theFreeState(par, err),
   theLocalError(InvalidError()),
   theLocalParameters(),
-  theLocalParametersValid(false),
-  theValid(true),
   theSurfaceSide(side), 
   theSurfaceP( &aSurface), 
-  theWeight(1.)
-  {}
+  theWeight(1.),
+  theValid(true)
+  {
+    createLocalParameters();
+    createLocalError();
+  }
 
 
   /** Constructor from global parameters and surface. For surfaces with material
@@ -196,7 +198,7 @@ public:
 	missingError(" accesing cartesian error.");
 	return CartesianTrajectoryError();
       }
-    return freeTrajectoryState(true)->cartesianError();
+    return freeTrajectoryState()->cartesianError();
   }
   const CurvilinearTrajectoryError& curvilinearError() const {
     if unlikely(!hasError()) {
@@ -204,14 +206,13 @@ public:
 	static const CurvilinearTrajectoryError crap;
 	return crap;
       }
-    return freeTrajectoryState(true)->curvilinearError();
+    return freeTrajectoryState()->curvilinearError();
   }
 
 
-
-  FreeTrajectoryState const* freeTrajectoryState(bool withErrors=true) const {
+  FreeTrajectoryState const* freeTrajectoryState() const {
     if unlikely(!isValid()) notValid();
-    if(withErrors && hasError()) { // this is the right thing
+    if(hasError()) { // this is the right thing
       checkCurvilinError();
     }
     return &theFreeState;
@@ -223,8 +224,6 @@ public:
 // access local parameters/errors
   const LocalTrajectoryParameters& localParameters() const {
     if unlikely(!isValid()) notValid();
-    if unlikely(!theLocalParametersValid)
-      createLocalParameters();
     return theLocalParameters;
   }
   LocalPoint localPosition() const {
@@ -242,7 +241,6 @@ public:
 	missingError(" accessing local error.");
 	return theLocalError;
       }
-    if unlikely(theLocalError.invalid()) createLocalError();
     return theLocalError;
   }
 
@@ -262,7 +260,7 @@ public:
   }
 
   bool hasError() const {
-    return theFreeState.hasError() || theLocalError.valid();
+    return theLocalError.valid();
   }
 
 
@@ -310,26 +308,22 @@ private:
   void checkCurvilinError() const; //  dso_internal;
   
   // create local parameters and errors from global
-  void createLocalParameters() const;
+  void createLocalParameters();
   // create local errors from global
-  void createLocalError() const;
-  void createLocalErrorFromCurvilinearError() const  dso_internal;
+  void createLocalError() ;
+  void createLocalErrorFromCurvilinearError()  dso_internal;
   
 private:
 
   mutable FreeTrajectoryState theFreeState;
 
-  mutable LocalTrajectoryError      theLocalError;
-  mutable LocalTrajectoryParameters theLocalParameters;
-
-  mutable bool theLocalParametersValid;
-  mutable bool theValid;
-
- 
+  LocalTrajectoryError      theLocalError;
+  LocalTrajectoryParameters theLocalParameters; 
   SurfaceSide theSurfaceSide;
   ConstReferenceCountingPointer<SurfaceType> theSurfaceP;
 
   double theWeight=0.;
+  bool theValid;
 };
 
 #endif

--- a/TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h
@@ -154,12 +154,12 @@ private:
 
 
 // convert cartesian errors to curvilinear
-  void createCurvilinearError(CartesianTrajectoryError const & aCartesianError) const; // dso_internal;
+  void createCurvilinearError(CartesianTrajectoryError const & aCartesianError); // dso_internal;
 
 private:
 
   GlobalTrajectoryParameters  theGlobalParameters;
-  mutable CurvilinearTrajectoryError  theCurvilinearError;
+  CurvilinearTrajectoryError  theCurvilinearError;
  
 };
 

--- a/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
+++ b/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
@@ -67,11 +67,11 @@ public:
     return data().hasError();
   }
 
-  FreeTrajectoryState const* freeState(bool withErrors = true) const {
+  FreeTrajectoryState const* freeState() const {
     return data().freeTrajectoryState();
   }
 
-  FreeTrajectoryState const* freeTrajectoryState(bool withErrors = true) const {
+  FreeTrajectoryState const* freeTrajectoryState() const {
     return freeState();
   }
 

--- a/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
@@ -42,11 +42,10 @@ BasicTrajectoryState::
 BasicTrajectoryState(const SurfaceType& aSurface) :
   theLocalError(InvalidError()),
   theLocalParameters(),
-  theLocalParametersValid(false),
-  theValid(false),
   theSurfaceSide(SurfaceSideDefinition::atCenterOfSurface), 
   theSurfaceP( &aSurface), 
-  theWeight(1.)
+  theWeight(1.),
+  theValid(false)
 {}
 
 
@@ -81,12 +80,16 @@ BasicTrajectoryState( const FreeTrajectoryState& fts,
   theFreeState(fts),
   theLocalError(InvalidError()),
   theLocalParameters(),
-  theLocalParametersValid(false),
-  theValid(true),
   theSurfaceSide(side), 
   theSurfaceP( &aSurface), 
-  theWeight(1.)
-{}    
+  theWeight(1.),
+  theValid(true)
+{
+  createLocalParameters();
+  if(fts.hasError()) {
+    createLocalError();
+  }
+}    
 
 
 BasicTrajectoryState::
@@ -97,12 +100,14 @@ BasicTrajectoryState( const GlobalTrajectoryParameters& par,
   theFreeState(par, err),
   theLocalError(InvalidError()),
   theLocalParameters(),
-  theLocalParametersValid(false),
-  theValid(true),
   theSurfaceSide(side), 
   theSurfaceP( &aSurface), 
-  theWeight(1.)
-{}
+  theWeight(1.),
+  theValid(true)
+{
+    createLocalParameters();
+    createLocalError();
+}
 
 
 
@@ -115,11 +120,10 @@ BasicTrajectoryState( const LocalTrajectoryParameters& par,
   theFreeState(makeFTS(par,aSurface,field)),
   theLocalError(err),
   theLocalParameters(par),
-  theLocalParametersValid(true),
-  theValid(true),
   theSurfaceSide(side), 
   theSurfaceP( &aSurface),
-  theWeight(1.)
+  theWeight(1.),
+  theValid(true)
 {}
 
 
@@ -132,18 +136,22 @@ void BasicTrajectoryState::notValid() {
 
 namespace {
   void verifyLocalErr(LocalTrajectoryError const & err, const FreeTrajectoryState & state ) {
-     if unlikely(!err.posDef())
+    if unlikely(!err.posDef()) {
                  edm::LogWarning("BasicTrajectoryState") << "local error not pos-def\n"
                                                         <<  err.matrix()
                                                          << "\npos/mom/mf " << state.position() << ' ' << state.momentum()
                                                           <<  ' ' << state.parameters().magneticFieldInTesla();
+                 //throw cms::Exception("NotPosDef");
+      }
   }
   void verifyCurvErr(CurvilinearTrajectoryError const & err, const FreeTrajectoryState & state ) {
-     if unlikely(!err.posDef())
+    if unlikely(!err.posDef()) {
                  edm::LogWarning("BasicTrajectoryState") << "curv error not pos-def\n" 
                                                         <<  err.matrix()
                                                          << "\npos/mom/mf " << state.position() << ' ' << state.momentum()
                                                          <<  ' ' << state.parameters().magneticFieldInTesla();
+                 //throw cms::Exception("NotPosDef");
+      }
   }
 }
 
@@ -165,8 +173,6 @@ void BasicTrajectoryState::missingError(char const * where) const{
 void BasicTrajectoryState::checkCurvilinError() const {
   if likely(theFreeState.hasCurvilinearError()) return;
 
-  if unlikely(!theLocalParametersValid) createLocalParameters();
-  
   JacobianLocalToCurvilinear loc2Curv(surface(), localParameters(), globalParameters(), *magneticField());
   const AlgebraicMatrix55& jac = loc2Curv.jacobian();
   const AlgebraicSymMatrix55 &cov = ROOT::Math::Similarity(jac, theLocalError.matrix());
@@ -180,7 +186,7 @@ void BasicTrajectoryState::checkCurvilinError() const {
 
  
 // create local parameters from global
-void BasicTrajectoryState::createLocalParameters() const {
+void BasicTrajectoryState::createLocalParameters() {
   LocalPoint  x = surface().toLocal(theFreeState.position());
   LocalVector p = surface().toLocal(theFreeState.momentum());
 // believe p.z() never exactly equals 0.
@@ -188,17 +194,16 @@ void BasicTrajectoryState::createLocalParameters() const {
   theLocalParameters =
     LocalTrajectoryParameters(isCharged?theFreeState.signedInverseMomentum():1./p.mag(),
       p.x()/p.z(), p.y()/p.z(), x.x(), x.y(), p.z()>0. ? 1.:-1., isCharged);
-  theLocalParametersValid = true;
 }
 
-void BasicTrajectoryState::createLocalError() const {
+void BasicTrajectoryState::createLocalError() {
   if likely(theFreeState.hasCurvilinearError())
     createLocalErrorFromCurvilinearError();
   else theLocalError = InvalidError();
 }
 
 void 
-BasicTrajectoryState::createLocalErrorFromCurvilinearError() const {
+BasicTrajectoryState::createLocalErrorFromCurvilinearError() {
   
   JacobianCurvilinearToLocal curv2Loc(surface(), localParameters(), globalParameters(), *magneticField());
   const AlgebraicMatrix55 & jac = curv2Loc.jacobian();
@@ -221,7 +226,6 @@ BasicTrajectoryState::update( const LocalTrajectoryParameters& p, const SurfaceS
    theFreeState=makeFTS(p,surface(),magneticField(), theFreeState.parameters().magneticFieldInTesla());
   
    theValid   = true;
-   theLocalParametersValid  = true;
 
 }
 
@@ -240,7 +244,6 @@ BasicTrajectoryState::update( const LocalTrajectoryParameters& p,
     theFreeState=makeFTS(p,aSurface,field);
 
     theValid   = true;
-    theLocalParametersValid  = true;
 }
 
 void
@@ -259,7 +262,6 @@ BasicTrajectoryState::update(double weight,
     theFreeState=makeFTS(p,aSurface,field);
 
     theValid   = true;
-    theLocalParametersValid  = true;
 }
 
 
@@ -274,7 +276,6 @@ BasicTrajectoryState::update( const LocalTrajectoryParameters& p,
     theFreeState=   theFreeState=makeFTS(p,surface(),magneticField(), theFreeState.parameters().magneticFieldInTesla());
 
     theValid   = true;
-    theLocalParametersValid  = true;
 }
 
 

--- a/TrackingTools/TrajectoryState/src/FreeTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/FreeTrajectoryState.cc
@@ -36,7 +36,7 @@ void FreeTrajectoryState::createCartesianError(CartesianTrajectoryError & aCarte
 }
 
 // convert cartesian errors to curvilinear
-void FreeTrajectoryState::createCurvilinearError(CartesianTrajectoryError const& aCartesianError) const{
+void FreeTrajectoryState::createCurvilinearError(CartesianTrajectoryError const& aCartesianError) {
   
   JacobianCartesianToCurvilinear cart2Curv(theGlobalParameters);
   const AlgebraicMatrix56& jac = cart2Curv.jacobian();


### PR DESCRIPTION
Modified BasicTrajectoryState so that it would be thread safe. This is needed because the class is used in Event data products.
