### PR TITLE
Switch phase1 tracking to generic pixel CPE

### DIFF
--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -47,6 +47,10 @@ displacedTracksSequence = cms.Sequence(
     displacedTracks
     )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(duplicateDisplacedTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -45,6 +45,10 @@ GlobalMuonRefitter = cms.PSet(
     RefitFlag = cms.bool( True )
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(GlobalMuonRefitter, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -69,6 +69,14 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         ),
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(GlobalTrajectoryBuilderCommon, # FIXME
+    TrackerRecHitBuilder = 'WithTrackAngle',
+    TrackTransformer = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
+    GlbRefitterParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
+)
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
+++ b/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
@@ -18,6 +18,10 @@ TrackerKinkFinderParametersBlock = cms.PSet(
     )
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TrackerKinkFinderParametersBlock, TrackerKinkFinderParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle')) # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -84,6 +84,11 @@ MuonTrackLoaderForCosmic = cms.PSet(
     )
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+for _loader in [MuonTrackLoaderForSTA, MuonTrackLoaderForGLB, MuonTrackLoaderForL2, MuonTrackLoaderForL3, MuonTrackLoaderForCosmic]:
+    phase1Pixel.toModify(_loader, TrackLoaderParameters = dict(TTRHBuilder = 'WithTrackAngle')) # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -49,6 +49,10 @@ trackerDrivenElectronSeeds = cms.EDProducer("GoodSeedProducer",
     Min_dr = cms.double(0.2)
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(trackerDrivenElectronSeeds, TTRHBuilder  = 'WithTrackAngle') # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -22,6 +22,11 @@ duplicateTrackClassifier.mva.maxChi2n = [10.,1.0,0.4]  # [9999.,9999.,9999.]
 duplicateTrackClassifier.mva.minLayers = [0,0,0]
 duplicateTrackClassifier.mva.min3DLayers = [0,0,0]
 duplicateTrackClassifier.mva.maxLostLayers = [99,99,99]
+
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(duplicateTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
@@ -21,6 +21,10 @@ inOutSeedsFromTrackerMuons = cms.EDProducer("MuonReSeeder",
     Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(inOutSeedsFromTrackerMuons, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -27,6 +27,10 @@ TrackProducer = cms.EDProducer("TrackProducer",
     MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )
 
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TrackProducer, TTRHBuilder = 'WithTrackAngle') # FIXME
+
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/TrackProducer/python/TrackRefitter_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackRefitter_cfi.py
@@ -39,4 +39,6 @@ TrackRefitter = cms.EDProducer("TrackRefitter",
     #NavigationSchool = cms.string('') 
 )
 
-
+# Switch back to GenericCPE until bias in template CPE gets fixed
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TrackRefitter, TTRHBuilder = 'WithTrackAngle') # FIXME


### PR DESCRIPTION
Following the pixel offline presentation on last Friday's TRK DPG-POG meeting https://indico.cern.ch/event/536891/contributions/2376928/attachments/1374299/2086018/2016_11_18_PixelOfflineMeeting_PhaseIOfflinePlansUpdate.pdf showing a bias in the template CPE for the (final) phase1 pixel, we decided to switch the phase1 tracking (back) to generic CPE until the bias is fixed (in a way or another). This PR effectively reverts #14159.

Here are MTV plots for 1000 ttbar+35 PU events in 810pre16
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_genericCPE
There are tiny effects in efficiencies, fake rates etc. Most visible effects are in 
* resolutions
   * https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_genericCPE/ttbar_pu35_ootb/resolutionsEta.pdf
   * https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_genericCPE/ttbar_pu35_ootb/resolutionsPt.pdf
* pulls
  * https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_genericCPE/ttbar_pu35_ootb/pulls.pdf
* chi2
   * https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_genericCPE/ttbar_pu35_ootb/tuning.pdf

Tested in 8_1_0_pre16, expecting changes in 2017 workflows.

@rovere @VinInn @veszpv @boudoul 