### PR TITLE
[81X] update phase-I Simulation geometry

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v7',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v23',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v24',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
backport of #16671

# Summary of changes in Global Tags 
 
## Upgrade 
 
   * **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v24](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v24) as [81X_upgrade2017_realistic_v23](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v23) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v24/81X_upgrade2017_realistic_v23): 
      * improved simulation geometry: fix all remaining overlaps in Pixel support structure, subtraction with Union solid replacement in ES support structure
 
   * **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v8) as [81X_upgrade2017_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v8/81X_upgrade2017_design_IdealBS_v7): 
      * improved simulation geometry: fix all remaining overlaps in Pixel support structure, subtraction with Union solid replacement in ES support structure

@ianna this addresses [this request](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2752.html)