### PR TITLE
Remove empty TProfile2D bin formatting.

### DIFF
--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -74,10 +74,11 @@ EcalMEFormatter::formatDet2D_(ecaldqm::MESet& _meSet)
         int bin(prof->GetBin(iX, iY));
         if(prof->GetBinEntries(bin) == 0.){
           if(verbosity_ > 2) edm::LogInfo("EcalDQM") << "Found empty bin " << bin << " in histogram " << prof->GetName();
-          // TEMPORARY SETUP UNTIL RENDERPLUGIN IS UPDATED TO DO THIS
-          // WHEN IT IS, SWITCH TO ENTRIES -1 CONTENT 0
-          prof->SetBinEntries(bin, 1.);
-          prof->SetBinContent(bin, -std::numeric_limits<double>::max());
+          // To distinguish empty bins from bins filled with value 0 in offline DQM, set empty bins to a suitable default value instead
+          // Since several Timing MEs allow for negative values, choose a sufficiently large magnitude default value
+          // but not too large as to crash DQM GUI.
+          prof->SetBinEntries(bin,   1.);
+          prof->SetBinContent(bin,-999.);
         }
       }
     }

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -63,26 +63,7 @@ EcalMEFormatter::format_(DQMStore::IGetter& _igetter, bool _checkLumi)
 void
 EcalMEFormatter::formatDet2D_(ecaldqm::MESet& _meSet)
 {
-  if(_meSet.getKind() != MonitorElement::DQM_KIND_TPROFILE2D) return;
-
-  MonitorElement* me(0);
-  unsigned iME(0);
-  while((me = _meSet.getME(iME++))){
-    TProfile2D* prof(me->getTProfile2D());
-    for(int iX(1); iX <= prof->GetNbinsX(); ++iX){
-      for(int iY(1); iY <= prof->GetNbinsY(); ++iY){
-        int bin(prof->GetBin(iX, iY));
-        if(prof->GetBinEntries(bin) == 0.){
-          if(verbosity_ > 2) edm::LogInfo("EcalDQM") << "Found empty bin " << bin << " in histogram " << prof->GetName();
-          // To distinguish empty bins from bins filled with value 0 in offline DQM, set empty bins to a suitable default value instead
-          // Since several Timing MEs allow for negative values, choose a sufficiently large magnitude default value
-          // but not too large as to crash DQM GUI.
-          prof->SetBinEntries(bin,   1.);
-          prof->SetBinContent(bin,-999.);
-        }
-      }
-    }
-  }
+  return;
 }
 
 DEFINE_FWK_MODULE(EcalMEFormatter);


### PR DESCRIPTION
- ~~Change default value for empty TProfile2D bins in EcalMEFormatter (only used in offline DQM) to prevent DQM GUI crashes.~~
- Remove TProfile2D formatting altogether--empty bins now correctly rendered vs. bins filled with 0 in ROOT 6.

In conjunction with 81X PRs https://github.com/cms-sw/cmssw/pull/16422, https://github.com/cms-sw/cmssw/pull/16437.