### PR TITLE
Config l1t Layer2 emulator tower-count in CMSSW_8_0_22

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -36,7 +36,7 @@ if eras.stage2L1Trigger.isChosen():
     
     # from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis    
     
-    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_2_cfi import *    
+    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi import *    
     
     # What about CaloConfig?  Related:  How will we switch PP/HH?
     #


### PR DESCRIPTION
Configuration to run Calo Layer2 emulator also for TowerCount algo of EtSum.
Useful for re-running L1T emulation.

Description:
Simple switch Calo configuration to caloStage2Params_2016_v3_3 for HI run.

**********************************************************************************************************
Note:
This is superseded by #16390, which adds configuration functionality to Calo Layer2
emulator relevant for  HI run.
**********************************************************************************************************


