### PR TITLE
Log the number of Streams since it might be different than the number of Threads

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -433,9 +433,9 @@ namespace edm {
       if(nStreams==0) {
         nStreams = nThreads;
       }
-    }
     // PG: Log the number of streams
-    edm::LogInfo("StreamSetup") <<"setting # streams "<<nStreams;
+      edm::LogInfo("StreamSetup") <<"setting # streams "<<nStreams;
+    }
     /*
       bool nRunsSet = false;
     */

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -434,6 +434,8 @@ namespace edm {
         nStreams = nThreads;
       }
     }
+    // PG: Log the number of streams
+    edm::LogInfo("StreamSetup") <<"setting # streams "<<nStreams;
     /*
       bool nRunsSet = false;
     */


### PR DESCRIPTION
I found this to be missing when running benchmarks on the KNL system.
