### PR TITLE
Fixed supports composites in Flat and Tilted OT in 81X (negligeable effect on MB though)

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseII/FlatTracker/tracker.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/FlatTracker/tracker.xml
@@ -31196,12 +31196,12 @@ note: see Baseline_flat_2016_04_12.cfg for full config files
 <rMaterial name="tracker:TEDD_Steel"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.338*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1190Z1450" density="0.338*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1150Z2000" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -31209,27 +31209,27 @@ note: see Baseline_flat_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R721Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R928Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R721Z1180" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R928Z1180" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1113Z599" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -31237,7 +31237,7 @@ note: see Baseline_flat_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R655Z599" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -31245,27 +31245,27 @@ note: see Baseline_flat_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R267Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R393Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R267Z1160" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R393Z1160" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R540Z580" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -41094,55 +41094,55 @@ note: see Baseline_flat_2016_04_12.cfg for full config files
 </LogicalPart>
 <LogicalPart name="supportR1190Z1450" category="unspecified">
 <rSolid name="tracker:supportR1190Z1450"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1190Z1450"/>
 </LogicalPart>
 <LogicalPart name="supportR1150Z2000" category="unspecified">
 <rSolid name="tracker:supportR1150Z2000"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1150Z2000"/>
 </LogicalPart>
 <LogicalPart name="supportR721Z295" category="unspecified">
 <rSolid name="tracker:supportR721Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R721Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR928Z295" category="unspecified">
 <rSolid name="tracker:supportR928Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R928Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR721Z1180" category="unspecified">
 <rSolid name="tracker:supportR721Z1180"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R721Z1180"/>
 </LogicalPart>
 <LogicalPart name="supportR928Z1180" category="unspecified">
 <rSolid name="tracker:supportR928Z1180"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R928Z1180"/>
 </LogicalPart>
 <LogicalPart name="supportR1113Z599" category="unspecified">
 <rSolid name="tracker:supportR1113Z599"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1113Z599"/>
 </LogicalPart>
 <LogicalPart name="supportR655Z599" category="unspecified">
 <rSolid name="tracker:supportR655Z599"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R655Z599"/>
 </LogicalPart>
 <LogicalPart name="supportR267Z295" category="unspecified">
 <rSolid name="tracker:supportR267Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R267Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR393Z295" category="unspecified">
 <rSolid name="tracker:supportR393Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R393Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR267Z1160" category="unspecified">
 <rSolid name="tracker:supportR267Z1160"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R267Z1160"/>
 </LogicalPart>
 <LogicalPart name="supportR393Z1160" category="unspecified">
 <rSolid name="tracker:supportR393Z1160"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R393Z1160"/>
 </LogicalPart>
 <LogicalPart name="supportR540Z580" category="unspecified">
 <rSolid name="tracker:supportR540Z580"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R540Z580"/>
 </LogicalPart>
 </LogicalPartSection>
 <SolidSection label="tracker.xml">

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker/tracker.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker/tracker.xml
@@ -28333,12 +28333,12 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 <rMaterial name="tracker:TEDD_Steel"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.338*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1190Z1450" density="0.338*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1150Z2000" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -28346,27 +28346,27 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R721Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R928Z295" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R721Z1180" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.4563*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R928Z1180" density="0.4563*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="1">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R1113Z599" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -28374,7 +28374,7 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R655Z599" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -28382,7 +28382,7 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 <rMaterial name="tracker:PE"/>
 </MaterialFraction>
 </CompositeMaterial>
-<CompositeMaterial name="supportcomposite5" density="0.18853*g/cm3" method="mixture by weight">
+<CompositeMaterial name="supportcomposite5R577Z590" density="0.18853*g/cm3" method="mixture by weight">
 <MaterialFraction fraction="0.914337">
 <rMaterial name="tracker:CF"/>
 </MaterialFraction>
@@ -37051,39 +37051,39 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 </LogicalPart>
 <LogicalPart name="supportR1190Z1450" category="unspecified">
 <rSolid name="tracker:supportR1190Z1450"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1190Z1450"/>
 </LogicalPart>
 <LogicalPart name="supportR1150Z2000" category="unspecified">
 <rSolid name="tracker:supportR1150Z2000"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1150Z2000"/>
 </LogicalPart>
 <LogicalPart name="supportR721Z295" category="unspecified">
 <rSolid name="tracker:supportR721Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R721Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR928Z295" category="unspecified">
 <rSolid name="tracker:supportR928Z295"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R928Z295"/>
 </LogicalPart>
 <LogicalPart name="supportR721Z1180" category="unspecified">
 <rSolid name="tracker:supportR721Z1180"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R721Z1180"/>
 </LogicalPart>
 <LogicalPart name="supportR928Z1180" category="unspecified">
 <rSolid name="tracker:supportR928Z1180"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R928Z1180"/>
 </LogicalPart>
 <LogicalPart name="supportR1113Z599" category="unspecified">
 <rSolid name="tracker:supportR1113Z599"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R1113Z599"/>
 </LogicalPart>
 <LogicalPart name="supportR655Z599" category="unspecified">
 <rSolid name="tracker:supportR655Z599"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R655Z599"/>
 </LogicalPart>
 <LogicalPart name="supportR577Z590" category="unspecified">
 <rSolid name="tracker:supportR577Z590"/>
-<rMaterial name="tracker:supportcomposite5"/>
+<rMaterial name="tracker:supportcomposite5R577Z590"/>
 </LogicalPart>
 </LogicalPartSection>
 <SolidSection label="tracker.xml">


### PR DESCRIPTION
@boudoul @VinInn @rovere @ebrondol @venturia @ianna @alkemyst

FlatTracker and TiltedTracker in 81X 
(Phase II Outer Trackers plugged on Phase I Pixel) : 

In a similar way as for PR #16410 (which was done for Tilted4021), CMSSW Sim MB have been compared with tkLayout.
This is for the Outer Trackers parts only.
We have been lucky, and for both Flat and Tilted, a good fit is observed with tkLayout MB already (without this PR).
This is shown by the plots below : 

FlatTracker : 
![comparison](https://cloud.githubusercontent.com/assets/11192654/19967651/8edb1da4-a1d1-11e6-90d0-a96198b49342.gif)

TiltedTracker : 
![comparison](https://cloud.githubusercontent.com/assets/11192654/19967669/a1146f66-a1d1-11e6-97f5-f705346e542d.gif)

A little mistake has appeared with OT support structures materials though (not in Tilted4021). This PR proposes to fix it.

Please see enclosed the effect of the PR on the MB (sorry the quality of the plots should be improved, but the idea is that the effect is negligeable anyway) : 
FlatTracker : 
![comparison_new](https://cloud.githubusercontent.com/assets/11192654/19967756/fa0f2b24-a1d1-11e6-9a8f-e2d8de961de7.gif)

TiltedTracker : 
![comparison_new](https://cloud.githubusercontent.com/assets/11192654/19967773/06ca50fa-a1d2-11e6-8659-a251610932b7.gif)



Summary : Outer Tracker parts of FlatTracker and TiltedTracker in 81X have a CMSSW Sim MB which is reasonably matching tkLayout MB.
This PR proposes a minor correction (not even necessary really needed) on Outer Trackers support structures materials.