### PR TITLE
Moving RecoLocalTracker from Legacy to Thread-Friendly

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
@@ -73,7 +73,7 @@
 // class decleration
 //
 
-class SiStripBaselineAnalyzer : public edm::EDAnalyzer {
+class SiStripBaselineAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
    public:
       explicit SiStripBaselineAnalyzer(const edm::ParameterSet&);
       ~SiStripBaselineAnalyzer();
@@ -123,6 +123,7 @@ class SiStripBaselineAnalyzer : public edm::EDAnalyzer {
 
 
 SiStripBaselineAnalyzer::SiStripBaselineAnalyzer(const edm::ParameterSet& conf){
+  usesResource("TFileService");
    
   srcBaseline_ =  conf.getParameter<edm::InputTag>( "srcBaseline" );
   srcBaselinePoints_ = conf.getParameter<edm::InputTag>( "srcBaselinePoints" );

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
@@ -50,7 +50,7 @@
 
 typedef std::map<uint32_t, std::vector<float> > CMMap;
 
-class SiStripMeanCMExtractor : public edm::EDProducer {
+class SiStripMeanCMExtractor : public edm::one::EDProducer<> {
    public:
       explicit SiStripMeanCMExtractor( const edm::ParameterSet&);
       ~SiStripMeanCMExtractor();


### PR DESCRIPTION
Changes according to [https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedAnalysisEDAnalyzer](FWMultithreadedAnalysisEDAnalyzer)