### PR TITLE
pr81x L1T demote muon low qual in OMTF region for HI

### DIFF
--- a/L1Trigger/L1TMuonOverlap/interface/OmtfName.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OmtfName.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <ostream>
 
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+
 class OmtfName {
 
 public:
@@ -19,7 +21,11 @@ public:
   OmtfName(const  std::string & name);
 
   //by giving procesor id [0,5] and endcap position {+1,-1} as in uGMT.
-  OmtfName(unsigned int iProcesor, int endcap);
+  explicit OmtfName(unsigned int iProcesor, int endcap);
+
+  //by giving procesor id [0,5] and endcap position as l1t::tftype of omtf_pos or omtf_neg.
+  explicit OmtfName(unsigned int iProcesor, l1t::tftype endcap);
+  
 
   operator int () const { return theBoard; } 
   bool operator==(const OmtfName& o) const { return theBoard == o.theBoard; } 
@@ -27,6 +33,7 @@ public:
 
   unsigned int processor() const;
   int position()  const;
+  l1t::tftype tftype() const;
 
   std::string name() const;
   

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -187,7 +187,10 @@ std::vector<l1t::RegionalMuonCand> OMTFSorter::candidates(unsigned int iProcesso
              || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001010000000").to_ulong()
            )
        ) quality =4;
-    if (abs(myCand.getEta()) == 121) quality = 4;
+
+//  if (abs(myCand.getEta()) == 121) quality = 4;
+    if (abs(myCand.getEta()) == 121) quality = 0; // changed on request from HI
+
     candidate.setHwQual (quality);
 
     std::map<int, int> trackAddr;

--- a/L1Trigger/L1TMuonOverlap/src/OmtfName.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OmtfName.cc
@@ -12,6 +12,13 @@ OmtfName::OmtfName(unsigned int iProcesor, int endcap)
   theBoard = static_cast<Board>( sgn(position)*(iproc+1) );
 }
 
+OmtfName::OmtfName(unsigned int iProcesor, l1t::tftype endcap)
+{
+  int iproc = (iProcesor <=5 ) ? static_cast<int>(iProcesor) : -1;
+  int position = (endcap == l1t::omtf_pos ) ? 1 : ( (endcap == l1t::omtf_neg ) ? -1 : 0);
+  theBoard = static_cast<Board>( sgn(position)*(iproc+1) );
+}
+
 OmtfName::OmtfName(const std::string & board) 
 {
   if (board=="OMTFn1") theBoard =  OMTFn1;
@@ -51,4 +58,6 @@ std::string OmtfName::name() const
 int OmtfName::position() const { return sgn(theBoard); } 
 
 unsigned int OmtfName::processor() const { return abs(theBoard)-1; }
+
+l1t::tftype OmtfName::tftype() const { return  sgn(theBoard) > 0 ? l1t::omtf_pos : l1t::omtf_neg; }
 


### PR DESCRIPTION
This is 81x PR for HI run.

OMTF: 
- force quality 0 for muons with |eta|=121 in OMTFSorter, as requested by HI 
- minor fix in OmtfName, used only in the Omtf analysis