### PR TITLE
add bunchSpacingProducer in localreco*

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -47,8 +47,8 @@ from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 # Cosmic During Collisions
 from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
 
-localreco = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
-localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
+localreco = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
+localreco_HcalNZS = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
 _ctpps_2016_localreco = localreco.copy()
 _ctpps_2016_localreco += totemRPLocalReconstruction


### PR DESCRIPTION
fixes a problem in hcalnzs setup in a workflow without miniAOD
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1490.html

[wait for jenkins before merging]