### PR TITLE
Thread-safety fix for cond::BTransitionAnalyzer class

### DIFF
--- a/CondTools/RunInfo/interface/BTransitionAnalyzer.h
+++ b/CondTools/RunInfo/interface/BTransitionAnalyzer.h
@@ -14,11 +14,10 @@
 
 namespace cond {
   template<class T, class R>
-  class BTransitionAnalyzer: public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
+  class BTransitionAnalyzer: public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     BTransitionAnalyzer( const edm::ParameterSet& pset ):
       m_currentThreshold( pset.getUntrackedParameter<double>( "currentThreshold", 18000. ) ) {
-      usesResource( "PoolDBOutputService" );
     }
 #ifdef __INTEL_COMPILER
     virtual ~BTransitionAnalyzer() = default;


### PR DESCRIPTION
`PoolDBOutputService` is thread-safe: drop the usage of the` edm::one::SharedResources` extended interface for `edm::one::EDAnalyzer` in `cond::BTransitionAnalyzer` class.