### PR TITLE
Fix Phase2 memory corruption

### DIFF
--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -112,7 +112,8 @@ void HGCalTrackCollectionProducer::beginLuminosityBlock(const edm::LuminosityBlo
     const HGCalDDDConstants &dddCons=hgcGeometries_[i]->topology().dddConstants();
     std::map<float,float> zrhoCoord;
     std::map<float,float> innerRadiusCoord;
-    const auto& firstLayerIt = dddCons.getTrForms().back();
+    auto theTrForms = dddCons.getTrForms();
+    const auto& firstLayerIt = theTrForms.back();
     float Z(std::abs(firstLayerIt.h3v.z()));
     // use hardcoded radii for now (FIX ME)
     diskInnerRadius_ = 31.5;

--- a/Utilities/BinningTools/interface/GenericBinFinderInZ.h
+++ b/Utilities/BinningTools/interface/GenericBinFinderInZ.h
@@ -22,11 +22,13 @@ public:
     theNbins( last-first)
   {
     theBins.reserve(theNbins);
+    theBorders.reserve(theNbins-1);
     for (ConstItr i=first; i<last-1; i++) {
       theBins.push_back((**i).position().z());
       theBorders.push_back(((**i).position().z() + 
 			    (**(i+1)).position().z()) / 2.);
     }
+    theBins.push_back((**(last-1)).position().z());
 
     theZOffset = theBorders.front(); 
     theZStep = (theBorders.back() - theBorders.front()) / (theNbins-2);


### PR DESCRIPTION
This PR addresses two of the memory corruption issues in Phase2 workflows, found by valgrind and noted in #16493 (which contains extensive discussion of the causes).