### PR TITLE
Fixing neglected gen filters from HepMC renaming

### DIFF
--- a/GeneratorInterface/GenFilters/interface/PythiaFilterHT.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilterHT.h
@@ -30,6 +30,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+namespace edm {
+    class HepMCProduct;
+}
 
 //
 // class decleration
@@ -45,7 +48,7 @@ class PythiaFilterHT : public edm::EDFilter {
    private:
       // ----------member data ---------------------------
       
-       std::string label_;
+       edm::EDGetTokenT<edm::HepMCProduct> label_;
        int particleID;
        double minpcut;
        double maxpcut;

--- a/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
@@ -33,6 +33,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+namespace edm {
+      class HepMCProduct;
+}
 
 //
 // class decleration
@@ -50,7 +53,7 @@ class PythiaMomDauFilter : public edm::EDFilter {
 
       // ----------member data ---------------------------
       
-       std::string label_;
+      edm::EDGetTokenT<edm::HepMCProduct> label_;
        std::vector<int> dauIDs;
        std::vector<int> desIDs;
        int particleID;

--- a/GeneratorInterface/GenFilters/src/ComphepSingletopFilterPy8.cc
+++ b/GeneratorInterface/GenFilters/src/ComphepSingletopFilterPy8.cc
@@ -61,7 +61,7 @@ void ComphepSingletopFilterPy8::endJob()
 bool ComphepSingletopFilterPy8::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 edm::Handle<edm::HepMCProduct> evt;
-iEvent.getByLabel("generator", evt);
+iEvent.getByLabel("generator","unsmeared", evt);
 const HepMC::GenEvent * myEvt = evt->GetEvent();
 
 int id_bdec=0, id_lJet=0, id_b_from_top=0, id_lep = 0;

--- a/GeneratorInterface/GenFilters/src/LQGenFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LQGenFilter.cc
@@ -4,7 +4,7 @@
 LQGenFilter::LQGenFilter(const edm::ParameterSet& iConfig)
 {
    //now do what ever initialization is needed
-  src_ = iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag("source"));
+  src_ = iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag("generator","unsmeared"));
   
   eejj_     = iConfig.getParameter<bool>("eejj");
   enuejj_   = iConfig.getParameter<bool>("enuejj");

--- a/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
+++ b/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
@@ -9,7 +9,7 @@ using namespace std;
 
 
 MCLongLivedParticles::MCLongLivedParticles(const edm::ParameterSet& iConfig) :
-  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")) {
+  hepMCProductTag_(iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag",edm::InputTag("generator","unsmeared"))) {
    //here do whatever other initialization is needed
   theCut = iConfig.getUntrackedParameter<double>("LengCut",10.);
 }

--- a/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
+++ b/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
@@ -9,7 +9,7 @@ using namespace std;
 
 
 MCLongLivedParticles::MCLongLivedParticles(const edm::ParameterSet& iConfig) :
-  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("hepMCProductTag")) {
+  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")) {
    //here do whatever other initialization is needed
   theCut = iConfig.getUntrackedParameter<double>("LengCut",10.);
 }

--- a/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
@@ -2,7 +2,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getParameter<edm::InputTag>("src")),
+  src_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")),
   numRequired_(iConfig.getParameter<int>("NumRequired")),
   acceptMore_(iConfig.getParameter<bool>("AcceptMore")),
   particleID_(iConfig.getParameter< std::vector<int> >("ParticleID")),

--- a/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
@@ -2,7 +2,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")),
+  src_(iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag(std::string("generator"),"unsmeared"))),
   numRequired_(iConfig.getParameter<int>("NumRequired")),
   acceptMore_(iConfig.getParameter<bool>("AcceptMore")),
   particleID_(iConfig.getParameter< std::vector<int> >("ParticleID")),

--- a/GeneratorInterface/GenFilters/src/MCPdgIndexFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCPdgIndexFilter.cc
@@ -3,7 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 MCPdgIndexFilter::MCPdgIndexFilter(const edm::ParameterSet& cfg) :
-  token_(consumes<edm::HepMCProduct>(cfg.getUntrackedParameter("moduleLabel",std::string("generator")))),
+  token_(consumes<edm::HepMCProduct>(edm::InputTag(cfg.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
   pdgID(cfg.getParameter<std::vector<int> >("PdgId")),
   index(cfg.getParameter<std::vector<unsigned> >("Index")),
   maxIndex(*std::max_element(index.begin(),index.end())),

--- a/GeneratorInterface/GenFilters/src/PythiaFilterEMJetHeep.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterEMJetHeep.cc
@@ -32,7 +32,7 @@ struct ParticlePtGreater{
 //}
 
 PythiaFilterEMJetHeep::PythiaFilterEMJetHeep(const edm::ParameterSet& iConfig) :
-token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter("moduleLabel",std::string("source")))),
+token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
 //
 minEventPt(iConfig.getUntrackedParameter<double>("MinEventPt",40.)),
 etaMax(iConfig.getUntrackedParameter<double>("MaxEta", 2.8)),

--- a/GeneratorInterface/GenFilters/src/PythiaFilterHT.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterHT.cc
@@ -7,8 +7,8 @@ using namespace std;
 
 
 PythiaFilterHT::PythiaFilterHT(const edm::ParameterSet& iConfig) :
-	label_(iConfig.getUntrackedParameter("moduleLabel",std::string("generator"))),
-	/*minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
+	label_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
+        /*minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
 	maxpcut(iConfig.getUntrackedParameter("MaxP", 10000.)),
 	minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
 	maxptcut(iConfig.getUntrackedParameter("MaxPt", 10000.)),

--- a/GeneratorInterface/GenFilters/src/PythiaFilterHT.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterHT.cc
@@ -18,8 +18,8 @@ PythiaFilterHT::PythiaFilterHT(const edm::ParameterSet& iConfig) :
 	maxrapcut(iConfig.getUntrackedParameter("MaxRapidity", 20.)),
 	minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
 	maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),*/
-	minhtcut(iConfig.getUntrackedParameter("MinHT", 0.)),
-	motherID(iConfig.getUntrackedParameter("MotherID", 0)) {
+	minhtcut(iConfig.getUntrackedParameter<double>("MinHT", 0.)),
+	motherID(iConfig.getUntrackedParameter<int>("MotherID", 0)) {
 
 		theNumberOfTestedEvt = 0;
 		theNumberOfSelected = 0;
@@ -59,7 +59,7 @@ bool PythiaFilterHT::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 	bool accepted = false;
 	Handle<HepMCProduct> evt;
-	iEvent.getByLabel(label_, evt);
+	iEvent.getByToken(label_, evt);
 
 	const HepMC::GenEvent * myGenEvent = evt->GetEvent();
 

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
@@ -9,7 +9,7 @@ using namespace std;
 
 
 PythiaFilterMultiMother::PythiaFilterMultiMother(const edm::ParameterSet& iConfig) :
-token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")))),
+token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
 particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
 minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
 maxpcut(iConfig.getUntrackedParameter("MaxP", 10000.)),

--- a/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
@@ -11,7 +11,7 @@ using namespace std;
 
 
 PythiaMomDauFilter::PythiaMomDauFilter(const edm::ParameterSet& iConfig) :
-label_(iConfig.getUntrackedParameter("moduleLabel",std::string("generator"))),
+label_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
 particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
 daughterID(iConfig.getUntrackedParameter("DaughterID", 0)),
 chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),

--- a/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
@@ -12,19 +12,19 @@ using namespace std;
 
 PythiaMomDauFilter::PythiaMomDauFilter(const edm::ParameterSet& iConfig) :
 label_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
-particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
-daughterID(iConfig.getUntrackedParameter("DaughterID", 0)),
-chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),
-ndaughters(iConfig.getUntrackedParameter("NumberDaughters", 0)),
-ndescendants(iConfig.getUntrackedParameter("NumberDescendants", 0)),
-minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
-maxptcut(iConfig.getUntrackedParameter("MaxPt", 14000.)),
-minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
-maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
-mom_minptcut(iConfig.getUntrackedParameter("MomMinPt", 0.)),
-mom_maxptcut(iConfig.getUntrackedParameter("MomMaxPt", 14000.)),
-mom_minetacut(iConfig.getUntrackedParameter("MomMinEta", -10.)),
-mom_maxetacut(iConfig.getUntrackedParameter("MomMaxEta", 10.))
+particleID(iConfig.getUntrackedParameter<int>("ParticleID", 0)),
+daughterID(iConfig.getUntrackedParameter<int>("DaughterID", 0)),
+chargeconju(iConfig.getUntrackedParameter<bool>("ChargeConjugation", true)),
+ndaughters(iConfig.getUntrackedParameter<int>("NumberDaughters", 0)),
+ndescendants(iConfig.getUntrackedParameter<int>("NumberDescendants", 0)),
+minptcut(iConfig.getUntrackedParameter<double>("MinPt", 0.)),
+maxptcut(iConfig.getUntrackedParameter<double>("MaxPt", 14000.)),
+minetacut(iConfig.getUntrackedParameter<double>("MinEta", -10.)),
+maxetacut(iConfig.getUntrackedParameter<double>("MaxEta", 10.)),
+mom_minptcut(iConfig.getUntrackedParameter<double>("MomMinPt", 0.)),
+mom_maxptcut(iConfig.getUntrackedParameter<double>("MomMaxPt", 14000.)),
+mom_minetacut(iConfig.getUntrackedParameter<double>("MomMinEta", -10.)),
+mom_maxetacut(iConfig.getUntrackedParameter<double>("MomMaxEta", 10.))
 {
    //now do what ever initialization is needed
    vector<int> defdauID;
@@ -56,7 +56,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
  bool accepted = false;
  bool mom_accepted = false;
  Handle<HepMCProduct> evt;
- iEvent.getByLabel(label_, evt);
+ iEvent.getByToken(label_, evt);
 
  const HepMC::GenEvent * myGenEvent = evt->GetEvent();
  int ndauac = 0;

--- a/GeneratorInterface/GenFilters/src/STFilter.cc
+++ b/GeneratorInterface/GenFilters/src/STFilter.cc
@@ -28,7 +28,7 @@
 
 
 STFilter::STFilter(const edm::ParameterSet& iConfig) :
-  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("hepMCProductTag")) {
+  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")) {
 
   pTMax_ = iConfig.getParameter<double>("pTMax");
   edm::LogInfo("SingleTopMatchingFilter")<<"+++ maximum pt of associated-b  pTMax = "<<pTMax_;

--- a/GeneratorInterface/GenFilters/src/STFilter.cc
+++ b/GeneratorInterface/GenFilters/src/STFilter.cc
@@ -28,7 +28,7 @@
 
 
 STFilter::STFilter(const edm::ParameterSet& iConfig) :
-  hepMCProductTag_(iConfig.getParameter<edm::InputTag>("generator","unsmeared")) {
+  hepMCProductTag_(iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag",edm::InputTag("generator","unsmeared"))) {
 
   pTMax_ = iConfig.getParameter<double>("pTMax");
   edm::LogInfo("SingleTopMatchingFilter")<<"+++ maximum pt of associated-b  pTMax = "<<pTMax_;


### PR DESCRIPTION
HepMC naming migration from commit (here: https://github.com/cms-sw/cmssw/commit/f719245b0f6537cf9b1de74fd1aa19d7d9a2d43b) neglected to rename the inputs to a few gen filters needed for HI production

Also pinging @mandrenguyen @yetkinyilmaz @bendavid 
