### PR TITLE
Pr90x l1t HI Layer2 TowerCount maxEta and BMTFUnpacker mem fix  (l1t-integration 89.9)

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.cc
@@ -136,7 +136,7 @@ namespace l1t
 					for (int i = 0; i < 3; i++)
 					{
 						if (zeroFlag[i])
-							theData.push_back(L1MuDTChambThDigi( ibx, wheel, sector, i+1, etaHits[i], linkAndQual_[blockId/2 - 1].hits[i]) );
+							theData.push_back(L1MuDTChambThDigi( ibx, wheel, sector, i+1, etaHits[i], linkAndQual_.hits[i]) );
 					}
 
 				}

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.cc
@@ -36,7 +36,7 @@ namespace l1t
 				return (value == 0);
 		}
 
-		bool unpacking(const Block& block, UnpackerCollections *coll, std::map<int, qualityHits>& linkAndQual_, const bool& isNewFw)
+		bool unpacking(const Block& block, UnpackerCollections *coll, qualityHits& linkAndQual_, const bool& isNewFw)
 		{
 
 			unsigned int ownLinks[] = {4,5,12,13,20,21,22,23,28,29};
@@ -142,10 +142,14 @@ namespace l1t
 				}
 				else
 				{
+					/*
 					qualityHits temp;
 					temp.linkNo = blockId/2;
 					std::copy(&etaHits[0][0], &etaHits[0][0]+3*7,&temp.hits[0][0]);
 					linkAndQual_[blockId/2] = temp;	
+					*/
+					linkAndQual_.linkNo = blockId/2;
+                                        std::copy(&etaHits[0][0], &etaHits[0][0]+3*7,&linkAndQual_.hits[0][0]);
 				}
 
 			}//ibx

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.h
@@ -15,7 +15,8 @@ namespace l1t{
 			public:
 				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
-				std::map<int, qualityHits> linkAndQual_;
+				qualityHits linkAndQual_;
+				//std::map<int, qualityHits> linkAndQual_;
 		};
 
 		class BMTFUnpackerInputsNewQual : public Unpacker
@@ -23,7 +24,8 @@ namespace l1t{
 			public:
 				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
-				std::map<int, qualityHits> linkAndQual_;
+				qualityHits linkAndQual_;
+				//std::map<int, qualityHits> linkAndQual_;
 		};
 
 	}

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
@@ -92,14 +92,6 @@ namespace stage2 {
        res_->push_back(bx,ht);
 
 
-       //HI-SUM
-
-       l1t::EtSum towCount = l1t::EtSum();
-       towCount.setHwPt( (raw_data>>12) & 0x1FFF );
-       towCount.setType( (l1t::EtSum::kTowerCount) );
-
-       res_->push_back(bx, towCount);
-
        //MBHFMT0
 
        l1t::EtSum mbm0 = l1t::EtSum();
@@ -186,6 +178,14 @@ namespace stage2 {
 
        res_->push_back(bx,mhthf);
        
+       //HI-SUM
+
+       l1t::EtSum towCount = l1t::EtSum();
+       towCount.setHwPt( (raw_data>>12) & 0x1FFF );
+       towCount.setType( (l1t::EtSum::kTowerCount) );
+
+       res_->push_back(bx, towCount);
+
        
      }
 

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_HI_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_HI_cfi.py
@@ -128,7 +128,7 @@ caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorim
 # sums: 0=ET, 1=HT, 2=MET, 3=MHT
 caloStage2Params.etSumLsb                = cms.double(0.5)
 caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
-caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28, 28)
+caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28, 27)
 caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.)
 
 caloStage2Params.etSumXPUSLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")

--- a/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage2Params_2016_v3_3_cfi.py
@@ -117,7 +117,7 @@ caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorim
 # sums: 0=ET, 1=HT, 2=MET, 3=MHT
 caloStage2Params.etSumLsb                = cms.double(0.5)
 caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
-caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28, 28)
+caloStage2Params.etSumEtaMax             = cms.vint32(28,  28,  28,  28, 27)
 caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.)
 
 caloStage2Params.etSumXPUSLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")

--- a/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
+++ b/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 def reEmulateLayer2(process):
 
     process.load('L1Trigger/L1TCalorimeter/simCaloStage2Digis_cfi')
-    process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi')
+    process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_cfi')
 
     process.simCaloStage2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
     

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
@@ -103,7 +103,7 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 	  ringMB0 += 1;
 	  
         // tower counting 
-	if (tower.hwPt()>nTowThresholdHw_ && CaloTools::mpEta(abs(tower.hwEta()))<=nTowEtaMax_) 
+	if (tower.hwPt()>nTowThresholdHw_ && CaloTools::mpEta(abs(tower.hwEta()))<=nTowEtaMax_+1) 
 	  ringNtowers += 1;
       }    
       

--- a/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
+++ b/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
@@ -121,7 +121,7 @@ process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis:EcalTrigger
 process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis")
 
 # emulator ES
-process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_cfi')
 
 # histograms
 process.load('L1Trigger.L1TCalorimeter.l1tStage2CaloAnalyzer_cfi')

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -348,8 +348,10 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
     int etaBin1    = 0;
 
     int etIndex0  = 0;
+    int etBin0    = 0;
     double et0Phy = 0.;
     int etIndex1  = 0;
+    int etBin1    = 0;
     double et1Phy = 0.;
     
     int chrg0 = -1;
@@ -416,11 +418,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		if(etaBin0<0) etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0; //twos complement		
 //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
 		
+		etBin0 = etIndex0;
 		int ssize = m_gtScales->getMUScales().etBins.size();
-		if (etIndex0 >= ssize){ 
-		  etIndex0 = ssize-1; 			  
+		if (etBin0 >= ssize){ 
+		  etBin0 = ssize-1; 			  
 		  edm::LogWarning("L1TGlobal") 
-		    << "muon0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+		    << "muon0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
 		} 
 		
 		// Determine Floating Pt numbers for floating point caluclation
@@ -428,7 +431,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		phi0Phy = 0.5*(binEdges.second + binEdges.first);
 		binEdges = m_gtScales->getMUScales().etaBins.at(etaBin0);
 		eta0Phy = 0.5*(binEdges.second + binEdges.first);		
-		binEdges = m_gtScales->getMUScales().etBins.at(etIndex0);
+		binEdges = m_gtScales->getMUScales().etBins.at(etBin0);
 		et0Phy = 0.5*(binEdges.second + binEdges.first);
 
 		LogDebug("L1TGlobal") << "Found all quantities for the muon 0" << std::endl;		
@@ -449,11 +452,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    if(etaBin0<0) etaBin0 = m_gtScales->getEGScales().etaBins.size() + etaBin0;
 //		    LogDebug("L1TGlobal") << "EG0 phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0 << " et " << etIndex0 << std::endl;
 
+                    etBin0 = etIndex0;
 		    int ssize = m_gtScales->getEGScales().etBins.size();
-		    if (etIndex0 >= ssize){ 
-		      etIndex0 = ssize-1; 			  
+		    if (etBin0 >= ssize){ 
+		      etBin0 = ssize-1; 			  
 		      edm::LogWarning("L1TGlobal") 
-			<< "EG0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+			<< "EG0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
 		    } 
 	    
 		    // Determine Floating Pt numbers for floating point caluclation
@@ -461,7 +465,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    phi0Phy = 0.5*(binEdges.second + binEdges.first);					    
 		    binEdges = m_gtScales->getEGScales().etaBins.at(etaBin0);
 		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
-		    binEdges = m_gtScales->getEGScales().etBins.at(etIndex0);
+		    binEdges = m_gtScales->getEGScales().etBins.at(etBin0);
 		    et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    
 		 }
@@ -475,11 +479,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getJETScales().etaBins.size() + etaBin0;
 
+		    etBin0 = etIndex0;
 		    int ssize = m_gtScales->getJETScales().etBins.size();
-		    if (etIndex0 >= ssize){ 
+		    if (etBin0 >= ssize){ 
 		      //edm::LogWarning("L1TGlobal") 
-		      //<< "jet0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
-		      etIndex0 = ssize-1; 			  
+		      //<< "jet0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
+		      etBin0 = ssize-1; 			  
 		    } 
 		    
 		    // Determine Floating Pt numbers for floating point caluclation
@@ -487,7 +492,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    phi0Phy = 0.5*(binEdges.second + binEdges.first);			
 		    binEdges = m_gtScales->getJETScales().etaBins.at(etaBin0);
 		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
-		    binEdges = m_gtScales->getJETScales().etBins.at(etIndex0);
+		    binEdges = m_gtScales->getJETScales().etBins.at(etBin0);
 		    et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    
 		 }
@@ -499,12 +504,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getTAUScales().etaBins.size() + etaBin0;
-
+		    
+		    etBin0 = etIndex0;
 		    int ssize = m_gtScales->getTAUScales().etBins.size();
-		    if (etIndex0 >= ssize){ 		      
-		      etIndex0 = ssize-1; 			  
+		    if (etBin0 >= ssize){ 		      
+		      etBin0 = ssize-1; 			  
 		      edm::LogWarning("L1TGlobal") 
-			<< "tau0 hw et" << etIndex0 << " out of scale range.  Setting to maximum.";
+			<< "tau0 hw et" << etBin0 << " out of scale range.  Setting to maximum.";
 		    } 
 
 		    
@@ -513,7 +519,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    phi0Phy = 0.5*(binEdges.second + binEdges.first);
 		    binEdges = m_gtScales->getTAUScales().etaBins.at(etaBin0);
 		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
-		    binEdges = m_gtScales->getTAUScales().etBins.at(etIndex0);
+		    binEdges = m_gtScales->getTAUScales().etBins.at(etBin0);
 		    et0Phy = 0.5*(binEdges.second + binEdges.first);		    			
 		    lutObj0 = "TAU";
 		 }
@@ -607,34 +613,37 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		      std::pair<double, double> binEdges = m_gtScales->getETMScales().phiBins.at(phiIndex0);
 		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
 		      eta0Phy = 0.; //No Eta for Energy Sums
-
+		      
+		      etBin0 = etIndex0;
 		      int ssize = m_gtScales->getETMScales().etBins.size();
 		      assert(ssize > 0);
-		      if (etIndex0 >= ssize){ etIndex0 = ssize-1; } 			   
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
 		      
-		      binEdges = m_gtScales->getETMScales().etBins.at(etIndex0);
+		      binEdges = m_gtScales->getETMScales().etBins.at(etBin0);
 		      et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    } else if (cndObjTypeVec[0] == gtHTM) {
 		      std::pair<double, double> binEdges = m_gtScales->getHTMScales().phiBins.at(phiIndex0);
 		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
 		      eta0Phy = 0.; //No Eta for Energy Sums
-
+		      
+		      etBin0 = etIndex0;
 		      int ssize = m_gtScales->getHTMScales().etBins.size();
 		      assert(ssize > 0);
-		      if (etIndex0 >= ssize){ etIndex0 = ssize-1; } 			   
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
 
-		      binEdges = m_gtScales->getHTMScales().etBins.at(etIndex0);
+		      binEdges = m_gtScales->getHTMScales().etBins.at(etBin0);
 		      et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    } else if (cndObjTypeVec[0] == gtETMHF) {
 		      std::pair<double, double> binEdges = m_gtScales->getETMHFScales().phiBins.at(phiIndex0);
 		      phi0Phy = 0.5*(binEdges.second + binEdges.first);
 		      eta0Phy = 0.; //No Eta for Energy Sums
-
+		      
+		      etBin0 = etIndex0;
 		      int ssize = m_gtScales->getETMHFScales().etBins.size();
 		      assert(ssize > 0);
-		      if (etIndex0 >= ssize){ etIndex0 = ssize-1; } 			   
+		      if (etBin0 >= ssize){ etBin0 = ssize-1; } 			   
 
-		      binEdges = m_gtScales->getETMHFScales().etBins.at(etIndex0);
+		      binEdges = m_gtScales->getETMHFScales().etBins.at(etBin0);
 		      et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    } 
 
@@ -703,12 +712,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   etaBin1 = etaIndex1;
 		   if(etaBin1<0) etaBin1 = m_gtScales->getMUScales().etaBins.size() + etaBin1;	   
 //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
-
+ 
+		   etBin1 = etIndex1;
 		   int ssize = m_gtScales->getMUScales().etBins.size();
-		   if (etIndex1 >= ssize){ 
+		   if (etBin1 >= ssize){ 
 		     edm::LogWarning("L1TGlobal") 
-		       << "muon2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
-		     etIndex1 = ssize-1;   
+		       << "muon2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+		     etBin1 = ssize-1;   
 		   } 
 
 		   // Determine Floating Pt numbers for floating point caluclation
@@ -716,7 +726,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   phi1Phy = 0.5*(binEdges.second + binEdges.first);
 		   binEdges = m_gtScales->getMUScales().etaBins.at(etaBin1);
 		   eta1Phy = 0.5*(binEdges.second + binEdges.first);		
-		   binEdges = m_gtScales->getMUScales().etBins.at(etIndex1);
+		   binEdges = m_gtScales->getMUScales().etBins.at(etBin1);
 		   et1Phy = 0.5*(binEdges.second + binEdges.first);		
 	   
                 }
@@ -730,12 +740,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1   =   etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getEGScales().etaBins.size() + etaBin1;
-
+			
+			etBin1 = etIndex1;
 			int ssize = m_gtScales->getEGScales().etBins.size();
-			if (etIndex1 >= ssize){ 
+			if (etBin1 >= ssize){ 
 			  edm::LogWarning("L1TGlobal") 
-			    << "EG1 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
-			  etIndex1 = ssize-1; 			  
+			    << "EG1 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
 			} 
 			
 			// Determine Floating Pt numbers for floating point caluclation
@@ -743,7 +754,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
 			binEdges = m_gtScales->getEGScales().etaBins.at(etaBin1);
 			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
-			binEdges = m_gtScales->getEGScales().etBins.at(etIndex1);
+			binEdges = m_gtScales->getEGScales().etBins.at(etBin1);
 			et1Phy = 0.5*(binEdges.second + binEdges.first);
 		    	lutObj1 = "EG";
 		     }
@@ -755,13 +766,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getJETScales().etaBins.size() + etaBin1;
-						
+			
+			etBin1 = etIndex1;						
 			int ssize = m_gtScales->getJETScales().etBins.size();
 			assert(ssize);
-			if (etIndex1 >= ssize){ 			  
+			if (etBin1 >= ssize){ 			  
 			  //edm::LogWarning("L1TGlobal") 
-			  //<< "jet2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
-			  etIndex1 = ssize-1; 			  
+			  //<< "jet2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
 			} 
 
 			// Determine Floating Pt numbers for floating point caluclation
@@ -770,7 +782,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			binEdges = m_gtScales->getJETScales().etaBins.at(etaBin1);
 			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
 			//CRASHES HERE:
-			binEdges = m_gtScales->getJETScales().etBins.at(etIndex1);
+			binEdges = m_gtScales->getJETScales().etBins.at(etBin1);
 			et1Phy = 0.5*(binEdges.second + binEdges.first);
 			lutObj1 = "JET";
 		     }
@@ -782,12 +794,13 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getTAUScales().etaBins.size() + etaBin1;
-
+			
+			etBin1 = etIndex1;
 			int ssize = m_gtScales->getTAUScales().etBins.size();
-			if (etIndex1 >= ssize){ 
+			if (etBin1 >= ssize){ 
 			  edm::LogWarning("L1TGlobal") 
-			    << "tau2 hw et" << etIndex1 << " out of scale range.  Setting to maximum.";
-			  etIndex1 = ssize-1; 			  
+			    << "tau2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
+			  etBin1 = ssize-1; 			  
 			} 
 						
 			// Determine Floating Pt numbers for floating point caluclation
@@ -795,7 +808,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   	phi1Phy = 0.5*(binEdges.second + binEdges.first);			
 			binEdges = m_gtScales->getTAUScales().etaBins.at(etaBin1);
 			eta1Phy = 0.5*(binEdges.second + binEdges.first);		
-			binEdges = m_gtScales->getTAUScales().etBins.at(etIndex1);
+			binEdges = m_gtScales->getTAUScales().etBins.at(etBin1);
 			et1Phy = 0.5*(binEdges.second + binEdges.first);	
 			lutObj1 = "TAU";
 		     }
@@ -890,34 +903,37 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		         std::pair<double, double> binEdges = m_gtScales->getETMScales().phiBins.at(phiIndex1);
 			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
 			 eta1Phy = 0.; //No Eta for Energy Sums
-
+			 
+			 etBin1 = etIndex1;
 			 int ssize = m_gtScales->getETMScales().etBins.size();
 			 assert(ssize > 0);
-			 if (etIndex1 >= ssize){ etIndex1 = ssize-1; } 			   
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
 		      
-			 binEdges = m_gtScales->getETMScales().etBins.at(etIndex1);
+			 binEdges = m_gtScales->getETMScales().etBins.at(etBin1);
 			 et1Phy = 0.5*(binEdges.second + binEdges.first);
 		       } else if(cndObjTypeVec[1] == gtHTM) {
 		         std::pair<double, double> binEdges = m_gtScales->getHTMScales().phiBins.at(phiIndex1);
 			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
 			 eta1Phy = 0.; //No Eta for Energy Sums
-
+			 
+			 etBin1 = etIndex1;
 			 int ssize = m_gtScales->getHTMScales().etBins.size();
 			 assert(ssize > 0);
-			 if (etIndex1 >= ssize){ etIndex1 = ssize-1; } 			   
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
 
-			 binEdges = m_gtScales->getHTMScales().etBins.at(etIndex1);
+			 binEdges = m_gtScales->getHTMScales().etBins.at(etBin1);
 			 et1Phy = 0.5*(binEdges.second + binEdges.first);
 		       } else if(cndObjTypeVec[1] == gtETMHF) {
 		         std::pair<double, double> binEdges = m_gtScales->getETMHFScales().phiBins.at(phiIndex1);
 			 phi1Phy = 0.5*(binEdges.second + binEdges.first);
 			 eta1Phy = 0.; //No Eta for Energy Sums
-
+			 
+			 etBin1 = etIndex1;
 			 int ssize = m_gtScales->getETMHFScales().etBins.size();
 			 assert(ssize > 0);
-			 if (etIndex1 >= ssize){ etIndex1 = ssize-1; } 			   
+			 if (etBin1 >= ssize){ etBin1 = ssize-1; } 			   
 
-			 binEdges = m_gtScales->getETMHFScales().etBins.at(etIndex1);
+			 binEdges = m_gtScales->getETMHFScales().etBins.at(etBin1);
 			 et1Phy = 0.5*(binEdges.second + binEdges.first);
 		       }
 

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -465,7 +465,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		    phi0Phy = 0.5*(binEdges.second + binEdges.first);					    
 		    binEdges = m_gtScales->getEGScales().etaBins.at(etaBin0);
 		    eta0Phy = 0.5*(binEdges.second + binEdges.first);		
-		    binEdges = m_gtScales->getEGScales().etBins.at(etBin0);
+		    binEdges = m_gtScales->getEGScales().etBins[etBin0];
 		    et0Phy = 0.5*(binEdges.second + binEdges.first);
 		    
 		 }

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *


### PR DESCRIPTION
90x version of  https://github.com/cms-sw/cmssw/pull/16717

This PR Includes all fixes for the L1T emulator:
- BMTF unpacker memory leak
- TwinMux memory leak (already in 81x and EXCLUDED from this PR)
- Layer2 emulator to do what in FW (bug in FW tower max eta in TowerCount for HI)
- Turn off warnings in L1T Ntuple maker.
- uGT handling of saturated Et bins in CorrelationConditions to be as in FW.

Additional commit to import eras, not available by default to cmsDriver.py. 