### PR TITLE
added dark photon model to SimG4Core custom physics

### DIFF
--- a/SimG4Core/CustomPhysics/data/particle_darkphoton.txt
+++ b/SimG4Core/CustomPhysics/data/particle_darkphoton.txt
@@ -1,0 +1,4 @@
+Block MASS   #
+#  PDG code    mass                 particle
+      1072000   0.0                 # darkphoton
+Block

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
@@ -1,55 +1,12 @@
 //
-// ********************************************************************
-// * License and Disclaimer                                           *
-// *                                                                  *
-// * The  Geant4 software  is  copyright of the Copyright Holders  of *
-// * the Geant4 Collaboration.  It is provided  under  the terms  and *
-// * conditions of the Geant4 Software License,  included in the file *
-// * LICENSE and available at  http://cern.ch/geant4/license .  These *
-// * include a list of copyright holders.                             *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.  Please see the license in the file  LICENSE  and URL above *
-// * for the full disclaimer and the limitation of liability.         *
-// *                                                                  *
-// * This  code  implementation is the result of  the  scientific and *
-// * technical work of the GEANT4 collaboration.                      *
-// * By using,  copying,  modifying or  distributing the software (or *
-// * any work based  on the software)  you  agree  to acknowledge its *
-// * use  in  resulting  scientific  publications,  and indicate your *
-// * acceptance of all terms of the Geant4 Software license.          *
-// ********************************************************************
-//
-// $Id: CMSDarkPhotonModel.cc 74581 2013-10-15 12:03:25Z gcosmo $
-//
-// -------------------------------------------------------------------
-//
-// GEANT4 Class file
-//
-//
 // File name:     CMSDarkPairProduction
 //
 // Author:        Dustin Stolp (dostolp@ucdavis.edu)
 //                Sushil S. Chauhan (schauhan@cern.ch)  
 // Creation date: 01.22.2015
-//
-// Modifications:
-//
-// Class Description:
-//
-// Main References:
-//  J.W.Motz et.al., Rev. Mod. Phys. 41 (1969) 581.
-//  S.Klein,  Rev. Mod. Phys. 71 (1999) 1501.
-//  T.Stanev et.al., Phys. Rev. D25 (1982) 1291.
-//  M.L.Ter-Mikaelian, High-energy Electromagnetic Processes in Condensed Media,
-//                     Wiley, 1972.
-//
 // -------------------------------------------------------------------
 //
-#ifndef CMSDarkPairProduction_h
+#ifndef SimG4Core_CustomPhysics_CMSDarkPairProduction_h
 #define CMSDarkPairProduction_h 1
 
 #include <CLHEP/Units/PhysicalConstants.h>
@@ -61,7 +18,6 @@
 
 class CMSDarkPairProduction : public G4PairProductionRelModel
 {
-  //G4double dark_factor; 
 public:
   CMSDarkPairProduction(const G4ParticleDefinition* p = 0,
 		      const G4double df = 1E0,

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
@@ -1,0 +1,89 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id: CMSDarkPhotonModel.cc 74581 2013-10-15 12:03:25Z gcosmo $
+//
+// -------------------------------------------------------------------
+//
+// GEANT4 Class file
+//
+//
+// File name:     CMSDarkPairProduction
+//
+// Author:        Dustin Stolp (dostolp@ucdavis.edu)
+//                Sushil S. Chauhan (schauhan@cern.ch)  
+// Creation date: 01.22.2015
+//
+// Modifications:
+//
+// Class Description:
+//
+// Main References:
+//  J.W.Motz et.al., Rev. Mod. Phys. 41 (1969) 581.
+//  S.Klein,  Rev. Mod. Phys. 71 (1999) 1501.
+//  T.Stanev et.al., Phys. Rev. D25 (1982) 1291.
+//  M.L.Ter-Mikaelian, High-energy Electromagnetic Processes in Condensed Media,
+//                     Wiley, 1972.
+//
+// -------------------------------------------------------------------
+//
+#ifndef CMSDarkPairProduction_h
+#define CMSDarkPairProduction_h 1
+
+#include <CLHEP/Units/PhysicalConstants.h>
+
+#include "G4PairProductionRelModel.hh"
+#include "G4PhysicsTable.hh"
+#include "G4NistManager.hh"
+#include "G4VEmModel.hh"
+
+class CMSDarkPairProduction : public G4PairProductionRelModel
+{
+  //G4double dark_factor; 
+public:
+  CMSDarkPairProduction(const G4ParticleDefinition* p = 0,
+		      const G4double df = 1E0,
+                      const G4String& nam = "BetheHeitlerLPM");
+
+  virtual ~CMSDarkPairProduction();
+
+  virtual G4double ComputeCrossSectionPerAtom(
+                      const G4ParticleDefinition*,
+                      G4double kinEnergy,
+                      G4double Z,
+                      G4double A=0.,
+                      G4double cut=0.,
+                      G4double emax=DBL_MAX);
+
+  void SampleSecondaries(std::vector<G4DynamicParticle*>* fvect,
+               	      const G4MaterialCutsCouple* couple,
+               	      const G4DynamicParticle* aDynamicGamma,
+                      G4double e1,
+                      G4double e2); 
+
+private:
+  G4int count=0;
+};
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
@@ -7,7 +7,7 @@
 // -------------------------------------------------------------------
 //
 #ifndef SimG4Core_CustomPhysics_CMSDarkPairProduction_h
-#define CMSDarkPairProduction_h 1
+#define SimG4Core_CustomPhysics_CMSDarkPairProduction_h
 
 #include <CLHEP/Units/PhysicalConstants.h>
 
@@ -39,7 +39,5 @@ public:
                       G4double e1,
                       G4double e2); 
 
-private:
-  G4int count=0;
 };
 #endif

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
@@ -5,7 +5,7 @@
 //                 Sushil S. Chauhan (schauhan@cern.ch)  
 // --------------------------------------------------------
 #ifndef SimG4Core_CustomPhysics_CMSDarkPairProductionProcess_h
-#define CMSDarkPairProductionProcess_h 1
+#define SimG4Core_CustomPhysics_CMSDarkPairProductionProcess_h
 
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
 #include "globals.hh"

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
@@ -1,4 +1,10 @@
-#ifndef CMSDarkPairProductionProcess_h
+//--------------------------------------------------------   
+// File name:     CMSDarkPairProductionProcess
+// 
+//  Author:        Dustin Stolp (dostolp@ucdavis.edu)
+//                 Sushil S. Chauhan (schauhan@cern.ch)  
+// --------------------------------------------------------
+#ifndef SimG4Core_CustomPhysics_CMSDarkPairProductionProcess_h
 #define CMSDarkPairProductionProcess_h 1
 
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
@@ -6,7 +12,6 @@
 #include "G4VEmProcess.hh"
 #include "G4Gamma.hh"
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 class G4ParticleDefinition;
 class G4VEmModel;
@@ -20,8 +25,6 @@ public:  // with description
 
   CMSDarkPairProductionProcess(G4double df = 1E0,
   		      const G4String& processName ="conv",
-                      //const G4ParticleDefinition* p = 0,
-                      //const G4double df = 1E0,
 		      G4ProcessType type = fElectromagnetic);
 
   virtual ~CMSDarkPairProductionProcess();
@@ -38,13 +41,11 @@ public:  // with description
 protected:
 
   virtual void InitialiseProcess(const G4ParticleDefinition*);
-  //double darkFactor;
 
 private:
   G4bool  isInitialised;
 };
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
   
 #endif
  

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
@@ -1,0 +1,50 @@
+#ifndef CMSDarkPairProductionProcess_h
+#define CMSDarkPairProductionProcess_h 1
+
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
+#include "globals.hh"
+#include "G4VEmProcess.hh"
+#include "G4Gamma.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class G4ParticleDefinition;
+class G4VEmModel;
+class G4MaterialCutsCouple;
+class G4DynamicParticle;
+
+class CMSDarkPairProductionProcess : public G4VEmProcess
+
+{
+public:  // with description
+
+  CMSDarkPairProductionProcess(G4double df = 1E0,
+  		      const G4String& processName ="conv",
+                      //const G4ParticleDefinition* p = 0,
+                      //const G4double df = 1E0,
+		      G4ProcessType type = fElectromagnetic);
+
+  virtual ~CMSDarkPairProductionProcess();
+
+  // true for Gamma only.
+  virtual G4bool IsApplicable(const G4ParticleDefinition&);
+
+  virtual G4double MinPrimaryEnergy(const G4ParticleDefinition*,
+				    const G4Material*);
+
+  // Print few lines of informations about the process: validity range,
+  virtual void PrintInfo();
+
+protected:
+
+  virtual void InitialiseProcess(const G4ParticleDefinition*);
+  //double darkFactor;
+
+private:
+  G4bool  isInitialised;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+  
+#endif
+ 

--- a/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
@@ -16,6 +16,7 @@ public:
  static bool s_isMesonino(int pdg);
  static bool s_isSbaryon(int pdg);
  static bool s_isRGlueball(int pdg);
+ static bool s_isDphoton(int pdg);
  static bool s_isChargino(int pdg);
  static double s_charge(int pdg);
  static double s_spin(int pdg);

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -32,6 +32,7 @@ private:
 
   std::string particleDefFilePath;
   std::string processDefFilePath;
+  double dfactor;
 };
  
 #endif

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -1,51 +1,7 @@
 //
-// ********************************************************************
-// * License and Disclaimer                                           *
-// *                                                                  *
-// * The  Geant4 software  is  copyright of the Copyright Holders  of *
-// * the Geant4 Collaboration.  It is provided  under  the terms  and *
-// * conditions of the Geant4 Software License,  included in the file *
-// * LICENSE and available at  http://cern.ch/geant4/license .  These *
-// * include a list of copyright holders.                             *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.  Please see the license in the file  LICENSE  and URL above *
-// * for the full disclaimer and the limitation of liability.         *
-// *                                                                  *
-// * This  code  implementation is the result of  the  scientific and *
-// * technical work of the GEANT4 collaboration.                      *
-// * By using,  copying,  modifying or  distributing the software (or *
-// * any work based  on the software)  you  agree  to acknowledge its *
-// * use  in  resulting  scientific  publications,  and indicate your *
-// * acceptance of all terms of the Geant4 Software license.          *
-// ********************************************************************
-//
-// $Id: CMSDarkPhotonModel.cc 74581 2013-10-15 12:03:25Z gcosmo $
-//
-// -------------------------------------------------------------------
-//
-// GEANT4 Class file
-//
-//
-// File name:     CMSDarkPhotonModel
-//
 // Authors of this file:        Dustin Stolp (dostolp@ucdavis.edu)
 //                              Sushil S. Chauhan (schauhan@cern.ch) 
 // Creation date: 01.22.2015
-//
-// Modifications:
-//
-// Class Description:
-//
-// Main References:
-//  J.W.Motz et.al., Rev. Mod. Phys. 41 (1969) 581.
-//  S.Klein,  Rev. Mod. Phys. 71 (1999) 1501.
-//  T.Stanev et.al., Phys. Rev. D25 (1982) 1291.
-//  M.L.Ter-Mikaelian, High-energy Electromagnetic Processes in Condensed Media,
-//                     Wiley, 1972.
 //
 // -------------------------------------------------------------------
 //
@@ -73,10 +29,8 @@ G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(const G4ParticleDefin
                                                      G4double, G4double, G4double)
 {
   count++;
-//  gammaEnergy = gammaEnergy*1E5;
   
   G4double crossSection = 0.0 ;
-  //  if ( Z < 0.9 ) return crossSection;
   if ( gammaEnergy <= 2.0*electron_mass_c2 ) return crossSection;
   
   SetCurrentElement(Z);

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -28,7 +28,6 @@ G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(const G4ParticleDefin
                                                      G4double gammaEnergy, G4double Z,
                                                      G4double, G4double, G4double)
 {
-  count++;
   
   G4double crossSection = 0.0 ;
   if ( gammaEnergy <= 2.0*electron_mass_c2 ) return crossSection;

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -1,0 +1,101 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id: CMSDarkPhotonModel.cc 74581 2013-10-15 12:03:25Z gcosmo $
+//
+// -------------------------------------------------------------------
+//
+// GEANT4 Class file
+//
+//
+// File name:     CMSDarkPhotonModel
+//
+// Authors of this file:        Dustin Stolp (dostolp@ucdavis.edu)
+//                              Sushil S. Chauhan (schauhan@cern.ch) 
+// Creation date: 01.22.2015
+//
+// Modifications:
+//
+// Class Description:
+//
+// Main References:
+//  J.W.Motz et.al., Rev. Mod. Phys. 41 (1969) 581.
+//  S.Klein,  Rev. Mod. Phys. 71 (1999) 1501.
+//  T.Stanev et.al., Phys. Rev. D25 (1982) 1291.
+//  M.L.Ter-Mikaelian, High-energy Electromagnetic Processes in Condensed Media,
+//                     Wiley, 1972.
+//
+// -------------------------------------------------------------------
+//
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4PairProductionRelModel.hh"
+
+using namespace std;
+
+static const G4double xsfactor =
+  4*fine_structure_const*classic_electr_radius*classic_electr_radius;
+
+static G4double dark_factor;
+
+CMSDarkPairProduction::CMSDarkPairProduction(const G4ParticleDefinition* p,G4double df,const G4String& nam) : G4PairProductionRelModel(p,nam){
+  dark_factor = df;
+
+}
+
+CMSDarkPairProduction::~CMSDarkPairProduction(){}
+
+G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(const G4ParticleDefinition*,
+                                                     G4double gammaEnergy, G4double Z,
+                                                     G4double, G4double, G4double)
+{
+  count++;
+//  gammaEnergy = gammaEnergy*1E5;
+  
+  G4double crossSection = 0.0 ;
+  //  if ( Z < 0.9 ) return crossSection;
+  if ( gammaEnergy <= 2.0*electron_mass_c2 ) return crossSection;
+  
+  SetCurrentElement(Z);
+  // choose calculator according to parameters and switches
+  // in the moment only one calculator:
+  crossSection=ComputeXSectionPerAtom(gammaEnergy,Z);
+  
+  G4double xi = Finel/(Fel - fCoulomb); // inelastic contribution
+  crossSection *= dark_factor * xsfactor*Z*(Z+xi);
+  return crossSection;
+}
+void
+CMSDarkPairProduction::SampleSecondaries(std::vector<G4DynamicParticle*>* fvect,
+               const G4MaterialCutsCouple* couple,
+               const G4DynamicParticle* aDynamicGamma,
+               G4double e1,
+               G4double e2)
+{
+G4PairProductionRelModel::SampleSecondaries(fvect, couple, aDynamicGamma, e1, e2);
+        
+}
+

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -1,0 +1,143 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+// Authors of this file: Dustin Stolp (dostolp@ucdavis.edu)
+//                       Sushil S. Chauhan (schauhan@cern.ch)   
+// $Id: G4GammaConversion.cc 84598 2014-10-17 07:39:15Z gcosmo $
+//
+// 
+//------------------ G4GammaConversion physics process -------------------------
+//                   by Michel Maire, 24 May 1996
+//
+// 11-06-96 Added SelectRandomAtom() method, M.Maire
+// 21-06-96 SetCuts implementation, M.Maire
+// 24-06-96 simplification in ComputeCrossSectionPerAtom, M.Maire
+// 24-06-96 in DoIt : change the particleType stuff, M.Maire
+// 25-06-96 modification in the generation of the teta angle, M.Maire
+// 16-09-96 minors optimisations in DoIt. Thanks to P.Urban
+//          dynamical array PartialSumSigma
+// 13-12-96 fast sampling of epsil below 2 MeV, L.Urban
+// 14-01-97 crossection table + meanfreepath table.
+//          PartialSumSigma removed, M.Maire
+// 14-01-97 in DoIt the positron is always created, even with Ekine=0,
+//          for further annihilation, M.Maire
+// 14-03-97 new Physics scheme for geant4alpha, M.Maire
+// 28-03-97 protection in BuildPhysicsTable, M.Maire
+// 19-06-97 correction in ComputeCrossSectionPerAtom, L.Urban
+// 04-06-98 in DoIt, secondary production condition:
+//            range>std::min(threshold,safety)
+// 13-08-98 new methods SetBining() PrintInfo()
+// 28-05-01 V.Ivanchenko minor changes to provide ANSI -wall compilation
+// 11-07-01 PostStepDoIt - sampling epsil: power(rndm,0.333333)
+// 13-07-01 DoIt: suppression of production cut for the (e-,e+) (mma)
+// 06-08-01 new methods Store/Retrieve PhysicsTable (mma)
+// 06-08-01 BuildThePhysicsTable() called from constructor (mma)
+// 17-09-01 migration of Materials to pure STL (mma)
+// 20-09-01 DoIt: fminimalEnergy = 1*eV (mma)
+// 01-10-01 come back to BuildPhysicsTable(const G4ParticleDefinition&)
+// 11-01-02 ComputeCrossSection: correction of extrapolation below EnergyLimit
+// 21-03-02 DoIt: correction of the e+e- angular distribution (bug 363) mma
+// 08-11-04 Remove of Store/Retrieve tables (V.Ivantchenko)
+// 19-04-05 Migrate to model interface and inherit 
+//          from G4VEmProcess (V.Ivanchenko) 
+// 04-05-05, Make class to be default (V.Ivanchenko)
+// 09-08-06, add SetModel(G4VEmModel*) (mma)
+// 12-09-06, move SetModel(G4VEmModel*) in G4VEmProcess (mma)
+// -----------------------------------------------------------------------------
+
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4BetheHeitlerModel.hh"
+#include "G4PairProductionRelModel.hh"
+#include "G4Electron.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+using namespace std;
+
+static G4double darkFactor;
+
+CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(
+  G4double df,
+  const G4String& processName,  
+  G4ProcessType type):G4VEmProcess (processName, type),
+    isInitialised(false)
+{ 
+  darkFactor = df;
+  SetMinKinEnergy(2.0*electron_mass_c2);
+  SetProcessSubType(fGammaConversion);
+  SetStartFromNullFlag(true);
+  SetBuildTableFlag(true);
+  SetSecondaryParticle(G4Electron::Electron());
+  SetLambdaBinning(220);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+ 
+CMSDarkPairProductionProcess::~CMSDarkPairProductionProcess()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4bool CMSDarkPairProductionProcess::IsApplicable(const G4ParticleDefinition& p)
+{
+  return (p.GetParticleType()=="darkpho");
+  //return (&p == G4Gamma::Gamma()); //change this to dark photon condition
+  //return true;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition* p)
+{
+  if(!isInitialised) {
+    isInitialised = true;
+    
+      //          With CMSSW74X
+      //if(!EmModel(1)) { SetEmModel(new CMSDarkPairProduction() , 1); }  //our new dark photon model
+      // EmModel(1)->SetLowEnergyLimit(std::max(2*electron_mass_c2,0.)); 
+      //AddEmModel(1, EmModel(1));
+
+       //        With CMSSW_5XX 
+       AddEmModel(0, new CMSDarkPairProduction(p,darkFactor));
+
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition*,
+					     const G4Material*)
+{
+  return 2*electron_mass_c2;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void CMSDarkPairProductionProcess::PrintInfo()
+{}         
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -1,80 +1,17 @@
 //
 // ********************************************************************
-// * License and Disclaimer                                           *
-// *                                                                  *
-// * The  Geant4 software  is  copyright of the Copyright Holders  of *
-// * the Geant4 Collaboration.  It is provided  under  the terms  and *
-// * conditions of the Geant4 Software License,  included in the file *
-// * LICENSE and available at  http://cern.ch/geant4/license .  These *
-// * include a list of copyright holders.                             *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.  Please see the license in the file  LICENSE  and URL above *
-// * for the full disclaimer and the limitation of liability.         *
-// *                                                                  *
-// * This  code  implementation is the result of  the  scientific and *
-// * technical work of the GEANT4 collaboration.                      *
-// * By using,  copying,  modifying or  distributing the software (or *
-// * any work based  on the software)  you  agree  to acknowledge its *
-// * use  in  resulting  scientific  publications,  and indicate your *
-// * acceptance of all terms of the Geant4 Software license.          *
-// ********************************************************************
 // Authors of this file: Dustin Stolp (dostolp@ucdavis.edu)
 //                       Sushil S. Chauhan (schauhan@cern.ch)   
-// $Id: G4GammaConversion.cc 84598 2014-10-17 07:39:15Z gcosmo $
 //
-// 
-//------------------ G4GammaConversion physics process -------------------------
-//                   by Michel Maire, 24 May 1996
-//
-// 11-06-96 Added SelectRandomAtom() method, M.Maire
-// 21-06-96 SetCuts implementation, M.Maire
-// 24-06-96 simplification in ComputeCrossSectionPerAtom, M.Maire
-// 24-06-96 in DoIt : change the particleType stuff, M.Maire
-// 25-06-96 modification in the generation of the teta angle, M.Maire
-// 16-09-96 minors optimisations in DoIt. Thanks to P.Urban
-//          dynamical array PartialSumSigma
-// 13-12-96 fast sampling of epsil below 2 MeV, L.Urban
-// 14-01-97 crossection table + meanfreepath table.
-//          PartialSumSigma removed, M.Maire
-// 14-01-97 in DoIt the positron is always created, even with Ekine=0,
-//          for further annihilation, M.Maire
-// 14-03-97 new Physics scheme for geant4alpha, M.Maire
-// 28-03-97 protection in BuildPhysicsTable, M.Maire
-// 19-06-97 correction in ComputeCrossSectionPerAtom, L.Urban
-// 04-06-98 in DoIt, secondary production condition:
-//            range>std::min(threshold,safety)
-// 13-08-98 new methods SetBining() PrintInfo()
-// 28-05-01 V.Ivanchenko minor changes to provide ANSI -wall compilation
-// 11-07-01 PostStepDoIt - sampling epsil: power(rndm,0.333333)
-// 13-07-01 DoIt: suppression of production cut for the (e-,e+) (mma)
-// 06-08-01 new methods Store/Retrieve PhysicsTable (mma)
-// 06-08-01 BuildThePhysicsTable() called from constructor (mma)
-// 17-09-01 migration of Materials to pure STL (mma)
-// 20-09-01 DoIt: fminimalEnergy = 1*eV (mma)
-// 01-10-01 come back to BuildPhysicsTable(const G4ParticleDefinition&)
-// 11-01-02 ComputeCrossSection: correction of extrapolation below EnergyLimit
-// 21-03-02 DoIt: correction of the e+e- angular distribution (bug 363) mma
-// 08-11-04 Remove of Store/Retrieve tables (V.Ivantchenko)
-// 19-04-05 Migrate to model interface and inherit 
-//          from G4VEmProcess (V.Ivanchenko) 
-// 04-05-05, Make class to be default (V.Ivanchenko)
-// 09-08-06, add SetModel(G4VEmModel*) (mma)
-// 12-09-06, move SetModel(G4VEmModel*) in G4VEmProcess (mma)
 // -----------------------------------------------------------------------------
 
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
-#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4BetheHeitlerModel.hh"
 #include "G4PairProductionRelModel.hh"
 #include "G4Electron.hh"
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 using namespace std;
 
@@ -95,39 +32,27 @@ CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(
   SetLambdaBinning(220);
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
  
 CMSDarkPairProductionProcess::~CMSDarkPairProductionProcess()
 {}
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
 G4bool CMSDarkPairProductionProcess::IsApplicable(const G4ParticleDefinition& p)
 {
   return (p.GetParticleType()=="darkpho");
-  //return (&p == G4Gamma::Gamma()); //change this to dark photon condition
-  //return true;
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
 void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition* p)
 {
   if(!isInitialised) {
     isInitialised = true;
     
-      //          With CMSSW74X
-      //if(!EmModel(1)) { SetEmModel(new CMSDarkPairProduction() , 1); }  //our new dark photon model
-      // EmModel(1)->SetLowEnergyLimit(std::max(2*electron_mass_c2,0.)); 
-      //AddEmModel(1, EmModel(1));
-
-       //        With CMSSW_5XX 
        AddEmModel(0, new CMSDarkPairProduction(p,darkFactor));
 
   }
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
 G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition*,
 					     const G4Material*)
@@ -135,9 +60,7 @@ G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefiniti
   return 2*electron_mass_c2;
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void CMSDarkPairProductionProcess::PrintInfo()
 {}         
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -45,6 +45,13 @@ bool CustomPDGParser::s_isRGlueball(int pdg)
 
 }
 
+bool CustomPDGParser::s_isDphoton(int pdg)
+{                      
+ int pdgAbs=abs(pdg);  
+ return  (pdgAbs == 1072000);
+                       
+}
+
 bool CustomPDGParser::s_isRMeson(int pdg)
 {
  int pdgAbs=abs(pdg);
@@ -88,6 +95,10 @@ double CustomPDGParser::s_charge(int pdg)
       	      return -sign;
 	}
 
+      if(s_isDphoton(pdg)){                                                                                                                           
+          charge = 0;
+          return charge;
+      }
       if (s_isChargino(pdg)) {
 	return sign;
       } 

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -96,7 +96,6 @@ double CustomPDGParser::s_charge(int pdg)
 	}
 
       if(s_isDphoton(pdg)){                                                                                                                           
-          charge = 0;
           return charge;
       }
       if (s_isChargino(pdg)) {

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -126,6 +126,20 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
   int baryon = 1;  //FIXME: 
   bool stable = true;
   double lifetime = -1;
+
+  if(CustomPDGParser::s_isDphoton(pdgCode)){
+    pType = "darkpho";
+    spin = 2;
+    parity = -1;
+    conjugation = -1;
+    isospin = 0;
+    isospinZ = 0;
+    gParity = 0;
+    lepton = 0;
+    baryon =0;
+    stable = true;
+    lifetime = -1;
+  }    
  
   G4DecayTable *decaytable = nullptr;
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -15,6 +15,8 @@
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
 
 using namespace CLHEP;
 
@@ -25,6 +27,7 @@ CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet &
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
+    dfactor = p.getParameter<double>("dark_factor");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
   fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
 
@@ -82,6 +85,10 @@ void CustomPhysicsList::ConstructProcess() {
           if(!myHelper) { myHelper = new G4ProcessHelper(myConfig); }
 	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
 	}
+        if(particle->GetParticleType()=="darkpho"){
+          CMSDarkPairProductionProcess * darkGamma = new CMSDarkPairProductionProcess(dfactor);
+          pmanager->AddDiscreteProcess(darkGamma);
+        }
       }
     }
   }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -15,7 +15,6 @@
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
-#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
 
 using namespace CLHEP;


### PR DESCRIPTION
Added dark photon interaction model to SimG4Core/CustomPhysics/ package. Its similar to Bethe-Heitler model but with a dark factor.  Dark factor could be change from gen level config. pdg-id set  to 1072000 for dark photon. Presented in simulation meeting on 15th November 2016.