### PR TITLE
re-enable HLT DQM, Validation and Harvesting sequences

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
@@ -26,6 +26,6 @@ crt_dqmoffline = cms.Sequence( siStripCertificationInfo *
                                dqmOfflineTriggerCert )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(crt_dqmoffline, crt_dqmoffline.copyAndExclude([ # FIXME
-    dqmOfflineTriggerCert, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#    dqmOfflineTriggerCert, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
     sipixelCertification # segfaults with pixel harvesting plots missing
 ]))

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -55,7 +55,7 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              runTauEff)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(DQMOffline_SecondStep_PrePOG, DQMOffline_SecondStep_PrePOG.copyAndExclude([
-    hltOfflineDQMClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#    hltOfflineDQMClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
     runTauEff,           # Excessive printouts because 2017 doesn't have HLT yet
 ]))
 
@@ -72,9 +72,9 @@ DQMOffline_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
                                       HLTMonitoringClient *
                                       DQMMessageLoggerClientSeq *
                                       dqmFastTimerServiceClient)
-phase1Pixel.toReplaceWith(DQMOffline_SecondStep, DQMOffline_SecondStep.copyAndExclude([
-    HLTMonitoringClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-]))
+#phase1Pixel.toReplaceWith(DQMOffline_SecondStep, DQMOffline_SecondStep.copyAndExclude([
+#    HLTMonitoringClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#]))
 
 DQMOffline_SecondStep_FakeHLT = cms.Sequence( DQMOffline_SecondStep )
 DQMOffline_SecondStep_FakeHLT.remove( HLTMonitoringClient )

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -54,10 +54,6 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              SusyPostProcessorSequence *
                                              runTauEff)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-#phase1Pixel.toReplaceWith(DQMOffline_SecondStep_PrePOG, DQMOffline_SecondStep_PrePOG.copyAndExclude([
-#    hltOfflineDQMClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-#    runTauEff,           # Excessive printouts because 2017 doesn't have HLT yet
-#]))
 
 DQMOffline_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PrePOG *
@@ -72,10 +68,6 @@ DQMOffline_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
                                       HLTMonitoringClient *
                                       DQMMessageLoggerClientSeq *
                                       dqmFastTimerServiceClient)
-#phase1Pixel.toReplaceWith(DQMOffline_SecondStep, DQMOffline_SecondStep.copyAndExclude([
-#    HLTMonitoringClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-#]))
-
 DQMOffline_SecondStep_FakeHLT = cms.Sequence( DQMOffline_SecondStep )
 DQMOffline_SecondStep_FakeHLT.remove( HLTMonitoringClient )
 

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -54,10 +54,10 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              SusyPostProcessorSequence *
                                              runTauEff)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(DQMOffline_SecondStep_PrePOG, DQMOffline_SecondStep_PrePOG.copyAndExclude([
+#phase1Pixel.toReplaceWith(DQMOffline_SecondStep_PrePOG, DQMOffline_SecondStep_PrePOG.copyAndExclude([
 #    hltOfflineDQMClient, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-    runTauEff,           # Excessive printouts because 2017 doesn't have HLT yet
-]))
+#    runTauEff,           # Excessive printouts because 2017 doesn't have HLT yet
+#]))
 
 DQMOffline_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PrePOG *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -62,10 +62,6 @@ DQMOfflinePrePOG = cms.Sequence( TrackingDQMSourceTier0 *
                                  produceDenoms *
                                  pfTauRunDQMValidation)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-#phase1Pixel.toReplaceWith(DQMOfflinePrePOG, DQMOfflinePrePOG.copyAndExclude([ # FIXME
-#    triggerOfflineDQMSource, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-#    pfTauRunDQMValidation,   # Excessive printouts because 2017 doesn't have HLT yet
-#]))
 
 DQMOfflinePOG = cms.Sequence( DQMOfflinePrePOG *
                               DQMMessageLogger )
@@ -77,10 +73,6 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            HLTMonitoring *
                            dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
-
-#phase1Pixel.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([
-#    HLTMonitoring # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-#]))
 
 _ctpps_2016_DQMOffline = DQMOffline.copy()
 _ctpps_2016_DQMOffline *= totemDQM

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -62,10 +62,10 @@ DQMOfflinePrePOG = cms.Sequence( TrackingDQMSourceTier0 *
                                  produceDenoms *
                                  pfTauRunDQMValidation)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(DQMOfflinePrePOG, DQMOfflinePrePOG.copyAndExclude([ # FIXME
+#phase1Pixel.toReplaceWith(DQMOfflinePrePOG, DQMOfflinePrePOG.copyAndExclude([ # FIXME
 #    triggerOfflineDQMSource, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-    pfTauRunDQMValidation,   # Excessive printouts because 2017 doesn't have HLT yet
-]))
+#    pfTauRunDQMValidation,   # Excessive printouts because 2017 doesn't have HLT yet
+#]))
 
 DQMOfflinePOG = cms.Sequence( DQMOfflinePrePOG *
                               DQMMessageLogger )

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -63,7 +63,7 @@ DQMOfflinePrePOG = cms.Sequence( TrackingDQMSourceTier0 *
                                  pfTauRunDQMValidation)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(DQMOfflinePrePOG, DQMOfflinePrePOG.copyAndExclude([ # FIXME
-    triggerOfflineDQMSource, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#    triggerOfflineDQMSource, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
     pfTauRunDQMValidation,   # Excessive printouts because 2017 doesn't have HLT yet
 ]))
 
@@ -77,9 +77,10 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            HLTMonitoring *
                            dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
-phase1Pixel.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([
-    HLTMonitoring # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-]))
+
+#phase1Pixel.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([
+#    HLTMonitoring # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#]))
 
 _ctpps_2016_DQMOffline = DQMOffline.copy()
 _ctpps_2016_DQMOffline *= totemDQM

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -37,7 +37,6 @@ hltpostvalidation = cms.Sequence(
     +HltBTagPostVal
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-#phase1Pixel.toReplaceWith(hltpostvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -37,7 +37,7 @@ hltpostvalidation = cms.Sequence(
     +HltBTagPostVal
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(hltpostvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
+#phase1Pixel.toReplaceWith(hltpostvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -33,7 +33,7 @@ hltassociation = cms.Sequence(
     +ExoticaValidationProdSeq
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(hltassociation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
+#phase1Pixel.toReplaceWith(hltassociation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 hltvalidation = cms.Sequence(
     HLTMuonVal
@@ -50,7 +50,7 @@ hltvalidation = cms.Sequence(
     +SMPValidationSequence
     +hltbtagValidationSequence
     )
-phase1Pixel.toReplaceWith(hltvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
+#phase1Pixel.toReplaceWith(hltvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 # some hlt collections have no direct fastsim equivalent
 # remove the dependent modules for now

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -33,7 +33,6 @@ hltassociation = cms.Sequence(
     +ExoticaValidationProdSeq
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-#phase1Pixel.toReplaceWith(hltassociation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 hltvalidation = cms.Sequence(
     HLTMuonVal
@@ -50,7 +49,6 @@ hltvalidation = cms.Sequence(
     +SMPValidationSequence
     +hltbtagValidationSequence
     )
-#phase1Pixel.toReplaceWith(hltvalidation, cms.Sequence()) # FIXME: No HLT yet for 2017, so no need to run the validation
 
 # some hlt collections have no direct fastsim equivalent
 # remove the dependent modules for now


### PR DESCRIPTION
this PR is needed to have the plots needed for the validation of the HLT menu in phase1 workflows
please, sign it as soon as possible

I tested w/ 10224.0 workflow, the corresponding DQM output is [1]

unfortunately, we realized this fix was not done yet only this afternoon :(
thanks !

[1]
/afs/cern.ch/work/t/tosi/public/STEAM/validation/2017_workflow/CMSSW_8_1_0_pre16/src/10224.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFull+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root