### PR TITLE
Pixel Phase I - CA - improving fake rejection at high pt

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -168,7 +168,14 @@ public:
         float tan_12_13_half_mul_distance_13_squared = fabs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
         if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4f*distance_13_squared)
         {
-        	return true;
+        	
+            float distance_3_beamspot_squared = (x3-region_origin_x) * (x3-region_origin_x) + (y3-region_origin_y) * (y3-region_origin_y);
+         
+            float dot_13_bs3_squared = (x1 - x3)*(x3 - region_origin_x) + (y1 - y3) * (y3 - region_origin_y);
+            float distance_13_beamspot_squared  = distance_3_beamspot_squared -  dot_13_bs3_squared;
+         
+            if(distance_13_beamspot_squared < (region_origin_radius+phiCut)*(region_origin_radius+phiCut) )        	
+                return true;
 
         }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -168,14 +168,16 @@ public:
         float tan_12_13_half_mul_distance_13_squared = fabs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
         if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4f*distance_13_squared)
         {
-        	
+
             float distance_3_beamspot_squared = (x3-region_origin_x) * (x3-region_origin_x) + (y3-region_origin_y) * (y3-region_origin_y);
-         
-            float dot_13_bs3_squared = (x1 - x3)*(x3 - region_origin_x) + (y1 - y3) * (y3 - region_origin_y);
-            float distance_13_beamspot_squared  = distance_3_beamspot_squared -  dot_13_bs3_squared;
-         
-            if(distance_13_beamspot_squared < (region_origin_radius+phiCut)*(region_origin_radius+phiCut) )        	
-                return true;
+
+            float dot_bs3_13 = ((x1 - x3)*( region_origin_x - x3) + (y1 - y3) * (region_origin_y-y3));
+            float proj_bs3_on_13_squared = dot_bs3_13*dot_bs3_13/distance_13_squared;
+
+            float distance_13_beamspot_squared  = distance_3_beamspot_squared -  proj_bs3_on_13_squared;
+
+            if(distance_13_beamspot_squared > (region_origin_radius+phiCut)*(region_origin_radius+phiCut) )
+                return false;
 
         }
 


### PR DESCRIPTION
In the Cellular Automaton, we now require that, if two doublets are aligned in the xy-plane, they also have to be aligned with the beamspot ± (region radius + tolerance).
This has the effect of reducing the fake rate for pt > 10GeV/c, for quadruplets and especially for triplets.

@VinInn @rovere @makortel 
Automatically ported from CMSSW_8_1_X #16491 (original by @felicepantaleo).