### PR TITLE
Avoid warning on clang

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -66,7 +66,7 @@ namespace edm {
    {
    public:
       SerialTaskQueue():
-      m_taskChosen{ATOMIC_FLAG_INIT},
+      m_taskChosen(ATOMIC_FLAG_INIT),
       m_pauseCount{0}
       {  }
       


### PR DESCRIPTION
Use () instead of {} when initializing atomic to avoid a warning
from clang because of how the symbol ATOMIC_FLAG_INIT is defined.