### PR TITLE
[PhysicsTools/FWLite] Solve warning found by gcc 5.3.0

### DIFF
--- a/PhysicsTools/FWLite/src/CommandLineParser.cc
+++ b/PhysicsTools/FWLite/src/CommandLineParser.cc
@@ -752,7 +752,7 @@ CommandLineParser::_getSectionFiles (const SVec &inputList, SVec &outputList,
 void 
 CommandLineParser::_finishDefaultOptions (std::string tag)
 {
-   if (! m_optionsType & kEventContOpt)
+   if ((! m_optionsType) & kEventContOpt)
    {
       // nothing to see here, folks
       return;


### PR DESCRIPTION
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc530/CMSSW_8_1_X_2016-03-02-1100/PhysicsTools/FWLite
The behavior is unchanged, the parentheses makes clear the order of the logical operation while suppressing the warning.

Automatically ported from CMSSW_8_1_X #13574 (original by @degano).