### PR TITLE
fix unnecessary ptr copy in HcalObjects

### DIFF
--- a/CondFormats/HcalObjects/src/HcalDcsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalDcsMap.cc
@@ -136,7 +136,7 @@ const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findById (unsigned long 
   sortById();
   
   hcal_impl::LessById lessById;
-  auto ptr = (*mItemsById.load(std::memory_order_acquire));
+  auto const& ptr = (*mItemsById.load(std::memory_order_acquire));
   item = std::lower_bound (ptr.begin(), ptr.end(), &target, lessById);
   if (item == ptr.end() || (*item)->mId != fId){
     //    throw cms::Exception ("Conditions not found") << "Unavailable Dcs map for cell " << fId;
@@ -159,7 +159,7 @@ const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findByDcsId (unsigned lo
   sortByDcsId();
 
   hcal_impl::LessByDcsId lessByDcsId;  
-  auto ptr = (*mItemsByDcsId.load(std::memory_order_acquire));
+  auto const& ptr = (*mItemsByDcsId.load(std::memory_order_acquire));
   item = std::lower_bound (ptr.begin(), ptr.end(), &target, lessByDcsId);
   if (item == ptr.end() || (*item)->mDcsId != fDcsId) {
     //    throw cms::Exception ("Conditions not found") << "Unavailable Dcs map for cell " << fDcsId;

--- a/CondFormats/HcalObjects/src/HcalFrontEndMap.cc
+++ b/CondFormats/HcalObjects/src/HcalFrontEndMap.cc
@@ -46,7 +46,7 @@ const HcalFrontEndMap::PrecisionItem* HcalFrontEndMap::findById (uint32_t fId) c
   std::vector<const HcalFrontEndMap::PrecisionItem*>::const_iterator item;
 
   sortById();
-  auto ptr = (*mPItemsById.load(std::memory_order_acquire));
+  auto const& ptr = (*mPItemsById.load(std::memory_order_acquire));
   item = std::lower_bound (ptr.begin(), ptr.end(), &target, hcal_impl::LessById());
   if (item == ptr.end() || (*item)->mId != fId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;

--- a/CondFormats/HcalObjects/src/HcalSiPMCharacteristics.cc
+++ b/CondFormats/HcalObjects/src/HcalSiPMCharacteristics.cc
@@ -44,7 +44,7 @@ const HcalSiPMCharacteristics::PrecisionItem* HcalSiPMCharacteristics::findByTyp
   std::vector<const HcalSiPMCharacteristics::PrecisionItem*>::const_iterator item;
 
   sortByType();
-  auto ptr = (*mPItemsByType.load(std::memory_order_acquire));
+  auto const& ptr = (*mPItemsByType.load(std::memory_order_acquire));
   item = std::lower_bound (ptr.begin(), ptr.end(), &target, hcal_impl::LessByType());
   if (item == ptr.end() || (*item)->type_ != type)
     //    throw cms::Exception ("Conditions not found") << "Unavailable SiPMCharacteristics for type " << type;


### PR DESCRIPTION
@slava77 followup to https://github.com/cms-sw/cmssw/pull/15959#issuecomment-256348080, this propagates the fix from https://github.com/cms-sw/cmssw/commit/df0c1b3a3f41c978caa40b76f0b0f9240170be58 to all other affected classes in `CondFormats/HcalObjects`. CPU usage in `HBHEIsolatedNoiseReflagger` is reduced dramatically (igprof output from step3 of WF 10024.0):

```
CMSSW_8_1_X_2016-10-27-1100:             0.1  .........       0.13 / 0.13         HBHEIsolatedNoiseReflagger::produce(edm::Event&, edm::EventSetup const&) [2893]
                    PR15959:             0.1  .........       0.26 / 0.26         HBHEIsolatedNoiseReflagger::produce(edm::Event&, edm::EventSetup const&) [1932]
                     fixptr:             0.0  .........       0.02 / 0.02         HBHEIsolatedNoiseReflagger::produce(edm::Event&, edm::EventSetup const&) [6527]
             fixptr+PR15959:             0.0  .........       0.04 / 0.04         HBHEIsolatedNoiseReflagger::produce(edm::Event&, edm::EventSetup const&) [5496]
```

attn: @igv4321
