### PR TITLE
pr81x L1T suppress warning - Too many Taus

### DIFF
--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -224,7 +224,7 @@ void l1t::GlobalBoard::receiveCaloObjectData(edm::Event& iEvent,
 	        if(nObj<nrL1Tau) {
 		   (*m_candL1Tau).push_back(i,&(*tau));
 	        } else {
-		  edm::LogWarning("L1TGlobal") << " Too many Tau ("<<nObj<<") for uGT Configuration maxTau =" <<nrL1Tau << std::endl;
+		  LogTrace("L1TGlobal") << " Too many Tau ("<<nObj<<") for uGT Configuration maxTau =" <<nrL1Tau << std::endl;
 		}
 		   
 	        LogDebug("L1TGlobal") << "tau  Pt " << tau->hwPt() << " Eta  " << tau->hwEta() << " Phi " << tau->hwPhi() << "  Qual " << tau->hwQual() <<"  Iso " << tau->hwIso() << std::endl;


### PR DESCRIPTION
PR 81x

Suppress the flooding message of Too many Taus for now, caused by L1T Layer2 emulation sending more Taus then uGT currently considers.  Will address later by uGT.