### PR TITLE
8_0_X backport of cms-sw/cmssw#15049

### DIFF
--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <boost/shared_ptr.hpp>
 #include <vector>
+#include "FWCore/Utilities/interface/InputTag.h" 
 
 namespace reweight{
 
@@ -220,10 +221,11 @@ namespace edm {
   public:
     LumiReWeighting( std::string generatedFile,
 		     std::string dataFile,
-		     std::string GenHistName,
-		     std::string DataHistName);
+		     std::string GenHistName = "pileup",
+		     std::string DataHistName = "pileup",
+		     const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) );
     
-    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr);
+    LumiReWeighting( const std::vector< float >& MC_distr, const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag = edm::InputTag( "addPileupInfo" ) );
 
     LumiReWeighting ( ) { } ;
 
@@ -241,6 +243,7 @@ namespace edm {
     std::string dataFileName_;
     std::string GenHistName_;
     std::string DataHistName_;
+    edm::InputTag pileupSumInfoTag_;
     boost::shared_ptr<TFile>     generatedFile_;
     boost::shared_ptr<TFile>     dataFile_;
     boost::shared_ptr<TH1>      weights_;

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -38,12 +38,14 @@ using namespace edm;
 
 LumiReWeighting::LumiReWeighting( std::string generatedFile,
 		   std::string dataFile,
-		   std::string GenHistName = "pileup",
-		   std::string DataHistName = "pileup" ) :
+		   std::string GenHistName,
+		   std::string DataHistName,
+		   const edm::InputTag& PileupSumInfoInputTag ) :
       generatedFileName_( generatedFile), 
       dataFileName_     ( dataFile ), 
-      GenHistName_        ( GenHistName ), 
-      DataHistName_        ( DataHistName )
+      GenHistName_      ( GenHistName ), 
+      DataHistName_     ( DataHistName ),
+      pileupSumInfoTag_ ( PileupSumInfoInputTag )
       {
 	generatedFile_ = boost::shared_ptr<TFile>( new TFile(generatedFileName_.c_str()) ); //MC distribution
 	dataFile_      = boost::shared_ptr<TFile>( new TFile(dataFileName_.c_str()) );      //Data distribution
@@ -81,7 +83,9 @@ LumiReWeighting::LumiReWeighting( std::string generatedFile,
 	OldLumiSection_ = -1;
 }
 
-LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr) {
+LumiReWeighting::LumiReWeighting(const std::vector< float >& MC_distr,const std::vector< float >& Lumi_distr, const edm::InputTag& PileupSumInfoInputTag ) :
+      pileupSumInfoTag_ ( PileupSumInfoInputTag )
+{
   // no histograms for input: use vectors
   
   // now, make histograms out of them:
@@ -173,7 +177,7 @@ double LumiReWeighting::weight( const edm::EventBase &e ) {
   // get pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
-  e.getByLabel(edm::InputTag("addPileupInfo"), PupInfo);
+  e.getByLabel(pileupSumInfoTag_, PupInfo);
 
   std::vector<PileupSummaryInfo>::const_iterator PVI;
 
@@ -224,7 +228,7 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
   // find the pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
-  e.getByLabel(edm::InputTag("addPileupInfo"), PupInfo);
+  e.getByLabel(pileupSumInfoTag_, PupInfo);
 
   std::vector<PileupSummaryInfo>::const_iterator PVI;
 


### PR DESCRIPTION
Added the capability to set the input tag for the PileupSummaryInfo collection retrieval. This new method can be used for the interaction with MiniAOD files (using slimmedAddPileupInfo instead of addPileupInfo as a label for the vector<PileupSummaryInfo> collection)