### PR TITLE
Add QCD muon-enriched for upgrade relvals

### DIFF
--- a/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00042),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(7.20648e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 20',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(15.,15.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat > 20 GeV, with INCLUSIVE muon preselection (pt(mu) > 15 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -221,6 +221,7 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
                   'ZEE_14TeV_TuneCUETP8M1_cfi',
                   'QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi',
                   'H125GGgluonfusion_13TeV_TuneCUETP8M1_cfi',
+                  'QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff',
 ]
 
 howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
@@ -272,6 +273,7 @@ howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
            'ZEE_14TeV_TuneCUETP8M1_cfi':Kby(9,100),
            'QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi':Kby(9,100),
            'H125GGgluonfusion_13TeV_TuneCUETP8M1_cfi':Kby(9,50),
+           'QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff':Kby(9,100),
 }
 
 upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
@@ -323,4 +325,5 @@ upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
                             'ZEE_14TeV_TuneCUETP8M1_cfi' : 'ZEE_14',
                             'QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi' : 'QCD_Pt_80_120_13',
                             'H125GGgluonfusion_13TeV_TuneCUETP8M1_cfi' : 'H125GGgluonfusion_13',
+                            'QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff' : 'QCD_Pt-20toInf_MuEnrichedPt15',
 }


### PR DESCRIPTION
Adding gen fragment + python bits so qcd muon enriched can be added to upgrade/timing relvals.

Gen fragment is from BTV-RunIISummer15GS-00001