### PR TITLE
remove assert in OuterHitPhiPrediction.h

### DIFF
--- a/RecoTracker/TkTrackingRegions/src/OuterHitPhiPrediction.h
+++ b/RecoTracker/TkTrackingRegions/src/OuterHitPhiPrediction.h
@@ -20,7 +20,7 @@ public:
       float originRBound) 
     : thePhiAtVertex(phiAtVertex), theCurvature(curvature),
       theOriginRBound (originRBound) {
-       assert(theCurvature.max()>0);
+       // assert(theCurvature.max()>0);
        assert(theCurvature.max() == -theCurvature.min()); 
       } 
 


### PR DESCRIPTION
remove assert that can fail for straight-line

to fix https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1488.html
and more

note: this assert has been already removed in 810