### PR TITLE
JER MET uncertainties and METSignifiance re-estimation

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -117,8 +117,8 @@ pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pa
         case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "");   break;
         case pat::MET::JetEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");   break;
         case pat::MET::JetEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown"); break;
-        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), isSmeared?"JetResUp":"");   break;
-        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), isSmeared?"JetResDown":""); break;
+        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");   break;
+        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown"); break;
         case pat::MET::MuonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");   break;
         case pat::MET::MuonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown"); break;
         case pat::MET::ElectronEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");   break;

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -131,7 +131,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
 
                 std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
-		_nomVar=1;
+		m_nomVar=1;
                 if (variation == 0)
                     m_systematic_variation = Variation::NOMINAL;
                 else if (variation == 1)
@@ -140,11 +140,11 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     m_systematic_variation = Variation::DOWN;
 		else if (variation == 101) {
 		  m_systematic_variation = Variation::NOMINAL;
-		  _nomVar=1;
+		  m_nomVar=1;
 		}
 		else if (variation == -101) {
 		  m_systematic_variation = Variation::NOMINAL;
-		  _nomVar=-1;
+		  m_nomVar=-1;
 		}
                 else
                     throw edm::Exception(edm::errors::ConfigFileReadError, "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
@@ -243,7 +243,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     double dPt = jet.pt() - genJet->pt();
-                    smearFactor = 1 + _nomVar*(jer_sf - 1.) * dPt / jet.pt();
+                    smearFactor = 1 + m_nomVar*(jer_sf - 1.) * dPt / jet.pt();
 
                 } else if (jer_sf > 1) {
                     /*
@@ -256,7 +256,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + _nomVar*d(m_random_generator);
+                    smearFactor = 1. + m_nomVar*d(m_random_generator);
                 } else if (m_debug) {
                     std::cout << "Impossible to smear this jet" << std::endl;
                 }
@@ -308,6 +308,6 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
 
         GreaterByPt<T> jetPtComparator;
 
-	int _nomVar;
+	int m_nomVar;
 };
 #endif

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -131,14 +131,23 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
 
                 std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
+		_nomVar=1;
                 if (variation == 0)
                     m_systematic_variation = Variation::NOMINAL;
                 else if (variation == 1)
                     m_systematic_variation = Variation::UP;
                 else if (variation == -1)
                     m_systematic_variation = Variation::DOWN;
+		else if (variation == 101) {
+		  m_systematic_variation = Variation::NOMINAL;
+		  _nomVar=1;
+		}
+		else if (variation == -101) {
+		  m_systematic_variation = Variation::NOMINAL;
+		  _nomVar=-1;
+		}
                 else
-                    throw edm::Exception(edm::errors::ConfigFileReadError, "Invalid value for 'variation' parameter. Only -1, 0 or 1 are supported.");
+                    throw edm::Exception(edm::errors::ConfigFileReadError, "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
             }
 
             produces<JetCollection>();
@@ -234,7 +243,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     double dPt = jet.pt() - genJet->pt();
-                    smearFactor = 1 + (jer_sf - 1.) * dPt / jet.pt();
+                    smearFactor = 1 + _nomVar*(jer_sf - 1.) * dPt / jet.pt();
 
                 } else if (jer_sf > 1) {
                     /*
@@ -247,7 +256,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     }
 
                     std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + d(m_random_generator);
+                    smearFactor = 1. + _nomVar*d(m_random_generator);
                 } else if (m_debug) {
                     std::cout << "Impossible to smear this jet" << std::endl;
                 }
@@ -298,5 +307,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
         std::mt19937 m_random_generator;
 
         GreaterByPt<T> jetPtComparator;
+
+	int _nomVar;
 };
 #endif

--- a/PhysicsTools/PatUtils/plugins/CorrectedPATMETProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/CorrectedPATMETProducer.cc
@@ -15,6 +15,7 @@
 #include "DataFormats/METReco/interface/CorrMETData.h"
 
 #include "JetMETCorrections/Type1MET/interface/AddCorrectionsToGenericMET.h"
+#include "RecoMET/METAlgorithms/interface/METSignificance.h"
 
 #include <vector>
 
@@ -49,7 +50,6 @@ private:
 
   edm::EDGetTokenT<METCollection> token_;
  
-
   void produce(edm::Event& evt, const edm::EventSetup& es) override
   {
     edm::Handle<METCollection> srcMETCollection;
@@ -62,6 +62,14 @@ private:
     pat::MET outMET(corrMET, srcMET);
   
     auto product = std::make_unique<METCollection>();
+
+    reco::METCovMatrix cov=srcMET.getSignificanceMatrix();
+    if( !(cov(0,0)==0 && cov(0,1)==0 && cov(1,0)==0 && cov(1,1)==0) ) {
+      outMET.setSignificanceMatrix(cov);
+      double metSig=metsig::METSignificance::getSignificance(cov, outMET);
+      outMET.setMETSignificance(metSig);
+    }  
+
     product->push_back(outMET);
     evt.put(std::move(product));
   }

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -966,7 +966,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             smear=False
             if "Smear" in metModName:
                 smear=True
-     
+            else:
+                smear=True
+                varyByNsigmas=101
+
             shiftedCollModules['Up'] = self.createShiftedJetResModule(process, smear, objectCollection, +1.*varyByNsigmas,
                                                                  "Up", postfix)
             shiftedCollModules['Down'] = self.createShiftedJetResModule(process, smear, objectCollection, -1.*varyByNsigmas,
@@ -1464,6 +1467,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if hasattr(process, "patPFMetTxyCorr"+postfix):
                 getattr(process, "patPFMetTxyCorr"+postfix).vertexCollection = cms.InputTag("offlineSlimmedPrimaryVertices")
 
+        if self._parameters['computeUncertainties'].value:
+            getattr(process, "shiftedPatJetResDown"+postfix).genJets = cms.InputTag("slimmedGenJets")
+            getattr(process, "shiftedPatJetResUp"+postfix).genJets = cms.InputTag("slimmedGenJets")
 
 
     def miniAODConfiguration(self, process, pfCandCollection, jetCollection,

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -46,7 +46,7 @@ namespace metsig {
 					  JME::JetResolutionScaleFactor & resSFObj,
 					  bool isRealData);
 
-     double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met ) const;
+     static double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met );
 
       private:
          bool cleanJet(const reco::Jet& jet, 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -20,17 +20,15 @@ Implementation:
 
 metsig::METSignificance::METSignificance(const edm::ParameterSet& iConfig) {
 
-  // if(iConfig.exists("parameters")) {
-    edm::ParameterSet cfgParams = iConfig.getParameter<edm::ParameterSet>("parameters");
+  edm::ParameterSet cfgParams = iConfig.getParameter<edm::ParameterSet>("parameters");
 
-    double dRmatch = cfgParams.getParameter<double>("dRMatch");
-    dR2match_ = dRmatch*dRmatch;
+  double dRmatch = cfgParams.getParameter<double>("dRMatch");
+  dR2match_ = dRmatch*dRmatch;
   
-    jetThreshold_ = cfgParams.getParameter<double>("jetThreshold");
-    jetEtas_ = cfgParams.getParameter<std::vector<double> >("jeta");
-    jetParams_ = cfgParams.getParameter<std::vector<double> >("jpar");
-    pjetParams_ = cfgParams.getParameter<std::vector<double> >("pjpar");
-    // }
+  jetThreshold_ = cfgParams.getParameter<double>("jetThreshold");
+  jetEtas_ = cfgParams.getParameter<std::vector<double> >("jeta");
+  jetParams_ = cfgParams.getParameter<std::vector<double> >("jpar");
+  pjetParams_ = cfgParams.getParameter<std::vector<double> >("pjpar");
   
 }
 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -20,16 +20,18 @@ Implementation:
 
 metsig::METSignificance::METSignificance(const edm::ParameterSet& iConfig) {
 
-  edm::ParameterSet cfgParams = iConfig.getParameter<edm::ParameterSet>("parameters");
+  // if(iConfig.exists("parameters")) {
+    edm::ParameterSet cfgParams = iConfig.getParameter<edm::ParameterSet>("parameters");
 
-  double dRmatch = cfgParams.getParameter<double>("dRMatch");
-  dR2match_ = dRmatch*dRmatch;
+    double dRmatch = cfgParams.getParameter<double>("dRMatch");
+    dR2match_ = dRmatch*dRmatch;
   
-  jetThreshold_ = cfgParams.getParameter<double>("jetThreshold");
-  jetEtas_ = cfgParams.getParameter<std::vector<double> >("jeta");
-  jetParams_ = cfgParams.getParameter<std::vector<double> >("jpar");
-  pjetParams_ = cfgParams.getParameter<std::vector<double> >("pjpar");
-
+    jetThreshold_ = cfgParams.getParameter<double>("jetThreshold");
+    jetEtas_ = cfgParams.getParameter<std::vector<double> >("jeta");
+    jetParams_ = cfgParams.getParameter<std::vector<double> >("jpar");
+    pjetParams_ = cfgParams.getParameter<std::vector<double> >("pjpar");
+    // }
+  
 }
 
 metsig::METSignificance::~METSignificance() {
@@ -172,7 +174,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 }
 
 double
-metsig::METSignificance::getSignificance(const reco::METCovMatrix& cov, const reco::MET& met) const {
+metsig::METSignificance::getSignificance(const reco::METCovMatrix& cov, const reco::MET& met) {
 
    // covariance matrix determinant
    double det = cov(0,0)*cov(1,1) - cov(0,1)*cov(1,0);


### PR DESCRIPTION
This PR enables the re-computation of the MET significance for the corrected METs on PAT, and enable the JER uncertainty propagation to the MET when the jets are not smeared.

Packages touched:
- PhysicsTools/PatAlgos
- RecoMET/METAlgorithms

Format and content changes :
- JER uncertainties for non-smeared not set to the central value anymore
- central MET significance is not supposed to change when reprocessing AODs (i.e. in slimmedMET)

No real changes of performances/miniAOD size is expected. the MET significance changes only has an effect when the MET is recomputed on top of miniAOD, but the covariance matrix is not recomputed, which means that CPU ressources stays basically the same. The jet smearing used to compute the JER variation is small and does not reduce significantly the processing rate