### PR TITLE
Fix crosstalk

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -76,7 +76,7 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
 	((theHitFilter == 0) || (theHitFilter->accepts(hit)))) {
       HcalDetId id(hit.id());
       const HcalSimParameters& pars = dynamic_cast<const HcalSimParameters&>(theParameterMap->simParameters(id));
-      double signal(analogSignalAmplitude(id, hit.energy(), pars, engine));
+      double signal(analogSignalAmplitude(id, hit.energy(), pars, engine)/pars.sipmCrossTalk());
       unsigned int photons(signal + 0.5);
       double time( hit.time() );
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -76,7 +76,8 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
 	((theHitFilter == 0) || (theHitFilter->accepts(hit)))) {
       HcalDetId id(hit.id());
       const HcalSimParameters& pars = dynamic_cast<const HcalSimParameters&>(theParameterMap->simParameters(id));
-      double signal(analogSignalAmplitude(id, hit.energy(), pars, engine)/pars.sipmCrossTalk());
+      //divide out mean of crosstalk distribution 1/(1-lambda) = multiply by (1-lambda)
+      double signal(analogSignalAmplitude(id, hit.energy(), pars, engine)*(1-pars.sipmCrossTalk()));
       unsigned int photons(signal + 0.5);
       double time( hit.time() );
 


### PR DESCRIPTION
It turns out that the measured gain for SiPMs in fC/GeV includes the crosstalk. Therefore, when this gain is divided out of the Geant4 energy in the simulation to calculate the number of photoelectrons, the crosstalk should also be divided out. We model the crosstalk with a Borel-Tanner distribution which has mean 1/(1-lambda).

@mariadalfonso showed that this fixes the single pion response: https://dalfonso.web.cern.ch/dalfonso/HCAL/isoTrack/AbsoluteHCALResponse_afterfixes.pdf
