### PR TITLE
ME0 pseudo digitizer: Fix the BX mixing window + enable bkg scaling with lumi

### DIFF
--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
@@ -46,6 +46,8 @@ private:
   int minBunch_;
   int maxBunch_;
 
+  double instLumi_;
+
   // params for the simple pol6 model of neutral bkg for ME0:
   std::vector<double> neuBkg, eleBkg;
 

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -19,5 +19,6 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     simulateNeutralBkg  = cms.bool(True),       # True - will simulate neutral (n+g)  background
     minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
     maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
+    instLumi = cms.double(5.0),       # in units of 1E34 cm^-2 s^-1
     mixLabel = cms.string('mix'),
 )

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -54,7 +54,7 @@ for (const auto & hit: simHits)
   if (std::abs(hit.particleType()) != 13 && digitizeOnlyMuons_) continue;
   // Digitize only in [minBunch,maxBunch] window
   // window is: [(2n-1)*bxw/2, (2n+1)*bxw/2], n = [minBunch, maxBunch]
-  if(hit.timeOfFlight() < (2*minBunch_-1)*bxwidth*1.0/2 || hit.timeOfFlight() > (2*maxBunch_+1)*bxwidth*1.0/2) continue;
+  if(hit.timeOfFlight() < (2*minBunch_+1)*bxwidth*1.0/2 || hit.timeOfFlight() > (2*maxBunch_+3)*bxwidth*1.0/2) continue;
   // is GEM efficient?
   if (CLHEP::RandFlat::shoot(engine) > averageEfficiency_) continue;
   // create digi

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -55,7 +55,7 @@ for (const auto & hit: simHits)
   // Digitize only Muons?
   if (std::abs(hit.particleType()) != 13 && digitizeOnlyMuons_) continue;
   // Digitize only in [minBunch,maxBunch] window
-  // window is: [(2n-1)*bxw/2, (2n+1)*bxw/2], n = [minBunch, maxBunch]
+  // window is: [(2n+1)*bxw/2, (2n+3)*bxw/2], n = [minBunch, maxBunch]
   if(hit.timeOfFlight() < (2*minBunch_+1)*bxwidth*1.0/2 || hit.timeOfFlight() > (2*maxBunch_+3)*bxwidth*1.0/2) continue;
   // is GEM efficient?
   if (CLHEP::RandFlat::shoot(engine) > averageEfficiency_) continue;

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -33,9 +33,11 @@ ME0PreRecoGaussianModel::ME0PreRecoGaussianModel(const edm::ParameterSet& config
   simulateElectronBkg_(config.getParameter<bool>("simulateElectronBkg")), 
   simulateNeutralBkg_(config.getParameter<bool>("simulateNeutralBkg")), 
   minBunch_(config.getParameter<int>("minBunch")), 
-  maxBunch_(config.getParameter<int>("maxBunch"))
+  maxBunch_(config.getParameter<int>("maxBunch")),
+  instLumi_(config.getParameter<double>("instLumi"))
 {
   // polynomial parametrisation of neutral (n+g) and electron background
+  // This is the background for an Instantaneous Luminosity of L = 5E34 cm^-2 s^-1
   neuBkg.push_back(899644.0);     neuBkg.push_back(-30841.0);     neuBkg.push_back(441.28);
   neuBkg.push_back(-3.3405);      neuBkg.push_back(0.0140588);    neuBkg.push_back(-3.11473e-05); neuBkg.push_back(2.83736e-08);
   eleBkg.push_back(4.68590e+05);  eleBkg.push_back(-1.63834e+04); eleBkg.push_back(2.35700e+02);
@@ -161,7 +163,10 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll, CLHEP::
       double averageElectronRatePerRoll = 0.0;
       double yy_helper = 1.0;
       for(int j=0; j<7; ++j) { averageElectronRatePerRoll += eleBkg[j]*yy_helper; yy_helper *= yy_glob; }
-      
+
+      // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)      
+      averageElectronRatePerRoll *= instLumi_*1.0/5;
+
       // Rate [Hz/cm^2] * Nbx * 25*10^-9 [s] * Area [cm] = # hits in this roll in this bx
       const double averageElecRate(averageElectronRatePerRoll * (maxBunch_-minBunch_+1)*(bxwidth*1.0e-9) * areaIt); 
       
@@ -209,6 +214,9 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll, CLHEP::
       double averageNeutralRatePerRoll = 0.0;
       double yy_helper = 1.0;
       for(int j=0; j<7; ++j) { averageNeutralRatePerRoll += neuBkg[j]*yy_helper; yy_helper *= yy_glob; }
+
+      // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)      
+      averageNeutralRatePerRoll *= instLumi_*1.0/5;
       
       // Rate [Hz/cm^2] * Nbx * 25*10^-9 [s] * Area [cm] = # hits in this roll
       const double averageNeutrRate(averageNeutralRatePerRoll * (maxBunch_-minBunch_+1)*(bxwidth*1.0e-9) * areaIt);


### PR DESCRIPTION
It appears that in the ME0 pseudo digitizer module the TOF distribution corresponding to BX=0 in the BX window [-5,3] is centered at -7.5 ns. It should be at 18.5 ns (distance from ME0 to beam-spot). This pull request fixes that. The effect is visible when comparing the TOF from hits at PU200. See plots below.

<img width="377" alt="screen shot 2016-10-19 at 16 29 58" src="https://cloud.githubusercontent.com/assets/4134786/19538381/5cb0d2d8-9619-11e6-8c74-b3721e230088.png">
<img width="363" alt="screen shot 2016-10-19 at 16 30 08" src="https://cloud.githubusercontent.com/assets/4134786/19538380/5cacbf0e-9619-11e6-8311-d6b4870aae74.png">

The second part of this pull request enables to scale up/down the electron/neutron background for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34).

@nickmccoll @pietverwilligen
