### PR TITLE
Do not sort the das results if CMSSDT_DAS_CLIENT_NO_SORT env is set

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -128,7 +128,8 @@ class InputInfo(object):
         if self.ib_blacklist:
             command += " | grep -E -v "
             command += " ".join(["-e '{0}'".format(pattern) for pattern in self.ib_blacklist])
-        command += " | sort -u"
+        from os import getenv
+        if getenv("CMSSDT_DAS_CLIENT_NO_SORT","NOT_SET") == "NOT_SET": command += " | sort -u"
         return command
 
     def lumiRanges(self):


### PR DESCRIPTION
Changes are trivial and does not change the default behaviour of runTheMatrix. 
For the IBs/PRs tests (where we use das_client wrapper) we would like to feed in different order of files e.g. files in cmsbuild eos cache should comes first (in sorted order) and then the rest (in sorted order). So that we always pick our files first.