### PR TITLE
Fix another place where Services created on demand

### DIFF
--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -108,7 +108,7 @@ public:
                } else {
                   //Actually create the service in order to 'flush out' any
                   // configuration errors for the service
-                  itFoundMaker->second.add(const_cast<ServicesManager&>(*this));
+                 const_cast<ServicesManager&>(*this).createServiceFor(itFoundMaker->second);
                   itFound = type2Service_.find(TypeIDBase(typeid(T)));
                   //the 'add()' should have put the service into the list
                   assert(itFound != type2Service_.end());


### PR DESCRIPTION
The fact that isAvailable also can trigger the creation of a
Service on demand was missed during the first round of the fix.
This now applies the same call to guarantee that fillDescriptions
gets called for all Service constructions.
