### PR TITLE
[81X] Re-add eventSetupPathKey to ALCARECOLumiPixels

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOLumiPixelsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, # choose logical OR between Triggerbits
+    eventSetupPathsKey='LumiPixels',
+    #HLTPaths = ['AlCa_LumiPixels_Random_*', 'AlCa_LumiPixels_ZeroBias_*'],
+    throw = False # tolerate triggers stated above, but not available
+)
+
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
 siPixelDigisForLumi = siPixelDigis.clone()
 siPixelDigisForLumi.InputLabel = cms.InputTag("hltFEDSelectorLumiPixels")
@@ -9,4 +17,4 @@ siPixelClustersForLumi = siPixelClustersPreSplitting.clone()
 siPixelClustersForLumi.src = cms.InputTag("siPixelDigisForLumi")
 
 # Sequence #
-seqALCARECOLumiPixels = cms.Sequence(siPixelDigisForLumi + siPixelClustersForLumi)
+seqALCARECOLumiPixels = cms.Sequence(ALCARECOLumiPixelsHLT + siPixelDigisForLumi + siPixelClustersForLumi)


### PR DESCRIPTION
This PR allows the possibility to steer the selection of the trigger bits populating the `ALCARECOLumiPixels` ALCARECO via TriggerBit stored in DB.

This should solve the issue with the problematic version of the trigger: 
`AlCa_PAL1MinimumBiasHF_OR_SinglePixelTrack_v1` 
creating events with event content not manageable by the `ALCARECOLumiPixels` reported in: [HN link](https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1492.html) by filtering out the offending trigger with an appropriate DB payload.

fwd-port of #16684