### PR TITLE
Hcal dump calibrations

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -8,6 +8,8 @@
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h"
 
 /**
    \class HcalDbASCIIIO
@@ -44,6 +46,10 @@ Text file formats for different data types is as following:
  HBHE-FGAlgorithm HF-ADCThreshold HF-TDCMask HF-SelfTriggerBits auxi1 auxi2
 - HcalTPChannelParameters
  eta(int)  phi(int) depth(int) det(HB,HE,HF) Mask FGBitInfo auxi1 auxi2
+- HcalCalibrationsSet (dump-only)
+  eta(int)  phi(int) depth(int) det(HB,HE,HF) cap1_ped(float) cap2_ped(float) cap3_ped(float) cap4_ped(float) cap1_respcorrgain(float) cap2_respcorrgain(float) cap3_respcorrgain(float) cap4_respcorrgain(float) HcalDetId(int,optional)
+- HcalCalibrationWidthsSet (dump-only)
+  eta(int)  phi(int) depth(int) det(HB,HE,HF) cap1_pedw(float) cap2_pedw(float) cap3_pedw(float) cap4_pedw(float) cap1_gainw(float) cap2_gainw(float) cap3_gainw(float) cap4_gainw(float) HcalDetId(int,optional)
 */
 namespace HcalDbASCIIIO {
   bool getObject (std::istream& fInput, HcalPedestals* fObject);
@@ -115,6 +121,9 @@ namespace HcalDbASCIIIO {
   bool dumpObject (std::ostream& fOutput, const HcalTPParameters& fObject);
   bool getObject (std::istream& fInput, HcalTPChannelParameters* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalTPChannelParameters& fObject);
+
+  bool dumpObject (std::ostream& fOutput, const HcalCalibrationsSet& fObject);
+  bool dumpObject (std::ostream& fOutput, const HcalCalibrationWidthsSet& fObject);
 
   DetId getId (const std::vector <std::string> & items);
   void dumpId (std::ostream& fOutput, DetId id);

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -2081,3 +2081,44 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalTPParameters& f
 
   return true;
 }
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationsSet& fObject) {
+  char buffer [1024];
+  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n", 
+    "eta", "phi", "dep", "det", "pedcap0", "pedcap1", "pedcap2", "pedcap3", "gaincap0", "gaincap1", "gaincap2", "gaincap3", "DetId");
+  fOutput << buffer;
+
+  std::vector<DetId> channels = fObject.getAllChannels ();
+  std::sort (channels.begin(), channels.end(), DetIdLess ());
+  for (std::vector<DetId>::iterator channel = channels.begin (); channel != channels.end (); ++channel) {
+    dumpId (fOutput, *channel);
+    const HcalCalibrations& values = fObject.getCalibrations(*channel);
+    sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+      values.pedestal(0), values.pedestal(1), values.pedestal(2), values.pedestal(3),
+      values.respcorrgain(0), values.respcorrgain(1), values.respcorrgain(2), values.respcorrgain(3), channel->rawId ());
+    fOutput << buffer;
+  }
+  return true;
+}
+
+bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationWidthsSet& fObject) {
+  char buffer [1024];
+  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %9s %9s %9s %9s %10s\n", 
+    "eta", "phi", "dep", "det", "pedwcap0", "pedwcap1", "pedwcap2", "pedwcap3", "gainwcap0", "gainwcap1", "gainwcap2", "gainwcap3", "DetId");
+  fOutput << buffer;
+
+  std::vector<DetId> channels = fObject.getAllChannels ();
+  std::sort (channels.begin(), channels.end(), DetIdLess ());
+  for (std::vector<DetId>::iterator channel = channels.begin (); channel != channels.end (); ++channel) {
+    dumpId (fOutput, *channel);
+    const HcalCalibrationWidths& values = fObject.getCalibrationWidths(*channel);
+    sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+      values.pedestal(0), values.pedestal(1), values.pedestal(2), values.pedestal(3),
+      values.gain(0), values.gain(1), values.gain(2), values.gain(3), channel->rawId ());
+    fOutput << buffer;
+  }
+  return true;
+}
+

--- a/CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h
@@ -5,6 +5,7 @@
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
+#include <vector>
 #include <unordered_map>
 #include <stdint.h>
 
@@ -18,6 +19,7 @@ public:
   const HcalCalibrationWidths& getCalibrationWidths(const DetId id) const;
   void setCalibrationWidths(const DetId id, const HcalCalibrationWidths& ca);
   void clear();
+  std::vector<DetId> getAllChannels() const;
 private:
   struct CalibWidthSetObject {
     CalibWidthSetObject(const DetId& aid) {

--- a/CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h
@@ -5,6 +5,7 @@
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
+#include <vector>
 #include <unordered_map>
 #include <stdint.h>
 
@@ -18,6 +19,7 @@ public:
   const HcalCalibrations& getCalibrations(const DetId id) const;
   void setCalibrations(const DetId id, const HcalCalibrations& ca);
   void clear();
+  std::vector<DetId> getAllChannels() const;
 private:
   struct CalibSetObject {
     CalibSetObject(const DetId& aid) {

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -32,7 +32,9 @@ class HcalDbService {
   const HcalTopology* getTopologyUsed() const;
   
   const HcalCalibrations& getHcalCalibrations(const HcalGenericDetId& fId) const;
-    const HcalCalibrationWidths& getHcalCalibrationWidths(const HcalGenericDetId& fId) const;
+  const HcalCalibrationWidths& getHcalCalibrationWidths(const HcalGenericDetId& fId) const;
+  const HcalCalibrationsSet* getHcalCalibrationsSet() const;
+  const HcalCalibrationWidthsSet* getHcalCalibrationWidthsSet() const;
 
   const HcalPedestal* getPedestal (const HcalGenericDetId& fId) const;
   const HcalPedestalWidth* getPedestalWidth (const HcalGenericDetId& fId) const;

--- a/CalibFormats/HcalObjects/src/HcalCalibrationWidthsSet.cc
+++ b/CalibFormats/HcalObjects/src/HcalCalibrationWidthsSet.cc
@@ -30,3 +30,12 @@ void HcalCalibrationWidthsSet::setCalibrationWidths(DetId fId, const HcalCalibra
 void HcalCalibrationWidthsSet::clear() {
   mItems.clear();
 }
+
+std::vector<DetId> HcalCalibrationWidthsSet::getAllChannels() const {
+  std::vector<DetId> channels;
+  channels.reserve(mItems.size());
+  for(const auto& tmp : mItems){
+    channels.push_back(tmp.second.id);
+  }
+  return channels;
+}

--- a/CalibFormats/HcalObjects/src/HcalCalibrationsSet.cc
+++ b/CalibFormats/HcalObjects/src/HcalCalibrationsSet.cc
@@ -30,3 +30,12 @@ void HcalCalibrationsSet::setCalibrations(DetId fId, const HcalCalibrations& ca)
 void HcalCalibrationsSet::clear() {
   mItems.clear();
 }
+
+std::vector<DetId> HcalCalibrationsSet::getAllChannels() const {
+  std::vector<DetId> channels;
+  channels.reserve(mItems.size());
+  for(const auto& tmp : mItems){
+    channels.push_back(tmp.second.id);
+  }
+  return channels;
+}

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -59,6 +59,18 @@ const HcalCalibrationWidths& HcalDbService::getHcalCalibrationWidths(const HcalG
   return (*mCalibWidthSet.load(std::memory_order_acquire)).getCalibrationWidths(fId);
 }
 
+const HcalCalibrationsSet* HcalDbService::getHcalCalibrationsSet() const 
+{ 
+  buildCalibrations();
+  return mCalibSet.load(std::memory_order_acquire);
+}
+
+const HcalCalibrationWidthsSet* HcalDbService::getHcalCalibrationWidthsSet() const 
+{ 
+  buildCalibWidths();
+  return mCalibWidthSet.load(std::memory_order_acquire);
+}
+
 void HcalDbService::buildCalibrations() const {
   // we use the set of ids for pedestals as the master list
   if ((!mPedestals) || (!mGains) || (!mQIEData) || (!mQIETypes) || (!mRespCorrs) || (!mTimeCorrs) || (!mLUTCorrs) ) return;

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -109,6 +109,9 @@ namespace edmtest
     context.get<HcalRecNumberingRecord>().get( topology );
     const HcalTopology* topo=&(*topology);
 
+    edm::ESHandle<HcalDbService> pSetup;
+    context.get<HcalDbRecord>().get( pSetup );
+
     using namespace edm::eventsetup;
     std::cout <<"HcalDumpConditions::analyze-> I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
 
@@ -171,6 +174,15 @@ namespace edmtest
       dumpIt(new HcalTPChannelParameters(&(*topology)), new HcalTPChannelParametersRcd, e,context,"TPChannelParameters", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TPParameters")) != mDumpRequest.end())
       dumpIt(new HcalTPParameters, new HcalTPParametersRcd, e,context,"TPParameters");
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("CalibrationsSet")) != mDumpRequest.end()){
+      const HcalCalibrationsSet* tmp = pSetup->getHcalCalibrationsSet();
+      writeToFile(tmp,e,"CalibrationsSet");
+    }
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("CalibrationWidthsSet")) != mDumpRequest.end()){
+      const HcalCalibrationWidthsSet* tmp = pSetup->getHcalCalibrationWidthsSet();
+      writeToFile(tmp,e,"CalibrationWidthsSet");
+    }
+
   }
   DEFINE_FWK_MODULE(HcalDumpConditions);
 }

--- a/CondTools/Hcal/test/dumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/dumpHcalCond_cfg.py
@@ -37,6 +37,13 @@ process.prod = cms.EDAnalyzer("HcalDumpConditions",
 #    ,'LongRecoParams'
 #    ,'MCParams'
 #    ,'FlagHFDigiTimeParams'
+#    ,'SiPMParameters'
+#    ,'SiPMCharacteristics'
+#    ,'TPParameters'
+#    ,'TPChannelParameters'
+#    ,'FrontEndMap'
+#    ,'CalibrationsSet'
+#    ,'CalibrationWidthsSet'
         ),
     outFilePrefix = cms.untracked.string('DumpCond')
 )

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -12,7 +12,6 @@ using namespace std;
 #include <iostream>
 #include "EventFilter/CastorRawToDigi/interface/CastorRawCollections.h"
 #include "CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h"
-#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"


### PR DESCRIPTION
HcalCalibrationsSet and HcalCalibrationWidthsSet are derived calibration objects which can contain some non-trivial information: pedestals and pedestal widths converted from adc to fC (using QIE coder), and "respcorrgain" (production of RespCorrs and Gains). This PR adds the ability to dump the relevant non-trivial information from these derived objects to text files, using the existing HCAL database tools.