### PR TITLE
Factorize fast timing layer geometry dependent things from RECO algorithms.

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C2_timing_layer_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C2_timing_layer_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C2_timing_cff import Phase2C2_timing
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+
+Phase2C2_timing_layer = cms.ModifierChain(Phase2C2_timing, phase2_timing_layer)
+

--- a/Configuration/Eras/python/Modifier_phase2_timing_layer_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_timing_layer_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_timing_layer =  cms.Modifier()
+

--- a/Configuration/Geometry/scripts/dict2023Geometry.py
+++ b/Configuration/Geometry/scripts/dict2023Geometry.py
@@ -497,7 +497,7 @@ timingDict = {
             'from Geometry.HGCalCommonData.fastTimeParametersInitialization_cfi import *',
             'from Geometry.HGCalCommonData.fastTimeNumberingInitialization_cfi import *',
         ],
-        "era" : "phase2_timing",
+        "era" : "phase2_timing, phase2_timing_layer",
     }
 }
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -117,7 +117,7 @@ upgradeProperties[2023] = {
         'Geom' : 'Extended2023D5',
         'HLTmenu': '@fake',
         'GT' : 'auto:phase2_realistic',
-        'Era' : 'Phase2C2_timing',
+        'Era' : 'Phase2C2_timing_layer',
         'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
     },
     '2023D6' : {

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -26,7 +26,8 @@ class Eras (object):
                  'Phase2C1',
                  'Phase2C2',
                  'Phase2C1_timing',
-                 'Phase2C2_timing']
+                 'Phase2C2_timing',
+                 'Phase2C2_timing_layer']
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
                            'run2_50ns_specific', 'run2_HI_specific',
@@ -38,7 +39,7 @@ class Eras (object):
                            'phase1Pixel', 'run3_GEM',
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
-                           'phase2_hcal',
+                           'phase2_timing_layer','phase2_hcal',
                            'trackingLowPU', 'trackingPhase1', 'trackingPhase1PU70', 'ctpps_2016', 'trackingPhase2PU140',
                            'tracker_apv_vfp30_2016']
         internalUseModChains = ['run2_2017_core']

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -57,11 +57,12 @@ phase2_common.toModify( theDigitizers, castor = None )
 
 from SimGeneral.MixingModule.ecalTimeDigitizer_cfi import ecalTimeDigitizer
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing.toModify( theDigitizers,
                         ecalTime = ecalTimeDigitizer.clone() )
     
 from SimFastTiming.Configuration.SimFastTiming_cff import fastTimeDigitizer
-phase2_timing.toModify( theDigitizers,
+phase2_timing_layer.toModify( theDigitizers,
                         fastTimingLayer = fastTimeDigitizer.clone() )
 
 theDigitizersValid = cms.PSet(

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -247,8 +247,8 @@ phase2_hgcal.toModify( theMixObjects,
     )
 )
 
-from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toModify( theMixObjects,
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify( theMixObjects,
     mixSH = dict(
         input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","FastTimerHitsBarrel"), cms.InputTag("g4SimHits","FastTimerHitsEndcap") ],
         subdets = theMixObjects.mixSH.subdets + [ 'FastTimerHitsBarrel','FastTimerHitsEndcap' ],


### PR DESCRIPTION
Allows D*Timing Eras to run as well as D5.