### PR TITLE
Provenance_Histos_Renormalization_80X_V1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -59,6 +59,14 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }
 /**/
+
+  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
+  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
+
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPmatchingObjectVsPhi","","#phi (rad)","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -61,11 +61,14 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
 /**/
 
   MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
-  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  if (h1_ele_provenance->getBinContent(3)>0)
+    {h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));}
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
-  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  if (h1_ele_provenance_barrel->getBinContent(3)>0)
+    {h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));}
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));*/
+  if (h1_ele_provenance_endcaps->getBinContent(3)>0)
+    {h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));}
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -58,7 +58,13 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
      { xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
     h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
   }/**/
-
+  
+  MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
+  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
+  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
+  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));/**/
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}", 0.8);
@@ -104,47 +110,6 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "seedDrz2Pos_VsPt","mean ele seed dr(dz) 2nd layer positron vs pt","p_{T} (GeV/c)","<r(z)_{pred} - r(z)_{hit}, 2nd layer> (cm)",-0.15,0.15);
 /**/
 
-//  // investigation
-//  TH2F * h2 = get("PoPtrueVsEta")->getTH2F() ;
-//  std::cout<<"H2   entries : "<<h2->GetEntries()<<std::endl ;
-//  std::cout<<"H2 effective entries : "<<h2->GetEffectiveEntries()<<std::endl ;
-//  Int_t ix, nx = h2->GetNbinsX(), iy, ny = h2->GetNbinsY(), is, nu = 0, no = 0, nb = 0 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//    for ( ix = 0 ; ix<=(nx+1) ; ++ix )
-//     {
-//      is = iy*(nx+2) + ix ;
-//      if (h2->IsBinUnderflow(is)) ++nu ;
-//      if (h2->IsBinOverflow(is)) ++no ;
-//     }
-//  ix = 0 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//   {
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  ix = nx+1 ;
-//  for ( iy = 0 ; iy<=(ny+1) ; ++iy )
-//   {
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  for ( ix = 1 ; ix<=nx ; ++ix )
-//   {
-//    iy = 0 ;
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//    iy = ny+1 ;
-//    is = iy*(nx+2) + ix ;
-//    nb += (*h2->GetSumw2())[is] ;
-//   }
-//  std::cout<<"H2   nx      : "<<nx<<std::endl ;
-//  std::cout<<"H2   ny      : "<<ny<<std::endl ;
-//  std::cout<<"H2   nsumw2  : "<<(*h2->GetSumw2()).fN<<std::endl ;
-//  std::cout<<"H2   nu      : "<<nu<<std::endl ;
-//  std::cout<<"H2   no      : "<<no<<std::endl ;
-//  std::cout<<"H2   outside : "<<nb<<std::endl ;
-//  std::cout<<"PFX  entries : "<<h2->ProfileX()->GetEntries()<<std::endl ;
-//  std::cout<<"PFX effective entries : "<<h2->ProfileX()->GetEffectiveEntries()<<std::endl ;
 
 
 }

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -60,11 +60,15 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   }/**/
   
   MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
-  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  if (h1_ele_provenance->getBinContent(3)>0)
+    {h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));}
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
-  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  if (h1_ele_provenance_barrel->getBinContent(3)>0)
+    {h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));}
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));/**/
+  if (h1_ele_provenance_endcaps->getBinContent(3)>0)
+    {h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));}
+
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}", 0.8);
@@ -73,8 +77,8 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi","mean ele momentum / gen momentum vs phi","#phi (rad)","<P/P_{gen}>");
   profileX(iBooker, iGetter, "sigmaIetaIetaVsPt","SigmaIetaIeta vs pt","p_{T} (GeV/c)","SigmaIetaIeta");
-  profileX(iBooker, iGetter, "EoEtruePfVsEg","mean pflow sc energy / true energy vs e/g sc energy","E/E_{gen} (e/g)","<E/E_{gen}> (pflow)") ;
-  profileY(iBooker, iGetter, "EoEtruePfVsEg","mean e/g sc energy / true energy vs pflow sc energy","E/E_{gen} (pflow)","<E/E_{gen}> (eg)") ;
+  profileX(iBooker, iGetter, "EoEtruePfVsEg","mean mustache SC/true energy vs final SC/true energy","E_{final SC}/E_{gen}","E_{mustache}/E_{gen}") ;
+  profileY(iBooker, iGetter, "EoEtruePfVsEg","mean mustache SC/true energy vs final SC/true energy","E_{final SC}/E_{gen}","E_{mustache}/E_{gen}") ;
   profileX(iBooker, iGetter, "EtaMnEtaTrueVsEta","mean ele eta - gen eta vs eta","#eta","<#eta_{rec} - #eta_{gen}>");
   profileX(iBooker, iGetter, "EtaMnEtaTrueVsPhi","mean ele eta - gen eta vs phi","#phi (rad)","<#eta_{rec} - #eta_{gen}>");
   profileX(iBooker, iGetter, "PhiMnPhiTrueVsEta","mean ele phi - gen phi vs eta","#eta","<#phi_{rec} - #phi_{gen}> (rad)");

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,17 +1,17 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_0_0_pre4_pmx_DQM_std">
-<var name="TEST_REF" value="8_0_0_pre4">
+<var name="TEST_NEW" value="8_0_20_miniAOD_DQM_std">
+<var name="TEST_REF" value="8_0_20_miniAOD_DQM_std">
 
-<var name="TAG_STARTUP" value="76X_mcRun2_startup_v12">
+<var name="TAG_STARTUP" value="80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
+<var name="DD_COND_REF" value="80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
-<var name="STORE_DIR" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_0_pre4_ValELE/src/Validation/RecoEgamma/test/8_0_0_pre4">
-<var name="STORE_REF" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_0_pre4_ValELE/src/Validation/RecoEgamma/test/8_0_0_pre4">
+<var name="STORE_DIR" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_20_ValELE/src/Validation/RecoEgamma/test/8_0_20">
+<var name="STORE_REF" value="/afs/cern.ch/work/a/archiron/private/CMSSW_8_0_20_ValELE/src/Validation/RecoEgamma/test/8_0_20">
 
 <var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
 
@@ -47,18 +47,18 @@ FullSim
   This set of targets is currently used for the validation of electrons.
 
   Used if DD_source=/eos/...
-  <var name="DD_TIER" value="GEN-SIM-RECO">
+  <var name="DD_TIER" value="MINIAODSIM">
 
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistosMiniAOD.txt">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationMiniAOD_cfg">
 
-  <environment name="ValPileUpStartup">
+  <environment name="ValFullgedvsged">
 
-    <var name="TAG_STARTUP" value="${TAG_STARTUP}">
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
     <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
 
     <environment name="Valdummy">
 
@@ -66,37 +66,37 @@ FullSim
 
         <var name="RED_FILE" value="DQM_DUMMY.root">
  <var name="BLUE_FILE" value="DQM_DUMMY.root">
- <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+ <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
 
-    <var name="DD_COND" value="PUpmx50ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+      <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
 
-    <var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
+        <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
 
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
-
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_0_pre4-PUpmx50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="8_0_0_pre4/DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_0_pre4-PU50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/PUpmx50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+        <var name="RED_FILE" value="DQM_V0001_R000000001__RelValSingleElectronPt10_UP15__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <var name="BLUE_FILE" value="8_0_20/DQM_V0001_R000000001__RelValSingleElectronPt10_UP15__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
       </environment>
 
-    <var name="DD_COND" value="PUpmx50ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+      <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
 
-    <var name="DD_COND_REF" value="PU50ns_76X_mcRun2_startup_v12-v1">
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
 
-      <environment name="ValPileUpZEEStartup_gedGsfE">
+        <var name="RED_FILE" value="DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <var name="BLUE_FILE" value="8_0_20/DQM_V0001_R000000001__RelValTTbar_13__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+      </environment>
+
+      <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
 
         <var name="DD_SAMPLE" value="RelValZEE_13">
 
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_0_pre4-PUpmx50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="8_0_0_pre4/DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_0_pre4-PU50ns_76X_mcRun2_startup_v12-v1__DQMIO.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed_${TEST_REF}/PUpmx50ns_${DD_SAMPLE}_gedGsfE_Startup'>
+        <var name="RED_FILE" value="DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <var name="BLUE_FILE" value="8_0_20/DQM_V0001_R000000001__RelValZEE_13__CMSSW_8_0_20-80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1__DQMIO.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
 
       </environment>
 

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -173,7 +173,7 @@ int electronCompare()
     file_ref = TFile::Open(CMP_BLUE_FILE) ;
     if (file_ref!=0)
      {
-      std::cout<<"open "<<CMP_BLUE_FILE<<std::endl ;
+      std::cout<<"open ref : "<<CMP_BLUE_FILE<<std::endl ;
       if (file_ref->cd(internal_path)==kTRUE)
        {
         std::cerr<<"cd "<<internal_path<<std::endl ;
@@ -203,7 +203,7 @@ int electronCompare()
     file_new = TFile::Open(CMP_RED_FILE) ;
     if (file_new!=0)
      {
-      std::cout<<"open "<<CMP_RED_FILE<<std::endl ;
+      std::cout<<"open new : "<<CMP_RED_FILE<<std::endl ;
       if (file_new->cd(internal_path)==kTRUE)
        {
         std::cerr<<"cd "<<internal_path<<std::endl ;
@@ -426,10 +426,23 @@ int electronCompare()
     // search histo_ref
     if ( file_ref != 0 )
      {
+      TString histo_reduced_path = histo_path.c_str();
+//      std::cout << "histo path : " << histo_reduced_path << std::endl;
       if (file_ref_dir.IsNull())
        { histo_full_path = histo_name ; /*std::cout << "file_ref_dir.IsNull()" << std::endl ;*/ }
       else
-       { histo_full_path = file_ref_dir ; histo_full_path += histo_path.c_str() ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ }
+       { 
+        if (histo_reduced_path.BeginsWith("ElectronMcSignalValidatorMiniAOD"))
+        { 
+            histo_reduced_path.Remove(25,7); /*std::cout << "OK !!" << histo_reduced_path << std::endl;*/ 
+            histo_full_path = file_ref_dir ; histo_full_path += histo_reduced_path ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ }
+        else 
+        {
+            histo_full_path = file_ref_dir ; histo_full_path += histo_path.c_str() ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ 
+        }
+       }
+      std::cout << "histo ref : " << histo_full_path << std::endl;
+ 
    // WARNING
    // the line below have to be unmasked if the reference release is prior to 740pre8 and for Pt1000
    // before 740pre8 : DQMData/Run 1/EgammaV/Run summary/ ElectronMcSignalValidator/ histo name (same as Pt35, Pt10, ....)
@@ -462,6 +475,7 @@ int electronCompare()
 
     // search histo_new
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
+    std::cout <<  "histo new : " << histo_full_path << std::endl;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
 
     // special treatments
@@ -594,7 +608,7 @@ int electronCompare()
        } while (cat.empty()) ;
      }
    }
-  std::cout << "on ferme le fichier : " << histo_file2 << std::endl;
+//  std::cout << "on ferme le fichier : " << histo_file2 << std::endl;
   histo_file2.close() ;
   web_page<<"</td></tr></table>\n" ;
 


### PR DESCRIPTION
80X Backport : please insert it after PR15442.
A new normalization was made for "provenance (*)" histos for standard histos (SingleElectronPt10, 35, .., TTbar, ZEE) and QCD_80_120 in ElectronMcSignalPostValidator.cc and ElectronMcFakePostValidator.cc files.
No other modification was made.

(*) h1_ele_provenance, h1_ele_provenance_barrel, h1_ele_provenance_endcaps
@beaudett @fcouderc 
