### PR TITLE
[81X] Update Hcal tags for SiPM characteristics in Run1/2 MC and data and several fixes in 2017 hcal conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,47 +2,47 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v3',
+    'run1_design'       :   '81X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v3',
+    'run1_mc'           :   '81X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '81X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v8',
+    'run2_design'       :   '81X_mcRun2_design_v9',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v10',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v11',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v9',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v10',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v8',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v9',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v9',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v10',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v8',
+    'run1_data'         :   '81X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v8',
+    'run2_data'         :   '81X_dataRun2_v9',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v10',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v11',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v2',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v0',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v16',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v17',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '81X_upgrade2023_realistic_v1'
+    'phase2_realistic'     : '81X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags
## RunI simulation
- **RunI Ideal scenario** : [81X_mcRun1_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v4) as [81X_mcRun1_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_design_v4/81X_mcRun1_design_v3): 
  - updated `HcalSiPMCharacteristics` in HO
- **RunI Heavy Ions scenario** : [81X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v4) as [81X_mcRun1_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_HeavyIon_v4/81X_mcRun1_HeavyIon_v3): 
  - updated `HcalSiPMCharacteristics` in HO
- **RunI Realistic scenario** : [81X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v4) as [81X_mcRun1_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_realistic_v4/81X_mcRun1_realistic_v3): 
  - updated `HcalSiPMCharacteristics` in HO
- **RunI Proton-Lead scenario** : [81X_mcRun1_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v4) as [81X_mcRun1_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_pA_v4/81X_mcRun1_pA_v3): 
  - updated `HcalSiPMCharacteristics` in HO
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v9) as [81X_mcRun2_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v9/81X_mcRun2_design_v8): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v10) as [81X_mcRun2_asymptotic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v10/81X_mcRun2_asymptotic_v9): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII Startup scenario** : [81X_mcRun2_startup_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v11) as [81X_mcRun2_startup_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v11/81X_mcRun2_startup_v10): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v4) as [81X_mcRun2_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v4/81X_mcRun2_pA_v3): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v9) as [81X_mcRun2cosmics_startup_peak_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v9/81X_mcRun2cosmics_startup_peak_v8): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v10) as [81X_mcRun2_HeavyIon_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v10/81X_mcRun2_HeavyIon_v9): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
## RunII data
- **RunII Offline processing** : [81X_dataRun2_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v9) as [81X_dataRun2_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v9/81X_dataRun2_v8): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
  - update SiStripDQM TriggerBit selection for Heavy Ion data
- **RunII HLTHI processing** : [81X_dataRun2_HLTHI_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v3) as [81X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v3/81X_dataRun2_HLTHI_frozen_v2): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v5) as [81X_dataRun2_HLT_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v5/81X_dataRun2_HLT_relval_v4): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII HLT processing** : [81X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v3) as [81X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v3/81X_dataRun2_HLT_frozen_v2): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
- **RunII Offline relval processing** : [81X_dataRun2_relval_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v11) as [81X_dataRun2_relval_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v11/81X_dataRun2_relval_v10): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
  - update SiStripDQM TriggerBit selection for Heavy Ion data
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v17) as [81X_upgrade2017_realistic_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v16) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v17/81X_upgrade2017_realistic_v16): 
  - update L1 menu to be in synch with 2016 queues 
  - updated SiPM characteristics in HO 
  - updated Hcal LUTs for bug fixes 
  - updated Hcal Pedestals: fixes for HB/HO from ADC counts to fC 
  - reduced HcalRespCorr for depth1 in HE by factor 0.5/1.2 = 0.417
- **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v1) as [81X_upgrade2017_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v1/81X_upgrade2017_design_IdealBS_v0): 
  -  updated SiPM characteristics in HO 
  - updated Hcal LUTs for bug fixes 
  - updated Hcal Pedestals: fixes for HB/HO from ADC counts to fC 
  - reduced HcalRespCorr for depth1 in HE by factor 0.5/1.2 = 0.417
- **PhaseII realistic scenario** : [81X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v2) as [81X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2023_realistic_v2/81X_upgrade2023_realistic_v1): 
  - updated `HcalSiPMCharacteristics` in HO
  - updated `HcalSiPMParameters` in HO
