### PR TITLE
Timing information in PF 

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -414,6 +414,15 @@ namespace reco {
     virtual double vy() const {return vertex().y();}
     virtual double vz() const {return vertex().z();}
 
+    /// do we have a valid time information
+    bool isTimeValid() const { return timeError_ >= 0.f; }
+    /// \return the timing
+    float time() const { return time_; }
+    /// \return the timing uncertainty
+    float timeError() const { return timeError_; }
+    /// \set the timing information
+    void setTime(float time, float timeError = 0.f) { time_ = time; timeError_ = timeError; }
+
   private:
     /// Polymorphic overlap
     virtual bool overlap( const Candidate & ) const;
@@ -509,6 +518,11 @@ namespace reco {
     unsigned short storedRefsBitPattern_;
     std::vector<unsigned long long> refsInfo_;
     std::vector<const void *> refsCollectionCache_;
+
+    /// timing information (valid if timeError_ >= 0)
+    float time_;
+    /// timing information uncertainty (<0 if timing not available)
+    float timeError_;
 
   };
 

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -48,7 +48,8 @@ PFCandidate::PFCandidate() :
   mva_nothing_gamma_(bigMva_),
   mva_nothing_nh_(bigMva_),
   mva_gamma_nh_(bigMva_),
-  getter_(0),storedRefsBitPattern_(0)
+  getter_(0),storedRefsBitPattern_(0),
+  time_(0.f),timeError_(-1.f)
 {
 
   muonTrackType_ = reco::Muon::None;
@@ -89,7 +90,8 @@ PFCandidate::PFCandidate( Charge charge,
   mva_nothing_gamma_(bigMva_),
   mva_nothing_nh_(bigMva_),
   mva_gamma_nh_(bigMva_),
-  getter_(0),storedRefsBitPattern_(0)
+  getter_(0),storedRefsBitPattern_(0),
+  time_(0.f),timeError_(-1.f)
 {
   refsInfo_.reserve(3);
   blocksStorage_.reserve(10);
@@ -152,7 +154,8 @@ PFCandidate::PFCandidate( PFCandidate const& iOther) :
   getter_(iOther.getter_),
   storedRefsBitPattern_(iOther.storedRefsBitPattern_),
   refsInfo_(iOther.refsInfo_),
-  refsCollectionCache_(iOther.refsCollectionCache_)
+  refsCollectionCache_(iOther.refsCollectionCache_),
+  time_(iOther.time_),timeError_(iOther.timeError_)
 {
   auto tmp = iOther.elementsInBlocks_.load(std::memory_order_acquire);
   if(nullptr != tmp) {
@@ -195,6 +198,8 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   storedRefsBitPattern_=iOther.storedRefsBitPattern_;
   refsInfo_=iOther.refsInfo_;
   refsCollectionCache_=iOther.refsCollectionCache_;
+  time_=iOther.time_;
+  timeError_=iOther.timeError_;
 
   return *this;
 }

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="17">
+   <class name="reco::PFCandidate" ClassVersion="18">
+    <version ClassVersion="18" checksum="910857761"/>
     <version ClassVersion="17" checksum="3126170233"/>
     <version ClassVersion="16" checksum="3060382005"/>
     <version ClassVersion="15" checksum="1136968957"/>
@@ -48,7 +49,8 @@
   <class name="edm::ValueMap<edm::Ptr<reco::PFCandidate> >"/>
   <class name="edm::reftobase::RefVectorHolder<reco::PFCandidateRefVector >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="13">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="14">
+   <version ClassVersion="14" checksum="207328514"/>
    <version ClassVersion="13" checksum="1855164250"/>
    <version ClassVersion="12" checksum="2650360086"/>
    <version ClassVersion="11" checksum="696008414"/>
@@ -61,7 +63,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="13">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="14">
+   <version ClassVersion="14" checksum="4065938015"/>
    <version ClassVersion="13" checksum="1734488695"/>
    <version ClassVersion="12" checksum="2377890195"/>
    <version ClassVersion="11" checksum="1422984859"/>

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -60,7 +60,9 @@ namespace reco {
     PFBlockElement(Type type=NONE) :  
       type_(type), 
       locked_(false),
-      index_( static_cast<unsigned>(-1) ) {
+      index_( static_cast<unsigned>(-1) ),
+      time_(0.f), timeError_(-1.f)
+    {
     }
 
 
@@ -134,6 +136,15 @@ namespace reco {
     const PFMultilinksType& getMultilinks() const {return multilinks_.linkedClusters;}
     // ! Glowinski & Gouzevitch
 
+    /// do we have a valid time information
+    bool isTimeValid() const { return timeError_ >= 0.f; }
+    /// \return the timing
+    float time() const { return time_; }
+    /// \return the timing uncertainty
+    float timeError() const { return timeError_; }
+    /// \set the timing information
+    void setTime(float time, float timeError = 0.f) { time_ = time; timeError_ = timeError; }
+
   protected:  
 
     /// type, see PFBlockElementType
@@ -151,6 +162,11 @@ namespace reco {
     // Glowinski & Gouzevitch
     PFMultiLinksTC multilinks_;
     // ! Glowinski & Gouzevitch
+    
+    /// timing information (valid if timeError_ >= 0)
+    float time_;
+    /// timing information uncertainty (<0 if timing not available)
+    float timeError_;
 
     const static reco::TrackRef nullTrack_;
     const static PFRecTrackRef nullPFRecTrack_;

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -81,12 +81,16 @@ namespace reco {
     /// cluster energy
     double        energy() const {return energy_;}
 
-    /// cluster time
-    double        time() const {return time_;}
+    /// \return cluster time
+    float time() const {return time_;}
+    /// \return the timing uncertainty
+    float timeError() const { return timeError_; }
+
     /// cluster depth
     double        depth() const {return depth_;}
 
-    void         setTime(double time) {time_ = time;}
+    void         setTime(float time, float timeError=0) {time_ = time; timeError_ = timeError; }
+    void         setTimeError(float timeError) { timeError_ = timeError; }
     void         setDepth(double depth) {depth_ = depth;}
     
     /// cluster position: rho, eta, phi
@@ -180,7 +184,7 @@ namespace reco {
     REPPoint            posrep_;
 
     ///Michalis :Add timing and depth information
-    double time_;
+    float time_, timeError_;
     double depth_;
 
     /// transient layer

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -1,7 +1,8 @@
 <lcgdict>
 <selection>
 
-  <class name="reco::PFCluster" ClassVersion="16">
+  <class name="reco::PFCluster" ClassVersion="17">
+   <version ClassVersion="17" checksum="3021111509"/>
    <version ClassVersion="16" checksum="1786894710"/>
    <version ClassVersion="15" checksum="1837961152"/>
    <version ClassVersion="14" checksum="3610074122"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -124,7 +124,8 @@
   <class name="std::vector<reco::PFSimParticle>"/>
   <class name="edm::Wrapper<std::vector<reco::PFSimParticle> >"/>
 
-  <class name="reco::PFBlockElement" ClassVersion="12">
+  <class name="reco::PFBlockElement" ClassVersion="13">
+   <version ClassVersion="13" checksum="4257111441"/>
    <version ClassVersion="12" checksum="3101496393"/>
    <version ClassVersion="11" checksum="3944635097"/>
     <!-- <field name="multilinkslinks_" transient="true"/> -->
@@ -140,7 +141,8 @@
   <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >"/>
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
-  <class name="reco::PFBlockElementTrack" ClassVersion="13">
+  <class name="reco::PFBlockElementTrack" ClassVersion="14">
+   <version ClassVersion="14" checksum="3952424659"/>
    <version ClassVersion="13" checksum="1449646331"/>
    <version ClassVersion="12" checksum="417575083"/>
    <version ClassVersion="10" checksum="2342660248"/>
@@ -150,7 +152,8 @@
 -->
   </class>
 
-  <class name="reco::PFBlockElementGsfTrack" ClassVersion="12">
+  <class name="reco::PFBlockElementGsfTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="2453155267"/>
    <version ClassVersion="12" checksum="1521047275"/>
    <version ClassVersion="11" checksum="1367777435"/>
    <version ClassVersion="10" checksum="549349370"/>
@@ -160,7 +163,8 @@
 -->
   </class>
 
-  <class name="reco::PFBlockElementBrem" ClassVersion="12">
+  <class name="reco::PFBlockElementBrem" ClassVersion="13">
+   <version ClassVersion="13" checksum="157699540"/>
    <version ClassVersion="12" checksum="112730380"/>
    <version ClassVersion="11" checksum="2362699420"/>
    <version ClassVersion="10" checksum="2231967579"/>
@@ -171,7 +175,8 @@
   </class>
 
 
-  <class name="reco::PFBlockElementCluster" ClassVersion="13">
+  <class name="reco::PFBlockElementCluster" ClassVersion="14">
+   <version ClassVersion="14" checksum="407383072"/>
    <version ClassVersion="13" checksum="775826696"/>
    <version ClassVersion="12" checksum="1263691576"/>
    <version ClassVersion="10" checksum="2503385411"/>
@@ -284,7 +289,8 @@
   <class name="edm::Wrapper<edm::ValueMap<reco::PreIdRef> >"/>
   <class name="edm::Ref<std::vector<reco::PreId>,reco::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::PreId>,reco::PreId> >" />
 
-  <class name="reco::PFBlockElementSuperCluster" ClassVersion="13">
+  <class name="reco::PFBlockElementSuperCluster" ClassVersion="14">
+   <version ClassVersion="14" checksum="285242772"/>
    <version ClassVersion="13" checksum="3749373244"/>
    <version ClassVersion="12" checksum="1656578540"/>
    <version ClassVersion="10" checksum="456156271"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -264,7 +264,8 @@
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="13">
+  <class name="pat::PFParticle"  ClassVersion="14">
+   <version ClassVersion="14" checksum="2795911745"/>
    <version ClassVersion="13" checksum="223824921"/>
    <version ClassVersion="12" checksum="4118931093"/>
    <version ClassVersion="11" checksum="2923110109"/>

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -2080,6 +2080,37 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             m1.toModify(p.a, flintstones = dict(fred = int32(2)))
             self.assertEqual(p.a.flintstones.fred.value(),2)
             self.assertEqual(p.a.flintstones.wilma.value(),1)
+            #test setting a value in a VPSet
+            m1 = Modifier()
+            p = Process("test",m1)
+            p.a = EDAnalyzer("MyAnalyzer", flintstones = VPSet(PSet(fred = int32(1)), PSet(wilma = int32(1))))
+            m1.toModify(p.a, flintstones = {1:dict(wilma = int32(2))})
+            self.assertEqual(p.a.flintstones[0].fred.value(),1)
+            self.assertEqual(p.a.flintstones[1].wilma.value(),2)
+            #test setting a value in a list of values
+            m1 = Modifier()
+            p = Process("test",m1)
+            p.a = EDAnalyzer("MyAnalyzer", fred = vuint32(1,2,3))
+            m1.toModify(p.a, fred = {1:7})
+            self.assertEqual(p.a.fred[0],1)
+            self.assertEqual(p.a.fred[1],7)
+            self.assertEqual(p.a.fred[2],3)
+            #test IndexError setting a value in a list to an item key not in the list
+            m1 = Modifier()
+            p = Process("test",m1)
+            p.a = EDAnalyzer("MyAnalyzer", fred = vuint32(1,2,3))
+            raised = False
+            try: m1.toModify(p.a, fred = {5:7})
+            except IndexError, e: raised = True
+            self.assertEqual(raised, True)
+            #test TypeError setting a value in a list using a key that is not an int
+            m1 = Modifier()
+            p = Process("test",m1)
+            p.a = EDAnalyzer("MyAnalyzer", flintstones = VPSet(PSet(fred = int32(1)), PSet(wilma = int32(1))))
+            raised = False
+            try: m1.toModify(p.a, flintstones = dict(bogus = int32(37)))
+            except TypeError, e: raised = True
+            self.assertEqual(raised, True)
             #test that load causes process wide methods to run
             def _rem_a(proc):
                 del proc.a

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -628,8 +628,10 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                             setattr(pset,k,v)
                     elif isinstance(params[key],_ValidatingParameterListBase):
                         if any(type(k) != int for k in value.keys()):
-                            raise ValueError("Attempted to change a list using a dict whose keys are not integers")
+                            raise TypeError("Attempted to change a list using a dict whose keys are not integers")
                         plist = params[key]
+                        if any((k < 0 or k >= len(plist)) for k in value.keys()):
+                            raise IndexError("Attempted to set an index which is not in the list")
                         p = dict(enumerate(plist))
                         _modifyParametersFromDict(p,
                                                   value,errorRaiser,
@@ -638,8 +640,8 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                             plist[k] = v
                     else:
                         raise ValueError("Attempted to change non PSet value "+keyDepth+" using a dictionary")
-                elif isinstance(value,_ParameterTypeBase):
-                    params[key] =value
+                elif isinstance(value,_ParameterTypeBase) or (type(key) == int):
+                    params[key] = value
                 else:
                     params[key].setValue(value)
             else:

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -623,9 +623,19 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                         p =pset.parameters_()
                         _modifyParametersFromDict(p,
                                                   value,errorRaiser,
-                                                  keyDepth+"."+key)
+                                                  ("%s.%s" if type(key)==str else "%s[%s]")%(keyDepth,key))
                         for k,v in p.iteritems():
                             setattr(pset,k,v)
+                    elif isinstance(params[key],_ValidatingParameterListBase):
+                        if any(type(k) != int for k in value.keys()):
+                            raise ValueError("Attempted to change a list using a dict whose keys are not integers")
+                        plist = params[key]
+                        p = dict(enumerate(plist))
+                        _modifyParametersFromDict(p,
+                                                  value,errorRaiser,
+                                                  ("%s.%s" if type(key)==str else "%s[%s]")%(keyDepth,key))
+                        for k,v in p.iteritems():
+                            plist[k] = v
                     else:
                         raise ValueError("Attempted to change non PSet value "+keyDepth+" using a dictionary")
                 elif isinstance(value,_ParameterTypeBase):

--- a/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
@@ -37,6 +37,7 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
     const float TrueNumInteractions = psu.getTrueNumInteractions();
     
     std::vector<float> zpositions;
+    std::vector<float> times;
     std::vector<float> sumpT_lowpT;
     std::vector<float> sumpT_highpT;
     std::vector<int> ntrks_lowpT;
@@ -50,6 +51,7 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
     
     if( keep_details ) {
       zpositions   = psu.getPU_zpositions();
+      times        = psu.getPU_times();
       sumpT_lowpT  = psu.getPU_sumpT_lowpT();
       sumpT_highpT = psu.getPU_sumpT_highpT();
       ntrks_lowpT  = psu.getPU_ntrks_lowpT();
@@ -60,6 +62,7 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
     // insert the slimmed vertex info
     output->emplace_back(num_PU_vertices,
                          zpositions,
+                         times,
                          sumpT_lowpT, sumpT_highpT,
                          ntrks_lowpT, ntrks_highpT,
                          eventInfo,

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
@@ -18,6 +19,9 @@ public:
     muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
     DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
     NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
+    useTiming_(conf.existsAs<edm::InputTag>("timeValueMap")),
+    srcTime_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+    srcTimeError_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
     useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
     cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
     debug_(conf.getUntrackedParameter<bool>("debug",false)) {
@@ -38,6 +42,8 @@ private:
   edm::EDGetTokenT<reco::MuonCollection> muons_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
+  const bool useTiming_;
+  edm::EDGetTokenT<edm::ValueMap<float>> srcTime_, srcTimeError_;
   const bool useIterTracking_,cleanBadConvBrems_,debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
@@ -66,6 +72,11 @@ importToBlock( const edm::Event& e,
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(),true);
   reco::MuonRef muonref;
+  edm::Handle<edm::ValueMap<float>> timeH, timeErrH;
+  if (useTiming_) {
+    e.getByToken(srcTime_, timeH);
+    e.getByToken(srcTimeError_, timeErrH);
+  }
   // remove converted brems with bad pT resolution if requested
   // this reproduces the old behavior of PFBlockAlgo
   if( cleanBadConvBrems_ ) {
@@ -147,6 +158,9 @@ importToBlock( const edm::Event& e,
 		  << " pt " << pftrackref->trackRef()->p() << std::endl; 
       }
       if( muId != -1 ) trkElem->setMuonRef(muonref);
+      if ( useTiming_ ) {
+        trkElem->setTime( (*timeH)[pftrackref->trackRef()], (*timeErrH)[pftrackref->trackRef()] );
+      }
       elems.emplace_back(trkElem);
     }
   }

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
@@ -9,37 +9,3 @@ from copy import deepcopy
 # include "RecoTracker/TrackProducer/data/CTFFinalFitWithMaterial.cff"
 from RecoParticleFlow.PFProducer.particleFlowBlock_cfi import *
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-# kill tracks in the HGCal
-phase2_hgcal.toModify(
-    particleFlowBlock,
-    elementImporters = { 5 : dict(
-        importerName = cms.string('GeneralTracksImporterWithVeto'),
-        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
-    ) }
-)
-### for later
-#_phase2_hgcal_Linkers.append( 
-#    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),
-#              linkType   = cms.string("SC:HGCAL"),
-#              useKDTree  = cms.bool(False),
-#              SuperClusterMatchByRef = cms.bool(True) ) 
-#)
-#_phase2_hgcal_Linkers.append(
-#    cms.PSet( linkerName = cms.string("HGCalAndBREMLinker"),
-#              linkType   = cms.string("HGCAL:BREM"),
-#              useKDTree  = cms.bool(False) )
-#)
-#_phase2_hgcal_Linkers.append(
-#    cms.PSet( linkerName = cms.string("GSFAndHGCalLinker"), 
-#                  linkType   = cms.string("GSF:HGCAL"),
-#                  useKDTree  = cms.bool(False) )
-#)
-
-
-from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toModify(
-    particleFlowBlock,
-    elementImporters = { 5  : dict( timeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
-                                timeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")) }
-)

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
@@ -9,17 +9,15 @@ from copy import deepcopy
 # include "RecoTracker/TrackProducer/data/CTFFinalFitWithMaterial.cff"
 from RecoParticleFlow.PFProducer.particleFlowBlock_cfi import *
 
-_phase2_hgcal_Importers = deepcopy(particleFlowBlock.elementImporters)
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 # kill tracks in the HGCal
-_phase2_hgcal_Importers[5].importerName = cms.string('GeneralTracksImporterWithVeto')
-_phase2_hgcal_Importers[5].veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
-#_phase2_hgcal_Importers[2].source_ee = cms.InputTag('particleFlowSuperClusterHGCal')
-#_phase2_hgcal_Importers.append(
-#    cms.PSet( importerName = cms.string("HGCalClusterImporter"),
-#              source = cms.InputTag("particleFlowClusterHGCal"),
-#              BCtoPFCMap = cms.InputTag('particleFlowSuperClusterHGCal:PFClusterAssociationEBEE') ),
-#)
-_phase2_hgcal_Linkers = deepcopy(particleFlowBlock.linkDefinitions)
+phase2_hgcal.toModify(
+    particleFlowBlock,
+    elementImporters = { 5 : dict(
+        importerName = cms.string('GeneralTracksImporterWithVeto'),
+        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+    ) }
+)
 ### for later
 #_phase2_hgcal_Linkers.append( 
 #    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),
@@ -38,9 +36,10 @@ _phase2_hgcal_Linkers = deepcopy(particleFlowBlock.linkDefinitions)
 #                  useKDTree  = cms.bool(False) )
 #)
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify(
+
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify(
     particleFlowBlock,
-    linkDefinitions = _phase2_hgcal_Linkers,
-    elementImporters = _phase2_hgcal_Importers
+    elementImporters = { 5  : dict( timeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
+                                timeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")) }
 )

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -136,4 +136,52 @@ particleFlowBlock = cms.EDProducer(
         )          
 )
 
+def _findIndicesByModule(name):
+   ret = []
+   for i, pset in enumerate(particleFlowBlock.elementImporters):
+        if pset.importerName.value() == name:
+            ret.append(i)
+   return ret
 
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+# kill tracks in the HGCal
+_insertGeneralTracksImporter = {}
+for idx in _findIndicesByModule('GeneralTracksImporter'):
+    _insertGeneralTracksImporter[idx] = dict(
+        importerName = cms.string('GeneralTracksImporterWithVeto'),
+        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+    )
+phase2_hgcal.toModify(
+    particleFlowBlock,
+    elementImporters = _insertGeneralTracksImporter
+)
+### for later
+#_phase2_hgcal_Linkers.append( 
+#    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),
+#              linkType   = cms.string("SC:HGCAL"),
+#              useKDTree  = cms.bool(False),
+#              SuperClusterMatchByRef = cms.bool(True) ) 
+#)
+#_phase2_hgcal_Linkers.append(
+#    cms.PSet( linkerName = cms.string("HGCalAndBREMLinker"),
+#              linkType   = cms.string("HGCAL:BREM"),
+#              useKDTree  = cms.bool(False) )
+#)
+#_phase2_hgcal_Linkers.append(
+#    cms.PSet( linkerName = cms.string("GSFAndHGCalLinker"), 
+#                  linkType   = cms.string("GSF:HGCAL"),
+#                  useKDTree  = cms.bool(False) )
+#)
+
+
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+_addTiming = {}
+for idx in _findIndicesByModule('GeneralTracksImporter') + _findIndicesByModule('GeneralTracksImporterWithVeto'):
+    _addTiming[idx] = dict( 
+            timeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
+            timeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")
+    ) 
+phase2_timing.toModify(
+    particleFlowBlock,
+    elementImporters = _addTiming
+)

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -14,3 +14,12 @@ simPFProducer = cms.EDProducer(
     simClustersSrc = cms.InputTag('particleFlowClusterHGCal'),
     associators = cms.VInputTag(cms.InputTag('quickTrackAssociatorByHits') )
     )
+
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify(
+    simPFProducer,
+    trackTimeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
+    trackTimeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution"),
+    gsfTrackTimeValueMap = cms.InputTag("trackTimeValueMapProducer:electronGsfTracksConfigurableFlatResolutionModel"),
+gsfTrackTimeErrorMap = cms.InputTag("trackTimeValueMapProducer:electronGsfTracksConfigurableFlatResolutionModelResolution"),
+)

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -3284,7 +3284,7 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
   pfCandidates_->back().setVertex(vertexPos);  
 
   //Set the time
-  pfCandidates_->back().setTime( cluster.time() );
+  pfCandidates_->back().setTime( cluster.time(), cluster.timeError() );
 
   if(debug_) 
     cout<<"** candidate: "<<pfCandidates_->back()<<endl; 

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -3283,6 +3283,9 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
   //Set the cnadidate Vertex
   pfCandidates_->back().setVertex(vertexPos);  
 
+  //Set the time
+  pfCandidates_->back().setTime( cluster.time() );
+
   if(debug_) 
     cout<<"** candidate: "<<pfCandidates_->back()<<endl; 
 

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -3139,6 +3139,8 @@ unsigned PFAlgo::reconstructTrack( const reco::PFBlockElement& elt, bool allowLo
     pfCandidates_->back().setMuonRef( muonRef );
 
 
+  //Set time
+  if (elt.isTimeValid()) pfCandidates_->back().setTime( elt.time(), elt.timeError() );
 
   //OK Now try to reconstruct the particle as a muon
   bool isMuon=pfmu_->reconstructMuon(pfCandidates_->back(),muonRef,allowLoose);

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2025,7 +2025,8 @@ fillPFCandidates(const pfEGHelpers::HeavyObjectCache* hoc,
 
     // forward the time from the seed cluster
     if (!RO.ecalclusters.empty()) {
-        cand.setTime( RO.ecalclusters.front().first->clusterRef()->time() );
+        auto const & seedPFClust = *RO.ecalclusters.front().first->clusterRef();
+        cand.setTime( seedPFClust.time(), seedPFClust.timeError() );
     }
     
     const reco::SuperCluster& the_sc = refinedscs_.back();

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2022,6 +2022,11 @@ fillPFCandidates(const pfEGHelpers::HeavyObjectCache* hoc,
     
     // build the refined supercluster from those clusters left in the cand
     refinedscs_.push_back(buildRefinedSuperCluster(RO));
+
+    // forward the time from the seed cluster
+    if (!RO.ecalclusters.empty()) {
+        cand.setTime( RO.ecalclusters.front().first->clusterRef()->time() );
+    }
     
     const reco::SuperCluster& the_sc = refinedscs_.back();
     // with the refined SC in hand we build a naive candidate p4 

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -62,11 +62,14 @@ public:
 private:
   // parameters
   const double superClusterThreshold_, neutralEMThreshold_, neutralHADThreshold_;
+  const bool useTiming_;
   
   // inputs
   const edm::EDGetTokenT<edm::View<reco::PFRecTrack> > pfRecTracks_;
   const edm::EDGetTokenT<edm::View<reco::Track> > tracks_;
   const edm::EDGetTokenT<edm::View<reco::Track> > gsfTracks_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> srcGsfTrackTime_, srcGsfTrackTimeError_;
   const edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_;
   const edm::EDGetTokenT<SimClusterCollection> simClustersTruth_;
   const edm::EDGetTokenT<CaloParticleCollection> caloParticles_;
@@ -91,9 +94,14 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf) :
   superClusterThreshold_( conf.getParameter<double>("superClusterThreshold") ),
   neutralEMThreshold_( conf.getParameter<double>("neutralEMThreshold") ),
   neutralHADThreshold_( conf.getParameter<double>("neutralHADThreshold") ),
+  useTiming_(conf.existsAs<edm::InputTag>("trackTimeValueMap")),
   pfRecTracks_(consumes<edm::View<reco::PFRecTrack> >(conf.getParameter<edm::InputTag> ("pfRecTrackSrc"))),
   tracks_(consumes<edm::View<reco::Track> >( conf.getParameter<edm::InputTag>("trackSrc") ) ),
   gsfTracks_(consumes<edm::View<reco::Track> >( conf.getParameter<edm::InputTag>("gsfTrackSrc") ) ),
+  srcTrackTime_(useTiming_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+  srcTrackTimeError_(useTiming_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+  srcGsfTrackTime_(useTiming_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeValueMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+  srcGsfTrackTimeError_(useTiming_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeErrorMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
   trackingParticles_(consumes<TrackingParticleCollection>( conf.getParameter<edm::InputTag>("trackingParticleSrc") ) ),
   simClustersTruth_(consumes<SimClusterCollection>( conf.getParameter<edm::InputTag>("simClusterTruthSrc") ) ),
   caloParticles_(consumes<CaloParticleCollection>( conf.getParameter<edm::InputTag>("caloParticlesSrc") ) ),
@@ -128,7 +136,16 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
   edm::Handle<edm::View<reco::Track> > TrackCollectionH;
   evt.getByToken(tracks_, TrackCollectionH);
   const edm::View<reco::Track>& TrackCollection = *TrackCollectionH;
-  
+ 
+  // get timing, if enabled
+  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, gsfTrackTimeH, gsfTrackTimeErrH;
+  if (useTiming_) {
+    evt.getByToken(srcTrackTime_, trackTimeH);
+    evt.getByToken(srcTrackTimeError_, trackTimeErrH);
+    evt.getByToken(srcGsfTrackTime_, gsfTrackTimeH);
+    evt.getByToken(srcGsfTrackTimeError_, gsfTrackTimeErrH);
+  }
+ 
   //get tracking particle collections
   edm::Handle<TrackingParticleCollection>  TPCollectionH;
   evt.getByToken(trackingParticles_, TPCollectionH);
@@ -260,6 +277,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
     auto& candidate = candidates->back();
 
     candidate.setTrackRef(tkRef.castTo<reco::TrackRef>());
+    if (useTiming_) candidate.setTime( (*trackTimeH)[tkRef], (*trackTimeErrH)[tkRef] );
     
     // bind to cluster if there is one and try to gather conversions, etc
     for( const auto& match : matches ) {      

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -342,6 +342,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
 	candidates->emplace_back(0, clu_p4, part_type);
 	auto& candidate = candidates->back();
 	candidate.addElementInBlock(blref,elem.index());
+        candidate.setTime(ref->time());
       }
     }
   }

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -342,7 +342,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
 	candidates->emplace_back(0, clu_p4, part_type);
 	auto& candidate = candidates->back();
 	candidate.addElementInBlock(blref,elem.index());
-        candidate.setTime(ref->time());
+        candidate.setTime(ref->time(), ref->timeError());
       }
     }
   }

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
@@ -28,41 +28,46 @@ class PileupSummaryInfo {
   PileupSummaryInfo(){};
  
   PileupSummaryInfo( const int num_PU_vertices,
-		     std::vector<float>& zpositions,
-		     std::vector<float>& sumpT_lowpT,
-		     std::vector<float>& sumpT_highpT,
-		     std::vector<int>& ntrks_lowpT,
-		     std::vector<int>& ntrks_highpT );
+		     const std::vector<float>& zpositions,
+		     const std::vector<float>& times, // may be empty
+		     const std::vector<float>& sumpT_lowpT,
+		     const std::vector<float>& sumpT_highpT,
+		     const std::vector<int>& ntrks_lowpT,
+		     const std::vector<int>& ntrks_highpT );
 
   PileupSummaryInfo( const int num_PU_vertices,
-		     std::vector<float>& zpositions,
-		     std::vector<float>& sumpT_lowpT,
-		     std::vector<float>& sumpT_highpT,
-		     std::vector<int>& ntrks_lowpT,
-		     std::vector<int>& ntrks_highpT,
+		     const std::vector<float>& zpositions,
+		     const std::vector<float>& times, // may be empty
+		     const std::vector<float>& sumpT_lowpT,
+		     const std::vector<float>& sumpT_highpT,
+		     const std::vector<int>& ntrks_lowpT,
+		     const std::vector<int>& ntrks_highpT,
 		     int bunchCrossing);
 
   PileupSummaryInfo( const int num_PU_vertices,
-		     std::vector<float>& zpositions,
-		     std::vector<float>& sumpT_lowpT,
-		     std::vector<float>& sumpT_highpT,
-		     std::vector<int>& ntrks_lowpT,
-		     std::vector<int>& ntrks_highpT,
-		     std::vector<edm::EventID>& eventInfo,
-		     std::vector<float>& pT_hats,
+		     const std::vector<float>& zpositions,
+		     const std::vector<float>& times, // may be empty
+		     const std::vector<float>& sumpT_lowpT,
+		     const std::vector<float>& sumpT_highpT,
+		     const std::vector<int>& ntrks_lowpT,
+		     const std::vector<int>& ntrks_highpT,
+		     const std::vector<edm::EventID>& eventInfo,
+		     const std::vector<float>& pT_hats,
 		     int bunchCrossing,
 		     float TrueNumInteractions,
 		     int bunchSpacing);
 
   PileupSummaryInfo( const int num_PU_vertices,
-		     std::vector<float>& instLumi,
-		     std::vector<edm::EventID>& eventInfo );
+		     const std::vector<float>& instLumi,
+		     const std::vector<edm::EventID>& eventInfo );
 
 
   ~PileupSummaryInfo();
 
   const int getPU_NumInteractions() const { return num_PU_vertices_; }
   const std::vector<float>& getPU_zpositions() const { return zpositions_; }
+  bool  has_times() const { return !times_.empty(); }
+  const std::vector<float>& getPU_times() const { return times_; }
   const std::vector<float>& getPU_sumpT_lowpT() const { return sumpT_lowpT_; }
   const std::vector<float>& getPU_sumpT_highpT() const { return sumpT_highpT_; }
   const std::vector<int>& getPU_ntrks_lowpT() const { return ntrks_lowpT_; }
@@ -80,6 +85,7 @@ class PileupSummaryInfo {
 
   int num_PU_vertices_;
   std::vector<float> zpositions_;
+  std::vector<float> times_;
   std::vector<float> sumpT_lowpT_;
   std::vector<float> sumpT_highpT_;
   std::vector<int> ntrks_lowpT_;

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h
@@ -29,10 +29,12 @@ class PileupVertexContent {
 
   PileupVertexContent(){};
 
-  PileupVertexContent( std::vector<float>& pT_hat,
-		       std::vector<float>& z_Vtx ):
+  PileupVertexContent( const std::vector<float>& pT_hat,
+		       const std::vector<float>& z_Vtx,
+                       const std::vector<float>& t_Vtx):
   pT_hats_(pT_hat),
-  z_Vtxs_(z_Vtx)
+  z_Vtxs_(z_Vtx),
+  t_Vtxs_(t_Vtx)
  { };
 
 
@@ -41,10 +43,12 @@ class PileupVertexContent {
   ~PileupVertexContent(){
     pT_hats_.clear();
     z_Vtxs_.clear();
+    t_Vtxs_.clear();
   };
 
   const std::vector<float>& getMix_pT_hats() const { return pT_hats_; }
   const std::vector<float>& getMix_z_Vtxs() const { return z_Vtxs_; }
+  const std::vector<float>& getMix_t_Vtxs() const { return t_Vtxs_; }
 
  private:
 
@@ -53,6 +57,7 @@ class PileupVertexContent {
 
   std::vector<float> pT_hats_;
   std::vector<float> z_Vtxs_;
+  std::vector<float> t_Vtxs_; // may be empty if time information is not available
 
 };
 

--- a/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
+++ b/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
@@ -13,114 +13,78 @@
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
-                     std::vector<float>& zpositions, 
-                     std::vector<float>& sumpT_lowpT,
-                     std::vector<float>& sumpT_highpT,
-                     std::vector<int>&   ntrks_lowpT,
-                     std::vector<int>&   ntrks_highpT )
+                    const std::vector<float>& zpositions, 
+                    const std::vector<float>& times, 
+                    const std::vector<float>& sumpT_lowpT,
+                    const std::vector<float>& sumpT_highpT,
+                    const std::vector<int>&   ntrks_lowpT,
+                    const std::vector<int>&   ntrks_highpT ) :
+    num_PU_vertices_(num_PU_vertices),
+    zpositions_(zpositions),
+    times_(times),
+    sumpT_lowpT_(sumpT_lowpT),
+    sumpT_highpT_(sumpT_highpT),
+    ntrks_lowpT_(ntrks_lowpT),
+    ntrks_highpT_(ntrks_highpT)
 {
-
-  num_PU_vertices_ =  num_PU_vertices;
-  zpositions_.clear();
-  sumpT_lowpT_.clear();
-  sumpT_highpT_.clear();
-  ntrks_lowpT_.clear();
-  ntrks_highpT_.clear();
-  instLumi_.clear();
-  eventInfo_.clear();
-
-  int NLoop = zpositions.size();
-
-  for( int ivtx = 0; ivtx<NLoop ; ++ivtx) {
-    zpositions_.push_back(zpositions[ivtx]); 
-    sumpT_lowpT_.push_back(sumpT_lowpT[ivtx]);
-    sumpT_highpT_.push_back(sumpT_highpT[ivtx]);
-    ntrks_lowpT_.push_back(ntrks_lowpT[ivtx]);
-    ntrks_highpT_.push_back(ntrks_highpT[ivtx]);
-  }
-
 }
 
 PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
-                     std::vector<float>& zpositions, 
-                     std::vector<float>& sumpT_lowpT,
-                     std::vector<float>& sumpT_highpT,
-                     std::vector<int>&   ntrks_lowpT,
-		     std::vector<int>&   ntrks_highpT,
-		     int bunchCrossing)
+                     const std::vector<float>& zpositions, 
+                     const std::vector<float>& times, 
+                     const std::vector<float>& sumpT_lowpT,
+                     const std::vector<float>& sumpT_highpT,
+                     const std::vector<int>&   ntrks_lowpT,
+		     const std::vector<int>&   ntrks_highpT,
+		     int bunchCrossing) :
+    num_PU_vertices_(num_PU_vertices),
+    zpositions_(zpositions),
+    times_(times),
+    sumpT_lowpT_(sumpT_lowpT),
+    sumpT_highpT_(sumpT_highpT),
+    ntrks_lowpT_(ntrks_lowpT),
+    ntrks_highpT_(ntrks_highpT),
+    bunchCrossing_(bunchCrossing)
 {
-
-  num_PU_vertices_ =  num_PU_vertices;
-  zpositions_.clear();
-  sumpT_lowpT_.clear();
-  sumpT_highpT_.clear();
-  ntrks_lowpT_.clear();
-  ntrks_highpT_.clear();
-  instLumi_.clear();
-  eventInfo_.clear();
-  bunchCrossing_ = bunchCrossing;
-
-  int NLoop = zpositions.size();
-
-  for( int ivtx = 0; ivtx<NLoop ; ++ivtx) {
-    zpositions_.push_back(zpositions[ivtx]); 
-    sumpT_lowpT_.push_back(sumpT_lowpT[ivtx]);
-    sumpT_highpT_.push_back(sumpT_highpT[ivtx]);
-    ntrks_lowpT_.push_back(ntrks_lowpT[ivtx]);
-    ntrks_highpT_.push_back(ntrks_highpT[ivtx]);
-  }
-
 }
 
 
 PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
-                     std::vector<float>& zpositions, 
-                     std::vector<float>& sumpT_lowpT,
-                     std::vector<float>& sumpT_highpT,
-                     std::vector<int>&   ntrks_lowpT,
-		     std::vector<int>&   ntrks_highpT,
-		     std::vector<edm::EventID>& eventInfo,
-                     std::vector<float>& pThats, 
+                     const std::vector<float>& zpositions, 
+                     const std::vector<float>& times, 
+                     const std::vector<float>& sumpT_lowpT,
+                     const std::vector<float>& sumpT_highpT,
+                     const std::vector<int>&   ntrks_lowpT,
+		     const std::vector<int>&   ntrks_highpT,
+		     const std::vector<edm::EventID>& eventInfo,
+                     const std::vector<float>& pThats, 
 		     int bunchCrossing,
 		     float TrueNumInteractions,
  	             int bunchSpacing):
+  num_PU_vertices_(num_PU_vertices),
   zpositions_(zpositions),
+  times_(times),
   sumpT_lowpT_(sumpT_lowpT),
   sumpT_highpT_(sumpT_highpT),
   ntrks_lowpT_(ntrks_lowpT),
   ntrks_highpT_(ntrks_highpT),
   eventInfo_(eventInfo),
-  pT_hats_(pThats)
+  pT_hats_(pThats),
+  bunchCrossing_(bunchCrossing),
+  bunchSpacing_(bunchSpacing),
+  TrueNumInteractions_(TrueNumInteractions)
 {
-
-  num_PU_vertices_ =  num_PU_vertices;
-  instLumi_.clear();
-  bunchCrossing_ = bunchCrossing;
-  TrueNumInteractions_ = TrueNumInteractions;
-  bunchSpacing_ = bunchSpacing;
-
 }
 
 
 
 PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
-				      std::vector<float>& instLumi,
-				      std::vector<edm::EventID>& eventInfo)
+				      const std::vector<float>& instLumi,
+				      const std::vector<edm::EventID>& eventInfo) :
+    num_PU_vertices_(num_PU_vertices),
+    eventInfo_(eventInfo),
+    instLumi_(instLumi)
 {
-  num_PU_vertices_ =  num_PU_vertices;
-  zpositions_.clear();
-  sumpT_lowpT_.clear();
-  sumpT_highpT_.clear();
-  ntrks_lowpT_.clear();
-  ntrks_highpT_.clear();
-  instLumi_.clear();
-  eventInfo_.clear();
-
-
-  for( int ivtx = 0; ivtx<num_PU_vertices ; ++ivtx) {
-    instLumi_.push_back(instLumi[ivtx]);
-    eventInfo_.push_back(eventInfo[ivtx]);
-  }
 }
 
 PileupSummaryInfo::~PileupSummaryInfo(){

--- a/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
+++ b/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="PileupSummaryInfo" ClassVersion="12">
+  <class name="PileupSummaryInfo" ClassVersion="13">
+   <version ClassVersion="13" checksum="1980628569"/>
    <version ClassVersion="12" checksum="231481749"/>
    <version ClassVersion="11" checksum="1526417022"/>
   </class>
@@ -13,7 +14,8 @@
   <class name="std::vector<PileupMixingContent>"/>  
   <class name="edm::Wrapper<PileupMixingContent>"/>
   <class name="edm::Wrapper<std::vector<PileupMixingContent> >"/>
-  <class name="PileupVertexContent" ClassVersion="3">
+  <class name="PileupVertexContent" ClassVersion="4">
+   <version ClassVersion="4" checksum="1959165237"/>
    <version ClassVersion="3" checksum="3263569137"/>
   </class>
   <class name="std::vector<PileupVertexContent>"/>  

--- a/SimGeneral/MixingModule/python/pileupVtxDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pileupVtxDigitizer_cfi.py
@@ -5,5 +5,8 @@ pileupVtxDigitizer = cms.PSet(
     hitsProducer = cms.string('generator'),
     vtxTag = cms.InputTag("generatorSmeared"),
     vtxFallbackTag = cms.InputTag("generator"),
-    makeDigiSimLinks = cms.untracked.bool(False))
+    makeDigiSimLinks = cms.untracked.bool(False),
+    saveVtxTimes = cms.bool(False))
 
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify( pileupVtxDigitizer, saveVtxTimes = cms.bool(True) )

--- a/SimGeneral/PileupInformation/interface/PileupInformation.h
+++ b/SimGeneral/PileupInformation/interface/PileupInformation.h
@@ -66,6 +66,8 @@ private:
 
     bool LookAtTrackingTruth_ ;
 
+    bool saveVtxTimes_;
+
     std::string MessageCategory_;
     //std::string simHitLabel_;
     //std::unique_ptr<MixCollection<SimTrack> >   simTracks_;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -69,7 +69,8 @@ namespace cms
 {
   PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
     Mtag_(iConfig.getParameter<edm::InputTag>("vtxTag")),
-    fallbackMtag_(iConfig.getParameter<edm::InputTag>("vtxFallbackTag"))
+    fallbackMtag_(iConfig.getParameter<edm::InputTag>("vtxFallbackTag")),
+    saveVtxTimes_(iConfig.getParameter<bool>("saveVtxTimes"))
   {
     edm::LogInfo ("PixelDigitizer ") <<"Enter the Pixel Digitizer";
     
@@ -95,6 +96,7 @@ namespace cms
 
     pT_Hats_.clear();
     z_posns_.clear();
+    t_posns_.clear();
   }
 
   void
@@ -131,6 +133,11 @@ namespace cms
       float zpos = v->position().z()*0.1;
  
       z_posns_.push_back(zpos);
+
+      if (saveVtxTimes_) {
+          float tpos = v->position().t()/299792458e-6; // turn from mm to ns
+          t_posns_.push_back(tpos);
+      }
     }
 
     //    delete myGenEvent;
@@ -141,7 +148,7 @@ namespace cms
   void
   PileupVertexAccumulator::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-    std::unique_ptr<PileupVertexContent> PUVtxC(new PileupVertexContent(pT_Hats_, z_posns_));
+    std::unique_ptr<PileupVertexContent> PUVtxC(new PileupVertexContent(pT_Hats_, z_posns_, t_posns_));
 
     // write output to event
     iEvent.put(std::move(PUVtxC));

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -55,8 +55,10 @@ namespace cms {
   private:
     std::vector<float> pT_Hats_;
     std::vector<float> z_posns_;
+    std::vector<float> t_posns_;
     edm::InputTag Mtag_;
     edm::InputTag fallbackMtag_;
+    bool saveVtxTimes_;
 
   };
 }

--- a/SimGeneral/PileupInformation/python/AddPileupSummary_cfi.py
+++ b/SimGeneral/PileupInformation/python/AddPileupSummary_cfi.py
@@ -11,8 +11,11 @@ addPileupInfo = cms.EDProducer("PileupInformation",
     volumeZ = cms.double(3000.0),
     pTcut_1 = cms.double(0.1),
     pTcut_2 = cms.double(0.5),                               
-    doTrackTruth = cms.untracked.bool(False)                          
-
+    doTrackTruth = cms.untracked.bool(False),
+    saveVtxTimes = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify( addPileupInfo, saveVtxTimes = cms.bool(True) )
 
 #addPileupInfo = cms.Sequence(pileupSummary)


### PR DESCRIPTION
As presented in the Reco meeting of 02/11/16 ( https://indico.cern.ch/event/581218/ ), with a few updates: added timeError on PFClusters and time for PU vertices.

**DataFormats**: 
add support for timing in PF objects
* time() and timeError() added to PFCandidate and PFBlockElement
* timeError() added to PFCluster (before, it had only time()), and changed doubles to floats

**Reco**:  
minimal implementation of timing in PFCandidates
* in the pase2_timing era, MIP timing is propagated from the ValueMaps to the charged PFCandidates
* PFCluster timing is propagated to PFCandidates (for E/gamma candidates, the timing is taken from the seed cluster)

**MC Truth information**: 
add some truth information in AOD formats
* genParticleProducer saves t0 and xyz0 of the true signal vertex also saved as a global float and a XYZPointF object
* getPU_times() added to PileupSummaryInfo and filled if the phase2_timing era 

**Framework**:
* support for modifying VPSets entries in eras

@bendavid @lgray @bachtis 
