### PR TITLE
Phase1 Pixel DQM cleanup and online features

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -88,8 +88,6 @@ SiPixelPhase1ClustersPositionXZ = DefaultHisto.clone(
   range_y_min = -60, range_y_max = 60, range_y_nbins = 1200,
   dimensions = 2,
   specs = cms.VPSet(
-    Specification().groupBy(DefaultHisto.defaultGrouping)
-                   .saveAll(),
   )
 )
 
@@ -102,8 +100,6 @@ SiPixelPhase1ClustersPositionYZ = DefaultHisto.clone(
   range_y_min = -60, range_y_max = 60, range_y_nbins = 1200,
   dimensions = 2,
   specs = cms.VPSet(
-    Specification().groupBy(DefaultHisto.defaultGrouping)
-                   .saveAll(),
   )
 )
 

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -63,7 +63,7 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
 
   if (nforward > 180) 
     histo[EVENTRATE].fill(DetId(0), &iEvent);
-  histo[NCLUSTERS].executePerEventHarvesting();
+  histo[NCLUSTERS].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1Clusters);

--- a/DQM/SiPixelPhase1Common/README.md
+++ b/DQM/SiPixelPhase1Common/README.md
@@ -88,7 +88,7 @@ Since the framework can see where quantities go during the computation of derive
 How to actually use it
 ----------------------
 
-If you plugin derives from `SiPixelPhase1Base`, you should automatically have access to `HistogramManager`s, in the array `histo[...]`. Every HistogramManager should be used for one quantity. The indices to the array should be enum constants, use something like this
+If your plugin derives from `SiPixelPhase1Base`, you should automatically have access to `HistogramManager`s, in the array `histo[...]`. Every HistogramManager should be used for one quantity. The indices to the array should be enum constants, use something like this
 
     enum {
       ADC, // digi ADC readouts
@@ -100,7 +100,7 @@ in the C++ header to name your quantities and refer to them as `histo[ADC]`.
 
 In the Analyzer code, call the `fill` function on the `histo[...]` whenever you have a datapoint to add. If you are just counting something (in the histograms above, all except the `ADC` are counts), use the `fill` function without any `double` argument. 
 
-The `fill` function takes a number of mandatory and optional parameters the the left-hand side columns are derived from. You always have to pass a module ID (`DetId`), the `Event`is only for time-based things (if you want per lumisection or per bunchcrossing plots), and `row` and `col` are needed for ROC information, or if you want a 2D map of the module.
+The `fill` function takes a number of mandatory and optional parameters that the left-hand side columns are derived from. You always have to pass a module ID (`DetId`), the `Event`is only for time-based things (if you want per lumisection or per bunchcrossing plots), and `row` and `col` are needed for ROC information, or if you want a 2D map of the module.
 
 Now, you need to add some specifications in the config file.
 
@@ -203,6 +203,8 @@ This section explains for every class in the framework what it does. This might 
 
 This is an unspectacular wrapper around histogram-like things. It is used as the right-hand side of all tables that are actually kept in memory. It can contain either a root `TH1`, a `MonitorElement` (then the `th1` points to the MEs TH1) or a simple counter (`int`). The counter can be used independently of the histogram and is used to concatenate histograms in harvesting and count things per event in step1.
 
+There is also a full set of meta information in it (ranges, labels, ...) but these are not used normally; they are only needed once during the booking process. This could be handled more elegantly.
+
 ### SiPixelPhase1Base
 
 This is the base class that all plugins should derive from. It instantiates `HistogramManager`s from config, sets up a `GeometryInterface`, and calls the `book` method of the `HistogramManager`s. If you need anything special, you can also do this yourself ad ignore the base class.
@@ -211,7 +213,7 @@ The same file declares the `SiPixelPhase1Harvester`, which is very similar to th
 
 ### SummationSpecification
 
-A dumb datastructure that represents a specification, as introduced above. The specification is in an internal, slightly different format, which is created by the SpecfiactionBuilder in Python code; the C++ SummationSpecification just takes the `PSet` structure and does no special processing, except for converting columns from the string form to the efficient `GeometryInterface` form.
+A dumb datastructure that represents a specification, as introduced above. The specification is in an internal, slightly different format, which is created by the SpecificationBuilder in Python code; the C++ SummationSpecification just takes the `PSet` structure and does no special processing, except for converting columns from the string form to the efficient `GeometryInterface` form.
 
 ### SpecficationBuilder
 

--- a/DQM/SiPixelPhase1Common/README.md
+++ b/DQM/SiPixelPhase1Common/README.md
@@ -1,7 +1,7 @@
 The SiPixelPhase1Common Framework
 =================================
 
-This framework is used for DQM on the upgraded Pixel Detector. Since it is designed to be geometry independent, it could also be used for the old detector, given the geometry-specific code paths and configuration are added. This framework goes deeper than what was used before, with the goal to move as much redundant work as possible from the DQM plugins into a central place.
+This framework is used for DQM on the upgraded Pixel Detector. Since it is designed to be geometry independent, it can also be used for the old detector, up to some geometry-specific code paths. This framework goes deeper than what was used before, with the goal to move as much redundant work as possible from the DQM plugins into a central place.
 
 This document decomposes into three sections:
 
@@ -73,17 +73,17 @@ As of now we discarded the information of the columns that we removed. However, 
 
 For now, we combined histograms by merging the data sets that the histogram is computed over (which is equivalent to summing up the bin counts). But there are also other ways to summarise histograms: For example, we can reduce a histogram into in single number (e.g. the mean), and then create a new plot (which may or may not be a histogram) of this derived quantity. One common special case of this are profiles, which show the mean of a set of histograms vs. some other quantity (they can also be considered a special representation of a 2D histogram, which is equivalent but we will ignore that for now). We can also create such histograms using projections. One way is to first reduce the right side histograms into a single number each and then move a column from the left side to the right side, using the value for the x-axis. Drawing the now 2D-values on the right side into a scatter plot might give us what we expect, but we could as well end up with a mess, since the x-axis values are not guaranteed to be unique. They could also be unevenly distributed, which also does not give a nice plot.
 
-Another way is to apply the projection, and concatenate the histograms that get merged along the x- or y-axis. Now it matters that we sorted the rows before, since the ordering of the rows will now dictate where the histograms go. If we reduced the histograms into single-bin histograms that show the extracted quantity (e.g. the mean) as the value of that bin, we will now end up with a nice profile. This is the preferred way to create profiles in the framework. The procedure outlined before is only used when it is necessary for technical reasons (DQM step1).
+Another way is to apply the projection, and concatenate the histograms that get merged along the x- or y-axis. Now it matters that we sorted the rows before, since the ordering of the rows will now dictate where the histograms go. If we reduced the histograms into single-bin histograms that show the extracted quantity (e.g. the mean) as the value of that bin, we will now end up with a nice profile. This is the preferred way to create 1D summary profiles in the framework. The procedure outlined before is also used, e.g. for 2D profiles. It has the advantage that t can be computed in DQM step1, while the second method reqires intermediate historams saved for step2 (harvesting).
 
 The framework provides a few simple commands to describe histograms using this model:
 
 - The `groupBy` command projects onto the columns given as the first parameter, and combines the histograms by summing or concatenating along some axis, specified by the second parameter.
 - The `reduce` command reduces the right-hand side histograms into histograms of a lower dimensionality. Typically, e.g. for the mean, this is a 0D-histogram, which means a single bin with the respective value. The quantity to extract is specified by the parameter.
-- The `save`command tells the framework the we are happy with the histograms that are now in the table and that they should be saved to the output file. Proper names are inferred from the column names and steps specified before.
+- The `save`command tells the framework that we are happy with the histograms that are now in the table and that they should be saved to the output file. Proper names are inferred from the column names and steps specified before.
 
 The framework also allows a `custom` command that passes the current table state to custom code, to compute things that the framework does not allow itself. However, this should be used carefully, since such code has to be heavily dependent on internal data structures.
 
-Since the framework can follow see where quantities go during the computation of derived histograms, it can also automatically keep track of the axis labels and ranges and set them to useful, consistent values automatically. For technical reasons the framework is not able to execute every conceivable specification, but it is able to handle all relevant cases in an efficient way. Since the specification is very abstract, it gives the framework a lot of freedom to implement it in the most efficient way possible.
+Since the framework can see where quantities go during the computation of derived histograms, it can also automatically keep track of the axis labels and ranges and set them to useful, consistent values automatically. For technical reasons the framework is not able to execute every conceivable specification, but it is able to handle all relevant cases in an efficient way. Since the specification is very abstract, it gives the framework a lot of freedom to implement it in the most efficient way possible.
 
 How to actually use it
 ----------------------
@@ -139,46 +139,59 @@ The second part initializes a default harvesting plugin, which is needed to exec
 The most important thing in the configuration are the specifications. Add them by setting `specs` in the `clone`. Since you can have many specifications per quantity, this has to be a `VPSet` as well. To make a specification use the `Specification()` builder:
 
     specs = cms.VPSet(
-      Specification().groupBy(DefaultHisto.defaultGrouping) 
+      Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/PXLadder|PXBlade") 
                      .save()
     )
 
-This will give you a default set of histogram, usually grouped by ladders etc. (but configurable). To add histograms per disk as well, add
+This will give you a set of histograms, grouped by ladders and blades. The `groupBy` line specifies 3 levels, each for FPIX and BPIX independently. In the output, this will lead to nested folders of the given names, where the last level of folders (one per ladder/blade) contains the histograms. The string lists columns separated by `/`, which has the same meaning as in a directory hierarchy. For the histograms that are created, the order of columns does not matter; however, the order defines the directory nesting and where the histograms go. (Also, if you use the shorthand `saveAll`, you get summations defined by the ordering/directory hierarchy). Make sure you always list columns in the same order within one specification, otherwise you might hit unsupported or buggy cases. Within a column, a `|` can separate two names. This is used to handle barrel and endcap structure in one go, where barrel- and endcap-names are separated by the `|`. The HistogramManager will try to extract the left value first, and only try the right when that fails. For structures that have no equivalent in one of the subdetectors, you can use the empty column name (e.g. `/PXRing|/`), which will not appear in the directory structure. There is no central list of available column names, as new extractors could be added anywhere. However, most are defined in the `GeometryInterface`, which will also output a list of known columns at runtime (if sufficient debug  logging is enabled). 
 
-    Specification().groupBy(DefaultHisto.defaultGrouping) 
+To add histograms per disk as well, add
+
+    Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/PXLadder|PXBlade") 
                    .save()
-                   .groupBy(parent(DefaultHisto.defaultGrouping)
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk")
                    .save()
 
-You can also add histograms for all default partitions by adding `saveAll()`. 
+You can also add histograms for all mentioned levels by adding `saveAll()`. 
 
-To get profiles, add instead
+To get a summary profle, add instead
 
-    Specification().groupBy(DefaultHisto.defaultGrouping) # per-ladder and profiles
+    Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/PXLadder|PXBlade") # per-ladder and profiles
                    .save()
                    .reduce("MEAN")
-                   .groupBy(parent(DefaultHisto.defaultGrouping), "EXTEND_X")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_X")
                    .saveAll(),
                    
 For quantities where it makes sense to have per-module plots, you can add a specification like this:
 
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule).save()
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId").save()
 
 The `PerModule` parameter (defined in `HistogramManager_cfi.py`, allows the per-module histograms to be turned off by default.
 
-One of the more complicated things is counting things per event, as in e. g. the `NDigis` histograms. The specification for this is
+One of the more complicated things is counting things per event, as in e. g. the `NDigis` histograms. The specification for this is something like this:
 
-      Specification().groupBy(DefaultHisto.defaultGrouping.value() + "/Event") 
+      Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/PXLadder|PXBlade/DetId/Event") 
                      .reduce("COUNT") # per-event counting
-                     .groupBy(DefaultHisto.defaultGrouping) 
+                     .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/PXLadder|PXBlade") 
                      .save()
                      
-You can still add e.g. the profile snippet below to get profiles. For the per-event counting, you also need to call the per-event harvesting method at the end of your `analyze` method:
+We group by module and Event first, since this is the range that we want counted, then we reduce and group as usual to get a histogram of the counts. You can still add e.g. the profile snippet below to get profiles. For the per-event counting, you also need to call the per-event harvesting method at the end of your `analyze` method:
     histo[NDIGIS].executePerEventHarvesting(); 
-    
-If you take a look into `HistogramManager_cfi.py`, where `DefaultHisto` is defined, you will, among other options, see the actual table columns used for grouping in `defaultGrouping`. The string lists columns separated by `/`, which has the same meaning as in a directory hierarchy. For the histograms that are created, the order of columns does not matter; however, the order defines the directory nesting and where the histograms go. (Also, if you use the shorthand `saveAll`, you get summations defined by the ordering/directory hierarchy). Make sure you always list columns in the same order within one specification, otherwise you might hit unsupported or buggy cases. Within a column, a `|` can separate two names. This is used to handle barrel and endcap structure in one go, where barrel- and endcap-names are separated by the `|`. The HistogramManager will try to extract the left value first, and only try the right when that fails. For structures that have no equivalent in one of the subdetectors, you can use the empty column name (e.g. `/PXRing|/`), which will not appear in the directory structure. There is no central list of available column names, as new extractors could be added anywhere. However, most are defined in the `GeometryInterface`, which will also output a list of known columns at runtime (if sufficient debug  logging is enabled). 
 
-For all the specifications, the steps up to the first `save` are executed in DQM step1. The histograms specified after the first `save` are created in DQM step2, Harvesting. Since step1 is very restricted due to multi-threading and performance requirements, not all specifications can be executed in step1. So, sometimes a `save` is necessary to make a specification work (this is e.g. the case with the profiles). After the first `save` however, you can or remove others freely to see or not see plots.
+However, usually you don't have to write specifications yourself. There are a set of predefined specifications (defined in `HistogramManager_cfi.py`) that can be used for most standard histograms:
+
+    StandardSpecifications1D,
+    StandardSpecificationsTrend,
+    StandardSpecifications2DProfile,
+    StandardSpecifications1D_Num,
+    StandardSpecificationsTrend_Num,
+    StandardSpecifications2DProfile_Num,
+
+The `_Num` versions perform a NDigis-like counting, while the others expect a simple 1D quantity. They produce, respectively, 1D histograms and summary profiles, a trend plot over time and a profile of the quantity as a 2D map of each layer.
+
+For more complicated cases, first check whether something similar already exists. In that case, you might be able to steal a working specification there...
+
+For all the specifications, the steps up to the first `save` are executed in DQM step1. The histograms specified after the first `save` are created in DQM step2, Harvesting. Since step1 is very restricted due to multi-threading and performance requirements, not all specifications can be executed in step1. So, sometimes a `save` is necessary to make a specification work (this is e.g. the case with the profiles).
 
 
 How it really works

--- a/DQM/SiPixelPhase1Common/interface/AbstractHistogram.h
+++ b/DQM/SiPixelPhase1Common/interface/AbstractHistogram.h
@@ -13,58 +13,17 @@
 //
 
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQM/SiPixelPhase1Common/interface/GeometryInterface.h"
 #include <vector>
 #include <utility>
 #include <cassert>
 
 struct AbstractHistogram {
 
-  void fill(double x, double y, double z) {
-    if (me) {
-      me->Fill(x, y, z);
-      return;
-    } else if (th1) {
-      assert(!"Invalid operation on TH1");
-    } else {
-      assert(!"Invalid histogram. This is a problem in the HistogramManager.");
-    } 
-  }; 
-
-  void fill(double x, double y) {
-    if (me) {
-      me->Fill(x, y);
-      return;
-    } else if (th1) {
-      th1->Fill(x, y);
-    } else {
-      assert(!"Invalid histogram. This is a problem in the HistogramManager.");
-    } 
-  }; 
-  
-  void fill(double x) {
-    if (me) {
-      me->Fill(x);
-      return;
-    } else if (th1) {
-      th1->Fill(x);
-    } else {
-      assert(!"Invalid histogram. This is a problem in the HistogramManager.");
-    }
-  };
-  
   int count = 0; // how many things where inserted already. For concat.
   MonitorElement* me = nullptr;
   TH1* th1 = nullptr;
-
-  // full set of metadata. _Only_ used during the booking method.
-  double range_x_min = 1e12;
-  double range_x_max = -1e12;
-  double range_y_min = 1e12;
-  double range_y_max = -1e12;
-  int range_x_nbins = 0;
-  int range_y_nbins = 0;
-  std::string name, title, xlabel, ylabel;
-  MonitorElement::Kind kind = MonitorElement::DQM_KIND_INVALID;
+  GeometryInterface::InterestingQuantities iq_sample;
 
   ~AbstractHistogram() {
     // if both are set the ME should own the TH1

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -47,7 +47,8 @@ public:
 
   // These functions perform step2, for online (per lumisection) or offline (endRun) respectively.
   // Note that the EventSetup from PerLumi is used in offline as well, so PerLumi always has to be called first.
-  void executePerLumiHarvesting(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::EventSetup const& iSetup);
+  void executePerLumiHarvesting(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter,
+                                edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& iSetup);
   void executeHarvesting(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
 
   typedef std::map<GeometryInterface::Values, AbstractHistogram> Table;
@@ -99,6 +100,9 @@ public: // these are available in config as is, and may be used in harvesting.
   int range_y_nbins;
   double range_y_min;
   double range_y_max;
+
+  // can be used in "custom" harvesting in online.
+  edm::LuminosityBlock const* lumisection = nullptr; 
 
 private:
   // These are actually more like local variables, and they might be shadowed

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -78,17 +78,14 @@ private:
     AbstractHistogram& dest);
  
   void loadFromDQMStore(SummationSpecification& s, Table& t, DQMStore::IGetter& iGetter);
-  void executeSave(SummationStep& step, Table& t, DQMStore::IBooker& iBooker);
-  void executeGroupBy(SummationStep& step, Table& t);
-  void executeReduce(SummationStep& step, Table& t);
-  void executeExtend(SummationStep& step, Table& t, bool isX);
+  void executeGroupBy(SummationStep& step, Table& t, DQMStore::IBooker& iBooker);
+  void executeExtend(SummationStep& step, Table& t, std::string const& reduction, DQMStore::IBooker& iBooker);
 
 public: // these are available in config as is, and may be used in harvesting.
   bool enabled;
   bool perLumiHarvesting;
   bool bookUndefined;
   std::string top_folder_name;
-  std::string default_grouping;
 
   std::string name;
   std::string title;
@@ -114,10 +111,6 @@ private:
   GeometryInterface::InterestingQuantities iq;
   // "immutable" cache
   std::vector<GeometryInterface::Values> significantvalues;
-  // copy that executeStep1Spec can freely clobber
-  GeometryInterface::Values significantvalues_scratch;
-  // temporary copy for executeStep1Spec, to avoid the alloc.
-  GeometryInterface::Values new_vals;
   // Direct links to the Histogram if the caching above succeeds.
   std::vector<AbstractHistogram*> fastpath;
 };

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -66,6 +66,7 @@ private:
 
   std::vector<SummationSpecification> specs;
   std::vector<Table> tables;
+  std::vector<Table> counters;
 
   std::string makePath(GeometryInterface::Values const&);
   std::string makeName(SummationSpecification const& s,

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -68,6 +68,10 @@ private:
   std::vector<Table> tables;
 
   std::string makePath(GeometryInterface::Values const&);
+  std::pair<GeometryInterface::Values, std::string> makeName(
+      SummationSpecification const& s,
+      GeometryInterface::InterestingQuantities const& iq);
+
 
   void executeStep1Spec(double x, double y,
                         GeometryInterface::Values& significantvalues, 

--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -40,7 +40,7 @@ public:
   void fill(double x, double y, DetId sourceModule, const edm::Event *sourceEvent = nullptr, int col = 0, int row = 0); 
 
   // This needs to be called after each event (in the analyzer) for per-event counting, like ndigis.
-  void executePerEventHarvesting();
+  void executePerEventHarvesting(edm::Event const* ev);
   
   // Initiate the geometry extraction and book all required frames. Requires the specs to be set.
   void book(DQMStore::IBooker& iBooker, edm::EventSetup const& iSetup);
@@ -68,17 +68,14 @@ private:
   std::vector<Table> tables;
 
   std::string makePath(GeometryInterface::Values const&);
-  std::pair<GeometryInterface::Values, std::string> makeName(
-      SummationSpecification const& s,
+  std::string makeName(SummationSpecification const& s,
       GeometryInterface::InterestingQuantities const& iq);
 
-
-  void executeStep1Spec(double x, double y,
-                        GeometryInterface::Values& significantvalues, 
-                        SummationSpecification& s, 
-                        Table& t,
-                        SummationStep::Stage stage,
-                        AbstractHistogram*& fastpath);
+  void fillInternal(double x, double y, int n_parameters,
+    GeometryInterface::InterestingQuantities const& iq,
+    std::vector<SummationStep>::iterator first,
+    std::vector<SummationStep>::iterator last,
+    AbstractHistogram& dest);
  
   void loadFromDQMStore(SummationSpecification& s, Table& t, DQMStore::IGetter& iGetter);
   void executeSave(SummationStep& step, Table& t, DQMStore::IBooker& iBooker);
@@ -98,9 +95,9 @@ public: // these are available in config as is, and may be used in harvesting.
   std::string xlabel;
   std::string ylabel;
   int dimensions;
-  int range_nbins;
-  double range_min;
-  double range_max;
+  int range_x_nbins;
+  double range_x_min;
+  double range_x_max;
   int range_y_nbins;
   double range_y_min;
   double range_y_max;

--- a/DQM/SiPixelPhase1Common/interface/SummationSpecification.h
+++ b/DQM/SiPixelPhase1Common/interface/SummationSpecification.h
@@ -22,13 +22,25 @@ struct SummationStep {
   // to allow fill() to exectute it very quickly.
   // For step2 stuff (after the first SAVE), we can also keep strings, since 
   // step2 will only be executed once by an executor.
-  enum Type  {NO_TYPE, GROUPBY, EXTEND_X, EXTEND_Y, COUNT, REDUCE, SAVE, CUSTOM};
+  enum Type  {NO_TYPE  = 0, 
+              GROUPBY  = 1, 
+              EXTEND_X = 2, 
+              EXTEND_Y = 3,
+              COUNT    = 4, 
+              REDUCE   = 5, 
+              SAVE     = 6, 
+              CUSTOM   = 7,
+              USE_X    = 8, 
+              USE_Y    = 9,
+              USE_Z    = 10, 
+              PROFILE  = 11
+  };
   Type type = NO_TYPE;
   // STAGE1 is DQM step1, STAGE2 step2. STAGE1_2 is somewhere in between, it runs
   // in the analyze()-method (step1) but does a sort of harvesting (per-event).
   // STAGE1_2 is for ndigis-like counters.
   // FIRST is the first group-by, which is special.
-  enum Stage {NO_STAGE, FIRST, STAGE1, STAGE1_2, STAGE2};
+  enum Stage {NO_STAGE, FIRST, STAGE1, STAGE2};
   Stage stage = NO_STAGE;
 
   std::vector<GeometryInterface::Column> columns;

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
@@ -9,13 +9,17 @@ class SiPixelPhase1OnlineHarvester : public SiPixelPhase1Harvester {
   SiPixelPhase1OnlineHarvester(const edm::ParameterSet& iConfig) 
    : SiPixelPhase1Harvester(iConfig)  {
 
+    int onlineblock = iConfig.getParameter<edm::ParameterSet>("geometry").getParameter<int>("onlineblock");
+    int n_onlineblocks = iConfig.getParameter<edm::ParameterSet>("geometry").getParameter<int>("n_onlineblocks");
+
     for (auto& h : histo) {
-      h.setCustomHandler([&h] (SummationStep& s, HistogramManager::Table & t) {
+      h.setCustomHandler([&h, onlineblock, n_onlineblocks] (SummationStep& s, HistogramManager::Table & t) {
         if (!h.lumisection) return; // not online
         uint32_t ls = h.lumisection->id().luminosityBlock();
-        // TODO: keep in sync with Geometry interface
-        uint32_t block = (ls / 10) % 3;
-        uint32_t next_block = ((ls / 10)+1) % 3;
+
+        // TODO: this is hard to get right if we don't see all LS.
+        uint32_t block = (ls / onlineblock) % n_onlineblocks;
+        uint32_t next_block = ((ls / onlineblock)+1) % n_onlineblocks;
         if (block == next_block) return;
 
         for (auto& e : t) {

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
@@ -11,7 +11,7 @@ class SiPixelPhase1OnlineHarvester : public SiPixelPhase1Harvester {
 
     for (auto& h : histo) {
       h.setCustomHandler([&h] (SummationStep& s, HistogramManager::Table & t) {
-        assert(h.lumisection || !"This plugin only works in online");
+        if (!h.lumisection) return; // not online
         uint32_t ls = h.lumisection->id().luminosityBlock();
         // TODO: keep in sync with Geometry interface
         uint32_t block = (ls / 10) % 3;

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1OnlineHarvester.cc
@@ -1,0 +1,38 @@
+// Harvester with a custom step to reset histograms.
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+class SiPixelPhase1OnlineHarvester : public SiPixelPhase1Harvester {
+
+  public:
+  SiPixelPhase1OnlineHarvester(const edm::ParameterSet& iConfig) 
+   : SiPixelPhase1Harvester(iConfig)  {
+
+    for (auto& h : histo) {
+      h.setCustomHandler([&h] (SummationStep& s, HistogramManager::Table & t) {
+        assert(h.lumisection || !"This plugin only works in online");
+        uint32_t ls = h.lumisection->id().luminosityBlock();
+        // TODO: keep in sync with Geometry interface
+        uint32_t block = (ls / 10) % 3;
+        uint32_t next_block = ((ls / 10)+1) % 3;
+        if (block == next_block) return;
+
+        for (auto& e : t) {
+          TH1* th1 = e.second.th1;
+          if (std::string(th1->GetYaxis()->GetTitle()).find("OnlineBlock") != std::string::npos) {
+            for (int i = 1; i <= th1->GetNbinsX(); i++) {
+              th1->SetBinContent(i, next_block+1, 0);
+            }
+          } else {
+            // TODO: do sth.like exponential decay here.
+          }
+        }
+      });
+    }
+  }
+
+};
+
+DEFINE_FWK_MODULE(SiPixelPhase1OnlineHarvester);
+

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -17,7 +17,10 @@ SiPixelPhase1Geometry = cms.PSet(
 
   # "time geometry" parameters
   max_lumisection = cms.int32(1000),
-  max_bunchcrossing = cms.int32(3600)
+  max_bunchcrossing = cms.int32(3600),
+  # online-secific things
+  onlineblock = cms.int32(20),    # #LS after which histograms are reset
+  n_onlineblocks = cms.int32(5),  # #blocks to keep for histograms with history
 
   # other geometry parameters (n_layers, n_ladders per layer, etc.) are inferred.
   # there are lots of geometry assuptions in the code.

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -59,13 +59,6 @@ DefaultHisto = cms.PSet(
   range_y_max = cms.double(100), 
   range_y_nbins = cms.int32(100),
 
-  # This grouping should be used as a default (explicitly in the Plugin config). It should be era-dependent.
-  # The column names are either defined in the GeometryInterface.cc or read from TrackerTopology.
-  # The "|" means "try the first, if not present try the second", it should be used to have Barrel- and 
-  # Endcap names side by side. The "/" separates columns and also defines how the output folders are nested.
-  defaultGrouping  = cms.string("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|/PXLadder|PXBlade"),
-  defaultPerModule = cms.string("PXBarrel|PXForward/PXLayer|PXDisk/DetId"),
-
   # This structure is output by the SpecficationBuilder.
   specs = cms.VPSet()
   #  cms.PSet(spec = 
@@ -89,14 +82,19 @@ DefaultHisto = cms.PSet(
 
 # Commonly used specifications. 
 StandardSpecifications1D = [
-    Specification(PerLadder).groupBy(DefaultHisto.defaultGrouping) # per-ladder and profiles
+    # The column names are either defined in the GeometryInterface.cc or read from TrackerTopology.
+    # The "|" means "try the first, if not present try the second", it should be used to have Barrel- and 
+    # Endcap names side by side. The "/" separates columns and also defines how the output folders are nested.
+
+    # per-ladder and profiles
+    Specification(PerLadder).groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|/PXLadder|PXBlade")
                             .save()
                             .reduce("MEAN")
-                            .groupBy(parent(DefaultHisto.defaultGrouping), "EXTEND_X")
+                            .groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|", "EXTEND_X")
                             .saveAll(),
-    Specification(PerLayer1D).groupBy(parent(DefaultHisto.defaultGrouping)) # per-layer
+    Specification(PerLayer1D).groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|") # per-layer
                              .save(),
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule).save()
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId").save()
 ]
 
 StandardSpecificationTrend = ( # the () are only for syntax reasons
@@ -118,15 +116,15 @@ StandardSpecification2DProfile = (
 
 # the same for NDigis and friends. Needed due to technical limitations...
 StandardSpecifications1D_Num = [
-    Specification(PerLadder).groupBy(DefaultHisto.defaultGrouping.value() + "/DetId/Event") 
+    Specification(PerLadder).groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|/PXLadder|PXBlade/DetId/Event") 
                             .reduce("COUNT") # per-event counting
-                            .groupBy(DefaultHisto.defaultGrouping).save()
+                            .groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|/PXLadder|PXBlade").save()
                             .reduce("MEAN")
-                            .groupBy(parent(DefaultHisto.defaultGrouping), "EXTEND_X")
+                            .groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|", "EXTEND_X")
                             .saveAll(),
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule.value() + "/Event")
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/Event")
                             .reduce("COUNT")
-                            .groupBy(DefaultHisto.defaultPerModule)
+                            .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId")
                             .save()
 ]
 

--- a/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
@@ -8,19 +8,22 @@ from copy import deepcopy
 
 # these need to stay in sync with the C++ enums.  TODO: Can we use Python3 enum or sth.?
 NO_TYPE  = cms.int32(0)
-GROUPBY  = cms.int32(1)
-EXTEND_X = cms.int32(2) 
+GROUPBY  = cms.int32(1)  # only "SUM", real histograms
+EXTEND_X = cms.int32(2)  # use geometry column as coordinate axis, concatenate 
 EXTEND_Y = cms.int32(3)
-COUNT    = cms.int32(4)
-REDUCE   = cms.int32(5)
-SAVE     = cms.int32(6)
-CUSTOM   = cms.int32(7)
+COUNT    = cms.int32(4)  # drop all values, only count entries. Atm only step1.
+REDUCE   = cms.int32(5)  # histogram-to-scalar operator for harvesting, atm only MEAN
+SAVE     = cms.int32(6)  # atm not used in execution. Marks stage1/2 switch.
+CUSTOM   = cms.int32(7)  # call callback in harvesting
+USE_X    = cms.int32(8)  # use arg-th fill(...) parameter for the respective axis. 
+USE_Y    = cms.int32(9)
+USE_Z    = cms.int32(10)
+PROFILE  = cms.int32(11) # marker for step1 to make a profile, related to REDUCE(MEAN)
 
 NO_STAGE = cms.int32(0)
-FIRST    = cms.int32(1)
-STAGE1   = cms.int32(2)
-STAGE1_2 = cms.int32(3)
-STAGE2   = cms.int32(4)
+FIRST    = cms.int32(1)  # first grouping, before and/or after counting 
+STAGE1   = cms.int32(2)  # USE/EXTEND/PROFILE for step1
+STAGE2   = cms.int32(3)  # REDUCE/EXTEND/GROUPBY/CUSTOM for harvesting
 
 def val(maybecms):
   if hasattr(maybecms, "value"):
@@ -34,6 +37,22 @@ def parent(path):
 
 # do not change values here, Pass in a PSet instead
 DefaultConf = cms.PSet(enabled = cms.bool(True))
+
+
+# The Specification format is very rigid and looks much less like a program in
+# the internal form:
+# - There is one entry FIRST, which is a GROUPBY(SUM) or COUNT and some columns
+# - There is another entry FIRST, which is a GROUPBY(SUM) and some columns iff
+#   the one before was COUNT
+# - There are some entries STAGE1
+#  - There is one entry per dimension (ordered)
+#  - which is either USE_* or EXTEND_*
+#  - with one column, that is usually NOT listed in first.
+#  - There is optionally an entry PROFILE to make a profile.
+# - There are 0-n steps STAGE2, which are one of GROUPBY(SUM), EXTEND_X, CUSTOM
+#  - The argument for GROUPBY and EXTEND_X is a subset of columns of last step
+#  - CUSTOM may have an arbitrary argument that is simply passed down
+#  - SAVE is ignored
 
 class Specification(cms.PSet):
   def __init__(self, conf = DefaultConf):
@@ -52,62 +71,146 @@ class Specification(cms.PSet):
 
   def groupBy(self, cols, mode = "SUM"):
     cnames = val(cols).split("/")
+    newstate = self._state
 
-    if mode == "SUM":
-      if self._state == STAGE1:
-        if not "Event" in self.spec[0].columns:
-          raise Exception("Only per-event counting supported for step1.")
-        self.spec[0].columns.remove("Event"); # per-Event groupng is done automatically
-        self._state = STAGE1_2
-      t = GROUPBY
-      cstrings = cms.vstring(cnames)
-    elif mode == "EXTEND_X" or mode == "EXTEND_Y":
-      if self._state == FIRST: 
+    if self._state == FIRST:
+      cname = cnames
+      if mode != "SUM":
         raise Exception("First grouping must be SUM") 
+      if "Event" in cnames:
+        cnames.remove("Event"); # per-Event grouping is done automatically
+        t = COUNT
+        mode =  "COUNT"
+        newstate = FIRST
+      else:
+        t = GROUPBY
+        newstate = STAGE1
+
+    if self._state == STAGE1:
       cname = self._activeColumns.difference(cnames)
       if len(cname) != 1:
         raise Exception("EXTEND must drop exactly one column.")
-      cstrings = cms.vstring(cname)
 
       if mode == "EXTEND_X":
-        t = EXTEND_X
+        self._x.type = EXTEND_X
+        self._x.columns = cms.vstring(cname)
+      elif mode == "EXTEND_Y":
+        self._y.type = EXTEND_Y
+        self._y.columns = cms.vstring(cname)
       else:
-        t = EXTEND_Y
-    else:
-      raise Exception("Summation mode %s unknown" % mode)
+        raise Exception("Only EXTEND_X or EXTEND_Y allowed here, not " + mode)
+
+      # remove the column in earlier steps, we always re-extract in step1.
+      c = list(cname)[0]
+      for s in self.spec:
+        if s.stage == FIRST and c in s.columns:
+          s.columns.remove(c)
+      if c in self._activeColumns:
+        self._activeColumns.remove(c)
+      if c in self._lastColumns:
+        self._lastColumns.remove(c)
+
+      return self # done here, no new step to add
+
+    if self._state == STAGE2:
+      cname = cnames
+      if self._activeColumns.issubset(cname):
+        raise Exception("Harvesting GROUPBY must drop some columns")
+      if mode == "EXTEND_X":
+        t = EXTEND_X
+      elif mode == "SUM":
+        t = GROUPBY
+      else:
+        raise Exception("Currently only EXTEND_X and SUM supported in harvesting, not " + mode)
 
     self._activeColumns = set(cnames)
     self._lastColumns = cnames
     self._lastMode = mode
-    
+
     self.spec.append(cms.PSet(
       type = t, 
       stage = self._state, 
-      columns = cstrings,
+      columns = cms.vstring(cname),
       arg = cms.string(mode)
     ))
 
+    if newstate == STAGE1 and self._state == FIRST:
+      # emit standard column assignments, will be changed later
+      self._x = cms.PSet(
+        type = USE_X, stage = STAGE1,
+        columns = cms.vstring(),
+        arg = cms.string("")
+      )
+      self.spec.append(self._x)
+      self._y = cms.PSet(
+        type = USE_Y, stage = STAGE1,
+        columns = cms.vstring(),
+        arg = cms.string("")
+      )
+      self.spec.append(self._y)
+      self._z = cms.PSet(
+        type = USE_Z, stage = STAGE1,
+        columns = cms.vstring(),
+        arg = cms.string("")
+      )
+      self.spec.append(self._z)
+
+    self._state = newstate
+
+    return self
+
+  def reduce(self, sort):
     if self._state == FIRST:
-      self._state = STAGE1
+      if sort != "COUNT":
+        raise Exception("First statement must be groupBy.")
+      self.spec[0].type = COUNT # this is actually a noop
+      # groupBy already saw the "Event" column and set up counting.
+
+      return self
+
+    if self._state == STAGE1:
+      if sort == "MEAN":
+        self.spec.append(cms.PSet(
+          type = PROFILE, stage = STAGE1,
+          columns = cms.vstring(), arg = cms.string("")
+        ))
+      return self
+
+    if sort != "MEAN":
+      raise Exception("Harvesting allows only reduce(MEAN) at the moment, not " + sort)
+
+    self.spec.append(cms.PSet(
+      type = REDUCE, 
+      stage = self._state, 
+      columns = cms.vstring(),
+      arg = cms.string(sort)
+    ))
     return self
 
   def save(self):
     if self._state == FIRST:
       raise Exception("First statement must be groupBy.")
-    self.spec.append(cms.PSet(
-      type = SAVE, 
-      stage = self._state, 
-      columns = cms.vstring(),
-      arg = cms.string("")
-    ))
+
+    if self._state == STAGE1:
+      # end of STAGE1, fix the parameter assignments
+      n = 1
+      if self._x.type == USE_X: self._x.arg = cms.string(str(n)); n = n+1
+      if self._y.type == USE_Y: self._y.arg = cms.string(str(n)); n = n+1
+      if self._z.type == USE_Z: self._z.arg = cms.string(str(n)); n = n+1
+      # we don't know how many parameters the user wants to pass here, but the 
+      # HistogramManager knows. So we just add 3.
+
+    # SAVE is implicit in step1 and ignored in harvesting, so not really needed.
+    #self.spec.append(cms.PSet(
+    #  type = SAVE, 
+    #  stage = self._state, 
+    #  columns = cms.vstring(),
+    #  arg = cms.string("")
+    #))
     self._state = STAGE2
     return self
 
   def custom(self, arg = ""):
-    if self.spec[-1].type != SAVE:
-      # this is not obvious but needed for now, to avoid memory management
-      # trouble with bare TH1's. After save all data is in MEs which are save.
-      self.save()
     if self._state != STAGE2:
       raise Exception("Custom processing exists only in Harvesting.")
     self.spec.append(cms.PSet(
@@ -118,28 +221,6 @@ class Specification(cms.PSet):
     ))
     return self
 
-  def reduce(self, sort):
-    if self._state == FIRST:
-      raise Exception("First statement must be groupBy.")
-    if sort != "MEAN" and sort != "COUNT":
-      raise Exception("reduction type %s not known" % sort)
-    if self._state == STAGE1:
-      if sort == "COUNT":
-        t = COUNT
-      elif sort == "MEAN":
-        t = REDUCE
-      else:
-        raise Exception("reduction type %s not allowed in step1" % sort)
-    else:
-      t = REDUCE
-
-    self.spec.append(cms.PSet(
-      type = t, 
-      stage = self._state, 
-      columns = cms.vstring(),
-      arg = cms.string(sort)
-    ))
-    return self
 
   def saveAll(self):
     self.save()

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -123,7 +123,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   auto detids = trackerGeometryHandle->detIds();
   for (DetId id : detids) {
     if (id.subdetId() != PixelSubdetector::PixelBarrel && id.subdetId() != PixelSubdetector::PixelEndcap) continue;
-    auto iq = InterestingQuantities{.sourceModule = id };
+    auto iq = InterestingQuantities{nullptr, id, 0, 0};
     auto layer = pxlayer(iq);
     if (layer != UNDEFINED) {
       if (layer >= Value(maxladders.size())) maxladders.resize(layer+1);
@@ -336,7 +336,7 @@ void GeometryInterface::loadFEDCabling(edm::EventSetup const& iSetup, const edm:
   addExtractor(intern("FED"),
     [fedmap] (InterestingQuantities const& iq) {
       if (iq.sourceModule == 0xFFFFFFFF)
-        return iq.col; // hijacked for the raw data plugin
+        return Value(iq.col); // hijacked for the raw data plugin
       auto it = fedmap.find(iq.sourceModule);
       if (it == fedmap.end()) return GeometryInterface::UNDEFINED;
       return it->second;
@@ -347,7 +347,7 @@ void GeometryInterface::loadFEDCabling(edm::EventSetup const& iSetup, const edm:
       // TODO: we also should be able to compute the channel from the ROC.
       // But for raw data, we only need this hack.
       //if (iq.sourceModule == 0xFFFFFFFF)
-      return iq.row; // hijacked for the raw data plugin
+      return Value(iq.row); // hijacked for the raw data plugin
     },
     0, 39 // TODO: real range
   );

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -236,13 +236,15 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
     },
     1, iConfig.getParameter<int>("max_lumisection")
   );
+  int onlineblock = iConfig.getParameter<int>("onlineblock");
+  int n_onlineblocks = iConfig.getParameter<int>("n_onlineblocks");
   addExtractor(intern("OnlineBlock"),
-    [] (InterestingQuantities const& iq) {
+    [onlineblock, n_onlineblocks] (InterestingQuantities const& iq) {
       if(!iq.sourceEvent) return UNDEFINED;
       // TODO: set good range for real online with all LS present
-      return Value(iq.sourceEvent->luminosityBlock() / 10 % 3);
+      return Value(iq.sourceEvent->luminosityBlock() / onlineblock % n_onlineblocks);
     },
-    0, 2
+    0, n_onlineblocks-1
   );
   addExtractor(intern("BX"),
     [] (InterestingQuantities const& iq) {

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -236,12 +236,13 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
     },
     1, iConfig.getParameter<int>("max_lumisection")
   );
-  addExtractor(intern("LumiDecade"),
+  addExtractor(intern("OnlineBlock"),
     [] (InterestingQuantities const& iq) {
       if(!iq.sourceEvent) return UNDEFINED;
-      return Value(iq.sourceEvent->luminosityBlock() % 10);
+      // TODO: set good range for real online with all LS present
+      return Value(iq.sourceEvent->luminosityBlock() / 10 % 3);
     },
-    0, 9
+    0, 2
   );
   addExtractor(intern("BX"),
     [] (InterestingQuantities const& iq) {

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -71,7 +71,7 @@ void HistogramManager::fill(double x, double y, DetId sourceModule,
   if (col != this->iq.col || row != this->iq.row ||
       sourceModule != this->iq.sourceModule ||
       sourceEvent != this->iq.sourceEvent ||
-      // TODO: add the RawData fake DetId here
+      sourceModule == 0xFFFFFFFF ||
       sourceModule == DetId(0)  // Hack for eventrate-like things, since the
                                 // sourceEvent ptr might not change.
       ) {
@@ -330,7 +330,10 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
         // create new histo
         MEInfo& mei = toBeBooked[significantvalues]; 
         mei.name = makeName(s, iq);
-        mei.title = bookCounters ? "Number of " + this->title : this->title;
+        mei.title = this->title;
+        if (bookCounters) 
+          mei.title = "Number of " + mei.title + " per Event and " 
+            + geometryInterface.pretty(geometryInterface.extract(*(s.steps[0].columns.end()-1), iq).first);
         std::string xlabel = bookCounters ? "#" + this->xlabel : this->xlabel;
 
         // refer to fillInternal() for the actual execution
@@ -360,7 +363,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
               assert(mei.range_x_nbins == 0);
               auto col = geometryInterface.extract(it->columns[0], iq).first;
               mei.xlabel = geometryInterface.pretty(col);
-              mei.title = mei.title + " per " + mei.xlabel;
+              mei.title = mei.title + " by " + mei.xlabel;
               if(geometryInterface.minValue(col[0]) != GeometryInterface::UNDEFINED)
                 mei.range_x_min = geometryInterface.minValue(col[0]);
               if(geometryInterface.maxValue(col[0]) != GeometryInterface::UNDEFINED)
@@ -370,7 +373,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
             case SummationStep::EXTEND_Y: {
               auto col = geometryInterface.extract(it->columns[0], iq).first;
               mei.ylabel = geometryInterface.pretty(col);
-              mei.title = mei.title + " per " + mei.ylabel;
+              mei.title = mei.title + " by " + mei.ylabel;
               if(geometryInterface.minValue(col[0]) != GeometryInterface::UNDEFINED)
                 mei.range_y_min = geometryInterface.minValue(col[0]);
               if(geometryInterface.maxValue(col[0]) != GeometryInterface::UNDEFINED)

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -131,7 +131,8 @@ void HistogramManager::executeStep1Spec(
     auto histo = t.find(significantvalues);  // avoid modification
     if (histo == t.end() || (!histo->second.th1 && !histo->second.me)) {
       // No histogram was booked.
-      assert(!bookUndefined || !"All histograms were booked but one is missing. This is a problem in the booking process.");
+      assert(!bookUndefined || !"All histograms were booked but one is missing."
+      "The geometry in the GeometryInterface probably does not match the data.");
       // else, ignore the sample.
       return;
     }
@@ -196,9 +197,9 @@ void HistogramManager::fill(DetId sourceModule, const edm::Event* sourceEvent,
 void HistogramManager::executePerEventHarvesting() {
   // We have a masive problem here regarding semantics: for geometrical structure,
   // we always want to see all the counters, even if they are 0. The counters are
-  // all created during booking ad then ket, all fine.
+  // all created during booking and then kept, all fine.
   // For time-based things however, we do not know the range before we see the
-  // data, so we cannot book the counters beforhand. Also, it does not make sense
+  // data, so we cannot book the counters beforehand. Also, it does not make sense
   // to record 0 counts: a event can only be in one Lumisection, it does not make
   // sense to record it as a 0 count for all others.
   // The hacky solution is to check that the quantity was UNDEFINED in booking,
@@ -252,6 +253,8 @@ void HistogramManager::executePerEventHarvesting() {
 std::string HistogramManager::makePath(
     GeometryInterface::Values const& significantvalues) {
   // non-number output names (_pO etc.) are hardwired here.
+  // PERF: memoize the names in a map, probably ignoring row/col
+  // TODO: more pretty names for DetIds using PixelBarrelName etc.
   std::ostringstream dir("");
   for (auto e : significantvalues.values) {
     std::string name = geometryInterface.pretty(e.first);

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -513,6 +513,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
 
 void HistogramManager::executePerLumiHarvesting(DQMStore::IBooker& iBooker,
                                                 DQMStore::IGetter& iGetter,
+                                                edm::LuminosityBlock const& lumiBlock,
                                                 edm::EventSetup const& iSetup) {
   if (!enabled) return;
   // this should also give us the GeometryInterface for offline, though it is a
@@ -521,7 +522,9 @@ void HistogramManager::executePerLumiHarvesting(DQMStore::IBooker& iBooker,
     geometryInterface.load(iSetup);
   }
   if (perLumiHarvesting) {
+    this->lumisection = &lumiBlock; // "custom" steps can use this
     executeHarvesting(iBooker, iGetter);
+    this->lumisection = nullptr;
   }
 }
 

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Harvester.cc
@@ -6,7 +6,7 @@
 
 void SiPixelPhase1Harvester::dqmEndLuminosityBlock(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup) {
   for (HistogramManager& histoman : histo)
-    histoman.executePerLumiHarvesting(iBooker, iGetter, eSetup);
+    histoman.executePerLumiHarvesting(iBooker, iGetter, lumiBlock, eSetup);
 };
 void SiPixelPhase1Harvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {
   for (HistogramManager& histoman : histo)

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -8,6 +8,12 @@ StandardSpecifications1D.append(
                              .custom()
                              .save()
 )
+StandardSpecifications1D.append(
+    Specification().groupBy("PXBarrel|PXForward/OnlineBlock") # per-layer with history for online
+                   .groupBy("PXBarrel|PXForward", "EXTEND_Y")
+                   .custom()
+                   .save()
+)
 
 StandardSpecifications1D_Num.append(
     Specification(PerLayer1D).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/OnlineBlock/DetId/Event") # per-layer with history for online
@@ -16,6 +22,14 @@ StandardSpecifications1D_Num.append(
                              .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_Y")
                              .custom()
                              .save()
+)
+StandardSpecifications1D_Num.append(
+    Specification().groupBy("PXBarrel|PXForward/OnlineBlock/DetId/Event") # per-layer with history for online
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel|PXForward/OnlineBlock") 
+                   .groupBy("PXBarrel|PXForward", "EXTEND_Y")
+                   .custom()
+                   .save()
 )
 
 # Configure Phase1 DQM for Phase0 data

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -2,6 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
+StandardSpecifications1D.append(
+    Specification(PerLayer1D).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/OnlineBlock") # per-layer with history for online
+                             .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_Y")
+                             .custom()
+                             .save()
+)
+
+StandardSpecifications1D_Num.append(
+    Specification(PerLayer1D).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/OnlineBlock/DetId/Event") # per-layer with history for online
+                             .reduce("COUNT")
+                             .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/OnlineBlock") 
+                             .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_Y")
+                             .custom()
+                             .save()
+)
+
 # Configure Phase1 DQM for Phase0 data
 SiPixelPhase1Geometry.n_inner_ring_blades = 24 # no outer ring
 
@@ -14,8 +30,19 @@ DefaultHisto.perLumiHarvesting = True
 from DQM.SiPixelPhase1Digis.SiPixelPhase1Digis_cfi import *
 SiPixelPhase1DigisAnalyzer.src = cms.InputTag("siPixelDigis") # adapt for real data
 
+SiPixelPhase1DigisHarvester = cms.EDAnalyzer("SiPixelPhase1OnlineHarvester",
+    histograms = SiPixelPhase1DigisConf,
+    geometry = SiPixelPhase1Geometry
+)
+
 # Cluster (track-independent) monitoring
 from DQM.SiPixelPhase1Clusters.SiPixelPhase1Clusters_cfi import *
+
+SiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1OnlineHarvester",
+    histograms = SiPixelPhase1ClustersConf,
+    geometry = SiPixelPhase1Geometry
+)
+
 
 # Raw data errors
 from DQM.SiPixelPhase1RawData.SiPixelPhase1RawData_cfi import *

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -75,15 +75,15 @@ SiPixelPhase1DigisHitmap = DefaultHisto.clone(
   ylabel = "#digis",
   dimensions = 0,
   specs = cms.VPSet(
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule.value() + "/row/col")
-                   .groupBy(DefaultHisto.defaultPerModule.value() + "/row", "EXTEND_X")
-                   .groupBy(DefaultHisto.defaultPerModule.value(), "EXTEND_Y")
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/row/col")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/row", "EXTEND_Y")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId", "EXTEND_X")
                    .save(),
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule.value() + "/col")
-                   .groupBy(DefaultHisto.defaultPerModule.value(), "EXTEND_X")
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/col")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId", "EXTEND_X")
                    .save(),
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule.value() + "/row")
-                   .groupBy(DefaultHisto.defaultPerModule.value(), "EXTEND_X")
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/row")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId", "EXTEND_X")
                    .save()
 
   )
@@ -97,10 +97,10 @@ SiPixelPhase1DigisDebug = DefaultHisto.clone(
   range_max = 64,
   range_nbins = 64,
   specs = cms.VPSet(
-    Specification().groupBy(DefaultHisto.defaultGrouping) 
+    Specification().groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|/PXLadder|PXBlade") 
                    .save()
                    .reduce("MEAN")
-                   .groupBy(parent(DefaultHisto.defaultGrouping), "EXTEND_X")
+                   .groupBy("PXBarrel|PXForward/Shell|HalfCylinder/PXLayer|PXDisk/PXRing|", "EXTEND_X")
                    .saveAll(),
   )
 )

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -41,15 +41,19 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
   range_nbins = 200,
   dimensions = 0, 
   specs = cms.VPSet(
-    Specification().groupBy("FED/Event")
+    # the double "FED" here is due to a "bug", caused by how the specs are
+    # translated for step1. Interpret as "count by FED, extend by FED".
+    Specification().groupBy("FED/FED/Event")
                    .reduce("COUNT")
                    .groupBy("FED")
                    .groupBy("", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED")
+    Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED/FED/Event")
                    .reduce("COUNT")
+                   .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED")
                    .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection", "EXTEND_Y")
                    .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_X")
+                   .save()
                    .custom("ratio_to_average")
                    .save()
   )

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -51,6 +51,7 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone(
     Specification().groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED/FED/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection/FED")
+                   .reduce("MEAN")
                    .groupBy("PXBarrel|PXForward/PXLayer|PXDisk/Lumisection", "EXTEND_Y")
                    .groupBy("PXBarrel|PXForward/PXLayer|PXDisk", "EXTEND_X")
                    .save()

--- a/DQM/SiPixelPhase1Digis/src/SiPixelPhase1Digis.cc
+++ b/DQM/SiPixelPhase1Digis/src/SiPixelPhase1Digis.cc
@@ -42,8 +42,8 @@ void SiPixelPhase1Digis::analyze(const edm::Event& iEvent, const edm::EventSetup
     histo[DEBUG].fill(geometryInterface.extract(geometryInterface.intern("PXLadder"), DetId(it->detId())), DetId(it->detId()));
   }
   histo[EVENT].fill(DetId(0), &iEvent);
-  histo[NDIGIS    ].executePerEventHarvesting();
-  histo[NDIGIS_FED].executePerEventHarvesting(); 
+  histo[NDIGIS    ].executePerEventHarvesting(&iEvent);
+  histo[NDIGIS_FED].executePerEventHarvesting(&iEvent); 
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1Digis);

--- a/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
+++ b/DQM/SiPixelPhase1RawData/src/SiPixelPhase1RawData.cc
@@ -83,7 +83,7 @@ void SiPixelPhase1RawData::analyze(const edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  histo[NERRORS].executePerEventHarvesting();
+  histo[NERRORS].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1RawData);

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -57,7 +57,7 @@ SiPixelPhase1RecHitsPosition = DefaultHisto.clone(
   ylabel = "y offset",
   dimensions = 2,
   specs = cms.VPSet(
-    Specification(PerModule).groupBy(DefaultHisto.defaultPerModule).save(),
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/Event").save(),
   )
 )
 

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -57,7 +57,7 @@ SiPixelPhase1RecHitsPosition = DefaultHisto.clone(
   ylabel = "y offset",
   dimensions = 2,
   specs = cms.VPSet(
-    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId/Event").save(),
+    Specification(PerModule).groupBy("PXBarrel|PXForward/PXLayer|PXDisk/DetId").save(),
   )
 )
 

--- a/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
@@ -53,7 +53,7 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  histo[NRECHITS].executePerEventHarvesting();
+  histo[NRECHITS].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1RecHits);

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -150,8 +150,8 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
     }
   }
 
-  histo[ONTRACK_NCLUSTERS].executePerEventHarvesting();
-  histo[OFFTRACK_NCLUSTERS].executePerEventHarvesting();
+  histo[ONTRACK_NCLUSTERS].executePerEventHarvesting(&iEvent);
+  histo[OFFTRACK_NCLUSTERS].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1TrackClusters);

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -9,7 +9,7 @@ SiPixelPhase1TrackEfficiencyClusterProb = DefaultHisto.clone(
   range_min = -10, range_max = 0, range_nbins = 200,
   dimensions = 1,
   specs = cms.VPSet(
-    Specification().groupBy(DefaultHisto.defaultGrouping).saveAll()
+    *StandardSpecifications1D
   )
 )
 


### PR DESCRIPTION
This PR is another set of accumulated changes of the last weeks.

- The biggest item is a significant rewrite of the HistogramManager. A number of features that are not used by the current DQM histograms were removed, a number of bugs and inconsistencies fixed, it is faster than before and yet it should be easier to follow and understand the code now. The new implementation behaves almost the same as the old one, so plugins were only changed to fix bugs uncovered.

- Second item is a new feature for online, to get histograms that are reset after a few lumisections but always retain some history. Together with a special renderplugin (https://github.com/dmwm/deployment/pull/402) this allows showing multiple, overlaid curves over time, which could be useful especially for detector comissioning.

- Minor changes include removing the `defaultGrouping` string, which was replaced by a more high-level approach (default specifiactions) and updating the README to reflect this and a bunch of other changes that happened after writing.



