### PR TITLE
HBHE M2-parameters: chi2, energy, pedSigma in M2

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -69,6 +69,13 @@ def customiseFor15499(process):
             producer.noiseHPD = cms.double(1.0)
             producer.noiseSiPM = cms.double(2.)
     return process
+
+def customiseFor16569(process):
+    for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
+        if hasattr(process,mod):
+            getattr(process,mod).ts4chi2 = cms.vdouble(15.,5000.)
+    return process
+
 #
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -82,6 +89,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor14833(process)
         process = customiseFor15440(process)
         process = customiseFor15499(process)
+        process = customiseFor16569(process)
 #       process = customiseFor12718(process)
         pass
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -90,7 +90,7 @@ public:
 		       double iPedMean,double iPedSig, double iPedSigSiPM,
 		       double iNoise,double iNoiseSiPM,
 		       double iTMin, double iTMax,
-		       double its4Chi2, int iFitTimes);
+		       std::vector<double> its4Chi2, int iFitTimes);
   void setMeth3Params(bool iApplyTimeSlew, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
                
 private:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -85,12 +85,12 @@ public:
   }
 
   void setpuCorrParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,bool iApplyTimeSlew,
-		       double iTS4Min, std::vector<double> iTS4Max, double iPulseJitter,
+		       double iTS4Min, const std::vector<double> & iTS4Max, double iPulseJitter,
 		       double iTimeMean,double iTimeSig,double iTimeSigSiPM,
 		       double iPedMean,double iPedSig, double iPedSigSiPM,
 		       double iNoise,double iNoiseSiPM,
 		       double iTMin, double iTMax,
-		       std::vector<double> its4Chi2, int iFitTimes);
+		       const std::vector<double> & its4Chi2, int iFitTimes);
   void setMeth3Params(bool iApplyTimeSlew, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
                
 private:

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -114,7 +114,7 @@ public:
 		     double iPedMean, double iPedSigHPD, double iPedSigSiPM,
 		     double iNoiseHPD, double iNoiseSiPM,
 		     double iTMin, double iTMax,
-		     double its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
+		     std::vector<double> its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
 
     void setChi2Term( bool isHPD );
 
@@ -139,7 +139,8 @@ private:
     ROOT::Math::Functor *tpfunctor_;
     int TSMin_;
     int TSMax_;
-    double ts4Chi2_;
+    mutable double ts4Chi2_;
+    std::vector<double> vts4Chi2_;
     bool pedestalConstraint_;
     bool timeConstraint_;
     bool addPulseJitter_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -108,13 +108,13 @@ public:
 	       float& chi2) const;
 
     void setPUParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,bool iApplyTimeSlew,
-		     double iTS4Min, std::vector<double> iTS4Max,
+		     double iTS4Min, const std::vector<double> & iTS4Max,
 		     double iPulseJitter,
 		     double iTimeMean, double iTimeSigHPD, double iTimeSigSiPM,
 		     double iPedMean, double iPedSigHPD, double iPedSigSiPM,
 		     double iNoiseHPD, double iNoiseSiPM,
 		     double iTMin, double iTMax,
-		     std::vector<double> its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
+		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
 
     void setChi2Term( bool isHPD );
 

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -51,13 +51,13 @@ void HcalSimpleRecAlgo::setRecoParams(bool correctForTimeslew, bool correctForPu
 }
 
 void HcalSimpleRecAlgo::setpuCorrParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,
-					bool iApplyTimeSlew,double iTS4Min, std::vector<double> iTS4Max,
+					bool iApplyTimeSlew,double iTS4Min, const std::vector<double> & iTS4Max,
 					double iPulseJitter,
 					double iTimeMean, double iTimeSig, double iTimeSigSiPM,
 					double iPedMean, double iPedSig, double iPedSigSiPM,
 					double iNoise, double iNoiseSiPM,
 					double iTMin,double iTMax,
-					std::vector<double> its4Chi2, int iFitTimes) {
+					const std::vector<double> & its4Chi2, int iFitTimes) {
   if( iPedestalConstraint ) assert ( iPedSig );
   if( iTimeConstraint ) assert( iTimeSig );
   psFitOOTpuCorr_->setPUParams(iPedestalConstraint,iTimeConstraint,iAddPulseJitter,iApplyTimeSlew,

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -57,7 +57,7 @@ void HcalSimpleRecAlgo::setpuCorrParams(bool   iPedestalConstraint, bool iTimeCo
 					double iPedMean, double iPedSig, double iPedSigSiPM,
 					double iNoise, double iNoiseSiPM,
 					double iTMin,double iTMax,
-					double its4Chi2, int iFitTimes) {
+					std::vector<double> its4Chi2, int iFitTimes) {
   if( iPedestalConstraint ) assert ( iPedSig );
   if( iTimeConstraint ) assert( iTimeSig );
   psFitOOTpuCorr_->setPUParams(iPedestalConstraint,iTimeConstraint,iAddPulseJitter,iApplyTimeSlew,

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -209,7 +209,7 @@ namespace FitterFuncs{
 
 PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0),
 								       psfPtr_(nullptr), spfunctor_(nullptr), dpfunctor_(nullptr), tpfunctor_(nullptr),
-								       TSMin_(0), TSMax_(0), ts4Chi2_(0), pedestalConstraint_(0),
+								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(0),
 								       timeConstraint_(0), addPulseJitter_(0), applyTimeSlew_(0),
 								       ts4Min_(0), vts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
 								       noise_(0) {
@@ -246,12 +246,13 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
 						   double iPedMean, double iPedSigHPD, double iPedSigSiPM,
 						   double iNoiseHPD,double iNoiseSiPM,
 						   double iTMin,double iTMax,
-						   double its4Chi2,
+						   std::vector<double> its4Chi2,
 						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes) {
 
   TSMin_ = iTMin;
   TSMax_ = iTMax;
-  ts4Chi2_   = its4Chi2;
+  //  ts4Chi2_   = its4Chi2;
+  vts4Chi2_   = its4Chi2;
   pedestalConstraint_ = iPedestalConstraint;
   timeConstraint_     = iTimeConstraint;
   addPulseJitter_     = iAddPulseJitter;
@@ -338,6 +339,7 @@ void PulseShapeFitOOTPileupCorrection::apply(const CaloSamples & cs,
    }
 
    ts4Max_=vts4Max_[0]; //  HB and HE are identical for Run2
+   ts4Chi2_=vts4Chi2_[0]; //  HB and HE are identical for Run2
 
    std::vector<float> fitParsVec;
 
@@ -563,8 +565,8 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     }
   }
 
-  if(!channelData.hasTimeInfo()) ts4Max_=vts4Max_[0];
-  if(channelData.hasTimeInfo()) ts4Max_=vts4Max_[1];
+  if(!channelData.hasTimeInfo()) { ts4Max_=vts4Max_[0]; ts4Chi2_=vts4Chi2_[0]; }
+  if(channelData.hasTimeInfo()) { ts4Max_=vts4Max_[1]; ts4Chi2_=vts4Chi2_[1]; }
 
   std::vector<float> fitParsVec;
   if(tstrig >= ts4Min_ && tsTOTen > 0.) { //Two sigma from 0

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -241,12 +241,12 @@ void PulseShapeFitOOTPileupCorrection::setChi2Term( bool isHPD ) {
 
 
 void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, bool iTimeConstraint,bool iAddPulseJitter,
-						   bool iApplyTimeSlew,double iTS4Min, std::vector<double> iTS4Max,
+						   bool iApplyTimeSlew,double iTS4Min, const std::vector<double> & iTS4Max,
 						   double iPulseJitter,double iTimeMean,double iTimeSigHPD,double iTimeSigSiPM,
 						   double iPedMean, double iPedSigHPD, double iPedSigSiPM,
 						   double iNoiseHPD,double iNoiseSiPM,
 						   double iTMin,double iTMax,
-						   std::vector<double> its4Chi2,
+						   const std::vector<double> & its4Chi2,
 						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes) {
 
   TSMin_ = iTMin;
@@ -565,8 +565,11 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     }
   }
 
-  if(!channelData.hasTimeInfo()) { ts4Max_=vts4Max_[0]; ts4Chi2_=vts4Chi2_[0]; }
-  if(channelData.hasTimeInfo()) { ts4Max_=vts4Max_[1]; ts4Chi2_=vts4Chi2_[1]; }
+  if(channelData.hasTimeInfo()) { 
+    ts4Max_=vts4Max_[1]; ts4Chi2_=vts4Chi2_[1]; 
+  } else {
+    ts4Max_=vts4Max_[0]; ts4Chi2_=vts4Chi2_[0];
+  }
 
   std::vector<float> fitParsVec;
   if(tstrig >= ts4Min_ && tsTOTen > 0.) { //Two sigma from 0

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -30,7 +30,7 @@ parseHBHEMethod2Description(const edm::ParameterSet& conf)
     const double iNoiseSiPM =        conf.getParameter<double>("noiseSiPM");
     const double iTMin =             conf.getParameter<double>("timeMin");
     const double iTMax =             conf.getParameter<double>("timeMax");
-    const double its4Chi2 =          conf.getParameter<double>("ts4chi2");
+    const std::vector<double> its4Chi2 =           conf.getParameter<std::vector<double>>("ts4chi2");
     const int iFitTimes =            conf.getParameter<int>   ("fitTimes");
 
     if (iPedestalConstraint) assert(iPedSigHPD);

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
@@ -8,7 +8,7 @@ m2Parameters = cms.PSet(
     applyPulseJitter      = cms.bool(False),
     applyTimeSlew         = cms.bool(True),           #units
     ts4Min                = cms.double(0.),           #fC
-    ts4Max                = cms.vdouble(100.,70000.), #fC # this is roughly 20 GeV
+    ts4Max                = cms.vdouble(100.,45000.), #fC # this is roughly 20 GeV
     pulseJitter           = cms.double(1.),           #GeV/bin 
     ###
     meanTime              = cms.double(0.),   #ns 
@@ -16,13 +16,13 @@ m2Parameters = cms.PSet(
     timeSigmaSiPM         = cms.double(2.5),  #ns
     meanPed               = cms.double(0.),   #GeV
     pedSigmaHPD           = cms.double(0.5),  #GeV
-    pedSigmaSiPM          = cms.double(0.00043),  #GeV # this correspond roughtly to 1.5 fC for a gain of 3500
+    pedSigmaSiPM          = cms.double(0.00065),   #GeV # this correspond roughtly to 1.5 fC for a gain of 2276
     noiseHPD              = cms.double(1),    #fC
     noiseSiPM             = cms.double(1),    #fC
     ###
     timeMin               = cms.double(-12.5),#ns
     timeMax               = cms.double(12.5), #ns
-    ts4chi2               = cms.double(15.),  #chi2 for triple pulse # placeholder for siPM
+    ts4chi2               = cms.vdouble(15.,5000.),  #chi2 for triple pulse
     fitTimes              = cms.int32(1)      # -1 means no constraint on number of fits per channel
 
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
@@ -22,7 +22,7 @@ m2Parameters = cms.PSet(
     ###
     timeMin               = cms.double(-12.5),#ns
     timeMax               = cms.double(12.5), #ns
-    ts4chi2               = cms.vdouble(15.,5000.),  #chi2 for triple pulse
+    ts4chi2               = cms.vdouble(15.,15.),  #chi2 for triple pulse
     fitTimes              = cms.int32(1)      # -1 means no constraint on number of fits per channel
 
 )

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -273,7 +273,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
 			  conf.getParameter<double>("noiseSiPM"),
 			  conf.getParameter<double>("timeMin"),
 			  conf.getParameter<double>("timeMax"),
-			  conf.getParameter<double>("ts4chi2"),
+			  conf.getParameter<std::vector<double>>("ts4chi2"),
                           conf.getParameter<int>   ("fitTimes")
 			  );
   }


### PR DESCRIPTION
This PR adjusts some of the M2 parameters.

1. Follow up on the siPM parameters changes happened in GT 81X_upgrade2017_realistic_v23 and PR#16526 (i.e. pedestal width and 20GeV threshold both passed in fC)

Also discussed the chi2 threshold for the 1 vs 3 pulses but not merged in this PR.
No effects expected in the run2 workflow

Validation plots in 
http://dalfonso.web.cern.ch/dalfonso/dalfonso_siPM_M2_parameters.pdf