### PR TITLE
Make it possible for track selectors to include timing cuts (via a ref)

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
@@ -9,6 +9,7 @@
 
 class RecoTrackSelector: public RecoTrackSelectorBase {
  public:
+  typedef reco::TrackRef reference_type;
   typedef reco::TrackCollection collection;
   typedef std::vector<const reco::Track *> container;
   typedef container::const_iterator const_iterator;
@@ -25,10 +26,12 @@ class RecoTrackSelector: public RecoTrackSelectorBase {
     init(event,es);
     selected_.clear();
     for( reco::TrackCollection::const_iterator trk = c->begin();
-         trk != c->end(); ++ trk )
-      if ( operator()(*trk) ) {
+         trk != c->end(); ++ trk ) {
+      reference_type tkref(c,std::distance(c->begin(),trk));
+      if ( operator()(*tkref) ) {
 	selected_.push_back( & * trk );
       }
+    }
   }
 
   size_t size() const { return selected_.size(); }

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -50,6 +50,10 @@ public:
      vertex_ = (*hVtx)[0].position();
   }
 
+  bool operator()( const reco::TrackRef& tref ) const {
+    return (*this)(*tref);
+  }
+
   bool operator()( const reco::Track & t) const {
     bool quality_ok = true;
     if (quality_.size()!=0) {

--- a/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
@@ -83,9 +83,11 @@ private:
       TrackRefKey current = 0;
 
       selector_.init(evt,es);
-      for (reco::TrackCollection::const_iterator it = hSrcTrack->begin(), ed = hSrcTrack->end(); it != ed; ++it, ++current) {
-          const reco::Track & trk = * it;
-          if (!selector_(trk)) continue;
+      auto tkBegin = hSrcTrack->begin();
+      for (reco::TrackCollection::const_iterator it = tkBegin, ed = hSrcTrack->end(); it != ed; ++it, ++current) {
+	  const reco::Track & trk = * it;
+	  const reco::TrackRef tkref(hSrcTrack,std::distance(tkBegin,it));
+          if (!selector_(tkref)) continue;
 
           selTracks_->push_back( Track( trk ) ); // clone and store
           if (!copyExtras_) continue;

--- a/CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h
+++ b/CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h
@@ -10,6 +10,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -23,14 +24,21 @@ class TrackWithVertexSelector {
 
       void init(const edm::Event & event, const edm::EventSetup&) {init(event);}
       void init(const edm::Event & event);
-
-
+      
       bool operator()(const reco::Track &t) const ;
       bool operator()(const reco::Track &t, const edm::Event &iEvent) {
          init(iEvent); return (*this)(t);   
       }
+
+      bool operator()(const reco::TrackRef &t) const ;
+      bool operator()(const reco::TrackRef &t, const edm::Event &iEvent) {
+         init(iEvent); return (*this)(t);   
+      }
       bool testTrack(const reco::Track &t) const ;
       bool testVertices(const reco::Track &t, const reco::VertexCollection &vtxs) const ;
+
+      bool testTrack(const reco::TrackRef &t) const ;
+      bool testVertices(const reco::TrackRef &t, const reco::VertexCollection &vtxs) const ;
    private:
       uint32_t numberOfValidHits_;
       uint32_t numberOfValidPixelHits_;
@@ -43,10 +51,13 @@ class TrackWithVertexSelector {
 
       uint32_t      nVertices_;
       edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+      edm::EDGetTokenT<edm::ValueMap<float> > timesToken_, timeResosToken_;
       bool          vtxFallback_;
-      double        zetaVtx_, rhoVtx_;
+      double        zetaVtx_, rhoVtx_, nSigmaDtVertex_;
 
       reco::VertexCollection const * vcoll_ = nullptr;
+      edm::ValueMap<float> const * timescoll_ = nullptr;
+      edm::ValueMap<float> const * timeresoscoll_ = nullptr;
       typedef math::XYZPoint Point;
 };
 

--- a/CommonTools/RecoAlgos/python/TrackWithVertexSelectorParams_cff.py
+++ b/CommonTools/RecoAlgos/python/TrackWithVertexSelectorParams_cff.py
@@ -21,11 +21,14 @@ trackWithVertexSelectorParams = cms.PSet(
     # compatibility with a vertex ?
     useVtx = cms.bool(True),
     vertexTag = cms.InputTag('offlinePrimaryVertices'),
+    timesTag = cms.InputTag(''),
+    timeResosTag = cms.InputTag(''),
     nVertices = cms.uint32(0), ## how many vertices to look at before dropping the track
     vtxFallback = cms.bool(True), ## falback to beam spot if there are no vertices
     # uses vtx=(0,0,0) with deltaZeta=15.9, deltaRho = 0.2
     zetaVtx = cms.double(1.0),
     rhoVtx = cms.double(0.2), ## tags used by b-tagging folks
+    nSigmaDtVertex = cms.double(0),
     # should _not_ be used for the TrackWithVertexRefSelector
     copyExtras = cms.untracked.bool(False), ## copies also extras and rechits on RECO
     copyTrajectories = cms.untracked.bool(False), # don't set this to true on AOD!

--- a/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
@@ -1,7 +1,12 @@
 #include "CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 //
 // constructors and destructor
 //
+
+namespace {
+  constexpr float fakeBeamSpotTimeWidth = 0.175f;
+}
 
 TrackWithVertexSelector::TrackWithVertexSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector & iC) :
   numberOfValidHits_(iConfig.getParameter<uint32_t>("numberOfValidHits")),
@@ -18,9 +23,12 @@ TrackWithVertexSelector::TrackWithVertexSelector(const edm::ParameterSet& iConfi
   quality_(iConfig.getParameter<std::string>("quality")),
   nVertices_(iConfig.getParameter<bool>("useVtx") ? iConfig.getParameter<uint32_t>("nVertices") : 0),
   vertexToken_(iC.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"))),
+  timesToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timesTag"))),
+  timeResosToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timeResosTag"))),
   vtxFallback_(iConfig.getParameter<bool>("vtxFallback")),
   zetaVtx_(iConfig.getParameter<double>("zetaVtx")),
-  rhoVtx_(iConfig.getParameter<double>("rhoVtx")) {
+  rhoVtx_(iConfig.getParameter<double>("rhoVtx")),
+  nSigmaDtVertex_(iConfig.getParameter<double>("nSigmaDtVertex")) {
 }
 
 TrackWithVertexSelector::~TrackWithVertexSelector() {  }
@@ -30,8 +38,15 @@ void TrackWithVertexSelector::init(const edm::Event & event) {
     edm::Handle<reco::VertexCollection> hVtx;
     event.getByToken(vertexToken_, hVtx);
     vcoll_ = hVtx.product();
-}
 
+    edm::Handle<edm::ValueMap<float> > hTimes;
+    event.getByToken(timesToken_, hTimes);
+    timescoll_ = hTimes.isValid() ? hTimes.product() : nullptr;
+
+    edm::Handle<edm::ValueMap<float> > hTimeResos;
+    event.getByToken(timeResosToken_, hTimeResos);
+    timeresoscoll_ = hTimeResos.isValid() ? hTimeResos.product() : nullptr;
+}
 
 bool TrackWithVertexSelector::testTrack(const reco::Track &t) const {
   using std::abs;
@@ -41,8 +56,8 @@ bool TrackWithVertexSelector::testTrack(const reco::Track &t) const {
       (t.normalizedChi2()    <= normalizedChi2_) &&
       (t.ptError()/t.pt()*std::max(1.,t.normalizedChi2()) <= ptErrorCut_) &&
       (t.quality(t.qualityByName(quality_))) &&
-      (t.pt()         >= ptMin_)      &&
-      (t.pt()         <= ptMax_)      &&
+      (t.pt()              >= ptMin_)      &&
+      (t.pt()              <= ptMax_)      &&
       (abs(t.eta())   <= etaMax_)     &&
       (abs(t.eta())   >= etaMin_)     &&
       (abs(t.dz())    <= dzMax_)      &&
@@ -52,14 +67,52 @@ bool TrackWithVertexSelector::testTrack(const reco::Track &t) const {
   return false;
 }
 
-bool TrackWithVertexSelector::testVertices(const reco::Track &t, const reco::VertexCollection &vtxs) const {
+bool TrackWithVertexSelector::testTrack(const reco::TrackRef &tref) const {
+  return testTrack(*tref);
+}
+
+bool TrackWithVertexSelector::testVertices(const reco::Track& t, const reco::VertexCollection &vtxs) const {
   bool ok = false;
   if (vtxs.size() > 0) {
     unsigned int tested = 1;
     for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end();
 	 it != ed; ++it) {
-      if ((std::abs(t.dxy(it->position())) < rhoVtx_) &&
-          (std::abs(t.dz(it->position())) < zetaVtx_)) {
+      if ( (std::abs(t.dxy(it->position())) < rhoVtx_) &&
+           (std::abs(t.dz(it->position())) < zetaVtx_)  ) {
+        ok = true; break;
+      }
+      if (tested++ >= nVertices_) break;
+    }
+  } else if (vtxFallback_) {
+    return ( (std::abs(t.vertex().z()) < 15.9) && (t.vertex().Rho() < 0.2) );
+  }
+  return ok;
+}
+
+bool TrackWithVertexSelector::testVertices(const reco::TrackRef &tref, const reco::VertexCollection &vtxs) const {
+  const auto& t = *tref;
+  const bool timeAvailable = timescoll_ != nullptr && timeresoscoll_ != nullptr;
+  bool ok = false;
+  if (vtxs.size() > 0) {
+    unsigned int tested = 1;
+    for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end();
+	 it != ed; ++it) {
+      const bool useTime = timeAvailable && it->t() != 0.;
+      float time = useTime ? (*timescoll_)[tref] : -1.f;
+      float timeReso = useTime ? (*timeresoscoll_)[tref] : -1.f;
+      timeReso = ( timeReso > 1e-6 ? timeReso : fakeBeamSpotTimeWidth );
+
+      if( edm::isNotFinite(time) ) {
+	time = 0.0;
+	timeReso = 2.0*fakeBeamSpotTimeWidth;
+      }
+
+      const double vtxSigmaT2 = it->tError() * it->tError();
+      const double vtxTrackErr = std::sqrt( vtxSigmaT2 + timeReso*timeReso );
+
+      if ( (std::abs(t.dxy(it->position())) < rhoVtx_) &&
+           (std::abs(t.dz(it->position())) < zetaVtx_) &&
+	   ( !useTime || (std::abs(time - it->t())/vtxTrackErr < nSigmaDtVertex_) ) ) {
         ok = true; break;
       }
       if (tested++ >= nVertices_) break;
@@ -74,5 +127,11 @@ bool TrackWithVertexSelector::operator()(const reco::Track &t) const {
   if (!testTrack(t)) return false;
   if (nVertices_ == 0) return true;
   return testVertices(t, *vcoll_);
+}
+
+bool TrackWithVertexSelector::operator()(const reco::TrackRef &tref) const {
+  if (!testTrack(tref)) return false;
+  if (nVertices_ == 0) return true;
+  return testVertices(tref, *vcoll_);
 }
 

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
@@ -32,7 +32,7 @@ struct SingleElementCollectionSelectorPlusEvent {
   void select(const edm::Handle<InputCollection> & c, const edm::Event &ev, const edm::EventSetup &) {
     selected_.clear();
     for(size_t idx = 0; idx < c->size(); ++ idx) {
-      if(select_((*c)[idx], ev))
+      if(select_( edm::Ref<InputCollection>(c,idx), ev) ) //(*c)[idx]
 	addRef_(selected_, c, idx);
     }
   }


### PR DESCRIPTION
Adds in the capability for making timing cuts in track selector modules via a ref.
Automatically ported from CMSSW_8_1_X #16500 (original by @lgray).