### PR TITLE
bsunanda:Phase2-hgx68 Remove some unnecessary transformations

### DIFF
--- a/Geometry/CaloTopology/interface/HGCalTopology.h
+++ b/Geometry/CaloTopology/interface/HGCalTopology.h
@@ -28,7 +28,7 @@ public:
     DetId nextId= goNorth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
 
@@ -40,7 +40,7 @@ public:
     DetId nextId= goSouth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
 
@@ -52,7 +52,7 @@ public:
     DetId nextId=goEast(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
 
@@ -64,7 +64,7 @@ public:
     DetId nextId=goWest(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
   
@@ -72,7 +72,7 @@ public:
     DetId nextId=changeZ(id,+1);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
   
@@ -80,7 +80,7 @@ public:
     DetId nextId=changeZ(id,-1);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
-      vNeighborsDetId.push_back(DetId(nextId.rawId()));
+      vNeighborsDetId.push_back(nextId);
     return vNeighborsDetId;
   }
 

--- a/Geometry/CaloTopology/src/HGCalTopology.cc
+++ b/Geometry/CaloTopology/src/HGCalTopology.cc
@@ -109,7 +109,7 @@ DetId HGCalTopology::offsetBy(const DetId startId, int nrStepsX,
 
   if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)){
     DetId id = changeXY(startId,nrStepsX,nrStepsY);
-    if (valid(id)) return id.rawId();
+    if (valid(id)) return id;
   }
   return DetId(0);
 }
@@ -120,7 +120,7 @@ DetId HGCalTopology::switchZSide(const DetId startId) const {
     HGCalTopology::DecodedDetId id_ = decode(startId);
     id_.zside  =-id_.zside;
     DetId id   = encode(id_);
-    if (valid(id)) return id.rawId();
+    if (valid(id)) return id;
   }
   return DetId(0);
 }


### PR DESCRIPTION
This refers to HGCalTopology class where DetId was changed unnecessarily to its rawId and transformed back