### PR TITLE
bsunanda:Phase2-ft11 Update README file in Configuration/Geometry and add required files for FastTime Reco Geometry

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -9,7 +9,8 @@ Tracker:
 
 Calorimeters:
 * C1: Run2 calorimeters
-* C2: HGCal (v7) + Phase2 HCAL
+* C2: HGCal (v7) + Phase2 HCAL and EB
+* C3: HGCal (v8) + Phase2 HCAL and EB
 
 Muon system:
 * M1: Phase2 muon system (TP baseline) w/ GE21, ME0, RE3/1, RE4/1

--- a/Configuration/Geometry/scripts/dict2023Geometry.py
+++ b/Configuration/Geometry/scripts/dict2023Geometry.py
@@ -496,6 +496,10 @@ timingDict = {
             'from Geometry.HGCalCommonData.fastTimeParametersInitialization_cfi import *',
             'from Geometry.HGCalCommonData.fastTimeNumberingInitialization_cfi import *',
         ],
+        "reco" :[
+            'from Geometry.CaloEventSetup.FastTimeTopology_cfi import *',
+            'from Geometry.HGCalGeometry.FastTimeGeometryESProducer_cfi import *',
+        ],
         "era" : "phase2_timing, phase2_timing_layer",
     }
 }

--- a/Geometry/HGCalGeometry/test/BuildFile.xml
+++ b/Geometry/HGCalGeometry/test/BuildFile.xml
@@ -4,4 +4,4 @@
 <use   name="CoralBase"/>
 
 <flags   EDM_PLUGIN="1"/>
-<library   file="HGCalGeometryTester.cc" name="testGeometryHCCalGeometry"> </library>
+<library   file="*.cc" name="testGeometryHCCalGeometry"> </library>


### PR DESCRIPTION
Updating the README file; include fast time RECO geometry in I2; making room for Geometry tester for FastTimer. This is an addition after PR# 16562
Automatically ported from CMSSW_8_1_X #16590 (original by @bsunanda).