### PR TITLE
Provenance_Histos_Renormalization_81X_V1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -60,7 +60,7 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
   }
 /**/
 
-/*  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
   h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
   h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));

--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -65,7 +65,7 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
   h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -59,6 +59,14 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }
 /**/
+
+/*  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
+  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
+
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPmatchingObjectVsPhi","","#phi (rad)","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -59,12 +59,12 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }/**/
   
-/*  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
   h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
   h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));/**/
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -58,6 +58,13 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
      { xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }/**/
+  
+/*  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
+  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);
@@ -103,49 +110,6 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "seedDrz2Pos_VsEta","mean ele seed dr(dz) 2nd layer positron vs eta","#eta","<r(z)_{pred} - r(z)_{hit}, 2nd layer> (cm)",-0.15,0.15);
   profileX(iBooker, iGetter, "seedDrz2Pos_VsPt","mean ele seed dr(dz) 2nd layer positron vs pt","p_{T} (GeV/c)","<r(z)_{pred} - r(z)_{hit}, 2nd layer> (cm)",-0.15,0.15);
 /**/
-
-//  // investigation
-//  TH2F * h2 = get("PoPtrueVsEta")->getTH2F() ;
-//  std::cout<<"H2   entries : "<<h2->GetEntries()<<std::endl ;
-//  std::cout<<"H2 effective entries : "<<h2->GetEffectiveEntries()<<std::endl ;
-//  Int_t ix, nx = h2->GetNbinsX(), iy, ny = h2->GetNbinsY(), is, nu = 0, no = 0, nb = 0 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//    for ( ix = 0 ; ix<=(nx+1) ; ++ix )
-//     {
-//      is = iy*(nx+2) + ix ;
-//      if (h2->IsBinUnderflow(is)) ++nu ;
-//      if (h2->IsBinOverflow(is)) ++no ;
-//     }
-//  ix = 0 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//   {
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  ix = nx+1 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//   {
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  for ( ix = 1 ; ix<=nx ; ++ix )
-//   {
-//    iy = 0 ;
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//    iy = ny+1 ;
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  std::cout<<"H2   nx      : "<<nx<<std::endl ;
-//  std::cout<<"H2   ny      : "<<ny<<std::endl ;
-//  std::cout<<"H2   nsumw2  : "<<(*h2->GetSumw2()).fN<<std::endl ;
-//  std::cout<<"H2   nu      : "<<nu<<std::endl ;
-//  std::cout<<"H2   no      : "<<no<<std::endl ;
-//  std::cout<<"H2   outside : "<<nb<<std::endl ;
-//  std::cout<<"PFX  entries : "<<h2->ProfileX()->GetEntries()<<std::endl ;
-//  std::cout<<"PFX effective entries : "<<h2->ProfileX()->GetEffectiveEntries()<<std::endl ;
-
 
 }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -111,6 +111,8 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "seedDrz2Pos_VsPt","mean ele seed dr(dz) 2nd layer positron vs pt","p_{T} (GeV/c)","<r(z)_{pred} - r(z)_{hit}, 2nd layer> (cm)",-0.15,0.15);
 /**/
 
+
+
 }
 
 

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,25 +1,50 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_1_0_pre9_Geant4102_pmx_DQM_std">
-<var name="TEST_REF" value="8_1_0_pre9_DQM_std">
+<var name="TEST_NEW" value="8_1_0_pre12_std2">
+<var name="TEST_REF" value="8_1_0_pre12_std2">
 
-<var name="TAG_STARTUP" value="81X_mcRun2_asymptotic_v2">
+<var name="TAG_STARTUP" value="81X_mcRun2_asymptotic_v8">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="PU25ns_81X_mcRun2_asymptotic_v2-v1">
+<var name="DD_COND_REF" value="81X_mcRun2_asymptotic_v8-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
 
-<var name="STORE_DIR" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_1_0_pre9_ValELE/src/Validation/RecoEgamma/test/8_1_0_pre9">
-<var name="STORE_REF" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_1_0_pre9_ValELE/src/Validation/RecoEgamma/test/8_1_0_pre9">
+<var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
+<var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
+ 
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+<!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
+<!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
 
 The value of OVAL_ENVNAME is automatically set by Oval to the name
 of the current environment, before running any executable. Using it below,
 we have an output file name which is unique for each execution.
 
+<var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root">
 <var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
+<!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
+<!--difffile name="electronHistos.root"-->
+
+The DD_* variables are configuration variables for the script electronDataDiscovery.py,
+which prepares and send a query to the Data Discovery web server,
+and receive as a result the corresponding list of input data files.
+<!--var name="DD_SOURCE" value="das"-->
+
+The tags below are to be used when DAS seems not up-to-date,
+as compared to what you see within castor directories.
+These parameters have been added to each RelVal sample environment
+<!--var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}"-->
+<!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  
+  
+The tags below are to be used when you want to process some files
+made with a modified code, and generated locally, thanks to the
+targets RedoFrom% defined later on.
+<!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
+<!--var name="DD_COND" value="STARTUP"-->
 
 Oval is able to check the output channel of an execution and compare it with a reference output.
 The tags below are defining which are lines to be compared. The currently specification is a
@@ -36,6 +61,27 @@ first draft, and we do not yet check the differences that Oval could raise.
 <diffnumber expr="^h_\S+ has \d+ entries of mean value (\S+)$" tolerance="10%">
 <!diffvar name="HISTO" expr="^TH1.Print Name = [a-zA-Z_]+, Entries= \d+, Total sum= (\S+)$" tolerance="10%">
 
+The file defined below is used by the script electronDataDiscovery.py when we want to analyze
+some RelVal reco files which have been regenerated locally.
+
+<var name="TEST_AFS_DIR" value="/afs/cern.ch/cms/CAF/CMSPHYS/PHYS_EGAMMA/electrons/chamont/ReleaseValidationTmp/SeedsRemaker3">
+<!--var name="TEST_AFS_DIR" value="/afs/cern.ch/user/a/archiron/private/Root_Regress"-->
+<file name="electronInputDataFiles.txt">
+file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValTTbar-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
+</file>
+  
+Here comes the concrete executables to run. They are split among few different
+environments, each one defining the relevant variales for a given scenario and/or
+data sample. Running electronDataDiscovery.py is only usefull to check the correctness
+of the list of input data files returned by the data discovery web server. We guess
+that from time to time we will have to upgrade the values DD_* variable so to keep in
+touch with changes in data catalog structure.
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ================================================================================
 FullSim
@@ -46,60 +92,956 @@ FullSim
 
   This set of targets is currently used for the validation of electrons.
 
+  Used if DD_SOURCE=das
+  <!--var name="DD_TIER" value="*RECO*"-->
+
   Used if DD_source=/eos/...
   <var name="DD_TIER" value="GEN-SIM-RECO">
-
+  
   <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
   <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
   <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
   <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-
-  <environment name="ValPileUpStartup">
-
-    <var name="TAG_STARTUP" value="${TAG_STARTUP}">
+      
+  <environment name="ValFullStdStatsStartup">
+  
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
     <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <!--var name="DD_COND" value="STARTUP"-->
+    <environment name="ValFullPt10Startup_UP15">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
 
-    <environment name="Valdummy">
+    <environment name="ValFullPt35Startup_UP15">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+            
+    </environment>
 
-      <var name="DD_SAMPLE" value="dummy">
+    <environment name="ValFullPt1000Startup_UP15">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
 
-        <var name="RED_FILE" value="DQM_DUMMY.root">
- <var name="BLUE_FILE" value="DQM_DUMMY.root">
- <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+    <environment name="ValFullTTbarStartup_13">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
+
+    <environment name="ValFullZEEStartup_13">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
+
+    <environment name="ValFullQcdPt80Pt120Startup_13">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
+
+    <environment name="ValFullPt10Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
-    <var name="DD_COND" value="PUpmx25ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+    <environment name="ValFullPt35Startup_UP15_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      
+    </environment>
+    
+    <environment name="ValFullPt1000Startup_UP15_gedGsfE">
+    
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-    <var name="DD_COND_REF" value="PU25ns_81X_mcRun2_asymptotic_v2-v1">
+    </environment>
 
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
+    <environment name="ValFullTTbarStartup_13_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
+    </environment>
+  
+    <environment name="ValFullZEEStartup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
 
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_1_0_pre9_Geant4102-PUpmx25ns_81X_mcRun2_asymptotic_v2-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="8_1_0_pre9/DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_1_0_pre9-PU25ns_81X_mcRun2_asymptotic_v2-v1__DQMIO.root">
+    <environment name="ValFullQcdPt80Pt120Startup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PUpmx25ns_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
-    <var name="DD_COND" value="PUpmx25ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-    <var name="DD_COND_REF" value="PU25ns_81X_mcRun2_asymptotic_v2-v1">
-
-      <environment name="ValPileUpZEEStartup_gedGsfE">
-
-        <var name="DD_SAMPLE" value="RelValZEE_13">
-
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_1_0_pre9_Geant4102-PUpmx25ns_81X_mcRun2_asymptotic_v2-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="8_1_0_pre9/DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_1_0_pre9-PU25ns_81X_mcRun2_asymptotic_v2-v1__DQMIO.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PUpmx25ns_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
+    </environment>  
+  
   </environment>
 
+  <environment name="ValFullGsfvsGsf">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <!--var name="DD_COND" value="STARTUP"-->
+    <environment name="ValGsfvsGsfFullPt10Startup_UP15">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+    <environment name="ValGsfvsGsfFullPt35Startup_UP15">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+            
+    </environment>
+
+    <environment name="ValGsfvsGsfFullPt1000Startup_UP15">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+    <environment name="ValGsfvsGsfFullTTbarStartup_13">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+    <environment name="ValGsfvsGsfFullZEEStartup_13">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullZEEStartup_13.root">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+    <environment name="ValGsfvsGsfFullQcdPt80Pt120Startup_13">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
+      
+      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+  </environment>
+  
+  <environment name="ValFullgedvsGsf">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <!--var name="DD_COND" value="STARTUP"-->
+
+    <environment name="ValgedvsGsfFullPt10Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsGsfFullPt35Startup_UP15_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+      
+    </environment>
+    
+    <environment name="ValgedvsGsfFullPt1000Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsGsfFullTTbarStartup_13_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+  
+    <environment name="ValgedvsGsfFullZEEStartup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+  
+    </environment>
+
+    <environment name="ValgedvsGsfFullQcdPt80Pt120Startup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
+
+      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>  
+  
+  </environment>
+  
+  <environment name="ValFullgedvsged">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <!--var name="DD_COND" value="STARTUP"-->
+
+    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullPt35Startup_UP15_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      
+    </environment>
+    
+    <environment name="ValgedvsgedFullPt1000Startup_UP15_gedGsfE">
+    
+      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+  
+    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+  
+    </environment>
+
+    <environment name="ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
+
+      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>  
+  
+  </environment>
+
+  <environment name="ValPileUpStartup">
+    
+    <var name="TAG_STARTUP" value="PU_${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+
+      <environment name="ValPileUpTTbarStartup">
+        
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+      
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
+  
+      </environment>
+
+    <environment name="ValPileUpZEEStartup">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} /${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
+  
+    </environment>
+
+      <environment name="ValPileUpTTbarStartup_gedGsfE">
+        
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+	
+	    <var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup.root">
+        <var name="RED_FILE" value="electronHistos.ValPileUpTTbarStartup_gedGsfE.root">
+ 
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+      
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
+
+      </environment>
+
+    <environment name="ValPileUpZEEStartup_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+     
+      <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup.root">
+      <var name="RED_FILE" value="electronHistos.ValPileUpZEEStartup_gedGsfE.root">
+
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+  
+  </environment>
+    
+</environment>
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+FastSim
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="FastSim">
+
+  <var name="DD_TIER" value="GEN-SIM-DIGI-RECO">
+
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
+ 
+  <environment name="ValFast">
+
+    <environment name="ValFastStartup">
+
+      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+      <var name="DD_COND" value="/${TEST_GLOBAL_TAG}_FastSim-${DATA_VERSION}">
+      
+      <environment name="ValFastTTbarStartup">
+      
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <var name="DD_SAMPLE" value="RelValTTbar">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+	
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+        
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+        
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        
+      </environment>
+    
+      <environment name="ValFastZEEStartup">
+      
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <var name="DD_SAMPLE" value="RelValZEE">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+	
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+        
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+        
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        
+      </environment>
+    
+    </environment>
+    
+  </environment>
+  
+  <environment name="ValFastVsFast">
+  
+    <environment name="ValFastVsFastStartup">
+    
+      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}*FastSim*-${DATA_VERSION}">
+
+      <environment name="ValFastVsFastTTbarStartup">
+        <var name="DD_SAMPLE" value="RelValTTbar">
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+      </environment>
+      
+      <environment name="ValFastVsFastZEEStartup">
+        <var name="DD_SAMPLE" value="RelValZEE">
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+      </environment>
+        
+    </environment>
+    
+  </environment>
+  
+  <environment name="ValFastVsFull">
+  
+    <environment name="ValFastVsFullStartup">
+    
+      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+
+      <environment name="ValFastVsFullTTbarStartup">
+        <var name="DD_SAMPLE" value="RelValTTbar">
+        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
+        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+      </environment>
+      
+      <environment name="ValFastVsFullZEEStartup">
+        <var name="DD_SAMPLE" value="RelValZEE">
+        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
+        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+      </environment>
+      
+    </environment>
+        
+  </environment>
+  
+</environment>
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+This set of targets is made to redo the electrons
+with the local modified code.
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="Redo">
+
+  <environment name="SeedsRemaker">
+
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+    <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+    <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      
+    <environment name="SeedsRemakerStep1">
+
+      <var name="DD_TIER" value="*RAW*">
+      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-FIRST-RECO.root">
+
+      <target name="cfg" cmd="cmsDriver.py step3 -n -1 -s RAW2DIGI,L1Reco,RECO,VALIDATION,DQM --conditions auto:startup --datatier GEN-SIM-RECO,DQM --eventcontent RECOSIM,DQM --filein=Dummy-STARTUP-RAW.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.storeseed --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="reco" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
+      
+    </environment>
+  
+    <environment name="SeedsRemakerStep2">
+    
+      <var name="DD_TIER" value="*FIRST-RECO*">
+      <var name="DD_SOURCE" value="electronInputDataFiles.txt">
+      <var name="DD_COND" value="STARTUP">
+      <file name="electronInputDataFiles.txt">
+      file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-FIRST-RECO.root
+      </file>
+      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+      
+      <target name="cfg" cmd="cmsDriver.py step3 -n -1 --process reRECO --filtername RECOfromRECO -s RECO:reconstruction_fromRECO_noTrackingTest --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-STARTUP-RECO.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.reseed+regenseed+reconv --python_filename=SeedsRemaker_driver_cfg.py --no_exec">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="redo" cmd="cmsRun SeedsRemaker_cfg.py">
+      
+    </environment>
+
+  </environment>
+  
+  <environment name="RedoFromTrackSeeds">
+
+    <var name="VAL_CONFIGURATION" value="ElectronRedoFromTrackSeeds_cfg">
+    
+    <environment name="RedoFromTrackSeedsPt35">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+    </environment>
+  
+    <environment name="RedoFromTrackSeedsQcdPt80Pt120">
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
+      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+    </environment>
+  
+    <environment name="RedoFromTrackSeedsPt10">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+    </environment>
+  
+  </environment>
+
+  <environment name="RedoFromCore">
+
+    <environment name="RedoFromCoreStartup">
+  
+      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+
+      <environment name="RedoFromCoreZEEStartup">
+        <var name="DD_SAMPLE" value="RelValZEE">
+        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+        <executable name="electronDataDiscovery.py">
+        <executable name="cmsRun" args="ElectronRedoFromCore_cfg.py">
+      </environment>
+    
+    </environment>
+        
+  </environment>
+
+  <environment name="RedoFromRaw">
+
+    <var name="DD_TIER" value="*RAW*">
+
+    <!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
+    <file name="electronInputDataFiles.txt">
+    ${TEST_AFS_DIR}/RelValSingleElectronPt10-IDEAL-RAW.root
+    ${TEST_AFS_DIR}/RelValSingleElectronPt35-IDEAL-RAW.root
+    ${TEST_AFS_DIR}/RelValTTbar-IDEAL-RAW.root
+    ${TEST_AFS_DIR}/RelValZEE-IDEAL-RAW.root
+    ${TEST_AFS_DIR}/RelValZEE-STARTUP-RAW.root
+    ${TEST_AFS_DIR}/RelValQCD_Pt_80_120-IDEAL-RAW.root
+    </file>
+
+    <environment name="RedoFromRawStartup">
+
+      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+      <!--var name="DD_COND" value="STARTUP"-->
+
+      <target name="cfg" cmd="cmsDriver.py reco -s RAW2DIGI,RECO -n -1 --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-RAW.root --fileout=Dummy-STARTUP-RECO.root --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
+
+      <environment name="RedoFromRawPt35Startup">
+        <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
+      </environment>
+    
+      <environment name="RedoFromRawQcdPt80Pt120Startup">
+        <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
+        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
+      </environment>
+    
+      <environment name="RedoFromRawPt10Startup">
+        <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
+      </environment>
+  
+      <environment name="RedoFromRawZEEStartup">
+        <var name="DD_SAMPLE" value="RelValZEE">
+        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
+      </environment>
+    
+    </environment>
+    
+  </environment>
+  
+</environment>
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+This set of targets is made to test cmsDriver.py steps
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="Validation">
+
+  <target name="step1" cmd="cmsDriver.py SingleElectronPt35_cfi.py -s GEN,SIM,DIGI,L1,DIGI2RAW,HLT:GRun -n 10 --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RAW.root">
+  <target name="step2" cmd="cmsDriver.py step2 -s RAW2DIGI,RECO,VALIDATION,DQM -n 10 --filein file:SingleElectronPt35-10-IDEAL-RAW.root --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RECO.root">
+  <target name="step3" cmd="cmsDriver.py step3 -s HARVESTING:validationHarvesting+dqmHarvesting --harvesting AtRunEnd --conditions auto:mc --filein file:SingleElectronPt35-10-IDEAL-RECO.root --mc">
+
+</environment>
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+Process uncleaned superclusters
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="Uncleaned">
+
+  <var name="DD_TIER" value="*RAW*">
+  <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+  <var name="TEST_HISTOS_FILE" value="${DD_SAMPLE}-IDEAL-UNCLEANED-RECO.root">
+  
+  <target name="dd" cmd="electronDataDiscovery.py">
+  <target name="py" cmd="python ElectronFromUncleanedOnly_cfg.py">
+  <target name="reco" cmd="cmsRun ElectronFromUncleanedOnly_cfg.py">
+  
+</environment>
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+================================================================================
+Photons
+================================================================================
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+<environment name="Photons">
+
+  Those few photons datasets are checked so to compare
+  size and performance with electrons.
+
+  <var name="DD_TIER_SECONDARY" value="*RAW*">
+  <!--var name="DD_RELEASE" value="LOCAL"-->
+  <!--var name="DD_COND" value=""-->
+
+  <environment name="PhotonPt35">
+    <var name="DD_SAMPLE" value="RelValSingleGammaPt35">
+    <executable name="electronDataDiscovery.py">
+    <executable name="cmsRun" args="PhotonValidation_cfg.py">
+  </environment>
+  
+  <environment name="PhotonQcdPt80-120">
+    <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
+    <executable name="electronDataDiscovery.py">
+    <executable name="cmsRun" args="PhotonValidation_cfg.py">
+  </environment>
+  
 </environment>

--- a/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
@@ -111,7 +111,7 @@ else
 #    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
 #	list="Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
 #	list="Pt1000Startup_UP15 "
-	list="TTbarStartup_13 ZEEStartup_13 "
+	list="TTbarStartup_13 ZEEStartup_13  QcdPt80Pt120Startup_13 "
     for element in $list    
     do   
         echo "element =" $element   


### PR DESCRIPTION
A new normalization was made for "provenance (*)" histos for standard histos (SingleElectronPt10, 35, .., TTbar, ZEE) and QCD_80_120 in ElectronMcSignalPostValidator.cc and ElectronMcFakePostValidator.cc files.
No other modification was made.

(*) h1_ele_provenance, h1_ele_provenance_barrel, h1_ele_provenance_endcaps
@beaudett @fcouderc 
