### PR TITLE
Fixing static analyzer warnings in CosmicClusterAlgo.cc, PreshowerClusterAlgo.cc, PreshowerPhiClusterAlgo.cc ,EcalClusterEnergyCorrectionObjectSpecific.cc and SiStripElectronAlgo.cc

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/CosmicClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/CosmicClusterAlgo.cc
@@ -227,7 +227,6 @@ void CosmicClusterAlgo::makeCluster(
    double energy = 0;
    double energySecond = 0.;//JHaupt 4-27-08 Added for the second crystal stream
    double energyMax = 0.;//JHaupt 4-27-08 Added for the max crystal stream
-   double chi2   = 0;
    DetId detFir;
    DetId detSec;
    //bool goodCluster = false; //JHaupt 4-27-08 Added so that some can be earased.. used another day Might not be needed as seeds are energy ordered... 
@@ -277,7 +276,6 @@ void CosmicClusterAlgo::makeCluster(
          // energy fraction = 1
          current_v25Sup.push_back( std::pair<DetId, float>( hit_p.id(), 1.) );
          energy += hit_p.energy(); //Keep the fully corrected energy 
-         chi2 += 0;
       }     
    }
    
@@ -287,7 +285,6 @@ void CosmicClusterAlgo::makeCluster(
    //don't write empty clusters
    if (energy == 0 && position == Point(0,0,0)) return;
 
-   chi2 /= energy;
    if (verbosity < pINFO)
    { 
       std::cout << "JH******** NEW CLUSTER ********" << std::endl;

--- a/RecoEcal/EgammaClusterAlgos/src/PreshowerClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PreshowerClusterAlgo.cc
@@ -232,7 +232,6 @@ reco::PreshowerCluster PreshowerClusterAlgo::makeOneCluster(ESDetId strip,
   LogTrace("PreShowerClusterAlgo") << " radius =" << cluster.position().r();
   LogTrace("PreShowerClusterAlgo") << " (x,y,z) =" << "(" << cluster.x() <<", "<< cluster.y() <<","<< cluster.z()<<")" ;
  
-  used_strips = used_s;
 
   // return the cluster if its energy is greater a threshold
   if( cluster.energy() > preshClusterEnergyCut_ ) 

--- a/RecoEcal/EgammaClusterAlgos/src/PreshowerPhiClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PreshowerPhiClusterAlgo.cc
@@ -90,7 +90,6 @@ reco::PreshowerCluster PreshowerPhiClusterAlgo::makeOneCluster(ESDetId strip,
   Point pos(x_pos,y_pos,z_pos);
 
   reco::PreshowerCluster cluster = reco::PreshowerCluster(Eclust, pos, usedHits, plane);
-  used_strips = used_s;
 
   return cluster; 
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.cc
@@ -335,8 +335,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) co
     par2 = (params_->params())[172];
     par3 = (params_->params())[173];
     par4 = (params_->params())[174];
-    par5 = (params_->params())[175];//should be 0 (not used)
-    par6 = (params_->params())[176];//should be 0 (not used)
+    //assignments to 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
 
     if (ET > 200) ET =200;   		  
     if (             ET <    5 ) return         1.;  
@@ -353,9 +352,8 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) co
     par2 = (params_->params())[179];
     par3 = (params_->params())[180];
     par4 = (params_->params())[181];
-    par5 = (params_->params())[182];//should be 0 (not used)
-    par6 = (params_->params())[183];//should be 0 (not used)
-    
+    //assignments to variables 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
+
     if (ET > 200) ET =200;   		  
     if (             ET <    5 ) return         1.;  
     if (  5 <= ET && ET <   10 ) return         par0;  
@@ -372,8 +370,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) co
     par2 =  (params_->params())[186];	   
     par3 =  (params_->params())[187];	   
     par4 =  (params_->params())[188];  
-    par5 =  (params_->params())[189];//should be 0 (not used)	   
-    par6 =  (params_->params())[190];//should be 0 (not used)
+    //assignments to 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
 
     if (             ET <   5 ) return         1.;  
     if (  5 <= ET && ET <  10 ) return         par0 ;  
@@ -447,9 +444,8 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEnergy(float E, int algorithm)
     par0 = (params_->params())[203];             
     par1 = (params_->params())[204];
     par2 = (params_->params())[205];
-    par3 = (params_->params())[206];//should be 0 (not used)
-    par4 = (params_->params())[207];//should be 0 (not used)
-  				 	  
+    //assignments to 'par3'&'par4' have been deleted from here as they serve no purpose and cause dead assignment errors
+
     if (E  > par0 ) E = par0 ;   		  
     if (            E <   0     ) return      1.;  
     if (  0 <= E && E <=  par0  ) return      par1 + E*par2; 

--- a/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronAlgo.cc
@@ -386,30 +386,25 @@ void SiStripElectronAlgo::coarseHitSelection(std::vector<const SiStripRecHit2D*>
 	  continue ;
 	}
         std::string theDet = "null";
-        int theLayer = -999;
         bool isStereoDet = false ;
         if(tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB) { 
           theDet = "TIB" ;
-          theLayer = tTopo->tibLayer(id); 
           if(tTopo->tibStereo(id)==1) { isStereoDet = true ; }
         } else if
           (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB) { 
           theDet = "TOB" ;
-          theLayer = tTopo->tobLayer(id); 
           if(tTopo->tobStereo(id)==1) { isStereoDet = true ; }
         }else if
           (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TID) { 
           theDet = "TID" ;
-          theLayer = tTopo->tidWheel(id);  // or ring  ?
           if(tTopo->tidStereo(id)==1) { isStereoDet = true ; }
         }else if
           (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TEC) { 
           theDet = "TEC" ;
-          theLayer = tTopo->tecWheel(id);  // or ring or petal ?
           if(tTopo->tecStereo(id)==1) { isStereoDet = true ; }
         } else {
           LogDebug("") << " UHOH BIG PROBLEM - Unrecognized SI Layer" ;
-          LogDebug("") << " Det "<< theDet << " Lay " << theLayer ;
+          LogDebug("") << " Det "<< theDet ;
           assert(1!=1) ;
         }
 


### PR DESCRIPTION
Deleting unnecessary assignments to variables flagged by the static analyzer. The code changes have been discussed and tests performed do not raise any conflicts or errors.