### PR TITLE
Condition access fix for Castor online DQM client

### DIFF
--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -28,35 +28,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 # Castor Conditions: from Global Conditions Tag 
 #============================================
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-#FIXME: they should use an official GT, not define custom records and conditions on their own!!!
-process.GlobalTag.toGet = cms.VPSet( cms.PSet( record = cms.string('CastorGainsRcd'),
-                                               tag = cms.string('CastorGains_v2.1_hlt'), 
-                                               ),
-                                     cms.PSet( record = cms.string('CastorSaturationCorrsRcd'),
-                                               tag = cms.string('CastorSaturationCorrs_v3.00_offline'),
-                                               ),
-                                     cms.PSet( record = cms.string('CastorPedestalWidthsRcd'),
-                                               tag = cms.string('CastorPedestalWidths_v3.00_offline'),
-                                               ),
-                                     cms.PSet( record = cms.string('CastorGainWidthsRcd'),
-                                               tag = cms.string('CastorGainWidths_v3.00_offline'),
-                                               ),
-                                     cms.PSet( record = cms.string('CastorQIEDataRcd'),
-                                               tag = cms.string('CastorQIEData_v3.00_offline'),
-                                               ),
-                                     cms.PSet( record = cms.string('CastorChannelQualityRcd'),
-                                               tag = cms.string('CastorChannelQuality_v3.00_offline'),
-                                               ),
-                                     cms.PSet( record = cms.string('CastorElectronicsMapRcd'),
-                                               tag = cms.string('CastorElectronicsMap_v3.00_offline'),
-                                               ),
-                                      )
-
-process.CastorDbProducer = cms.ESProducer("CastorDbProducer")
-
-##most likely the real fix:
-#process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-## Condition for lxplus: change and possibly customise the GT
+##
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 


### PR DESCRIPTION
The Castor online DQM application configured `DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py` now consumes all Castor related conditions by fetching them via the Global Tag centrally configured for online DQM.
Back-port of #16564 