### PR TITLE
Added functionality to TrackHistory.cc(.h) to get matched TrackingParticle to the Track

### DIFF
--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -65,10 +65,10 @@ public:
     }
     
     // return the TrackingParticle to which the Track was matched
-    const std::pair<TrackingParticleRef, double>  GetMatchedTrackingParticle() const
+    const std::pair<TrackingParticleRef, double>  getMatchedTrackingParticle() const
     {
     	std::pair<TrackingParticleRef, double> result;
-    	result.first = TrackingParticle_;
+    	result.first = trackingParticle_;
     	result.second = quality_;
     	
     	return result;
@@ -97,7 +97,7 @@ private:
 
     reco::TrackBaseRef recotrack_;
     
-    TrackingParticleRef TrackingParticle_;
+    TrackingParticleRef trackingParticle_;
 
     reco::RecoToSimCollection recoToSim_;
 

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -63,6 +63,16 @@ public:
     {
         return recotrack_;
     }
+    
+    // return the TrackingParticle to which the Track was matched
+    const std::pair<TrackingParticleRef, double>  GetMatchedTrackingParticle() const
+    {
+    	std::pair<TrackingParticleRef, double> result;
+    	result.first = TrackingParticle_;
+    	result.second = quality_;
+    	
+    	return result;
+    }
 
     double quality() const
     {
@@ -86,6 +96,8 @@ private:
     edm::InputTag trackAssociator_;
 
     reco::TrackBaseRef recotrack_;
+    
+    TrackingParticleRef TrackingParticle_;
 
     reco::RecoToSimCollection recoToSim_;
 

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -71,7 +71,7 @@ bool TrackHistory::evaluate ( reco::TrackBaseRef tr )
 
     TrackingParticleRef tpr( result.first );
     quality_ = result.second;
-    TrackingParticle_ = tpr;
+    trackingParticle_ = tpr;
 
     if ( !tpr.isNull() )
     {

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -71,6 +71,7 @@ bool TrackHistory::evaluate ( reco::TrackBaseRef tr )
 
     TrackingParticleRef tpr( result.first );
     quality_ = result.second;
+    TrackingParticle_ = tpr;
 
     if ( !tpr.isNull() )
     {


### PR DESCRIPTION
This change introduces the possibility to access the matched TrackingParticle to the Track whenever the TrackHistory::Evaluate() function is used. This allows the user to investigate the properties of the truth-track (i.e. the TrackingParticle) of which the history is being calculated with this code. 

This functionality is needed in the BTV group to easily monitor possible differences between reco-quantities and truth-level information form tracks of different origins (BWeakDecays, CWeakDecays, ...)
