### PR TITLE
Reclustering of SiPixelClusters

### DIFF
--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -68,7 +68,7 @@ public:
   typedef std::pair<PixelDigiIter,PixelDigiIter>   PixelDigiRange;
   
   
-  static constexpr unsigned int MAXSPAN=127;
+  static constexpr unsigned int MAXSPAN=255;
   static constexpr unsigned int MAXPOS=2047;
   
   /** Construct from a range of digis that form a cluster and from 

--- a/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
+++ b/DataFormats/SiPixelCluster/test/SiPixelCluster_t.cpp
@@ -5,7 +5,7 @@
 
 typedef SiPixelCluster::PixelPos PiPos;
 typedef SiPixelCluster::Pixel Pixel;
-#define MAXSPAN 127
+#define MAXSPAN 255
 
 template<int N>
 inline
@@ -62,10 +62,10 @@ int main() {
   bool ok=true;
 
   PiPos const normal[] = { {3,3}, {3,4}, {3,5}, {5,4} ,{4,7}, {5,5} };
-  PiPos const bigX[] = { {3,3}, {3,60}, {3,5}, {161,4} ,{162,62}, {162,5} };
-  PiPos const bigY[] = { {3,3}, {3,100}, {3,5}, {61,234} ,{62,102}, {45,65} };
+  PiPos const bigX[] = { {3,3}, {3,60}, {3,5}, {161,4} ,{162,62}, {262,5} };
+  PiPos const bigY[] = { {3,3}, {3,100}, {3,5}, {61,264} ,{62,102}, {45,65} };
   PiPos const ylarge[] = { {3,352}, {3,352}, {3,400}, {20,400} ,{40,363}, {62,350} };
-  PiPos const huge[] = { {3,3}, {3,332}, {3,400}, {201,400} ,{212,323}, {122,350} };
+  PiPos const huge[] = { {3,3}, {3,332}, {3,400}, {201,400} ,{262,323}, {122,350} };
 
   ok &=verify(normal,false,false);
   assert(ok);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
@@ -21,9 +21,9 @@ public:
   struct AccretionCluster {
     typedef unsigned short UShort;
     static constexpr UShort MAXSIZE = 256;
-    UShort adc[256];
-    UShort x[256];
-    UShort y[256];
+    UShort adc[MAXSIZE];
+    UShort x[MAXSIZE];
+    UShort y[MAXSIZE];
     UShort xmin=16000;
     UShort ymin=16000;
     unsigned int isize=0;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
@@ -16,6 +16,7 @@ class PixelGeomDetUnit;
 class PixelClusterizerBase {
 public:
   typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
+  typedef edmNew::DetSet<SiPixelCluster>::const_iterator    ClusterIterator;
 
   struct AccretionCluster {
     typedef unsigned short UShort;
@@ -53,6 +54,11 @@ public:
 				  const PixelGeomDetUnit * pixDet,
 				  const std::vector<short>& badChannels,
 				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) = 0;
+
+  virtual void clusterizeDetUnit( const edmNew::DetSet<SiPixelCluster> & input,
+                                  const PixelGeomDetUnit * pixDet,
+                                  const std::vector<short>& badChannels,
+                                  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) = 0;
 
   // Configure gain calibration service
   void setSiPixelGainCalibrationService( SiPixelGainCalibrationServiceBase* in){ 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
@@ -17,6 +17,33 @@ class PixelClusterizerBase {
 public:
   typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
 
+  struct AccretionCluster {
+    typedef unsigned short UShort;
+    static constexpr UShort MAXSIZE = 256;
+    UShort adc[256];
+    UShort x[256];
+    UShort y[256];
+    UShort xmin=16000;
+    UShort ymin=16000;
+    unsigned int isize=0;
+    unsigned int curr=0;
+
+    // stack interface (unsafe ok for use below)
+    UShort top() const { return curr;}
+    void pop() { ++curr;}
+    bool empty() { return curr==isize;}
+
+    bool add(SiPixelCluster::PixelPos const & p, UShort const iadc) {
+      if (isize==MAXSIZE) return false;
+      xmin=std::min(xmin,(unsigned short)(p.row()));
+      ymin=std::min(ymin,(unsigned short)(p.col()));
+      adc[isize]=iadc;
+      x[isize]=p.row();
+      y[isize++]=p.col();
+      return true;
+    }
+  };
+
   // Virtual destructor, this is a base class.
   virtual ~PixelClusterizerBase() {}
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -43,32 +43,21 @@ using namespace std;
 //----------------------------------------------------------------------------
 PixelThresholdClusterizer::PixelThresholdClusterizer
   (edm::ParameterSet const& conf) :
-    bufferAlreadySet(false), theNumOfRows(0), theNumOfCols(0), detid_(0) 
+    bufferAlreadySet(false),
+    // Get thresholds in electrons
+    thePixelThreshold( conf.getParameter<int>("ChannelThreshold") ),
+    theSeedThreshold( conf.getParameter<int>("SeedThreshold") ),
+    theClusterThreshold( conf.getParameter<double>("ClusterThreshold") ),
+    theConversionFactor( conf.getParameter<int>("VCaltoElectronGain") ),
+    theOffset( conf.getParameter<int>("VCaltoElectronOffset") ),
+    theStackADC_( conf.exists("AdcFullScaleStack") ? conf.getParameter<int>("AdcFullScaleStack") : 255 ),
+    theFirstStack_( conf.exists("FirstStackLayer") ? conf.getParameter<int>("FirstStackLayer") : 5 ),
+    theElectronPerADCGain_( conf.exists("ElectronPerADCGain") ? conf.getParameter<double>("ElectronPerADCGain") : 135. ),
+    theNumOfRows(0), theNumOfCols(0), detid_(0),
+    // Get the constants for the miss-calibration studies
+    doMissCalibrate( conf.getUntrackedParameter<bool>("MissCalibrate",true) ),
+    doSplitClusters( conf.getParameter<bool>("SplitClusters") )
 {
-  // Get thresholds in electrons
-  thePixelThreshold   = 
-    conf.getParameter<int>("ChannelThreshold");
-  theSeedThreshold    = 
-    conf.getParameter<int>("SeedThreshold");
-  theClusterThreshold = 
-    conf.getParameter<double>("ClusterThreshold");
-  theConversionFactor = 
-    conf.getParameter<int>("VCaltoElectronGain");
-  theOffset = 
-    conf.getParameter<int>("VCaltoElectronOffset");
-  if ( conf.exists("AdcFullScaleStack") ) theStackADC_=conf.getParameter<int>("AdcFullScaleStack");
-  else 
-    theStackADC_=255;
-  if ( conf.exists("FirstStackLayer") ) theFirstStack_=conf.getParameter<int>("FirstStackLayer");
-  else
-    theFirstStack_=5;
-  if ( conf_.exists("ElectronPerADCGain") ) theElectronPerADCGain_=conf_.getParameter<double>("ElectronPerADCGain");
-  else
-    theElectronPerADCGain_=135.;
-  
-  // Get the constants for the miss-calibration studies
-  doMissCalibrate=conf.getUntrackedParameter<bool>("MissCalibrate",true); 
-  doSplitClusters = conf.getParameter<bool>("SplitClusters");
   theBuffer.setSize( theNumOfRows, theNumOfCols );
 }
 /////////////////////////////////////////////////////////////////////////////

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -265,7 +265,7 @@ void PixelThresholdClusterizer::copy_to_buffer( ClusterIterator begin, ClusterIt
       int col = pixel.y;
       int adc = pixel.adc;
       if ( adc >= thePixelThreshold) {
-        theBuffer.set_adc( row, col, adc);
+        theBuffer.add_adc( row, col, adc);
         if ( adc >= theSeedThreshold) theSeeds.push_back( SiPixelCluster::PixelPos(row,col) );
       }
     }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -195,7 +195,8 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
     // std::cout << (doMissCalibrate ? "VI from db" : "VI linear") << std::endl;
   }
 #endif
-  int electron[end-begin] = {0};
+  int electron[end-begin];
+  memset(electron, 0, sizeof(electron));
   if ( doMissCalibrate ) {
     (*theSiPixelGainCalibrationService_).calibrate(detid_,begin,end,theConversionFactor, theOffset,electron);
   } else {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -312,38 +312,6 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
   return electrons;
 }
 
-
-namespace {
-
-  struct AccretionCluster {
-    typedef unsigned short UShort;
-    static constexpr UShort MAXSIZE = 256;
-    UShort adc[256];
-    UShort x[256];
-    UShort y[256];
-    UShort xmin=16000;
-    UShort ymin=16000;
-    unsigned int isize=0;
-    unsigned int curr=0;
-
-    // stack interface (unsafe ok for use below)
-    UShort top() const { return curr;}
-    void pop() { ++curr;}   
-    bool empty() { return curr==isize;}
-
-    bool add(SiPixelCluster::PixelPos const & p, UShort const iadc) {
-      if (isize==MAXSIZE) return false;
-      xmin=std::min(xmin,(unsigned short)(p.row()));
-      ymin=std::min(ymin,(unsigned short)(p.col()));
-      adc[isize]=iadc;
-      x[isize]=p.row();
-      y[isize++]=p.col();
-      return true;
-    }
-  };
-
-}
-
 //----------------------------------------------------------------------------
 //!  \brief The actual clustering algorithm: group the neighboring pixels around the seed.
 //----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -195,7 +195,7 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
     // std::cout << (doMissCalibrate ? "VI from db" : "VI linear") << std::endl;
   }
 #endif
-  int electron[end-begin];
+  int electron[end-begin] = {0};
   if ( doMissCalibrate ) {
     (*theSiPixelGainCalibrationService_).calibrate(detid_,begin,end,theConversionFactor, theOffset,electron);
   } else {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -43,23 +43,23 @@ using namespace std;
 //----------------------------------------------------------------------------
 PixelThresholdClusterizer::PixelThresholdClusterizer
   (edm::ParameterSet const& conf) :
-    conf_(conf), bufferAlreadySet(false), theNumOfRows(0), theNumOfCols(0), detid_(0) 
+    bufferAlreadySet(false), theNumOfRows(0), theNumOfCols(0), detid_(0) 
 {
   // Get thresholds in electrons
   thePixelThreshold   = 
-    conf_.getParameter<int>("ChannelThreshold");
+    conf.getParameter<int>("ChannelThreshold");
   theSeedThreshold    = 
-    conf_.getParameter<int>("SeedThreshold");
+    conf.getParameter<int>("SeedThreshold");
   theClusterThreshold = 
-    conf_.getParameter<double>("ClusterThreshold");
+    conf.getParameter<double>("ClusterThreshold");
   theConversionFactor = 
-    conf_.getParameter<int>("VCaltoElectronGain");
+    conf.getParameter<int>("VCaltoElectronGain");
   theOffset = 
-    conf_.getParameter<int>("VCaltoElectronOffset");
-  if ( conf_.exists("AdcFullScaleStack") ) theStackADC_=conf_.getParameter<int>("AdcFullScaleStack");
+    conf.getParameter<int>("VCaltoElectronOffset");
+  if ( conf.exists("AdcFullScaleStack") ) theStackADC_=conf.getParameter<int>("AdcFullScaleStack");
   else 
     theStackADC_=255;
-  if ( conf_.exists("FirstStackLayer") ) theFirstStack_=conf_.getParameter<int>("FirstStackLayer");
+  if ( conf.exists("FirstStackLayer") ) theFirstStack_=conf.getParameter<int>("FirstStackLayer");
   else
     theFirstStack_=5;
   if ( conf_.exists("ElectronPerADCGain") ) theElectronPerADCGain_=conf_.getParameter<double>("ElectronPerADCGain");
@@ -67,7 +67,7 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
     theElectronPerADCGain_=135.;
   
   // Get the constants for the miss-calibration studies
-  doMissCalibrate=conf_.getUntrackedParameter<bool>("MissCalibrate",true); 
+  doMissCalibrate=conf.getUntrackedParameter<bool>("MissCalibrate",true); 
   doSplitClusters = conf.getParameter<bool>("SplitClusters");
   theBuffer.setSize( theNumOfRows, theNumOfCols );
 }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -88,33 +88,33 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   float theSeedThresholdInNoiseUnits;     // Pixel cluster seed in units of noise
   float theClusterThresholdInNoiseUnits;  // Cluster threshold in units of noise
 
-  int   thePixelThreshold;  // Pixel threshold in electrons
-  int   theSeedThreshold;   // Seed threshold in electrons 
-  float theClusterThreshold;  // Cluster threshold in electrons
-  int   theConversionFactor;  // adc to electron conversion factor
-  int   theOffset;            // adc to electron conversion offset
+  const int   thePixelThreshold;  // Pixel threshold in electrons
+  const int   theSeedThreshold;   // Seed threshold in electrons
+  const float theClusterThreshold;  // Cluster threshold in electrons
+  const int   theConversionFactor;  // adc to electron conversion factor
+  const int   theOffset;            // adc to electron conversion offset
+
+  const int   theStackADC_;          // The maximum ADC count for the stack layers
+  const int   theFirstStack_;        // The index of the first stack layer
+  const double theElectronPerADCGain_;  //  ADC to electrons conversion
 
   //! Geometry-related information
   int  theNumOfRows;
   int  theNumOfCols;
   uint32_t detid_;
   bool dead_flag;
-  bool doMissCalibrate; // Use calibration or not
-  bool doSplitClusters;
+  const bool doMissCalibrate; // Use calibration or not
+  const bool doSplitClusters;
   //! Private helper methods:
   bool setup(const PixelGeomDetUnit * pixDet);
   void copy_to_buffer( DigiIterator begin, DigiIterator end );   
   void copy_to_buffer( ClusterIterator begin, ClusterIterator end );
   void clear_buffer( DigiIterator begin, DigiIterator end );
   void clear_buffer( ClusterIterator begin, ClusterIterator end );
-  SiPixelCluster make_cluster( const SiPixelCluster::PixelPos& pix, edmNew::DetSetVector<SiPixelCluster>::FastFiller& output
-);
+  SiPixelCluster make_cluster( const SiPixelCluster::PixelPos& pix, edmNew::DetSetVector<SiPixelCluster>::FastFiller& output);
   // Calibrate the ADC charge to electrons 
   int calibrate(int adc, int col, int row);
-  int   theStackADC_;          // The maximum ADC count for the stack layers
-  int   theFirstStack_;        // The index of the first stack layer
 
-  double theElectronPerADCGain_;  //  ADC to electrons conversion
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -63,11 +63,19 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   void clusterizeDetUnit( const edm::DetSet<PixelDigi> & input,	
 				  const PixelGeomDetUnit * pixDet,
 				  const std::vector<short>& badChannels,
-				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output
-);
+				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, badChannels, output); }
+  void clusterizeDetUnit( const edmNew::DetSet<SiPixelCluster> & input,
+                          const PixelGeomDetUnit * pixDet,
+                          const std::vector<short>& badChannels,
+                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, badChannels, output); }
 
-  
  private:
+
+  template<typename T>
+  void clusterizeDetUnitT( const T & input,
+                           const PixelGeomDetUnit * pixDet,
+                           const std::vector<short>& badChannels,
+                           edmNew::DetSetVector<SiPixelCluster>::FastFiller& output);
 
   //! Data storage
   SiPixelArrayBuffer               theBuffer;         // internal nrow * ncol matrix
@@ -96,7 +104,9 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   //! Private helper methods:
   bool setup(const PixelGeomDetUnit * pixDet);
   void copy_to_buffer( DigiIterator begin, DigiIterator end );   
-  void clear_buffer( DigiIterator begin, DigiIterator end );   
+  void copy_to_buffer( ClusterIterator begin, ClusterIterator end );
+  void clear_buffer( DigiIterator begin, DigiIterator end );
+  void clear_buffer( ClusterIterator begin, ClusterIterator end );
   SiPixelCluster make_cluster( const SiPixelCluster::PixelPos& pix, edmNew::DetSetVector<SiPixelCluster>::FastFiller& output
 );
   // Calibrate the ADC charge to electrons 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -69,8 +69,6 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   
  private:
 
-  edm::ParameterSet conf_;
-
   //! Data storage
   SiPixelArrayBuffer               theBuffer;         // internal nrow * ncol matrix
   bool                             bufferAlreadySet;  // status of the buffer array

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
@@ -39,6 +39,7 @@ class SiPixelArrayBuffer
   inline bool inside(int row, int col) const;
   inline void set_adc( int row, int col, int adc);
   inline void set_adc( const SiPixelCluster::PixelPos&, int adc);
+  inline void add_adc( int row, int col, int adc);
   int size() const { return pixel_vec.size();}
 
   /// Definition of indexing within the buffer.
@@ -87,5 +88,9 @@ void SiPixelArrayBuffer::set_adc( const SiPixelCluster::PixelPos& pix, int adc)
   pixel_vec[index(pix)] = adc;
 }
 
+void SiPixelArrayBuffer::add_adc( int row, int col, int adc)
+{
+  pixel_vec[index(row,col)] += adc;
+}
 
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -48,7 +48,6 @@
   //---------------------------------------------------------------------------
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
-    conf_(conf),
     theSiPixelGainCalibration_(0), 
     clusterMode_("None"),     // bogus
     clusterizer_(0),          // the default, in case we fail to make one
@@ -56,6 +55,8 @@
     src_( conf.getParameter<edm::InputTag>( "src" ) ),
     maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) )
   {
+    clusterMode_ = conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer");
+
     tPixelDigi = consumes<edm::DetSetVector<PixelDigi>>(src_);
     //--- Declare to the EDM what kind of collections we will be making.
     produces<SiPixelClusterCollectionNew>(); 
@@ -71,7 +72,7 @@
 
     //--- Make the algorithm(s) according to what the user specified
     //--- in the ParameterSet.
-    setupClusterizer();
+    setupClusterizer(conf);
 
   }
 
@@ -119,12 +120,10 @@
   //!  TO DO: in the future, we should allow for a different algorithm for 
   //!  each detector subset (e.g. barrel vs forward, per layer, etc).
   //---------------------------------------------------------------------------
-  void SiPixelClusterProducer::setupClusterizer()  {
-    clusterMode_ = 
-      conf_.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer");
+  void SiPixelClusterProducer::setupClusterizer(const edm::ParameterSet& conf)  {
 
     if ( clusterMode_ == "PixelThresholdClusterizer" ) {
-      clusterizer_ = new PixelThresholdClusterizer(conf_);
+      clusterizer_ = new PixelThresholdClusterizer(conf);
       clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_);
       readyToCluster_ = true;
     } 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -49,13 +49,12 @@
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
     theSiPixelGainCalibration_(0), 
-    clusterMode_("None"),     // bogus
+    clusterMode_( conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer") ),
     clusterizer_(0),          // the default, in case we fail to make one
     readyToCluster_(false),   // since we obviously aren't
-    maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) )
+    maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) ),
+    payloadType_( conf.getParameter<std::string>( "payloadType" ) )
   {
-    clusterMode_ = conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer");
-
     if ( clusterMode_ == "PixelThresholdReclusterizer" )
       tPixelClusters = consumes<SiPixelClusterCollectionNew>( conf.getParameter<edm::InputTag>("src") );
     else
@@ -63,13 +62,11 @@
     //--- Declare to the EDM what kind of collections we will be making.
     produces<SiPixelClusterCollectionNew>(); 
 
-    std::string payloadType = conf.getParameter<std::string>( "payloadType" );
-
-    if (strcmp(payloadType.c_str(), "HLT") == 0)
+    if (strcmp(payloadType_.c_str(), "HLT") == 0)
        theSiPixelGainCalibration_ = new SiPixelGainCalibrationForHLTService(conf);
-    else if (strcmp(payloadType.c_str(), "Offline") == 0)
+    else if (strcmp(payloadType_.c_str(), "Offline") == 0)
        theSiPixelGainCalibration_ = new SiPixelGainCalibrationOfflineService(conf);
-    else if (strcmp(payloadType.c_str(), "Full") == 0)
+    else if (strcmp(payloadType_.c_str(), "Full") == 0)
        theSiPixelGainCalibration_ = new SiPixelGainCalibrationService(conf);
 
     //--- Make the algorithm(s) according to what the user specified

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -61,18 +61,19 @@
     virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     //--- Execute the algorithm(s).
-    void run(const edm::DetSetVector<PixelDigi>   & input,
-	     edm::ESHandle<TrackerGeometry>       & geom,
+    template<typename T>
+    void run(const T                              & input,
+             const edm::ESHandle<TrackerGeometry> & geom,
              edmNew::DetSetVector<SiPixelCluster> & output);
 
   private:
+    edm::EDGetTokenT<SiPixelClusterCollectionNew>  tPixelClusters;
     edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
     // TO DO: maybe allow a map of pointers?
     SiPixelGainCalibrationServiceBase * theSiPixelGainCalibration_;
     std::string clusterMode_;               // user's choice of the clusterizer
     PixelClusterizerBase * clusterizer_;    // what we got (for now, one ptr to base class)
     bool readyToCluster_;                   // needed clusterizers valid => good to go!
-    edm::InputTag src_;
 
     //! Optional limit on the total number of clusters
     int32_t maxTotalClusters_;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -55,7 +55,7 @@
     explicit SiPixelClusterProducer(const edm::ParameterSet& conf);
     virtual ~SiPixelClusterProducer();
 
-    void setupClusterizer();
+    void setupClusterizer(const edm::ParameterSet& conf);
 
     //--- The top-level event method.
     virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
@@ -66,7 +66,6 @@
              edmNew::DetSetVector<SiPixelCluster> & output);
 
   private:
-    edm::ParameterSet conf_;
     edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
     // TO DO: maybe allow a map of pointers?
     SiPixelGainCalibrationServiceBase * theSiPixelGainCalibration_;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -71,12 +71,14 @@
     edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
     // TO DO: maybe allow a map of pointers?
     SiPixelGainCalibrationServiceBase * theSiPixelGainCalibration_;
-    std::string clusterMode_;               // user's choice of the clusterizer
+    const std::string clusterMode_;         // user's choice of the clusterizer
     PixelClusterizerBase * clusterizer_;    // what we got (for now, one ptr to base class)
     bool readyToCluster_;                   // needed clusterizers valid => good to go!
 
     //! Optional limit on the total number of clusters
-    int32_t maxTotalClusters_;
+    const int32_t maxTotalClusters_;
+
+    const std::string payloadType_;
   };
 
 


### PR DESCRIPTION
This PR adds the necessary code to allow reclustering of already clustered SiPixelClusters. Its primary use case is to remake the pre-splitting SiPixelClusters from the split ones to allow re-running of the tracking sequence from the RECO data tier.

This PR slightly modifies the SiPixelCluster DataFormat code but without changing the format version. The only effect will be a slight increase in the size of the `siPixelClusters` collection. All other objects downstream from the pixel clusters should remain unchanged.

**Update (Nov. 7, 2016):** Rebased to CMSSW_8_1_X_2016-11-07-1100
Automatically ported from CMSSW_8_1_X #16393 (original by @ferencek).