### PR TITLE
Fix MiniAOD validation

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1954,6 +1954,7 @@ class ConfigBuilder(object):
                         pathName='dqmofflineOnPAT_%d_step'%(i)
 
                 setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
+                self.schedule.append(getattr(self.process,pathName))
 
     def prepare_HARVESTING(self, sequence = None):
         """ Enrich the process with harvesting step """


### PR DESCRIPTION
In 8_1_0_pre12 the MiniAOD DQM paths `process.dqmofflineOnPAT_step` and `process.dqmofflineOnPAT_1_step` do not end up in `process.schedule`, while in pre11 they did. I believe this causes the loss of MiniAOD validation histograms reported here
https://hypernews.cern.ch/HyperNews/CMS/get/relval/6213/46/2.html

It seems to me that the problem was caused by #15810 by (accidentally?) removing this line.

Tested in 8_1_0_pre12, only expected change is the recovery of MiniAOD validation histograms.
