### PR TITLE
Added a getter for the ClusterTPAssociation::map_

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -51,6 +51,8 @@ public:
   range equal_range(const OmniClusterRef& key) const {
     return std::equal_range(map_.begin(), map_.end(), value_type(key, TrackingParticleRef()), compare);
   }
+  
+  const map_type& map() const { return map_; }
 
   void checkMappedProductID(const edm::HandleBase& mappedHandle) const { checkMappedProductID(mappedHandle.id()); }
   void checkMappedProductID(const TrackingParticleRef& tp) const { checkMappedProductID(tp.id()); }


### PR DESCRIPTION
This PR only adds a getter function for the map_ data member in the ClusterTPAssociation. 

This change is needed in the BTV group to match to a given TrackingParticle (TP) the clusters assigned to it. The ClusterTPAssociation is built in a way that for a given cluster you can access the corresponding TP using the equal_range function. The other way around (for a given TP get the clusters) is not possible due to the ordering of the map. After a discussion with Matti Kortelainen (@makortel)  he proposed to add this getter function, such that externally the user can order the map in his/her preferred way (according to TP rather than according to the clusters) and get the clusters for a given TP.

This was tested and indeed works. 
