### PR TITLE
Change L1 menu for HLT tests with phase1 2017 geometry

### DIFF
--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -64,8 +64,8 @@ hltGTs = {
     'run2_data_PIon'         : ('run2_data_relval'    ,l1Menus['PIon']),
     'run2_data_PRef'         : ('run2_data_relval'    ,l1Menus['PRef']),
     
-    'phase1_2017_design'     : ('phase1_2017_design'   ,l1Menus['GRun']),
-    'phase1_2017_realistic'  : ('phase1_2017_realistic',l1Menus['GRun']),
+    'phase1_2017_design_GRun'     : ('phase1_2017_design'   ,l1Menus['GRun']),
+    'phase1_2017_realistic_GRun'  : ('phase1_2017_realistic',l1Menus['GRun']),
 }
 
 def autoCondHLT(autoCond):

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -63,7 +63,9 @@ hltGTs = {
     'run2_data_HIon'         : ('run2_data'           ,l1Menus['HIon']),
     'run2_data_PIon'         : ('run2_data_relval'    ,l1Menus['PIon']),
     'run2_data_PRef'         : ('run2_data_relval'    ,l1Menus['PRef']),
-
+    
+    'phase1_2017_design'     : ('phase1_2017_design'   ,l1Menus['GRun']),
+    'phase1_2017_realistic'  : ('phase1_2017_realistic',l1Menus['GRun']),
 }
 
 def autoCondHLT(autoCond):


### PR DESCRIPTION
This PR is needed to run the HLT GRun menu with the new phase1 2017 geometry.
It overwrites the L1 menu in the global tag to use the correct one.
