### PR TITLE
fix beamspot for 14TeV upgrade workflows in regular matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -26,6 +26,8 @@ for i,key in enumerate(upgradeKeys[2023]):
         stepList=[]
         for step in upgradeProperties[2023][key]['ScenToRun']:
             if 'Sim' in step:
+                if 'HLBeamSpotFull' in step and '14TeV' in frag:
+                    step = 'GenSimHLBeamSpotFull14'
                 stepList.append(k+'_'+step)
             else:
                 stepList.append(step+'_'+key)


### PR DESCRIPTION
@slava77 @lgray This fixes the issue noted in #16665. This commit will be added to the still-pending 81X version #16666.

```
runTheMatrix.py -w upgrade -n | grep 20034.0
20034.0 TTbar_14TeV_TuneCUETP8M1_2023D1_GenSimHLBeamSpotFull14+DigiFull_2023D1+RecoFullGlobal_2023D1+HARVESTFullGlobal_2023D1 
runTheMatrix.py -n | grep 20034.0
20034.0 TTbar_14TeV_TuneCUETP8M1_2023D1_GenSimHLBeamSpotFull14+DigiFull_2023D1+RecoFullGlobal_2023D1+HARVESTFullGlobal_2023D1 
```