### PR TITLE
Track history fixes backport80 x

### DIFF
--- a/SimTracker/TrackHistory/interface/HistoryBase.h
+++ b/SimTracker/TrackHistory/interface/HistoryBase.h
@@ -82,7 +82,7 @@ public:
      //! Return all reco::GenParticle in the history.
     RecoGenParticleTrail const & recoGenParticleTrail() const
     {
-        return recoGenParticlesTrail_;
+        return recoGenParticleTrail_;
     }
 
     //! Return the initial tracking particle from the history.

--- a/SimTracker/TrackHistory/interface/HistoryBase.h
+++ b/SimTracker/TrackHistory/interface/HistoryBase.h
@@ -20,7 +20,7 @@ public:
     //! reco::GenParticle trail type.
     typedef std::vector<const reco::GenParticle *> RecoGenParticleTrail;
     
-    //! GenVertex trail helper type.
+    //!reco::GenParticle trail helper type.
     typedef std::set<const reco::GenParticle *> RecoGenParticleTrailHelper;
 
     //! GenVertex trail type.
@@ -73,7 +73,7 @@ public:
         return genVertexTrail_;
     }
 
-    //! Return all generated particle in the history.
+    //! Return all generated particle (HepMC::GenParticle) in the history.
     GenParticleTrail const & genParticleTrail() const
     {
         return genParticleTrail_;
@@ -82,7 +82,7 @@ public:
      //! Return all reco::GenParticle in the history.
     RecoGenParticleTrail const & recoGenParticleTrail() const
     {
-        return recoGenParticleTrail_;
+        return recoGenParticlesTrail_;
     }
 
     //! Return the initial tracking particle from the history.
@@ -104,7 +104,7 @@ public:
         return genParticleTrail_[genParticleTrail_.size()-1];
     }
     
-    //! Returns a pointer to most primitive status 1 or 2 particle.
+    //! Returns a pointer to most primitive status 1 or 2 particle in the recoGenParticleTrail_.
     const reco::GenParticle * recoGenParticle() const
     {
         if ( recoGenParticleTrail_.empty() ) return 0;

--- a/SimTracker/TrackHistory/interface/HistoryBase.h
+++ b/SimTracker/TrackHistory/interface/HistoryBase.h
@@ -14,8 +14,14 @@ class HistoryBase
 
 public:
 
-    //! GenParticle trail type.
+    //! HepMC::GenParticle trail type.
     typedef std::vector<const HepMC::GenParticle *> GenParticleTrail;
+    
+    //! reco::GenParticle trail type.
+    typedef std::vector<const reco::GenParticle *> RecoGenParticleTrail;
+    
+    //! GenVertex trail helper type.
+    typedef std::set<const reco::GenParticle *> RecoGenParticleTrailHelper;
 
     //! GenVertex trail type.
     typedef std::vector<const HepMC::GenVertex *> GenVertexTrail;
@@ -72,6 +78,12 @@ public:
     {
         return genParticleTrail_;
     }
+    
+     //! Return all reco::GenParticle in the history.
+    RecoGenParticleTrail const & recoGenParticleTrail() const
+    {
+        return recoGenParticleTrail_;
+    }
 
     //! Return the initial tracking particle from the history.
     const TrackingParticleRef & simParticle() const
@@ -85,11 +97,18 @@ public:
         return simVertexTrail_[0];
     }
 
-    //! Returns a pointer to most primitive status 1 or 2 particle.
+    //! Returns a pointer to most primitive status 1 or 2 particle in the genParticleTrail_.
     const HepMC::GenParticle * genParticle() const
     {
         if ( genParticleTrail_.empty() ) return 0;
         return genParticleTrail_[genParticleTrail_.size()-1];
+    }
+    
+    //! Returns a pointer to most primitive status 1 or 2 particle.
+    const reco::GenParticle * recoGenParticle() const
+    {
+        if ( recoGenParticleTrail_.empty() ) return 0;
+        return recoGenParticleTrail_[recoGenParticleTrail_.size()-1];
     }
 
 protected:
@@ -97,11 +116,13 @@ protected:
     // History cointainers
     GenVertexTrail genVertexTrail_;
     GenParticleTrail genParticleTrail_;
+    RecoGenParticleTrail recoGenParticleTrail_;
     SimVertexTrail simVertexTrail_;
     SimParticleTrail simParticleTrail_;
 
     // Helper function to speedup search
     GenVertexTrailHelper genVertexTrailHelper_;
+    RecoGenParticleTrailHelper recoGenParticleTrailHelper_;
 
     //! Evaluate track history using a TrackingParticleRef.
     /* Return false when the history cannot be determined upto a given depth.
@@ -141,8 +162,12 @@ private:
     //! Trace all the simulated information for a given reference to a TrackingVertex.
     bool traceSimHistory (TrackingVertexRef const &, int);
 
-    //! Trace all the simulated information for a given pointer to a GenParticle.
+    //! Trace all the simulated information for a given pointer to a HepMC::GenParticle.
     void traceGenHistory (HepMC::GenParticle const *);
+    
+    //! Trace all the simulated information for a given pointer to a reco::GenParticle.
+    void traceRecoGenHistory (reco::GenParticle const *);
+    
 
     //! Trace all the simulated information for a given pointer to a GenVertex.
     void traceGenHistory (HepMC::GenVertex const *);
@@ -154,6 +179,8 @@ private:
         simVertexTrail_.clear();
         genVertexTrail_.clear();
         genParticleTrail_.clear();
+        recoGenParticleTrail_.clear();
+        recoGenParticleTrailHelper_.clear();
         genVertexTrailHelper_.clear();
     }
 

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -65,10 +65,10 @@ public:
     }
     
     // return the TrackingParticle to which the Track was matched
-    const std::pair<TrackingParticleRef, double>  GetMatchedTrackingParticle() const
+    const std::pair<TrackingParticleRef, double>  getMatchedTrackingParticle() const
     {
     	std::pair<TrackingParticleRef, double> result;
-    	result.first = TrackingParticle_;
+    	result.first = trackingParticle_;
     	result.second = quality_;
     	
     	return result;
@@ -97,7 +97,7 @@ private:
 
     reco::TrackBaseRef recotrack_;
     
-    TrackingParticleRef TrackingParticle_;
+    TrackingParticleRef trackingParticle_;
 
     reco::RecoToSimCollection recoToSim_;
 

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -63,6 +63,16 @@ public:
     {
         return recotrack_;
     }
+    
+    // return the TrackingParticle to which the Track was matched
+    const std::pair<TrackingParticleRef, double>  GetMatchedTrackingParticle() const
+    {
+    	std::pair<TrackingParticleRef, double> result;
+    	result.first = TrackingParticle_;
+    	result.second = quality_;
+    	
+    	return result;
+    }
 
     double quality() const
     {
@@ -86,6 +96,8 @@ private:
     edm::InputTag trackAssociator_;
 
     reco::TrackBaseRef recotrack_;
+    
+    TrackingParticleRef TrackingParticle_;
 
     reco::RecoToSimCollection recoToSim_;
 

--- a/SimTracker/TrackHistory/src/HistoryBase.cc
+++ b/SimTracker/TrackHistory/src/HistoryBase.cc
@@ -5,6 +5,27 @@
 #include "SimTracker/TrackHistory/interface/HistoryBase.h"
 
 
+void HistoryBase::traceRecoGenHistory(reco::GenParticle const * genParticle)
+{
+    // fill the trace of reco::GenParticle for correct reading of the History flags etc.
+    // This is called from the TrackingParticle->genParticle_begin() which is a reco::GenParticle
+    if ( genParticle->status() <= abs(depth_) && (genParticle->pdgId() < 88 || genParticle->pdgId() > 99) )
+    {
+        //If the particle is already in the history, it is looping and you should stop
+        if ( recoGenParticleTrailHelper_.find(genParticle) != recoGenParticleTrailHelper_.end() ){
+           return;
+        }
+        recoGenParticleTrail_.push_back(genParticle);
+        recoGenParticleTrailHelper_.insert(genParticle);
+        // Get the genParticle's mother and trace its history
+        //std::cout << "reco::GenParticle::pdgId() : " << genParticle->pdgId() << std::endl;
+        if (genParticle->mother() != 0){
+        	traceRecoGenHistory( (const reco::GenParticle *)genParticle->mother() );
+        }
+    }
+}
+
+
 void HistoryBase::traceGenHistory(HepMC::GenParticle const * genParticle)
 {
     // Third stop criteria: status abs(depth_) particles after the hadronization.
@@ -48,9 +69,9 @@ bool HistoryBase::traceSimHistory(TrackingParticleRef const & trackingParticle, 
 				 << std::endl;
 	//#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
 	// this code does not compile likely due to the wrong type of iterator
-	#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-	traceGenHistory(&(**(trackingParticle->genParticle_begin()))); 
-	#endif
+	//#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
+	traceRecoGenHistory(&(**(trackingParticle->genParticle_begin()))); 
+	//#endif
 
     }
 

--- a/SimTracker/TrackHistory/src/HistoryBase.cc
+++ b/SimTracker/TrackHistory/src/HistoryBase.cc
@@ -9,6 +9,9 @@ void HistoryBase::traceRecoGenHistory(reco::GenParticle const * genParticle)
 {
     // fill the trace of reco::GenParticle for correct reading of the History flags etc.
     // This is called from the TrackingParticle->genParticle_begin() which is a reco::GenParticle
+    
+    // Take onlt genParticles with a status() smaller than "depth_". Typically depth is 2 and so you trace back untill you reach the hard partons
+    // see for status(): https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenParticleCandidate#GenPCand
     if ( genParticle->status() <= abs(depth_) && (genParticle->pdgId() < 88 || genParticle->pdgId() > 99) )
     {
         //If the particle is already in the history, it is looping and you should stop
@@ -18,7 +21,6 @@ void HistoryBase::traceRecoGenHistory(reco::GenParticle const * genParticle)
         recoGenParticleTrail_.push_back(genParticle);
         recoGenParticleTrailHelper_.insert(genParticle);
         // Get the genParticle's mother and trace its history
-        //std::cout << "reco::GenParticle::pdgId() : " << genParticle->pdgId() << std::endl;
         if (genParticle->mother() != 0){
         	traceRecoGenHistory( (const reco::GenParticle *)genParticle->mother() );
         }
@@ -67,17 +69,15 @@ bool HistoryBase::traceSimHistory(TrackingParticleRef const & trackingParticle, 
     {
         LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId() << " has a GenParicle image." 
 				 << std::endl;
-	//#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-	// this code does not compile likely due to the wrong type of iterator
-	//#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
+
 	traceRecoGenHistory(&(**(trackingParticle->genParticle_begin()))); 
-	//#endif
+
 
     }
 
     LogDebug("TrackHistory") << "No GenParticle image for " << trackingParticle->pdgId() << std::endl;
 
-    // get a reference to the TP's parent vertex and trace it history
+    // if no association between TP and genParticles is found: get a reference to the TP's parent vertex and trace its history
     return traceSimHistory( trackingParticle->parentVertex(), depth );
 }
 

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -262,7 +262,7 @@ void TrackClassifier::qualityInformation(reco::TrackBaseRef const & track)
 
 void TrackClassifier::hadronFlavor()
 {
-    // Get the initial hadron
+    // Get the initial hadron from the recoGenParticleTrail
     const reco::GenParticle * particle = tracer_.recoGenParticle();
 
     // Check for the initial hadron
@@ -281,10 +281,10 @@ void TrackClassifier::processesAtGenerator()
     // pdgid of the "in" particle to the production vertex
     int pdgid = 0;
 
-    // Get the generated particles from track history
+    // Get the generated particles from track history (reco::GenParticle in the recoGenParticleTrail)
     TrackHistory::RecoGenParticleTrail const & recoGenParticleTrail = tracer_.recoGenParticleTrail();
 
-    // Loop over the generated particles
+    // Loop over the generated particles (reco::GenParticle in the recoGenParticleTrail)
     for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle = recoGenParticleTrail.begin(); iparticle != recoGenParticleTrail.end(); ++iparticle)
     {
                 pdgid = std::abs((*iparticle)->pdgId());
@@ -311,7 +311,6 @@ void TrackClassifier::processesAtGenerator()
                         for( size_t i = 0; i < ndau; ++ i ){
     						daughterIds.insert((*iparticle)->daughter(i)->pdgId());
     					}
-                        //if (ndau != 0){daughterId = abs((*iparticle)->daughter()->pdgId());}
                         update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && (daughterIds.find(13) != daughterIds.end()));
                         update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && (daughterIds.find(13) != daughterIds.end()));
                     }

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -263,12 +263,12 @@ void TrackClassifier::qualityInformation(reco::TrackBaseRef const & track)
 void TrackClassifier::hadronFlavor()
 {
     // Get the initial hadron
-    const HepMC::GenParticle * particle = tracer_.genParticle();
+    const reco::GenParticle * particle = tracer_.recoGenParticle();
 
     // Check for the initial hadron
     if (particle)
     {
-        HepPDT::ParticleID pid(particle->pdg_id());
+        HepPDT::ParticleID pid(particle->pdgId());
         flags_[Bottom] = pid.hasBottom();
         flags_[Charm] =  pid.hasCharm();
         flags_[Light] = !pid.hasCharm() && !pid.hasBottom();
@@ -282,25 +282,12 @@ void TrackClassifier::processesAtGenerator()
     int pdgid = 0;
 
     // Get the generated particles from track history
-    TrackHistory::GenParticleTrail const & genParticleTrail = tracer_.genParticleTrail();
+    TrackHistory::RecoGenParticleTrail const & recoGenParticleTrail = tracer_.recoGenParticleTrail();
 
     // Loop over the generated particles
-    for (TrackHistory::GenParticleTrail::const_iterator iparticle = genParticleTrail.begin(); iparticle != genParticleTrail.end(); ++iparticle)
+    for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle = recoGenParticleTrail.begin(); iparticle != recoGenParticleTrail.end(); ++iparticle)
     {
-        // Get the source vertex for the particle
-        HepMC::GenVertex * productionVertex = (*iparticle)->production_vertex();
-
-        // Get the pointer to the vertex by removing the const-ness (no const methos in HepMC::GenVertex)
-        // HepMC::GenVertex * vertex = const_cast<HepMC::GenVertex *>(*ivertex);
-
-        // Check for a non-null pointer to the production vertex
-        if (productionVertex)
-        {
-            // Only case track history will navegate (one in or source particle per vertex)
-            if ( productionVertex->particles_in_size() == 1 )
-            {
-                // Look at the pdgid of the first "in" particle to the vertex
-                pdgid = std::abs((*productionVertex->particles_in_const_begin())->pdg_id());
+                pdgid = std::abs((*iparticle)->pdgId());
                 // Get particle type
                 HepPDT::ParticleID particleID(pdgid);
 
@@ -319,9 +306,14 @@ void TrackClassifier::processesAtGenerator()
                         update(flags_[BWeakDecay], particleID.hasBottom());
                         update(flags_[CWeakDecay], particleID.hasCharm());
                         // Check for B and C pure leptonic decay
-                        int daughterId = abs((*iparticle)->pdg_id());
-                        update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && daughterId == 13);
-                        update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && daughterId == 13);
+                        std::set<int> daughterIds;
+                        size_t ndau = (*iparticle)->numberOfDaughters();
+                        for( size_t i = 0; i < ndau; ++ i ){
+    						daughterIds.insert((*iparticle)->daughter(i)->pdgId());
+    					}
+                        //if (ndau != 0){daughterId = abs((*iparticle)->daughter()->pdgId());}
+                        update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && (daughterIds.find(13) != daughterIds.end()));
+                        update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && (daughterIds.find(13) != daughterIds.end()));
                     }
                     // Check Tau, Ks and Lambda decay
                     update(flags_[ChargePionDecay], pdgid == 211);
@@ -333,9 +325,7 @@ void TrackClassifier::processesAtGenerator()
                     update(flags_[XiDecay], pdgid == 3312);
                     update(flags_[SigmaPlusDecay], pdgid == 3222);
                     update(flags_[SigmaMinusDecay], pdgid == 3112);
-                }
-            }
-        }
+                }            
     }
     // Decays in flight
     update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -71,7 +71,7 @@ bool TrackHistory::evaluate ( reco::TrackBaseRef tr )
 
     TrackingParticleRef tpr( result.first );
     quality_ = result.second;
-    TrackingParticle_ = tpr;
+    trackingParticle_ = tpr;
 
     if ( !tpr.isNull() )
     {

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -71,6 +71,7 @@ bool TrackHistory::evaluate ( reco::TrackBaseRef tr )
 
     TrackingParticleRef tpr( result.first );
     quality_ = result.second;
+    TrackingParticle_ = tpr;
 
     if ( !tpr.isNull() )
     {

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -51,6 +51,8 @@ public:
   range equal_range(const OmniClusterRef& key) const {
     return std::equal_range(map_.begin(), map_.end(), value_type(key, TrackingParticleRef()), compare);
   }
+  
+  const map_type& map() const { return map_; }
 
   void checkMappedProductID(const edm::HandleBase& mappedHandle) const { checkMappedProductID(mappedHandle.id()); }
   void checkMappedProductID(const TrackingParticleRef& tp) const { checkMappedProductID(tp.id()); }


### PR DESCRIPTION
This PR is simply a backport to 80X from the following PRs in 81X (already merged)
https://github.com/cms-sw/cmssw/pull/16161
https://github.com/cms-sw/cmssw/pull/16280
https://github.com/cms-sw/cmssw/pull/16367 (Fully-approved, orp-pending)

It applies some fixes to the TrackHistory code needed for Track monitoring in the BTV group.
