### PR TITLE
 DataFormats/HcalDetId : fix for root 608 dictionary generation warning/compilation error

### DIFF
--- a/DataFormats/HcalDetId/src/classes_def.xml
+++ b/DataFormats/HcalDetId/src/classes_def.xml
@@ -9,9 +9,10 @@
    <version ClassVersion="12" checksum="1604420376"/>
    <version ClassVersion="11" checksum="1604420376"/>
    <version ClassVersion="10" checksum="193306378"/>
-   <ioread sourceClass = "HcalDetId" version="[-11]" targetClass="HcalDetId" source="uint32_t DetId::id_;" target="DetId::id_">
+   <ioread sourceClass = "HcalDetId" version="[-11]" targetClass="HcalDetId" source="" target="">
     <![CDATA[
-      newFromOld(onfile.rawId());
+      HcalDetId tmp(HcalDetId::newForm(newObj->rawId()));
+      *newObj=tmp;
     ]]>
    </ioread>
   </class>


### PR DESCRIPTION
Log File for DataFormats/HcalDetId

> > Entering Package DataFormats/HcalDetId
> > Entering library rule at DataFormats/HcalDetId
> > Building LCG reflex dict from header file src/DataFormats/HcalDetId/src/classes.h
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/bin/genreflex src/DataFormats/HcalDetId/src/classes.h -s src/DataFormats/HcalDetId/src/classes_def.xml -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc --deep --fail_on_warnings --rootmap=DataFormatsHcalDetId_xr.rootmap --rootmap-lib=libDataFormatsHcalDetId.so -m DataFormatsDetId_xr_rdict.pcm -m DataFormatsCommon_xr_rdict.pcm -m DataFormatsProvenance_xr_rdict.pcm -m FWCoreMessageLogger_xr_rdict.pcm -m DataFormatsStdDictionaries_xr_rdict.pcm -m DataFormatsStdDictionaries_x1r_rdict.pcm -m DataFormatsStdDictionaries_x2r_rdict.pcm -m DataFormatsStdDictionaries_x3r_rdict.pcm --capabilities=DataFormatsHcalDetId_xi.cc -DCMS_DICT_IMPL -D_REENTRANT -DGNUSOURCE -D__STRICT_ANSI__ -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -DCMSSW_REFLEX_DICT
> >   Warning: IO rule for class HcalDetId data member: DetId::id_ was specified as a target in the rule but doesn't seem to appear in target class
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalGenericDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalGenericDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalGenericDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalGenericDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalCalibDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCalibDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalCalibDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCalibDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalDcsDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDcsDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalDcsDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDcsDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalOtherDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalOtherDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalOtherDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalOtherDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalTrigTowerDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalTrigTowerDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalFrontEndId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalFrontEndId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalFrontEndId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalFrontEndId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalCastorDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCastorDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalCastorDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCastorDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalZDCDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalZDCDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalZDCDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalZDCDetId.o
> > Selected class -> HcalElectronicsId for ROOT: HcalElectronicsId
> > Selected class -> HcalFrontEndId for ROOT: HcalFrontEndId
> > Selected class -> HcalDetId for ROOT: HcalDetId
> > Selected class -> HcalTrigTowerDetId for ROOT: HcalTrigTowerDetId
> > Selected class -> HcalOtherDetId for ROOT: HcalOtherDetId
> > Selected class -> HcalCalibDetId for ROOT: HcalCalibDetId
> > Selected class -> HcalZDCDetId for ROOT: HcalZDCDetId
> > Selected class -> HcalDcsDetId for ROOT: HcalDcsDetId
> > Selected class -> HcalCastorDetId for ROOT: HcalCastorDetId
> > Selected class -> CastorElectronicsId for ROOT: CastorElectronicsId
> > Selected class -> std::vector<HcalElectronicsId, std::allocator<HcalElectronicsId> > for ROOT: vector<HcalElectronicsId>
> > Selected class -> std::vector<HcalFrontEndId, std::allocator<HcalFrontEndId> > for ROOT: vector<HcalFrontEndId>
> > Selected class -> std::vector<CastorElectronicsId, std::allocator<CastorElectronicsId> > for ROOT: vector<CastorElectronicsId>
> > gmake: **\* [tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc] Error 1
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/CastorElectronicsId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/CastorElectronicsId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/CastorElectronicsId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/CastorElectronicsId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalDetId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDetId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalDetId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDetId.o
> > Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalElectronicsId.cc 
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalElectronicsId.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src/DataFormats/HcalDetId/src/HcalElectronicsId.cc -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalElectronicsId.o
> > Compiling LCG dictionary: tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -MMD -MF DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.d -c -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100 -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_8_1_ROOT6_X_2016-10-18-1100" -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.08.00-epaelh/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-giojec2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/44_20151115oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-giojec/include -DCMSSW_REFLEX_DICT -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Os -Wno-unused-variable -fPIC DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc -o DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.o
> > c++: error: DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc: No such file or directory
> > c++: fatal error: no input files
> > compilation terminated.
> >   gmake: **\* [tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.o] Error 1
> >  /bin/mv: cannot stat `tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.cc.dx': No such file or directory
> >   gmake: **\* [tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.o] Error 1
> > Building shared library tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/libDataFormatsHcalDetId.so
> > /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -fipa-pta -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=maybe-uninitialized -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -shared -Wl,-E -Wl,-z,defs tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalGenericDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCalibDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDcsDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalOtherDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalTrigTowerDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalFrontEndId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalCastorDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalZDCDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/CastorElectronicsId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalDetId.o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/HcalElectronicsId.o -o tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/libDataFormatsHcalDetId.so -Wl,-E -Wl,--hash-style=gnu -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/lib/slc6_amd64_gcc530 -L/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/338e1057adfe1c6090c806d3cbb791c4/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_8_1_ROOT6_X_2016-10-18-1100/external/slc6_amd64_gcc530/lib -lDataFormatsDetId -lDataFormatsCommon -lDataFormatsProvenance -lFWCoreMessageLogger -lDataFormatsStdDictionaries -lFWCoreUtilities -lTree -lNet -lThread -lMathCore -lRIO -lboost_filesystem -lCore -lboost_regex -lboost_system -lpcre -lboost_thread -lboost_signals -lboost_date_time -lbz2 -luuid -ltbb -lz -lcms-md5 -lnsl -lcrypt -ldl -lrt -ltinyxml
> > c++: error: tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/a/DataFormatsHcalDetId_xr.o: No such file or directory
> >   gmake: **\* [tmp/slc6_amd64_gcc530/src/DataFormats/HcalDetId/src/DataFormatsHcalDetId/libDataFormatsHcalDetId.so] Error 1
> >  Leaving library rule at DataFormats/HcalDetId
> > Leaving Package DataFormats/HcalDetId
> > Package DataFormats/HcalDetId built
