### PR TITLE
Fixing typo in PrimaryVertex validation template

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -343,7 +343,7 @@ done
 
 for PngOutputFile in $(ls *png ); do
     xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/
-    rfcp ${PngOutputFile}  .oO[datadri]Oo.
+    rfcp ${PngOutputFile}  .oO[datadir]Oo.
 done
 
 """


### PR DESCRIPTION
Fixing a typo : in one line there was "datadri" instead of "datadir". 
This prevents the primary vertex validation to run correctly.

In CMSSW_8_1_X this typo is not present. 
