### PR TITLE
Pixel clusterizer configurable gain cmssw 81 x

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -62,6 +62,9 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
   if ( conf_.exists("FirstStackLayer") ) theFirstStack_=conf_.getParameter<int>("FirstStackLayer");
   else
     theFirstStack_=5;
+  if ( conf_.exists("ElectronPerADCGain") ) theElectronPerADCGain_=conf_.getParameter<double>("ElectronPerADCGain");
+  else
+    theElectronPerADCGain_=135.;
   
   // Get the constants for the miss-calibration studies
   doMissCalibrate=conf_.getUntrackedParameter<bool>("MissCalibrate",true); 
@@ -197,7 +200,7 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
     int i=0;
     for(DigiIterator di = begin; di != end; ++di) {
       auto adc = di->adc();
-      const float gain = 135.; // 1 ADC = 135 electrons
+      const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
       const float pedestal = 0.; //
       electron[i] = int(adc * gain + pedestal);
       if (layer>=theFirstStack_) {
@@ -205,7 +208,7 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
 	  electron[i] = int(255*135); // Arbitrarily use overflow value.
 	}
 	if (theStackADC_>1&&theStackADC_!=255&&adc>=1){
-	  const float gain = 135.; // 1 ADC = 135 electrons
+	  const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
 	  electron[i] = int((adc-1) * gain * 255/float(theStackADC_-1));
 	}
       }
@@ -290,7 +293,7 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
   else 
     { // No misscalibration in the digitizer
       // Simple (default) linear gain 
-      const float gain = 135.; // 1 ADC = 135 electrons
+      const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
       const float pedestal = 0.; //
       electrons = int(adc * gain + pedestal);
       if (layer>=theFirstStack_) {
@@ -300,7 +303,7 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
 	  }
 	if (theStackADC_>1&&theStackADC_!=255&&adc>=1)
 	  {
-	    const float gain = 135.; // 1 ADC = 135 electrons
+	    const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
 	    electrons = int((adc-1) * gain * 255/float(theStackADC_-1));
 	  }
       }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -106,7 +106,7 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   int   theStackADC_;          // The maximum ADC count for the stack layers
   int   theFirstStack_;        // The index of the first stack layer
 
-
+  double theElectronPerADCGain_;  //  ADC to electrons conversion
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -10,7 +10,8 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     MissCalibrate = cms.untracked.bool(True),
     SplitClusters = cms.bool(False),
     VCaltoElectronGain = cms.int32(65),
-    VCaltoElectronOffset = cms.int32(-414),                          
+    VCaltoElectronOffset = cms.int32(-414),  
+    ElectronPerADCGain = cms.double(600.),                        
     # **************************************
     # ****  payLoadType Options         ****
     # ****  HLT - column granularity    ****

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -11,7 +11,7 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     SplitClusters = cms.bool(False),
     VCaltoElectronGain = cms.int32(65),
     VCaltoElectronOffset = cms.int32(-414),  
-    ElectronPerADCGain = cms.double(600.),                        
+    ElectronPerADCGain = cms.double(135.),                        
     # **************************************
     # ****  payLoadType Options         ****
     # ****  HLT - column granularity    ****

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -11,7 +11,6 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     SplitClusters = cms.bool(False),
     VCaltoElectronGain = cms.int32(65),
     VCaltoElectronOffset = cms.int32(-414),  
-    ElectronPerADCGain = cms.double(135.),                        
     # **************************************
     # ****  payLoadType Options         ****
     # ****  HLT - column granularity    ****
@@ -29,5 +28,6 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siPixelClusters, # FIXME
   src = cms.InputTag('simSiPixelDigis', "Pixel"),
-  MissCalibrate = False
+  MissCalibrate = False,
+  ElectronPerADCGain = cms.double(135.) # it can be changed to something else (e.g. 600e) if needed
 )


### PR DESCRIPTION
PR for making the variable "gain" of PixelThresholdClusterizer.cc configurable from pset similarly to what is done for the variable "ElectronPerAdc" of the digitizer. 
The current value of "gain" is 135 and it is hardcoded.
So when the value of the digitizer is changed this does not propagate to the SiPixelCluster and to the SiPixelRecHit.
Default value in the .cc and in the pset are kept to 135 anyway.

 @boudoul @ebrondol @dkotlins @atricomi @VinInn @mtosi @delaere @suchandradutta 

