### PR TITLE
HCAL 2017 HF TP dual-anode readout fixes.

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -595,16 +595,17 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             if (saturated) {
                output[ibin] = QIE10_MAX_LINEARIZATION_ET;
             } else {
-               // If both channels are valid, we cut the sum in half.
-               if (long_fiber_count == 2)
-                  long_fiber_val *= 0.5;
-               if (short_fiber_count == 2)
-                  short_fiber_val *= 0.5;
+               // if one of the dual anode read-outs is valid, double the
+               // energy of the remaining one
+               if (long_fiber_count == 1)
+                  long_fiber_val *= 2;
+               if (short_fiber_count == 1)
+                  short_fiber_val *= 2;
 
                auto sum = long_fiber_val + short_fiber_val;
                // If both towers are valid, we cut the sum in half
-               if (long_fiber_count > 0 and short_fiber_count > 0)
-                  sum *= 0.5;
+               if (long_fiber_count == 0 or short_fiber_count == 0)
+                  sum *= 2;
 
                output[ibin] += sum;
             }
@@ -628,7 +629,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
     }
 
     for (int bin = 0; bin < numberOfSamples_; ++bin) {
-       output[bin] = min({(unsigned int) QIE10_MAX_LINEARIZATION_ET, output[bin]});
+       output[bin] = min({(unsigned int) QIE10_MAX_LINEARIZATION_ET, output[bin]}) >> hf_lumi_shift;
     }
     std::vector<int> finegrain_converted;
     for (const auto& fg: finegrain)

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -595,15 +595,21 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             if (saturated) {
                output[ibin] = QIE10_MAX_LINEARIZATION_ET;
             } else {
-               // if one of the dual anode read-outs is valid, double the
-               // energy of the remaining one
+               // For details of the energy handling, see:
+               // https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12306
+               //
+               // If a channel for one fiber is invalid, use the value of the
+               // other channel (by doubling the sum) to calculate the
+               // energy in the fiber
                if (long_fiber_count == 1)
                   long_fiber_val *= 2;
                if (short_fiber_count == 1)
                   short_fiber_val *= 2;
 
                auto sum = long_fiber_val + short_fiber_val;
-               // If both towers are valid, we cut the sum in half
+               // Similar to above, if a fiber is invalid (i.e., both
+               // channels for the fiber invalid), substitute the value of
+               // the other fiber by doubling the sum.
                if (long_fiber_count == 0 or short_fiber_count == 0)
                   sum *= 2;
 


### PR DESCRIPTION
Fix the energy calculation to match firmware. Duplicate valid energies when one part of the readout fails, and shift over the lower energy bits properly.
Automatically ported from CMSSW_8_1_X #16464 (original by @matz-e).