### PR TITLE
Improvements for upgrade matrix

### DIFF
--- a/Configuration/Generator/python/QCD_Pt_600_800_14TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_600_800_14TeV_TuneCUETP8M1_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(14000.0),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'HardQCD:all = on',
+            'PhaseSpace:pTHatMin = 600.',
+            'PhaseSpace:pTHatMax = 800.'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters',
+                                    )
+        )
+                         )

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -13,12 +13,10 @@ workflows = Matrix()
 
 #just define all of them
 
-numWFStart=10000
-numWFSkip=200
 #2017 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 numWFIB = [10021.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0]
 for i,key in enumerate(upgradeKeys[2017]):
-    numWF=numWFStart+i*numWFSkip
+    numWF=numWFAll[2017][i]
     for frag in upgradeFragments:
         k=frag[:-4]+'_'+key
         stepList=[]

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -15,11 +15,12 @@ workflows = Matrix()
 numWFStart=20000
 numWFSkip=200
 #2023 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias)
-numWFIB = [20021.0,20024.0,20025.0,20026.0] #2023D1 scenario
-numWFIB.extend([20421.0,20424.0,20425.0,20426.0]) #2023D2
-numWFIB.extend([20821.0,20824.0,20825.0,20826.0]) #2023D3
-numWFIB.extend([21221.0,21224.0,21225.0,21226.0]) #2023D4
-numWFIB.extend([23224.0]) #2023D5
+numWFIB = [20021.0,20034.0,20046.0,20053.0] #2023D1 scenario
+numWFIB.extend([20421.0,20434.0,20446.0,20453.0]) #2023D2
+numWFIB.extend([20821.0,20834.0,20846.0,20853.0]) #2023D3
+numWFIB.extend([21221.0,21234.0,21246.0,21253.0]) #2023D4
+numWFIB.extend([23221.0,23234.0,23246.0,23253.0]) #2023D5
+numWFIB.extend([23621.0,23634.0,23646.0,23653.0]) #2023D6
 for i,key in enumerate(upgradeKeys[2023]):
     numWF=numWFStart+i*numWFSkip
     for frag in upgradeFragments:

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -12,8 +12,6 @@ workflows = Matrix()
 
 #just define all of them
 
-numWFStart=20000
-numWFSkip=200
 #2023 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias)
 numWFIB = [20021.0,20034.0,20046.0,20053.0] #2023D1 scenario
 numWFIB.extend([20421.0,20434.0,20446.0,20453.0]) #2023D2
@@ -22,7 +20,7 @@ numWFIB.extend([21221.0,21234.0,21246.0,21253.0]) #2023D4
 numWFIB.extend([23221.0,23234.0,23246.0,23253.0]) #2023D5
 numWFIB.extend([23621.0,23634.0,23646.0,23653.0]) #2023D6
 for i,key in enumerate(upgradeKeys[2023]):
-    numWF=numWFStart+i*numWFSkip
+    numWF=numWFAll[2023][i]
     for frag in upgradeFragments:
         k=frag[:-4]+'_'+key
         stepList=[]

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -35,7 +35,7 @@ for year in upgradeKeys:
             workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList]
 
             # special workflows for tracker
-            if upgradeDatasetFromFragment[frag]=="TTbar_13" and not 'PU' in key:
+            if (upgradeDatasetFromFragment[frag]=="TTbar_13" or upgradeDatasetFromFragment[frag]=="TTbar_14TeV") and not 'PU' in key:
                 stepListTk=[]
                 hasHarvest = False
                 for step in upgradeProperties[year][key]['ScenToRun']:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -13,15 +13,9 @@ workflows = Matrix()
 
 #just define all of them
 
-numWFStart={
-    2017: 10000,
-    2023: 20000,
-}
-numWFSkip=200
-
 for year in upgradeKeys:
     for i,key in enumerate(upgradeKeys[year]):
-        numWF=numWFStart[year]+i*numWFSkip
+        numWF=numWFAll[year][i]
         for frag in upgradeFragments:
             k=frag[:-4]+'_'+key
             stepList=[]

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -225,6 +225,7 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
                   'ZMM_14TeV_TuneCUETP8M1_cfi',
                   'QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff',
                   'H125GGgluonfusion_14TeV_TuneCUETP8M1_cfi',
+                  'QCD_Pt_600_800_14TeV_TuneCUETP8M1_cfi',
 ]
 
 howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
@@ -280,6 +281,7 @@ howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
            'ZMM_14TeV_TuneCUETP8M1_cfi':Kby(18,100),
            'QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff':Kby(9,50),
            'H125GGgluonfusion_14TeV_TuneCUETP8M1_cfi':Kby(9,50),
+           'QCD_Pt_600_800_14TeV_TuneCUETP8M1_cfi':Kby(9,50),
 }
 
 upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
@@ -335,4 +337,5 @@ upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
                             'ZMM_14TeV_TuneCUETP8M1_cfi' : 'ZMM_14',
                             'QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff' : 'QCD_Pt-15To7000_Flat_14TeV',
                             'H125GGgluonfusion_14TeV_TuneCUETP8M1_cfi' : 'H125GGgluonfusion_14',
+                            'QCD_Pt_600_800_14TeV_TuneCUETP8M1_cfi' : 'QCD_Pt_600_800_14',
 }

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -34,6 +34,27 @@ upgradeKeys[2023] = [
     '2023D6PU'
 ]
 
+# pre-generation of WF numbers
+numWFStart={
+    2017: 10000,
+    2023: 20000,
+}
+numWFSkip=200
+numWFConflict = [[25000,26000],[50000,51000]]
+numWFAll={
+    2017: [numWFStart[2017]],
+    2023: [numWFStart[2023]]
+}
+
+for year in upgradeKeys:
+    for i in range(1,len(upgradeKeys[year])):
+        numWFtmp = numWFAll[year][i-1] + numWFSkip
+        for conflict in numWFConflict:
+            if numWFtmp>=conflict[0] and numWFtmp<conflict[1]:
+                numWFtmp = conflict[1]
+                break
+        numWFAll[year].append(numWFtmp)
+
 upgradeSteps=[
     'GenSimFull',
     'GenSimHLBeamSpotFull',

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -59,9 +59,9 @@ if __name__ == '__main__':
                      135.4, #Run 2 Zee ttbar
                      10021.0, #2017 tenmu
                      10024.0, #2017 ttbar
-                     20024.0, #2023D1 ttbar (Run2 calo)
-                     23224.0, #2023D5 ttbar (HGCal + timing)
-		     21224.0, #2024D4 ttbar (TDR baseline Tracker)
+                     20034.0, #2023D1 ttbar (Run2 calo)
+                     23234.0, #2023D5 ttbar (HGCal + timing)
+                     21234.0, #2024D4 ttbar (TDR baseline Tracker)
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC


### PR DESCRIPTION
Changes:
1) Moved all 2023 PR/IB tests to 14 TeV processes
2) Added standard set of test WFs for D6 (and some for D5)
3) Added 14 TeV tracker validation WFs for ttbar
4) Centralized the calculation of upgrade WF numbers, and added ability to skip over conflicts with standard matrix WF numbers

I tested 4) by adding a bunch of fake upgrade keys and observed the intended numbering:
```
24853.0 QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D6PU6_GenSimHLBeamSpotFull14+DigiFull_2023D6PU6+RecoFullGlobal_2023D6PU6+HARVESTFullGlobal_2023D6PU6 
26000.0 FourMuPt_1_200_pythia8_2023D6PU7_GenSimHLBeamSpotFull+DigiFull_2023D6PU7+RecoFullGlobal_2023D6PU7+HARVESTFullGlobal_2023D6PU7 
```

attn: @slava77, @boudoul, @makortel 
This may cause some "missing matrix maps" when merged...
will be backported to 81X