### PR TITLE
HBHE M3 and timeSlew

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h
@@ -25,7 +25,7 @@ class HcalTimeSlew {
    number of fC will be delayed by the timeslew effect, for the
    specified bias setting. */
   static double delay(double fC, BiasSetting bias=Medium);
-  static double delay(double fC, ParaSource source=InputPars, BiasSetting bias=Medium, double par0=tspar[0], double par1=tspar[1], double par2=tspar[2]);
+  static double delay(double fC, ParaSource source=InputPars, BiasSetting bias=Medium, double par0=tspar[0], double par1=tspar[1], double par2=tspar[2], bool isHPD=true);
 };
 
 #endif

--- a/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
@@ -8,13 +8,16 @@ static const double cap = 6.0;
 static const double tspar0[2] = {15.5, 12.2999};
 static const double tspar1[2] = {-3.2,-2.19142};
 static const double tspar2[2] = {32, 0};
+static const double tspar0_siPM[2] = {0, 0};
+static const double tspar1_siPM[2] = {0, 0};
+static const double tspar2_siPM[2] = {0, 0};
 
 double HcalTimeSlew::delay(double fC, BiasSetting bias) {
   double rawDelay=tzero[bias]+slope[bias]*log(fC);
   return (rawDelay<0)?(0):((rawDelay>tmax[bias])?(tmax[bias]):(rawDelay));			   
 }
 
-double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, double par0, double par1, double par2) {
+double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, double par0, double par1, double par2, bool isHPD) {
 
   if (source==TestStand) {
     return HcalTimeSlew::delay(fC, bias);
@@ -23,7 +26,8 @@ double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, doubl
     return std::fmin(cap, par0 + par1*log(fC+par2));
   }
   else if (source==Data || source==MC){
-    return std::fmin(cap,tspar0[source-1]+tspar1[source-1]*log(fC+tspar2[source-1]));
+    if(isHPD) return std::fmin(cap,tspar0[source-1]+tspar1[source-1]*log(fC+tspar2[source-1]));
+    return std::fmin(cap,tspar0_siPM[source-1]+tspar1_siPM[source-1]*log(fC+tspar2_siPM[source-1]));
   }
   return 0;
 }

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
@@ -18,7 +18,7 @@ class HcalDeterministicFit {
   HcalDeterministicFit();
   ~HcalDeterministicFit();
 
-  void init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr);
+  void init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, bool iApplyTimeSlew, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr);
 
   void phase1Apply(const HBHEChannelInfo& channelData,
 		   float& reconstructedEnergy,
@@ -33,6 +33,7 @@ class HcalDeterministicFit {
   HcalTimeSlew::ParaSource fTimeSlew;
   HcalTimeSlew::BiasSetting fTimeSlewBias;
   PedestalSub fPedestalSubFxn_;
+  bool applyTimeSlew_;
 
   double fpars[9];
   double frespCorr;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -91,7 +91,7 @@ public:
 		       double iNoise,double iNoiseSiPM,
 		       double iTMin, double iTMax,
 		       double its4Chi2, int iFitTimes);
-  void setMeth3Params(float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
+  void setMeth3Params(bool iApplyTimeSlew, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
                
 private:
   bool correctForTimeslew_;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -16,15 +16,17 @@ HcalDeterministicFit::HcalDeterministicFit() {
 HcalDeterministicFit::~HcalDeterministicFit() { 
 }
 
-void HcalDeterministicFit::init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr) {
+void HcalDeterministicFit::init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, bool iApplyTimeSlew, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr) {
   for(int fi=0; fi<9; fi++){
 	fpars[fi] = pars.at(fi);
   }
 
+  applyTimeSlew_=iApplyTimeSlew;
   fTimeSlew=tsParam;
   fTimeSlewBias=bias;
   fPedestalSubFxn_=pedSubFxn_;
   frespCorr=respCorr;
+
 }
 
 constexpr float HcalDeterministicFit::landauFrac[];
@@ -92,6 +94,12 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   float tsShift3=HcalTimeSlew::delay(inputCharge[3], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
   float tsShift4=HcalTimeSlew::delay(inputCharge[4], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
   float tsShift5=HcalTimeSlew::delay(inputCharge[5], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
+
+  if(!applyTimeSlew_) {
+    tsShift3=0;
+    tsShift4=0;
+    tsShift5=0;
+  }
 
   float i3=0;
   getLandauFrac(-tsShift3,-tsShift3+tsWidth,i3);

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -91,14 +91,16 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   else if (fTimeSlew==2)respCorr=rCorr[1];
   else if (fTimeSlew==3)respCorr=frespCorr;
 
-  float tsShift3=HcalTimeSlew::delay(inputCharge[3], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
-  float tsShift4=HcalTimeSlew::delay(inputCharge[4], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
-  float tsShift5=HcalTimeSlew::delay(inputCharge[5], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2);
+  float tsShift3=0;
+  float tsShift4=0;
+  float tsShift5=0;
 
-  if(!applyTimeSlew_) {
-    tsShift3=0;
-    tsShift4=0;
-    tsShift5=0;
+  if(applyTimeSlew_) {
+
+    tsShift3=HcalTimeSlew::delay(inputCharge[3], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2,!channelData.hasTimeInfo());
+    tsShift4=HcalTimeSlew::delay(inputCharge[4], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2,!channelData.hasTimeInfo());
+    tsShift5=HcalTimeSlew::delay(inputCharge[5], fTimeSlew, fTimeSlewBias, fpar0, fpar1 ,fpar2,!channelData.hasTimeInfo());
+
   }
 
   float i3=0;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -70,10 +70,11 @@ void HcalSimpleRecAlgo::setpuCorrParams(bool   iPedestalConstraint, bool iTimeCo
 //  psFitOOTpuCorr_->setPulseShapeTemplate(theHcalPulseShapes_.getShape(shapeNum));
 }
 
-void HcalSimpleRecAlgo::setMeth3Params( float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3) {
+void HcalSimpleRecAlgo::setMeth3Params( bool iApplyTimeSlew, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3) {
 
   pedSubFxn_->init(0, iPedSubThreshold, 0.0);
-  hltOOTpuCorr_->init((HcalTimeSlew::ParaSource)iTimeSlewParsType, HcalTimeSlew::Medium, *pedSubFxn_, iTimeSlewPars,irespCorrM3);
+  hltOOTpuCorr_->init((HcalTimeSlew::ParaSource)iTimeSlewParsType, HcalTimeSlew::Medium, iApplyTimeSlew, *pedSubFxn_, iTimeSlewPars,irespCorrM3);
+
 }
 
 void HcalSimpleRecAlgo::setForData (int runnum) { 

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -57,8 +57,9 @@ parseHBHEMethod2Description(const edm::ParameterSet& conf)
 static std::unique_ptr<HcalDeterministicFit>
 parseHBHEMethod3Description(const edm::ParameterSet& conf)
 {
-    const float iPedSubThreshold = conf.getParameter<double>("pedestalUpperLimit");
-    const int iTimeSlewParsType =  conf.getParameter<int>   ("timeSlewParsType");
+    const bool iApplyTimeSlew  =  conf.getParameter<bool>  ("applyTimeSlewM3");
+    const float iPedSubThreshold =  conf.getParameter<double>("pedestalUpperLimit");
+    const int iTimeSlewParsType  =  conf.getParameter<int>   ("timeSlewParsType");
     const double irespCorrM3 =     conf.getParameter<double>("respCorrM3");
     const std::vector<double>& iTimeSlewPars =
                      conf.getParameter<std::vector<double> >("timeSlewPars");
@@ -68,7 +69,7 @@ parseHBHEMethod3Description(const edm::ParameterSet& conf)
 
     std::unique_ptr<HcalDeterministicFit> fit = std::make_unique<HcalDeterministicFit>();
     fit->init( (HcalTimeSlew::ParaSource)iTimeSlewParsType,
-	       HcalTimeSlew::Medium,
+	       HcalTimeSlew::Medium, iApplyTimeSlew,
 	       pedSubFxn, iTimeSlewPars, irespCorrM3);
     return fit;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod3Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod3Parameters_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Configuration parameters for Method 3
 m3Parameters = cms.PSet(
+    applyTimeSlewM3         = cms.bool(True),
     pedestalUpperLimit      = cms.double(2.7),
     timeSlewParsType        = cms.int32(1),     # 0: TestStand, 1:Data, 2:MC, 3:InputPars. Parametrization function is par0 + par1*log(fC+par2).
     timeSlewPars            = cms.vdouble(12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0), # HB par0, HB par1, HB par2, BE par0, BE par1, BE par2, HE par0, HE par1, HE par2

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -278,6 +278,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
 			  );
   }
   reco_.setMeth3Params(
+	    conf.getParameter<bool>    ("applyTimeSlewM3"),
             conf.getParameter<double>  ("pedestalUpperLimit"),
             conf.getParameter<int>     ("timeSlewParsType"),
             conf.getParameter<std::vector<double> >("timeSlewPars"),
@@ -290,6 +291,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
 void HcalHitReconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setAllowAnything();
+  desc.add<bool>("applyTimeSlewM3", true);
   desc.add<double>("pedestalUpperLimit", 2.7); 
   desc.add<int>("timeSlewParsType",3);
   desc.add<std::vector<double>>("timeSlewPars", { 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 });

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -30,6 +30,7 @@ HcalSimpleReconstructor::HcalSimpleReconstructor(edm::ParameterSet const& conf):
 {
   // Intitialize "method 3"
   reco_.setMeth3Params(
+	    conf.getParameter<bool>    ("applyTimeSlewM3"),
             conf.getParameter<double>  ("pedestalUpperLimit"),
             conf.getParameter<int>     ("timeSlewParsType"),
             conf.getParameter<std::vector<double> >("timeSlewPars"),
@@ -84,6 +85,7 @@ HcalSimpleReconstructor::HcalSimpleReconstructor(edm::ParameterSet const& conf):
 void HcalSimpleReconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setAllowAnything();
+  desc.add<bool>("applyTimeSlewM3", true);
   desc.add<double>("pedestalUpperLimit", 2.7); 
   desc.add<int>("timeSlewParsType",3);
   desc.add<std::vector<double>>("timeSlewPars", { 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 });


### PR DESCRIPTION
This PR add add a switch to disable the timeslew for the online HCAL energy (Method3).
Added dedicated siPM delay parameters (for now they contains zero).

changes expected only in the 2017 scenario and for HE only

Validation plots here
http://dalfonso.web.cern.ch/dalfonso/ChangesInM3.pdf
