### PR TITLE
Remove obsolete customize cust_2023tilted from 2023D6 workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -145,7 +145,6 @@ upgradeProperties[2023] = {
         'Geom' : 'Extended2023D6',
         'GT' : 'auto:phase2_realistic',
         'HLTmenu': '@fake',
-        'Custom' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023tilted',
         'Era' : 'Phase2C1',
         'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
     }


### PR DESCRIPTION
Title says it all (commit picked from #16635).

The customize was removed in #16385, and the D6 workflows were added in #16185. I suspect their integration got somehow interleaved leading to the non-existing customize to stay in the workflow definition.

Tested in CMSSW_9_0_X_2016-11-17-2300, workflows `236xx` run again.

@kpedro88 @pietverwilligen 