### PR TITLE
add bunchSpacingProducer in localreco* (fw port of #16560)

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -47,7 +47,7 @@ from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
 
 localreco = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
-localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
+localreco_HcalNZS = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
 _phase2_localreco = localreco.copyAndExclude([castorreco])
 _phase2_localreco_HcalNZS = localreco_HcalNZS.copyAndExclude([castorreco])


### PR DESCRIPTION
fixes a problem in hcalnzs setup in a workflow without miniAOD
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1490.html

The issue was almost fixed in 81X already, except that  (localreco was already prepended with bunchSpacingProducer while localreco_HcalNZS  didn't get it)

[wait for jenkins before merging]
