### PR TITLE
Digi occupancy vs LS plots for Pixel DQM (80X)

### DIFF
--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -77,6 +77,9 @@ class SiPixelActionExecutor {
 				    DQMStore::IGetter  		 & iGetter);
  void normaliseAvDigiOcc(	    DQMStore::IBooker		 & iBooker,
 				    DQMStore::IGetter		 & iGetter);
+ void normaliseAvDigiOccVsLumi(	    DQMStore::IBooker		 & iBooker,
+				    DQMStore::IGetter		 & iGetter,
+                                    int                            lumisec);
  bool readConfiguration(	    int 			 & tkmap_freq, 
                         	    int 			 & sum_barrel_freq, 
 				    int 			 & sum_endcap_freq, 

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -1655,6 +1655,31 @@ void SiPixelActionExecutor::normaliseAvDigiOcc(DQMStore::IBooker & iBooker, DQMS
 
 //=============================================================================================================
 
+void SiPixelActionExecutor::normaliseAvDigiOccVsLumi(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter, int lumisec){
+
+  iGetter.cd();
+
+  MonitorElement* avgfedDigiOccvsLumi = iGetter.get("Pixel/avgfedDigiOccvsLumi");
+
+  float totalDigisBPIX = 0.; 
+  float totalDigisFPIX = 0.;
+  for (int i = 1; i !=41; i++){
+    if (i < 33) totalDigisBPIX += avgfedDigiOccvsLumi->getBinContent(lumisec,i);
+    else        totalDigisFPIX += avgfedDigiOccvsLumi->getBinContent(lumisec,i);
+  }  
+  float averageBPIXOcc = totalDigisBPIX/32.;
+  float averageFPIXOcc = totalDigisFPIX/8.;
+  for (int i = 1; i !=41; i++){
+    if (i < 33) avgfedDigiOccvsLumi->setBinContent(lumisec,i,avgfedDigiOccvsLumi->getBinContent(lumisec,i)/averageBPIXOcc);
+    else        avgfedDigiOccvsLumi->setBinContent(lumisec,i,avgfedDigiOccvsLumi->getBinContent(lumisec,i)/averageFPIXOcc);
+  }
+
+  iGetter.setCurrentFolder(iBooker.pwd());
+
+}
+
+//=============================================================================================================
+
 void SiPixelActionExecutor::bookEfficiency(DQMStore::IBooker & iBooker, bool isUpgrade){
   // Barrel
   iBooker.cd();

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -207,6 +207,8 @@ void SiPixelEDAClient::dqmEndLuminosityBlock(DQMStore::IBooker & iBooker, DQMSto
   
   edm::LogInfo("SiPixelEDAClient") << "====================================================== " << endl << " ===> Iteration # " << nLumiSecs_ << " " << lumiSeg.luminosityBlock() << endl  << "====================================================== " << endl;
 
+  if(Tier0Flag_) sipixelActionExecutor_->normaliseAvDigiOccVsLumi(iBooker,iGetter,nLumiSecs_);
+
   bool init=true;  
   if(actionOnLumiSec_ && nLumiSecs_ % 1 == 0 ){
 

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -143,6 +143,8 @@
        MonitorElement* noOccROCsEndcap;
        MonitorElement* loOccROCsEndcap;
        MonitorElement* averageDigiOccupancy;
+       MonitorElement* avgBarrelFedOccvsLumi;
+       MonitorElement* avgEndcapFedOccvsLumi;
        MonitorElement* avgfedDigiOccvsLumi;
        MonitorElement* meNDigisCOMBBarrel_;
        MonitorElement* meNDigisCOMBEndcap_;

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -178,6 +178,7 @@ SiPixelDigiSource::endLuminosityBlock(const edm::LuminosityBlock& lb, edm::Event
 	}
 	if (!modOn){
 	  averageDigiOccupancy->Fill(i,nDigisPerFed[i]); //In offline we fill all digis and normalise at the end of the run for thread safe behaviour.
+          avgfedDigiOccvsLumi->setBinContent(thisls, i+1, nDigisPerFed[i]); //Same plot vs lumi section
 	}        
 	if ( modOn ){
 	  if (thisls % 10 == 0)
@@ -185,6 +186,11 @@ SiPixelDigiSource::endLuminosityBlock(const edm::LuminosityBlock& lb, edm::Event
 	  if (avgfedDigiOccvsLumi && thisls % 5 == 0)
 	    avgfedDigiOccvsLumi->setBinContent(int(thisls / 5), i+1, averageOcc); //fill with the mean over 5 lumisections, previous code was filling this histo only with last event of each 10th lumisection
 	}
+      }
+
+      if(modOn && thisls % 10 == 0) {
+        avgBarrelFedOccvsLumi->setBinContent(int(thisls / 10), averageBPIXFed); //<NDigis> vs lumisection for barrel, filled every 10 lumi sections
+        avgEndcapFedOccvsLumi->setBinContent(int(thisls / 10), averageFPIXFed); //<NDigis> vs lumisection for endcap, filled every 10 lumi sections
       }
   }
 }
@@ -794,14 +800,19 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker, const edm::EventSet
   char title6[80];  sprintf(title6, "Number of Low-Efficiency Endcap ROCs;LumiSection;N_{LO EFF} Endcap ROCs");
   loOccROCsEndcap = iBooker.book1D("loOccROCsEndcap",title6,500,0.,5000.);
   char title7[80];  sprintf(title7, "Average digi occupancy per FED;FED;NDigis/<NDigis>");
+  char title8[80];  sprintf(title8, "FED Digi Occupancy (NDigis/<NDigis>) vs LumiSections;Lumi Section;FED");
   if (modOn){
     averageDigiOccupancy = iBooker.bookProfile("averageDigiOccupancy",title7,40,-0.5,39.5,0.,3.);
     averageDigiOccupancy->setLumiFlag();
-    char title4[80]; sprintf(title4, "FED Digi Occupancy (NDigis/<NDigis>) vs LumiSections;Lumi Section;FED");
-    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title4, 640,0., 3200., 40, -0.5, 39.5);
+    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title8, 640,0., 3200., 40, -0.5, 39.5);
+    char title9[80];  sprintf(title9, "Average Barrel FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED");
+    avgBarrelFedOccvsLumi = iBooker.book1D ("avgBarrelFedOccvsLumi", title9, 320,0., 3200.);
+    char title10[80];  sprintf(title10, "Average Endcap FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED");
+    avgEndcapFedOccvsLumi = iBooker.book1D ("avgEndcapFedOccvsLumi", title10, 320,0., 3200.);
   }
   if (!modOn){
     averageDigiOccupancy = iBooker.book1D("averageDigiOccupancy",title7,40,-0.5,39.5); //Book as TH1 for offline to ensure thread-safe behaviour
+    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title8, 3200, 0., 3200., 40, -0.5, 39.5);
   }
   std::map<uint32_t,SiPixelDigiModule*>::iterator struct_iter;
  


### PR DESCRIPTION
Digi occupancy per FED vs LS for offline DQM and average occupancy for BPIX and FPIX FEDs vs LS for online DQM
