### PR TITLE
Fix for warnings from static analyzer for data class const correctness

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h
@@ -77,9 +77,9 @@ class TotemRPGeometry
     /// performs necessary checks, returns NULL if fails
     /// input is raw ID
     DetGeomDesc *GetDetector(unsigned int) const;
-    DetGeomDesc *GetDetector(const TotemRPDetId & id) const { return GetDetector(id.rawId()); }
+    DetGeomDesc const *GetDetector(const TotemRPDetId & id) const { return GetDetector(id.rawId()); }
     /// same as GetDetector
-    DetGeomDesc *operator[] (unsigned int id) const { return GetDetector(id); }
+    DetGeomDesc const *operator[] (unsigned int id) const { return GetDetector(id); }
 
     /// returns the position of the edge of a detector
     CLHEP::Hep3Vector GetDetEdgePosition(unsigned int id) const;


### PR DESCRIPTION
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_8_1_X_2016-10-19-2300/slc6_amd64_gcc530/llvm-analysis/report-5699da.html#EndPath

Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h:80:5: warning: TotemRPGeometry::GetDetector is a const member function that returns a pointer or reference to a non-const object
Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h:82:5: warning: TotemRPGeometry::operator[] is a const member function that returns a pointer or reference to a non-const object
