### PR TITLE
increase number of high pT jets for flat QCD

### DIFF
--- a/Configuration/Generator/python/QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff.py
@@ -21,7 +21,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                         'PhaseSpace:pTHatMin = 15',
                         'PhaseSpace:pTHatMax = 7000',
                         'PhaseSpace:bias2Selection = on',
-                        'PhaseSpace:bias2SelectionPow = 4.5',
+                        'PhaseSpace:bias2SelectionPow = 6.0',
                         'PhaseSpace:bias2SelectionRef = 15.',
 
                 ),


### PR DESCRIPTION
Very minor followup to #16535 requested by @aperloff:
>This will “flatten” the pT hat spectrum more to increase the number of jets at high pT. This is something we have requested for the regular JEC samples as well.

This PR just makes the change for Phase2 relvals; the corresponding change in [cms-sw/genproductions](https://github.com/cms-sw/genproductions) will be done by JetMET.