### PR TITLE
Small fixes for 2017 TP generation

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -610,7 +610,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             }
 
             for (const auto& detail: details) {
-               if (detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
+               if (idx < int(detail.digi.size()) and detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
                   finegrain[ibin][1] = finegrain[ibin][1] or (detail.digi[idx].adc() > (int) FG_HF_threshold_);
                }
             }

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -52,7 +52,7 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 
    if (ps.exists("parameters")) {
       auto pset = ps.getUntrackedParameter<edm::ParameterSet>("parameters");
-      theAlgo_.overrideParameters(ps);
+      theAlgo_.overrideParameters(pset);
    }
    theAlgo_.setUpgradeFlags(upgrades[0], upgrades[1], upgrades[2]);
 


### PR DESCRIPTION
Two small fixes:
- Protect against missing dataframes when generating TP.
  
  Needed when running on the QIE10 present in 2016 data, where not all depths are present.  Similar code is already in place when forming the energy.
- Fix variable name for overriding parameters correctly.
