### PR TITLE
[81X] enable fetching of phase-I geometry from DB

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_25_16_45_28',
+    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_26_10_02_46',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_25_16_48_57',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_26_09_59_52',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_26_10_02_46',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_26_09_59_52',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v20',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_21_11_48_19',
+    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_25_16_45_28',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_21_08_51_44',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_25_16_48_57',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v3',
+    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_21_11_48_19',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v19',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_21_08_51_44',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/Geometry/python/GeometryExtended2017NewFPixReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017NewFPixReco_cff.py
@@ -21,7 +21,6 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = False
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2017newReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017newReco_cff.py
@@ -21,7 +21,6 @@ from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
-trackerGeometry.applyAlignment = False
 
 #  Calorimeters
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -61,13 +61,13 @@ upgradeProperties = {}
 
 upgradeProperties[2017] = {
     '2017' : {
-        'Geom' : 'Extended2017new',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2017_realistic',
         'Era' : 'Run2_2017',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
     },
     '2017Design' : {
-        'Geom' : 'Extended2017new',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2017_design',
         'Era' : 'Run2_2017',
         'BeamSpot': 'GaussSigmaZ4cm',


### PR DESCRIPTION
This PR re-introduces in the 2017 phase-I workflows the fetching of the geometry from DB.
It should contain the state of the art of the tags for geometry description of the detector. 
Current status (as of Oct 27th) of the changes:
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v20](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v20) as [81X_upgrade2017_realistic_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v19) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v20/81X_upgrade2017_realistic_v19): 
  - updated Phase-I geometry: fixes the problem with CutTubs observed in GeometryFileRcd (81YV11) as well as a problem with mixing vector content in an Hcal reco schema (relevant code changes are already in pre13) and aligns sim geometry and Tracker reco geometry to a current one built from xml. 
  - updated Tracker alignment (ideal Pixel + asymptotic misalignment scenario for Strips) consistently with Tracker geometry
- **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v4) as [81X_upgrade2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v4/81X_upgrade2017_design_IdealBS_v3): 
  - updated Phase-I geometry: fixes the problem with CutTubs observed in GeometryFileRcd (81YV11) as well as a problem with mixing vector content in an Hcal reco schema (relevant code changes are already in pre13) and aligns sim geometry and Tracker reco geometry to a current one built from xml. 
  - updated Tracker alignment (ideal Pixel + ideal Strips) consistently with Tracker geometry

Tracker alignment payloads are from @ghellwig
This PR also re-activates the alignment on top of the geometry in case it is fetched via XML. 
@makortel you might want to follow this PR in its current state
