### PR TITLE
Fix 'on demand' Service building

### DIFF
--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -83,7 +83,7 @@ public:
                         typeid(T).name(),
                         "'.\n");
                } else {
-                  itFoundMaker->second.add(const_cast<ServicesManager&>(*this));
+                  const_cast<ServicesManager&>(*this).createServiceFor(itFoundMaker->second);
                   itFound = type2Service_.find(TypeIDBase(typeid(T)));
                   //the 'add()' should have put the service into the list
                   assert(itFound != type2Service_.end());
@@ -150,6 +150,7 @@ private:
 
          void fillListOfMakers(std::vector<ParameterSet>&);
          void createServices();
+         void createServiceFor(MakerHolder const&);
 
          // ---------- member data --------------------------------
          //hold onto the Manager passed in from the ServiceToken so that


### PR DESCRIPTION
If a Service asks for another Service in its constructor and the
second Service has not yet been created, the ServiceManager will
create the second Service 'on demand'. Unfortunately, the on
demand building was not running the ParameterSet validation
code.
