### PR TITLE
Fixing static analyzer warnings in JetValidation.cc, JetPlusTrackCorrector.cc, PileupJPTJetIdAlgo.cc and ElectronMVAEstimator.cc

### DIFF
--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -101,8 +101,7 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   bool validKF= false;
 
   reco::TrackRef myTrackRef = myElectron.closestCtfTrackRef();
-  validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF = (myTrackRef.isNonnull() && myTrackRef.isAvailable());   
 
   vars[9] = (validKF) ? myTrackRef->normalizedChi2() : 0 ;
   vars[10] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.; 

--- a/RecoJets/JetAnalyzers/src/JetValidation.cc
+++ b/RecoJets/JetAnalyzers/src/JetValidation.cc
@@ -175,7 +175,6 @@ void JetValidation::analyze(edm::Event const& evt, edm::EventSetup const& iSetup
           e = MatchedJet.energy();
           pt = MatchedJet.pt();
           eta = MatchedJet.eta();
-          phi = MatchedJet.phi();
           emEB = MatchedJet.emEnergyInEB();
           emEE = MatchedJet.emEnergyInEE();
           emHF = MatchedJet.emEnergyInHF();

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
@@ -1258,8 +1258,6 @@ double NewResponse = fJet.energy();
 if( trBgOutOfVertex.size() == 0 ) return mScale;
    double EnergyOfBackgroundCharged         = 0.;
    double ResponseOfBackgroundCharged       = 0.;
-   double NumberOfBackgroundChargedVertex   = 0.;
-   double NumberOfBackgroundChargedCalo     = 0.;
 
 //   
 // calculate the mean response
@@ -1292,11 +1290,9 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 	 
 	 EnergyOfBackgroundCharged += echarBg/efficiency_.value(ieta,ipt);
 
-         NumberOfBackgroundChargedVertex++;
 	 
        } // Energy BG tracks
 
-//        std::cout<<" JetPlusTrackCorrector.cc, NumberOfBackgroundChargedVertex ="<<NumberOfBackgroundChargedVertex<<std::endl;
 
 //============= ResponseOfBackgroundCharged =======================>
 
@@ -1323,11 +1319,9 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 //       std::cout<<" Efficiency of bg tracks "<<efficiency_.value(ieta,ipt)<<std::endl;
 
 
-         NumberOfBackgroundChargedCalo++;
 
        } // Response of BG tracks
 
-//  std::cout<<" JetPlusTrackCorrector.cc, NumberOfBackgroundChargedCalo ="<<NumberOfBackgroundChargedCalo<<std::endl;
 //=================================================================>
 
 //=================================================================>
@@ -1378,15 +1372,11 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
        
     EnergyOfBackgroundCharged       = EnergyOfBackgroundCharged/SquareEtaRingWithoutJets;
     ResponseOfBackgroundCharged     = ResponseOfBackgroundCharged/SquareEtaRingWithoutJets;
-    NumberOfBackgroundChargedVertex = NumberOfBackgroundChargedVertex/SquareEtaRingWithoutJets;
-    NumberOfBackgroundChargedCalo   = NumberOfBackgroundChargedCalo/SquareEtaRingWithoutJets;
 //    NumberOfBackgroundCharged   = NumberOfBackgroundCharged/SquareEtaRingWithoutJets;
 
 
     EnergyOfBackgroundCharged       = M_PI*mConeSize*mConeSize*EnergyOfBackgroundCharged;
     ResponseOfBackgroundCharged     = M_PI*mConeSize*mConeSize*ResponseOfBackgroundCharged;
-    NumberOfBackgroundChargedVertex = M_PI*mConeSize*mConeSize*NumberOfBackgroundChargedVertex;
-    NumberOfBackgroundChargedCalo   = M_PI*mConeSize*mConeSize*NumberOfBackgroundChargedCalo;
 //    NumberOfBackgroundCharged   = M_PI*mConeSize*mConeSize*NumberOfBackgroundCharged;
 
 
@@ -1395,8 +1385,6 @@ if( trBgOutOfVertex.size() == 0 ) return mScale;
 //      std::cout<<"====JetPlusTrackCorrector, Old response=fJet.energy()"<<fJet.energy()
 //               <<" EnergyOfBackgroundCharged="<<EnergyOfBackgroundCharged
 //               <<" ResponseOfBackgroundCharged="<<ResponseOfBackgroundCharged
-//               <<" NewResponse="<<NewResponse<<" NumberOfBackgroundChargedVertex="<<NumberOfBackgroundChargedVertex
-//               <<" NumberOfBackgroundChargedCalo="<<NumberOfBackgroundChargedCalo<<std::endl;
     
     mScale = NewResponse/fJet.energy();
     if(mScale <0.) mScale=0.;       

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -151,8 +151,6 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
 
        if (verbosity > 0)  std::cout<<" CaloTower jet eta "<<(*jet).eta()<<" tower eta "<<(*icalot)->eta()<<" jet phi "<<(*jet).phi()<<" tower phi "<<(*icalot)->phi()<<" dphi "<<dphi<<" "<<(*icalot)->pt()<<" ieta "<<(*icalot)->ieta()<<" "<<abs((*icalot)->ieta())<<std::endl;
 
-        double dr = sqrt(dphi*dphi+deta*deta);
-        double enc = (*icalot)->emEnergy()+(*icalot)->hadEnergy();
 	
         if(abs((*icalot)->ieta())<30) EE = EE + (*icalot)->emEnergy();
         if(abs((*icalot)->ieta())<30) HE = HE + (*icalot)->hadEnergy();

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -130,11 +130,6 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
       double dphi1=0.;
       double dphideta=0.;     
       double deta1=0.;
-      double ffrac01=0.;
-      double ffrac02=0.;
-      double ffrac03=0.;
-      double ffrac04=0.;
-      double ffrac05=0.;
       double EE=0.;
       double HE=0.;
       double EELong=0.;
@@ -158,11 +153,6 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
 
         double dr = sqrt(dphi*dphi+deta*deta);
         double enc = (*icalot)->emEnergy()+(*icalot)->hadEnergy();
-        if(dr < 0.1) ffrac01 = ffrac01 + enc;
-        if(dr < 0.2) ffrac02 = ffrac02 + enc;
-        if(dr < 0.3) ffrac03 = ffrac03 + enc;
-        if(dr < 0.4) ffrac04 = ffrac04 + enc;
-        if(dr < 0.5) ffrac05 = ffrac05 + enc;
 	
         if(abs((*icalot)->ieta())<30) EE = EE + (*icalot)->emEnergy();
         if(abs((*icalot)->ieta())<30) HE = HE + (*icalot)->hadEnergy();
@@ -199,13 +189,6 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
       double x2 = (detavar+dphivar-det)/2.;
       
       
-  // Energy fraction in cone
- 
-      ffrac01 = ffrac01/(*jet).energy();
-      ffrac02 = ffrac02/(*jet).energy();
-      ffrac03 = ffrac03/(*jet).energy();
-      ffrac04 = ffrac04/(*jet).energy();
-      ffrac05 = ffrac05/(*jet).energy();
   
 if (verbosity > 0)  
 std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "<<deta1<<" dphi1 "<<dphi1<<" detavar "<<detavar<<" dphivar "<<dphivar<<" dphidetacov "<<dphidetacov<<" sqrt(det) "<<sqrt(det)<<" x1 "<<x1<<" x2 "<<x2<<std::endl;


### PR DESCRIPTION
This pull request is fixing dead-assignment errors reported by static analyzer. The proposed fixes have been discussed and checks performed demonstrate they cause no problems.