### PR TITLE
Fix some exceptions of cms.Modifier

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1128,8 +1128,9 @@ class _ParameterModifier(object):
         else:
             #the parameter must have been removed
             delattr(obj,k)
+  @staticmethod
   def _raiseUnknownKey(key):
-    raise KeyError("Unknown parameter name "+k+" specified while calling Modifier")
+    raise KeyError("Unknown parameter name "+key+" specified while calling Modifier")
 
 class _AndModifier(object):
   """A modifier which only applies if multiple Modifiers are chosen"""
@@ -2080,6 +2081,11 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             m1.toModify(p.a, flintstones = dict(fred = int32(2)))
             self.assertEqual(p.a.flintstones.fred.value(),2)
             self.assertEqual(p.a.flintstones.wilma.value(),1)
+            #test proper exception from nonexisting parameter name
+            m1 = Modifier()
+            p = Process("test",m1)
+            p.a = EDAnalyzer("MyAnalyzer", flintstones = PSet(fred = PSet(wilma = int32(1))))
+            self.assertRaises(KeyError, lambda: m1.toModify(p.a, flintstones = dict(imnothere = dict(wilma=2))))
             #test that load causes process wide methods to run
             def _rem_a(proc):
                 del proc.a

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1119,8 +1119,6 @@ class _ParameterModifier(object):
     for k in self.__args.iterkeys():
         if hasattr(obj,k):
             params[k] = getattr(obj,k)
-        else:
-            params[k] = self.__args[k]
     _modifyParametersFromDict(params, self.__args, self._raiseUnknownKey)
     for k in self.__args.iterkeys():
         if k in params:
@@ -2086,6 +2084,7 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", flintstones = PSet(fred = PSet(wilma = int32(1))))
             self.assertRaises(KeyError, lambda: m1.toModify(p.a, flintstones = dict(imnothere = dict(wilma=2))))
+            self.assertRaises(KeyError, lambda: m1.toModify(p.a, foo = 1))
             #test that load causes process wide methods to run
             def _rem_a(proc):
                 del proc.a


### PR DESCRIPTION
While working on something else, I found out that when having a typo in the cms.Modifier parameters (i.e. trying to modify a non-existing parameter without an explicit type), the cms.Modifier machinery does not raise a helpful exception. This PR proposes fixes for those along unit tests (that demonstrate the "mistakes").

Without this PR, the first error case gives the following traceback
```
  File "FWCore/ParameterSet/python/Config.py", line 1194, in toModify
    temp(obj)
  File "FWCore/ParameterSet/python/Config.py", line 1124, in __call__
    _modifyParametersFromDict(params, self.__args, self._raiseUnknownKey)
  File "FWCore/ParameterSet/python/Mixins.py", line 626, in _modifyParametersFromDict
    keyDepth+"."+key)
  File "FWCore/ParameterSet/python/Mixins.py", line 639, in _modifyParametersFromDict
    errorRaiser(key)
TypeError: _raiseUnknownKey() takes exactly 1 argument (2 given)
```

and the second the following
```
  File "FWCore/ParameterSet/python/Config.py", line 1194, in toModify
    temp(obj)
  File "FWCore/ParameterSet/python/Config.py", line 1124, in __call__
    _modifyParametersFromDict(params, self.__args, self._raiseUnknownKey)
  File "FWCore/ParameterSet/python/Mixins.py", line 634, in _modifyParametersFromDict
    params[key].setValue(value)
```


Tested in 8_1_0_pre16, no changes expected.