### PR TITLE
Hcal digi validation

### DIFF
--- a/Validation/HcalDigis/BuildFile.xml
+++ b/Validation/HcalDigis/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="Geometry/CaloGeometry"/>
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="DQMServices/Core"/>
+<use   name="SimDataFormats/CaloTest"/>
 <use   name="root"/>
 <use   name="clhep"/>
 <use   name="CalibFormats/CaloTPG"/>

--- a/Validation/HcalDigis/interface/HcalDigisValidation.h
+++ b/Validation/HcalDigis/interface/HcalDigisValidation.h
@@ -38,6 +38,8 @@
 
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
+#include "SimDataFormats/CaloTest/interface/HcalTestNumbering.h"
+
 /*TP Code*/
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
@@ -116,6 +118,7 @@ private:
     std::string mode_;
     std::string mc_;
     int noise_;
+    bool testNumber_;
 
     edm::EDGetTokenT<edm::PCaloHitContainer> tok_mc_;
     edm::EDGetTokenT< HBHEDigiCollection > tok_hbhe_; 

--- a/Validation/HcalDigis/interface/HcalDigisValidation.h
+++ b/Validation/HcalDigis/interface/HcalDigisValidation.h
@@ -111,8 +111,10 @@ private:
     std::string subdet_;
     std::string zside_;
     std::string dirName_;
-    std::string inputLabel_;
+//    std::string inputLabel_;
     edm::InputTag inputTag_;
+    edm::InputTag QIE10inputTag_;
+    edm::InputTag QIE11inputTag_;
     edm::InputTag emulTPsTag_;
     edm::InputTag dataTPsTag_;
     std::string mode_;

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -9,7 +9,8 @@ hcaldigisAnalyzer = cms.EDAnalyzer("HcalDigisValidation",
     mc		= cms.untracked.string('yes'),
     simHits     = cms.untracked.InputTag("g4SimHits","HcalHits"),
     emulTPs     = cms.InputTag("emulDigis"),
-    dataTPs     = cms.InputTag("simHcalTriggerPrimitiveDigis")
+    dataTPs     = cms.InputTag("simHcalTriggerPrimitiveDigis"),
+    TestNumber    = cms.bool(False)
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -19,5 +20,6 @@ if fastSim.isChosen():
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify(hcaldigisAnalyzer,
     dataTPs = cms.InputTag(""),
-    digiLabel = cms.string("simHcalDigis")
+    digiLabel = cms.string("simHcalDigis"),
+    TestNumber    = cms.bool(True)
 )

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 
 hcaldigisAnalyzer = cms.EDAnalyzer("HcalDigisValidation",
     outputFile	= cms.untracked.string(''),
-    digiLabel	= cms.string("hcalDigis"),
+    digiTag	= cms.InputTag("hcalDigis"),
+    QIE10digiTag= cms.InputTag("hcalDigis"),
+    QIE11digiTag= cms.InputTag("hcalDigis"),
     mode	= cms.untracked.string('multi'),
     hcalselector= cms.untracked.string('all'),
     mc		= cms.untracked.string('yes'),
@@ -20,6 +22,8 @@ if fastSim.isChosen():
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify(hcaldigisAnalyzer,
     dataTPs = cms.InputTag(""),
-    digiLabel = cms.string("simHcalDigis"),
+    digiTag = cms.InputTag("simHcalDigis"),
+    QIE10digiTag = cms.InputTag("simHcalDigis","HFQIE10DigiCollection"),
+    QIE11digiTag = cms.InputTag("simHcalDigis","HBHEQIE11DigiCollection"),
     TestNumber    = cms.bool(True)
 )

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -235,24 +235,6 @@ void HcalDigisValidation::booking(DQMStore::IBooker &ib, const std::string bsubd
         sprintf(histo, "HcalDigiTask_Ndigis_%s", sub);
         book1D(ib, histo, Ndigis);
 
-	//KH
-	std::cout << "subdet_ "
-		  << "outputFile_ "
-		  << "inputTag_ "
-		  << "mc_ "
-		  << "mode_ "
-		  << "dirName_" << std::endl;
-	std::cout << subdet_ << " " 
-		  << outputFile_ << " "
-		  << inputTag_ << " "
-		  << mc_ << " "
-		  << mode_ << " "
-		  << dirName_ << std::endl;
-	std::cout<< maxDepth_[0] << " "
-		 << maxDepth_[1] << " "
-		 << maxDepth_[2] << " "
-		 << maxDepth_[3] << std::endl;
-
         // maps of occupancies
 	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) {
 	  sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth%d_%s", depth, sub);

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -656,6 +656,10 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
         int ieta = cell.ieta();
         int sub = cell.subdet();
 
+        if(depth > maxDepth_[isubdet]){
+		edm::LogWarning("HcalDetId") << "HcalDetID presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
+                continue;
+        }
 
         //  amplitude for signal cell at diff. depths
 	std::vector<double> v_ampl(maxDepth_[isubdet]+1,0);
@@ -832,6 +836,12 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                   iphi          = id.iphi();
                 }
 
+                if(depth > maxDepth_[isubdet]){
+	        	edm::LogWarning("HcalDetId") << "HcalDetID(SimHit) presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
+                        continue;
+                }
+
+
                 // take cell already found to be max energy in a particular subdet
                 if (sub == isubdet && ieta == ieta_Sim && iphi == iphi_Sim) {
                     double en = simhits->energy();
@@ -977,6 +987,10 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
         int ieta = cell.ieta();
         int sub = cell.subdet();
 
+        if(depth > maxDepth_[isubdet]){
+		edm::LogWarning("HcalDetId") << "HcalDetID presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
+                continue;
+        }
 
         //  amplitude for signal cell at diff. depths
 	std::vector<double> v_ampl(maxDepth_[isubdet]+1,0);
@@ -1152,6 +1166,12 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
                   ieta          = id.ieta();
                   iphi          = id.iphi();
                 }
+
+                if(depth > maxDepth_[isubdet]){
+	        	edm::LogWarning("HcalDetId") << "HcalDetID(SimHit) presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
+                        continue;
+                }
+
 
                 // take cell already found to be max energy in a particular subdet
                 if (sub == isubdet && ieta == ieta_Sim && iphi == iphi_Sim) {

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -33,6 +33,7 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
     mc_ = iConfig.getUntrackedParameter<std::string > ("mc", "no");
     mode_ = iConfig.getUntrackedParameter<std::string > ("mode", "multi");
     dirName_ = iConfig.getUntrackedParameter<std::string > ("dirName", "HcalDigisV/HcalDigiTask");
+    testNumber_= iConfig.getParameter<bool>("TestNumber");
 
     // register for data access
     if (iConfig.exists("simHits"))
@@ -656,7 +657,7 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
         int ieta = cell.ieta();
         int sub = cell.subdet();
 
-        if(depth > maxDepth_[isubdet]){
+        if(depth > maxDepth_[isubdet] && sub == isubdet){
 		edm::LogWarning("HcalDetId") << "HcalDetID presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
                 continue;
         }
@@ -836,7 +837,7 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                   iphi          = id.iphi();
                 }
 
-                if(depth > maxDepth_[isubdet]){
+                if(depth > maxDepth_[isubdet] && sub == isubdet){
 	        	edm::LogWarning("HcalDetId") << "HcalDetID(SimHit) presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
                         continue;
                 }
@@ -987,7 +988,7 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
         int ieta = cell.ieta();
         int sub = cell.subdet();
 
-        if(depth > maxDepth_[isubdet]){
+        if(depth > maxDepth_[isubdet] && sub == isubdet){
 		edm::LogWarning("HcalDetId") << "HcalDetID presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
                 continue;
         }
@@ -1167,7 +1168,7 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
                   iphi          = id.iphi();
                 }
 
-                if(depth > maxDepth_[isubdet]){
+                if(depth > maxDepth_[isubdet] && sub == isubdet){
 	        	edm::LogWarning("HcalDetId") << "HcalDetID(SimHit) presents conflicting information. Depth: " << depth << ", iphi: " << iphi << ", ieta: " << ieta << ". Max depth from geometry is: " << maxDepth_[isubdet] << ". TestNumber = " << testNumber_;
                         continue;
                 }

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -609,11 +609,22 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
 
             for (std::vector<PCaloHit>::const_iterator simhits = simhitResult->begin(); simhits != simhitResult->end(); ++simhits) {
 
-                HcalDetId cell(simhits->id());
+                unsigned int id_ = simhits->id();
+                int sub, depth, ieta, iphi;
+                if (testNumber_) {
+                  int z, lay;
+                  HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
+                  int sign = (z==0) ? (-1):(1);
+                  ieta     *= sign;
+                } else {
+                  HcalDetId id = HcalDetId(id_);
+                  sub       = id.subdet(); 
+                  depth        = id.depth();
+                  ieta          = id.ieta();
+                  iphi          = id.iphi();
+                }
+
                 double en = simhits->energy();
-                int sub = cell.subdet();
-                int ieta = cell.ieta();
-                int iphi = cell.iphi();
 
                 if (en > emax_Sim && sub == isubdet) {
                     emax_Sim = en;
@@ -812,14 +823,23 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
             const edm::PCaloHitContainer * simhitResult = hcalHits.product();
             for (std::vector<PCaloHit>::const_iterator simhits = simhitResult->begin(); simhits != simhitResult->end(); ++simhits) {
 
-                HcalDetId cell(simhits->id());
-                int ieta = cell.ieta();
-                int iphi = cell.iphi();
-                int sub = cell.subdet();
+                unsigned int id_ = simhits->id();
+                int sub, depth, ieta, iphi;
+                if (testNumber_) {
+                  int z, lay;
+                  HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
+                  int sign = (z==0) ? (-1):(1);
+                  ieta     *= sign;
+                } else {
+                  HcalDetId id = HcalDetId(id_);
+                  sub       = id.subdet(); 
+                  depth        = id.depth();
+                  ieta          = id.ieta();
+                  iphi          = id.iphi();
+                }
 
                 // take cell already found to be max energy in a particular subdet
                 if (sub == isubdet && ieta == ieta_Sim && iphi == iphi_Sim) {
-                    int depth = cell.depth();
                     double en = simhits->energy();
 
                     v_ehits[0] += en;
@@ -914,11 +934,22 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
 
             for (std::vector<PCaloHit>::const_iterator simhits = simhitResult->begin(); simhits != simhitResult->end(); ++simhits) {
 
-                HcalDetId cell(simhits->id());
+                unsigned int id_ = simhits->id();
+                int sub, depth, ieta, iphi;
+                if (testNumber_) {
+                  int z, lay;
+                  HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
+                  int sign = (z==0) ? (-1):(1);
+                  ieta     *= sign;
+                } else {
+                  HcalDetId id = HcalDetId(id_);
+                  sub          = id.subdet();
+                  depth        = id.depth();
+                  ieta         = id.ieta();
+                  iphi         = id.iphi();
+                }
+              
                 double en = simhits->energy();
-                int sub = cell.subdet();
-                int ieta = cell.ieta();
-                int iphi = cell.iphi();
 
                 if (en > emax_Sim && sub == isubdet) {
                     emax_Sim = en;
@@ -1119,14 +1150,23 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
             const edm::PCaloHitContainer * simhitResult = hcalHits.product();
             for (std::vector<PCaloHit>::const_iterator simhits = simhitResult->begin(); simhits != simhitResult->end(); ++simhits) {
 
-                HcalDetId cell(simhits->id());
-                int ieta = cell.ieta();
-                int iphi = cell.iphi();
-                int sub = cell.subdet();
+                unsigned int id_ = simhits->id();
+                int sub, depth, ieta, iphi;
+                if (testNumber_) {
+                  int z, lay;
+                  HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
+                  int sign = (z==0) ? (-1):(1);
+                  ieta     *= sign;
+                } else {
+                  HcalDetId id = HcalDetId(id_);
+                  sub       = id.subdet();
+                  depth        = id.depth();
+                  ieta          = id.ieta();
+                  iphi          = id.iphi();
+                }
 
                 // take cell already found to be max energy in a particular subdet
                 if (sub == isubdet && ieta == ieta_Sim && iphi == iphi_Sim) {
-                    int depth = cell.depth();
                     double en = simhits->energy();
 
                     v_ehits[0] += en;

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -49,8 +49,8 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
         tok_dataTPs_ = consumes<HcalTrigPrimDigiCollection>(dataTPsTag_);
     }
 
-    tok_qie10_hf_ = consumes< QIE10DigiCollection >(edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
-    tok_qie11_hbhe_ = consumes< QIE11DigiCollection >(edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
+    tok_qie10_hf_ = consumes< QIE10DigiCollection >(inputTag_);
+    tok_qie11_hbhe_ = consumes< QIE11DigiCollection >(inputTag_);
 
     nevent1 = 0;
     nevent2 = 0;

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -587,9 +587,7 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
 
     int indigis = 0;
     //  amplitude for signal cell at diff. depths
-    std::vector<double> v_ampl_c;
-    v_ampl_c.push_back(0.);
-    for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ampl_c.push_back(0.);
+    std::vector<double> v_ampl_c(maxDepth_[isubdet]+1,0);
 
     // is set to 1 if "seed" SimHit is found
     int seedSimHit = 0;
@@ -660,9 +658,7 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
 
 
         //  amplitude for signal cell at diff. depths
-	std::vector<double> v_ampl;
-	v_ampl.push_back(0.);
-	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ampl.push_back(0.);
+	std::vector<double> v_ampl(maxDepth_[isubdet]+1,0);
 
         // Gains, pedestals (once !) and only for "noise" case
         if (((nevent1 == 1 && isubdet == 1) ||
@@ -813,9 +809,7 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
 
         // SimHits once again !!!
         double eps = 1.e-3;
-	std::vector<double> v_ehits;
-	v_ehits.push_back(0.);
-	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ehits.push_back(0.);
+	std::vector<double> v_ehits(maxDepth_[isubdet]+1,0);
 
         if (mc_ == "yes") {
             edm::Handle<edm::PCaloHitContainer> hcalHits;
@@ -912,9 +906,7 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
 
     int indigis = 0;
     //  amplitude for signal cell at diff. depths
-    std::vector<double> v_ampl_c;
-    v_ampl_c.push_back(0.);
-    for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ampl_c.push_back(0.);
+    std::vector<double> v_ampl_c(maxDepth_[isubdet]+1,0);
 
     // is set to 1 if "seed" SimHit is found
     int seedSimHit = 0;
@@ -987,9 +979,7 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
 
 
         //  amplitude for signal cell at diff. depths
-	std::vector<double> v_ampl;
-	v_ampl.push_back(0.);
-	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ampl.push_back(0.);
+	std::vector<double> v_ampl(maxDepth_[isubdet]+1,0);
 
         // Gains, pedestals (once !) and only for "noise" case
         if (((nevent1 == 1 && isubdet == 1) ||
@@ -1140,9 +1130,7 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
 
         // SimHits once again !!!
         double eps = 1.e-3;
-	std::vector<double> v_ehits;
-	v_ehits.push_back(0.);
-	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) v_ehits.push_back(0.);
+	std::vector<double> v_ehits(maxDepth_[isubdet]+1,0);
 
         if (mc_ == "yes") {
             edm::Handle<edm::PCaloHitContainer> hcalHits;

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -26,8 +26,10 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
 
     subdet_ = iConfig.getUntrackedParameter<std::string > ("subdetector", "all");
     outputFile_ = iConfig.getUntrackedParameter<std::string > ("outputFile", "");
-    inputLabel_ = iConfig.getParameter<std::string > ("digiLabel");
-    inputTag_   = edm::InputTag(inputLabel_);
+//    inputLabel_ = iConfig.getParameter<std::string > ("digiLabel");
+    inputTag_   = iConfig.getParameter<edm::InputTag > ("digiTag");
+    QIE10inputTag_   = iConfig.getParameter<edm::InputTag > ("QIE10digiTag");
+    QIE11inputTag_   = iConfig.getParameter<edm::InputTag > ("QIE11digiTag");
     emulTPsTag_ = iConfig.getParameter<edm::InputTag > ("emulTPs");
     dataTPsTag_ = iConfig.getParameter<edm::InputTag > ("dataTPs");
     mc_ = iConfig.getUntrackedParameter<std::string > ("mc", "no");
@@ -50,8 +52,8 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
         tok_dataTPs_ = consumes<HcalTrigPrimDigiCollection>(dataTPsTag_);
     }
 
-    tok_qie10_hf_ = consumes< QIE10DigiCollection >(inputTag_);
-    tok_qie11_hbhe_ = consumes< QIE11DigiCollection >(inputTag_);
+    tok_qie10_hf_ = consumes< QIE10DigiCollection >(QIE10inputTag_);
+    tok_qie11_hbhe_ = consumes< QIE11DigiCollection >(QIE11inputTag_);
 
     nevent1 = 0;
     nevent2 = 0;
@@ -200,6 +202,8 @@ void HcalDigisValidation::booking(DQMStore::IBooker &ib, const std::string bsubd
     HistLim ietaLim(85, -42.5, 42.5);
     HistLim iphiLim(74, -0.5, 73.5);
 
+    HistLim depthLim(15,-0.5,14.5);
+
     if (bsubdet == "HB") {
         Ndigis = HistLim( ((int)(nChannels_[1]/100) + 1)*100, 0., (float)((int)(nChannels_[1]/100) + 1)*100);
     } else if (bsubdet == "HE") {
@@ -254,6 +258,10 @@ void HcalDigisValidation::booking(DQMStore::IBooker &ib, const std::string bsubd
 	  sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth%d_%s", depth, sub);
 	  book2D(ib, histo, ietaLim, iphiLim);
         }
+
+        //Depths
+        sprintf(histo, "HcalDigiTask_depths_%s",sub);
+        book1D(ib,histo, depthLim);
 
         // occupancies vs ieta
 	for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) {
@@ -712,6 +720,8 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
             // OCCUPANCY maps fill
             fill2D("HcalDigiTask_ieta_iphi_occupancy_map_depth" + str(depth) + "_" + subdet_, double(ieta), double(iphi));
 
+            fill1D("HcalDigiTask_depths_"+subdet_,double(depth));
+
             // Cycle on time slices
             // - for each Digi
             // - for one Digi with max SimHits E in subdet
@@ -1043,6 +1053,8 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
 
             // OCCUPANCY maps fill
             fill2D("HcalDigiTask_ieta_iphi_occupancy_map_depth" + str(depth) + "_" + subdet_, double(ieta), double(iphi));
+
+            fill1D("HcalDigiTask_depths_"+subdet_,double(depth));
 
             // Cycle on time slices
             // - for each Digi


### PR DESCRIPTION
This address the memory leak in Phase 2 work flows when HcalDigisValidation doesn't proper decode SimHit DetIDs when testNumbering is enabled.

It also fixes a bug in 2017 Work flows where HE and HF digi plots were not being filled, and more cleanly initializes vectors of doubles.