### PR TITLE
Add a new python configuration for EcalADCToGeV B transitions in CondTools/Ecal/python

### DIFF
--- a/CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+from CondCore.CondDB.CondDB_cfi import *
+import CondTools.Ecal.conddb_init as conddb_init
+
+process = cms.Process("EcalADCToGeVConstantPopulator")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations = cms.untracked.vstring("cout"),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string("INFO"))
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(conddb_init.options.runNumber),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(conddb_init.options.runNumber),
+                            interval = cms.uint64(1)
+)
+
+CondDBConnection = CondDB.clone(connect = cms.string(conddb_init.options.destinationDatabase))
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnection,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string("EcalADCToGeVConstantRcd"),
+                                                                     tag = cms.string(conddb_init.options.destinationTag)
+                                                                     )
+                                                            )
+                                          )
+
+process.popConEcalADCToGeVConstant = cms.EDAnalyzer("EcalADCToGeVConstantPopConBTransitionAnalyzer",
+                                                    SinceAppendMode = cms.bool(True),
+                                                    record = cms.string("EcalADCToGeVConstantRcd"),
+                                                    Source = cms.PSet(BTransition = cms.PSet(CondDBConnection, #We write and read from the same DB
+                                                                                             runNumber = cms.uint64(conddb_init.options.runNumber),
+                                                                                             tagForRunInfo = cms.string(conddb_init.options.tagForRunInfo),
+                                                                                             tagForBOff = cms.string(conddb_init.options.tagForBOff),
+                                                                                             tagForBOn = cms.string(conddb_init.options.tagForBOn),
+                                                                                             currentThreshold = cms.untracked.double(conddb_init.options.currentThreshold)
+                                                                                             )
+                                                                      ),
+                                                    loggingOn = cms.untracked.bool(True),
+                                                    targetDBConnectionString = cms.untracked.string("")
+                                                    )
+
+process.p = cms.Path(process.popConEcalADCToGeVConstant)

--- a/CondTools/Ecal/python/conddb_init.py
+++ b/CondTools/Ecal/python/conddb_init.py
@@ -1,14 +1,39 @@
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 options = VarParsing.VarParsing()
+options.register('runNumber',
+                1,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.int,
+                "the run number to be uploaded.")
 options.register('destinationDatabase',
                 '',
                 VarParsing.VarParsing.multiplicity.singleton,
                 VarParsing.VarParsing.varType.string,
-                "the destination database connection string")
+                "the destination database connection string.")
 options.register('destinationTag',
                 '',
                 VarParsing.VarParsing.multiplicity.singleton,
                 VarParsing.VarParsing.varType.string,
-                "the destination tag name")
+                "the destination tag name.")
+options.register('tagForRunInfo',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the RunInfo payload and the magnet current therein.")
+options.register('tagForBOff',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the reference payload for magnet off.")
+options.register('tagForBOn',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the reference payload for magnet on.")
+options.register('currentThreshold',
+                7000.0,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.float,
+                "the threshold on the magnet current for considering a switch of the magnetic field.")
 options.parseArguments()


### PR DESCRIPTION
A new python configuration file `CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py` is added: it targets the deployment of the new `PopCon` modules handling magnet current transitions into the production O2O workflow for the `EcalADCToGeVConstant` payloads.
The configuration has been recently tested by @depasse in the development Database.
@franzoni @mmusich @arunhep this is something you might want to watch as well.

Back-port of #16710 in 8.1.X