### PR TITLE
reduction of in-module memory peaks (backport of #16375)

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
@@ -66,16 +66,16 @@
 
 namespace std {
   template<>
-    struct hash<std::pair<size_t,size_t> > {
-    typedef std::pair<size_t,size_t> arg_type;
-    typedef std::size_t value_type;
+    struct hash<std::pair<unsigned int,unsigned int> > {
+    typedef std::pair<unsigned int,unsigned int> arg_type;
+    typedef unsigned int value_type;
     value_type operator()(const arg_type& arg) const {
       return arg.first ^ (arg.second << 1);
     }
   };
   template<>
-    struct equal_to<std::pair<size_t,size_t> > {
-    typedef std::pair<size_t,size_t> arg_type;    
+    struct equal_to<std::pair<unsigned int,unsigned int> > {
+    typedef std::pair<unsigned int,unsigned int> arg_type;    
     bool operator()(const arg_type& arg1, const arg_type& arg2) const {
       return ( (arg1.first == arg2.first) & (arg1.second == arg2.second) );
     }
@@ -101,7 +101,7 @@ class PFBlockAlgo {
   typedef ElementList::const_iterator IEC;  
   typedef reco::PFBlockCollection::const_iterator IBC;
   //for skipping ranges
-  typedef std::array<std::pair<size_t,size_t>,reco::PFBlockElement::kNBETypes> ElementRanges;
+  typedef std::array<std::pair<unsigned int,unsigned int>,reco::PFBlockElement::kNBETypes> ElementRanges;
   
   PFBlockAlgo();
 
@@ -139,7 +139,7 @@ class PFBlockAlgo {
   /// compute missing links in the blocks 
   /// (the recursive procedure does not build all links)  
   void packLinks(reco::PFBlock& block, 
-		 const std::unordered_map<std::pair<size_t,size_t>,PFBlockLink>& links) const; 
+		 const std::unordered_map<std::pair<unsigned int,unsigned int>,PFBlockLink>& links) const; 
   
   /// Avoid to check links when not useful
   inline bool linkPrefilter(const reco::PFBlockElement* last, 

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -207,7 +207,7 @@ void PFBlockAlgo::findBlocks() {
     the_block.addElement(p1);
     const unsigned block_size = blocksmap.count(key) + 1;
     //reserve up to 1M or 8MB; pay rehash cost for more
-    std::unordered_map<std::pair<size_t,size_t>, PFBlockLink > links(max(1000000u,block_size*block_size));
+    std::unordered_map<std::pair<unsigned int,unsigned int>, PFBlockLink > links(min(1000000u,block_size*block_size));
     auto itr = range.first;
     ++itr;
     for( ; itr != range.second; ++itr ) {
@@ -234,7 +234,7 @@ void PFBlockAlgo::findBlocks() {
 
 void 
 PFBlockAlgo::packLinks( reco::PFBlock& block, 
-			   const std::unordered_map<std::pair<size_t,size_t>,PFBlockLink>& links ) const {
+			   const std::unordered_map<std::pair<unsigned int,unsigned int>,PFBlockLink>& links ) const {
   constexpr unsigned rowsize = reco::PFBlockElement::kNBETypes;
   
   const edm::OwnVector< reco::PFBlockElement >& els = block.elements();

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -206,7 +206,8 @@ void PFBlockAlgo::findBlocks() {
     ElementList::value_type::pointer p1(bare_elements_[range.first->second]);
     the_block.addElement(p1);
     const unsigned block_size = blocksmap.count(key) + 1;
-    std::unordered_map<std::pair<size_t,size_t>, PFBlockLink > links(block_size*block_size);
+    //reserve up to 1M or 8MB; pay rehash cost for more
+    std::unordered_map<std::pair<size_t,size_t>, PFBlockLink > links(max(1000000u,block_size*block_size));
     auto itr = range.first;
     ++itr;
     for( ; itr != range.second; ++itr ) {

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -39,7 +39,6 @@ class PFDisplacedVertexFinder {
 
   /// -------- Useful Types -------- ///
 
-  typedef std::set< reco::TrackBaseRef >::iterator IEset;
   typedef reco::PFDisplacedVertexSeedCollection::iterator IDVS;
   typedef reco::PFDisplacedVertexCollection::iterator IDV;
 
@@ -128,7 +127,7 @@ class PFDisplacedVertexFinder {
   void mergeSeeds(reco::PFDisplacedVertexSeedCollection&, std::vector<bool>& bLocked);
 
   /// Fit one by one the vertex points with associated tracks to get displaced vertices
-  bool fitVertexFromSeed(reco::PFDisplacedVertexSeed&, reco::PFDisplacedVertex&);
+  bool fitVertexFromSeed(const reco::PFDisplacedVertexSeed&, reco::PFDisplacedVertex&);
 
   /// Remove potentially fakes displaced vertices
   void selectAndLabelVertices(reco::PFDisplacedVertexCollection&,  std::vector <bool>&);

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -40,7 +40,6 @@ class PFDisplacedVertexFinder {
   /// -------- Useful Types -------- ///
 
   typedef std::set< reco::TrackBaseRef >::iterator IEset;
-  typedef reco::PFDisplacedVertexCandidateCollection::iterator IDVC;
   typedef reco::PFDisplacedVertexSeedCollection::iterator IDVS;
   typedef reco::PFDisplacedVertexCollection::iterator IDV;
 
@@ -123,7 +122,7 @@ class PFDisplacedVertexFinder {
   /// -------- Different steps of the finder algorithm -------- ///
 
   /// Analyse a vertex candidate and select potential vertex point(s)
-  void findSeedsFromCandidate(reco::PFDisplacedVertexCandidate&, reco::PFDisplacedVertexSeedCollection&);
+  void findSeedsFromCandidate(const reco::PFDisplacedVertexCandidate&, reco::PFDisplacedVertexSeedCollection&);
 
   /// Sometimes two vertex candidates can be quite close and coming from the same vertex
   void mergeSeeds(reco::PFDisplacedVertexSeedCollection&, std::vector<bool>& bLocked);
@@ -153,7 +152,7 @@ class PFDisplacedVertexFinder {
 
   /// -------- Members -------- ///
 
-  std::auto_ptr< reco::PFDisplacedVertexCandidateCollection >  displacedVertexCandidates_;
+  reco::PFDisplacedVertexCandidateCollection const*  displacedVertexCandidates_;
   std::auto_ptr< reco::PFDisplacedVertexCollection >    displacedVertices_;
 
   /// -------- Parameters -------- ///

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -104,7 +104,7 @@ PFDisplacedVertexFinder::findDisplacedVertices() {
     if (!tempDisplacedVertexSeeds[idv].isEmpty() && !bLockedSeeds[idv]) {
       PFDisplacedVertex displacedVertex;  
       bLockedSeeds[idv] = fitVertexFromSeed(tempDisplacedVertexSeeds[idv], displacedVertex);
-      if (!bLockedSeeds[idv])  tempDisplacedVertices.push_back(displacedVertex);
+      if (!bLockedSeeds[idv])  tempDisplacedVertices.emplace_back(displacedVertex);
     }
   }
 
@@ -220,7 +220,7 @@ PFDisplacedVertexFinder::mergeSeeds(PFDisplacedVertexSeedCollection& tempDisplac
 
 
 bool
-PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVertexSeed, PFDisplacedVertex& displacedVertex) {
+PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displacedVertexSeed, PFDisplacedVertex& displacedVertex) {
 
 
   if (debug_) cout << "== Start vertexing procedure ==" << endl;
@@ -228,7 +228,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
 
   // ---- Prepare transient track list ----
 
-  set < TrackBaseRef, PFDisplacedVertexSeed::Compare > tracksToFit = displacedVertexSeed.elements();
+  set < TrackBaseRef, PFDisplacedVertexSeed::Compare > const& tracksToFit = displacedVertexSeed.elements();
   GlobalPoint seedPoint = displacedVertexSeed.seedPoint();
 
   vector<TransientTrack> transTracks;
@@ -260,7 +260,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
 
   if (rho > tobCut_ || fabs(z) > tecCut_) {
     if (debug_) cout << "Seed Point out of the tracker rho = " << rho << " z = "<< z << " nTracks = " << tracksToFit.size() << endl;
-  return true;
+    return true;
   }
 
   if (debug_) displacedVertexSeed.Dump();
@@ -269,13 +269,13 @@ PFDisplacedVertexFinder::fitVertexFromSeed(PFDisplacedVertexSeed& displacedVerte
   int nNotIterative = 0;
 
   // Fill vectors of TransientTracks and TrackRefs after applying preselection cuts.
-  for(IEset ie = tracksToFit.begin(); ie !=  tracksToFit.end(); ie++){
-    TransientTrack tmpTk( *((*ie).get()), magField_, globTkGeomHandle_);
+  for(auto const& ie : tracksToFit){
+    TransientTrack tmpTk( *(ie.get()), magField_, globTkGeomHandle_);
     transTracksRaw.push_back( tmpTk );
-    transTracksRefRaw.push_back( *ie );
-    bool nonIt = PFTrackAlgoTools::nonIterative((*ie)->algo());
-    bool step45 = PFTrackAlgoTools::step45((*ie)->algo());
-    bool highQ = PFTrackAlgoTools::highQuality((*ie)->algo());   
+    transTracksRefRaw.push_back( ie );
+    bool nonIt = PFTrackAlgoTools::nonIterative((ie)->algo());
+    bool step45 = PFTrackAlgoTools::step45((ie)->algo());
+    bool highQ = PFTrackAlgoTools::highQuality((ie)->algo());   
     if (step45)
       nStep45++;
     else if (nonIt)

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -43,7 +43,11 @@ void
 PFDisplacedVertexFinder::setInput(
 				  const edm::Handle<reco::PFDisplacedVertexCandidateCollection>& displacedVertexCandidates) {
 
-  displacedVertexCandidates_ = displacedVertexCandidates.product();
+  if (displacedVertexCandidates.isValid()){
+    displacedVertexCandidates_ = displacedVertexCandidates.product();
+  } else {
+    displacedVertexCandidates_ = nullptr;
+  }
 
 }
 
@@ -61,6 +65,10 @@ PFDisplacedVertexFinder::findDisplacedVertices() {
   else 
     displacedVertices_.reset( new PFDisplacedVertexCollection );
 
+  if (displacedVertexCandidates_ == nullptr) {
+    edm::LogInfo("EmptyVertexInput")<<"displacedVertexCandidates are not set or the setInput was called with invalid vertex";
+    return;
+  }
 
   // Prepare the collections
   PFDisplacedVertexSeedCollection tempDisplacedVertexSeeds;

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -26,7 +26,7 @@ using namespace reco;
 //#define PFLOW_DEBUG
 
 PFDisplacedVertexFinder::PFDisplacedVertexFinder() : 
-  displacedVertexCandidates_( new PFDisplacedVertexCandidateCollection ),
+  displacedVertexCandidates_( nullptr),
   displacedVertices_( new PFDisplacedVertexCollection ),
   transvSize_(0.0),
   longSize_(0.0),
@@ -43,19 +43,7 @@ void
 PFDisplacedVertexFinder::setInput(
 				  const edm::Handle<reco::PFDisplacedVertexCandidateCollection>& displacedVertexCandidates) {
 
-  if( displacedVertexCandidates_.get() ) {
-    displacedVertexCandidates_->clear();
-  }
-  else 
-    displacedVertexCandidates_.reset( new PFDisplacedVertexCandidateCollection );
-
-
-  if(displacedVertexCandidates.isValid()) {
-    for(unsigned i=0;i<displacedVertexCandidates->size(); i++) {
-      PFDisplacedVertexCandidateRef dvcref( displacedVertexCandidates, i); 
-      displacedVertexCandidates_->push_back( (*dvcref));
-    }
-  }
+  displacedVertexCandidates_ = displacedVertexCandidates.product();
 
 }
 
@@ -88,15 +76,14 @@ PFDisplacedVertexFinder::findDisplacedVertices() {
 
   int i = -1;
 
-  for(IDVC idvc = displacedVertexCandidates_->begin(); 
-      idvc != displacedVertexCandidates_->end(); idvc++) {
+  for(auto const& idvc : *displacedVertexCandidates_) {
 
     i++;
     if (debug_) {
       cout << "Analyse Vertex Candidate " << i << endl;
     }
     
-    findSeedsFromCandidate(*idvc, tempDisplacedVertexSeeds);
+    findSeedsFromCandidate(idvc, tempDisplacedVertexSeeds);
     
   }     
 
@@ -145,7 +132,7 @@ PFDisplacedVertexFinder::findDisplacedVertices() {
 
 
 void 
-PFDisplacedVertexFinder::findSeedsFromCandidate(PFDisplacedVertexCandidate& vertexCandidate, PFDisplacedVertexSeedCollection& tempDisplacedVertexSeeds){
+PFDisplacedVertexFinder::findSeedsFromCandidate(const PFDisplacedVertexCandidate& vertexCandidate, PFDisplacedVertexSeedCollection& tempDisplacedVertexSeeds){
   
   const PFDisplacedVertexCandidate::DistMap r2Map = vertexCandidate.r2Map();
   bool bNeedNewCandidate = false;


### PR DESCRIPTION
Significant in-module memory use peaks were found in tests of HLTPhysicsIsolatedBunch data in 283171 (LS 60 was used in tests):
- particleFlowDisplacedVertex with ~2GB: the blow up happened in AdaptiveVertexFitter trying to fit vertices with 3-4 K tracks passed to the algo without pre-filtering with a simpler fitting. 
  - Apparently the pre-filtering was designed with a 1K track preselection in mind. In a normal situation we should not have displaced vertices with O(1000) tracks. So, the candidate selection will need to be updated.
  - main change in this PR is to skip candidates with more than 1000 tracks (in addition to some simpler cosmetics). This should be rare enough in Run2 that we can have this update in the 80X.
- particleFlowBlock with up to ~1GB: here, map hash initialization was made too large
  - HO-to-others linking may need to be revisited to see if cases of linking 10K block elements (as happened in these events) is meaningful
  - the main change in this PR for PFBA is to limit the block link map reserve to 1M (this apparently  rarely ever happens even in PU200 in simulation). The cost is some extra CPU to extend the hash if the links size in the map ever gets over the 1M count. I have also changed the indexing from 64 bit size_t to unsigned_int.

No changes are expected in jenkins tests.
