### PR TITLE
Revert FEStatus to run based. Get LS reports from FEMap instead.

### DIFF
--- a/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
@@ -20,7 +20,6 @@ ecalRawDataClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
-            perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('Summary of the raw data (DCC and front-end) quality. A channel is red if it has nonzero events with FE status that is different from any of ENABLED, DISABLED, SUPPRESSED, FIFOFULL, FIFOFULL_L1ADESYNC, and FORCEDZS. A FED can also go red if its number of L1A desynchronization errors is greater than ' + str(synchErrThresholdFactor) + ' * log10(total entries).')
         ),
         ErrorsSummary = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/SummaryClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/SummaryClient_cfi.py
@@ -27,6 +27,7 @@ ecalSummaryClient = cms.untracked.PSet(
         RawData = ecalRawDataClient.MEs.QualitySummary,
         DesyncByLumi = ecalRawDataTask.MEs.DesyncByLumi,
         FEByLumi = ecalRawDataTask.MEs.FEByLumi,
+        FEStatusErrMapByLumi = ecalRawDataTask.MEs.FEStatusErrMapByLumi,
         TriggerPrimitives = ecalTrigPrimClient.MEs.EmulQualitySummary,
         HotCell = ecalOccupancyClient.MEs.QualitySummary,
         BXSRP = ecalRawDataTask.MEs.BXSRP,

--- a/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
@@ -276,7 +276,6 @@ ecalRawDataTask = cms.untracked.PSet(
             ),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('SuperCrystal'),
-            perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('FE status counter.')
         ),
         FEStatusErrMapByLumi = cms.untracked.PSet(
@@ -284,6 +283,7 @@ ecalRawDataTask = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
+            perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('FE status error occupancy map for this lumisection. Nominal FE status flags such as ENABLED, SUPPRESSED, FIFOFILL, FIFOFULLL1ADESYNC, and FORCEDZS are NOT included.')
         )
     )


### PR DESCRIPTION
**Fix issue in offline DQM where FE Status Flag plots only display stats from last LS**
- Harvesting step in offline DQM causes LS-based plots to only keep stats from the last LS due to multi-threading, which affects all FE Status Flag plots in offline DQM since the introduction of PR https://github.com/cms-sw/cmssw/pull/15411 (starting [CMSSW 8_0_18](https://github.com/cms-sw/cmssw/releases/CMSSW_8_0_18) or ~run 279498).
- Revert changes introduced in that PR: set ecalRawDataClient.MEs.QualitySummary and ecalRawDataTask.MEs.FEStatus to be run-based again
- To maintain functionality of GOOD channel reporting introduced in that PR, get RawData info instead from ecalRawDataTask.MEs.FEStatusErrMapByLumi (introduced later, in PR https://github.com/cms-sw/cmssw/pull/16112) which, by design, is already reset every LS, and is filled independently of the affected MEs above.

In conjunction with 80X PR https://github.com/cms-sw/cmssw/pull/16304.
