### PR TITLE
Stop clang warning from use of atomic_flag in SerialTaskQueue

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -66,7 +66,7 @@ namespace edm {
    {
    public:
       SerialTaskQueue():
-      m_taskChosen(ATOMIC_FLAG_INIT),
+      m_taskChosen(false),
       m_pauseCount{0}
       {  }
       
@@ -176,7 +176,7 @@ namespace edm {
       
       // ---------- member data --------------------------------
       tbb::concurrent_queue<TaskBase*> m_tasks;
-      std::atomic_flag m_taskChosen;
+      std::atomic<bool> m_taskChosen;
       std::atomic<unsigned long> m_pauseCount;
    };
    

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -56,29 +56,31 @@ SerialTaskQueue::pushAndGetNextTask(TaskBase* iTask) {
 
 tbb::task*
 SerialTaskQueue::finishedTask() {
-  m_taskChosen.clear();
+  m_taskChosen.store(false);
   return pickNextTask();
 }
 
 SerialTaskQueue::TaskBase*
 SerialTaskQueue::pickNextTask() {
   
-  if likely(0 == m_pauseCount and not m_taskChosen.test_and_set()) {
+  bool expect = false;
+  if likely(0 == m_pauseCount and m_taskChosen.compare_exchange_strong(expect,true)) {
     TaskBase* t=0;
     if likely(m_tasks.try_pop(t)) {
       return t;
     }
     //no task was actually pulled
-    m_taskChosen.clear();
+    m_taskChosen.store(false);
     
     //was a new entry added after we called 'try_pop' but before we did the clear?
-    if(not m_tasks.empty() and not m_taskChosen.test_and_set()) {
+    expect = false;
+    if(not m_tasks.empty() and m_taskChosen.compare_exchange_strong(expect,true)) {
       TaskBase* t=0;
       if(m_tasks.try_pop(t)) {
         return t;
       }
       //no task was still pulled since a different thread beat us to it
-      m_taskChosen.clear();
+      m_taskChosen.store(false);
       
     }
   }


### PR DESCRIPTION
Switched from std::atomic_flag to std::atomic<bool> to avoid clang
warnings because of how the system defined ATOMIC_FLAG_INIT.