### PR TITLE
[81X] Update HCal TP parameters and fixes in 2017 wf

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -68,8 +68,6 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             globaltag = globaltag[5:]
             if globaltag not in autoCond:
                 raise Exception('no correspondence for '+globaltag+'\navailable keys are\n'+','.join(autoCond.keys()))
-            if 'upgradePLS3' == globaltag:
-                sys.stderr.write('Warning: %s now points to %s, instead of POSTLS262_V1'%(globaltag,autoCond[globaltag]))
             if 'phase1_2017_design' == globaltag:
                 sys.stderr.write('Warning: %s now points to %s. This has reco- Beamspot centered to (0,0,0)'%(globaltag,autoCond[globaltag]))
             autoKey = autoCond[globaltag]

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,47 +2,47 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v4',
+    'run1_design'       :   '81X_mcRun1_design_v5',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v4',
+    'run1_mc'           :   '81X_mcRun1_realistic_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v4',
+    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v5',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v4',
+    'run1_mc_pa'        :   '81X_mcRun1_pA_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v10',
+    'run2_design'       :   '81X_mcRun2_design_v11',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v12',
+    'run2_mc_50ns'      :   '81X_mcRun2_startup_v13',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v11',
+    'run2_mc'           :   '81X_mcRun2_asymptotic_v12',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v10',
+    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v10',
+    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v11',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v4',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v9',
+    'run1_data'         :   '81X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v9',
+    'run2_data'         :   '81X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v12',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v13',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v6',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v22',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v23',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '81X_upgrade2023_realistic_v3'
+    'phase2_realistic'     : '81X_upgrade2023_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Ideal scenario** : [81X_mcRun1_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v5) as [81X_mcRun1_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_design_v5/81X_mcRun1_design_v4): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunI Heavy Ions scenario** : [81X_mcRun1_HeavyIon_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v5) as [81X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_HeavyIon_v5/81X_mcRun1_HeavyIon_v4): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunI Realistic scenario** : [81X_mcRun1_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v5) as [81X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_realistic_v5/81X_mcRun1_realistic_v4): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunI Proton-Lead scenario** : [81X_mcRun1_pA_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v5) as [81X_mcRun1_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun1_pA_v5/81X_mcRun1_pA_v4): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
## RunII simulation 
 
   * **RunII Ideal scenario** : [81X_mcRun2_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v11) as [81X_mcRun2_design_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_design_v11/81X_mcRun2_design_v10): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII Asymptotic scenario** : [81X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v12) as [81X_mcRun2_asymptotic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_asymptotic_v12/81X_mcRun2_asymptotic_v11): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII Startup scenario** : [81X_mcRun2_startup_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v13) as [81X_mcRun2_startup_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_startup_v13/81X_mcRun2_startup_v12): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v5) as [81X_mcRun2_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v5/81X_mcRun2_pA_v4): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII CRAFT scenario** : [81X_mcRun2cosmics_startup_peak_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v11) as [81X_mcRun2cosmics_startup_peak_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2cosmics_startup_peak_v11/81X_mcRun2cosmics_startup_peak_v10): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII Heavy Ions scenario** : [81X_mcRun2_HeavyIon_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v11) as [81X_mcRun2_HeavyIon_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_HeavyIon_v11/81X_mcRun2_HeavyIon_v10): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
## RunII data 
 
   * **RunII Offline processing** : [81X_dataRun2_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v10) as [81X_dataRun2_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v10/81X_dataRun2_v9): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII HLTHI processing** : [81X_dataRun2_HLTHI_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v4) as [81X_dataRun2_HLTHI_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v4/81X_dataRun2_HLTHI_frozen_v3): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v7) as [81X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v7/81X_dataRun2_HLT_relval_v6): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII HLT processing** : [81X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v4) as [81X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v4/81X_dataRun2_HLT_frozen_v3): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
   * **RunII Offline relval processing** : [81X_dataRun2_relval_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v13) as [81X_dataRun2_relval_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v13/81X_dataRun2_relval_v12): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
 
## Upgrade 
 
   * **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v23](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v23) as [81X_upgrade2017_realistic_v22](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v22) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v23/81X_upgrade2017_realistic_v22): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
      * updated Hcal gains and SiPM configuration from the initial test beam analysis to get better agreement with expected running conditions ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2734.html))
      * updated Hcal pedestals to fix the ADC2fc conversion for HB and HO the QIE offsets were not taken into account the excess of low pt rechits ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2734.html))
 
   * **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v7) as [81X_upgrade2017_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v7/81X_upgrade2017_design_IdealBS_v6): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
      * updated Hcal gains and SiPM configuration from the initial test beam analysis to get better agreement with expected running conditions ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2734.html))
      * updated Hcal pedestals to fix the ADC2fc conversion for HB and HO the QIE offsets were not taken into account the excess of low pt rechits ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2734.html))
 
   * **PhaseII realistic scenario** : [81X_upgrade2023_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v4) as [81X_upgrade2023_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2023_realistic_v4/81X_upgrade2023_realistic_v3): 
      * bug fix in Hcal Trigger Primitive Parameters ([ref.](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2726.html))
