### PR TITLE
Bugfix for PR #16176 - Initialization of udscAsEquivalent and udscbAsEquivalent in ResonanceDecayFilter

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -247,6 +247,8 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params) :
   fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent",false);
   fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent",false);
   fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent",false);
+  fMasterGen->settings.addFlag("ResonanceDecayFilter:udscAsEquivalent",false);
+  fMasterGen->settings.addFlag("ResonanceDecayFilter:udscbAsEquivalent",false);
   fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers",std::vector<int>(),false,false,0,0);
   fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters",std::vector<int>(),false,false,0,0);
 


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/16176 did not initialize 2 variables. No effect on anything which would not use them.

This is needed for Moriond part 2 MC production, thus relatively urgent