### PR TITLE
Use HCAL Phase1 digi/reco for Phase2

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -91,9 +91,9 @@ class HcalDbHardcode {
     void makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm);
     HcalTPChannelParameter makeHardcodeTPChannelParameter (HcalGenericDetId fId);
     void makeHardcodeTPParameters (HcalTPParameters& tppar);
+    int getLayersInDepth(int ieta, int depth, const HcalTopology* topo);
     
   private:
-    int getLayersInDepth(int ieta, int depth, const HcalTopology* topo);
     //member variables
     HcalHardcodeParameters theDefaultParameters_;
     HcalHardcodeParameters theHBParameters_, theHEParameters_, theHFParameters_, theHOParameters_;

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -164,32 +164,5 @@ phase2_hcal.toModify( es_hardcode,
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify( es_hardcode,
-                       toGet = cms.untracked.vstring(
-                                         'GainWidths',
-                                         'MCParams',
-                                         'RecoParams',
-                                         'RespCorrs',
-                                         'QIEData',
-                                         'QIETypes',
-                                         'Gains',
-                                         'Pedestals',
-                                         'PedestalWidths',
-                                         'ChannelQuality',
-                                         'ZSThresholds',
-                                         'TimeCorrs',
-                                         'LUTCorrs',
-                                         'LutMetadata',
-                                         'L1TriggerObjects',
-                                         'PFCorrs',
-                                         'FrontEndMap',
-                                         'CovarianceMatrices',
-                                         'SiPMParameters',
-                                         'SiPMCharacteristics',
-                                         'TPChannelParameters',
-                                         'TPParameters',
-                                         'FlagHFDigiTimeParams'
-                                         ),
-                            killHE = cms.bool(True)
-)
+phase2_hgcal.toModify( es_hardcode, killHE = cms.bool(True) )
                             

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -24,6 +24,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
     useHOUpgrade = cms.bool(True),
     testHFQIE10  = cms.bool(False),
     killHE = cms.bool(False),
+    useLayer0Weight = cms.bool(False),
     hb = cms.PSet(
         pedestal      = cms.double(3.0),
         pedestalWidth = cms.double(0.55),
@@ -160,7 +161,8 @@ phase2_hcal.toModify( es_hardcode,
                              HEreCalibCutoff = cms.double(100.),
                              useHBUpgrade = cms.bool(True),
                              useHEUpgrade = cms.bool(True),
-                             useHFUpgrade = cms.bool(True)
+                             useHFUpgrade = cms.bool(True),
+                             useLayer0Weight = cms.bool(True),
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -460,6 +460,11 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const
       ((cell.genericSubdet() == HcalGenericDetId::HcalGenEndcap) || (cell.genericSubdet() == HcalGenericDetId::HcalGenBarrel)) &&
       (HcalDetId(cell).depth()==1 && dbHardcode.getLayersInDepth(HcalDetId(cell).ieta(),HcalDetId(cell).depth(),topo)==1) )
     {
+      //layer 0 is thicker than other layers (9mm vs 3.7mm) and brighter (Bicron vs SCSN81)
+      //in Run1/Run2 (pre-2017 for HE), ODU for layer 0 had neutral density filter attached
+      //NDF was simulated as weight of 0.5 applied to Geant energy deposits
+      //for Phase1, NDF is removed - simulated as weight of 1.2 applied to Geant energy deposits
+      //to maintain RECO calibrations, move the layer 0 energy scale back to its previous state using respcorrs
       corr = 0.5/1.2;
     }
 
@@ -467,15 +472,17 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const
       int depth_ = HcalDetId(cell).depth();
       int ieta_  = HcalDetId(cell).ieta();
       corr *= he_recalibration->getCorr(ieta_, depth_); 
-      
-      //std::cout << "HE ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
+#ifdef DebugLog      
+      std::cout << "HE ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
+#endif
     }
     else if ((hf_recalibration != 0 ) && (cell.genericSubdet() == HcalGenericDetId::HcalGenForward)) {
       int depth_ = HcalDetId(cell).depth();
       int ieta_  = HcalDetId(cell).ieta();
       corr = hf_recalibration->getCorr(ieta_, depth_, iLumi); 
-
-      //std::cout << "HF ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
+#ifdef DebugLog
+      std::cout << "HF ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
+#endif
     }
 
     HcalRespCorr item(cell.rawId(),corr);

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -147,6 +147,7 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
   dbHardcode.setKillHE(iConfig.getParameter<bool>("killHE"));
   dbHardcode.setSiPMCharacteristics(iConfig.getParameter<std::vector<edm::ParameterSet>>("SiPMCharacteristics"));
 
+  useLayer0Weight = iConfig.getParameter<bool>("useLayer0Weight");
   // HE and HF recalibration preparation
   iLumi=iConfig.getParameter<double>("iLumi");
 
@@ -450,37 +451,34 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const
  
   auto result = std::make_unique<HcalRespCorrs>(topo);
   std::vector <HcalGenericDetId> cells = allCells(*topo, dbHardcode.killHE());
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
+  for (const auto& cell : cells) {
 
     double corr = 1.0; 
 
-    if ((he_recalibration != 0 ) && 
-	((*cell).genericSubdet() == HcalGenericDetId::HcalGenEndcap)) {
-      
-      int depth_ = HcalDetId(*cell).depth();
-      int ieta_  = HcalDetId(*cell).ieta();
-      corr = he_recalibration->getCorr(ieta_, depth_); 
-      
-      /*
-	std::cout << "HE ieta, depth = " << ieta_  << ",  " << depth_  
-	<< "   corr = "  << corr << std::endl;
-      */
-
+    //check for layer 0 reweighting: when depth 1 has only one layer, it is layer 0
+    if( useLayer0Weight && 
+      ((cell.genericSubdet() == HcalGenericDetId::HcalGenEndcap) || (cell.genericSubdet() == HcalGenericDetId::HcalGenBarrel)) &&
+      (HcalDetId(cell).depth()==1 && dbHardcode.getLayersInDepth(HcalDetId(cell).ieta(),HcalDetId(cell).depth(),topo)==1) )
+    {
+      corr = 0.5/1.2;
     }
-    else if ((hf_recalibration != 0 ) && 
-	((*cell).genericSubdet() == HcalGenericDetId::HcalGenForward)) {   
-      int depth_ = HcalDetId(*cell).depth();
-      int ieta_  = HcalDetId(*cell).ieta();
+
+    if ((he_recalibration != 0 ) && (cell.genericSubdet() == HcalGenericDetId::HcalGenEndcap)) {
+      int depth_ = HcalDetId(cell).depth();
+      int ieta_  = HcalDetId(cell).ieta();
+      corr *= he_recalibration->getCorr(ieta_, depth_); 
+      
+      //std::cout << "HE ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
+    }
+    else if ((hf_recalibration != 0 ) && (cell.genericSubdet() == HcalGenericDetId::HcalGenForward)) {
+      int depth_ = HcalDetId(cell).depth();
+      int ieta_  = HcalDetId(cell).ieta();
       corr = hf_recalibration->getCorr(ieta_, depth_, iLumi); 
 
-      /*
-	std::cout << "HF ieta, depth = " << ieta_  << ",  " << depth_  
-	<< "   corr = "  << corr << std::endl;
-      */
-
+      //std::cout << "HF ieta, depth = " << ieta_  << ",  " << depth_ << "   corr = "  << corr << std::endl;
     }
 
-    HcalRespCorr item(cell->rawId(),corr);
+    HcalRespCorr item(cell.rawId(),corr);
     result->addValues(item);
   }
   return result;
@@ -853,6 +851,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc.add<bool>("useHOUpgrade",true);
 	desc.add<bool>("testHFQIE10",false);
 	desc.add<bool>("killHE",false);
+	desc.add<bool>("useLayer0Weight",false);
 	desc.addUntracked<std::vector<std::string> >("toGet",std::vector<std::string>());
 	desc.addUntracked<bool>("fromDDD",false);
 	

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -458,7 +458,7 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const
     //check for layer 0 reweighting: when depth 1 has only one layer, it is layer 0
     if( useLayer0Weight && 
       ((cell.genericSubdet() == HcalGenericDetId::HcalGenEndcap) || (cell.genericSubdet() == HcalGenericDetId::HcalGenBarrel)) &&
-      (HcalDetId(cell).depth()==1 && dbHardcode.getLayersInDepth(HcalDetId(cell).ieta(),HcalDetId(cell).depth(),topo)==1) )
+      (HcalDetId(cell).depth()==1 && dbHardcode.getLayersInDepth(HcalDetId(cell).ietaAbs(),HcalDetId(cell).depth(),topo)==1) )
     {
       //layer 0 is thicker than other layers (9mm vs 3.7mm) and brighter (Bicron vs SCSN81)
       //in Run1/Run2 (pre-2017 for HE), ODU for layer 0 had neutral density filter attached

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -107,5 +107,6 @@ private:
   bool switchGainWidthsForTrigPrims; 
   bool setHEdsegm;
   bool setHBdsegm;
+  bool useLayer0Weight;
 };
 

--- a/Configuration/Eras/python/Era_Phase2C2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C2_cff.py
@@ -4,10 +4,16 @@ from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
-Phase2C2 = cms.ModifierChain(run2_common, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_hcal, phase2_hgcal, phase2_muon, run3_GEM)
+Phase2C2 = cms.ModifierChain(run2_common, phase2_common, phase2_tracker, trackingPhase2PU140, 
+    run2_HE_2017, run2_HF_2017, run2_HCAL_2017, run3_HB, phase2_hcal, phase2_hgcal, phase2_muon, run3_GEM
+)
 

--- a/Configuration/Eras/python/Modifier_run3_HB_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_HB_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for HB-specific changes for sim, reco, etc.
+
+run3_HB =  cms.Modifier()
+

--- a/Configuration/Geometry/scripts/dict2023Geometry.py
+++ b/Configuration/Geometry/scripts/dict2023Geometry.py
@@ -26,7 +26,7 @@ commonDict = {
         5 : [
             'Geometry/CMSCommonData/data/FieldParameters.xml',
         ],
-        "era" : "self.run2_common, self.phase2_common",
+        "era" : "run2_common, phase2_common",
     }
 }
 
@@ -102,7 +102,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "self.phase2_tracker, self.trackingPhase2PU140",
+        "era" : "phase2_tracker, trackingPhase2PU140",
     },
     "T2" : {
         1 : [
@@ -173,7 +173,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "self.phase2_tracker, self.trackingPhase2PU140",
+        "era" : "phase2_tracker, trackingPhase2PU140",
     },
     "T3" : {
         1 : [
@@ -210,7 +210,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "self.phase2_tracker, self.trackingPhase2PU140",
+        "era" : "phase2_tracker, trackingPhase2PU140",
     }   
 }
 
@@ -352,7 +352,7 @@ caloDict = {
             'from Geometry.EcalMapping.EcalMapping_cfi import *',
             'from Geometry.EcalMapping.EcalMappingRecord_cfi import *',
         ],
-        "era" : "self.phase2_hcal, self.phase2_hgcal",
+        "era" : "run2_HE_2017, run2_HF_2017, run2_HCAL_2017, run3_HB, phase2_hcal, phase2_hgcal",
     }
 }
 
@@ -399,7 +399,7 @@ muonDict = {
             'from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *',
             'from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *',
         ],
-        "era" : "self.phase2_muon, self.run3_GEM",
+        "era" : "phase2_muon, run3_GEM",
     },
     "M2" : {
         1 : [
@@ -442,7 +442,7 @@ muonDict = {
             'from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *',
             'from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *',
         ],
-        "era" : "self.phase2_muon, self.run3_GEM",
+        "era" : "phase2_muon, run3_GEM",
     }
 
 }
@@ -497,7 +497,7 @@ timingDict = {
             'from Geometry.HGCalCommonData.fastTimeParametersInitialization_cfi import *',
             'from Geometry.HGCalCommonData.fastTimeNumberingInitialization_cfi import *',
         ],
-        "era" : "self.phase2_timing",
+        "era" : "phase2_timing",
     }
 }
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -32,6 +32,7 @@ class Eras (object):
                            'peripheralPbPb', 'pA_2016',
                            'run2_HE_2017', 'stage2L1Trigger',
                            'run2_HF_2017', 'run2_HCAL_2017',
+                           'run3_HB',
                            'phase1Pixel', 'run3_GEM',
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',

--- a/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
+++ b/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
@@ -37,3 +37,8 @@ run2_HCAL_2017.toReplaceWith( hcalOfflineSourceSequence, _phase1_hcalOfflineSour
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 _phase2_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copyAndExclude([digiTask,tpTask,rawTask])
 phase2_hcal.toReplaceWith(hcalOfflineSourceSequence, _phase2_hcalOfflineSourceSequence)
+phase2_hcal.toModify(digiPhase1Task,
+    tagHBHE = cms.untracked.InputTag("simHcalDigis","HBHEQIE11DigiCollection"),
+    tagHO = cms.untracked.InputTag("simHcalDigis"),
+    tagHF = cms.untracked.InputTag("simHcalDigis","HFQIE10DigiCollection")
+)

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -12,7 +12,10 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
                      'DQMHarvestMuon+DQMCertMuon'],
             'hcal':     ['DQMOfflineHcal',
                          'PostDQMOffline',
-                         'DQMHarvestHcal+DQMCertHcal'],
+                         'DQMHarvestHcal'],
+            'hcal2': ['HcalDQMOfflineSequence',
+                      'PostDQMOffline',
+                      'HcalDQMOfflinePostProcessor'],
             'jetmet':  ['DQMOfflineJetMET',
                         'PostDQMOffline',
                         'DQMHarvestJetMET+DQMCertJetMET'],
@@ -50,7 +53,8 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
                           'dqmHarvesting']
             }
 
-_phase2_allowed = ['trackingOnlyDQM','muon','hcal']
+_phase2_allowed = ['trackingOnlyDQM','muon','hcal','hcal2']
 autoDQM['phase2'] = ['','','']
-for i in range(0,3):
+for i in [0,2]:
     autoDQM['phase2'][i] = '+'.join([autoDQM[m][i] for m in _phase2_allowed])
+autoDQM['phase2'][1] = 'PostDQMOffline'

--- a/DQMOffline/Hcal/python/HcalDQMOfflineSequence_cff.py
+++ b/DQMOffline/Hcal/python/HcalDQMOfflineSequence_cff.py
@@ -15,3 +15,7 @@ NoiseRatesDQMOffline    = DQMOffline.Hcal.HcalNoiseRatesParam_cfi.hcalNoiseRates
 
 HcalDQMOfflineSequence = cms.Sequence(NoiseRatesDQMOffline*RecHitsDQMOffline*AllCaloTowersDQMOffline)
 #HcalDQMOfflineSequence = cms.Sequence(NoiseRatesDQMOffline*AllCaloTowersDQMOffline)
+
+_phase2_HcalDQMOfflineSequence = HcalDQMOfflineSequence.copyAndExclude([NoiseRatesDQMOffline])
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toReplaceWith(HcalDQMOfflineSequence, _phase2_HcalDQMOfflineSequence)

--- a/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
@@ -3,8 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalCalo.HcalRecProducers.HBHEIsolatedNoiseReflagger_cfi import *
 hcalGlobalRecoSequence = cms.Sequence(hbhereco)
 
-from RecoLocalCalo.HcalRecProducers.HBHEUpgradeReconstructor_cfi import hbheUpgradeReco as _hbheUpgradeReco
+from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hbhereco, _hbheUpgradeReco )
-phase2_hcal.toModify( hbhereco, digiLabel = cms.InputTag('simHcalDigis','HBHEUpgradeDigiCollection') )
+phase2_hcal.toReplaceWith( hbhereco, _phase1_hbheprereco )
+phase2_hcal.toModify( hbhereco,
+    digiLabelQIE8 = cms.InputTag('simHcalDigis'),
+    digiLabelQIE11 = cms.InputTag('simHcalDigis','HBHEQIE11DigiCollection')
+)

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -11,16 +11,6 @@ hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
 
 from RecoLocalCalo.HcalRecProducers.HFUpgradeReconstructor_cfi import hfUpgradeReco as _hfUpgradeReco
 
-_phase2_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
-_phase2_hcalLocalRecoSequence.remove(hbheprereco)
-
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify( horeco, digiLabel = cms.InputTag('simHcalDigis') )
-phase2_hcal.toReplaceWith( hfreco, _hfUpgradeReco )
-phase2_hcal.toModify( hfreco, digiLabel = cms.InputTag('simHcalDigis','HFUpgradeDigiCollection') )
-phase2_hcal.toModify( zdcreco, digiLabel = cms.InputTag('simHcalUnsuppressedDigis'), digiLabelhcal = cms.InputTag('simHcalUnsuppressedDigis') )
-phase2_hcal.toReplaceWith( hcalLocalRecoSequence, _phase2_hcalLocalRecoSequence )
-
 from RecoLocalCalo.HcalRecProducers.hfprereco_cfi import hfprereco
 from RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi import hfreco as _phase1_hfreco
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
@@ -33,3 +23,13 @@ run2_HF_2017.toReplaceWith( hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence
 run2_HF_2017.toReplaceWith( hfreco, _phase1_hfreco )
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 run2_HE_2017.toReplaceWith( hbheprereco, _phase1_hbheprereco )
+
+_phase2_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
+_phase2_hcalLocalRecoSequence.remove(hbheprereco)
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify( horeco, digiLabel = cms.InputTag('simHcalDigis') )
+phase2_hcal.toModify( hfprereco, digiLabel = cms.InputTag('simHcalDigis','HFQIE10DigiCollection') )
+phase2_hcal.toModify( zdcreco, digiLabel = cms.InputTag('simHcalUnsuppressedDigis'), digiLabelhcal = cms.InputTag('simHcalUnsuppressedDigis') )
+phase2_hcal.toReplaceWith( hcalLocalRecoSequence, _phase2_hcalLocalRecoSequence )
+

--- a/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
@@ -9,9 +9,7 @@ hcalDigiSequence = cms.Sequence(simHcalTriggerPrimitiveDigis
                                 +simHcalDigis
                                 *simHcalTTPDigis)
 
-_phase2_hcalDigiSequence = hcalDigiSequence.copy()
-_phase2_hcalDigiSequence.remove(simHcalTriggerPrimitiveDigis)
-_phase2_hcalDigiSequence.remove(simHcalTTPDigis)
+_phase2_hcalDigiSequence = hcalDigiSequence.copyAndExclude([simHcalTriggerPrimitiveDigis,simHcalTTPDigis])
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toReplaceWith( hcalDigiSequence, _phase2_hcalDigiSequence )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -129,6 +129,17 @@ run2_HE_2017.toModify( hcalSimParameters,
     )
 )
 
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify( hcalSimParameters,
+    hb = dict(
+        photoelectronsToAnalog = cms.vdouble([57.5]*14),
+        pixels = cms.int32(27370), 
+        sipmDarkCurrentuA = cms.double(0.055),
+        sipmCrossTalk = cms.double(0.32),
+        doSiPMSmearing = cms.bool(True),
+    )
+)
+
 _newFactors = cms.vdouble(
     210.55, 197.93, 186.12, 189.64, 189.63,
     189.96, 190.03, 190.11, 190.18, 190.25,

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -132,11 +132,9 @@ run2_HE_2017.toModify( hcalSimParameters,
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify( hcalSimParameters,
     hb = dict(
-        photoelectronsToAnalog = cms.vdouble([57.5]*14),
-        pixels = cms.int32(27370), 
-        sipmDarkCurrentuA = cms.double(0.055),
-        sipmCrossTalk = cms.double(0.32),
+        photoelectronsToAnalog = cms.vdouble([57.5]*16),
         doSiPMSmearing = cms.bool(True),
+        sipmTau = cms.double(10.),
     )
 )
 
@@ -161,15 +159,7 @@ _newFactors = cms.vdouble(
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify( hcalSimParameters,
-    hb = dict(
-        photoelectronsToAnalog = cms.vdouble([57.5]*16),
-        doSiPMSmearing = cms.bool(True),
-        sipmTau = cms.double(10.),
-    ),
     he = dict(
         samplingFactors = _newFactors,
-        photoelectronsToAnalog = cms.vdouble([57.5]*len(_newFactors)),
-        doSiPMSmearing = cms.bool(True),
-        sipmTau = cms.double(10.),
     )
 )

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -32,11 +32,7 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( hcalSimBlock, hitsProducer=cms.string('famosSimHits') )
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify( hcalSimBlock,
-    HBHEUpgradeQIE = cms.bool(True),
-    HFUpgradeQIE = cms.bool(True),
-    TestNumbering = cms.bool(True)
-)
+phase2_hcal.toModify( hcalSimBlock, TestNumbering = cms.bool(True) )
 
 # remove HE processing for phase 2, completely put in HGCal land
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import hfTPScaleShift
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 
 LSParameter =cms.untracked.PSet(
 HcalFeatureHFEMBit= cms.bool(False),
@@ -55,3 +56,4 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
 
 run2_HE_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHE=cms.bool(True))
 run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHF=cms.bool(True))
+run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=cms.bool(True))

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -147,6 +147,7 @@ globalValidationHCAL = cms.Sequence(
     + hcaldigisValidationSequence
     + hcalSimHitStudy
     + hcalRecHitsValidationSequence
+    + calotowersValidationSequence
 )
 
 globalPrevalidationMuons = cms.Sequence(

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -87,6 +87,7 @@ postValidation_HCAL = cms.Sequence(
       hcalSimHitsPostProcessor
     + hcaldigisPostProcessor
     + hcalrechitsPostProcessor
+    + calotowersPostProcessor
 )
  
 postValidation_gen = cms.Sequence(

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -17,4 +17,7 @@ if fastSim.isChosen():
     hcaldigisAnalyzer.simHits = cms.untracked.InputTag("famosSimHits","HcalHits")
     
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(hcaldigisAnalyzer, dataTPs = cms.InputTag(""))
+phase2_hcal.toModify(hcaldigisAnalyzer,
+    dataTPs = cms.InputTag(""),
+    digiLabel = cms.string("simHcalDigis")
+)

--- a/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
+++ b/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
@@ -12,3 +12,5 @@ hcalSimHitStudy = cms.EDAnalyzer("HcalSimHitStudy",
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( hcalSimHitStudy, ModuleLabel = cms.untracked.string('famosSimHits') )
     
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify( hcalSimHitStudy, TestNumber = cms.bool(True) )

--- a/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
+++ b/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
@@ -9,3 +9,6 @@ simHitsValidationHcal = cms.EDAnalyzer("SimHitsValidationHcal",
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( simHitsValidationHcal, ModuleLabel = cms.string("famosSimHits") )
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify( simHitsValidationHcal, TestNumber = cms.bool(True) )


### PR DESCRIPTION
Now that the HCAL Phase1 digi/reco is near maturity, it is preferable to use the new dataframes and algorithms for Phase2 (rather than existing "generic" versions from the SLHC release). This PR addresses several points:
1) Introduce `run3_HB` Era to propagate a few necessary changes for the HB upgrade (scheduled for LS2)
2) Chain Phase1 HCAL Eras, digitization, reco algorithms, and validation/DQM into Phase2
3) Add option to apply respcorr of 0.5/1.2 to depth 1 (layer 0) when using hardcode conditions

Some things are still skipped for the Phase2 HCAL (packing/unpacking, noise flagging) due to lack of hardware maps.

A subsequent PR will remove `HcalUpgradeDataFrame` and related classes/code.

This PR will conflict with #16315; I would prefer to have that one merged first and then rebase this one.
