### PR TITLE
SiPM followups

### DIFF
--- a/CalibCalorimetry/HcalAlgos/BuildFile.xml
+++ b/CalibCalorimetry/HcalAlgos/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="boost"/>
 <use   name="root"/>
 <use   name="clhep"/>
+<use   name="gsl"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/HcalDetId"/>

--- a/CalibCalorimetry/HcalAlgos/src/HcalSiPMnonlinearity.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalSiPMnonlinearity.cc
@@ -1,5 +1,6 @@
 #include <iostream>
-#include "Math/Polynomial.h"
+#include <gsl/gsl_poly.h>
+#include <gsl/gsl_complex.h>
 #include "CalibCalorimetry/HcalAlgos/interface/HcalSiPMnonlinearity.h"
 
 // Assume parameters come to us from the reco side; i.e.,
@@ -7,13 +8,25 @@
 //
 int HcalSiPMnonlinearity::getPixelsFired(int inpes) const
 {
-  ROOT::Math::Polynomial p(a2,b1,c0,-inpes);
-  std::vector<double> roots = p.FindRealRoots();
-  assert(roots.size());
+  gsl_complex z[3];
+  double w = -inpes;
+  // normalize params
+  double a = a2/w;
+  double b = b1/w;
+  double c = c0/w;
+  int nroots = gsl_poly_complex_solve_cubic(a, b, c, &z[1], &z[2], &z[3]);
+  assert(nroots);
 
   // all use cases tested over the full range of anticipated values;
   // the first root is always the right one.
-  double realpix = roots[0];
+  double realpix = 0;
+  // find real roots
+  for(int i = 0; i < 3; ++i){
+    if(z[i].dat[1]==0){
+      realpix = z[i].dat[0];
+      break;
+    }
+  }
 
   return realpix > 0 ? (int)(realpix+0.5) : 0;
 }

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPM.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPM.h
@@ -39,7 +39,7 @@ class HcalSiPM {
   double getTempDep()     const { return theTempDep; }
 
   void setNCells(int nCells);
-  void setTau(double tau) {theTau=tau;}
+  void setTau(double tau);
   void setCrossTalk(double xtalk); //  Borel-Tanner "lambda"
   void setTemperatureDependence(double tempDep);
   void setSaturationPars(const std::vector<float>& pars);
@@ -61,6 +61,7 @@ class HcalSiPM {
   unsigned int theCellCount;
   std::vector< double > theSiPM;
   double theTau;
+  double theTauInv;
   double theCrossTalk;
   double theTempDep;
   double theLastHitTime;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
@@ -12,9 +12,10 @@
 using std::vector;
 //345678911234567892123456789312345678941234567895123456789612345678971234567898
 HcalSiPM::HcalSiPM(int nCells, double tau) :
-  theCellCount(nCells), theSiPM(nCells,1.), theTau(tau),
-  theCrossTalk(0.), theTempDep(0.), theLastHitTime(-1.), nonlin(0) {
-
+  theCellCount(nCells), theSiPM(nCells,1.),
+  theCrossTalk(0.), theTempDep(0.), theLastHitTime(-1.), nonlin(0)
+{
+  setTau(tau);
   assert(theCellCount>0);
   resetSiPM();
 }
@@ -147,6 +148,12 @@ void HcalSiPM::setNCells(int nCells) {
   resetSiPM();
 }
 
+void HcalSiPM::setTau(double tau) { 
+  theTau = tau;
+  if(theTau > 0) theTauInv = 1./theTau;
+  else theTauInv = 0;
+}
+
 void HcalSiPM::setCrossTalk(double xTalk) {
   // set the cross-talk probability
 
@@ -174,8 +181,8 @@ void HcalSiPM::setTemperatureDependence(double dTemp) {
 
 double HcalSiPM::cellCharge(double deltaTime) const {
   if (deltaTime <= 0.) return 0.;
-  if (deltaTime > 10.*theTau) return 1.;
-  double result(1. - std::exp(-deltaTime/theTau));
+  if (deltaTime*theTauInv > 10.) return 1.;
+  double result(1. - std::exp(-deltaTime*theTauInv));
   return (result > 0.99) ? 1.0 : result;
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMShape.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMShape.cc
@@ -47,6 +47,7 @@ inline double onePulse(double t, double A, double sigma, double theta, double m)
 
 double HcalSiPMShape::analyticPulseShape(double t, unsigned int signalShape) const {
   if(signalShape==HcalShapes::ZECOTEK || signalShape==HcalShapes::HAMAMATSU){
+    // HO SiPM pulse shape fit from Jake Anderson ca. 2013
     double A1(0.08757), c1(-0.5257), t01(2.4013), s1(0.6721);
     double A2(0.007598), c2(-0.1501), t02(6.9412), s2(0.8710);
     return gexp(t,A1,c1,t01,s1) + gexp(t,A2,c2,t02,s2);


### PR DESCRIPTION
@davidlange6, this PR addresses the three comments you made on #16315.

(I remembered that I also wanted to keep `theTau` as a member of `HcalSiPM` because, now that it is a configurable parameter, I added the safety check/option to disable the saturation/recovery model if `theTau<=0`. Therefore, the class now has both `theTau` and `theTauInv` as members, maintained consistently by a setter with a check to avoid nan/inf.)