### PR TITLE
[90X] update dataRun2 GT with conditions for Sept2016 re-reco

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,11 +22,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '81X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v10',
+    'run1_data'         :   '81X_dataRun2_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v10',
+    'run2_data'         :   '81X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v13',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v14',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII data 
 
   * **RunII Offline processing** : [81X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v11) as [81X_dataRun2_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v11/81X_dataRun2_v10): with updates of Sept2016 re-reco:
      * updated Tracker Alignment 
      * updated Tracker Surface deformations
      * update LS based Beamspot because of new alignment
      * updated CSC and DT alignment errors to use offline versions
      * updated ES and Ecal channel status
      * updated Hcal channel status
      * updated Ecal ADC2GeV
      * updated Ecal laser corrections
      * updated Ecal pulse shapes
      * updated Hcal response corrections
 
   * **RunII Offline relval processing** : [81X_dataRun2_relval_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v14) as [81X_dataRun2_relval_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v14/81X_dataRun2_relval_v13): 
      * updated Tracker Alignment 
      * updated Tracker Surface deformations
      * update LS based Beamspot because of new alignment
      * updated CSC and DT alignment errors to use offline versions
      * updated ES and Ecal channel status
      * updated Hcal channel status
      * updated Ecal ADC2GeV
      * updated Ecal laser corrections
      * updated Ecal pulse shapes
      * updated Hcal response corrections