### PR TITLE
[81X] Update phase-I L1 menu to same as 2016 pp simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v2',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v18',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v19',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
# Summary of changes in Global Tags
## Upgrade
- **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v19) as [81X_upgrade2017_realistic_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v18) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v19/81X_upgrade2017_realistic_v18): 
  - update L1 menu to be `L1Menu_Collisions2016_v9_m2_xml` (i.e. the same as 2016 pp simulation)
- **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v3) as [81X_upgrade2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v3/81X_upgrade2017_design_IdealBS_v2): 
  - update L1 menu to be `L1Menu_Collisions2016_v9_m2_xml`(i.e. the same as 2016 pp simulation)

attn: @Martin-Grunewald @silviodonato 
This is complementary to #16332 (same change implemented on the official Global Tags)
