### PR TITLE
New PopCon handler for dealing with B ON/OFF transitions, with test analyzer for EcalADCToGeVConstants

### DIFF
--- a/CondCore/PopCon/interface/PopConBTransitionSourceHandler.h
+++ b/CondCore/PopCon/interface/PopConBTransitionSourceHandler.h
@@ -1,0 +1,143 @@
+#ifndef PopConBTransitionSourceHandler_H
+#define PopConBTransitionSourceHandler_H
+
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/CondDB/interface/IOVProxy.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include <string>
+
+namespace popcon {
+  template <class T>
+  class PopConBTransitionSourceHandler: public PopConSourceHandler<T> {
+  public:
+    PopConBTransitionSourceHandler( edm::ParameterSet const & pset ):
+      m_isBOn( true ),
+      m_run( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<unsigned long long>( "runNumber" ) ),
+      m_currentThreshold( pset.getParameter<edm::ParameterSet>( "BTransition" ).getUntrackedParameter<double>( "currentThreshold", 18000. ) ),
+      m_tagForRunInfo( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<std::string>( "tagForRunInfo" ) ),
+      m_tagForBOff( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<std::string>( "tagForBOff" ) ),
+      m_tagForBOn( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<std::string>( "tagForBOn" ) ),
+      m_connectionString( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<std::string>( "connect" ) ),
+      m_connectionPset( pset.getParameter<edm::ParameterSet>( "BTransition" ).getParameter<edm::ParameterSet>( "DBParameters" ) ) {
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler:" << __func__ << "]: "
+                                                       << "Initialising Connection Pool" << std::endl;
+      m_connection.setParameters( m_connectionPset );
+      m_connection.configure();
+  }
+
+    virtual ~PopConBTransitionSourceHandler() {}
+
+    virtual std::string id() const override { return std::string( "PopConBTransitionSourceHandler" ); }
+
+    void isBOn() {
+      //reading RunInfo from Conditions
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "Initialising CondDB read-only session to " << m_connectionString << std::endl;
+      cond::persistency::Session session = m_connection.createReadOnlySession( m_connectionString, "" );
+      session.transaction().start();
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "Loading tag for RunInfo " << m_tagForRunInfo
+                                                       << " and IOV valid for run number: " << m_run << std::endl;
+      cond::persistency::IOVProxy iov = session.readIov( m_tagForRunInfo, true );
+      cond::Iov_t currentIov = *(iov.find( m_run ));
+      LogDebug( "PopConBTransitionSourceHandler" ) << "Loaded IOV sequence from tag " << m_tagForRunInfo
+                                                   << " with size: "<< iov.loadedSize()
+                                                   << ", IOV valid for run number " << m_run << " starting from: " << currentIov.since
+                                                   << ", with corresponding payload hash: " << currentIov.payloadId
+                                                   << std::endl;
+      double current_default = -1;
+      double avg_current = current_default;
+      avg_current = session.fetchPayload<RunInfo>( currentIov.payloadId )->m_avg_current;
+      LogDebug( "PopConBTransitionSourceHandler" ) << "Comparing value of magnet current: " << avg_current << " A for run: " << m_run
+                                                   << " with the corresponding threshold: "<< m_currentThreshold << " A." << std::endl;
+      if( avg_current != current_default && avg_current <= m_currentThreshold ) m_isBOn = false;
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "The magnet was " << ( m_isBOn ? "ON" : "OFF" )
+                                                       << " during run " << m_run << std::endl;
+      session.transaction().commit();
+    }
+
+    virtual void getObjectsForBTransition() {
+      //reading payloads for 0T and 3.8T from Conditions
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "Initialising CondDB read-only session to " << m_connectionString << std::endl;
+      cond::persistency::Session session = m_connection.createReadOnlySession( m_connectionString, "" );
+      session.transaction().start();
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "Loading tag for B " << ( m_isBOn ? "ON" : "OFF" ) << ": "
+                                                       << ( m_isBOn ? m_tagForBOn : m_tagForBOff )
+                                                       << " and IOV valid for run number: " << m_run << std::endl;
+      cond::persistency::IOVProxy iov = session.readIov( m_isBOn ? m_tagForBOn : m_tagForBOff, true );
+      cond::Iov_t currentIov = *(iov.find( m_run ));
+      LogDebug( "PopConBTransitionSourceHandler" ) << "Loaded IOV sequence from tag " << ( m_isBOn ? m_tagForBOn : m_tagForBOff )
+                                                   << " with size: "<< iov.loadedSize()
+                                                   << ", IOV valid for run number " << m_run << " starting from: " << currentIov.since
+                                                   << ", with corresponding payload hash: " << currentIov.payloadId
+                                                   << std::endl;
+      if( currentIov.payloadId != this->tagInfo().lastPayloadToken ) {
+        std::ostringstream ss;
+        ss << "Exporting payload with hash " << currentIov.payloadId
+           << " corresponding to the calibrations for magnetic field "
+           << ( m_isBOn ? "ON" : "OFF" )
+           << " starting from run number: " << m_run;
+        edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                         << ss.str() << std::endl;
+        T* pp = new T( *(session.fetchPayload<T>( currentIov.payloadId )) );
+        this->m_to_transfer.push_back( std::make_pair( pp, m_run ) );
+        this->m_userTextLog = ss.str();
+      } else {
+        edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                         << "The payload with hash " << currentIov.payloadId
+                                                         << " corresponding to the calibrations for magnetic field "
+                                                         << ( m_isBOn ? "ON" : "OFF" )
+                                                         << " is still valid for run " << m_run
+                                                         << " in the destination tag " << this->tagInfo().name
+                                                         << ".\nNo transfer needed." <<std::endl;
+      }
+      session.transaction().commit();
+    }
+
+    virtual void getNewObjects() final {
+      //check whats already inside of database
+       edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                        << "Destination Tag Info: name " << this->tagInfo().name
+                                                        << ", size " << this->tagInfo().size
+                                                        << ", last object valid since " << this->tagInfo().lastInterval.first
+                                                        << ", hash " << this->tagInfo().lastPayloadToken << std::endl;
+      //check if a transfer is needed:
+      //if the new run number is smaller than or equal to the latest IOV, exit.
+      //This is needed as now the IOV Editor does not always protect for insertions:
+      //ANY and VALIDATION sychronizations are allowed to write in the past.
+      if( this->tagInfo().size > 0  && this->tagInfo().lastInterval.first >= m_run ) {
+        edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                         << "last IOV " << this->tagInfo().lastInterval.first
+                                                         << ( this->tagInfo().lastInterval.first == m_run ? " is equal to" : " is larger than" )
+                                                         << " the run proposed for insertion " << m_run
+                                                         << ". No transfer needed." << std::endl;
+        return;
+      }
+      isBOn();
+      getObjectsForBTransition();
+      edm::LogInfo( "PopConBTransitionSourceHandler" ) << "[" << "PopConBTransitionSourceHandler::" << __func__ << "]: "
+                                                       << "END." << std::endl;
+    }
+
+  private:
+    bool m_isBOn;
+    unsigned long long m_run;
+    double m_currentThreshold;
+    // for reading from CondDB the current from RunInfo
+    std::string m_tagForRunInfo;
+    // for reading from CondDB the 0T and 3.8T payloads
+    std::string m_tagForBOff;
+    std::string m_tagForBOn;
+    std::string m_connectionString;
+    edm::ParameterSet m_connectionPset;
+    cond::persistency::ConnectionPool m_connection;
+  };
+} //namespace popcon
+
+#endif //PopConBTransitionSourceHandler_H

--- a/CondTools/Ecal/plugins/BuildFile.xml
+++ b/CondTools/Ecal/plugins/BuildFile.xml
@@ -1,16 +1,17 @@
-<use   name="xerces-c"/>
-<use   name="CondCore/PopCon"/>
-<use   name="CondTools/Ecal"/>
 <use   name="boost"/>
-<use   name="FWCore/PluginManager"/>
-<use   name="FWCore/Framework"/>
-<use   name="DataFormats/Common"/>
-<use   name="DataFormats/EcalDetId"/>
-<use   name="CondCore/DBOutputService"/>
+<use   name="xerces-c"/>
 <use   name="CondFormats/Alignment"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/RunInfo"/>
+<use   name="CondCore/DBOutputService"/>
+<use   name="CondCore/PopCon"/>
+<use   name="CondTools/Ecal"/>
+<use   name="CondTools/RunInfo"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/EcalDetId"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
 <use   name="Utilities/General"/>
 <library   file="*.cc" name="CondToolsEcalPlugin">
   <flags   EDM_PLUGIN="1"/>

--- a/CondTools/Ecal/plugins/BuildFile.xml
+++ b/CondTools/Ecal/plugins/BuildFile.xml
@@ -7,10 +7,11 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/EcalDetId"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="CondFormats/EcalObjects"/>
+<use   name="CondFormats/Alignment"/>
 <use   name="CondFormats/DataRecord"/>
-  <use   name="CondFormats/Alignment"/>
-  <use name="Utilities/General"/>
+<use   name="CondFormats/EcalObjects"/>
+<use   name="CondFormats/RunInfo"/>
+<use   name="Utilities/General"/>
 <library   file="*.cc" name="CondToolsEcalPlugin">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CondTools/Ecal/plugins/EcalADCToGeVConstantPopConBTransitionAnalyzer.cc
+++ b/CondTools/Ecal/plugins/EcalADCToGeVConstantPopConBTransitionAnalyzer.cc
@@ -1,6 +1,6 @@
-#include "CondCore/PopCon/interface/PopConBTransitionSourceHandler.h"
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondTools/RunInfo/interface/PopConBTransitionSourceHandler.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 typedef popcon::PopConAnalyzer< popcon::PopConBTransitionSourceHandler<EcalADCToGeVConstant> > EcalADCToGeVConstantPopConBTransitionAnalyzer;

--- a/CondTools/Ecal/plugins/EcalADCToGeVConstantPopConBTransitionAnalyzer.cc
+++ b/CondTools/Ecal/plugins/EcalADCToGeVConstantPopConBTransitionAnalyzer.cc
@@ -1,0 +1,9 @@
+#include "CondCore/PopCon/interface/PopConBTransitionSourceHandler.h"
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer< popcon::PopConBTransitionSourceHandler<EcalADCToGeVConstant> > EcalADCToGeVConstantPopConBTransitionAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EcalADCToGeVConstantPopConBTransitionAnalyzer);

--- a/CondTools/Ecal/test/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/test/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,128 @@
+import socket
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from CondCore.CondDB.CondDB_cfi import *
+
+options = VarParsing.VarParsing()
+options.register( 'runNumber'
+                , 1 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number to be uploaded."
+                  )
+options.register( 'destinationConnection'
+                , 'sqlite_file:EcalADCToGeVConstant_PopCon_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads will be possibly written."
+                  )
+options.register( 'targetConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the target DB:
+                     if not empty (default), this provides the latest IOV and payloads to compare;
+                     it is the DB where payloads should be finally uploaded."""
+                  )
+options.register( 'sourceConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the DB hosting tags for RunInfo and EcalADCToGeVConstant.
+                     It defaults to the same as the target connection, i.e. empty.
+                     If target connection is also empty, it is set to be the same as destination connection."""
+                  )
+options.register( 'tag'
+                , 'EcalADCToGeVConstant_PopCon_test'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag written in destinationConnection and finally appended in targetConnection."
+                  )
+options.register( 'tagForRunInfo'
+                , 'runInfo_31X_hlt'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the RunInfo payload and the magnet current therein."
+                  )
+options.register( 'tagForBOff'
+                , 'EcalADCToGeVConstant_0T_test0'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalADCToGeVConstant payload for magnet off."
+                  )
+options.register( 'tagForBOn'
+                , 'EcalADCToGeVConstant_3.8T_test0'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalADCToGeVConstant payload for magnet on."
+                  )
+options.register( 'currentThreshold'
+                , 18000.
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.float
+                , "The threshold on the magnet current for considering a switch of the magnetic field."
+                  )
+options.register( 'messageLevel'
+                , 0 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Message level; default to 0"
+                  )
+options.parseArguments()
+
+if not options.sourceConnection:
+    if options.targetConnection:
+        options.sourceConnection = options.targetConnection
+    else:
+        options.sourceConnection = options.destinationConnection
+
+CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
+CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+PopConConnection = CondDB.clone( connect = cms.string( options.sourceConnection ) )
+PopConConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+process = cms.Process( "EcalADCToGeVConstantPopulator" )
+
+process.MessageLogger = cms.Service( "MessageLogger"
+                                   , destinations = cms.untracked.vstring( 'cout' )
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
+                                     )
+
+if options.messageLevel == 3:
+    #enable LogDebug output: remember the USER_CXXFLAGS="-DEDM_ML_DEBUG" compilation flag!
+    process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string( 'DEBUG' ) )
+    process.MessageLogger.debugModules = cms.untracked.vstring( '*' )
+
+process.source = cms.Source( "EmptyIOVSource"
+                           , lastValue = cms.uint64( options.runNumber )
+                           , timetype = cms.string( 'runnumber' )
+                           , firstValue = cms.uint64( options.runNumber )
+                           , interval = cms.uint64( 1 )
+                             )
+
+process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
+                                         , CondDBConnection
+                                         , timetype = cms.untracked.string( 'runnumber' )
+                                         , toPut = cms.VPSet( cms.PSet( record = cms.string( 'EcalADCToGeVConstantRcd' )
+                                                                      , tag = cms.string( options.tag )
+                                                                        )
+                                                              )
+                                          )
+
+process.popConEcalADCToGeVConstant = cms.EDAnalyzer( "EcalADCToGeVConstantPopConBTransitionAnalyzer"
+                                                   , SinceAppendMode = cms.bool( True )
+                                                   , record = cms.string( 'EcalADCToGeVConstantRcd' )
+                                                   , Source = cms.PSet( BTransition = cms.PSet( PopConConnection
+                                                                                              , runNumber = cms.uint64( options.runNumber )
+                                                                                              , tagForRunInfo = cms.string( options.tagForRunInfo )
+                                                                                              , tagForBOff = cms.string( options.tagForBOff )
+                                                                                              , tagForBOn = cms.string( options.tagForBOn )
+                                                                                              , currentThreshold = cms.untracked.double( options.currentThreshold )
+                                                                                                )
+                                                                        )
+                                                   , loggingOn = cms.untracked.bool( True )
+                                                   , targetDBConnectionString = cms.untracked.string( options.targetConnection )
+                                                     )
+
+process.p = cms.Path( process.popConEcalADCToGeVConstant )

--- a/CondTools/RunInfo/BuildFile.xml
+++ b/CondTools/RunInfo/BuildFile.xml
@@ -1,9 +1,11 @@
+<use   name="CondCore/CondDB"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CondCore/PopCon"/>
 <use   name="CondFormats/RunInfo"/>
 <use   name="CoralBase"/>
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/Framework"/>
+<use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>


### PR DESCRIPTION
This code enables to automatically handle condition changes in case of magnetic field transitions using `PopCon` modules. It was developed during 2015.

The new analyzer requires as template arguments:
- the payload class

The new handler does the following:
1. it retrieves the value of the magnet current from the `RunInfo` payload relative to the IOV valid for the run defined in the configuration
2. it compares the average current with the threshold set by the user in the configuration
3. it loads the IOV from the target and the reference tags valid for the run defined in the configuration: the reference tag is chosen from the configuration according to the comparison of the above step
4. it compares the target and the reference payload hashes using a virtual method: endusers can override it, as they know how to assess whether or not two condition payloads are the same
5. if the payloads are different, it writes the reference payload into the target tag using `PopCon`.

A complete example is provided for the `EcalADCToGeVConstant` class.

@mmusich @franzoni this is something you might want to watch as well.
