### PR TITLE
Close the socket after it is used in StatisticsSenderService

### DIFF
--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -195,6 +195,8 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
     if (sock < 0) {
       continue;
     }
+    auto close_del = [](int* iSocket) { close(*iSocket); };
+    std::unique_ptr<int,decltype(close_del)> guard(&sock, close_del);
     if (sendto(sock, results.c_str(), results.size(), 0, address->ai_addr, address->ai_addrlen) >= 0) {
       break; 
     }


### PR DESCRIPTION
The StatisticsSenderService was opening a socket each time a file
closed but did not close it. This eventually lead to jobs with
many files to run out of file descriptors.