### PR TITLE
Make workspaces in HGCDigitizer only depend on signal size

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <map>
+#include <unordered_set>
 #include <memory>
 #include <tuple>
 
@@ -94,7 +95,7 @@ private :
   std::unique_ptr<HGCHEfrontDigitizer> theHGCHEfrontDigitizer_;
 
   //geometries
-  std::vector<DetId> validIds_;
+  std::unordered_set<DetId> validIds_;
   const HGCalGeometry* gHGCal_;
   const HcalGeometry* gHcal_;
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -15,6 +16,8 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h"
 
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h"
+
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
 namespace hgc = hgc_digi;
 
@@ -34,7 +37,9 @@ class HGCDigitizerBase {
  /**
     @short steer digitization mode
  */
-  void run(std::unique_ptr<DColl> &digiColl, hgc::HGCSimHitDataAccumulator &simData, uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
+  void run(std::unique_ptr<DColl> &digiColl, hgc::HGCSimHitDataAccumulator &simData, 
+	   const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+	   uint32_t digitizationType,CLHEP::HepRandomEngine* engine);
   
   /**
      @short getters
@@ -46,7 +51,9 @@ class HGCDigitizerBase {
   /**
      @short a trivial digitization: sum energies and digitize without noise
    */
-  void runSimple(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  void runSimple(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData, 
+		 const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+		 CLHEP::HepRandomEngine* engine);
   
   /**
      @short prepares the output according to the number of time samples to produce
@@ -56,7 +63,9 @@ class HGCDigitizerBase {
   /**
      @short to be specialized by top class
   */
-  virtual void runDigitizer(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
+  virtual void runDigitizer(std::unique_ptr<DColl> &coll, hgc::HGCSimHitDataAccumulator &simData,
+			    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+			    uint32_t digitizerType, CLHEP::HepRandomEngine* engine)
   {
     throw cms::Exception("HGCDigitizerBaseException") << " Failed to find specialization of runDigitizer";
   }

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
@@ -3,6 +3,18 @@
 
 #include <unordered_map>
 #include <array>
+#include <functional>
+
+#include "DataFormats/DetId/interface/DetId.h"
+
+namespace std {
+  template<>
+  struct hash<DetId> {
+    std::size_t operator()(const DetId& id) const {      
+      return std::hash<uint32_t>()(id.rawId());
+    }
+  };
+}
 
 namespace hgc_digi {
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
@@ -8,7 +8,9 @@ class HGCEEDigitizer : public HGCDigitizerBase<HGCEEDataFrame> {
 
 public:
   HGCEEDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
+		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override; 
   ~HGCEEDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
@@ -9,7 +9,9 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCBHDataFrame>
  public:
 
   HGCHEbackDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
+		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override;
   ~HGCHEbackDigitizer();
 
  private:
@@ -17,7 +19,9 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCBHDataFrame>
   //calice-like digitization parameters
   float keV2MIP_, noise_MIP_;
   float nPEperMIP_, nTotalPE_, xTalk_, sdPixels_;
-  void runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine);
+  void runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, 
+			      const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+			      CLHEP::HepRandomEngine* engine);
 };
 
 #endif 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
@@ -8,7 +8,9 @@ class HGCHEfrontDigitizer : public HGCDigitizerBase<HGCHEDataFrame> {
 
 public:
   HGCHEfrontDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine);
+  void runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,
+		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override;
   ~HGCHEfrontDigitizer();
 private:
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -33,21 +33,20 @@ namespace {
     return geom->getGeometry(id)->getPosition().mag();
   }
 
-  void getValidDetIds(const HGCalGeometry* geom, std::vector<DetId>& valid) {
+  void getValidDetIds(const HGCalGeometry* geom, std::unordered_set<DetId>& valid) {
     const std::vector<DetId>& ids = geom->getValidDetIds();
     valid.reserve(ids.size());
-    valid.insert(valid.end(),ids.begin(),ids.end());
+    valid.insert(ids.begin(),ids.end());
   }
 
-  void getValidDetIds(const HcalGeometry* geom, std::vector<DetId>& valid) {
+  void getValidDetIds(const HcalGeometry* geom, std::unordered_set<DetId>& valid) {
     const std::vector<DetId>& ids = geom->getValidDetIds();
-    valid.reserve(ids.size());
     for( const auto& id : ids ) {
-      if( DetId::Hcal == id.det() && 
-	  HcalEndcap == id.subdetId() ) 
-	valid.emplace_back(id);
+      if( HcalEndcap == id.subdetId() &&
+	  DetId::Hcal == id.det() ) 
+	valid.emplace(id);
     }
-    valid.shrink_to_fit();    
+    valid.reserve(valid.size());
   }
 
   DetId simToReco(const HcalGeometry* geom, unsigned simid) {
@@ -93,41 +92,6 @@ namespace {
     
     return result;
   }  
-
-  void addBaseData(const HcalGeometry* geom,
-		   const DetId& detid,
-		   std::unique_ptr<hgc::HGCSimHitDataAccumulator>& acc ) {
-    //base time samples for each DetId, initialized to 0
-    HGCCellInfo baseData;
-    baseData.hit_info[0].fill(0.f); //accumulated energy
-    baseData.hit_info[1].fill(0.f); //time-of-flight
-    baseData.size = 1.0;
-    baseData.thickness = 1.0;
-    uint32_t id(detid.rawId());
-    acc->emplace(id, baseData);    
-  }
-  
-  void addBaseData(const HGCalGeometry* geom, 
-		   const DetId& detid,
-		   std::unique_ptr<hgc::HGCSimHitDataAccumulator>& acc ) {
-    const auto& topo     = geom->topology();
-    const auto& dddConst = topo.dddConstants();
-    uint32_t id(detid.rawId());
-    int waferTypeL = 0;
-    bool isHalf = false;
-    HGCalDetId hid(id);
-    int wafer = HGCalDetId(id).wafer();
-    waferTypeL = dddConst.waferTypeL(wafer);        
-    isHalf = dddConst.isHalfCell(wafer,hid.cell());
-    //base time samples for each DetId, initialized to 0
-    HGCCellInfo baseData;
-    baseData.hit_info[0].fill(0.f); //accumulated energy
-    baseData.hit_info[1].fill(0.f); //time-of-flight
-    baseData.size = (isHalf ? 0.5 : 1.0);
-    baseData.thickness = waferTypeL;
-    acc->emplace(id, baseData);    
-  }
-
 }
 
 //
@@ -146,7 +110,7 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps,
   verbosity_         = ps.getUntrackedParameter< uint32_t >("verbosity",0);
   tofDelay_          = ps.getParameter< double >("tofDelay");  
   
-  std::vector<DetId>().swap(validIds_);
+  std::unordered_set<DetId>().swap(validIds_);
   
   iC.consumes<std::vector<PCaloHit> >(edm::InputTag("g4SimHits",hitCollection_));
   
@@ -169,75 +133,38 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps,
 //
 void HGCDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& es) 
 {
-  //get geometry
-  edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom);
-  
-  gHGCal_ = nullptr;
-  gHcal_ = nullptr;
-
-  if( producesEEDigis() )      gHGCal_ = dynamic_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
-  if( producesHEfrontDigis() ) gHGCal_ = dynamic_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
-  if( producesHEbackDigis() )  gHcal_  = dynamic_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
-  
-  int nadded(0);  
-  //create workspaces and valid ID lists
-  //add base data for noise simulation (and thicknesses)   
-  if( nullptr != gHGCal_ ) {
-    getValidDetIds( gHGCal_, validIds_ );
-    simHitAccumulator_->reserve(validIds_.size());
-    for(std::vector<DetId>::const_iterator it=validIds_.begin(); it!=validIds_.end(); ++it) {
-      addBaseData(gHGCal_, *it, simHitAccumulator_);
-      ++nadded;
-    }
-  } else if( nullptr != gHcal_ ) {
-    getValidDetIds( gHcal_, validIds_ );
-    simHitAccumulator_->reserve(validIds_.size());
-    for(std::vector<DetId>::const_iterator it=validIds_.begin(); it!=validIds_.end(); ++it) {
-      addBaseData(gHcal_, *it, simHitAccumulator_);
-      ++nadded;
-    }
-  } else {
-    throw cms::Exception("BadConfiguration")
-      << "HGCDigitizer is not producing EE, FH, or BH digis!";
-  }
-
-  if (verbosity_ > 0) 
-    edm::LogInfo("HGCDigitizer") 
-      << "Added " << nadded << ":" << validIds_.size() 
-      << " detIds without " << hitCollection_ 
-      << " in first event processed" << std::endl;
-
-  
 }
 
 //
 void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP::HepRandomEngine* hre)
 {
   
+  const CaloSubdetectorGeometry* theGeom = ( nullptr == gHGCal_ ? 
+					     static_cast<const CaloSubdetectorGeometry*>(gHcal_) : 
+					     static_cast<const CaloSubdetectorGeometry*>(gHGCal_)  );
+
   if( producesEEDigis() ) 
     {
       std::unique_ptr<HGCEEDigiCollection> digiResult(new HGCEEDigiCollection() );
-      theHGCEEDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
+      theHGCEEDigitizer_->run(digiResult,*simHitAccumulator_,theGeom,validIds_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " EE hits";      
       e.put(std::move(digiResult),digiCollection());
     }
   if( producesHEfrontDigis())
     {
       std::unique_ptr<HGCHEDigiCollection> digiResult(new HGCHEDigiCollection() );
-      theHGCHEfrontDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
+      theHGCHEfrontDigitizer_->run(digiResult,*simHitAccumulator_,theGeom,validIds_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " HE front hits";
       e.put(std::move(digiResult),digiCollection());
     }
   if( producesHEbackDigis() )
     {
       std::unique_ptr<HGCBHDigiCollection> digiResult(new HGCBHDigiCollection() );
-      theHGCHEbackDigitizer_->run(digiResult,*simHitAccumulator_,digitizationType_, hre);
+      theHGCHEbackDigitizer_->run(digiResult,*simHitAccumulator_,theGeom,validIds_,digitizationType_, hre);
       edm::LogInfo("HGCDigitizer") << " @ finalize event - produced " << digiResult->size() <<  " HE back hits";
       e.put(std::move(digiResult),digiCollection());
     }
-
-  std::vector<DetId>().swap(validIds_);
+  
   hgc::HGCSimHitDataAccumulator().swap(*simHitAccumulator_);
 }
 
@@ -342,13 +269,15 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
   
   //loop over sorted hits
   nchits = hitRefs.size();
+  simHitAccumulator_->reserve(simHitAccumulator_->size() + nchits);
   for(int i=0; i<nchits; ++i) {
     const int hitidx   = std::get<0>(hitRefs[i]);
     const uint32_t id  = std::get<1>(hitRefs[i]);
 
     //get the data for this cell, if not available then we skip it
-    HGCSimHitDataAccumulator::iterator simHitIt=simHitAccumulator_->find(id);
-    if( simHitIt == simHitAccumulator_->end() ) continue;
+   
+    if( !validIds_.count(id) ) continue;
+    HGCSimHitDataAccumulator::iterator simHitIt = simHitAccumulator_->emplace(id,HGCCellInfo()).first;
 
     if(id==0) continue; // to be ignored at RECO level
 
@@ -377,43 +306,71 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
     float accCharge=(simHitIt->second).hit_info[0][itime];
       
     //time-of-arrival (check how to be used)
-      if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
-      else if((simHitIt->second).hit_info[1][itime]==0)
-	{	
-	  if( accCharge>tdcOnset)
+    if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
+    else if((simHitIt->second).hit_info[1][itime]==0) {	
+      if( accCharge>tdcOnset)
+	{
+	  //extrapolate linear using previous simhit if it concerns to the same DetId
+	  float fireTDC=tof;
+	  if(i>0)
 	    {
-	      //extrapolate linear using previous simhit if it concerns to the same DetId
-	      float fireTDC=tof;
-	      if(i>0)
+	      uint32_t prev_id  = std::get<1>(hitRefs[i-1]);
+	      if(prev_id==id)
 		{
-		  uint32_t prev_id  = std::get<1>(hitRefs[i-1]);
-		  if(prev_id==id)
-		    {
-		      float prev_toa    = std::get<2>(hitRefs[i-1]);
-		      float prev_tof(prev_toa-dist2center/refSpeed_+tofDelay_);
-		      //float prev_charge = std::get<3>(hitRefs[i-1]);
-		      float deltaQ2TDCOnset = tdcOnset-((simHitIt->second).hit_info[0][itime]-charge);
-		      float deltaQ          = charge;
-		      float deltaT          = (tof-prev_tof);
-		      fireTDC               = deltaT*(deltaQ2TDCOnset/deltaQ)+prev_tof;
-		    }		  
-		}
-	      
-	      (simHitIt->second).hit_info[1][itime]=fireTDC;
+		  float prev_toa    = std::get<2>(hitRefs[i-1]);
+		  float prev_tof(prev_toa-dist2center/refSpeed_+tofDelay_);
+		  //float prev_charge = std::get<3>(hitRefs[i-1]);
+		  float deltaQ2TDCOnset = tdcOnset-((simHitIt->second).hit_info[0][itime]-charge);
+		  float deltaQ          = charge;
+		  float deltaT          = (tof-prev_tof);
+		  fireTDC               = deltaT*(deltaQ2TDCOnset/deltaQ)+prev_tof;
+		}		  
 	    }
+	  
+	  (simHitIt->second).hit_info[1][itime]=fireTDC;
 	}
     }
+  }
+  simHitAccumulator_->reserve(simHitAccumulator_->size());
   hitRefs.clear();
 }
 
 //
 void HGCDigitizer::beginRun(const edm::EventSetup & es)
 {
+  //get geometry
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  
+  gHGCal_ = nullptr;
+  gHcal_ = nullptr;
+
+  if( producesEEDigis() )      gHGCal_ = dynamic_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
+  if( producesHEfrontDigis() ) gHGCal_ = dynamic_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
+  if( producesHEbackDigis() )  gHcal_  = dynamic_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
+  
+  int nadded(0);  
+  //valid ID lists
+  if( nullptr != gHGCal_ ) {
+    getValidDetIds( gHGCal_, validIds_ );    
+  } else if( nullptr != gHcal_ ) {
+    getValidDetIds( gHcal_, validIds_ );    
+  } else {
+    throw cms::Exception("BadConfiguration")
+      << "HGCDigitizer is not producing EE, FH, or BH digis!";
+  }
+
+  if (verbosity_ > 0) 
+    edm::LogInfo("HGCDigitizer") 
+      << "Added " << nadded << ":" << validIds_.size() 
+      << " detIds without " << hitCollection_ 
+      << " in first event processed" << std::endl;
 }
 
 //
 void HGCDigitizer::endRun()
 {
+  std::unordered_set<DetId>().swap(validIds_);
 }
 
 //

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -1,6 +1,49 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 using namespace hgc_digi;
+
+namespace {
+  void addCellMetadata(HGCCellInfo& info, 
+		       const HcalGeometry* geom,
+		       const DetId& detid ) {
+    //base time samples for each DetId, initialized to 0
+    info.size = 1.0;
+    info.thickness = 1.0;
+  }
+  
+  void addCellMetadata(HGCCellInfo& info, 
+		       const HGCalGeometry* geom, 
+		       const DetId& detid ) {
+    const auto& topo     = geom->topology();
+    const auto& dddConst = topo.dddConstants();
+    uint32_t id(detid.rawId());
+    int waferTypeL = 0;
+    bool isHalf = false;
+    HGCalDetId hid(id);
+    int wafer = HGCalDetId(id).wafer();
+    waferTypeL = dddConst.waferTypeL(wafer);        
+    isHalf = dddConst.isHalfCell(wafer,hid.cell());
+    //base time samples for each DetId, initialized to 0
+    info.size = (isHalf ? 0.5 : 1.0);
+    info.thickness = waferTypeL;
+  }
+  
+  void addCellMetadata(HGCCellInfo& info,
+		       const CaloSubdetectorGeometry* geom,
+		       const DetId& detid ) {
+    if( DetId::Hcal == detid.det() ) {
+      const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
+      addCellMetadata(info,hc,detid);
+    } else {
+      const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
+      addCellMetadata(info,hg,detid);
+    }
+  }
+  
+}
+
 
 template<class DFr>
 HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) {
@@ -27,30 +70,42 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) {
 
 template<class DFr>
 void HGCDigitizerBase<DFr>::run( std::unique_ptr<HGCDigitizerBase::DColl> &digiColl,
-                                  HGCSimHitDataAccumulator &simData,
-                                  uint32_t digitizationType,
-                                  CLHEP::HepRandomEngine* engine) {
-  if(digitizationType==0) runSimple(digiColl,simData,engine);
-  else                    runDigitizer(digiColl,simData,digitizationType,engine);
+				 HGCSimHitDataAccumulator &simData,
+				 const CaloSubdetectorGeometry* theGeom, 
+				 const std::unordered_set<DetId>& validIds,
+				 uint32_t digitizationType,
+				 CLHEP::HepRandomEngine* engine) {
+  if(digitizationType==0) runSimple(digiColl,simData,theGeom,validIds,engine);
+  else                    runDigitizer(digiColl,simData,theGeom,validIds,digitizationType,engine);
 }
 
 template<class DFr>
 void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &coll,
-                                       HGCSimHitDataAccumulator &simData, 
-                                       CLHEP::HepRandomEngine* engine) {
+				      HGCSimHitDataAccumulator &simData, 
+				      const CaloSubdetectorGeometry* theGeom, 
+				      const std::unordered_set<DetId>& validIds,
+				      CLHEP::HepRandomEngine* engine) {
   HGCSimHitData chargeColl,toa;
-  for(HGCSimHitDataAccumulator::iterator it=simData.begin();
-      it!=simData.end();
-      it++) {
+
+  // this represents a cell with no signal charge
+  HGCCellInfo zeroData;
+  zeroData.hit_info[0].fill(0.f); //accumulated energy
+  zeroData.hit_info[1].fill(0.f); //time-of-flight
+
+  for( const auto& id : validIds ) {
     chargeColl.fill(0.f); 
     toa.fill(0.f);
-    for(size_t i=0; i<it->second.hit_info[0].size(); i++) {
-      double rawCharge((it->second).hit_info[0][i]);
+    HGCSimHitDataAccumulator::iterator it = simData.find(id);    
+    HGCCellInfo& cell = ( simData.end() == it ? zeroData : it->second );
+    addCellMetadata(cell,theGeom,id);
+    
+    for(size_t i=0; i<cell.hit_info[0].size(); i++) {
+      double rawCharge(cell.hit_info[0][i]);
       
       //time of arrival
-      toa[i]=(it->second).hit_info[1][i];
+      toa[i]=cell.hit_info[1][i];
       if(myFEelectronics_->toaMode()==HGCFEElectronics<DFr>::WEIGHTEDBYE && rawCharge>0) 
-        toa[i]=(it->second).hit_info[1][i]/rawCharge;
+        toa[i]=cell.hit_info[1][i]/rawCharge;
       
       //convert total energy in GeV to charge (fC)
       //double totalEn=rawEn*1e6*keV2fC_;
@@ -58,19 +113,19 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &
       
       //add noise (in fC)
       //we assume it's randomly distributed and won't impact ToA measurement
-      totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,it->second.size*noise_fC_[it->second.thickness-1]) , 0.f );
+      totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,cell.size*noise_fC_[cell.thickness-1]) , 0.f );
       if(totalCharge<0.f) totalCharge=0.f;
       
       chargeColl[i]= totalCharge;
     }
     
     //run the shaper to create a new data frame
-    DFr rawDataFrame( it->first );    
-    myFEelectronics_->runShaper(rawDataFrame, chargeColl, toa, it->second.thickness, engine);
+    DFr rawDataFrame( id );    
+    myFEelectronics_->runShaper(rawDataFrame, chargeColl, toa, cell.thickness, engine);
 
     //update the output according to the final shape
     updateOutput(coll,rawDataFrame);
-  }  
+  }   
 }
 
 template<class DFr>

--- a/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCEEDigitizer.cc
@@ -6,7 +6,9 @@ using namespace hgc_digi;
 HGCEEDigitizer::HGCEEDigitizer(const edm::ParameterSet& ps) : HGCDigitizerBase(ps) { }
 
 //
-void HGCEEDigitizer::runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
+void HGCEEDigitizer::runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,
+				  const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+				  uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
 }
 
 //

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -3,9 +3,52 @@
 #include "CLHEP/Random/RandPoissonQ.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+
 #include "vdt/vdtMath.h"
 
 using namespace hgc_digi;
+
+namespace {
+  void addCellMetadata(HGCCellInfo& info, 
+		       const HcalGeometry* geom,
+		       const DetId& detid ) {
+    //base time samples for each DetId, initialized to 0
+    info.size = 1.0;
+    info.thickness = 1.0;
+  }
+  
+  void addCellMetadata(HGCCellInfo& info, 
+		       const HGCalGeometry* geom, 
+		       const DetId& detid ) {
+    const auto& topo     = geom->topology();
+    const auto& dddConst = topo.dddConstants();
+    uint32_t id(detid.rawId());
+    int waferTypeL = 0;
+    bool isHalf = false;
+    HGCalDetId hid(id);
+    int wafer = HGCalDetId(id).wafer();
+    waferTypeL = dddConst.waferTypeL(wafer);        
+    isHalf = dddConst.isHalfCell(wafer,hid.cell());
+    //base time samples for each DetId, initialized to 0
+    info.size = (isHalf ? 0.5 : 1.0);
+    info.thickness = waferTypeL;
+  }
+  
+  void addCellMetadata(HGCCellInfo& info,
+		       const CaloSubdetectorGeometry* geom,
+		       const DetId& detid ) {
+    if( DetId::Hcal == detid.det() ) {
+      const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
+      addCellMetadata(info,hc,detid);
+    } else {
+      const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
+      addCellMetadata(info,hg,detid);
+    }
+  }
+  
+}
 
 //
 HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase(ps)
@@ -21,28 +64,39 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitiz
 }
 
 //
-void HGCHEbackDigitizer::runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine)
+void HGCHEbackDigitizer::runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,
+				      const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+				      uint32_t digitizationType, CLHEP::HepRandomEngine* engine)
 {
-  runCaliceLikeDigitizer(digiColl,simData,engine);
+  runCaliceLikeDigitizer(digiColl,simData,theGeom,validIds,engine);
 }
   
 //
-void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, CLHEP::HepRandomEngine* engine)
+void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData, 
+						const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+						CLHEP::HepRandomEngine* engine)
 {
   //switch to true if you want to print some details
   constexpr bool debug(false);
   
   HGCSimHitData chargeColl;
-  for(HGCSimHitDataAccumulator::iterator it=simData.begin();
-      it!=simData.end();
-      it++)
-    {
-      chargeColl.fill(0.f);      
-      for(size_t i=0; i<it->second.hit_info[0].size(); ++i)
-	{          
-	  //convert total energy keV->MIP, since converted to keV in accumulator
-	  const float totalIniMIPs( (it->second).hit_info[0][i]*keV2MIP_ );
-          //std::cout << "energy in MIP: " << std::scientific << totalIniMIPs << std::endl;
+
+  // this represents a cell with no signal charge
+  HGCCellInfo zeroData;
+  zeroData.hit_info[0].fill(0.f); //accumulated energy
+  zeroData.hit_info[1].fill(0.f); //time-of-flight
+
+  for( const auto& id : validIds ) {
+    chargeColl.fill(0.f); 
+    HGCSimHitDataAccumulator::iterator it = simData.find(id);    
+    HGCCellInfo& cell = ( simData.end() == it ? zeroData : it->second );
+    addCellMetadata(cell,theGeom,id);
+    
+    for(size_t i=0; i<cell.hit_info[0].size(); ++i)
+      {          
+	//convert total energy keV->MIP, since converted to keV in accumulator
+	const float totalIniMIPs( cell.hit_info[0][i]*keV2MIP_ );
+	//std::cout << "energy in MIP: " << std::scientific << totalIniMIPs << std::endl;
 
 	  //generate random number of photon electrons
 	  const uint32_t npe = std::floor(CLHEP::RandPoissonQ::shoot(engine,totalIniMIPs*nPEperMIP_));
@@ -66,12 +120,12 @@ void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollect
           
 	  //add noise (in MIPs)
 	  chargeColl[i] = totalMIPs+std::max( CLHEP::RandGaussQ::shoot(engine,0.,noise_MIP_), 0. );
-	  if(debug && (it->second).hit_info[0][i]>0) 
-	    std::cout << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << (it->second).hit_info[0][i] << " keV -> " << totalIniMIPs << " raw-MIPs -> " << chargeColl[i] << " digi-MIPs" << std::endl;          
+	  if(debug && cell.hit_info[0][i]>0) 
+	    std::cout << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << cell.hit_info[0][i] << " keV -> " << totalIniMIPs << " raw-MIPs -> " << chargeColl[i] << " digi-MIPs" << std::endl;          
 	}	
       
       //init a new data frame and run shaper
-      HGCBHDataFrame newDataFrame( it->first );
+      HGCBHDataFrame newDataFrame( id );
       myFEelectronics_->runTrivialShaper( newDataFrame, chargeColl, 1 );
 
       //prepare the output

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEfrontDigitizer.cc
@@ -7,7 +7,9 @@ HGCHEfrontDigitizer::HGCHEfrontDigitizer(const edm::ParameterSet &ps) : HGCDigit
 }
 
 //
-void HGCHEfrontDigitizer::runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
+void HGCHEfrontDigitizer::runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,
+				       const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
+				       uint32_t digitizationType, CLHEP::HepRandomEngine* engine) {
 }
 
 //


### PR DESCRIPTION
Change the HGCal digitizers such that only bx-vectors that contain signal are stored.
In the case of an empty detid, a single zeroed out bx-vector is used.

This reduces memory in 0 PU from avg 6.4 GB in 4-thread jobs to 2.5 GB.
This reduces memory in 200PU from peak 9.2GB in 4-thread jobs to 7.2 GB.

@slava77 would you mind running your usual tests on this PR to make sure things are OK, despite it being a SIM-only PR. I've checked to make sure everything looks sane but would like some deeper analysis.
