### PR TITLE
increasing lumi range for 2016E relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -232,7 +232,7 @@ steps['RunZeroBias2016D']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016D-v2/RAW'
 steps['RunMuOnia2016D']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016D-v2/RAW',label='muOnia2016D',events=100000,location='STD', ls=Run2016D)}
 
 #### run2 2016E ####
-Run2016E={277069: [[81, 120]]}
+Run2016E={277069: [[81, 200]]}
 steps['RunHLTPhy2016E']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2016E-v2/RAW',label='hltPhy2016E',events=100000,location='STD', ls=Run2016E)}
 steps['RunDoubleEG2016E']={'INPUT':InputInfo(dataSet='/DoubleEG/Run2016E-v2/RAW',label='doubEG2016E',events=100000,location='STD', ls=Run2016E)}
 steps['RunDoubleMuon2016E']={'INPUT':InputInfo(dataSet='/DoubleMuon/Run2016E-v2/RAW',label='doubMu2016E',events=100000,location='STD', ls=Run2016E)}


### PR DESCRIPTION
I have increased the lumi range for 2016E relvals, following the discussion here:
https://github.com/cms-sw/cmssw/commit/e2f9d1516b182e94fe182184e8069b7793641e49#commitcomment-19659749

Automatically ported from CMSSW_8_1_X #16420 (original by @fabozzi).