### PR TITLE
[80X] allow multi-IOV input in the geometry centering tool

### DIFF
--- a/Alignment/TrackerAlignment/test/alignment_forGeomComp_cfg_TEMPLATE.py
+++ b/Alignment/TrackerAlignment/test/alignment_forGeomComp_cfg_TEMPLATE.py
@@ -79,6 +79,7 @@ process.AlignmentProducer.algoConfig = process.MillePedeAlignmentAlgorithm
 process.AlignmentProducer.algoConfig.mode = 'pedeRead'
 process.AlignmentProducer.algoConfig.treeFile = 'TREEFILE'
 process.AlignmentProducer.algoConfig.pedeReader.readFile = 'FILE_MUST_NOT_EXIST.res'
+process.AlignmentProducer.algoConfig.runAtPCL = True # dirty hack to allow feeding the algorithm multi-IOV DB input (restores behaviour previous to https://github.com/cms-sw/cmssw/pull/16136
 
 process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(RUNNUMBER) # choose your run!


### PR DESCRIPTION
Quick fix to restore multi-IOV capability to the geometry barycenter determination tool after #16136.
Since @ghellwig is going to provide more general treatment of the multi-IOV handling in the `MillePedeAlignmentAlgorithm` in 81X an 90X I am not forward-porting.