### PR TITLE
[81X] Add Phase-I Cosmics

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic': '81X_upgrade2017_realistic_v24',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic': '81X_upgrade2017_realistic_v24',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -39,6 +39,8 @@ autoCond = {
     'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic': '81X_upgrade2017_realistic_v24',
+    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
+    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic': '81X_upgrade2017_realistic_v24',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -279,6 +279,9 @@ workflows[34] = ['', ['QQH1352T','DIGI','RECO','HARVEST']]
 
 workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
 workflows[7.1]= ['', ['CosmicsSPLoose','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
+workflows[7.2] = ['', ['Cosmics_UP17','DIGICOS_UP17','RECOCOS_UP17','ALCACOS_UP17','HARVESTCOS_UP17']]
+workflows[7.3] = ['', ['CosmicsSPLoose_UP17','DIGICOS_UP17','RECOCOS_UP17','ALCACOS_UP17','HARVESTCOS_UP17']]
+
 workflows[8]  = ['', ['BeamHalo','DIGICOS','RECOCOS','ALCABH','HARVESTCOS']]
 workflows[11] = ['', ['MinBias','DIGI','RECOMIN','HARVEST','ALCAMIN']]
 workflows[28] = ['', ['QCD_Pt_80_120','DIGI','RECO','HARVEST']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -569,6 +569,8 @@ steps['ZpTT_1500_8TeVINPUT']={'INPUT':InputInfo(dataSet='/RelValZpTT_1500_8TeV_T
 steps['Cosmics']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--scenario':'cosmics'},Kby(666,100000),step1Defaults])
 steps['CosmicsSPLoose']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--scenario':'cosmics'},Kby(5000,100000),step1Defaults])
 steps['CosmicsSPLoose_UP15']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics'},Kby(5000,500000),step1Up2015Defaults])
+steps['Cosmics_UP17']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','--scenario':'cosmics','--era':'Run2_2017'},Kby(666,100000),step1Defaults])
+steps['CosmicsSPLoose_UP17']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','--scenario':'cosmics','--era':'Run2_2017'},Kby(5000,500000),step1Up2015Defaults])
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
 
@@ -974,6 +976,7 @@ steps['DIGI']=merge([step2Defaults])
 steps['DIGICOS']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},stCond,step2Defaults])
 steps['DIGIHAL']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
 steps['DIGICOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
+steps['DIGICOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'DIGI:pdigi_valid,DIGI2RAW','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
 
 steps['DIGIPU1']=merge([PU,step2Defaults])
 steps['DIGIPU2']=merge([PU2,step2Defaults])
@@ -1260,6 +1263,8 @@ steps['RECOPRODUP15']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,DQM:DQMOfflineP
 steps['RECOCOS']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},stCond,step3Defaults])
 steps['RECOHAL']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlBeamHalo+MuAlBeamHaloOverlaps,DQM','--scenario':'cosmics'},step3Up2015Hal])
 steps['RECOCOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},step3Up2015Hal])
+steps['RECOCOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'RAW2DIGI,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
+
 steps['RECOMIN']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},stCond,step3Defaults])
 steps['RECOMINUP15']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},step3Up2015Defaults])
 steps['RECOAODUP15']=merge([{'--datatier':'AODSIM,MINIAODSIM,DQMIO','--eventcontent':'AODSIM,MINIAODSIM,DQM'},step3Up2015Defaults]) 
@@ -1372,7 +1377,7 @@ steps['ALCACOS']=merge([{'-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCos
 steps['ALCABH']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},stCond,step4Defaults])
 steps['ALCAHAL']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
 steps['ALCACOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
-
+steps['ALCACOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps"MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
 steps['ALCAHARVD']={'-s':'ALCAHARVEST:BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
                     '--conditions':'auto:run1_data',
                     '--scenario':'pp',
@@ -1504,6 +1509,17 @@ steps['HARVESTCOS_UP15']={'-s'          :'HARVESTING:dqmHarvesting',
                           '--filetype':'DQM',
                           '--era' : 'Run2_2016',
                           }
+steps['HARVESTCOS_UP17']={'-s'          :'HARVESTING:dqmHarvesting',
+                          '--conditions':'81X_upgrade2017cosmics_realistic_peak_v1',
+                          '--mc'        :'',
+                          '--filein'    :'file:step3_inDQM.root',
+                          '--scenario'    :'cosmics',
+                          '--filein':'file:step3_inDQM.root', # unnnecessary
+                          '--filetype':'DQM',
+                          '--era' : 'Run2_2017'
+                          }
+
+		  
 steps['HARVESTFS']={'-s':'HARVESTING:validationHarvesting',
                    '--conditions':'auto:run1_mc',
                    '--mc':'',
@@ -1776,6 +1792,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       }
     if cust!=None : upgradeStepDict['RecoFull'][k]['--customise']=cust
     if era is not None: upgradeStepDict['RecoFull'][k]['--era']=era
+
 
     if k2 in PUDataSets:
         upgradeStepDict['RecoFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFull'][k]])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -976,7 +976,7 @@ steps['DIGI']=merge([step2Defaults])
 steps['DIGICOS']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},stCond,step2Defaults])
 steps['DIGIHAL']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
 steps['DIGICOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
-steps['DIGICOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'DIGI:pdigi_valid,DIGI2RAW','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
+steps['DIGICOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
 
 steps['DIGIPU1']=merge([PU,step2Defaults])
 steps['DIGIPU2']=merge([PU2,step2Defaults])
@@ -1263,7 +1263,7 @@ steps['RECOPRODUP15']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,DQM:DQMOfflineP
 steps['RECOCOS']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},stCond,step3Defaults])
 steps['RECOHAL']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlBeamHalo+MuAlBeamHaloOverlaps,DQM','--scenario':'cosmics'},step3Up2015Hal])
 steps['RECOCOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},step3Up2015Hal])
-steps['RECOCOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'RAW2DIGI,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
+steps['RECOCOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
 
 steps['RECOMIN']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},stCond,step3Defaults])
 steps['RECOMINUP15']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},step3Up2015Defaults])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -976,7 +976,7 @@ steps['DIGI']=merge([step2Defaults])
 steps['DIGICOS']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},stCond,step2Defaults])
 steps['DIGIHAL']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
 steps['DIGICOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
-steps['DIGICOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
+steps['DIGICOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2016','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
 
 steps['DIGIPU1']=merge([PU,step2Defaults])
 steps['DIGIPU2']=merge([PU2,step2Defaults])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -569,8 +569,8 @@ steps['ZpTT_1500_8TeVINPUT']={'INPUT':InputInfo(dataSet='/RelValZpTT_1500_8TeV_T
 steps['Cosmics']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--scenario':'cosmics'},Kby(666,100000),step1Defaults])
 steps['CosmicsSPLoose']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--scenario':'cosmics'},Kby(5000,100000),step1Defaults])
 steps['CosmicsSPLoose_UP15']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics'},Kby(5000,500000),step1Up2015Defaults])
-steps['Cosmics_UP17']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','--scenario':'cosmics','--era':'Run2_2017'},Kby(666,100000),step1Defaults])
-steps['CosmicsSPLoose_UP17']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','--scenario':'cosmics','--era':'Run2_2017'},Kby(5000,500000),step1Up2015Defaults])
+steps['Cosmics_UP17']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--conditions':'auto:phase1_2017_cosmics','--scenario':'cosmics','--era':'Run2_2017'},Kby(666,100000),step1Defaults])
+steps['CosmicsSPLoose_UP17']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','--conditions':'auto:phase1_2017_cosmics','--scenario':'cosmics','--era':'Run2_2017'},Kby(5000,500000),step1Up2015Defaults])
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
 
@@ -976,7 +976,7 @@ steps['DIGI']=merge([step2Defaults])
 steps['DIGICOS']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},stCond,step2Defaults])
 steps['DIGIHAL']=merge([{'--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
 steps['DIGICOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW'},step2Upg2015Defaults])
-steps['DIGICOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
+steps['DIGICOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
 
 steps['DIGIPU1']=merge([PU,step2Defaults])
 steps['DIGIPU2']=merge([PU2,step2Defaults])
@@ -1263,7 +1263,7 @@ steps['RECOPRODUP15']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,DQM:DQMOfflineP
 steps['RECOCOS']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},stCond,step3Defaults])
 steps['RECOHAL']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlBeamHalo+MuAlBeamHaloOverlaps,DQM','--scenario':'cosmics'},step3Up2015Hal])
 steps['RECOCOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics'},step3Up2015Hal])
-steps['RECOCOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
+steps['RECOCOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
 
 steps['RECOMIN']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},stCond,step3Defaults])
 steps['RECOMINUP15']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},step3Up2015Defaults])
@@ -1377,7 +1377,7 @@ steps['ALCACOS']=merge([{'-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCos
 steps['ALCABH']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},stCond,step4Defaults])
 steps['ALCAHAL']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
 steps['ALCACOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
-steps['ALCACOS_UP17']=merge([{'--conditions':'81X_upgrade2017cosmics_realistic_peak_v1','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps"MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
+steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
 steps['ALCAHARVD']={'-s':'ALCAHARVEST:BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
                     '--conditions':'auto:run1_data',
                     '--scenario':'pp',
@@ -1510,7 +1510,7 @@ steps['HARVESTCOS_UP15']={'-s'          :'HARVESTING:dqmHarvesting',
                           '--era' : 'Run2_2016',
                           }
 steps['HARVESTCOS_UP17']={'-s'          :'HARVESTING:dqmHarvesting',
-                          '--conditions':'81X_upgrade2017cosmics_realistic_peak_v1',
+                          '--conditions':'auto:phase1_2017_cosmics',
                           '--mc'        :'',
                           '--filein'    :'file:step3_inDQM.root',
                           '--scenario'    :'cosmics',

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -15,7 +15,7 @@ sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
     UseOfflineXMLFile = cms.untracked.bool(True),
     Tier0Flag = cms.untracked.bool(True),
     DoHitEfficiency = cms.untracked.bool(True),
-    isUpgrade = cms.untracked.bool(False)	
+    isUpgrade = cms.untracked.bool(False)
 )
 
 #QualityTester
@@ -42,9 +42,11 @@ PixelOfflineDQMClient = cms.Sequence(sipixelEDAClient)
 PixelOfflineDQMClientWithDataCertification = cms.Sequence(sipixelQTester+
                                                           sipixelEDAClient+
                                                           sipixelDaqInfo+
-							  sipixelDcsInfo+
-							  sipixelCertification)
+                                                          sipixelDcsInfo+
+                                                          sipixelCertification)
 PixelOfflineDQMClientNoDataCertification = cms.Sequence(sipixelQTester+
+                                                          sipixelEDAClient)
+PixelOfflineDQMClientNoDataCertification_cosmics = cms.Sequence(sipixelQTester+
                                                           sipixelEDAClient)
 
 PixelOfflineDQMClientWithDataCertificationHI = cms.Sequence(PixelOfflineDQMClientNoDataCertification)
@@ -56,4 +58,5 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(PixelOfflineDQMClient, siPixelPhase1OfflineDQM_harvesting)
 #TODO: properly upgrade these and the others
 phase1Pixel.toReplaceWith(PixelOfflineDQMClientNoDataCertification, siPixelPhase1OfflineDQM_harvesting)
+phase1Pixel.toReplaceWith(PixelOfflineDQMClientNoDataCertification_cosmics, siPixelPhase1OfflineDQM_harvesting_cosmics)
 phase1Pixel.toReplaceWith(PixelOfflineDQMClientWithDataCertification, siPixelPhase1OfflineDQM_harvesting)

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -135,5 +135,7 @@ siPixelOfflineDQM_source_woTrack = cms.Sequence(SiPixelHLTSource + SiPixelRawDat
 from DQM.SiPixelPhase1Config.SiPixelPhase1OfflineDQM_source_cff import *
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(siPixelOfflineDQM_source, siPixelPhase1OfflineDQM_source)
+phase1Pixel.toReplaceWith(siPixelOfflineDQM_cosmics_source, siPixelPhase1OfflineDQM_source_cosmics)
+
 # don't forget the Harvesters, they are plugged in at PixelOfflineDQMClient
 # TODO: the same game for the other three.

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
@@ -9,3 +9,8 @@ siPixelPhase1OfflineDQM_harvesting = cms.Sequence(SiPixelPhase1DigisHarvester
                                                 + SiPixelPhase1TrackClustersHarvester
                                                 + SiPixelPhase1TrackEfficiencyHarvester
                                                 )
+
+siPixelPhase1OfflineDQM_harvesting_cosmics = siPixelPhase1OfflineDQM_harvesting.copyAndExclude([
+   SiPixelPhase1TrackClustersHarvester,
+   SiPixelPhase1TrackEfficiencyHarvester,
+])

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -22,3 +22,15 @@ siPixelPhase1OfflineDQM_source = cms.Sequence(SiPixelPhase1DigisAnalyzer
                                             + SiPixelPhase1TrackClustersAnalyzer
                                             + SiPixelPhase1TrackEfficiencyAnalyzer
                                             )
+
+siPixelPhase1OfflineDQM_source_cosmics = siPixelPhase1OfflineDQM_source.copyAndExclude([
+    SiPixelPhase1TrackEfficiencyAnalyzer, 
+    SiPixelPhase1TrackClustersAnalyzer
+])
+
+SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = "ctfWithMaterialTracksP5"
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
+
+siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackResidualsAnalyzer,
+                                               SiPixelPhase1TrackResidualsAnalyzer_cosmics)

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -17,9 +17,9 @@ from DQM.HcalTasks.OfflineHarvestingSequence_cosmic import *
 
 DQMOfflineCosmics_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient * 
                                                     ecal_dqm_client_offline *
-													hcalOfflineHarvesting *
+                                                    hcalOfflineHarvesting *
                                                     SiStripCosmicDQMClient *
-                                                    PixelOfflineDQMClientNoDataCertification *
+                                                    PixelOfflineDQMClientNoDataCertification_cosmics *
                                                     dtClientsCosmics *
                                                     rpcTier0Client *
                                                     cscOfflineCosmicsClients *

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -7,48 +7,88 @@ from RecoLocalCalo.Configuration.ecalLocalRecoSequenceCosmics_cff import *
 from RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi import *
 
 #defines a sequence ecalLocalRecoSequence
+
 #
 # Hcal part
 #
-# calo geometry
-#
-# changed by tommaso. now the calibrations are read from Configuration/StaqndardSequences/data/*Conditions.cff
-#
-# HCAL calibrations
-#include "CalibCalorimetry/HcalPlugins/data/hardwired_conditions.cfi"
 #HCAL reconstruction
-from RecoLocalCalo.Configuration.hcalLocalReco_cff import *
+import RecoLocalCalo.Configuration.hcalLocalReco_cff as _hcalLocalReco_cff
 #
-# sequence CaloLocalReco and CaloGlobalReco
+# sequence CaloLocalReco
 #
+hbheprereco = _hcalLocalReco_cff._default_hbheprereco.clone(
+    puCorrMethod = 0,
+    firstSample = 0,
+    samplesToAdd = 10,
+    correctForTimeslew = False,
+    correctForPhaseContainment = False,
+    tsFromDB = False,
+    recoParamsFromDB = cms.bool(False),
+)
+hfreco = _hcalLocalReco_cff._default_hfreco.clone(
+    firstSample = 0,
+    samplesToAdd = 10, ### min(10,size) in the algo
+    correctForTimeslew = False,
+    correctForPhaseContainment = False,
+    tsFromDB = False,
+    recoParamsFromDB = cms.bool(False),
+    digiTimeFromDB = False,
+)
+horeco = _hcalLocalReco_cff.horeco.clone(
+    firstSample = 0,
+    samplesToAdd = 10,
+    correctForTimeslew = False,
+    correctForPhaseContainment = False,
+    tsFromDB = False,
+    recoParamsFromDB = cms.bool(False),
+)
+zdcreco = _hcalLocalReco_cff.zdcreco.clone(
+#    firstSample = 1,
+#    samplesToAdd = 8,
+    correctForTimeslew = True,
+    correctForPhaseContainment = True,
+    correctionPhaseNS = 10.,
+)
+
+# 2017 customs
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+
+_phase1_hbheprereco = _hcalLocalReco_cff._phase1_hbheprereco.clone(
+    tsFromDB = cms.bool(False),
+    recoParamsFromDB = cms.bool(False),
+    algorithm = dict(
+        useM2 = cms.bool(False),
+        useM3 = cms.bool(False),
+        firstSampleShift = cms.int32(-1000),
+        samplesToAdd = cms.int32(10),
+        correctForPhaseContainment = cms.bool(False),
+    )
+)
+
+_phase1_hfreco = _hcalLocalReco_cff._phase1_hfreco.clone(
+    algorithm = dict(
+        Class = cms.string("HFSimpleTimeCheck"),
+        rejectAllFailures = cms.bool(False),
+    )
+)
+
+
+run2_HE_2017.toReplaceWith(hbheprereco, _phase1_hbheprereco )
+run2_HF_2017.toReplaceWith(hfreco, _phase1_hfreco )
+
+hfprereco = _hcalLocalReco_cff.hfprereco.clone(
+    sumAllTimeSlices = cms.bool(True)
+)
+
+# redefine hcal sequence
+hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
+
+_phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
+_phase1_hcalLocalRecoSequence.insert(0,hfprereco)
+run2_HF_2017.toReplaceWith(hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence)
+
 calolocalrecoCosmics = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence)
-hbheprereco.puCorrMethod = 0 
-hbheprereco.firstSample = 0
-hbheprereco.samplesToAdd = 10
-hbheprereco.correctForTimeslew = False
-hbheprereco.correctForPhaseContainment = False
-horeco.firstSample = 0
-horeco.samplesToAdd = 10
-horeco.correctForTimeslew = False
-horeco.correctForPhaseContainment = False
-hfreco.firstSample = 0
-hfreco.samplesToAdd = 10 ### min(10,size) in the algo
-hfreco.correctForTimeslew = False
-hfreco.correctForPhaseContainment = False
-#--- special temporary DB-usage unsetting 
-hbheprereco.tsFromDB = False
-hfreco.tsFromDB = False
-horeco.tsFromDB = False
-hfreco.digiTimeFromDB = False
-hbheprereco.recoParamsFromDB = cms.bool(False)
-horeco.recoParamsFromDB      = cms.bool(False)
-hfreco.recoParamsFromDB      = cms.bool(False)
-#zdcreco.firstSample = 1
-#zdcreco.samplesToAdd = 8
-zdcreco.correctForTimeslew = True
-zdcreco.correctForPhaseContainment = True
-zdcreco.correctionPhaseNS = 10.
-#caloglobalreco = cms.Sequence(hcalGlobalRecoSequence)
 
 #
 # R.Ofierzynski (29.Oct.2009): add NZS sequence

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -16,3 +16,35 @@ hfrecoMB.dropZSmarkedPassed = cms.bool(False)
 horecoMB.dropZSmarkedPassed = cms.bool(False)
 
 hcalLocalRecoSequenceNZS = cms.Sequence(hbherecoMB*hfrecoMB*horecoMB) 
+
+import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
+import RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi
+import RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi
+_phase1_hbherecoMB = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbheprereco.clone(
+    dropZSmarkedPassed = cms.bool(False),
+    recoParamsFromDB = cms.bool(False),
+    algorithm = dict(
+        useM2 = cms.bool(False),
+        useM3 = cms.bool(False)
+    ),
+)
+hfprerecoMB = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
+    dropZSmarkedPassed = cms.bool(False)
+)
+_phase1_hfrecoMB = RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi.hfreco.clone(
+    inputLabel = cms.InputTag("hfprerecoMB"),
+    setNoiseFlags = cms.bool(False),
+    algorithm = dict(
+        Class = cms.string("HFSimpleTimeCheck"),
+        rejectAllFailures = cms.bool(False)
+    ),
+)
+
+_phase1_hcalLocalRecoSequenceNZS = hcalLocalRecoSequenceNZS.copy()
+_phase1_hcalLocalRecoSequenceNZS.insert(0,hfprerecoMB)
+
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toReplaceWith( hcalLocalRecoSequenceNZS, _phase1_hcalLocalRecoSequenceNZS )
+run2_HF_2017.toReplaceWith( hfrecoMB, _phase1_hfrecoMB )
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+run2_HE_2017.toReplaceWith( hbherecoMB, _phase1_hbherecoMB )

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -13,6 +13,10 @@ from RecoLocalCalo.HcalRecProducers.hfprereco_cfi import hfprereco
 from RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi import hfreco as _phase1_hfreco
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
 
+# copies for cosmics
+_default_hbheprereco = hbheprereco.clone()
+_default_hfreco = hfreco.clone()
+
 _phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
 _phase1_hcalLocalRecoSequence.insert(0,hfprereco)
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -411,8 +411,22 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
   std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
   std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
-  std::unique_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection());
-  std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection());
+  std::unique_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
+  std::unique_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
+  std::unique_ptr<QIE10DigiCollection> hfQIE10Result(
+    new QIE10DigiCollection(
+      theHFQIE10DetIds.size()>0 ? 
+      theParameterMap->simParameters(theHFQIE10DetIds[0]).readoutFrameSize() : 
+      QIE10DigiCollection::MAXSAMPLES
+    )
+  );
+  std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(
+    new QIE11DigiCollection(
+      theHBHEQIE11DetIds.size()>0 ? 
+      theParameterMap->simParameters(theHBHEQIE11DetIds[0]).readoutFrameSize() : 
+      QIE11DigiCollection::MAXSAMPLES
+    )
+  );
 
   // Step C: Invoke the algorithm, getting back outputs.
   if(isHCAL&&hbhegeo){

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -411,8 +411,6 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
   std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
   std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
-  std::unique_ptr<HBHEUpgradeDigiCollection> hbheupgradeResult(new HBHEUpgradeDigiCollection());
-  std::unique_ptr<HFUpgradeDigiCollection> hfupgradeResult(new HFUpgradeDigiCollection());
   std::unique_ptr<QIE10DigiCollection> hfQIE10Result(
     new QIE10DigiCollection(
       theHFQIE10DetIds.size()>0 ? 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -128,8 +128,8 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   e.getByToken(tok_hbheQIE11_,hbheQIE11);
   
   // create empty output
-  std::unique_ptr<HBHEUpgradeDigiCollection> zs_hbheUpgrade(new HBHEUpgradeDigiCollection);
-  std::unique_ptr<HFUpgradeDigiCollection> zs_hfUpgrade(new HFUpgradeDigiCollection);
+  std::unique_ptr<HBHEDigiCollection> zs_hbheUpgrade(new HBHEDigiCollection);
+  std::unique_ptr<HFDigiCollection> zs_hfUpgrade(new HFDigiCollection);
   std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection(hfQIE10->samples()));
   std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection(hbheQIE11->samples()));
   

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -128,11 +128,12 @@ void HcalRealisticZS::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   e.getByToken(tok_hbheQIE11_,hbheQIE11);
   
   // create empty output
-  std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection);
-  std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection);
+  std::unique_ptr<HBHEUpgradeDigiCollection> zs_hbheUpgrade(new HBHEUpgradeDigiCollection);
+  std::unique_ptr<HFUpgradeDigiCollection> zs_hfUpgrade(new HFUpgradeDigiCollection);
+  std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection(hfQIE10->samples()));
+  std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection(hbheQIE11->samples()));
   
   //run the algorithm
-
   algo_->suppress(*(hbhe.product()),*zs_hbhe);
   algo_->suppress(*(ho.product()),*zs_ho);
   algo_->suppress(*(hf.product()),*zs_hf);

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
@@ -128,7 +128,7 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hfQIE10_,digi);
     
     // create empty output
-    std::unique_ptr<QIE10DigiCollection> zs(new QIE10DigiCollection);
+    std::unique_ptr<QIE10DigiCollection> zs(new QIE10DigiCollection(digi->samples()));
     // run the algorithm
     hfQIE10_->suppress(*(digi.product()),*zs);
 
@@ -144,7 +144,7 @@ void HcalSimpleAmplitudeZS::produce(edm::Event& e, const edm::EventSetup& eventS
     e.getByToken(tok_hbheQIE11_,digi);
     
     // create empty output
-    std::unique_ptr<QIE11DigiCollection> zs(new QIE11DigiCollection);
+    std::unique_ptr<QIE11DigiCollection> zs(new QIE11DigiCollection(digi->samples()));
     // run the algorithm
     hbheQIE11_->suppress(*(digi.product()),*zs);
 


### PR DESCRIPTION
This PR attempts to add a new cosmics simulation workflow using phase-I 2017 detector.
In order to consume cosmics reconstruction-tailored conditions a new autoCond Global Tag is added. 
To address comments occurring during the review, appropriate commits were included to handle Hcal 2017 reconstruction with cosmics data and propagate to this wf the new phase-I pixel DQM.  
On Hcal side (thanks @kpedro88):
   * Increased flexibility of HCAL cosmic setup by applying cosmic-specific settings to cloned modules and then assembling sequences for 2017 and pre-2017 separately
   * Updated HCAL NZS sequence for 2017 HF and HE changes (can be used in cosmic runs)
   * Modified size of simulated QIE10DigiCollection to be 4 samples instead of default 10, by accessing sim parameter `readoutFrameSize` and forwarding through ZS algos accordingly

On DQM side (thanks @schneiml):
   * Add a special cosmics sequence to the PixelPhase1 DQM config
   * Enable it for the phase1pixel era in the general Pixel offline DQM config
   * Add a special cosmics sequence for harvesting to the Pixel offline DQM
config, since it is needed for Phase1.