### PR TITLE
Updated Forward Pixel Geometry: flex cables, CF sheet, support arms, cooling tubes

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -20,6 +20,13 @@
 
  <Constant name="ZCylinder"      value="[AnchorZ]"/>
 
+ <Constant name="FlexCableDiskRmin" value="117.35*mm"/>
+ <Constant name="FlexCableDiskRmax" value="167.9*mm"/>
+ <Constant name="FlexCableDiskThickness" value="0.3*mm"/>
+
+ <Constant name="DistanceBetweenDisksAndFlexCable" value="37*mm"/>
+ <Constant name="DistanceBetweenDisksAndFlexCable3" value="36*mm"/>
+
 </ConstantsSection>
 
 <SolidSection label="pixfwd.xml">
@@ -41,6 +48,9 @@
  <ZSection z="-[RootMidZ1]"   rMin="[cms:TrackBeamR11]" rMax="[RootRadius]"/>
  <ZSection z="-[RootStartZ]"  rMin="[cms:TrackBeamR1]"  rMax="[RootRadius]"/>
  </Polycone>
+  
+ <Tubs name="FlexCableDisk" rMin="[FlexCableDiskRmin]" rMax="[FlexCableDiskRmax]" dz="[FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
+
 </SolidSection>
  
 <LogicalPartSection label="pixfwd.xml">
@@ -52,6 +62,11 @@
   <rSolid name="PixelForwardZminus"/>
   <rMaterial name="materials:Air"/>
  </LogicalPart>
+ <LogicalPart name="FlexCableDisk" category="support">
+    <rSolid name="FlexCableDisk"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
+ </LogicalPart>
+
 </LogicalPartSection>
 
 <!-- Position disks inside root -->
@@ -91,6 +106,77 @@
     <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]" />
   </PosPart>
 
+  <PosPart copyNumber="1">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]+[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="2">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]-[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="1">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk1Z]+[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="2">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk1Z]-[DistanceBetweenDisksAndFlexCable3]"/>
+  </PosPart>
+
+  <PosPart copyNumber="3">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]+[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="4">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]-[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="3">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk2Z]+[DistanceBetweenDisksAndFlexCable3]"/>
+  </PosPart>
+
+  <PosPart copyNumber="4">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk2Z]-[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="5">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk3Z]+[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="6">
+    <rParent name="pixfwd:PixelForwardZplus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="[AnchorZ]+[Disk3Z]-[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="5">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]+[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
+
+  <PosPart copyNumber="6">
+    <rParent name="pixfwd:PixelForwardZminus"/>
+    <rChild name="pixfwd:FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]-[DistanceBetweenDisksAndFlexCable]"/>
+  </PosPart>
 
   <PosPart copyNumber="1">
     <rParent name="pixfwd:PixelForwardZplus"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -22,10 +22,7 @@
 
  <Constant name="FlexCableDiskRmin" value="117.35*mm"/>
  <Constant name="FlexCableDiskRmax" value="167.9*mm"/>
- <Constant name="FlexCableDiskThickness" value="0.3*mm"/>
-
- <Constant name="DistanceBetweenDisksAndFlexCable" value="37*mm"/>
- <Constant name="DistanceBetweenDisksAndFlexCable3" value="36*mm"/>
+ <Constant name="FlexCableDiskThickness" value="0.3*mm"/> <!-- This is actually *half* thickness -->
 
 </ConstantsSection>
 
@@ -49,8 +46,6 @@
  <ZSection z="-[RootStartZ]"  rMin="[cms:TrackBeamR1]"  rMax="[RootRadius]"/>
  </Polycone>
   
- <Tubs name="FlexCableDisk" rMin="[FlexCableDiskRmin]" rMax="[FlexCableDiskRmax]" dz="[FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
-
 </SolidSection>
  
 <LogicalPartSection label="pixfwd.xml">
@@ -61,10 +56,6 @@
  <LogicalPart name="PixelForwardZminus" category="envelope">
   <rSolid name="PixelForwardZminus"/>
   <rMaterial name="materials:Air"/>
- </LogicalPart>
- <LogicalPart name="FlexCableDisk" category="support">
-    <rSolid name="FlexCableDisk"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
  </LogicalPart>
 
 </LogicalPartSection>
@@ -104,78 +95,6 @@
     <rParent name="pixfwd:PixelForwardZminus"/>
     <rChild name="pixfwdDisks:PixelForwardDiskZminus"/>
     <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]" />
-  </PosPart>
-
-  <PosPart copyNumber="1">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]+[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="2">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]-[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="1">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk1Z]+[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="2">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk1Z]-[DistanceBetweenDisksAndFlexCable3]"/>
-  </PosPart>
-
-  <PosPart copyNumber="3">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]+[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="4">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]-[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="3">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk2Z]+[DistanceBetweenDisksAndFlexCable3]"/>
-  </PosPart>
-
-  <PosPart copyNumber="4">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk2Z]-[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="5">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk3Z]+[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="6">
-    <rParent name="pixfwd:PixelForwardZplus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="[AnchorZ]+[Disk3Z]-[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="5">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]+[DistanceBetweenDisksAndFlexCable]"/>
-  </PosPart>
-
-  <PosPart copyNumber="6">
-    <rParent name="pixfwd:PixelForwardZminus"/>
-    <rChild name="pixfwd:FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[AnchorZ]-[Disk3Z]-[DistanceBetweenDisksAndFlexCable]"/>
   </PosPart>
 
   <PosPart copyNumber="1">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -22,7 +22,7 @@
 
  <Constant name="FlexCableDiskRmin" value="117.35*mm"/>
  <Constant name="FlexCableDiskRmax" value="167.9*mm"/>
- <Constant name="FlexCableDiskThickness" value="0.3*mm"/> <!-- This is actually *half* thickness -->
+ <Constant name="FlexCableDiskHalfThickness" value="0.15*mm"/>
 
 </ConstantsSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
@@ -63,8 +63,8 @@ root volume plus an anchor point for positioning.
  <Constant name="CylindersServiceZMin" value="[CylindersServiceZoff]"/>
  <Constant name="CylindersServiceZMax" value="[CylindersOuterLength]"/>
 
- <Constant name="CarbonFiberSheetNearIPRmin" value="101.0*mm"/>
  <Constant name="CarbonFiberSheetNearIPRmax" value="168.0*mm"/>
+ <Constant name="CarbonFiberSheetNearIPRmin" value="[CarbonFiberSheetNearIPRmax] - 77.0*mm"/>
  <Constant name="CarbonFiberSheetNearIPThickness" value="0.2*mm"/>
 
  <Constant name="FlexCableDepth" value="0.90*mm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
@@ -68,7 +68,7 @@ root volume plus an anchor point for positioning.
 
  <Constant name="FlexCableDepth" value="0.90*mm"/>
  <Constant name="FlexCableWidth" value="[CylindersPortCardsWidth]"/>
- <Constant name="FlexCableLength" value="440.00*mm"/>
+ <Constant name="FlexCableLength" value="(642*mm-[pixfwdDisks:DiskHalfWidth])"/>
 </ConstantsSection>
  
 
@@ -209,7 +209,7 @@ root volume plus an anchor point for positioning.
 
  <LogicalPart name="PixelForwardFlexCables" category="support">
     <rSolid name="PixelForwardFlexCables"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable3"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable3"/>
  </LogicalPart>
 
 </LogicalPartSection>
@@ -237,10 +237,12 @@ root volume plus an anchor point for positioning.
   <Constant name="PortCardsToIP" value="952.75*mm"/> 
   <Constant name="ZOffCylinder"  value="-325*mm"/>
 
+  <Constant name="FlexCablesToBeam" value="([PortCardsToBeam]-[CylindersPortCardsThickness]/2-[FlexCableDepth])"/>
+
   <Constant name="DiskLocation"  value="[pixfwd:Disk3Z]"/>
 
- <Constant name="SpaceBetweenCableBlocksandDisk3" value="100.00*mm"/>
- <Constant name="Spacing" value="90.0*mm"/>
+ <Constant name="SpaceBetweenCableBlocksandDisk3" value="4*mm"/>
+ <Constant name="Spacing" value="2.0*mm"/>
 
 </ConstantsSection>
 
@@ -460,62 +462,62 @@ root volume plus an anchor point for positioning.
    <PosPart copyNumber="1">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardCarbonFiberSheetNearIP"/>
-         <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[Spacing]"/>
+         <Translation x="0." y="0." z="[pixfwd:Disk1Z] - [pixfwdDisks:DiskHalfWidth] - [Spacing]"/>
       </PosPart>
 
    <PosPart copyNumber="1">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="[FlexCablesToBeam]*cos([PortCardsAngle2])" y="[FlexCablesToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot1"/>
       </PosPart>
 
    <PosPart copyNumber="2">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="[FlexCablesToBeam]*cos([PortCardsAngle1])" y="[FlexCablesToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot2"/>
       </PosPart>
 
    <PosPart copyNumber="3">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="[FlexCablesToBeam]*cos([PortCardsAngle1])" y="-[FlexCablesToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot3"/>
       </PosPart>
 
    <PosPart copyNumber="4">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="[FlexCablesToBeam]*cos([PortCardsAngle2])" y="-[FlexCablesToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot4"/>
       </PosPart>
 
    <PosPart copyNumber="5">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="-[FlexCablesToBeam]*cos([PortCardsAngle2])" y="[FlexCablesToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot5"/>
       </PosPart>
 
    <PosPart copyNumber="6">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="-[FlexCablesToBeam]*cos([PortCardsAngle1])" y="[FlexCablesToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot6"/>
       </PosPart>
 
    <PosPart copyNumber="7">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="-[FlexCablesToBeam]*cos([PortCardsAngle1])" y="-[FlexCablesToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot7"/>
       </PosPart>
 
    <PosPart copyNumber="8">
          <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
          <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
-         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <Translation x="-[FlexCablesToBeam]*cos([PortCardsAngle2])" y="-[FlexCablesToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
          <rRotation name="pixfwdCylinder:PortCardsRot8"/>
       </PosPart>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
@@ -61,6 +61,14 @@ root volume plus an anchor point for positioning.
  <Constant name="CylindersServiceZ0"   value="0*mm"/>
  <Constant name="CylindersServiceZMin" value="[CylindersServiceZoff]"/>
  <Constant name="CylindersServiceZMax" value="[CylindersOuterLength]"/>
+
+ <Constant name="CarbonFiberSheetNearIPRmin" value="101.0*mm"/>
+ <Constant name="CarbonFiberSheetNearIPRmax" value="168.0*mm"/>
+ <Constant name="CarbonFiberSheetNearIPThickness" value="0.2*mm"/>
+
+ <Constant name="FlexCableDepth" value="0.90*mm"/>
+ <Constant name="FlexCableWidth" value="[CylindersPortCardsWidth]"/>
+ <Constant name="FlexCableLength" value="440.00*mm"/>
 </ConstantsSection>
  
 
@@ -123,13 +131,17 @@ root volume plus an anchor point for positioning.
   <Tubs name="PixelForwardCylinderElectronics4" rMin="[CylindersElectronicsRmin]" rMax="[CylindersElectronicsRmax]" dz="[CylindersElectronicsLength]/2." startPhi="203.675*deg" deltaPhi="33.57*deg"/>
 
 
-  <Box name="PixelForwardCylindersCoilFiber" dx="[CylindersCoilFiberWidth]/2." dy="[CylindersCoilFiberThickness]/2." dz="[CylindersCoilFiberLength]/2."/>
+  <Box name="PixelForwardCylindersCoilFiber" dx="[CylindersCoilFiberWidth]/2." dy="[CylindersCoilFiberThickness]/2." dz="([CylindersServiceZMax]-[CylindersElectronicsLength]-[CoilFiblerToIP]-[ZOffCylinder]+[CylindersCoilFiberLength]/2.)/2."/>
 
   <Tubs name="PixelForwardCylinderPipe1" rMin="[CylinderPipeRmin]" rMax="[CylinderPipeRmax]" dz="[CylinderPipeLength1]/2." startPhi="0." deltaPhi="360*deg"/>
 
   <Tubs name="PixelForwardCylinderPipe2" rMin="[CylinderPipeRmin]" rMax="[CylinderPipeRmax]" dz="[CylinderPipeLength2]/2." startPhi="0." deltaPhi="360*deg"/>
 
   <Box name="PixelForwardCylindersPortCards1" dx="[CylindersPortCardsWidth]/2." dy="[CylindersPortCardsThickness]/2." dz="[CylindersPortCardsLength1]/2."/>
+
+  <Tubs name="PixelForwardCarbonFiberSheetNearIP" rMin="[CarbonFiberSheetNearIPRmin]" rMax="[CarbonFiberSheetNearIPRmax]" dz="[CarbonFiberSheetNearIPThickness]/2" startPhi="0." deltaPhi="360*deg"/>
+
+  <Box name="PixelForwardFlexCables" dx="[FlexCableWidth]/2" dy="[FlexCableDepth]/2" dz="[FlexCableLength]/2"/>
 
 </SolidSection>
  
@@ -190,6 +202,15 @@ root volume plus an anchor point for positioning.
     <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards_Phase1"/>
  </LogicalPart>
 
+ <LogicalPart name="PixelForwardCarbonFiberSheetNearIP" category="support">
+    <rSolid name="PixelForwardCarbonFiberSheetNearIP"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_Servi_Cylind"/>
+ </LogicalPart>
+
+ <LogicalPart name="PixelForwardFlexCables" category="support">
+    <rSolid name="PixelForwardFlexCables"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable3"/>
+ </LogicalPart>
 
 </LogicalPartSection>
 
@@ -215,6 +236,12 @@ root volume plus an anchor point for positioning.
 
   <Constant name="PortCardsToIP" value="952.75*mm"/> 
   <Constant name="ZOffCylinder"  value="-325*mm"/>
+
+  <Constant name="DiskLocation"  value="[pixfwd:Disk3Z]"/>
+
+ <Constant name="SpaceBetweenCableBlocksandDisk3" value="100.00*mm"/>
+ <Constant name="Spacing" value="90.0*mm"/>
+
 </ConstantsSection>
 
 
@@ -252,28 +279,28 @@ root volume plus an anchor point for positioning.
    <PosPart copyNumber="1">
      <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
      <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
-     <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+     <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CylindersServiceZMax]-[CylindersElectronicsLength]-([CylindersServiceZMax]-[CylindersElectronicsLength]-[CoilFiblerToIP]-[ZOffCylinder]+[CylindersCoilFiberLength]/2.)/2."/>
      <rRotation name="pixfwdCylinder:CoilFiberRot1"/>
    </PosPart>
 
    <PosPart copyNumber="2">
      <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
      <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
-     <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+     <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CylindersServiceZMax]-[CylindersElectronicsLength]-([CylindersServiceZMax]-[CylindersElectronicsLength]-[CoilFiblerToIP]-[ZOffCylinder]+[CylindersCoilFiberLength]/2.)/2."/>
      <rRotation name="pixfwdCylinder:CoilFiberRot2"/>
    </PosPart>
 
    <PosPart copyNumber="3">
      <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
      <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
-     <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+     <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CylindersServiceZMax]-[CylindersElectronicsLength]-([CylindersServiceZMax]-[CylindersElectronicsLength]-[CoilFiblerToIP]-[ZOffCylinder]+[CylindersCoilFiberLength]/2.)/2."/>
      <rRotation name="pixfwdCylinder:CoilFiberRot3"/>
    </PosPart>
 
    <PosPart copyNumber="4">
      <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
      <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
-     <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+     <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CylindersServiceZMax]-[CylindersElectronicsLength]-([CylindersServiceZMax]-[CylindersElectronicsLength]-[CoilFiblerToIP]-[ZOffCylinder]+[CylindersCoilFiberLength]/2.)/2."/>
      <rRotation name="pixfwdCylinder:CoilFiberRot4"/>
    </PosPart>
 
@@ -430,6 +457,67 @@ root volume plus an anchor point for positioning.
          <rRotation name="pixfwdCylinder:PortCardsRot8"/>
       </PosPart>
 
+   <PosPart copyNumber="1">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardCarbonFiberSheetNearIP"/>
+         <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[Spacing]"/>
+      </PosPart>
+
+   <PosPart copyNumber="1">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot1"/>
+      </PosPart>
+
+   <PosPart copyNumber="2">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot2"/>
+      </PosPart>
+
+   <PosPart copyNumber="3">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot3"/>
+      </PosPart>
+
+   <PosPart copyNumber="4">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot4"/>
+      </PosPart>
+
+   <PosPart copyNumber="5">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot5"/>
+      </PosPart>
+
+   <PosPart copyNumber="6">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot6"/>
+      </PosPart>
+
+   <PosPart copyNumber="7">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot7"/>
+      </PosPart>
+
+   <PosPart copyNumber="8">
+         <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+         <rChild name="pixfwdCylinder:PixelForwardFlexCables"/>
+         <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:Disk3Z]+[FlexCableLength]/2+[SpaceBetweenCableBlocksandDisk3]"/>
+         <rRotation name="pixfwdCylinder:PortCardsRot8"/>
+      </PosPart>
 
 </PosPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml
@@ -56,9 +56,10 @@ root volume plus an anchor point for positioning.
  <Constant name="CylindersPortCardsLength1" value="533.7*mm"/><!--523.0 mm-->
  <Constant name="CylindersPortCardsThickness" value="18.9*mm"/><!--5.40 mm-->
 
- <Constant name="CylindersServiceZoff" value="320.0*mm"/>
+ <Constant name="CylindersServiceZoff" value="[pixfwd:AnchorZ]+[pixfwd:Disk3Z]+[pixfwdDisks:DiskHalfWidth]"/>
  <Constant name="CylindersServiceRmin" value="100*mm"/>
  <Constant name="CylindersServiceZ0"   value="0*mm"/>
+ <Constant name="CylindersServiceZext"   value="-4*mm"/>
  <Constant name="CylindersServiceZMin" value="[CylindersServiceZoff]"/>
  <Constant name="CylindersServiceZMax" value="[CylindersOuterLength]"/>
 
@@ -111,6 +112,8 @@ root volume plus an anchor point for positioning.
 <SolidSection label="Cylinders">
 
  <Polycone name="PixelForwardServiceCylinder" startPhi="0*deg" deltaPhi="360*deg">
+  <ZSection z="[CylindersServiceZext]" rMin="[CarbonFiberSheetNearIPRmin]" rMax="[CylindersOuterRmax]"/>
+  <ZSection z="[CylindersServiceZ0]"   rMin="[CarbonFiberSheetNearIPRmin]" rMax="[CylindersOuterRmax]"/>
   <ZSection z="[CylindersServiceZ0]"   rMin="[CylindersOuterRmin]"   rMax="[CylindersOuterRmax]"/>
   <ZSection z="[CylindersServiceZMin]" rMin="[CylindersOuterRmin]"   rMax="[CylindersOuterRmax]"/>
   <ZSection z="[CylindersServiceZMin]" rMin="[CylindersServiceRmin]" rMax="[CylindersOuterRmax]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
@@ -102,11 +102,11 @@
  </LogicalPart>
  <LogicalPart name="CoolingTubeToInnerDisk" category="support">
     <rSolid name="CoolingTubeToInnerDisk"/>
-    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube_inner"/>
  </LogicalPart>
  <LogicalPart name="CoolingTubeToOuterDisk" category="support">
     <rSolid name="CoolingTubeToOuterDisk"/>
-    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube_outer"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
@@ -12,7 +12,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskOuterRing"/> 
-  <String  name="Material"         value="materials:C_C_InnerOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_InnerOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingRMax]"/>
@@ -23,7 +23,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskCFOuterRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_InnerOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_InnerOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]"/>
@@ -34,7 +34,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskInnerRing"/> 
-  <String  name="Material"         value="materials:C_C_InnerInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_InnerInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingRMax]"/>
@@ -45,7 +45,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskCFInnerRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_InnerInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_InnerInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingCFRMax]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
@@ -75,4 +75,61 @@
  <String  name="FlagString"      value="YYYYYYYYYYYYYYYYYYYYYY"/>
 </Algorithm>
 
+<!-- Support/Cooling -->
+
+<SolidSection label="pixfwdInnerDiskZminus.xml">
+ <Polycone name="SupportArm" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]" rMin="0*mm" rMax="5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="3.5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]-1*mm" rMin="0*mm" rMax="3.5*mm"/>
+ </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="pixfwdInnerDiskZplus.xml">
+ <LogicalPart name="SupportArm" category="support">
+    <rSolid name="SupportArm"/>
+    <rMaterial name="pixfwdMaterials:CF_SupportArm"/>
+ </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="pixfwdInnerDiskZplus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm1a"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm2a"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm3a"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm1b"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="5">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm2b"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="6">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm3b"/>
+    <Translation x="0." y="0." z="-[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+</PosPartSection>
+
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml
@@ -78,6 +78,15 @@
 <!-- Support/Cooling -->
 
 <SolidSection label="pixfwdInnerDiskZminus.xml">
+ <!-- Polycone here to make placement easier (origin stays at r=0) -->
+ <Polycone name="CoolingTubeToInnerDisk" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskInnerRingRMax]" rMin="0*mm" rMax="1*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]-1*mm" rMin="0*mm" rMax="1*mm"/>
+ </Polycone>
+ <Polycone name="CoolingTubeToOuterDisk" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskInnerRingRMax]+5*mm" rMin="0*mm" rMax="1*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingRMin]-1*mm" rMin="0*mm" rMax="1*mm"/>
+ </Polycone>
  <Polycone name="SupportArm" startPhi="0." deltaPhi="360*deg" >
    <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]" rMin="0*mm" rMax="5*mm"/>
    <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="5*mm"/>
@@ -91,9 +100,67 @@
     <rSolid name="SupportArm"/>
     <rMaterial name="pixfwdMaterials:CF_SupportArm"/>
  </LogicalPart>
+ <LogicalPart name="CoolingTubeToInnerDisk" category="support">
+    <rSolid name="CoolingTubeToInnerDisk"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+ </LogicalPart>
+ <LogicalPart name="CoolingTubeToOuterDisk" category="support">
+    <rSolid name="CoolingTubeToOuterDisk"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+ </LogicalPart>
 </LogicalPartSection>
 
 <PosPartSection label="pixfwdInnerDiskZplus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="+4*mm" z="-[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-4*mm" z="-[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+4*mm" z="-[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="-4*mm" z="-[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-5*mm" z="-[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-12*mm" z="-[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+5*mm" z="-[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+12*mm" z="-[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+
   <PosPart copyNumber="1">
     <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
     <rChild name="SupportArm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
@@ -75,4 +75,61 @@
  <String  name="FlagString"      value="YYYYYYYYYYYYYYYYYYYYYY"/>
 </Algorithm>
 
+<!-- Support/Cooling -->
+
+<SolidSection label="pixfwdInnerDiskZplus.xml">
+ <Polycone name="SupportArm" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]" rMin="0*mm" rMax="5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="3.5*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]-1*mm" rMin="0*mm" rMax="3.5*mm"/>
+ </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="pixfwdInnerDiskZplus.xml">
+ <LogicalPart name="SupportArm" category="support">
+    <rSolid name="SupportArm"/>
+    <rMaterial name="pixfwdMaterials:CF_SupportArm"/>
+ </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="pixfwdInnerDiskZplus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm1a"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm2a"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm3a"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm1b"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="5">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm2b"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+  <PosPart copyNumber="6">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="SupportArm"/>
+    <rRotation name="pixfwdSupportRingParameters:rArm3b"/>
+    <Translation x="0." y="0." z="[pixfwdSupportRingParameters:SupportArmZ]"/>
+  </PosPart>
+</PosPartSection>
+
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
@@ -78,6 +78,15 @@
 <!-- Support/Cooling -->
 
 <SolidSection label="pixfwdInnerDiskZplus.xml">
+ <!-- Polycone here to make placement easier (origin stays at r=0) -->
+ <Polycone name="CoolingTubeToInnerDisk" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:InnerDiskInnerRingRMax]" rMin="0*mm" rMax="1*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]-1*mm" rMin="0*mm" rMax="1*mm"/>
+ </Polycone>
+ <Polycone name="CoolingTubeToOuterDisk" startPhi="0." deltaPhi="360*deg" >
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskInnerRingRMax]+5*mm" rMin="0*mm" rMax="1*mm"/>
+   <ZSection z="[pixfwdSupportRingParameters:OuterDiskOuterRingRMin]-1*mm" rMin="0*mm" rMax="1*mm"/>
+ </Polycone>
  <Polycone name="SupportArm" startPhi="0." deltaPhi="360*deg" >
    <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]" rMin="0*mm" rMax="5*mm"/>
    <ZSection z="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]+9.5*mm" rMin="0*mm" rMax="5*mm"/>
@@ -87,6 +96,14 @@
 </SolidSection>
 
 <LogicalPartSection label="pixfwdInnerDiskZplus.xml">
+ <LogicalPart name="CoolingTubeToInnerDisk" category="support">
+    <rSolid name="CoolingTubeToInnerDisk"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+ </LogicalPart>
+ <LogicalPart name="CoolingTubeToOuterDisk" category="support">
+    <rSolid name="CoolingTubeToOuterDisk"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+ </LogicalPart>
  <LogicalPart name="SupportArm" category="support">
     <rSolid name="SupportArm"/>
     <rMaterial name="pixfwdMaterials:CF_SupportArm"/>
@@ -94,6 +111,56 @@
 </LogicalPartSection>
 
 <PosPartSection label="pixfwdInnerDiskZplus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="+4*mm" z="[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-4*mm" z="[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+4*mm" z="[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToInnerDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="-4*mm" z="[pixfwdSupportRingParameters:CoolingZ_inner]"/>
+  </PosPart>
+
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-5*mm" z="[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_a"/>
+    <Translation x="0." y="-12*mm" z="[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+5*mm" z="[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="CoolingTubeToOuterDisk"/>
+    <rRotation name="pixfwdSupportRingParameters:rCooling_b"/>
+    <Translation x="0." y="+12*mm" z="[pixfwdSupportRingParameters:CoolingZ_outer]"/>
+  </PosPart>
+
   <PosPart copyNumber="1">
     <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
     <rChild name="SupportArm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
@@ -12,7 +12,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskOuterRing"/> 
-  <String  name="Material"         value="materials:C_C_InnerOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_InnerOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingRMax]"/>
@@ -23,7 +23,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskCFOuterRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_InnerOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_InnerOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]"/>
@@ -34,7 +34,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskInnerRing"/> 
-  <String  name="Material"         value="materials:C_C_InnerInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_InnerInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingRMax]"/>
@@ -45,7 +45,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardInnerDiskCFInnerRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_InnerInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_InnerInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:InnerDiskInnerRingCFRMax]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml
@@ -98,11 +98,11 @@
 <LogicalPartSection label="pixfwdInnerDiskZplus.xml">
  <LogicalPart name="CoolingTubeToInnerDisk" category="support">
     <rSolid name="CoolingTubeToInnerDisk"/>
-    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube_inner"/>
  </LogicalPart>
  <LogicalPart name="CoolingTubeToOuterDisk" category="support">
     <rSolid name="CoolingTubeToOuterDisk"/>
-    <rMaterial name="pixfwdMaterials:DiskCoolingTube"/>
+    <rMaterial name="pixfwdMaterials:DiskCoolingTube_outer"/>
  </LogicalPart>
  <LogicalPart name="SupportArm" category="support">
     <rSolid name="SupportArm"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -552,7 +552,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="DiskCoolingTube" density="2.55*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="DiskCoolingTubeSteel" density="8*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.0005">
     <rMaterial name="materials:Carbon"/>
    </MaterialFraction>
@@ -569,6 +569,19 @@
     <rMaterial name="materials:Iron"/>
    </MaterialFraction>
   </CompositeMaterial> 
+
+  <CompositeMaterial name="DiskCoolingTube_inner" density="2.45*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="pixfwdMaterials:DiskCoolingTubeSteel"/>
+    </MaterialFraction>
+    <!-- TODO: some coolant (CO2) mssing -->
+  </CompositeMaterial>
+  <CompositeMaterial name="DiskCoolingTube_outer" density="2.618*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="pixfwdMaterials:DiskCoolingTubeSteel"/>
+    </MaterialFraction>
+    <!-- TODO: some coolant (CO2) mssing -->
+  </CompositeMaterial>
 
 
   <!-- Support ring materials. -->
@@ -605,7 +618,7 @@
     <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.122">
-    <rMaterial name="DiskCoolingTube"/>
+    <rMaterial name="DiskCoolingTubeSteel"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
@@ -613,7 +626,7 @@
     <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.141">
-    <rMaterial name="DiskCoolingTube"/>
+    <rMaterial name="DiskCoolingTubeSteel"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
@@ -621,7 +634,7 @@
     <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.075">
-    <rMaterial name="DiskCoolingTube"/>
+    <rMaterial name="DiskCoolingTubeSteel"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
@@ -629,7 +642,7 @@
     <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.111">
-    <rMaterial name="DiskCoolingTube"/>
+    <rMaterial name="DiskCoolingTubeSteel"/>
    </MaterialFraction>
   </CompositeMaterial>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -315,7 +315,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFelxCable" density="2.463*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable" density="2.463*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>
@@ -324,13 +324,13 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFelxCable2" density="1.311*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="1.311*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.000">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFelxCable3" density="6.615*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable3" density="3.3075*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.000">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -324,6 +324,18 @@
     </MaterialFraction>
   </CompositeMaterial>
 
+  <CompositeMaterial name="Pix_Fwd_AluFelxCable2" density="1.311*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AluFelxCable3" density="6.615*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
  
   <!-- Material used by the Simplified Forward Pixel Service Cylinder -->  
 
@@ -399,7 +411,7 @@
      </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.58559*g/cm3" symbol=" " method="mixture by weight">
+ <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.58559*g/cm3" symbol=" " method="mixture by weight">
      <MaterialFraction fraction="0.4518">
         <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
      </MaterialFraction>
@@ -424,7 +436,7 @@
      <MaterialFraction fraction="0.0028">
         <rMaterial name="materials:Silicon"/>
      </MaterialFraction>
-  </CompositeMaterial>
+   </CompositeMaterial>
 
   <CompositeMaterial name="Pix_Fwd_End_Pipe_1" density="1.31175*g/cm3" symbol=" " method="mixture by weight">
      <MaterialFraction fraction="0.65867">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -315,7 +315,6 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <!-- TODO: check densities. All 3 materials describe the same cable, but density has to vary due to smearing. -->
   <CompositeMaterial name="Pix_Fwd_AluFlexCable" density="2.463*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
@@ -325,7 +324,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="1.311*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="0.16*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>
@@ -334,7 +333,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFlexCable3" density="3.3075*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable3" density="2.55*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>
@@ -376,7 +375,7 @@
      </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_End_Electro_1" density="0.29369*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_End_Electro_1" density="0.558011*g/cm3" symbol=" " method="mixture by weight">
      <MaterialFraction fraction="0.34432">
        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
      </MaterialFraction>
@@ -397,7 +396,7 @@
      </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_End_Electro_2" density="0.27714*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_End_Electro_2" density="0.52653*g/cm3" symbol=" " method="mixture by weight">
      <MaterialFraction fraction="0.35884">
        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
      </MaterialFraction>
@@ -418,7 +417,7 @@
      </MaterialFraction>
   </CompositeMaterial>
 
- <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.58559*g/cm3" symbol=" " method="mixture by weight">
+ <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.39821*g/cm3" symbol=" " method="mixture by weight">
      <MaterialFraction fraction="0.4518">
         <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
      </MaterialFraction>
@@ -502,7 +501,7 @@
       <rMaterial name="materials:Silicon"/>
     </MaterialFraction>
   </CompositeMaterial>
-    <CompositeMaterial name="Pix_Fwd_Port_Cards_Phase1" density="1.23490*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="Pix_Fwd_Port_Cards_Phase1" density="0.7938*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.53523">
         <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
       </MaterialFraction>
@@ -530,8 +529,7 @@
     </CompositeMaterial>
 
 
-  <CompositeMaterial name="CF_SupportArm" density="1.495*g/cm3" symbol=" " method="mixture by weight">
-    <!-- TODO: check density, mixture -->
+  <CompositeMaterial name="FPix_Disk_CF" density="1.495*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.7498836">
       <rMaterial name="materials:Carbon"/>
     </MaterialFraction>
@@ -543,8 +541,18 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="DiskCoolingTube" density="1.5*g/cm3" symbol=" " method="mixture by weight">
-   <!-- TODO: add coolant (CO2), use correct mixture (atm stolen from barrel), adjust density -->
+
+  <CompositeMaterial name="CF_SupportArm" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.61">
+      <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+    </MaterialFraction>
+    <!-- TODO: some sort of steel -->
+    <MaterialFraction fraction="0.39">
+      <rMaterial name="materials:Iron"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="DiskCoolingTube" density="2.55*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.0005">
     <rMaterial name="materials:Carbon"/>
    </MaterialFraction>
@@ -554,7 +562,10 @@
    <MaterialFraction fraction="0.1">
     <rMaterial name="materials:Nickel"/>
    </MaterialFraction>
-   <MaterialFraction fraction="0.7195">
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Molybdenum"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.6995">
     <rMaterial name="materials:Iron"/>
    </MaterialFraction>
   </CompositeMaterial> 
@@ -562,61 +573,62 @@
 
   <!-- Support ring materials. -->
   
-  <!-- TODO: density, mixture -->
   <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00">
-    <rMaterial name="materials:Carbon"/>
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00">
-    <rMaterial name="materials:Carbon"/>
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00">
-    <rMaterial name="materials:Carbon"/>
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00">
-    <rMaterial name="materials:Carbon"/>
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="1.00">
-    <rMaterial name="materials:Carbon"/>
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
   </CompositeMaterial>
 
 
-  <!-- TODO: density, mixture -->
   <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
-   <MaterialFraction fraction="0.9">
-    <rMaterial name="materials:Carbon"/>
+   <MaterialFraction fraction="0.878">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.122">
+    <rMaterial name="DiskCoolingTube"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
-   <MaterialFraction fraction="0.9">
-    <rMaterial name="materials:Carbon"/>
+   <MaterialFraction fraction="0.859">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
-   <MaterialFraction fraction="0.1">
+   <MaterialFraction fraction="0.141">
     <rMaterial name="DiskCoolingTube"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
-   <MaterialFraction fraction="0.9">
-    <rMaterial name="materials:Carbon"/>
+   <MaterialFraction fraction="0.925">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
-   <MaterialFraction fraction="0.1">
+   <MaterialFraction fraction="0.075">
     <rMaterial name="DiskCoolingTube"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
-   <MaterialFraction fraction="0.9">
-    <rMaterial name="materials:Carbon"/>
+   <MaterialFraction fraction="0.889">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
    </MaterialFraction>
-   <MaterialFraction fraction="0.1">
+   <MaterialFraction fraction="0.111">
     <rMaterial name="DiskCoolingTube"/>
    </MaterialFraction>
   </CompositeMaterial>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -315,6 +315,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
+  <!-- TODO: check densities. All 3 materials describe the same cable, but density has to vary due to smearing. -->
   <CompositeMaterial name="Pix_Fwd_AluFlexCable" density="2.463*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
@@ -325,14 +326,20 @@
   </CompositeMaterial>
 
   <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="1.311*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="1.000">
+    <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.6015">
+      <rMaterial name="materials:Kapton"/>
     </MaterialFraction>
   </CompositeMaterial>
 
   <CompositeMaterial name="Pix_Fwd_AluFlexCable3" density="3.3075*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="1.000">
+    <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.6015">
+      <rMaterial name="materials:Kapton"/>
     </MaterialFraction>
   </CompositeMaterial>
 
@@ -524,6 +531,7 @@
 
 
   <CompositeMaterial name="CF_SupportArm" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <!-- TODO: check density, mixture -->
     <MaterialFraction fraction="0.7498836">
       <rMaterial name="materials:Carbon"/>
     </MaterialFraction>
@@ -550,5 +558,68 @@
     <rMaterial name="materials:Iron"/>
    </MaterialFraction>
   </CompositeMaterial> 
+
+
+  <!-- Support ring materials. -->
+  
+  <!-- TODO: density, mixture -->
+  <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <!-- TODO: density, mixture -->
+  <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="DiskCoolingTube"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="DiskCoolingTube"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="DiskCoolingTube"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
 </MaterialSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -521,5 +521,18 @@
         <rMaterial name="materials:Silicon" />
       </MaterialFraction>
     </CompositeMaterial>
+
+
+  <CompositeMaterial name="CF_SupportArm" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7498836">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05034303">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1997733">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 </MaterialSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -534,5 +534,21 @@
       <rMaterial name="materials:Oxygen"/>
     </MaterialFraction>
   </CompositeMaterial>
+
+  <CompositeMaterial name="DiskCoolingTube" density="1.5*g/cm3" symbol=" " method="mixture by weight">
+   <!-- TODO: add coolant (CO2), use correct mixture (atm stolen from barrel), adjust density -->
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.7195">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial> 
 </MaterialSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
@@ -3,9 +3,9 @@
 
 <ConstantsSection label="pixfwdOuterDiskZminus.xml" eval="true">
   <Constant name="OuterRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskOuterRingHalfWidth]"/>
-  <Constant name="OuterRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[OuterRingHalfWidth]-[pixfwd:FlexCableDiskThickness]*2"/>
+  <Constant name="OuterRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[OuterRingHalfWidth]-[pixfwd:FlexCableDiskHalfThickness]*2"/>
   <Constant name="InnerRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskInnerRingHalfWidth]"/>
-  <Constant name="InnerRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[InnerRingHalfWidth]-[pixfwd:FlexCableDiskThickness]*2"/>
+  <Constant name="InnerRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[InnerRingHalfWidth]-[pixfwd:FlexCableDiskHalfThickness]*2"/>
 </ConstantsSection>
  
 <!-- support ring solids -->
@@ -84,7 +84,7 @@
 </Algorithm>
 
 <SolidSection label="pixfwdOuterDiskZminus.xml">
- <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
+ <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskHalfThickness]" startPhi="0." deltaPhi="360*deg"/>
 </SolidSection>
 <LogicalPartSection label="pixfwdOuterDiskZminus.xml">
 
@@ -98,12 +98,12 @@
   <PosPart copyNumber="1">
     <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
     <rChild name="FlexCableDisk"/>
-    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskThickness]"/>
+    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskHalfThickness]"/>
   </PosPart>
   <PosPart copyNumber="2">
     <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
     <rChild name="FlexCableDisk"/>
-    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskThickness]-[OuterRingHalfWidth]*2"/>
+    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskHalfThickness]-[OuterRingHalfWidth]*2"/>
   </PosPart>
 </PosPartSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
@@ -90,7 +90,7 @@
 
  <LogicalPart name="FlexCableDisk" category="support">
     <rSolid name="FlexCableDisk"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable2"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
@@ -21,7 +21,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskOuterRing"/> 
-  <String  name="Material"         value="materials:C_C_OuterOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_OuterOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingRMax]"/>
@@ -32,7 +32,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskCFOuterRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_OuterOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_OuterOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]"/>
@@ -43,7 +43,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskInnerRing"/> 
-  <String  name="Material"         value="materials:C_C_OuterInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_OuterInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingRMax]"/>
@@ -54,7 +54,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskCFInnerRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_OuterInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_OuterInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingCFRMax]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml
@@ -3,9 +3,9 @@
 
 <ConstantsSection label="pixfwdOuterDiskZminus.xml" eval="true">
   <Constant name="OuterRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskOuterRingHalfWidth]"/>
-  <Constant name="OuterRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[OuterRingHalfWidth]"/>
+  <Constant name="OuterRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[OuterRingHalfWidth]-[pixfwd:FlexCableDiskThickness]*2"/>
   <Constant name="InnerRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskInnerRingHalfWidth]"/>
-  <Constant name="InnerRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[InnerRingHalfWidth]"/>
+  <Constant name="InnerRingZ"           value="[pixfwdDisks:DiskHalfWidth]-[InnerRingHalfWidth]-[pixfwd:FlexCableDiskThickness]*2"/>
 </ConstantsSection>
  
 <!-- support ring solids -->
@@ -83,4 +83,27 @@
   <String  name="FlagString"       value="YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"/>
 </Algorithm>
 
+<SolidSection label="pixfwdOuterDiskZminus.xml">
+ <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
+</SolidSection>
+<LogicalPartSection label="pixfwdOuterDiskZminus.xml">
+
+ <LogicalPart name="FlexCableDisk" category="support">
+    <rSolid name="FlexCableDisk"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
+ </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="pixfwdOuterDiskZminus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="FlexCableDisk"/>
+    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskThickness]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZminus"/>
+    <rChild name="FlexCableDisk"/>
+    <Translation x="0." y="0." z="[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskThickness]-[OuterRingHalfWidth]*2"/>
+  </PosPart>
+</PosPartSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
@@ -21,7 +21,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskOuterRing"/> 
-  <String  name="Material"         value="materials:C_C_OuterOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_OuterOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingRMax]"/>
@@ -32,7 +32,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskCFOuterRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_OuterOuterRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_OuterOuterRing"/> 
   <Numeric name="zPos"             value="[OuterRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskOuterRingCFRMax]"/>
@@ -43,7 +43,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskInnerRing"/> 
-  <String  name="Material"         value="materials:C_C_OuterInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:C_C_OuterInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingRMax]"/>
@@ -54,7 +54,7 @@
 <Algorithm name="track:DDCutTubsFromPoints">
   <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
   <String  name="SolidName"        value="PixelForwardOuterDiskCFInnerRing"/> 
-  <String  name="Material"         value="materials:FPix_CFSkin_OuterInnerRing"/> 
+  <String  name="Material"         value="pixfwdMaterials:FPix_CFSkin_OuterInnerRing"/> 
   <Numeric name="zPos"             value="[InnerRingZ]"/>
   <Numeric name="rMin"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingCFRMin]"/>
   <Numeric name="rMax"             value="[pixfwdSupportRingParameters:OuterDiskInnerRingCFRMax]"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
@@ -92,7 +92,7 @@
 <LogicalPartSection label="pixfwdOuterDiskZplus.xml">
  <LogicalPart name="FlexCableDisk" category="support">
     <rSolid name="FlexCableDisk"/>
-    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable2"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
@@ -3,9 +3,9 @@
 
 <ConstantsSection label="pixfwdOuterDiskZplus.xml" eval="true">
   <Constant name="OuterRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskOuterRingHalfWidth]"/>
-  <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]+[pixfwd:FlexCableDiskThickness]*2"/>
+  <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]+[pixfwd:FlexCableDiskHalfThickness]*2"/>
   <Constant name="InnerRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskInnerRingHalfWidth]"/>
-  <Constant name="InnerRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[InnerRingHalfWidth]+[pixfwd:FlexCableDiskThickness]*2"/>
+  <Constant name="InnerRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[InnerRingHalfWidth]+[pixfwd:FlexCableDiskHalfThickness]*2"/>
 </ConstantsSection>
 
 <!-- support ring solids -->
@@ -86,7 +86,7 @@
 </Algorithm>
 
 <SolidSection label="pixfwdOuterDiskZplus.xml">
- <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
+ <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskHalfThickness]" startPhi="0." deltaPhi="360*deg"/>
 </SolidSection>
 
 <LogicalPartSection label="pixfwdOuterDiskZplus.xml">
@@ -100,12 +100,12 @@
   <PosPart copyNumber="1">
     <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
     <rChild name="FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskThickness]"/>
+    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskHalfThickness]"/>
   </PosPart>
   <PosPart copyNumber="2">
     <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
     <rChild name="FlexCableDisk"/>
-    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskThickness]+[OuterRingHalfWidth]*2"/>
+    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskHalfThickness]+[OuterRingHalfWidth]*2"/>
   </PosPart>
 </PosPartSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml
@@ -3,9 +3,9 @@
 
 <ConstantsSection label="pixfwdOuterDiskZplus.xml" eval="true">
   <Constant name="OuterRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskOuterRingHalfWidth]"/>
-  <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]"/>
+  <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]+[pixfwd:FlexCableDiskThickness]*2"/>
   <Constant name="InnerRingHalfWidth"   value="[pixfwdSupportRingParameters:OuterDiskInnerRingHalfWidth]"/>
-  <Constant name="InnerRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[InnerRingHalfWidth]"/>
+  <Constant name="InnerRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[InnerRingHalfWidth]+[pixfwd:FlexCableDiskThickness]*2"/>
 </ConstantsSection>
 
 <!-- support ring solids -->
@@ -85,4 +85,27 @@
   <String  name="FlagString"       value="YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"/>
 </Algorithm>
 
+<SolidSection label="pixfwdOuterDiskZplus.xml">
+ <Tubs name="FlexCableDisk" rMin="[pixfwd:FlexCableDiskRmin]" rMax="[pixfwd:FlexCableDiskRmax]" dz="[pixfwd:FlexCableDiskThickness]" startPhi="0." deltaPhi="360*deg"/>
+</SolidSection>
+
+<LogicalPartSection label="pixfwdOuterDiskZplus.xml">
+ <LogicalPart name="FlexCableDisk" category="support">
+    <rSolid name="FlexCableDisk"/>
+    <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable2"/>
+ </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="pixfwdOuterDiskZplus.xml">
+  <PosPart copyNumber="1">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]+[pixfwd:FlexCableDiskThickness]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="pixfwdDisks:PixelForwardDiskZplus"/>
+    <rChild name="FlexCableDisk"/>
+    <Translation x="0." y="0." z="-[pixfwdDisks:DiskHalfWidth]-[pixfwd:FlexCableDiskThickness]+[OuterRingHalfWidth]*2"/>
+  </PosPart>
+</PosPartSection>
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
@@ -125,6 +125,10 @@
   <Constant name="SupportArmAngle_1" value="97*deg" /> 
   <Constant name="SupportArmAngle_2" value="83*deg" /> 
   <Constant name="SupportArmAngle_3" value="0*deg" /> 
+
+  <Constant name="CoolingZ_inner" value="33*mm" />
+  <Constant name="CoolingZ_outer" value="-7.8*mm" />
+  <Constant name="CoolingAngle" value="0*deg" /> 
  </ConstantsSection>
 
  <RotationSection label="pixfwdSupportRingParameters.xml">
@@ -134,6 +138,9 @@
     <Rotation name="rArm1b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_1]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_1]+180*deg"/>
     <Rotation name="rArm2b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_2]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_2]+180*deg"/>
     <Rotation name="rArm3b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_3]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_3]+180*deg"/>
+
+    <Rotation name="rCooling_a" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[CoolingAngle]-90*deg" thetaZ="90*deg" phiZ="[CoolingAngle]"/>
+    <Rotation name="rCooling_b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[CoolingAngle]+90*deg" thetaZ="90*deg" phiZ="[CoolingAngle]+180*deg"/>
  </RotationSection>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
@@ -106,14 +106,14 @@
 
   <!-- min: -499 max: -461 width: 38 -->
   <Vector  name="OuterDiskInnerRing_z_t_Plus" type="numeric" nEntries="12">
-    476*mm,   483*mm,   484*mm,   491*mm,   492*mm,   479*mm,   478*mm,   481*mm,   485*mm,   495*mm,   499*mm,   496*mm,   489*mm
+    476*mm,   483*mm,   484*mm,   491*mm,   492*mm,   479*mm,   478*mm,   481*mm,   485*mm,   495*mm,   499*mm,   495*mm,   489*mm
   </Vector>
   <Vector  name="OuterDiskInnerRing_z_l_Plus" type="numeric" nEntries="12">
     466*mm,   461*mm,   461*mm,   470*mm,   470*mm,   462*mm,   461*mm,   461*mm,   461*mm,   471*mm,   477*mm,   477*mm,   486*mm
   </Vector>
 
   <Vector  name="OuterDiskInnerRing_z_l_Minus" type="numeric" nEntries="12">
-   -476*mm,  -483*mm,  -484*mm,  -491*mm,  -492*mm,  -479*mm,  -478*mm,  -481*mm,  -485*mm,  -495*mm,  -499*mm,  -496*mm,  -489*mm
+   -476*mm,  -483*mm,  -484*mm,  -491*mm,  -492*mm,  -479*mm,  -478*mm,  -481*mm,  -485*mm,  -495*mm,  -499*mm,  -495*mm,  -489*mm
   </Vector>
   <Vector  name="OuterDiskInnerRing_z_t_Minus" type="numeric" nEntries="12">
    -466*mm,  -461*mm,  -461*mm,  -470*mm,  -470*mm,  -462*mm,  -461*mm,  -461*mm,  -461*mm,  -471*mm,  -477*mm,  -477*mm,  -486*mm

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml
@@ -119,5 +119,21 @@
    -466*mm,  -461*mm,  -461*mm,  -470*mm,  -470*mm,  -462*mm,  -461*mm,  -461*mm,  -461*mm,  -471*mm,  -477*mm,  -477*mm,  -486*mm
   </Vector>
 
+
+  <!-- Support arms (not rings, but related -->
+  <Constant name="SupportArmZ" value="13*mm" /> <!-- relative to disk origin -->
+  <Constant name="SupportArmAngle_1" value="97*deg" /> 
+  <Constant name="SupportArmAngle_2" value="83*deg" /> 
+  <Constant name="SupportArmAngle_3" value="0*deg" /> 
  </ConstantsSection>
+
+ <RotationSection label="pixfwdSupportRingParameters.xml">
+    <Rotation name="rArm1a" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_1]-90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_1]"/>
+    <Rotation name="rArm2a" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_2]-90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_2]"/>
+    <Rotation name="rArm3a" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_3]-90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_3]"/>
+    <Rotation name="rArm1b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_1]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_1]+180*deg"/>
+    <Rotation name="rArm2b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_2]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_2]+180*deg"/>
+    <Rotation name="rArm3b" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="[SupportArmAngle_3]+90*deg" thetaZ="90*deg" phiZ="[SupportArmAngle_3]+180*deg"/>
+ </RotationSection>
+
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZminus.xml
@@ -197,7 +197,7 @@
  </LogicalPart>
  <LogicalPart name="PixelForwardFlexCable" category="unspecified">
   <rSolid name="PixelForwardFlexCable"/>
-  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZplus.xml
@@ -197,7 +197,7 @@
  </LogicalPart>
  <LogicalPart name="PixelForwardFlexCable" category="unspecified">
   <rSolid name="PixelForwardFlexCable"/>
-  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZminus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZminus.xml
@@ -196,7 +196,7 @@
  </LogicalPart>
  <LogicalPart name="PixelForwardFlexCable" category="unspecified">
   <rSolid name="PixelForwardFlexCable"/>
-  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable"/>
  </LogicalPart>
 </LogicalPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZplus.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZplus.xml
@@ -196,7 +196,7 @@
  </LogicalPart>
  <LogicalPart name="PixelForwardFlexCable" category="unspecified">
   <rSolid name="PixelForwardFlexCable"/>
-  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFelxCable"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_AluFlexCable"/>
  </LogicalPart>
 </LogicalPartSection>
 


### PR DESCRIPTION
This PR supersedes #16316 .
- Commit 7f6d1c3 (thanks @Michael-Krohn !) but the dubious changes to the FPIX Polycone removed.
- Commit b222023 by myself to put the cable disks into the disk volumes.
- Commit 84246c7 with further changes by @tmulholland (thanks!)
- Update: Cooling tubes to disks added.
- Update: support arms added.

Still missing:
- extrusions due to Service cylinder volumes leaving the service cylinder. I'll try to fix this by growing it, there should be space for it. **Done**, CF sheet updated to real size. No overlaps now as far as I see.

To be fixed here or in another PR:
- Material mixtures should have the right components, but all mixtures/densities need to be checked.

@ianna : comments very welcome.
@davidlange6 : This PR seems ready to be merged to me. Update: still true, changing numbers can be a separate PR.

Also @veszpv , @friccita .
