### PR TITLE
Pixel Geometry Fixes

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -21,10 +21,8 @@
  <Constant name="ZvSupTubCab"       value="248.0*cm"/>
  <Constant name="SupportL"          value="221.0*cm"/>
  <Constant name="SupportRin"        value="21.65*cm"/>
- <Constant name="SupportW"          value="20.00*cm"/>
+ <Constant name="SupportW"          value="19.30*cm"/>
  <Constant name="SupportT"          value="0.350*cm"/>
- <Constant name="SupportL_cut"          value="[FlangeT]"/>
- <Constant name="SupportW_cut"          value="7.00*cm"/>
  <Constant name="SupportY_base"          value="19.00*cm"/>
  <Constant name="SupportY"          value="[SupportY_base]+[SupportT]/2"/>
  <Constant name="ShieldL"           value="54.0*cm"/> <!-- both shields end at the beginning of the flange (for simplicity is not glued on top of it)-->
@@ -226,20 +224,8 @@
  </Polycone> 
  <Tubs name="PixelBarrelSuppTub" rMin="[SupportRin]"     rMax="[Rout1]"
        dz="[SupportL]/2"         startPhi="0*deg"        deltaPhi="360*deg"/>
- <Box name="PixelBarrelSuppBox_full"  dx="[SupportW]/2"       dy="[SupportT]/2"
+ <Box name="PixelBarrelSuppBox"  dx="[SupportW]/2"       dy="[SupportT]/2"
        dz="[SupportL]/2"/>
- <Box name="PixelBarrelSuppBox_cut"  dx="[SupportW_cut]/2"       dy="[SupportT]/2"
-       dz="[SupportL_cut]/2"/>
- <SubtractionSolid name="PixelBarrelSuppBox_1">
-    <rSolid name="PixelBarrelSuppBox_full"/>
-    <rSolid name="PixelBarrelSuppBox_cut"/>
-    <Translation x="0*cm" y="0*cm" z="[FlangeZ]"/>
- </SubtractionSolid>
- <SubtractionSolid name="PixelBarrelSuppBox">
-    <rSolid name="PixelBarrelSuppBox_1"/>
-    <rSolid name="PixelBarrelSuppBox_cut"/>
-    <Translation x="0*cm" y="0*cm" z="-[FlangeZ]"/>
- </SubtractionSolid>
  <Tubs name="PixelBarrelShield1" rMin="[Shield1Rin]"     rMax="[Shield1Rout]"
        dz="[ShieldL]/2"          startPhi="0*deg"        deltaPhi="360*deg"/>
  <Tubs name="PixelBarrelShield2" rMin="[Shield1Rout]"    rMax="[Shield2Rout]"
@@ -375,7 +361,7 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelSuppBox" category="unspecified">
   <rSolid name="PixelBarrelSuppBox"/>
-  <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+  <rMaterial name="pixbarmaterial:T_CarbonFibreStrBox"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelShield1" category="unspecified">
   <rSolid name="PixelBarrelShield1"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -485,6 +485,12 @@
     </MaterialFraction>
   </CompositeMaterial>
 
+  <CompositeMaterial name="T_CarbonFibreStrBox" density="1.76355*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
   <CompositeMaterial name="FlangeOuter_Layer3_Upgrade" density="0.14381*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.00000000">
       <rMaterial name="FlangeOuter_Layer3"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -20,7 +20,7 @@
 
  <Constant name="ZCylinder"      value="[AnchorZ]"/>
 
- <Constant name="FlexCableDiskRmin" value="117.35*mm"/>
+ <Constant name="FlexCableDiskRmin" value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]"/>
  <Constant name="FlexCableDiskRmax" value="167.9*mm"/>
  <Constant name="FlexCableDiskHalfThickness" value="0.15*mm"/>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml
@@ -324,7 +324,7 @@
     </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="0.16*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="0.16132*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3985">
       <rMaterial name="materials:Aluminium"/>
     </MaterialFraction>


### PR DESCRIPTION
These two commits should fix the Phase1 Pixel geometry issues reported in the Offline week diskussion.

The pixbar volumes touched here were not modified for a long time, and it is not clear why the subtraction was used there in the first place. It seems safe to remove it, but this should be checked again.

We attempted to compensate the material budget changes by adjusting the material densities accordingly, even though the change is probably within the tolerance of these numbers.