### PR TITLE
Central skims for pA

### DIFF
--- a/Configuration/Skimming/python/PA_MinBiasSkim_cff.py
+++ b/Configuration/Skimming/python/PA_MinBiasSkim_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltMinBiasHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltMinBiasHI.HLTPaths = ["HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_ForSkim_v*"]
+hltMinBiasHI.throw = False
+hltMinBiasHI.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForMinBias = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),   # otherwise it won't filter the events
+    )
+
+# MinBias skim sequence
+minBiasSkimSequence = cms.Sequence(
+    hltMinBiasHI *
+    primaryVertexFilterForMinBias
+)

--- a/Configuration/Skimming/python/PA_ZEESkim_cff.py
+++ b/Configuration/Skimming/python/PA_ZEESkim_cff.py
@@ -1,8 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#cuts
-ELECTRON_CUT=("pt > 25 && abs(eta)<1.44")
-DIELECTRON_CUT=("mass > 80 && mass < 110")
 
 # HLT dimuon trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
@@ -13,35 +10,35 @@ hltZEEHI.andOr = True
 
 # selection of valid vertex
 primaryVertexFilterForZEE = cms.EDFilter("VertexSelector",
-    src = cms.InputTag("offlinePrimaryVertices"),
-    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
-    filter = cms.bool(True),   # otherwise it won't filter the events
-    )
+                                         src = cms.InputTag("offlinePrimaryVertices"),
+                                         cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+                                         filter = cms.bool(True),   # otherwise it won't filter the events
+                                         )
 
 # single lepton selector
-goodElectrons = cms.EDFilter("GsfElectronRefSelector",
-                                src = cms.InputTag("gedGsfElectrons"),
-                                cut = cms.string(ELECTRON_CUT)
-)
+goodElectronsForZEE = cms.EDFilter("GsfElectronRefSelector",
+                                   src = cms.InputTag("gedGsfElectrons"),
+                                   cut = cms.string("pt > 25 && abs(eta)<1.44")
+                                   )
 
-# dilepton selectors
-diElectrons = cms.EDProducer("CandViewShallowCloneCombiner",
-                             decay       = cms.string("goodElectrons goodElectrons"),
-                             checkCharge = cms.bool(False),
-                             cut         = cms.string(DIELECTRON_CUT)
-)
+## dilepton selectors
+diElectronsForZEE = cms.EDProducer("CandViewShallowCloneCombiner",
+                                   decay       = cms.string("goodElectronsForZEE goodElectronsForZEE"),
+                                   checkCharge = cms.bool(False),
+                                   cut         = cms.string("mass > 80 && mass < 110")
+                                   )
 
 # dilepton counter
-diElectronsFilter = cms.EDFilter("CandViewCountFilter",
-                                    src = cms.InputTag("diElectrons"),
-                                    minNumber = cms.uint32(1)
-)
+diElectronsFilterForZEE = cms.EDFilter("CandViewCountFilter",
+                                       src = cms.InputTag("diElectronsForZEE"),
+                                       minNumber = cms.uint32(1)
+                                       )
 
 # Z->ee skim sequence
 zEESkimSequence = cms.Sequence(
     hltZEEHI *
     primaryVertexFilterForZEE *
-    goodElectrons * 
-    diElectrons * 
-    diElectronsFilter
+    goodElectronsForZEE * 
+    diElectronsForZEE * 
+    diElectronsFilterForZEE
 )

--- a/Configuration/Skimming/python/PA_ZEESkim_cff.py
+++ b/Configuration/Skimming/python/PA_ZEESkim_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+#cuts
+ELECTRON_CUT=("pt > 25 && abs(eta)<1.44")
+DIELECTRON_CUT=("mass > 80 && mass < 110")
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltZEEHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltZEEHI.HLTPaths = ["HLT_PADoublePhoton15_Eta3p1_Mass50_1000_v*"]
+hltZEEHI.throw = False
+hltZEEHI.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForZEE = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),   # otherwise it won't filter the events
+    )
+
+# single lepton selector
+goodElectrons = cms.EDFilter("GsfElectronRefSelector",
+                                src = cms.InputTag("gedGsfElectrons"),
+                                cut = cms.string(ELECTRON_CUT)
+)
+
+# dilepton selectors
+diElectrons = cms.EDProducer("CandViewShallowCloneCombiner",
+                             decay       = cms.string("goodElectrons goodElectrons"),
+                             checkCharge = cms.bool(False),
+                             cut         = cms.string(DIELECTRON_CUT)
+)
+
+# dilepton counter
+diElectronsFilter = cms.EDFilter("CandViewCountFilter",
+                                    src = cms.InputTag("diElectrons"),
+                                    minNumber = cms.uint32(1)
+)
+
+# Z->ee skim sequence
+zEESkimSequence = cms.Sequence(
+    hltZEEHI *
+    primaryVertexFilterForZEE *
+    goodElectrons * 
+    diElectrons * 
+    diElectronsFilter
+)

--- a/Configuration/Skimming/python/PA_ZMMSkim_cff.py
+++ b/Configuration/Skimming/python/PA_ZMMSkim_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltZMMPA = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltZMMPA.HLTPaths = ["HLT_PAL3Mu15_v*"]
+hltZMMPA.throw = False
+hltZMMPA.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForZMM = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),   # otherwise it won't filter the events
+    )
+
+# selection of dimuons with mass in Z range
+muonSelectorForZMM = cms.EDFilter("MuonSelector",
+    src = cms.InputTag("muons"),
+    cut = cms.string("(isTrackerMuon && isGlobalMuon) && pt > 25."),
+    filter = cms.bool(True)
+    )
+
+muonFilterForZMM = cms.EDFilter("MuonCountFilter",
+    src = cms.InputTag("muonSelectorForZMM"),
+    minNumber = cms.uint32(2)
+    )
+
+dimuonMassCutForZMM = cms.EDProducer("CandViewShallowCloneCombiner",
+    checkCharge = cms.bool(True),
+    cut = cms.string(' 80 < mass < 110'),
+    decay = cms.string("muonSelectorForZMM@+ muonSelectorForZMM@-")
+    )
+
+dimuonMassCutFilterForZMM = cms.EDFilter("CandViewCountFilter",
+    src = cms.InputTag("dimuonMassCutForZMM"),
+    minNumber = cms.uint32(1)
+    )
+
+# Z->mumu skim sequence
+zMMSkimSequence = cms.Sequence(
+    hltZMMPA *
+    primaryVertexFilterForZMM *
+    muonSelectorForZMM *
+    muonFilterForZMM *
+    dimuonMassCutForZMM *
+    dimuonMassCutFilterForZMM
+    )

--- a/Configuration/Skimming/python/Skims_PA_cff.py
+++ b/Configuration/Skimming/python/Skims_PA_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.EventContent.EventContentHeavyIons_cff import FEVTEventContent
+
+skimFEVTContent = FEVTEventContent.clone()
+skimFEVTContent.outputCommands.append("drop *_MEtoEDMConverter_*_*")
+skimFEVTContent.outputCommands.append("drop *_*_*_SKIM")
+
+
+#####################
+
+
+from Configuration.Skimming.PA_MinBiasSkim_cff import *
+minBiasSkimPath = cms.Path( minBiasSkimSequence )
+SKIMStreamMinBias = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'MinBias',
+    paths = (minBiasSkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      
+
+
+from Configuration.Skimming.PA_ZEESkim_cff import *
+zEESkimPath = cms.Path( zEESkimSequence )
+SKIMStreamZEE = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'ZEE',
+    paths = (zEESkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      
+
+
+from Configuration.Skimming.PA_ZMMSkim_cff import *
+zMMSkimPath = cms.Path( zMMSkimSequence )
+SKIMStreamZMM = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'ZMM',
+    paths = (zMMSkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      

--- a/Configuration/StandardSequences/python/Skims_cff.py
+++ b/Configuration/StandardSequences/python/Skims_cff.py
@@ -30,3 +30,4 @@ from DPGAnalysis.Skims.Skims_DPG_cff import *
 
 ### Central Skims ###
 from Configuration.Skimming.Skims_PDWG_cff import *
+from Configuration.Skimming.Skims_PA_cff import *


### PR DESCRIPTION
Implemented three central skims for pA production.  

The skims were tested with the following driver command:
cmsDriver.py skims -s SKIM:ZMM+ZEE+MinBias   --filein=file:/afs/cern.ch/work/m/mnguyen/public/skims/step3_RAW2DIGI_L1Reco_RECO.root -n 1000 --conditions auto:run2_mc --python_filename=SKIM.py --processName=SKIM --no_exec

The central skims require the latest pA HLT menu, which is not in existing relval samples. 
To circumvent this, a re-emulation was done for the input file in the above driver.   Because the process name for the re-emulation was TEST, the following customization is needed:

from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
process = MassReplaceInputTag(process,cms.InputTag("TriggerResults","","HLT"),cms.InputTag("TriggerResults","","TEST"))

The size of each of these RAW+RECO skims will be ~100 GB 
I do not see any reason to make this PR in 81X.

@kfjack @kkrajczar 
