### PR TITLE
CondFormats/JetMETObjects : Fix clang static analyzer warnings

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -186,7 +186,7 @@ namespace JME {
                         return m_formula_str;
                     }
 
-                    TFormula* getFormula() const {
+                    TFormula const * getFormula() const {
                         return m_formula.get();
                     }
 

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -385,16 +385,16 @@ namespace JME {
             return 1;
 
         // Set parameters
-        TFormula* formula = new TFormula( * (m_definition.getFormula() ) );
-        if (! formula)
+        auto const* pFormula = m_definition.getFormula();
+        if (! pFormula)
             return 1;
-
+	auto formula=TFormula(*pFormula);
         // Create vector of variables value. Throw if some values are missing
         std::vector<float> variables = variables_parameters.createVector(m_definition.getVariables());
 
         const std::vector<float>& parameters = record.getParametersValues();
         for (size_t index = 0; index < parameters.size(); index++) {
-            formula->SetParameter(index, parameters[index]);
+            formula.SetParameter(index, parameters[index]);
         }
 
         double variables_[4] = {0};
@@ -402,9 +402,7 @@ namespace JME {
             variables_[index] = clip(variables[index], record.getVariablesRange()[index].min, record.getVariablesRange()[index].max);
         }
 
-        float results = formula->EvalPar(variables_);
-        delete formula;
-        return results;
+        return formula.EvalPar(variables_);
     }
 }
 

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -385,7 +385,7 @@ namespace JME {
             return 1;
 
         // Set parameters
-        TFormula* formula = m_definition.getFormula();
+        TFormula* formula = new TFormula( * (m_definition.getFormula() ) );
         if (! formula)
             return 1;
 
@@ -402,7 +402,9 @@ namespace JME {
             variables_[index] = clip(variables[index], record.getVariablesRange()[index].min, record.getVariablesRange()[index].max);
         }
 
-        return formula->EvalPar(variables_);
+        float results = formula->EvalPar(variables_);
+        delete formula;
+        return results;
     }
 }
 

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -388,7 +388,7 @@ namespace JME {
         auto const* pFormula = m_definition.getFormula();
         if (! pFormula)
             return 1;
-	auto formula=TFormula(*pFormula);
+	auto formula = *pFormula;
         // Create vector of variables value. Throw if some values are missing
         std::vector<float> variables = variables_parameters.createVector(m_definition.getVariables());
 


### PR DESCRIPTION
Data Class Const Correctness    Const function returns pointer or reference to non-const member data object /CondFormats/JetMETObjects/interface/JetResolutionObject.h  unknown 190
Data Class Const Correctness    Const function returns pointer or reference to non-const object /CondFormats/JetMETObjects/interface/JetResolutionObject.h  getFormula  189
