### PR TITLE
fix some DQM sequences for phase1 scenario

### DIFF
--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -15,6 +15,7 @@ from DQM.Physics.HiggsDQM_cfi import *
 from DQM.Physics.ExoticaDQM_cfi import *
 from DQM.Physics.B2GDQM_cfi import *
 from DQM.Physics.CentralityDQM_cfi import *
+from DQM.Physics.CentralitypADQM_cfi import *
 from DQM.Physics.topJetCorrectionHelper_cfi import *
 
 dqmPhysics = cms.Sequence( bphysicsOniaDQM 
@@ -34,7 +35,13 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *ExoticaDQM
                            *B2GDQM
                            )
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+from Configuration.StandardSequences.Eras import eras
+dqmPhysicspA  =  dqmPhysics.copy()
+dqmPhysicspA += CentralitypADQM
+eras.pA_2016.toReplaceWith(dqmPhysics, dqmPhysicspA)
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -35,11 +35,6 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *B2GDQM
                            )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(dqmPhysics, dqmPhysics.copyAndExclude([ # FIXME
-    ewkMuDQM,            # Excessive printouts because 2017 doesn't have HLT yet
-    ewkElecDQM,          # Excessive printouts because 2017 doesn't have HLT yet
-    ewkMuLumiMonitorDQM, # Excessive printouts because 2017 doesn't have HLT yet
-]))
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -15,7 +15,6 @@ from DQM.Physics.HiggsDQM_cfi import *
 from DQM.Physics.ExoticaDQM_cfi import *
 from DQM.Physics.B2GDQM_cfi import *
 from DQM.Physics.CentralityDQM_cfi import *
-from DQM.Physics.CentralitypADQM_cfi import *
 from DQM.Physics.topJetCorrectionHelper_cfi import *
 
 dqmPhysics = cms.Sequence( bphysicsOniaDQM 
@@ -35,13 +34,12 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *ExoticaDQM
                            *B2GDQM
                            )
-
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-
-from Configuration.StandardSequences.Eras import eras
-dqmPhysicspA  =  dqmPhysics.copy()
-dqmPhysicspA += CentralitypADQM
-eras.pA_2016.toReplaceWith(dqmPhysics, dqmPhysicspA)
+phase1Pixel.toReplaceWith(dqmPhysics, dqmPhysics.copyAndExclude([ # FIXME
+    ewkMuDQM,            # Excessive printouts because 2017 doesn't have HLT yet
+    ewkElecDQM,          # Excessive printouts because 2017 doesn't have HLT yet
+    ewkMuLumiMonitorDQM, # Excessive printouts because 2017 doesn't have HLT yet
+]))
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -154,9 +154,6 @@ SiStripDQMTier0 = cms.Sequence(
     *SiStripMonitorTrackCommon*SiStripMonitorTrackIB*MonitorTrackResiduals
     *dqmInfoSiStrip)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(SiStripDQMTier0, SiStripDQMTier0.copyAndExclude([ # FIXME
-    MonitorTrackResiduals # Excessive printouts because 2017 doesn't have HLT yet
-]))
 
 SiStripDQMTier0Common = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
@@ -167,9 +164,6 @@ SiStripDQMTier0MinBias = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*SiStripMonitorTrackIB*MonitorTrackResiduals
     *dqmInfoSiStrip)
-phase1Pixel.toReplaceWith(SiStripDQMTier0MinBias, SiStripDQMTier0MinBias.copyAndExclude([ # FIXME
-    MonitorTrackResiduals # Excessive printouts because 2017 doesn't have HLT yet
-]))
 
 
 

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -110,7 +110,6 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       *METDQMAnalyzerSequence)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-
 jetMETDQMOfflineRedoProductsMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD)
 
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -109,10 +109,7 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQM
                                       *METDQMAnalyzerSequence)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(jetMETDQMOfflineSource, jetMETDQMOfflineSource.copyAndExclude([ # FIXME
-    jetDQMAnalyzerSequence, # Excessive printouts because 2017 doesn't have HLT yet
-    METDQMAnalyzerSequence, # Excessive printouts because 2017 doesn't have HLT yet
-]))
+
 
 jetMETDQMOfflineRedoProductsMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD)
 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -23,9 +23,7 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             muonPFsequence*
                             muonRecoOneHLT)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(muonAnalyzer, muonAnalyzer.copyAndExclude([ # FIXME
-    muonRecoOneHLT # Doesn't work because TriggerResults::HLT is missing (because HLT not yet being part of 2017 workflow)
-]))
+
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(muonAnalyzer, muonAnalyzer.copyAndExclude([ # FIXME
     muonEnergyDepositAnalyzer

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -39,9 +39,6 @@ postValidation = cms.Sequence(
     + METPostProcessor
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(postValidation, postValidation.copyAndExclude([ # FIXME
-    runTauEff # Excessive printouts because 2017 doesn't have HLT yet
-]))
 
 postValidation_preprod = cms.Sequence(
     recoMuonPostProcessors

--- a/Validation/RecoTau/python/DQMMCValidation_cfi.py
+++ b/Validation/RecoTau/python/DQMMCValidation_cfi.py
@@ -19,11 +19,6 @@ pfTauRunDQMValidation = cms.Sequence(
     TauValNumeratorAndDenominatorZTT
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(pfTauRunDQMValidation, pfTauRunDQMValidation.copyAndExclude([ # FIXME
-    TauValNumeratorAndDenominatorRealData,          # Excessive printouts because 2017 doesn't have HLT yet
-    TauValNumeratorAndDenominatorRealElectronsData, # Excessive printouts because 2017 doesn't have HLT yet
-    TauValNumeratorAndDenominatorRealMuonsData,     # Excessive printouts because 2017 doesn't have HLT yet
-]))
 
 produceDenoms = cms.Sequence(
     produceDenominatorQCD+


### PR DESCRIPTION
thanks to @makortel 
I went through the list of python config files which still handle the phase1
by dropping some DQM/Validation modules

I did not update the following ones, though
- DQMOffline/Configuration/python/DQMOffline_CRT_cff.py:phase1Pixel.toReplaceWith(crt_dqmoffline, crt_dqmoffline.copyAndExclude([ # FIXME
- Validation/RecoTrack/python/SiTrackingRecHitsValid_cff.py:phase1Pixel.toReplaceWith(trackingRecHitsValid, trackingRecHitsValid.copyAndExclude([ # FIXME

because the comment suggests that need some work on the DQM side

in addition, I was not able to merge my original updates
because of conflict w/
- DQM/Physics/python/DQMPhysics_cff.py:phase1Pixel.toReplaceWith(dqmPhysics, dqmPhysics.copyAndExclude([ # FIXME
so, it still needs to be updated


I do not think they are super urgent, but I would suggest to integrate this PR as soon as possible ...