### PR TITLE
Fix 2017 design workflow for '-i all'

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1875,7 +1875,7 @@ for step in upgradeSteps:
                 #however, there can be a conflict of beam spots but this is lost in the dataset name
                 #so please be careful   
                 s=frag[:-4]+'_'+key
-                if 'FastSim' not in k and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and '2023' not in k: # temporarily exclude 2023 WFs
+                if 'FastSim' not in k and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and defaultDataSets[key] != '': # exclude upgradeKeys without input dataset
                     steps[k+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+upgradeDatasetFromFragment[frag]+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
    else:
         for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:


### PR DESCRIPTION
When introducing the 2017 design workflow in #15994, I missed the fact that with `runTheMatrix.py -i all` the input dataset will be queried even if the `defaultDataSet['2017Design']` is set to empty string. It turns out that all other workflows that have `defaultDataSet` set to empty string are `2023` workflows, and for them the input dataset query is explicitly disabled.

The proposed fix is to disable the input dataset query for all workflows to which `defaultDataSet` is set to empty string.

Tested in CMSSW_8_1_X_2016-11-03-1100. Expecting to fix `runTheMatrix.py -l 10424.0 -i all`, no changes expected to anything else.

Thanks to @smuzaffar for reporting the problem.

@smuzaffar @kpedro88 