### PR TITLE
Update to Hcal Validation

### DIFF
--- a/DQMOffline/Hcal/BuildFile.xml
+++ b/DQMOffline/Hcal/BuildFile.xml
@@ -15,3 +15,4 @@
 <use   name="CondFormats/HcalObjects"/>
 <use   name="RecoLocalCalo/HcalRecAlgos"/>
 <use   name="RecoLocalCalo/EcalRecAlgos"/>
+<use   name="Geometry/HcalTowerAlgo"/>

--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -28,6 +28,7 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 #include <vector>
 #include <utility>
@@ -82,6 +83,12 @@ class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
 
 
   int nChannels_[5]; // 0:any, 1:HB, 2:HE
+
+  int iphi_bins;
+  float iphi_min, iphi_max;
+
+  int ieta_bins;
+  float ieta_min, ieta_max;
 
   //RecHit Collection input tags
   edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;

--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -84,11 +84,11 @@ class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
 
   int nChannels_[5]; // 0:any, 1:HB, 2:HE
 
-  int iphi_bins;
-  float iphi_min, iphi_max;
+  int iphi_bins_;
+  float iphi_min_, iphi_max_;
 
-  int ieta_bins;
-  float ieta_min, ieta_max;
+  int ieta_bins_;
+  float ieta_min_, ieta_max_;
 
   //RecHit Collection input tags
   edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;

--- a/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
@@ -59,8 +59,6 @@ class HcalRecHitsDQMClient : public DQMEDHarvester {
   std::string dirNameJet_;
   std::string dirNameMET_;
 
-  edm::ESHandle<CaloGeometry> geometry ;
-
   const HcalDDDRecConstants *hcons;
   int maxDepthHB_, maxDepthHE_, maxDepthHO_, maxDepthHF_, maxDepthAll_;
  

--- a/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
@@ -28,6 +28,18 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -47,6 +59,11 @@ class HcalRecHitsDQMClient : public DQMEDHarvester {
   std::string dirNameJet_;
   std::string dirNameMET_;
 
+  edm::ESHandle<CaloGeometry> geometry ;
+
+  const HcalDDDRecConstants *hcons;
+  int maxDepthHB_, maxDepthHE_, maxDepthHO_, maxDepthHF_, maxDepthAll_;
+ 
   int nChannels_[5]; // 0:any, 1:HB, 2:HE, 3:HO, 4: HF
 
  public:
@@ -54,6 +71,7 @@ class HcalRecHitsDQMClient : public DQMEDHarvester {
   virtual ~HcalRecHitsDQMClient();
   
   virtual void beginJob(void);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   int HcalRecHitsEndjob(const std::vector<MonitorElement*> &hcalMEs);

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -60,28 +60,54 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
 
     es.get<CaloGeometryRecord > ().get(geometry);
 
-    const std::vector<DetId>& hbCells = geometry->getValidDetIds(DetId::Hcal, HcalBarrel);
-    const std::vector<DetId>& heCells = geometry->getValidDetIds(DetId::Hcal, HcalEndcap);
-    const std::vector<DetId>& hoCells = geometry->getValidDetIds(DetId::Hcal, HcalOuter);
-    const std::vector<DetId>& hfCells = geometry->getValidDetIds(DetId::Hcal, HcalForward);
+    const CaloGeometry* geo = geometry.product();
+    const HcalGeometry* gHB = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
+    const HcalGeometry* gHE = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalEndcap));
+    const HcalGeometry* gHO = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalOuter));
+    const HcalGeometry* gHF = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
 
-    nChannels_[1] = hbCells.size(); 
-    nChannels_[2] = heCells.size(); 
-    nChannels_[3] = hoCells.size(); 
-    nChannels_[4] = hfCells.size();
+    nChannels_[1] = gHB->getHxSize(1); 
+    nChannels_[2] = gHE->getHxSize(2); 
+    nChannels_[3] = gHO->getHxSize(3); 
+    nChannels_[4] = gHF->getHxSize(4); 
+
     nChannels_[0] = nChannels_[1] + nChannels_[2] + nChannels_[3] + nChannels_[4];
 
     //std::cout << "Channels HB:" << nChannels_[1] << " HE:" << nChannels_[2] << " HO:" << nChannels_[3] << " HF:" << nChannels_[4] << std::endl;
 
     //We hardcode the HF depths because in the dual readout configuration, rechits are not defined for depths 3&4
-    maxDepthHF_ = (maxDepthHF_ > 2 ? 2 : maxDepthHF_); //We reatin the dynamic possibility that HF might have 0 or 1 depths
+    maxDepthHF_ = (maxDepthHF_ > 2 ? 2 : maxDepthHF_); //We retain the dynamic possibility that HF might have 0 or 1 depths
 
     maxDepthAll_ = ( maxDepthHB_ + maxDepthHO_ > maxDepthHE_ ? maxDepthHB_ + maxDepthHO_ : maxDepthHE_ );
     maxDepthAll_ = ( maxDepthAll_ > maxDepthHF_ ? maxDepthAll_ : maxDepthHF_ );
 
-  }
+    //Get Phi segmentation from geometry, use the max phi number so that all iphi values are included.
 
-  void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & /* iRun*/, edm::EventSetup const & /* iSetup */)
+    int NphiMax = hcons->getNPhi(0);
+
+    NphiMax = (hcons->getNPhi(1) > NphiMax ? hcons->getNPhi(1) : NphiMax);
+    NphiMax = (hcons->getNPhi(2) > NphiMax ? hcons->getNPhi(2) : NphiMax);
+    NphiMax = (hcons->getNPhi(3) > NphiMax ? hcons->getNPhi(3) : NphiMax);
+
+    //Center the iphi bins on the integers
+    iphi_min = 0.5;
+    iphi_max = NphiMax + 0.5;
+    iphi_bins = (int) (iphi_max - iphi_min);
+
+    //Retain classic behavior, all plots have same ieta range.
+
+    int iEtaMax = (hcons->getEtaRange(0).second > hcons->getEtaRange(1).second ? hcons->getEtaRange(0).second : hcons->getEtaRange(1).second);
+    iEtaMax = (iEtaMax > hcons->getEtaRange(2).second ? iEtaMax : hcons->getEtaRange(2).second);
+    iEtaMax = (iEtaMax > hcons->getEtaRange(3).second ? iEtaMax : hcons->getEtaRange(3).second);
+
+    //Give an empty bin around the subdet ieta range to make it clear that all ieta rings have been included
+    ieta_min = -iEtaMax - 1.5;
+    ieta_max = iEtaMax + 1.5;
+    ieta_bins = (int) (ieta_max - ieta_min);
+
+    }
+
+ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & /* iRun*/, edm::EventSetup const & /* iSetup */)
 
 { 
 
@@ -92,25 +118,31 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     // General counters (drawn)
 
     //Produce both a total per subdetector, and number of rechits per subdetector depth
+    // The bins are 1 unit wide, and the range is determined by the number of channels per subdetector
+
     for(int depth = 0; depth <= maxDepthHB_; depth++){
       if(depth == 0){ sprintf  (histo, "N_HB" );}
       else{           sprintf  (histo, "N_HB_depth%d",depth );}
-      Nhb.push_back( ibooker.book1D(histo, histo, 2600,0.,2600.) );
+      int NBins = (int) (nChannels_[1] * 1.1);
+      Nhb.push_back( ibooker.book1D(histo, histo, NBins, 0., (float)NBins) );
     } 
     for(int depth = 0; depth <= maxDepthHE_; depth++){
       if(depth == 0){ sprintf  (histo, "N_HE" );}
       else{           sprintf  (histo, "N_HE_depth%d",depth );}
-      Nhe.push_back( ibooker.book1D(histo, histo, 2600,0.,2600.) );
+      int NBins	= (int) (nChannels_[2] * 1.1);
+      Nhe.push_back( ibooker.book1D(histo, histo, NBins,0., (float)NBins) );
     } 
     for(int depth = 0; depth <= maxDepthHO_; depth++){
       if(depth == 0){ sprintf  (histo, "N_HO" );}
       else{           sprintf  (histo, "N_HO_depth%d",depth );}
-      Nho.push_back( ibooker.book1D(histo, histo, 2200,0.,2200.) );
+      int NBins	= (int) (nChannels_[3] * 1.1);
+      Nho.push_back( ibooker.book1D(histo, histo, NBins,0., (float)NBins) );
     } 
     for(int depth = 0; depth <= maxDepthHF_; depth++){
       if(depth == 0){ sprintf  (histo, "N_HF" );}
       else{           sprintf  (histo, "N_HF_depth%d",depth );}
-      Nhf.push_back( ibooker.book1D(histo, histo, 1800,0.,1800.) );
+      int NBins	= (int) (nChannels_[4] * 1.1);
+      Nhf.push_back( ibooker.book1D(histo, histo, NBins,0., (float)NBins) );
     } 
 
     // ZS
@@ -129,58 +161,58 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
       
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HB%d",depth );
-	emean_vs_ieta_HB.push_back( ibooker.bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., " ") );
+	emean_vs_ieta_HB.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
       }
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HE%d",depth );
-	emean_vs_ieta_HE.push_back( ibooker.bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., " ") );
+	emean_vs_ieta_HE.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
       }
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HF%d",depth );
-	emean_vs_ieta_HF.push_back( ibooker.bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., " ") );
+	emean_vs_ieta_HF.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
       }
       sprintf  (histo, "emean_vs_ieta_HO" );
-      emean_vs_ieta_HO = ibooker.bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., " " );
+      emean_vs_ieta_HO = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " " );
 
       //The only occupancy histos drawn are occupancy vs. ieta
       //but the maps are needed because this is where the latter are filled from
 
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
          sprintf  (histo, "occupancy_map_HB%d",depth );
-         occupancy_map_HB.push_back( ibooker.book2D(histo, histo, 83, -41.5, 41.5, 73, -0.5, 72.5) );
+         occupancy_map_HB.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
       }
 
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
          sprintf  (histo, "occupancy_map_HE%d",depth );
-         occupancy_map_HE.push_back( ibooker.book2D(histo, histo, 83, -41.5, 41.5, 73, -0.5, 72.5) );
+         occupancy_map_HE.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
       }
 
       sprintf  (histo, "occupancy_map_HO" );
-      occupancy_map_HO = ibooker.book2D(histo, histo, 83, -41.5, 41.5, 73, -0.5, 72.5);      
+      occupancy_map_HO = ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max);      
 
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
          sprintf  (histo, "occupancy_map_HF%d",depth );
-         occupancy_map_HF.push_back( ibooker.book2D(histo, histo, 83, -41.5, 41.5, 73, -0.5, 72.5) );
+         occupancy_map_HF.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
       }
 
       //These are drawn
 
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HB%d",depth );
-         occupancy_vs_ieta_HB.push_back( ibooker.book1D(histo, histo, 83, -41.5, 41.5) );
+         occupancy_vs_ieta_HB.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
       }
 
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HE%d",depth );
-         occupancy_vs_ieta_HE.push_back( ibooker.book1D(histo, histo, 83, -41.5, 41.5) );
+         occupancy_vs_ieta_HE.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
       }
 
       sprintf  (histo, "occupancy_vs_ieta_HO" );
-      occupancy_vs_ieta_HO = ibooker.book1D(histo, histo, 83, -41.5, 41.5);
+      occupancy_vs_ieta_HO = ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max);
 
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HF%d",depth );
-         occupancy_vs_ieta_HF.push_back( ibooker.book1D(histo, histo, 83, -41.5, 41.5) );
+         occupancy_vs_ieta_HF.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
       }
 
 
@@ -225,13 +257,13 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     //Histograms drawn for single pion scan
     if(subdet_ != 0 && imc != 0) { // just not for noise  
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths");
-      meEnConeEtaProfile = ibooker.bookProfile(histo, histo, 82, -41., 41.,        2100, -100., 2000., " ");  
+      meEnConeEtaProfile = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,        2100, -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_E");
-      meEnConeEtaProfile_E = ibooker.bookProfile(histo, histo, 82, -41., 41.,      2100, -100., 2000., " ");  
+      meEnConeEtaProfile_E = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,      2100, -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_EH");
-      meEnConeEtaProfile_EH = ibooker.bookProfile(histo, histo, 82, -41., 41.,     2100, -100., 2000., " ");  
+      meEnConeEtaProfile_EH = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,     2100, -100., 2000., " ");  
     }
 
     // ************** HB **********************************
@@ -469,15 +501,11 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
   // Filling HCAL maps  ----------------------------------------------------
   //   double maxE = -99999.;
   
-  std::vector<int> nhb_v,nhe_v,nho_v, nhf_v; // element 0: any depth. element 1,2,..: depth 1,2
-  nhb_v.push_back(0.);
-  nhe_v.push_back(0.);
-  nho_v.push_back(0.);
-  nhf_v.push_back(0.);
-  for (int depth = 1; depth <= maxDepthHB_; depth++) nhb_v.push_back(0.);
-  for (int depth = 1; depth <= maxDepthHE_; depth++) nhe_v.push_back(0.);
-  for (int depth = 1; depth <= maxDepthHO_; depth++) nho_v.push_back(0.);
-  for (int depth = 1; depth <= maxDepthHF_; depth++) nhf_v.push_back(0.);
+  // element 0: any depth. element 1,2,..: depth 1,2
+  std::vector<int> nhb_v(maxDepthHB_+1,0);
+  std::vector<int> nhe_v(maxDepthHE_+1,0);
+  std::vector<int> nho_v(maxDepthHO_+1,0);
+  std::vector<int> nhf_v(maxDepthHF_+1,0);
 
   for (unsigned int i = 0; i < cen.size(); i++) {
     
@@ -533,6 +561,10 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
       if ( sub == 2){
 	 emean_vs_ieta_HE[depth-1]->Fill(double(ieta), en);
 	 occupancy_map_HE[depth-1]->Fill(double(ieta),double(iphi));
+      }
+      if ( sub == 3){
+	 emean_vs_ieta_HO->Fill(double(ieta), en);
+	 occupancy_map_HO->Fill(double(ieta),double(iphi));
       }
       if ( sub == 4){
 	 emean_vs_ieta_HF[depth-1]->Fill(double(ieta), en);
@@ -737,8 +769,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const& ev){
       int sub     = cell.subdet();
       int depth   = cell.depth();
       int inteta  = cell.ieta();
-      if(inteta > 0) inteta -= 1;
-      int intphi  = cell.iphi()-1;
+      int intphi  = cell.iphi();
       double en   = j->energy();
       double t    = j->time();
       int stwd    = j->flags();
@@ -785,8 +816,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const& ev){
       int sub      = cell.subdet();
       int depth    = cell.depth();
       int inteta   = cell.ieta();
-      if(inteta > 0) inteta -= 1;
-      int intphi   = cell.iphi()-1;
+      int intphi   = cell.iphi();
       double en    = j->energy();
       double t     = j->time();
       int stwd     = j->flags();
@@ -830,8 +860,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const& ev){
       int sub      = cell.subdet();
       int depth    = cell.depth();
       int inteta   = cell.ieta();
-      if(inteta > 0) inteta -= 1;
-      int intphi   = cell.iphi()-1;
+      int intphi   = cell.iphi();
       double t     = j->time();
       double en    = j->energy();
       int stwd     = j->flags();

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -90,9 +90,9 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     NphiMax = (hcons->getNPhi(3) > NphiMax ? hcons->getNPhi(3) : NphiMax);
 
     //Center the iphi bins on the integers
-    iphi_min = 0.5;
-    iphi_max = NphiMax + 0.5;
-    iphi_bins = (int) (iphi_max - iphi_min);
+    iphi_min_ = 0.5;
+    iphi_max_ = NphiMax + 0.5;
+    iphi_bins_ = (int) (iphi_max_ - iphi_min_);
 
     //Retain classic behavior, all plots have same ieta range.
 
@@ -101,9 +101,9 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     iEtaMax = (iEtaMax > hcons->getEtaRange(3).second ? iEtaMax : hcons->getEtaRange(3).second);
 
     //Give an empty bin around the subdet ieta range to make it clear that all ieta rings have been included
-    ieta_min = -iEtaMax - 1.5;
-    ieta_max = iEtaMax + 1.5;
-    ieta_bins = (int) (ieta_max - ieta_min);
+    ieta_min_ = -iEtaMax - 1.5;
+    ieta_max_ = iEtaMax + 1.5;
+    ieta_bins_ = (int) (ieta_max_ - ieta_min_);
 
     }
 
@@ -161,58 +161,58 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
       
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HB%d",depth );
-	emean_vs_ieta_HB.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
+	emean_vs_ieta_HB.push_back( ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_, 2010, -10., 2000., " ") );
       }
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HE%d",depth );
-	emean_vs_ieta_HE.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
+	emean_vs_ieta_HE.push_back( ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_, 2010, -10., 2000., " ") );
       }
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
 	sprintf  (histo, "emean_vs_ieta_HF%d",depth );
-	emean_vs_ieta_HF.push_back( ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " ") );
+	emean_vs_ieta_HF.push_back( ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_, 2010, -10., 2000., " ") );
       }
       sprintf  (histo, "emean_vs_ieta_HO" );
-      emean_vs_ieta_HO = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max, 2010, -10., 2000., " " );
+      emean_vs_ieta_HO = ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_, 2010, -10., 2000., " " );
 
       //The only occupancy histos drawn are occupancy vs. ieta
       //but the maps are needed because this is where the latter are filled from
 
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
          sprintf  (histo, "occupancy_map_HB%d",depth );
-         occupancy_map_HB.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
+         occupancy_map_HB.push_back( ibooker.book2D(histo, histo, ieta_bins_, ieta_min_, ieta_max_, iphi_bins_, iphi_min_, iphi_max_) );
       }
 
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
          sprintf  (histo, "occupancy_map_HE%d",depth );
-         occupancy_map_HE.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
+         occupancy_map_HE.push_back( ibooker.book2D(histo, histo, ieta_bins_, ieta_min_, ieta_max_, iphi_bins_, iphi_min_, iphi_max_) );
       }
 
       sprintf  (histo, "occupancy_map_HO" );
-      occupancy_map_HO = ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max);      
+      occupancy_map_HO = ibooker.book2D(histo, histo, ieta_bins_, ieta_min_, ieta_max_, iphi_bins_, iphi_min_, iphi_max_);      
 
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
          sprintf  (histo, "occupancy_map_HF%d",depth );
-         occupancy_map_HF.push_back( ibooker.book2D(histo, histo, ieta_bins, ieta_min, ieta_max, iphi_bins, iphi_min, iphi_max) );
+         occupancy_map_HF.push_back( ibooker.book2D(histo, histo, ieta_bins_, ieta_min_, ieta_max_, iphi_bins_, iphi_min_, iphi_max_) );
       }
 
       //These are drawn
 
       for (int depth = 1; depth <= maxDepthHB_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HB%d",depth );
-         occupancy_vs_ieta_HB.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
+         occupancy_vs_ieta_HB.push_back( ibooker.book1D(histo, histo, ieta_bins_, ieta_min_, ieta_max_) );
       }
 
       for (int depth = 1; depth <= maxDepthHE_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HE%d",depth );
-         occupancy_vs_ieta_HE.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
+         occupancy_vs_ieta_HE.push_back( ibooker.book1D(histo, histo, ieta_bins_, ieta_min_, ieta_max_) );
       }
 
       sprintf  (histo, "occupancy_vs_ieta_HO" );
-      occupancy_vs_ieta_HO = ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max);
+      occupancy_vs_ieta_HO = ibooker.book1D(histo, histo, ieta_bins_, ieta_min_, ieta_max_);
 
       for (int depth = 1; depth <= maxDepthHF_; depth++) {
          sprintf  (histo, "occupancy_vs_ieta_HF%d",depth );
-         occupancy_vs_ieta_HF.push_back( ibooker.book1D(histo, histo, ieta_bins, ieta_min, ieta_max) );
+         occupancy_vs_ieta_HF.push_back( ibooker.book1D(histo, histo, ieta_bins_, ieta_min_, ieta_max_) );
       }
 
 
@@ -257,13 +257,13 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     //Histograms drawn for single pion scan
     if(subdet_ != 0 && imc != 0) { // just not for noise  
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths");
-      meEnConeEtaProfile = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,        2100, -100., 2000., " ");  
+      meEnConeEtaProfile = ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_,        2100, -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_E");
-      meEnConeEtaProfile_E = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,      2100, -100., 2000., " ");  
+      meEnConeEtaProfile_E = ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_,      2100, -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_EH");
-      meEnConeEtaProfile_EH = ibooker.bookProfile(histo, histo, ieta_bins, ieta_min, ieta_max,     2100, -100., 2000., " ");  
+      meEnConeEtaProfile_EH = ibooker.bookProfile(histo, histo, ieta_bins_, ieta_min_, ieta_max_,     2100, -100., 2000., " ");  
     }
 
     // ************** HB **********************************

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -58,6 +58,8 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
     maxDepthHF_ = hcons->getMaxDepth(2);
     maxDepthHO_ = hcons->getMaxDepth(3);
 
+    edm::ESHandle<CaloGeometry> geometry;
+
     es.get<CaloGeometryRecord > ().get(geometry);
 
     const CaloGeometry* geo = geometry.product();
@@ -416,7 +418,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
   double phiHot  = 99999.; 
 
   //   previously was:  c.get<IdealGeometryRecord>().get (geometry);
-  c.get<CaloGeometryRecord>().get (geometry);
+  //c.get<CaloGeometryRecord>().get (geometry);
 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -418,7 +418,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
   double phiHot  = 99999.; 
 
   //   previously was:  c.get<IdealGeometryRecord>().get (geometry);
-  //c.get<CaloGeometryRecord>().get (geometry);
+  c.get<CaloGeometryRecord>().get (geometry);
 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;

--- a/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
@@ -40,6 +40,8 @@ void HcalRecHitsDQMClient::beginRun(const edm::Run& run, const edm::EventSetup& 
   maxDepthHF_ = hcons->getMaxDepth(2);
   maxDepthHO_ = hcons->getMaxDepth(3);
  
+  edm::ESHandle<CaloGeometry> geometry;
+
   es.get<CaloGeometryRecord > ().get(geometry);
  
   const std::vector<DetId>& hbCells = geometry->getValidDetIds(DetId::Hcal, HcalBarrel);

--- a/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
@@ -238,11 +238,14 @@ int HcalRecHitsDQMClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &
       int ny = emap_depths[depthIdx]->getNbinsY();
 
       float cnorm;
+      float enorm;
 
       for (int i = 1; i <= nx; i++) {      
          for (int j = 1; j <= ny; j++) {
 	    cnorm = emap_depths[depthIdx]->getBinContent(i,j) * scaleBynevtot;
+	    enorm = emap_depths[depthIdx]->getBinError(i,j) * scaleBynevtot;
             emap_depths[depthIdx]->setBinContent(i,j,cnorm);
+            emap_depths[depthIdx]->setBinError(i,j,enorm);
 
          }
       }
@@ -258,6 +261,7 @@ int HcalRecHitsDQMClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &
       int ny = occupancy_maps[occupancyIdx]->getNbinsY();
 
       float cnorm;
+      float enorm;
 
       unsigned int vsIetaIdx = occupancy_vs_ieta.size();
       omatched = false;
@@ -272,7 +276,9 @@ int HcalRecHitsDQMClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &
       for (int i = 1; i <= nx; i++) {      
          for (int j = 1; j <= ny; j++) {
 	    cnorm = occupancy_maps[occupancyIdx]->getBinContent(i,j) * scaleBynevtot;
+	    enorm = occupancy_maps[occupancyIdx]->getBinError(i,j) * scaleBynevtot;
             occupancy_maps[occupancyIdx]->setBinContent(i,j,cnorm);
+            occupancy_maps[occupancyIdx]->setBinError(i,j,enorm);
 
          }
       }
@@ -318,10 +324,13 @@ int HcalRecHitsDQMClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &
       int nx = RecHit_StatusWord[StatusWordIdx]->getNbinsX();
 
       float cnorm;
+      float enorm;
 
       for (int i = 1; i <= nx; i++) {      
          cnorm = RecHit_StatusWord[StatusWordIdx]->getBinContent(i) * scaleBynevtot / RecHit_StatusWord_Channels[StatusWordIdx];
+         enorm = RecHit_StatusWord[StatusWordIdx]->getBinError(i) * scaleBynevtot / RecHit_StatusWord_Channels[StatusWordIdx];
          RecHit_StatusWord[StatusWordIdx]->setBinContent(i,cnorm);
+         RecHit_StatusWord[StatusWordIdx]->setBinError(i,enorm);
 
       }
 
@@ -332,10 +341,13 @@ int HcalRecHitsDQMClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &
       int nx = RecHit_Aux_StatusWord[AuxStatusWordIdx]->getNbinsX();
 
       float cnorm;
+      float enorm;
 
       for (int i = 1; i <= nx; i++) {      
          cnorm = RecHit_Aux_StatusWord[AuxStatusWordIdx]->getBinContent(i) * scaleBynevtot / RecHit_Aux_StatusWord_Channels[AuxStatusWordIdx];
+         enorm = RecHit_Aux_StatusWord[AuxStatusWordIdx]->getBinError(i) * scaleBynevtot / RecHit_Aux_StatusWord_Channels[AuxStatusWordIdx];
          RecHit_Aux_StatusWord[AuxStatusWordIdx]->setBinContent(i,cnorm);
+         RecHit_Aux_StatusWord[AuxStatusWordIdx]->setBinError(i,enorm);
 
       }
 

--- a/Validation/HcalDigis/src/HcalDigisClient.cc
+++ b/Validation/HcalDigis/src/HcalDigisClient.cc
@@ -138,6 +138,7 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
 
     float phi_factor;
     float cnorm;
+    float enorm;
 
 
     for(int depth = 1; depth <= depths; depth++){
@@ -150,7 +151,9 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
 
                // occupancies
                cnorm = ieta_iphi_occupancy_maps[depth-1]->getBinContent(i, j) / fev;
+               enorm = ieta_iphi_occupancy_maps[depth-1]->getBinError(i, j) / fev;
                ieta_iphi_occupancy_maps[depth-1]->setBinContent(i, j, cnorm);
+               ieta_iphi_occupancy_maps[depth-1]->setBinError(i, j, enorm);
 
            } //for loop over NbinsYU
        } //for loop over NbinsX	    
@@ -225,11 +228,15 @@ void HcalDigisClient::scaleMETH2D(MonitorElement* ME, double s) {
     int ny = ME->getNbinsY();
 
     double content(0);
+    double error(0);
     for (int i = 1; i <= nx; i++) {
         for (int j = 1; j <= ny; j++) {
             content = ME->getBinContent(i, j);
+            error = ME->getBinError(i, j);
             content *= s;
+	    error *= s;
             ME->setBinContent(i, j, content);
+            ME->setBinError(i, j, error);
         }
     }
 }


### PR DESCRIPTION
This is a follow-up to PR #15714, it includes the following changes:

```
Uses getHxSize to obtain the number of channels per subdetector
N_Hx range based on number of channels
phi segmentation and ieta range taken from geometry
initialize std::vector without for loops
HO emean_vs_ieta, occupancy_maps filled

RecHit StatusWord and AuxStatus histograms are normalized by number of channels per subdet, as well as by nevts
```
