### PR TITLE
Re-add eventSetupPathKey to ALCARECOLumiPixels

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOLumiPixelsMinBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, # choose logical OR between Triggerbits
+    eventSetupPathsKey='LumiPixels',
+    #HLTPaths = ['AlCa_LumiPixels_Random_*', 'AlCa_LumiPixels_ZeroBias_*'],
+    throw = False # tolerate triggers stated above, but not available
+)
+
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
 siPixelDigisForLumi = siPixelDigis.clone()
 siPixelDigisForLumi.InputLabel = cms.InputTag("hltFEDSelectorLumiPixels")
@@ -9,4 +17,4 @@ siPixelClustersForLumi = siPixelClustersPreSplitting.clone()
 siPixelClustersForLumi.src = cms.InputTag("siPixelDigisForLumi")
 
 # Sequence #
-seqALCARECOLumiPixels = cms.Sequence(siPixelDigisForLumi + siPixelClustersForLumi)
+seqALCARECOLumiPixels = cms.Sequence(ALCARECOLumiPixelsMinBiasHLT + siPixelDigisForLumi + siPixelClustersForLumi)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
-ALCARECOLumiPixelsMinBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+ALCARECOLumiPixelsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, # choose logical OR between Triggerbits
     eventSetupPathsKey='LumiPixels',
     #HLTPaths = ['AlCa_LumiPixels_Random_*', 'AlCa_LumiPixels_ZeroBias_*'],
@@ -17,4 +17,4 @@ siPixelClustersForLumi = siPixelClustersPreSplitting.clone()
 siPixelClustersForLumi.src = cms.InputTag("siPixelDigisForLumi")
 
 # Sequence #
-seqALCARECOLumiPixels = cms.Sequence(ALCARECOLumiPixelsMinBiasHLT + siPixelDigisForLumi + siPixelClustersForLumi)
+seqALCARECOLumiPixels = cms.Sequence(ALCARECOLumiPixelsHLT + siPixelDigisForLumi + siPixelClustersForLumi)


### PR DESCRIPTION
This PR allows the possibility to steer the selection of the trigger bits populating the `ALCARECOLumiPixels` ALCARECO via TriggerBit stored in DB.

This should solve the issue with the problematic version of the trigger: 
`AlCa_PAL1MinimumBiasHF_OR_SinglePixelTrack_v1` 
creating events with event content not manageable by the `ALCARECOLumiPixels` reported in: [HN link](https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1492.html) by filtering out the offending trigger with an appropriate DB payload.

Tested working via:

```
cmsrel CMSSW_8_0_24
cd CMSSW_8_0_24/src
git cms-init
git remote add cms-AlCaDB git@github.com:cms-AlCaDB/cmssw.git
git fetch cms-AlCaDB
git checkout 80X_addSetupPathKeyLumiPixels
git cms-addpkg Calibration/TkAlCaRecoProducers
git cms-addpkg Configuration/DataProcessing
scramv1 b -j 8
cd Configuration/DataProcessing/test/
python RunPromptReco.py --scenario AlCaLumiPixels --global-tag 80X_dataRun2_Prompt_v15 --lfn /store/hidata/PARun2016B/AlCaLumiPixels/RAW/v1/000/285/368/00000/7EC99302-E2AC-E611-A135-02163E01465B.root --reco --dqmio --alcarecos=LumiPixels
cmsRun RunPromptReco.py
```

attn: @trtomei @tocheng @capalmer85 