### PR TITLE
pr80x_HI-configurable-CaloLayer2-emulator 

### DIFF
--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -2,6 +2,20 @@ import os.path
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
+def L1TSettingsToCaloStage2Params_v3_3_HI(process):
+    print " ##############################################################################"
+    print " # Loading configuration for calorimeter parameters for Heavy Ion run.        #"
+    print " #                                                                            #"
+    print " # pp-default parameters subjected to change:                                 #"
+    print " #   jetBypassPUS                                                             #"
+    print " #   egHoverECutBarrel                                                        #"
+    print " #   egHoverECutEndcap                                                        #"
+    print " #   egShapeIdLUTFile                                                         #"
+    print " #   egBypassEGVetos                                                          #"
+    print " ##############################################################################"
+    process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_cfi")
+    return process
+
 def L1TSettingsToCaloStage2Params_v3_3(process):
     process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi")
     return process

--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -3,16 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
 def L1TSettingsToCaloStage2Params_v3_3_HI(process):
-    print " ##############################################################################"
-    print " # Loading configuration for calorimeter parameters for Heavy Ion run.        #"
-    print " #                                                                            #"
-    print " # pp-default parameters subjected to change:                                 #"
-    print " #   jetBypassPUS                                                             #"
-    print " #   egHoverECutBarrel                                                        #"
-    print " #   egHoverECutEndcap                                                        #"
-    print " #   egShapeIdLUTFile                                                         #"
-    print " #   egBypassEGVetos                                                          #"
-    print " ##############################################################################"
     process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_cfi")
     return process
 

--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -36,7 +36,11 @@ namespace l1t {
 	   jetCompressEta=20, jetCompressPt=21,
 	   etSumXPUS=22, etSumYPUS=23, etSumEttPUS=24, etSumEcalSumPUS=25,
 	   tauIsolation2=26,
-	   NUM_CALOPARAMNODES=27
+           egBypassEGVetosFlag=27,
+           jetBypassPUSFlag=28,
+           egHOverEBarrel=29,
+           egHOverEEndcap=30,
+	   NUM_CALOPARAMNODES=31
     };
 
     CaloParamsHelper() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -119,6 +123,9 @@ namespace l1t {
     int egMaxPtJetIsolation() const { return egp_.maxPtJetIsolation_; }
     int egMinPtHOverEIsolation() const { return egp_.minPtHOverEIsolation_; }
     int egMaxPtHOverEIsolation() const { return egp_.maxPtHOverEIsolation_; }
+    unsigned egBypassEGVetos() { return pnode_[egBypassEGVetosFlag].uparams_[0]; }
+    int egHOverEcutBarrel() const {return pnode_[egHOverEBarrel].iparams_[0]; }
+    int egHOverEcutEndcap() const {return pnode_[egHOverEEndcap].iparams_[0]; }
 
     unsigned egIsoAreaNrTowersEta()const{return egp_.isoAreaNrTowersEta_;}
     unsigned egIsoAreaNrTowersPhi()const{return egp_.isoAreaNrTowersPhi_;}
@@ -151,6 +158,18 @@ namespace l1t {
     void setEgMaxPtJetIsolation(int cutValue) { egp_.maxPtJetIsolation_ = cutValue; }
     void setEgMinPtHOverEIsolation(int cutValue) { egp_.minPtHOverEIsolation_ = cutValue; }
     void setEgMaxPtHOverEIsolation(int cutValue) { egp_.maxPtHOverEIsolation_ = cutValue; }
+    void setEgBypassEGVetos(unsigned flag) { 
+      pnode_[egBypassEGVetosFlag].uparams_.resize(1);
+      pnode_[egBypassEGVetosFlag].uparams_[0] = flag; 
+    }
+    void setEgHOverEcutBarrel(int cut) { 
+      pnode_[egHOverEBarrel].iparams_.resize(1);
+      pnode_[egHOverEBarrel].iparams_[0] = cut; 
+    }
+    void setEgHOverEcutEndcap(int cut) { 
+      pnode_[egHOverEEndcap].iparams_.resize(1);
+      pnode_[egHOverEEndcap].iparams_[0] = cut; 
+    }
 
     void setEgIsoAreaNrTowersEta(unsigned iEgIsoAreaNrTowersEta){egp_.isoAreaNrTowersEta_=iEgIsoAreaNrTowersEta;}
     void setEgIsoAreaNrTowersPhi(unsigned iEgIsoAreaNrTowersPhi){egp_.isoAreaNrTowersPhi_=iEgIsoAreaNrTowersPhi;}
@@ -245,6 +264,8 @@ namespace l1t {
 	return 0;
     }
 
+    unsigned jetBypassPUS() const { return pnode_[jetBypassPUSFlag].uparams_[0]; }
+
     std::string jetPUSType() const { return pnode_[jetPUS].type_; }
     std::vector<double> jetPUSParams() { return pnode_[jetPUS].dparams_; }
     std::string jetCalibrationType() const { return pnode_[jetCalibration].type_; }
@@ -268,6 +289,10 @@ namespace l1t {
     void setJetCalibrationLUT(const l1t::LUT & lut) { pnode_[jetCalibration].LUT_ = lut; }
     void setJetCompressEtaLUT(const l1t::LUT & lut) { pnode_[jetCompressEta].LUT_ = lut; }
     void setJetCompressPtLUT(const l1t::LUT & lut) { pnode_[jetCompressPt].LUT_ = lut; }
+    void setJetBypassPUS(unsigned flag) { 
+      pnode_[jetBypassPUSFlag].uparams_.resize(1);
+      pnode_[jetBypassPUSFlag].uparams_[0] = flag; 
+    }
     
     // sums
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -107,10 +107,13 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
 
   m_params_helper.setEgMaxHcalEt(conf.getParameter<double>("egMaxHcalEt"));
   m_params_helper.setEgMaxPtHOverE(conf.getParameter<double>("egMaxPtHOverE"));
+  m_params_helper.setEgHOverEcutBarrel(conf.getParameter<int>("egHOverEcutBarrel"));
+  m_params_helper.setEgHOverEcutEndcap(conf.getParameter<int>("egHOverEcutEndcap"));
   m_params_helper.setEgMinPtJetIsolation(conf.getParameter<int>("egMinPtJetIsolation"));
   m_params_helper.setEgMaxPtJetIsolation(conf.getParameter<int>("egMaxPtJetIsolation"));
   m_params_helper.setEgMinPtHOverEIsolation(conf.getParameter<int>("egMinPtHOverEIsolation"));
   m_params_helper.setEgMaxPtHOverEIsolation(conf.getParameter<int>("egMaxPtHOverEIsolation"));
+  m_params_helper.setEgBypassEGVetos(conf.getParameter<unsigned>("egBypassEGVetos"));
 
 
   edm::FileInPath egMaxHOverELUTFile = conf.getParameter<edm::FileInPath>("egMaxHOverELUTFile");
@@ -214,6 +217,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setJetNeighbourThreshold(conf.getParameter<double>("jetNeighbourThreshold"));
   m_params_helper.setJetRegionMask(conf.getParameter<int>("jetRegionMask"));
   m_params_helper.setJetPUSType(conf.getParameter<std::string>("jetPUSType"));
+  m_params_helper.setJetBypassPUS(conf.getParameter<unsigned>("jetBypassPUS"));
   m_params_helper.setJetCalibrationType(conf.getParameter<std::string>("jetCalibrationType"));
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -107,10 +107,14 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
 
   m_params_helper.setEgMaxHcalEt(conf.getParameter<double>("egMaxHcalEt"));
   m_params_helper.setEgMaxPtHOverE(conf.getParameter<double>("egMaxPtHOverE"));
+  m_params_helper.setEgHOverEcutBarrel(conf.getParameter<int>("egHOverEcutBarrel"));
+  m_params_helper.setEgHOverEcutEndcap(conf.getParameter<int>("egHOverEcutEndcap"));
+
   m_params_helper.setEgMinPtJetIsolation(conf.getParameter<int>("egMinPtJetIsolation"));
   m_params_helper.setEgMaxPtJetIsolation(conf.getParameter<int>("egMaxPtJetIsolation"));
   m_params_helper.setEgMinPtHOverEIsolation(conf.getParameter<int>("egMinPtHOverEIsolation"));
   m_params_helper.setEgMaxPtHOverEIsolation(conf.getParameter<int>("egMaxPtHOverEIsolation"));
+  m_params_helper.setEgBypassEGVetos(conf.getParameter<unsigned>("egBypassEGVetos"));
 
 
   edm::FileInPath egMaxHOverELUTFile = conf.getParameter<edm::FileInPath>("egMaxHOverELUTFile");
@@ -209,6 +213,7 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setJetNeighbourThreshold(conf.getParameter<double>("jetNeighbourThreshold"));
   m_params_helper.setJetRegionMask(conf.getParameter<int>("jetRegionMask"));
   m_params_helper.setJetPUSType(conf.getParameter<std::string>("jetPUSType"));
+  m_params_helper.setJetBypassPUS(conf.getParameter<unsigned>("jetBypassPUS"));
   m_params_helper.setJetCalibrationType(conf.getParameter<std::string>("jetCalibrationType"));
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -35,6 +35,8 @@ caloParams = cms.ESProducer(
     egMaxHcalEt                = cms.double(0.),
     egTrimmingLUTFile          = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egTrimmingLUT_corners.txt"),
     egMaxPtHOverE          = cms.double(128.),
+    egHOverEcutBarrel          = cms.int32(5),
+    egHOverEcutEndcap          = cms.int32(4),
     egMaxHOverE                = cms.double(0.15),
     egMaxHOverELUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egMaxHOverELUT.txt"),
     egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egCompressShapesLUT.txt"),
@@ -59,6 +61,7 @@ caloParams = cms.ESProducer(
     egIsoPUEstTowerGranularity = cms.uint32(1),
     egIsoMaxEtaAbsForTowerSum  = cms.uint32(4),
     egIsoMaxEtaAbsForIsoSum    = cms.uint32(27),
+    egBypassEGVetos            = cms.uint32(0),
 
     # Tau
     tauRegionMask                 = cms.int32(0),
@@ -93,6 +96,7 @@ caloParams = cms.ESProducer(
     jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress.txt"),
     jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress.txt"),
     jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_add_mult.txt"),
+    jetBypassPUS             = cms.uint32(0),
 
     # sums
     etSumLsb                 = cms.double(0.5),

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_2_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_2_cfi.py
@@ -32,7 +32,6 @@ caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalor
 caloStage2Params.egShapeIdType              = cms.string("compressed")
 caloStage2Params.egShapeIdVersion           = cms.uint32(0)
 caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")
-caloStage2Params.egBypassEGVetos              = cms.bool(False)
 
 caloStage2Params.egPUSType                  = cms.string("None")
 caloStage2Params.egIsolationType            = cms.string("compressed")

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_HI_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_HI_cfi.py
@@ -4,6 +4,14 @@ from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
 import L1Trigger.L1TCalorimeter.caloParams_cfi
 caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
 
+# HI parameters
+caloStage2Params.jetBypassPUS               = cms.uint32(1)
+caloStage2Params.egHOverEcutBarrel          = cms.int32(1) #H/E < pow(2,-5) in barrel
+caloStage2Params.egHOverEcutEndcap          = cms.int32(1) #H/E < pow(2,-4) in endcaps
+caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_DUMMY_adapt0.75_compressedieta_compressedE_compressedshape_v16.04.01.txt")
+caloStage2Params.egBypassEGVetos            = cms.uint32(1)
+
+
 # towers
 caloStage2Params.towerLsbH        = cms.double(0.5)
 caloStage2Params.towerLsbE        = cms.double(0.5)
@@ -31,7 +39,7 @@ caloStage2Params.egMaxHOverELUTFile         = cms.FileInPath("L1Trigger/L1TCalor
 caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egCompressLUT_v4.txt")
 caloStage2Params.egShapeIdType              = cms.string("compressed")
 caloStage2Params.egShapeIdVersion           = cms.uint32(0)
-caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")
+#caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")
 
 caloStage2Params.egPUSType                  = cms.string("None")
 caloStage2Params.egIsolationType            = cms.string("compressed")
@@ -47,6 +55,7 @@ caloStage2Params.egPUSParams                = cms.vdouble(1,4,32) #Isolation win
 caloStage2Params.egCalibrationType          = cms.string("compressed")
 caloStage2Params.egCalibrationVersion       = cms.uint32(0)
 caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_v16.03.14.txt")
+
 
 
 # Tau
@@ -169,3 +178,4 @@ caloStage2Params.layer1HFScaleFactors = cms.vdouble([
     1.943941, 1.943941, 1.899826, 1.813950, 1.714978, 1.736184, 1.785928, 1.834211, 1.944230, 2.153565, 2.720887, 2.749795, 
     1.679984, 1.679984, 1.669753, 1.601871, 1.547276, 1.577805, 1.611497, 1.670184, 1.775022, 1.937061, 2.488311, 2.618629, 
     ])
+

--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -36,7 +36,7 @@ if eras.stage2L1Trigger.isChosen():
     
     # from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis    
     
-    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_2_cfi import *    
+    from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi import *    
     
     # What about CaloConfig?  Related:  How will we switch PP/HH?
     #

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2ClusterAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2ClusterAlgorithmFirmwareImp1.cc
@@ -476,9 +476,9 @@ bool l1t::Stage2Layer2ClusterAlgorithmFirmwareImp1::idHoverE(const l1t::CaloTowe
     hOverEBit = false;
   if (!denomZeroFlag && eOverHFlag){ // E >= H , so ratio==log(E/H)
     if(abs(tow.hwEta())< 16 )
-      hOverEBit = ratio >= 5;
+      hOverEBit = ratio >= params_->egHOverEcutBarrel(); // equivalent to H/E<=pow(2,-egHOverEcut)
     else
-    hOverEBit = ratio >= 4;
+      hOverEBit = ratio >= params_->egHOverEcutEndcap();
   }
   
   return hOverEBit;

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
@@ -214,7 +214,7 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
       int hOverEBit = egammas_raw.at(iEG).hwQual()>>1 & (0x1);
       int shapeBit  = egammas_raw.at(iEG).hwQual()>>2 & (0x1);
 
-      bool IDcuts = (fgBit && hOverEBit && shapeBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE());
+      bool IDcuts = (fgBit && hOverEBit && shapeBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE()) || (params_->egBypassEGVetos());
 
       if(!IDcuts) continue;
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -157,8 +157,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	    int caloEta = CaloTools::caloEta(ieta);
 	    l1t::Jet jet( p4, -999, caloEta, iphi, 0);
 
-	    // remove checking if(!params_->jetBypassPUS()). jetBypassPUS_ is currently always set and configured to false
-	    if(true){
+	    if(!params_->jetBypassPUS()){
 	      if (PUSubMethod == "Donut") {
 		puEt = donutPUEstimate(ieta, iphi, 5, towers);	    
 		iEt -= puEt;


### PR DESCRIPTION
This is 80x PR for L1T configurable emulation needed for 2016 HI run. 
- Introduce configuration functionality for some parameters of CaloLayer2 emulator, suitable for 2016 HI running: `jetBypassPUS`, `egHOverEcutBarrel`, `egHOverEcutEndcap`, `egBypassEGVetos`.  This is done via CaloParamsHelper class which ensures the backward compatibility of GlobalTags.
- Introduce a new calo configuration file caloStage2Params_2016_v3_3_HI_cfi, which configures the above parameters as for HI run needs, but also changes the `egShapeIdLUTFile` to a DUMMY LUT effectively bypassing egShapeID cut in the EG Layer2 emulator.
- Still keep the p-p default calo configuration in hackConditions as caloStage2Params_2016_v3_3_cfi.  This will probably be changed to the v3_3_HI or similar, pending confirmation from the HI community.

Instructions for HI users provided at this issue: https://github.com/cms-l1t-offline/cmssw/issues/432
