### PR TITLE
Revert "Do not sort the das results if CMSSDT_DAS_CLIENT_NO_SORT env is set"

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -128,8 +128,7 @@ class InputInfo(object):
         if self.ib_blacklist:
             command += " | grep -E -v "
             command += " ".join(["-e '{0}'".format(pattern) for pattern in self.ib_blacklist])
-        from os import getenv
-        if getenv("CMSSDT_DAS_CLIENT_NO_SORT","NOT_SET") == "NOT_SET": command += " | sort -u"
+        command += " | sort -u"
         return command
 
     def lumiRanges(self):


### PR DESCRIPTION
Reverts cms-sw/cmssw#16465

Looks like we do not need this this.