### PR TITLE
DQM timing propagation

### DIFF
--- a/Validation/RecoTrack/scripts/harvestTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/harvestTrackValidationPlots.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     os.chdir(_tempdir)
 
     # compile cmsDriver command
-    cmsDriverCommand = "cmsDriver.py harvest --scenario pp --filetype DQM --conditions auto:run2_mc --mc -s HARVESTING:@trackingOnlyValidation -n -1 --filein {0}".format(filelist)
+    cmsDriverCommand = "cmsDriver.py harvest --scenario pp --filetype DQM --conditions auto:run2_mc --mc -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM -n -1 --filein {0}".format(filelist)
     print "# running cmsDriver" + "\n" + cmsDriverCommand
     
     # run it


### PR DESCRIPTION
When harvesting track validation plots, the DQM timing information was not propagated to the next step.
@makortel @VinInn @rovere 