### PR TITLE
[81X] update L1T configuration to new menu for HLT post-MD3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,13 +10,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '81X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v9',
+    'run2_design'       :   '81X_mcRun2_design_v10',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v11',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v12',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v10',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v11',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v9',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v10',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v10',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '81X_dataRun2_v9',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v11',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v12',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
@@ -42,7 +42,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '81X_upgrade2023_realistic_v2'
+    'phase2_realistic'     : '81X_upgrade2023_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
This PR tracks the change of L1T menu for the HLT post-MD3 train in #16210. Not to be tested.
# Summary of changes in Global Tags
## RunII simulation
- **RunII Ideal scenario** : [81X_mcRun2_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v10) as [81X_mcRun2_design_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v10/81X_mcRun2_design_v9): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
- **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v10) as [81X_mcRun2cosmics_startup_peak_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v10/81X_mcRun2cosmics_startup_peak_v9): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
- **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v11) as [81X_mcRun2_asymptotic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v11/81X_mcRun2_asymptotic_v10): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
- **RunII Startup scenario** : [81X_mcRun2_startup_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v12) as [81X_mcRun2_startup_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v12/81X_mcRun2_startup_v11): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
## RunII data
- **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v6) as [81X_dataRun2_HLT_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v6/81X_dataRun2_HLT_relval_v5): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
- **RunII Offline relval processing** : [81X_dataRun2_relval_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v12) as [81X_dataRun2_relval_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v12/81X_dataRun2_relval_v11): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`
## Upgrade
- **PhaseII realistic scenario** : [81X_upgrade2023_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v3) as [81X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2023_realistic_v3/81X_upgrade2023_realistic_v2): 
  - updated L1T menu to `L1Menu_Collisions2016_v9_m2_xml`

attn: @Martin-Grunewald 
