### PR TITLE
Fix MultiTrackValidator MVA monitoring (81X)

### DIFF
--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -143,9 +143,14 @@ def createEarlySequence(eraName, postfix, modDict):
         seq += modDict[it]
     return seq
 
-def iterationAlgos(postfix):
+def iterationAlgos(postfix, includeSequenceName=False):
     muonVariable = "_iterations_muonSeeded"+postfix
-    return [_modulePrefix(i) for i in globals()["_iterations"+postfix] + globals().get(muonVariable, _iterations_muonSeeded)]
+    iterations = globals()["_iterations"+postfix] + globals().get(muonVariable, _iterations_muonSeeded)
+
+    if includeSequenceName:
+        return [(_modulePrefix(i), i) for i in iterations]
+    else:
+        return [_modulePrefix(i) for i in iterations]
 
 def _seedOrTrackProducers(postfix, typ):
     ret = []

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -195,15 +195,23 @@ for _eraName, _postfix, _era in _relevantEras:
     locals()["_seedingLayerSets"+_postfix] = _getSeedingLayers(locals()["_seedProducers"+_postfix])
 
 # MVA selectors
-def _getMVASelectors(iterations):
+def _getMVASelectors(postfix):
     import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
 
     # assume naming convention that the iteration name (when first
     # letter in lower case) is the selector name
     pset = cms.untracked.PSet()
-    for iterName in iterations:
+    for iterName, seqName in _cfg.iterationAlgos(postfix, includeSequenceName=True):
         if hasattr(_iterativeTk_cff, iterName):
             mod = getattr(_iterativeTk_cff, iterName)
+            seq = getattr(_iterativeTk_cff, seqName)
+
+            # Ignore iteration if the MVA selector module is not in the sequence
+            try:
+                print seq.index(mod)
+            except:
+                continue
+
             typeName = mod._TypedParameterizable__type
             classifiers = []
             if typeName == "ClassifierMerger":
@@ -215,7 +223,7 @@ def _getMVASelectors(iterations):
 
     return pset
 for _eraName, _postfix, _era in _relevantEras:
-    locals()["_mvaSelectors"+_postfix] = _getMVASelectors(_cfg.iterationAlgos(_postfix))
+    locals()["_mvaSelectors"+_postfix] = _getMVASelectors(_postfix)
 
 # Validation iterative steps
 _sequenceForEachEra(_addSelectorsByAlgo, args=["_algos"], names="_selectorsByAlgo", sequence="_tracksValidationSelectorsByAlgo", modDict=globals())

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -208,7 +208,7 @@ def _getMVASelectors(postfix):
 
             # Ignore iteration if the MVA selector module is not in the sequence
             try:
-                print seq.index(mod)
+                seq.index(mod)
             except:
                 continue
 


### PR DESCRIPTION
Backport of #16660 (submitting to 81X to fix workflows being run in IB):

This PR fixes a bug introduced in #16559. The logic inferring the track MVA selector names missed a check that the MVA selector is part of the iteration sequence. This omission lead errors for tracking eras without MVA selection (`trackingLowPU`, `trackingPhase1PU70`, `trackingPhase2PU140`) in trackingOnly workflows. The check is added here.

Tested in CMSSW_8_1_X_2016-11-15-2300, no changes expected in non-trackingOnly workflows, or in trackingOnly workflows with run2 or `trackingPhase1` tracking.

@rovere @VinInn 