### PR TITLE
81x L1T for HI run - tower-counting algorithm

### DIFF
--- a/CondFormats/L1TObjects/interface/CaloParams.h
+++ b/CondFormats/L1TObjects/interface/CaloParams.h
@@ -128,9 +128,13 @@ namespace l1t {
       // veto region is seed tower +/- <=egIsoVetoNrTowersPhi
       unsigned isoVetoNrTowersPhi_;
 
+      // turn on/off EG ID cuts
+      bool egBypassEGVetos_;
+
       EgParams() : lsb_(0), seedThreshold_(0), neighbourThreshold_(0), hcalThreshold_(0), maxHcalEt_(0), maxPtHOverE_(0),
 		   minPtJetIsolation_(0), maxPtJetIsolation_(0), minPtHOverEIsolation_(0), maxPtHOverEIsolation_(0),
-		   isoAreaNrTowersEta_(0), isoAreaNrTowersPhi_(0), isoVetoNrTowersPhi_(0)
+	isoAreaNrTowersEta_(0), isoAreaNrTowersPhi_(0), isoVetoNrTowersPhi_(0),
+	egBypassEGVetos_(0)
       { /* no-op */ }
 
       COND_SERIALIZABLE;
@@ -192,8 +196,11 @@ namespace l1t {
 
       // Et threshold on neighbouring towers/regions
       double neighbourThreshold_;
-
-      JetParams() : lsb_(0), seedThreshold_(0), neighbourThreshold_(0) { /* no-op */ }
+      
+      // turn on/off Jet PUS
+      bool jetBypassPUS_;
+      
+      JetParams() : lsb_(0), seedThreshold_(0), neighbourThreshold_(0), jetBypassPUS_(0) { /* no-op */ }
 
       COND_SERIALIZABLE;
     };

--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -24,6 +24,7 @@ enum GlobalObject
     gtHTT,
     gtHTM,
     gtETMHF,
+    gtTowerCount,
     gtMinBiasHFP0,
     gtMinBiasHFM0,
     gtMinBiasHFP1,

--- a/DataFormats/L1TGlobal/src/GlobalObject.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObject.cc
@@ -38,6 +38,7 @@ l1t::GlobalObject l1TGtObjectStringToEnum(const std::string& label) {
             {"HTT", gtHTT},
             {"HTM", gtHTM},
 	    {"ETMHF", gtETMHF},
+	    {"TowerCount",gtTowerCount},
 	    {"MinBiasHFP0", gtMinBiasHFP0},
 	    {"MinBiasHFM0", gtMinBiasHFM0},
 	    {"MinBiasHFP1", gtMinBiasHFP1},
@@ -122,6 +123,11 @@ std::string l1t::l1TGtObjectEnumToString(const GlobalObject& gtObject) {
 
         case gtETMHF: {
             gtObjectString = "ETMHF";
+        }
+            break;
+
+        case gtTowerCount: {
+            gtObjectString = "TowerCount";
         }
             break;
 

--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -38,7 +38,8 @@ namespace l1t {
       kTotalHtHF,
       kTotalHtxHF,
       kTotalHtyHF,
-      kMissingHtHF
+      kMissingHtHF,
+      kTowerCount      
     };
 
     EtSum(){}

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.cc
@@ -43,6 +43,7 @@ namespace stage2 {
 	  if (j->getType()==l1t::EtSum::kMinBiasHFM1)   mht_word |= (word << 28);
 	  if (j->getType()==l1t::EtSum::kMissingEtHF)   methf_word |= word;
 	  if (j->getType()==l1t::EtSum::kMissingHtHF)   mhthf_word |= word;
+	  if (j->getType()==l1t::EtSum::kTowerCount)    ht_word |= (word << 12);
 	}
 	
 	load.push_back(et_word);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
@@ -91,6 +91,15 @@ namespace stage2 {
 
        res_->push_back(bx,ht);
 
+
+       //HI-SUM
+
+       l1t::EtSum towCount = l1t::EtSum();
+       towCount.setHwPt( (raw_data>>12) & 0x1FFF );
+       towCount.setType( (l1t::EtSum::kTowerCount) );
+
+       res_->push_back(bx, towCount);
+
        //MBHFMT0
 
        l1t::EtSum mbm0 = l1t::EtSum();
@@ -98,6 +107,7 @@ namespace stage2 {
        mbm0.setType( l1t::EtSum::kMinBiasHFM0 );
 
        res_->push_back(bx, mbm0);
+
 
        //  MET (no HF)
 

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/CaloSetup.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/CaloSetup.cc
@@ -1,0 +1,102 @@
+#include "FWCore/Framework/interface/stream/EDProducerBase.h"
+
+#include "EventFilter/L1TRawToDigi/interface/Packer.h"
+#include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+
+#include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+
+#include "CaloCollections.h"
+#include "CaloTokens.h"
+
+namespace l1t {
+   namespace stage2 {
+      class CaloSetup : public PackingSetup {
+         public:
+            virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override {
+               return std::unique_ptr<PackerTokens>(new CaloTokens(cfg, cc));
+            };
+
+            virtual void fillDescription(edm::ParameterSetDescription& desc) override {
+	      desc.addOptional<edm::InputTag>("TowerInputLabel")->setComment("for stage 2");
+	    };
+
+            virtual PackerMap getPackers(int fed, unsigned int fw) override {
+               PackerMap res;
+
+               if (fed == 1366) {
+                  // Use board id 1 for packing
+                  res[{1, 1}] = {
+		    //                     PackerFactory::get()->make("stage2::CaloTowerPacker"),
+                     PackerFactory::get()->make("stage2::CaloEGammaPacker"),
+                     PackerFactory::get()->make("stage2::CaloEtSumPacker"),
+                     PackerFactory::get()->make("stage2::CaloJetPacker"),
+                     PackerFactory::get()->make("stage2::CaloTauPacker")
+                  };
+               }
+
+               return res;
+            };
+
+            virtual void registerProducts(edm::stream::EDProducerBase& prod) override {
+               prod.produces<CaloTowerBxCollection>("CaloTower");
+               prod.produces<EGammaBxCollection>("EGamma");
+               prod.produces<EtSumBxCollection>("EtSum");
+               prod.produces<JetBxCollection>("Jet");
+               prod.produces<TauBxCollection>("Tau");
+
+               prod.produces<EtSumBxCollection>("MP");
+               prod.produces<JetBxCollection>("MP");
+	       prod.produces<EGammaBxCollection>("MP");
+	       prod.produces<TauBxCollection>("MP");
+            };
+
+            virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override {
+               return std::unique_ptr<UnpackerCollections>(new CaloCollections(e));
+            };
+
+            virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override {
+               auto tower_unp = UnpackerFactory::get()->make("stage2::CaloTowerUnpacker");
+               auto egamma_unp = UnpackerFactory::get()->make("stage2::EGammaUnpacker");
+               auto etsum_unp = UnpackerFactory::get()->make("stage2::EtSumUnpacker");
+               auto jet_unp = UnpackerFactory::get()->make("stage2::JetUnpacker");
+               auto tau_unp = UnpackerFactory::get()->make("stage2::TauUnpacker");
+
+	       auto mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker");
+	       if (fw >= 0x1001000b) {
+		 mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x1001000b");
+	       }
+	       if (fw >= 0x10010010) {
+		 mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x10010010");
+	       }
+	       if (fw >= 0x10010033) {
+		 mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x10010033");
+	       }
+
+               UnpackerMap res;
+               if (fed == 1366 || (fed == 1360 && board == 0x221B)) {
+	          res[9]  = egamma_unp;
+	          res[11] = egamma_unp;
+                  res[13] = jet_unp;
+		  res[15] = jet_unp;
+		  res[17] = tau_unp;
+		  res[19] = tau_unp;
+                  res[21] = etsum_unp;
+	       } else if (fed == 1360 && board != 0x221B) {
+                  res[121] = mp_unp;
+                  res[123] = mp_unp;
+                  res[125] = mp_unp;
+                  res[127] = mp_unp;
+                  res[129] = mp_unp;
+                  res[131] = mp_unp;
+
+                  for (int link = 0; link < 144; link += 2)
+                     res[link] = tower_unp;
+               }
+
+               return res;
+            };
+      };
+   }
+}
+
+DEFINE_L1T_PACKING_SETUP(l1t::stage2::CaloSetup);

--- a/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
+++ b/EventFilter/L1TRawToDigi/src/implementations_stage2/MPUnpacker_0x10010033.cc
@@ -1,0 +1,382 @@
+#define EDM_ML_DEBUG 1
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+
+#include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
+
+#include "CaloCollections.h"
+
+#include "L1TStage2Layer2Constants.h"
+
+namespace l1t {
+   namespace stage2 {
+      class MPUnpacker_0x10010033 : public Unpacker {
+         public:
+            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+      };
+   }
+}
+
+// Implementation
+
+namespace l1t {
+namespace stage2 {
+   bool
+   MPUnpacker_0x10010033::unpack(const Block& block, UnpackerCollections *coll)
+   {
+
+     LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize() << " AMC = " << block.amc().getAMCNumber();
+
+     // check this is the correct MP
+     unsigned int tmt  = block.amc().getBoardID() - l1t::stage2::layer2::mp::offsetBoardId + 1;
+     unsigned int bxid = block.amc().getBX();
+
+     // handle offset between BC0 marker and actual BC0...
+     if( (tmt-1) != ((bxid-1+3)%9) ) return true;
+     LogDebug("L1T") << "Unpacking TMT # " << tmt << " for BX " << bxid;
+
+     auto res1_ = static_cast<CaloCollections*>(coll)->getMPJets();
+     auto res2_ = static_cast<CaloCollections*>(coll)->getMPEtSums();
+     auto res3_ = static_cast<CaloCollections*>(coll)->getMPEGammas();
+     auto res4_ = static_cast<CaloCollections*>(coll)->getMPTaus();
+     
+     res1_->setBXRange(0,0);
+     res2_->setBXRange(0,0);
+     res3_->setBXRange(0,0);
+     res4_->setBXRange(0,0);
+
+     // Initialise frame indices for each data type
+     int unsigned fet  = 0;
+     int unsigned fht  = 2;
+     int unsigned feg  = 4;
+     int unsigned ftau = 6;
+     int unsigned fjet = 8;
+     int unsigned faux = 10;
+
+     //      ===== Jets and Sums =====
+
+     // ET / MET(x) / MET (y) with HF (configurable)
+
+     uint32_t raw_data = block.payload()[fet];
+
+     l1t::EtSum ethf = l1t::EtSum();
+
+     switch(block.header().getID()){
+     case 123: // 61
+       ethf.setType(l1t::EtSum::kTotalEtHF);
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 121: // 60
+       ethf.setType(l1t::EtSum::kTotalEtxHF);
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 127: // 63
+       ethf.setType(l1t::EtSum::kTotalEtyHF);
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 125: // 62
+       ethf.setType(l1t::EtSum::kTotalEtHF);
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 131: // 65
+       ethf.setType(l1t::EtSum::kTotalEtxHF);
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 129: // 64
+       ethf.setType(l1t::EtSum::kTotalEtyHF); 
+       ethf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     default: 
+       break;
+     }
+
+     LogDebug("L1T") << "ET/METx/METy: pT " << ethf.hwPt();
+
+     res2_->push_back(0,ethf);
+
+
+     // ET / MET(x) / MET (y) without HF
+
+     raw_data = block.payload()[fet + 1];
+
+     l1t::EtSum etNoHF = l1t::EtSum();
+
+     switch(block.header().getID()){
+     case 123: // 61
+       etNoHF.setType(l1t::EtSum::kTotalEt);
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 121: // 60
+       etNoHF.setType(l1t::EtSum::kTotalEtx);
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 127: // 63
+       etNoHF.setType(l1t::EtSum::kTotalEty);
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 125: // 62
+       etNoHF.setType(l1t::EtSum::kTotalEt);
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 131: // 65
+       etNoHF.setType(l1t::EtSum::kTotalEtx);
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 129: // 64
+       etNoHF.setType(l1t::EtSum::kTotalEty); 
+       etNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     default:
+       break;
+     }
+
+     LogDebug("L1T") << "ET/METx/METy (no HF): pT " << etNoHF.hwPt();
+
+     res2_->push_back(0,etNoHF);
+
+
+     // HT / MHT(x)/ MHT (y) with HF
+
+     raw_data = block.payload()[fht];
+
+     l1t::EtSum hthf = l1t::EtSum(); 
+
+     switch(block.header().getID()){
+     case 123: // 61
+       hthf.setType(l1t::EtSum::kTotalHtHF);
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 121: // 60
+       hthf.setType(l1t::EtSum::kTotalHtxHF);
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 127: // 63
+       hthf.setType(l1t::EtSum::kTotalHtyHF);
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 125: // 62
+       hthf.setType(l1t::EtSum::kTotalHtHF);
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 131: // 65
+       hthf.setType(l1t::EtSum::kTotalHtxHF);
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 129: // 64
+       hthf.setType(l1t::EtSum::kTotalHtyHF); 
+       hthf.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     default: 
+       break;
+     }
+
+     LogDebug("L1T") << "HTHF/MHTHFx/MHTHFy: pT " << hthf.hwPt();
+
+     res2_->push_back(0,hthf);
+
+
+     // HT / MHT(x)/ MHT (y) no HF
+
+     raw_data = block.payload()[fht+1];
+
+     l1t::EtSum htNoHF = l1t::EtSum(); 
+
+     switch(block.header().getID()){
+     case 123: // 61
+       htNoHF.setType(l1t::EtSum::kTotalHt);
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 121: // 60
+       htNoHF.setType(l1t::EtSum::kTotalHtx);
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 127: // 63
+       htNoHF.setType(l1t::EtSum::kTotalHty);
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 125: // 62
+       htNoHF.setType(l1t::EtSum::kTotalHt);
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data & 0xFFFFFF) << 16 ) >> 16 );
+       break;
+     case 131: // 65
+       htNoHF.setType(l1t::EtSum::kTotalHtx);
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     case 129: // 64
+       htNoHF.setType(l1t::EtSum::kTotalHty); 
+       htNoHF.setHwPt( static_cast<int32_t>( uint32_t(raw_data) ) );
+       break;
+     default:
+       break;
+     }
+
+
+     LogDebug("L1T") << "HTNOHF/MHTNOHFx/MHTNOHFy: pT " << htNoHF.hwPt();
+
+     res2_->push_back(0,htNoHF);
+
+
+     // Two jets
+     for (unsigned nJet=0; nJet < 2; nJet++){
+
+       raw_data = block.payload()[fjet+nJet];
+
+       if (raw_data == 0)
+            continue;
+
+       l1t::Jet jet = l1t::Jet();
+
+       int etasign = 1;
+       if ((block.header().getID() == 125) ||
+           (block.header().getID() == 131) ||
+           (block.header().getID() == 129)) {
+         etasign = -1;
+       }
+
+       LogDebug("L1") << "block ID=" << block.header().getID() << " etasign=" << etasign;
+
+       int mpEta = etasign*(raw_data & 0x3F);
+       jet.setHwEta(CaloTools::caloEta(mpEta));
+       jet.setHwPhi((raw_data >> 6) & 0x7F);
+       jet.setHwPt((raw_data >> 13) & 0xFFFF);
+       jet.setHwQual((raw_data>>29) & 0x1 );
+
+       if (jet.hwPt()==0) continue;
+         
+       LogDebug("L1T") << "Jet: eta " << jet.hwEta() << " phi " << jet.hwPhi() << " pT " << jet.hwPt() << " qual " << jet.hwQual();
+
+       jet.setP4( l1t::CaloTools::p4MP(&jet) );
+       res1_->push_back(0,jet);
+
+     }
+
+     //      ===== EGammas =====
+     
+     // Two EGammas
+
+
+     for (unsigned nEG=0; nEG < 2; nEG++){
+       
+       raw_data = block.payload()[feg+nEG];
+       
+       if (raw_data == 0)
+	 continue;
+       
+       l1t::EGamma eg = l1t::EGamma();
+
+       int etasign = 1;
+       if ((block.header().getID() == 125) ||
+           (block.header().getID() == 131) ||
+           (block.header().getID() == 129)) {
+         etasign = -1;
+       }
+       
+       LogDebug("L1") << "block ID=" << block.header().getID() << " etasign=" << etasign;
+
+       eg.setHwEta(etasign*((raw_data >> 3) & 0x3F));
+       eg.setHwPhi((raw_data >> 9) & 0x7F);
+       eg.setHwPt((raw_data >> 20) & 0xFFF);
+       eg.setHwIso((raw_data>>1) & 0x3);       
+       eg.setHwQual((raw_data>>16) & 0xf );
+
+       if (eg.hwPt()==0) continue;
+	   
+       LogDebug("L1T") << "Egamma: eta " << eg.hwEta() << " phi " << eg.hwPhi() << " pT " << eg.hwPt() << " qual " << eg.hwQual();
+       
+       eg.setP4( l1t::CaloTools::p4MP(&eg) );
+       res3_->push_back(0,eg);
+     }
+
+     
+     //      ===== Taus =====
+     
+     // Two taus
+
+     for (unsigned nTau=0; nTau < 2; nTau++){
+       
+       raw_data = block.payload()[ftau+nTau];
+       
+       if (raw_data == 0)
+	 continue;
+       
+       l1t::Tau tau = l1t::Tau();
+
+       int etasign = 1;
+       if ((block.header().getID() == 125) ||
+           (block.header().getID() == 131) ||
+           (block.header().getID() == 129)) {
+         etasign = -1;
+       }
+       
+       LogDebug("L1") << "block ID=" << block.header().getID() << " etasign=" << etasign;
+       
+       tau.setHwEta(etasign*((raw_data >> 3) & 0x3F));
+       tau.setHwPhi((raw_data >> 9) & 0x7F);
+       tau.setHwPt((raw_data >> 20) & 0xFFF);
+       tau.setHwIso((raw_data>>1) & 0x3);       
+       tau.setHwQual((raw_data>>16) & 0xf );
+
+       if (tau.hwPt()==0) continue;
+       
+       LogDebug("L1T") << "Tau: eta " << tau.hwEta() << " phi " << tau.hwPhi() << " pT " << tau.hwPt() << " qual " << tau.hwQual();
+       
+       tau.setP4( l1t::CaloTools::p4MP(&tau) );
+       res4_->push_back(0,tau);
+     }
+
+      //      ===== Aux =====
+      raw_data = block.payload()[faux];
+
+      // create a sum object for each type of HF sum
+      l1t::EtSum mbp0 = l1t::EtSum();
+      l1t::EtSum mbm0 = l1t::EtSum();
+      l1t::EtSum mbm1 = l1t::EtSum();
+      l1t::EtSum mbp1 = l1t::EtSum();
+      l1t::EtSum towCount = l1t::EtSum();
+
+      // readout the sums only if the correct block is  being processed (first frame of AUX)
+      switch(block.header().getID()){
+      case 121: // this should correspond to the first link
+        // read 4 bits starting at position 24 (24 -> 28)
+        mbp0.setHwPt( ( raw_data >> 24 ) & 0xF );
+        mbp0.setType( l1t::EtSum::kMinBiasHFP0 );
+
+        // read 4 bits starting at position 16 (16 -> 20)
+        mbm0.setHwPt( ( raw_data >> 16 ) & 0xF );
+        mbm0.setType( l1t::EtSum::kMinBiasHFM0 );
+
+        // read 4 bits starting at position 8 (8 -> 12)
+        mbp1.setHwPt( ( raw_data >> 8 ) & 0xF );
+        mbp1.setType( l1t::EtSum::kMinBiasHFP1 );
+
+        // read the first 4 bits by masking with 0xF
+        mbm1.setHwPt( raw_data & 0xF );
+        mbm1.setType( l1t::EtSum::kMinBiasHFM1 );
+
+        LogDebug("L1T") << "mbp0 HF sum: " << mbp0.hwPt();
+        LogDebug("L1T") << "mbm0 HF sum: " << mbm0.hwPt();
+        LogDebug("L1T") << "mbp1 HF sum: " << mbp1.hwPt();
+        LogDebug("L1T") << "mbm1 HF sum: " << mbm1.hwPt();
+
+        res2_->push_back(0,mbp0);
+        res2_->push_back(0,mbm0);
+        res2_->push_back(0,mbp1);
+        res2_->push_back(0,mbm1);
+        break;
+      case 127:
+	towCount.setHwPt( raw_data & 0x1FFF );
+	towCount.setType( l1t::EtSum::kTowerCount );
+	res2_->push_back(0,towCount);
+	break;
+      default:
+        break;
+      }
+
+     return true;
+   }
+}
+}
+
+DEFINE_L1T_UNPACKER(l1t::stage2::MPUnpacker_0x10010033);

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -56,12 +56,13 @@ def unpack_stage1():
 
 def unpack_stage2():
     global L1TRawToDigi_Stage2
-    global bmtfDigis, caloStage2Digis, gmtStage2Digis, gtStage2Digis,L1TRawToDigi_Stage2    
+    global bmtfDigis, emtfStage2Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis,L1TRawToDigi_Stage2    
     from EventFilter.L1TRawToDigi.bmtfDigis_cfi import bmtfDigis 
+    from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import emtfStage2Digis
     from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import caloStage2Digis
     from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
     from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
-    L1TRawToDigi_Stage2 = cms.Sequence(bmtfDigis + caloStage2Digis + gmtStage2Digis + gtStage2Digis)
+    L1TRawToDigi_Stage2 = cms.Sequence(bmtfDigis + emtfStage2Digis + caloStage2Digis + gmtStage2Digis + gtStage2Digis)
     
 #
 # Legacy Trigger:

--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -1,6 +1,10 @@
 import os.path
 import FWCore.ParameterSet.Config as cms
 
+def L1TSettingsToCaloStage2Params_v3_3(process):
+    process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi")
+    return process
+
 def L1TSettingsToCaloStage2Params_v3_2(process):
     process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_2_cfi")
     return process

--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -119,6 +119,7 @@ namespace l1t {
     int egMaxPtJetIsolation() const { return egp_.maxPtJetIsolation_; }
     int egMinPtHOverEIsolation() const { return egp_.minPtHOverEIsolation_; }
     int egMaxPtHOverEIsolation() const { return egp_.maxPtHOverEIsolation_; }
+    bool egBypassEGVetos() const { return egp_.egBypassEGVetos_; }
 
     unsigned egIsoAreaNrTowersEta()const{return egp_.isoAreaNrTowersEta_;}
     unsigned egIsoAreaNrTowersPhi()const{return egp_.isoAreaNrTowersPhi_;}
@@ -151,6 +152,7 @@ namespace l1t {
     void setEgMaxPtJetIsolation(int cutValue) { egp_.maxPtJetIsolation_ = cutValue; }
     void setEgMinPtHOverEIsolation(int cutValue) { egp_.minPtHOverEIsolation_ = cutValue; }
     void setEgMaxPtHOverEIsolation(int cutValue) { egp_.maxPtHOverEIsolation_ = cutValue; }
+    void setEgBypassEGVetos(bool flag) { egp_.egBypassEGVetos_ = flag;}
 
     void setEgIsoAreaNrTowersEta(unsigned iEgIsoAreaNrTowersEta){egp_.isoAreaNrTowersEta_=iEgIsoAreaNrTowersEta;}
     void setEgIsoAreaNrTowersPhi(unsigned iEgIsoAreaNrTowersPhi){egp_.isoAreaNrTowersPhi_=iEgIsoAreaNrTowersPhi;}
@@ -244,6 +246,9 @@ namespace l1t {
       else
 	return 0;
     }
+
+    bool jetBypassPUS() const { return jetp_.jetBypassPUS_; }
+
     std::string jetPUSType() const { return pnode_[jetPUS].type_; }
     std::vector<double> jetPUSParams() { return pnode_[jetPUS].dparams_; }
     std::string jetCalibrationType() const { return pnode_[jetCalibration].type_; }
@@ -267,7 +272,8 @@ namespace l1t {
     void setJetCalibrationLUT(const l1t::LUT & lut) { pnode_[jetCalibration].LUT_ = lut; }
     void setJetCompressEtaLUT(const l1t::LUT & lut) { pnode_[jetCompressEta].LUT_ = lut; }
     void setJetCompressPtLUT(const l1t::LUT & lut) { pnode_[jetCompressPt].LUT_ = lut; }
-
+    void setJetBypassPUS(bool flag) { jetp_.jetBypassPUS_ = flag;}
+    
     // sums
 
     double etSumLsb() const { return etSumLsb_; }

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2EtSumAlgorithmFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2EtSumAlgorithmFirmware.h
@@ -35,7 +35,8 @@ namespace l1t {
     int32_t metEtaMaxHF_;
     int32_t ettEtaMax_;
     int32_t ettEtaMaxHF_;
-	
+    int32_t nTowThresholdHw_;
+    int32_t nTowEtaMax_;	
   };
 }
 

--- a/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
+++ b/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
@@ -161,7 +161,7 @@ void create_plot(
 }
 
 
-void compHwEmu_new (
+void compHwEmu (
   int runNo, const char * dataset, bool useEventDisplay = false, bool presentationMode = false
   ) {
 
@@ -257,6 +257,10 @@ void compHwEmu_new (
   // HTyHF
   TH1D* hwMPSumHtyHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummhtyhf/et");
   TH1D* emMPSumHtyHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummhtyhf/et");
+  
+  // HITowerCount
+  TH1D* hwMPSumHITowerCount = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumhitowercount/et");
+  TH1D* emMPSumHITowerCount = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumhitowercount/et");
 
   // Demux sums
 
@@ -286,6 +290,7 @@ void compHwEmu_new (
   TH1D* hwSumHt = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumht/et");
   TH1D* emSumHt = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumht/et");
 
+
   // MHT
   TH1D* hwSumMht = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/summht/et");
   TH1D* emSumMht = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/summht/et");
@@ -309,6 +314,10 @@ void compHwEmu_new (
   // MHTHF phi
   TH1D* hwMhtHFPhi = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/summhthf/phi");
   TH1D* emMhtHFPhi = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/summhthf/phi");
+
+   // HI Tower count
+  TH1D* hwHITowerCount = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumhitowercount/et");
+  TH1D* emHITowerCount = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumhitowercount/et");
 
   // Sorts
   TH1D* hwSortMP = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sortMP");
@@ -591,6 +600,11 @@ void compHwEmu_new (
       hwMPSumHtyHF, emMPSumHtyHF, runNo, dataset,
       "Jet iH_{T,y}", "MPSums/MPSumHtyHF.pdf", 1, 13, -20000, 20000
       );
+      // plot HI tower count
+    create_plot(
+      hwMPSumHITowerCount, emMPSumHITowerCount, runNo, dataset,
+      "# Towers", "MPSums/MPSumHITowerCount.pdf", 1, 13, 0, 5904
+      );
   } else {
 
     // plot MP sum Ht
@@ -629,6 +643,13 @@ void compHwEmu_new (
       hwMPSumHtyHF, emMPSumHtyHF, runNo, dataset,
       "Jet iH_{T,y}", "MPSums/MPSumHtyHF.pdf"
       );
+
+    // plot HI tower count
+    create_plot(
+      hwMPSumHITowerCount, emMPSumHITowerCount, runNo, dataset,
+      "# Towers", "MPSums/MPSumHITowerCount.pdf"
+      );
+
   }
 // ========================= MP sums end ========================
 // ======================== demux sums start ========================
@@ -638,14 +659,14 @@ void compHwEmu_new (
     create_plot(
       hwSumEt,
       emSumEt,
-      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEt.pdf", 20, 13, 0, 800
+      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEt.pdf", 10, 13, 0, 800
       );
 
     // plot demux sum EtEM
     create_plot(
       hwSumEtEM,
       emSumEtEM,
-      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtEM.pdf", 20, 13, 0, 800
+      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtEM.pdf", 10, 13, 0, 800
       );
 
     /*
@@ -653,7 +674,7 @@ void compHwEmu_new (
     create_plot(
     hwSumEtHF,
     emSumEtHF,
-    runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtHF.pdf", 20, 13, 0, 800
+    runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtHF.pdf", 10, 13, 0, 800
     );
     */
 
@@ -689,7 +710,14 @@ void compHwEmu_new (
     create_plot(
       hwSumHt,
       emSumHt,
-      runNo, dataset, "iH_{T}", "DemuxSums/DemSumHt.pdf", 20, 13, 0, 800
+      runNo, dataset, "iH_{T}", "DemuxSums/DemSumHt.pdf", 10, 13, 0, 800
+      );
+
+      // plot demux hi tower count
+    create_plot(
+      hwHITowerCount,
+      emHITowerCount,
+      runNo, dataset, "# Towers", "DemuxSums/DemHITowCount.pdf", 1, 13, 0, 5904
       );
 
     // plot demux sum Mht
@@ -776,6 +804,13 @@ void compHwEmu_new (
       hwSumHt,
       emSumHt,
       runNo, dataset, "iH_{T}", "DemuxSums/DemSumHt.pdf"
+      );
+
+      // plot demux hi tower count
+    create_plot(
+      hwHITowerCount,
+      emHITowerCount,
+      runNo, dataset, "# Towers", "DemuxSums/DemHITowCount.pdf", 1, 13, 0, 5904
       );
 
     // plot demux sum Mht

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -110,6 +110,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setEgMaxPtJetIsolation(conf.getParameter<int>("egMaxPtJetIsolation"));
   m_params_helper.setEgMinPtHOverEIsolation(conf.getParameter<int>("egMinPtHOverEIsolation"));
   m_params_helper.setEgMaxPtHOverEIsolation(conf.getParameter<int>("egMaxPtHOverEIsolation"));
+  m_params_helper.setEgBypassEGVetos(conf.getParameter<bool>("egBypassEGVetos"));
 
 
   edm::FileInPath egMaxHOverELUTFile = conf.getParameter<edm::FileInPath>("egMaxHOverELUTFile");
@@ -213,6 +214,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setJetNeighbourThreshold(conf.getParameter<double>("jetNeighbourThreshold"));
   m_params_helper.setJetRegionMask(conf.getParameter<int>("jetRegionMask"));
   m_params_helper.setJetPUSType(conf.getParameter<std::string>("jetPUSType"));
+  m_params_helper.setJetBypassPUS(conf.getParameter<bool>("jetBypassPUS"));
   m_params_helper.setJetCalibrationType(conf.getParameter<std::string>("jetCalibrationType"));
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -106,9 +106,11 @@ namespace l1t {
       MinBiasHFM1=34,
       MinBiasHFP0=35,
       MinBiasHFM0=36,
-      MPSumETEm = 37
+      MPSumETEm = 37,
+      MPSumHITowCount = 38,
+      SumHITowCount = 39
     };
-  
+    
     std::vector< ObjectType > types_;
     std::vector< std::string > typeStr_;
   
@@ -236,6 +238,8 @@ namespace l1t {
     types_.push_back( MinBiasHFM0 );
     types_.push_back( MinBiasHFP1 );
     types_.push_back( MinBiasHFM1 );
+    types_.push_back( MPSumHITowCount );
+    types_.push_back( SumHITowCount );
 
     typeStr_.push_back( "tower" );
     typeStr_.push_back( "cluster" );
@@ -273,6 +277,8 @@ namespace l1t {
     typeStr_.push_back( "minbiashfm0" );
     typeStr_.push_back( "minbiashfp1" );
     typeStr_.push_back( "minbiashfm1" );
+    typeStr_.push_back( "mpsumhitowercount");
+    typeStr_.push_back( "sumhitowercount");
   }
 
 
@@ -493,7 +499,7 @@ namespace l1t {
         if (  !m_allBx && ibx != m_mpBx ) continue;
 
         for ( auto itr = mpsums->begin(ibx); itr != mpsums->end(ibx); ++itr ) {
-
+	  
           switch(itr->getType()){
           case l1t::EtSum::EtSumType::kTotalEt:     het_.at(MPSumET)       ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kTotalEtHF:    het_.at(MPSumETHF)      ->Fill( itr->hwPt() ); break;
@@ -511,10 +517,11 @@ namespace l1t {
           case l1t::EtSum::EtSumType::kMinBiasHFP0: het_.at(MPMinBiasHFP0) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFM0: het_.at(MPMinBiasHFM0) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFP1: het_.at(MPMinBiasHFP1) ->Fill( itr->hwPt() ); break;
-          case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MPMinBiasHFM1) ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MPMinBiasHFM1) ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kTowerCount:  het_.at(MPSumHITowCount)  ->Fill( itr->hwPt() ); break;
+	    
           default: std::cout<<"wrong type of MP sum"<<std::endl;
           }
-	  
 	  text << "MP Sum : " << " type=" << itr->getType() << " BX=" << ibx << " ipt=" << itr->hwPt() << " ieta=" << itr->hwEta() << " iphi=" << itr->hwPhi() << std::endl;
         }
 
@@ -635,6 +642,7 @@ namespace l1t {
           case l1t::EtSum::EtSumType::kMinBiasHFM0: het_.at(MinBiasHFM0) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFP1: het_.at(MinBiasHFP1) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MinBiasHFM1) ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kTowerCount:  het_.at(SumHITowCount) ->Fill( itr->hwPt() ); break;
 
           default: std::cout<<"wrong type of demux sum"<<std::endl;
           }
@@ -645,14 +653,6 @@ namespace l1t {
     }
     
     if (doText_) edm::LogVerbatim("L1TCaloEvents") << text.str();
-
-    delete hEvtTow;
-    delete hEvtMPEG;
-    delete hEvtMPTau;
-    delete hEvtMPJet;
-    delete hEvtDemuxEG;
-    delete hEvtDemuxTau;
-    delete hEvtDemuxJet;
 
   }
 
@@ -686,6 +686,9 @@ namespace l1t {
                *itr==MinBiasHFP1 ||
                *itr==MinBiasHFM1)  {
         het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 16, -0.5, 15.5) )); 
+      }
+      else if (*itr==MPSumHITowCount || *itr==SumHITowCount){
+	het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 5904, -0.5, 5903.5)));
       }
       else {
         het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 100000, -0.5, 99999.5) ));

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -93,6 +93,7 @@ caloParams = cms.ESProducer(
     jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress.txt"),
     jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress.txt"),
     jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_add_mult.txt"),
+    jetBypassPUS             = cms.bool(False),
 
     # sums
     etSumLsb                 = cms.double(0.5),

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_0_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_0_cfi.py
@@ -113,9 +113,9 @@ caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorim
 
 # sums: 0=ET, 1=HT, 2=MET, 3=MHT
 caloStage2Params.etSumLsb                = cms.double(0.5)
-caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1)
-caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28)
-caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30.)
+caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
+caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28, 28)
+caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.)
 
 caloStage2Params.etSumXPUSLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
 caloStage2Params.etSumYPUSLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_2_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_2_cfi.py
@@ -32,6 +32,8 @@ caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalor
 caloStage2Params.egShapeIdType              = cms.string("compressed")
 caloStage2Params.egShapeIdVersion           = cms.uint32(0)
 caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")
+caloStage2Params.egBypassEGVetos              = cms.bool(False)
+
 caloStage2Params.egPUSType                  = cms.string("None")
 caloStage2Params.egIsolationType            = cms.string("compressed")
 #caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/IsoIdentification_adapt_extrap_v16.07.29.txt")

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_cfi.py
@@ -32,9 +32,12 @@ caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalor
 caloStage2Params.egShapeIdType              = cms.string("compressed")
 caloStage2Params.egShapeIdVersion           = cms.uint32(0)
 caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")
+caloStage2Params.egBypassEGVetos              = cms.bool(False)
+
 caloStage2Params.egPUSType                  = cms.string("None")
 caloStage2Params.egIsolationType            = cms.string("compressed")
-caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/IsoIdentification_0.25_adapt_extrap_v16.04.05.txt")
+#caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/IsoIdentification_adapt_extrap_v16.07.29.txt")
+caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/IsoIdentification_adapt_extrap_v16.08.08.txt") # new SK Sep '16
 caloStage2Params.egIsoAreaNrTowersEta       = cms.uint32(2)
 caloStage2Params.egIsoAreaNrTowersPhi       = cms.uint32(4)
 caloStage2Params.egIsoVetoNrTowersPhi       = cms.uint32(2)
@@ -46,6 +49,7 @@ caloStage2Params.egCalibrationType          = cms.string("compressed")
 caloStage2Params.egCalibrationVersion       = cms.uint32(0)
 caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_v16.03.14.txt")
 
+
 # Tau
 caloStage2Params.tauLsb                        = cms.double(0.5)
 caloStage2Params.tauSeedThreshold              = cms.double(0.)
@@ -54,9 +58,9 @@ caloStage2Params.tauIsoAreaNrTowersEta         = cms.uint32(2)
 caloStage2Params.tauIsoAreaNrTowersPhi         = cms.uint32(4)
 caloStage2Params.tauIsoVetoNrTowersPhi         = cms.uint32(2)
 caloStage2Params.tauPUSType                    = cms.string("None")
-caloStage2Params.tauIsoLUTFile                 = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_21_Layer1Calibration_noCompressionBlock_v4.0.0.txt")
-caloStage2Params.tauIsoLUTFile2                = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_21_Layer1Calibration_noCompressionBlock_v4.0.0.txt")
-caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_Layer1Calibration_v9.0.0.txt")
+caloStage2Params.tauIsoLUTFile                 = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_22_NewLayer1Calibration_noCompressionBlock_SK1616_EmuOldFormat_v6.2.0.txt")
+caloStage2Params.tauIsoLUTFile2                = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_22_NewLayer1Calibration_noCompressionBlock_SK1616_EmuOldFormat_v6.2.0.txt")
+caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_NewLayer1Calibration_SK1616_EmuOldFormat_v11.0.0.txt")
 caloStage2Params.tauCompressLUTFile            = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauCompressAllLUT_12bit_v3.txt")
 caloStage2Params.tauPUSParams                  = cms.vdouble(1,4,32)
 
@@ -68,10 +72,10 @@ caloStage2Params.jetPUSType            = cms.string("ChunkyDonut")
 
 # Calibration options
 # function6PtParams22EtaBins or None
-# caloStage2Params.jetCalibrationType    = cms.string("None")
-# caloStage2Params.jetCalibrationType = cms.string("function8PtParams22EtaBins")
-caloStage2Params.jetCalibrationType = cms.string("functionErf11PtParams16EtaBins")
-# caloStage2Params.jetCalibrationType = cms.string("None")
+#caloStage2Params.jetCalibrationType    = cms.string("None")
+#caloStage2Params.jetCalibrationType = cms.string("function8PtParams22EtaBins")
+caloStage2Params.jetCalibrationType = cms.string("LUT")
+caloStage2Params.jetBypassPUS       = cms.bool(False)
 
 #Vector with 6 parameters for eta bin, from low eta to high
 # 1,0,1,0,1,1 gives no correction
@@ -105,44 +109,11 @@ jetCalibParamsVector.extend([
         1,0,1,0,1,1,1.37830172245,1024,
         1,0,1,0,1,1,1.36123039014,1024
 ])
-# this vector corresponds to "function8PtParams22EtaBins"
-# caloStage2Params.jetCalibrationParams  = jetCalibParamsVector 
-
-
-# vector with 11 parameters for each eta bin
-# each eta bin represented by a new line, starting at first eta bin
-# the first seven parameters of a line are the 7 parameters for the correction function
-# the next four parameters are:
-# 1. the function value at the minimum pt of fit
-# 2. the minimum pt of the fit
-# 3. the function value at the maximum pt of the fit
-# 4. the maximum pt of the fit
-jetCalibParamsVector16 = cms.vdouble()
-jetCalibParamsVector16.extend([ 
-        0.661201, -1.08715e+06, -2.59519e-08, -10.8044, -1.04431e-06, -1.358, 0.830229, 1.9517, 21.7232, 1.11497, 308.136, 
-        0.595461, -242991, -5.38e-08, -31.5184, -8.65299e-06, -0.963764, 0.382539, 2.0419, 22.4169, 1.13073, 304.49, 
-        2.55569, -1.76867e+06, 6.783e-08, -8.05711, -3.97612e-07, -2.83151, 1.1268, 2.00221, 20.7898, 1.14923, 248.034, 
-        2.96018, -4.20761e+06, 7.63023e-08, -2.55568, -9.93322e-08, -6.08005, 1.29864, 2.04699, 17.3628, 1.20751, 193.13, 
-        3.08393, -4.49833e+06, 8.14721e-08, -2.23442, -8.46574e-08, -7.22304, 1.32952, 2.03851, 21.509, 1.19884, 211.281, 
-        2.1004, -2.69476e+06, 4.91209e-08, -4.5254, -2.40174e-07, -3.2305, 1.21127, 1.97181, 16.7042, 1.06621, 273.416, 
-        2.14597, -2.8508e+06, 5.17083e-08, -4.21701, -2.28694e-07, -3.40691, 1.18177, 1.98222, 15.4658, 1.05329, 242.235, 
-        2.35967, -3.55304e+06, 6.32171e-08, -2.95984, -1.3141e-07, -4.07551, 1.21547, 1.83235, 15.7161, 1.03703, 190.26, 
-        0.856007, -364884, -1.29766e-08, -22.9827, -2.11044e-06, -2.01542, 1.02893, 1.76636, 18.165, 1.00783, 273.301, 
-        3.21455, -286314, 3.16865e-07, -19.3786, -1.14632e-06, -4.6408, 1.33054, 1.46451, 21.5884, 0.987992, 246.126, 
-        -2.88427, -21731.7, -1.44395e-06, -106.655, -1.78369e-05, -3.42763, 1.28446, 1.37317, 21.5443, 0.983075, 288.211, 
-        -0.787852, -12400.7, -8.08595e-07, -152.002, -2.55708e-05, -3.91554, 1.28934, 1.27682, 27.3396, 0.962841, 225.501, 
-        -1.90211, -17583.4, -1.16672e-06, -119.776, -8.63159e-06, -7.56003, 1.45489, 1.06435, 36.2542, 0.929621, 112.707, 
-        -74.6452, -258031, -1.76366e-05, -11.9507, -3.53722e-05, -0.493146, 0.593305, 1.11432, 46.5187, 1.03823, 1024, 
-        0.568061, -7606.13, -5.39389e-07, -150.07, 4.85322e-05, -2.42215, 2.07552, 1.11686, 27.012, 0.967464, 1024, 
-        -0.819561, -12223.5, -7.93953e-07, -149.116, -3.22883e-05, -5.31212, 1.26463, 1.23498, 24.8899, 0.840316, 186  
-])
-# this vector corresponds to "functionErf11PtParams16EtaBins"
-caloStage2Params.jetCalibrationParams  = jetCalibParamsVector16
-
+caloStage2Params.jetCalibrationParams  = jetCalibParamsVector 
 
 caloStage2Params.jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress.txt")
-caloStage2Params.jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress.txt")
-caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_add_mult.txt")
+caloStage2Params.jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_30to40_hfHighPt_experiment2_changeLimits_eta.txt")
+caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_30to40_hfHighPt_experiment2_changeLimits_add_mult.txt")
 
 
 # sums: 0=ET, 1=HT, 2=MET, 3=MHT

--- a/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
+++ b/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 def reEmulateLayer2(process):
 
     process.load('L1Trigger/L1TCalorimeter/simCaloStage2Digis_cfi')
-    process.load('L1Trigger/L1TCalorimeter/caloStage2Params_2016_v2_2_cfi')
+    process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi')
 
     process.simCaloStage2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
     

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
@@ -58,9 +58,11 @@ void l1t::Stage2Layer2DemuxJetAlgoFirmwareImp1::processEvent(const std::vector<l
   // convert eta to GT coordinates
   for(auto& jet : outputJets){
 
+    int gtEt = jet.hwPt() == 0xFFFF ? 0x7FF :  jet.hwPt();
     int gtEta = CaloTools::gtEta(CaloTools::mpEta(jet.hwEta()));
     int gtPhi = CaloTools::gtPhi(CaloTools::mpEta(jet.hwEta()),jet.hwPhi());
     
+    jet.setHwPt(gtEt);
     jet.setHwEta(gtEta);
     jet.setHwPhi(gtPhi);
     

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -32,6 +32,7 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   int32_t et(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
   uint32_t met(0), metHF(0), mht(0), mhtHF(0);
   uint32_t mbp0(0), mbm0(0), mbp1(0), mbm1(0);
+  uint32_t ntow(0);
 
   // Add up the x, y and scalar components
   for (std::vector<l1t::EtSum>::const_iterator eSum = inputSums.begin() ; eSum != inputSums.end() ; ++eSum )
@@ -98,6 +99,10 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
 	mbm1 = eSum->hwPt();
 	break;
 
+      case l1t::EtSum::EtSumType::kTowerCount:
+	ntow = eSum->hwPt();
+	break;
+
       default:
         continue; // Should throw an exception or something?
       }
@@ -149,6 +154,7 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   l1t::EtSum etSumMinBiasHFM0(p4,l1t::EtSum::EtSumType::kMinBiasHFM0,mbm0,0,0,0);
   l1t::EtSum etSumMinBiasHFP1(p4,l1t::EtSum::EtSumType::kMinBiasHFP1,mbp1,0,0,0);
   l1t::EtSum etSumMinBiasHFM1(p4,l1t::EtSum::EtSumType::kMinBiasHFM1,mbm1,0,0,0);
+  l1t::EtSum etSumTowCount(p4,l1t::EtSum::EtSumType::kTowerCount,ntow,0,0,0);
 
   outputSums.push_back(etSumTotalEt);
   outputSums.push_back(etSumTotalEtEm);
@@ -161,5 +167,6 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   outputSums.push_back(etSumMinBiasHFM1);
   outputSums.push_back(etSumMissingEtHF);
   outputSums.push_back(htSumMissingHtHF);
+  outputSums.push_back(etSumTowCount);
   
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
@@ -214,7 +214,7 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
       int hOverEBit = egammas_raw.at(iEG).hwQual()>>1 & (0x1);
       int shapeBit  = egammas_raw.at(iEG).hwQual()>>2 & (0x1);
 
-      bool IDcuts = (fgBit && hOverEBit && shapeBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE());
+      bool IDcuts = (fgBit && hOverEBit && shapeBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE()) || (params_->egBypassEGVetos());
 
       if(!IDcuts) continue;
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -157,20 +157,22 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	    int caloEta = CaloTools::caloEta(ieta);
 	    l1t::Jet jet( p4, -999, caloEta, iphi, 0);
 
-	    if (PUSubMethod == "Donut") {
-	      puEt = donutPUEstimate(ieta, iphi, 5, towers);	    
-	      iEt -= puEt;
+	    if(!params_->jetBypassPUS()){
+	      if (PUSubMethod == "Donut") {
+		puEt = donutPUEstimate(ieta, iphi, 5, towers);	    
+		iEt -= puEt;
+	      }
+	      
+	      if (PUSubMethod == "ChunkyDonut"){
+		puEt = chunkyDonutPUEstimate(jet, 5, towers);
+		iEt -= puEt;
+	      }
 	    }
 	    
-	    if (PUSubMethod == "ChunkyDonut"){
-	      puEt = chunkyDonutPUEstimate(jet, 5, towers);
-	      iEt -= puEt;
-	    }
-
 	    if (iEt<=0) continue;
 
 	    // if tower Et is saturated, saturate jet Et
-	    if (seedEt >= 511) iEt = 65535;
+	    if (seedEt >= 509) iEt = 65535;
 
 	    jet.setHwPt(iEt);
 	    jet.setRawEt( (short int) rawEt);
@@ -427,7 +429,7 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
   // use lowest 3 strips as PU estimate
   std::sort( ring.begin(), ring.end() );
   
-  for(unsigned int i=0; i<4; ++i)    jet.setPUDonutEt(i, (short int) ring[i]);
+  for(uint i=0; i<4; ++i)    jet.setPUDonutEt(i, (short int) ring[i]);
     
   return ( ring[0] + ring[1] + ring[2] );
   

--- a/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
+++ b/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
@@ -121,7 +121,7 @@ process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis:EcalTrigger
 process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis")
 
 # emulator ES
-process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v2_2_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi')
 
 # histograms
 process.load('L1Trigger.L1TCalorimeter.l1tStage2CaloAnalyzer_cfi')

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -62,6 +62,7 @@ enum GtConditionType {
     TypeHTT,
     TypeHTM,
     TypeETMHF,
+    TypeTowerCount,
     TypeMinBiasHFP0,
     TypeMinBiasHFM0,
     TypeMinBiasHFP1,

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -323,7 +323,8 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                     condition.getType() == esConditionType::TotalHt ||
 		    condition.getType() == esConditionType::MissingEt ||
 		    condition.getType() == esConditionType::MissingHt ||
-		    condition.getType() == esConditionType::MissingEtHF ||		    
+		    condition.getType() == esConditionType::MissingEtHF ||
+		    condition.getType() == esConditionType::TowerCount ||
 		    condition.getType() == esConditionType::MinBiasHFP0 ||
 		    condition.getType() == esConditionType::MinBiasHFM0 ||
 		    condition.getType() == esConditionType::MinBiasHFP1 ||
@@ -2064,7 +2065,11 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
     else if( condEnergySum.getType() == esConditionType::MissingEtHF ){
       energySumObjType = GlobalObject::gtETMHF;
       cType = TypeETMHF;
-    } 
+    }
+    else if( condEnergySum.getType() == esConditionType::TowerCount ){
+      energySumObjType = GlobalObject::gtTowerCount;
+      cType = TypeTowerCount;
+    }
     else if( condEnergySum.getType() == esConditionType::MinBiasHFP0 ){
       energySumObjType = GlobalObject::gtMinBiasHFP0;
       cType = TypeMinBiasHFP0;
@@ -2293,7 +2298,11 @@ bool l1t::TriggerMenuParser::parseEnergySumCorr(const tmeventsetup::esObject* co
     else if( corrESum->getType()== esObjectType::ETMHF ){
       energySumObjType = GlobalObject::gtETMHF;
       cType = TypeETMHF;
-    } 
+    }
+    else if( corrESum->getType()== esObjectType::TOWERCOUNT ){
+      energySumObjType = GlobalObject::gtTowerCount;
+      cType = TypeTowerCount;
+    }
     else {
       edm::LogError("TriggerMenuParser")
 	<< "Wrong type for energy-sum correclation condition (" << type
@@ -2751,6 +2760,7 @@ bool l1t::TriggerMenuParser::parseCorrelation(
 	  
         } else if(object.getType() == esObjectType::ETM   ||
 	          object.getType() == esObjectType::ETMHF ||
+	          object.getType() == esObjectType::TOWERCOUNT ||
 	          object.getType() == esObjectType::HTM ) {
 	 
 	  // we have Energy Sum
@@ -2771,7 +2781,11 @@ bool l1t::TriggerMenuParser::parseCorrelation(
 	     case esObjectType::ETMHF: { 
 	      objType[jj] = GlobalObject::gtETMHF;
 	     }
-	        break; 		
+	        break;
+	     case esObjectType::TOWERCOUNT: {
+	      objType[jj] = GlobalObject::gtTowerCount;
+	     }
+	        break;
 	      default: {
 	      }
 	        break;			

--- a/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
+++ b/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
@@ -169,6 +169,10 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
     case gtETMHF:
       type = l1t::EtSum::EtSumType::kMissingEtHF;
       MissingEnergy = true;
+      break;
+    case gtTowerCount:
+      type = l1t::EtSum::EtSumType::kTowerCount;
+      MissingEnergy = false;
       break;      
     case gtMinBiasHFP0:
       type = l1t::EtSum::EtSumType::kMinBiasHFP0;

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -304,21 +304,38 @@ void l1t::GlobalBoard::receiveCaloObjectData(edm::Event& iEvent,
 /*  In case we need to split these out
 	          switch ( etsum->getType() ) {
 		     case l1t::EtSum::EtSumType::kMissingEt:
-		       (*m_candETM).push_back(i,&(*etsum));
-		       LogDebug("L1TGlobal") << "ETM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
+		       {
+			 //(*m_candETM).push_back(i,&(*etsum));
+			 LogDebug("L1TGlobal") << "ETM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
+		       }
 		       break; 
 		     case l1t::EtSum::EtSumType::kMissingHt:
-		       (*m_candHTM.push_back(i,&(*etsum);
-		       LogDebug("L1TGlobal") << "HTM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
+		       {
+			 //(*m_candHTM).push_back(i,&(*etsum));
+			 LogDebug("L1TGlobal") << "HTM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
+		       }
 		       break; 		     
 		     case l1t::EtSum::EtSumType::kTotalEt:
-		       (*m_candETT.push_back(i,&(*etsum);
-		       LogDebug("L1TGlobal") << "ETT:  Pt " << etsum->hwPt() << std::endl;
+		       {
+			 //(*m_candETT).push_back(i,&(*etsum));
+			 LogDebug("L1TGlobal") << "ETT:  Pt " << etsum->hwPt() << std::endl;
+		       }
 		       break; 		     
 		     case l1t::EtSum::EtSumType::kTotalHt:
-		       (*m_candHTT.push_back(i,&(*etsum);
-		       LogDebug("L1TGlobal") << "HTT:  Pt " << etsum->hwPt() << std::endl;
-		       break; 		     
+		       {
+			 //(*m_candHTT).push_back(i,&(*etsum));
+			 LogDebug("L1TGlobal") << "HTT:  Pt " << etsum->hwPt() << std::endl;
+		       }
+		       break;
+		     case l1t::EtSum::EtSumType::kTowerCount:
+		       {
+			 //(*m_candTowerCount).push_back(i,&(*etsum));
+			 LogDebug("L1TGlobal") << "TowerCount: " << etsum->hwPt() << std::endl;
+		       }
+		       break;
+		     default:
+		       LogDebug("L1TGlobal") << "Default encounted " << std::endl;
+		       break;
 		  }
 */
 	      
@@ -496,7 +513,7 @@ void l1t::GlobalBoard::runGTL(
 
         iChip++;
 
-       AlgorithmEvaluation::ConditionEvaluationMap& cMapResults =
+	AlgorithmEvaluation::ConditionEvaluationMap& cMapResults =
                m_conditionResultMaps[iChip];
 
 
@@ -683,7 +700,7 @@ void l1t::GlobalBoard::runGTL(
                 }
                     break;
                 case CondNull: {
-
+		  
                     // do nothing
 
                 }

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -110,6 +110,7 @@ const int GlobalCondition::nrObjects() const
         case l1t::TypeHTT:
         case l1t::TypeHTM:
 	case l1t::TypeETMHF:
+	case l1t::TypeTowerCount:
 	case l1t::TypeMinBiasHFP0:
 	case l1t::TypeMinBiasHFM0:
 	case l1t::TypeMinBiasHFP1:
@@ -252,15 +253,22 @@ void GlobalCondition::print(std::ostream& myCout) const
                 myCout << "  Condition type:     " << "TypeHTT"  << std::endl;
             }
 
-            break;
+	    break;
         case l1t::TypeHTM: {
                 myCout << "  Condition type:     " << "TypeHTM"  << std::endl;
             }
 
+	  break;
         case l1t::TypeETMHF: {
                 myCout << "  Condition type:     " << "TypeETMHF"  << std::endl;
             }
 
+	  break;
+        case l1t::TypeTowerCount: {
+	         myCout << "  Condition type:     " << "TypeTowerCount"  << std::endl;
+            }
+
+	  break;
         case l1t::TypeMinBiasHFP0: {
                 myCout << "  Condition type:     " << "TypeMinBiasHFP0"  << std::endl;
             }
@@ -352,6 +360,11 @@ void GlobalCondition::print(std::ostream& myCout) const
                     myCout << " ETMHF ";
                 }
 		
+		break;
+            case l1t::gtTowerCount: {
+                    myCout << " TowerCount ";
+                }
+
 		break;
             case l1t::gtMinBiasHFP0: {
                     myCout << " MinBiasHFP0 ";

--- a/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
@@ -65,6 +65,7 @@ constexpr entry<l1t::GtConditionType> l1GtConditionTypeStringToEnumMap[] = {
         {"l1t::TypeHTT", l1t::TypeHTT},
         {"l1t::TypeHTM", l1t::TypeHTM},
 	{"l1t::TypeETMHF", l1t::TypeETMHF},
+	{"l1t::TypeTowerCount", l1t::TypeTowerCount},
 	{"l1t::TypeMinBiasHFP0", l1t::TypeMinBiasHFP0},
 	{"l1t::TypeMinBiasHFM0", l1t::TypeMinBiasHFM0},
 	{"l1t::TypeMinBiasHFP1", l1t::TypeMinBiasHFP1},


### PR DESCRIPTION
This is a 81X version of #16318, tower-counting algorithm at L1T needed for pPb run.
- Tower-Counting L1T emulator, packer and unpacker for Layer2 and uGT
  - Addition in DataFormat
  - Requires utm library r47119-xsd330-patch (already available in CMSSW_8_1_X_2016-10-22-1100.

Book-keeping note: This is a slim-down and squashed commits addendum derived from l1t-integration-v88.0_CMSSW_8_0_21  (which contains TowrCounting for Layer2)  plus uGT development.
