### PR TITLE
Renorm provenance histos 81 x v1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -61,11 +61,14 @@ void ElectronMcFakePostValidator::finalize( DQMStore::IBooker & iBooker, DQMStor
 /**/
 
   MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
-  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  if (h1_ele_provenance->getBinContent(3)>0)
+    {h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));}
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
-  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  if (h1_ele_provenance_barrel->getBinContent(3)>0)
+    {h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));}
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));
+  if (h1_ele_provenance_endcaps->getBinContent(3)>0)
+    {h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));}
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -60,11 +60,14 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   }/**/
   
   MonitorElement * h1_ele_provenance = get(iGetter, "provenance") ;
-  h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));
+  if (h1_ele_provenance->getBinContent(3)>0)
+    {h1_ele_provenance->getTH1F()->Scale(1./h1_ele_provenance->getBinContent(3));}
   MonitorElement * h1_ele_provenance_barrel = get(iGetter, "provenance_barrel") ;
-  h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));
+  if (h1_ele_provenance_barrel->getBinContent(3)>0)
+    {h1_ele_provenance_barrel->getTH1F()->Scale(1./h1_ele_provenance_barrel->getBinContent(3));}
   MonitorElement * h1_ele_provenance_endcaps = get(iGetter, "provenance_endcaps") ;
-  h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));/**/
+  if (h1_ele_provenance_endcaps->getBinContent(3)>0)
+    {h1_ele_provenance_endcaps->getTH1F()->Scale(1./h1_ele_provenance_endcaps->getBinContent(3));}
 
   // profiles from 2D histos
   profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}", 0.8);


### PR DESCRIPTION
Same PR as #16246 : Update files to take into account that getBinContent(3) can be 0 and lead to NaN errors, as asked by @slava77 .

A new normalization was made for "provenance (*)" histos for standard histos (SingleElectronPt10, 35, .., TTbar, ZEE) and QCD_80_120 in ElectronMcSignalPostValidator.cc and ElectronMcFakePostValidator.cc files.
No other modification was made.

(*) h1_ele_provenance, h1_ele_provenance_barrel, h1_ele_provenance_endcaps
@beaudett @fcouderc
