### PR TITLE
Fixing static analyzer warnings in JetValidation.cc, JetPlusTrackCorrector.cc , PileupJPTJetIdAlgo.cc and ElectronMVAEstimator.cc

### DIFF
--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -101,8 +101,7 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   bool validKF= false;
 
   reco::TrackRef myTrackRef = myElectron.closestCtfTrackRef();
-  validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF = (myTrackRef.isNonnull() && myTrackRef.isAvailable());   
 
   vars[9] = (validKF) ? myTrackRef->normalizedChi2() : 0 ;
   vars[10] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.; 

--- a/RecoJets/JetAnalyzers/src/JetValidation.cc
+++ b/RecoJets/JetAnalyzers/src/JetValidation.cc
@@ -175,7 +175,6 @@ void JetValidation::analyze(edm::Event const& evt, edm::EventSetup const& iSetup
           e = MatchedJet.energy();
           pt = MatchedJet.pt();
           eta = MatchedJet.eta();
-          phi = MatchedJet.phi();
           emEB = MatchedJet.emEnergyInEB();
           emEE = MatchedJet.emEnergyInEE();
           emHF = MatchedJet.emEnergyInHF();

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
@@ -1258,8 +1258,6 @@ double NewResponse = fJet.energy();
 if( trBgOutOfVertex.size() == 0 ) return mScale;
    double EnergyOfBackgroundCharged         = 0.;
    double ResponseOfBackgroundCharged       = 0.;
-   double NumberOfBackgroundChargedVertex   = 0.;
-   double NumberOfBackgroundChargedCalo     = 0.;
 
 //   
 // calculate the mean response
@@ -1292,11 +1290,9 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 	 
 	 EnergyOfBackgroundCharged += echarBg/efficiency_.value(ieta,ipt);
 
-         NumberOfBackgroundChargedVertex++;
 	 
        } // Energy BG tracks
 
-//        std::cout<<" JetPlusTrackCorrector.cc, NumberOfBackgroundChargedVertex ="<<NumberOfBackgroundChargedVertex<<std::endl;
 
 //============= ResponseOfBackgroundCharged =======================>
 
@@ -1323,11 +1319,9 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 //       std::cout<<" Efficiency of bg tracks "<<efficiency_.value(ieta,ipt)<<std::endl;
 
 
-         NumberOfBackgroundChargedCalo++;
 
        } // Response of BG tracks
 
-//  std::cout<<" JetPlusTrackCorrector.cc, NumberOfBackgroundChargedCalo ="<<NumberOfBackgroundChargedCalo<<std::endl;
 //=================================================================>
 
 //=================================================================>
@@ -1378,15 +1372,11 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
        
     EnergyOfBackgroundCharged       = EnergyOfBackgroundCharged/SquareEtaRingWithoutJets;
     ResponseOfBackgroundCharged     = ResponseOfBackgroundCharged/SquareEtaRingWithoutJets;
-    NumberOfBackgroundChargedVertex = NumberOfBackgroundChargedVertex/SquareEtaRingWithoutJets;
-    NumberOfBackgroundChargedCalo   = NumberOfBackgroundChargedCalo/SquareEtaRingWithoutJets;
 //    NumberOfBackgroundCharged   = NumberOfBackgroundCharged/SquareEtaRingWithoutJets;
 
 
     EnergyOfBackgroundCharged       = M_PI*mConeSize*mConeSize*EnergyOfBackgroundCharged;
     ResponseOfBackgroundCharged     = M_PI*mConeSize*mConeSize*ResponseOfBackgroundCharged;
-    NumberOfBackgroundChargedVertex = M_PI*mConeSize*mConeSize*NumberOfBackgroundChargedVertex;
-    NumberOfBackgroundChargedCalo   = M_PI*mConeSize*mConeSize*NumberOfBackgroundChargedCalo;
 //    NumberOfBackgroundCharged   = M_PI*mConeSize*mConeSize*NumberOfBackgroundCharged;
 
 
@@ -1395,8 +1385,6 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 //      std::cout<<"====JetPlusTrackCorrector, Old response=fJet.energy()"<<fJet.energy()
 //               <<" EnergyOfBackgroundCharged="<<EnergyOfBackgroundCharged
 //               <<" ResponseOfBackgroundCharged="<<ResponseOfBackgroundCharged
-//               <<" NewResponse="<<NewResponse<<" NumberOfBackgroundChargedVertex="<<NumberOfBackgroundChargedVertex
-//               <<" NumberOfBackgroundChargedCalo="<<NumberOfBackgroundChargedCalo<<std::endl;
     
     mScale = NewResponse/fJet.energy();
     if(mScale <0.) mScale=0.;       

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -27,23 +27,21 @@ PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps, bool runMvas)
 	  {
 	    etaBinnedWeights_ = ps.getParameter<bool>("etaBinnedWeights");
 	    if(etaBinnedWeights_){
-
-              const std::vector<edm::ParameterSet>& trainings = ps.getParameter<std::vector <edm::ParameterSet> >("trainings");
-              nEtaBins_ = ps.getParameter<int>("nEtaBins");
-              for(int v=0; v<nEtaBins_;v++){
-                tmvaEtaWeights_.push_back( edm::FileInPath(trainings.at(v).getParameter<std::string>("tmvaWeights")).fullPath() );
-                jEtaMin_.push_back( trainings.at(v).getParameter<double>("jEtaMin") );
-                jEtaMax_.push_back( trainings.at(v).getParameter<double>("jEtaMax") );
-              }
-              for(int v=0; v<nEtaBins_;v++){
-                tmvaEtaVariables_.push_back( trainings.at(v).getParameter<std::vector<std::string> >("tmvaVariables") );
-              }
+	      tmvaWeights_jteta_0_2p5_    = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights_jteta_0_2p5")).fullPath();
+	      tmvaWeights_jteta_2p5_2p75_ = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights_jteta_2p5_2p75")).fullPath();
+	      tmvaWeights_jteta_2p75_3_   = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights_jteta_2p75_3")).fullPath();
+	      tmvaWeights_jteta_3_5_      = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights_jteta_3_5")).fullPath();
 	    }
 	    else{
-	      tmvaWeights_                  = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights")).fullPath();
-              tmvaVariables_       = ps.getParameter<std::vector<std::string> >("tmvaVariables");
+	      tmvaWeights_                  = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights")).fullPath();  
 	    }
 	    tmvaMethod_          = ps.getParameter<std::string>("tmvaMethod");
+	    if(etaBinnedWeights_){
+	    	tmvaVariables_jteta_0_3_       = ps.getParameter<std::vector<std::string> >("tmvaVariables_jteta_0_3");
+	    	tmvaVariables_jteta_3_5_       = ps.getParameter<std::vector<std::string> >("tmvaVariables_jteta_3_5");
+	    } else {
+		tmvaVariables_       = ps.getParameter<std::vector<std::string> >("tmvaVariables");
+	    }
 	    tmvaSpectators_      = ps.getParameter<std::vector<std::string> >("tmvaSpectators");
 	    version_             = ps.getParameter<int>("version");
 	  }
@@ -86,6 +84,7 @@ PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps, bool runMvas)
 	setup();
 }
 
+
 // ------------------------------------------------------------------------------------------
 PileupJetIdAlgo::PileupJetIdAlgo(int version,
 				 const std::string & tmvaWeights, 
@@ -112,7 +111,7 @@ void PileupJetIdAlgo::setup()
 	initVariables();
 
 	if( ! cutBased_ ){
-          assert( tmvaMethod_.empty() || ((! tmvaVariables_.empty() || ( !tmvaEtaVariables_.empty() )) && version_ == USER) );
+		assert( tmvaMethod_.empty() || ((! tmvaVariables_.empty() || ( !tmvaVariables_jteta_0_3_.empty() && !tmvaVariables_jteta_3_5_.empty() )) && version_ == USER) );
 	}
 	if(( ! cutBased_ ) && (runMvas_)) { bookReader();}
 }
@@ -143,22 +142,28 @@ void setPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi 
 void PileupJetIdAlgo::bookReader()
 {
 	if(etaBinnedWeights_){
-          for(int v=0; v<nEtaBins_;v++){
-                std::unique_ptr<TMVA::Reader> etaReader = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
-                etaReader_.push_back(std::move(etaReader));
-          }
+		reader_jteta_0_2p5_    = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_2p5_2p75_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_2p75_3_   = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_3_5_      = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
 	} else {
 		reader_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
 	}
 	if(etaBinnedWeights_){
-          for(int v=0; v<nEtaBins_;v++){
-            for(std::vector<std::string>::iterator it=tmvaEtaVariables_.at(v).begin(); it!=tmvaEtaVariables_.at(v).end(); ++it) {
-                if(  tmvaNames_[*it].empty() ) { 
+	  for(std::vector<std::string>::iterator it=tmvaVariables_jteta_0_3_.begin(); it!=tmvaVariables_jteta_0_3_.end(); ++it) {
+		if(  tmvaNames_[*it].empty() ) { 
 			tmvaNames_[*it] = *it;
 		}
-                etaReader_.at(v)->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
-            }
-          }
+		reader_jteta_0_2p5_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+		reader_jteta_2p5_2p75_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+		reader_jteta_2p75_3_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+	  }
+	  for(std::vector<std::string>::iterator it=tmvaVariables_jteta_3_5_.begin(); it!=tmvaVariables_jteta_3_5_.end(); ++it) {
+		if(  tmvaNames_[*it].empty() ) { 
+			tmvaNames_[*it] = *it;
+		}
+		reader_jteta_3_5_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+	  }
 	} else {
 	  for(std::vector<std::string>::iterator it=tmvaVariables_.begin(); it!=tmvaVariables_.end(); ++it) {
 		if(  tmvaNames_[*it].empty() ) { 
@@ -172,17 +177,19 @@ void PileupJetIdAlgo::bookReader()
 			tmvaNames_[*it] = *it;
 		}
 		if(etaBinnedWeights_){
-                  for(int v=0; v<nEtaBins_;v++){
-                        etaReader_.at(v)->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
-                  }
+			reader_jteta_0_2p5_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_2p5_2p75_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_2p75_3_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_3_5_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
 		} else {
 			reader_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
 		}
 	}
 	if(etaBinnedWeights_){
-          for(int v=0; v<nEtaBins_;v++){
-                reco::details::loadTMVAWeights(etaReader_.at(v).get(),  tmvaMethod_.c_str(), tmvaEtaWeights_.at(v).c_str() );
-          }
+		reco::details::loadTMVAWeights(reader_jteta_0_2p5_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_0_2p5_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2p5_2p75_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_2p5_2p75_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2p75_3_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_2p75_3_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_3_5_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_3_5_.c_str() ); 
 	} else {
 		reco::details::loadTMVAWeights(reader_.get(),  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
 	}
@@ -201,19 +208,13 @@ void PileupJetIdAlgo::runMva()
 		internalId_.idFlag_ = computeCutIDflag(internalId_.betaStarClassic_,internalId_.dR2Mean_,internalId_.nvtx_,internalId_.jetPt_,internalId_.jetEta_);
 	} else {
 	       if(std::abs(internalId_.jetEta_) >= 5.0) {
-                        internalId_.mva_ = -2.;
+			internalId_.mva_ = -2.;
 		} else {
 			if(etaBinnedWeights_){
-                          if(std::abs(internalId_.jetEta_) > jEtaMax_.at(nEtaBins_-1)) {
-                              internalId_.mva_ = -2.;
-                          } else {
-                            for(int v=0; v<nEtaBins_;v++){
-                                if(std::abs(internalId_.jetEta_)>=jEtaMin_.at(v) && std::abs(internalId_.jetEta_)<jEtaMax_.at(v)){
-                                    internalId_.mva_ = etaReader_.at(v)->EvaluateMVA( tmvaMethod_.c_str() );
-                                    break;
-                                }
-                            } 
-                          }
+			  if(std::abs(internalId_.jetEta_)<=2.5) internalId_.mva_ = reader_jteta_0_2p5_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else if(std::abs(internalId_.jetEta_)>2.5 && std::abs(internalId_.jetEta_)<=2.75) internalId_.mva_ = reader_jteta_2p5_2p75_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else if(std::abs(internalId_.jetEta_)>2.75 && std::abs(internalId_.jetEta_)<=3.) internalId_.mva_ = reader_jteta_2p75_3_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else internalId_.mva_ = reader_jteta_3_5_->EvaluateMVA( tmvaMethod_.c_str() );
 			} else {
 			  internalId_.mva_ = reader_->EvaluateMVA( tmvaMethod_.c_str() );
 			}
@@ -338,7 +339,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	    float candPt = icand->pt();
 	    float candPtFrac = candPt/jetPt;
 	    float candDr   = reco::deltaR(*icand,*jet);
-	    float candDeta = icand->eta() - jet->eta();
+	    float candDeta = std::abs( icand->eta() - jet->eta() );
 	    float candDphi = reco::deltaPhi(*icand,*jet);
 	    float candPtDr = candPt * candDr;
 	    size_t icone = std::lower_bound(&cones[0],&cones[ncones],candDr) - &cones[0];
@@ -428,7 +429,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 				sumTkPt += tkpt;
 				// 'classic' beta definition based on track-vertex association
 				bool inVtx0 = vtx->trackWeight ( lPF->trackRef()) > 0 ;
-
+					
 				bool inAnyOther = false;
 				// alternative beta definition based on track-vertex distance of closest approach
 				double dZ0 = std::abs(lPF->trackRef()->dz(vtx->position()));
@@ -459,41 +460,21 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 				    internalId_.betaStar_ += tkpt;
 				}
 			   } 
-		        }
+			}
 			else{
+				// setting classic and alternative to be the same for now
 			        float tkpt = candPt;
 			        sumTkPt += tkpt;
 				bool inVtx0 = false; 
 				bool inVtxOther = false; 
-				double dZ0=9999.;
-				double dZ_tmp = 9999.;
-				for (unsigned vtx_i = 0 ; vtx_i < allvtx.size() ; vtx_i++ ) {
-         			        auto iv = allvtx[vtx_i];
-
-					if (iv.isFake())
-						continue;
-
-					// Match to vertex in case of copy as above
-                                        bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
-
-					if (isVtx0) {
-					    if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit) inVtx0 = true;
-					    if (lPack->fromPV(vtx_i) == 0) inVtxOther = true;
-					    dZ0 = lPack->dz(vtx_i);
-					}
-
-					if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {
-						dZ_tmp = lPack->dz(iv.position());
-					}
-				}
+				if (lPack->fromPV() == pat::PackedCandidate::PVUsedInFit) inVtx0 = true;
+				if (lPack->fromPV() == 0) inVtxOther = true;
 				if (inVtx0){
 					internalId_.betaClassic_ += tkpt;
-				} else if (inVtxOther){
-					internalId_.betaStarClassic_ += tkpt;
-				}
-				if (fabs(dZ0) < 0.2){
 					internalId_.beta_ += tkpt;
-				} else if (fabs(dZ_tmp) < 0.2){
+				}
+				if (inVtxOther){
+					internalId_.betaStarClassic_ += tkpt;
 					internalId_.betaStar_ += tkpt;
 				}
 			}
@@ -637,7 +618,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	internalId_.sumNePt_ = sumPtNe;
 
 	internalId_.jetR_    = lLead->pt()/sumPt;
-	internalId_.jetRchg_ = lLeadCh->pt()/sumPt;
+	internalId_.jetRchg_ = lLeadEm->pt()/sumPt;
 	internalId_.dRMatch_ = dRmin;
 
 	if( sumTkPt != 0. ) {


### PR DESCRIPTION
These proposed fixes seem adequate and the deletion of dead assignments from these files have been checked and should cause no issues.