### PR TITLE
increase track length w/o increasing fake rate

### DIFF
--- a/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
@@ -31,8 +31,9 @@ private:
   template<typename T>
   float score (const T & t) const
   {
-
-    return t.chiSquared()-t.foundHits()*bonus+t.lostHits()*penalty 
+   auto bb = (t.dPhiCacheForLoopersReconstruction()==0 && t.foundHits()>8) ? 2*bonus : bonus; //extra bonus for long tracks not loopers
+    if (t.dPhiCacheForLoopersReconstruction()>0 || t.foundHits()<7) bb*=0.5f; 
+    return t.chiSquared()-t.foundHits()*bb+t.lostHits()*penalty 
       + looperPenalty(t);
   }
 

--- a/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedTrajCandLess.h
@@ -32,7 +32,7 @@ private:
   float score (const T & t) const
   {
    auto bb = (t.dPhiCacheForLoopersReconstruction()==0 && t.foundHits()>8) ? 2*bonus : bonus; //extra bonus for long tracks not loopers
-    if (t.dPhiCacheForLoopersReconstruction()>0 || t.foundHits()<7) bb*=0.5f; 
+    if ( t.lastMeasurement().updatedState().globalMomentum().perp2() < 0.81f ) bb*=0.5f; 
     return t.chiSquared()-t.foundHits()*bb+t.lostHits()*penalty 
       + looperPenalty(t);
   }

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -18,11 +18,11 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
     maxCand = cms.int32(5),
     intermediateCleaning = cms.bool(True),
     # Chi2 added to track candidate if no hit found in layer
-    lostHitPenalty = cms.double(20.0),
+    lostHitPenalty = cms.double(30.0),
+    foundHitBonus = cms.double(10.0),
     MeasurementTrackerName = cms.string(''),
     lockHits = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'),
-    foundHitBonus = cms.double(5.0),
     updator = cms.string('KFUpdator'),
     # If true, track building will allow for possibility of no hit
     # in a given layer, even if it finds compatible hits there.

--- a/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
@@ -22,7 +22,9 @@ void FastTrajectoryCleaner::clean( TempTrajectoryContainer & tc) const
       if (!h.isValid()) continue;
       dof+=h.dimension();
     }
-    float score = validHitBonus_*dof - missingHitPenalty_*it.lostHits() - it.chiSquared();
+    float score = validHitBonus_*float(dof) - missingHitPenalty_*it.lostHits() - it.chiSquared();
+    if (it.dPhiCacheForLoopersReconstruction()>0  || it.foundHits()<7) score -= 0.5f*validHitBonus_*float(dof);
+    else if (it.dPhiCacheForLoopersReconstruction()==0 &&it.foundHits()>8) score+=validHitBonus_*float(dof); // extra bonus for long tracks
     if (score>=maxScore) {
      bestTr = &it;
      maxScore = score;

--- a/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
+++ b/TrackingTools/TrajectoryCleaning/src/FastTrajectoryCleaner.cc
@@ -23,7 +23,7 @@ void FastTrajectoryCleaner::clean( TempTrajectoryContainer & tc) const
       dof+=h.dimension();
     }
     float score = validHitBonus_*float(dof) - missingHitPenalty_*it.lostHits() - it.chiSquared();
-    if (it.dPhiCacheForLoopersReconstruction()>0  || it.foundHits()<7) score -= 0.5f*validHitBonus_*float(dof);
+    if ( it.lastMeasurement().updatedState().globalMomentum().perp2() < 0.81f ) score -= 0.5f*validHitBonus_*float(dof);
     else if (it.dPhiCacheForLoopersReconstruction()==0 &&it.foundHits()>8) score+=validHitBonus_*float(dof); // extra bonus for long tracks
     if (score>=maxScore) {
      bestTr = &it;


### PR DESCRIPTION
It has been reported several time that the tracking hit-efficiency  seems to dramatically decrease with track length . It is easy to track this down to the score used to select the "best candiate" among all those spurring from the same seed. It's current tuning is clearly adjusted to reduce fake-rate in particular for "low pt" tracks.  Waiting for a clever score (ML based?) here we try to mitigate the effect increasing the weight of the number of hits w/r/t the chi2 for tracks with pt>0.9GeV (which seems to be a magic number in the whole history of CMS tracker).
 
Some evidence
SingleMuon 4GeV (PhaseI 810pre16) hit efficiency
black 810 out of the box
blue same w/o muon-seeding iterations
orange same + the proposed mitigation
![effmu4pt](https://cloud.githubusercontent.com/assets/4143702/20340901/2b455bc0-abe4-11e6-8a47-457420469f74.png)

here for real data JetHT Run 279685
black out of the box
blue proposed mitigation

![effrealdata](https://cloud.githubusercontent.com/assets/4143702/20341830/24af4358-abe8-11e6-9b67-9fa47a5782d9.png)

here is MTV for usual ttbar25ns PU35 phase0
https://innocent.web.cern.ch/innocent/RelVal/pu35_81_16f10pt/plots_highPurity/effandfake1.pdf

and in case you wonder, that's what happens if the pt cut is NOT applied
https://innocent.web.cern.ch/innocent/RelVal/pu35_81_16f10d/plots_highPurity/effandfake1.pdf
a future technical PR will try to optimize and  factorize code (it will most probably recompile half tracking and tracking dependent code)
Automatically ported from CMSSW_8_1_X #16592 (original by @VinInn).