### PR TITLE
Add HLT_PAZeroBias and HLT_PAL1AlwaysTrue trigger bits to the input event selection for PixelLumi online DQM client forVdM scan.

### DIFF
--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -31,7 +31,7 @@ process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = "PixelLumi"
 process.dqmSaver.tag = "PixelLumi"
 
-process.source.SelectEvents = cms.untracked.vstring("HLT_ZeroBias*","HLT_L1AlwaysTrue*")
+process.source.SelectEvents = cms.untracked.vstring("HLT_ZeroBias*","HLT_L1AlwaysTrue*", "HLT_PAZeroBias*", "HLT_PAL1AlwaysTrue*")
 #process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_pp.root'
 #if (process.runType.getRunType() == process.runType.hi_run):
 #    process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_hi.root'


### PR DESCRIPTION
The `HLT_PAZeroBias` and `HLT_PAL1AlwaysTrue` trigger paths are added to the event selection in the input source for the PixelLumi online DQM client.
This allows the application to consume events in pPb collisions. In particular:

* `ZeroBias` triggers like pp running are pre-scaled to 0 in the DQM stream, while the paths requiring at least a pixel track are sending event to DQM;
* `HLT_PAL1AlwaysTrue` is included in the HLT menu only for the VdM scan configuration.

Back-port of #16701 for `CMSSW_8_0_X`.