### PR TITLE
Remove inheritance in L1MuonPixelTrackFitter and L1MuonRegionProducer

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
@@ -1,7 +1,6 @@
 #ifndef RecoMuon_TrackerSeedGenerator_L1MuonPixelTrackFitter_H
 #define RecoMuon_TrackerSeedGenerator_L1MuonPixelTrackFitter_H
 
-#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalTag.h"
@@ -21,7 +20,7 @@ class L1MuGMTCand;
 class PixelRecoLineRZ;
 class SeedingHitSet;
 
-class L1MuonPixelTrackFitter : public PixelFitter {
+class L1MuonPixelTrackFitter {
 
 public:
   class Circle {

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
@@ -1,24 +1,21 @@
 #ifndef RecoMuon_TrackerSeedGenerator_L1MuonRegionProducer_H
 #define RecoMuon_TrackerSeedGenerator_L1MuonRegionProducer_H
-
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <vector>
+#include <memory>
 
 class TrackingRegion;
 class L1MuGMTCand;
 namespace edm { class Event; class EventSetup; class ParameterSet; }
 
-class L1MuonRegionProducer : public TrackingRegionProducer {
+class L1MuonRegionProducer {
 
 public:
-  L1MuonRegionProducer(const edm::ParameterSet& cfg,
-	   edm::ConsumesCollector && iC);
-  virtual ~L1MuonRegionProducer(){} 
+  L1MuonRegionProducer(const edm::ParameterSet& cfg);
+  ~L1MuonRegionProducer(){}
   void setL1Constraint(const L1MuGMTCand & muon); 
-  virtual std::vector<std::unique_ptr<TrackingRegion> >
-      regions(const edm::Event& ev, const edm::EventSetup& es) const override;
+  std::vector<std::unique_ptr<TrackingRegion> > regions() const;
 
 private:
   // region configuration

--- a/RecoMuon/TrackerSeedGenerator/plugins/SealModule.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/SealModule.cc
@@ -19,10 +19,6 @@ DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, DualByEtaTSG, "DualByEtaTSG");
 DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, DualByL2TSG, "DualByL2TSG");
 DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, CombinedTSG, "CombinedTSG");
 
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
-#include "RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h"
-DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, L1MuonRegionProducer, "L1MuonRegionProducer");
 
 
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/SealModule.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/SealModule.cc
@@ -19,11 +19,6 @@ DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, DualByEtaTSG, "DualByEtaTSG");
 DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, DualByL2TSG, "DualByL2TSG");
 DEFINE_EDM_PLUGIN(TrackerSeedGeneratorFactory, CombinedTSG, "CombinedTSG");
 
-#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h"
-#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterFactory.h"
-#include "RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h"
-DEFINE_EDM_PLUGIN(PixelFitterFactory, L1MuonPixelTrackFitter, "L1MuonPixelTrackFitter");
-
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h"

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
@@ -14,9 +14,6 @@
 #include "RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/L1MuonSeedsMerger.h"
 
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h"
 
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h"
@@ -44,7 +41,7 @@ template <class T> T sqr( T t) {return t*t;}
 
 
 TSGFromL1Muon::TSGFromL1Muon(const edm::ParameterSet& cfg)
-  : theConfig(cfg),theRegionProducer(0),theHitGenerator(0),theMerger(0)
+  : theConfig(cfg),theHitGenerator(0),theMerger(0)
 {
   produces<L3MuonTrajectorySeedCollection>();
   theSourceTag = cfg.getParameter<edm::InputTag>("L1MuonLabel");
@@ -61,6 +58,7 @@ TSGFromL1Muon::TSGFromL1Muon(const edm::ParameterSet& cfg)
 
   theSourceToken=iC.consumes<L1MuonParticleCollection>(theSourceTag);
 
+  theRegionProducer = std::make_unique<L1MuonRegionProducer>(theConfig.getParameter<edm::ParameterSet>("RegionFactoryPSet"));
   theFitter = std::make_unique<L1MuonPixelTrackFitter>(cfg.getParameter<edm::ParameterSet>("FitterPSet"));
 }
 
@@ -68,17 +66,10 @@ TSGFromL1Muon::~TSGFromL1Muon()
 {
   delete theMerger;
   delete theHitGenerator;
-  delete theRegionProducer;
 }
 
 void TSGFromL1Muon::beginRun(const edm::Run & run, const edm::EventSetup&es)
 {
-  edm::ParameterSet regfactoryPSet = theConfig.getParameter<edm::ParameterSet>("RegionFactoryPSet");
-  std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
-  TrackingRegionProducer * p =
-    TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector());
-  theRegionProducer = dynamic_cast<L1MuonRegionProducer* >(p);
-
   edm::ParameterSet cleanerPSet = theConfig.getParameter<edm::ParameterSet>("CleanerPSet");
   std::string  cleanerName = cleanerPSet.getParameter<std::string>("ComponentName");
 //  theMerger = PixelTrackCleanerFactory::get()->create( cleanerName, cleanerPSet);
@@ -108,7 +99,7 @@ void TSGFromL1Muon::produce(edm::Event& ev, const edm::EventSetup& es)
     theFitter->setL1Constraint(muon);
 
     typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
-    Regions regions = theRegionProducer->regions(ev,es);
+    Regions regions = theRegionProducer->regions();
     for (Regions::const_iterator ir=regions.begin(); ir != regions.end(); ++ir) {
 
       L1MuonSeedsMerger::TracksAndHits tracks;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
@@ -36,7 +36,7 @@ private:
 
   L1MuonRegionProducer * theRegionProducer;
   OrderedHitsGenerator * theHitGenerator;
-  L1MuonPixelTrackFitter * theFitter;
+  std::unique_ptr<L1MuonPixelTrackFitter> theFitter;
   std::unique_ptr<PixelTrackFilter> theFilter;
   L1MuonSeedsMerger * theMerger;
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
@@ -34,7 +34,7 @@ private:
   edm::InputTag theSourceTag;
   edm::EDGetTokenT<l1extra::L1MuonParticleCollection> theSourceToken; 
 
-  L1MuonRegionProducer * theRegionProducer;
+  std::unique_ptr<L1MuonRegionProducer> theRegionProducer;
   OrderedHitsGenerator * theHitGenerator;
   std::unique_ptr<L1MuonPixelTrackFitter> theFitter;
   std::unique_ptr<PixelTrackFilter> theFilter;

--- a/RecoMuon/TrackerSeedGenerator/src/L1MuonRegionProducer.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/L1MuonRegionProducer.cc
@@ -8,8 +8,7 @@
 
 using namespace std;
 
-L1MuonRegionProducer::L1MuonRegionProducer(const edm::ParameterSet& cfg,
-	   edm::ConsumesCollector && iC) { 
+L1MuonRegionProducer::L1MuonRegionProducer(const edm::ParameterSet& cfg) {
 
   edm::ParameterSet regionPSet = cfg.getParameter<edm::ParameterSet>("RegionPSet");
 
@@ -28,8 +27,7 @@ void L1MuonRegionProducer::setL1Constraint(const L1MuGMTCand & muon)
   theChargeL1 = muon.charge();
 }
 
-std::vector<std::unique_ptr<TrackingRegion> > L1MuonRegionProducer::
-      regions(const edm::Event& ev, const edm::EventSetup& es) const
+std::vector<std::unique_ptr<TrackingRegion> > L1MuonRegionProducer::regions() const
 {
   double dx = cos(thePhiL1);
   double dy = sin(thePhiL1);


### PR DESCRIPTION
While refactoring `PixelTrackProducer`, it occurred to me that for regions and fitter `TSGFromL1Muon` uses only `L1MuonRegionProducer` and `L1MuonPixelTrackFitter` (with an explicit `dynamic_cast` in the code and without failure check). Furthermore, these two classes are used only by `TSGFromL1Muon`. Therefore, for current use cases, there is no need for `L1MuonRegionProducer` to inherit from `TrackingRegionProducer`, and `L1MuonPixelTrackFitter` from `PixelFitter`. This PR suggests to remove those inheritances to ease a bit further refactoring elsewhere.

Tested in CMSSW_8_1_0_pre16, no changes expected in results.

@rovere @VinInn 