### PR TITLE
[CMSSW_9_0_X] Add a new python configuration for EcalADCToGeV B transition O2O, and new modules and configuration for EcalIntercalibConstants and EcalPedestals B transition O2O

### DIFF
--- a/CondTools/Ecal/plugins/EcalIntercalibConstantsPopConBTransitionAnalyzer.cc
+++ b/CondTools/Ecal/plugins/EcalIntercalibConstantsPopConBTransitionAnalyzer.cc
@@ -1,0 +1,9 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondTools/RunInfo/interface/PopConBTransitionSourceHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer< popcon::PopConBTransitionSourceHandler<EcalIntercalibConstants> > EcalIntercalibConstantsPopConBTransitionAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EcalIntercalibConstantsPopConBTransitionAnalyzer);

--- a/CondTools/Ecal/plugins/EcalPedestalsPopConBTransitionAnalyzer.cc
+++ b/CondTools/Ecal/plugins/EcalPedestalsPopConBTransitionAnalyzer.cc
@@ -1,0 +1,9 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondTools/RunInfo/interface/PopConBTransitionSourceHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer< popcon::PopConBTransitionSourceHandler<EcalPedestals> > EcalPedestalsPopConBTransitionAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EcalPedestalsPopConBTransitionAnalyzer);

--- a/CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+from CondCore.CondDB.CondDB_cfi import *
+import CondTools.Ecal.conddb_init as conddb_init
+
+process = cms.Process("EcalADCToGeVConstantPopulator")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations = cms.untracked.vstring("cout"),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string("INFO"))
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(conddb_init.options.runNumber),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(conddb_init.options.runNumber),
+                            interval = cms.uint64(1)
+)
+
+CondDBConnection = CondDB.clone(connect = cms.string(conddb_init.options.destinationDatabase))
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnection,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string("EcalADCToGeVConstantRcd"),
+                                                                     tag = cms.string(conddb_init.options.destinationTag)
+                                                                     )
+                                                            )
+                                          )
+
+process.popConEcalADCToGeVConstant = cms.EDAnalyzer("EcalADCToGeVConstantPopConBTransitionAnalyzer",
+                                                    SinceAppendMode = cms.bool(True),
+                                                    record = cms.string("EcalADCToGeVConstantRcd"),
+                                                    Source = cms.PSet(BTransition = cms.PSet(CondDBConnection, #We write and read from the same DB
+                                                                                             runNumber = cms.uint64(conddb_init.options.runNumber),
+                                                                                             tagForRunInfo = cms.string(conddb_init.options.tagForRunInfo),
+                                                                                             tagForBOff = cms.string(conddb_init.options.tagForBOff),
+                                                                                             tagForBOn = cms.string(conddb_init.options.tagForBOn),
+                                                                                             currentThreshold = cms.untracked.double(conddb_init.options.currentThreshold)
+                                                                                             )
+                                                                      ),
+                                                    loggingOn = cms.untracked.bool(True),
+                                                    targetDBConnectionString = cms.untracked.string("")
+                                                    )
+
+process.p = cms.Path(process.popConEcalADCToGeVConstant)

--- a/CondTools/Ecal/python/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/python/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+from CondCore.CondDB.CondDB_cfi import *
+import CondTools.Ecal.conddb_init as conddb_init
+
+process = cms.Process("EcalIntercalibConstantsPopulator")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations = cms.untracked.vstring("cout"),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string("INFO"))
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(conddb_init.options.runNumber),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(conddb_init.options.runNumber),
+                            interval = cms.uint64(1)
+)
+
+CondDBConnection = CondDB.clone(connect = cms.string(conddb_init.options.destinationDatabase))
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnection,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string("EcalIntercalibConstantsRcd"),
+                                                                     tag = cms.string(conddb_init.options.destinationTag)
+                                                                     )
+                                                            )
+                                          )
+
+process.popConEcalIntercalibConstants = cms.EDAnalyzer("EcalIntercalibConstantsPopConBTransitionAnalyzer",
+                                                    SinceAppendMode = cms.bool(True),
+                                                    record = cms.string("EcalIntercalibConstantsRcd"),
+                                                    Source = cms.PSet(BTransition = cms.PSet(CondDBConnection, #We write and read from the same DB
+                                                                                             runNumber = cms.uint64(conddb_init.options.runNumber),
+                                                                                             tagForRunInfo = cms.string(conddb_init.options.tagForRunInfo),
+                                                                                             tagForBOff = cms.string(conddb_init.options.tagForBOff),
+                                                                                             tagForBOn = cms.string(conddb_init.options.tagForBOn),
+                                                                                             currentThreshold = cms.untracked.double(conddb_init.options.currentThreshold)
+                                                                                             )
+                                                                      ),
+                                                    loggingOn = cms.untracked.bool(True),
+                                                    targetDBConnectionString = cms.untracked.string("")
+                                                    )
+
+process.p = cms.Path(process.popConEcalIntercalibConstants)

--- a/CondTools/Ecal/python/EcalPedestalsPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/python/EcalPedestalsPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+from CondCore.CondDB.CondDB_cfi import *
+import CondTools.Ecal.conddb_init as conddb_init
+
+process = cms.Process("EcalPedestalsPopulator")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations = cms.untracked.vstring("cout"),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string("INFO"))
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(conddb_init.options.runNumber),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(conddb_init.options.runNumber),
+                            interval = cms.uint64(1)
+)
+
+CondDBConnection = CondDB.clone(connect = cms.string(conddb_init.options.destinationDatabase))
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnection,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string("EcalPedestalsRcd"),
+                                                                     tag = cms.string(conddb_init.options.destinationTag)
+                                                                     )
+                                                            )
+                                          )
+
+process.popConEcalPedestals = cms.EDAnalyzer("EcalPedestalsPopConBTransitionAnalyzer",
+                                                    SinceAppendMode = cms.bool(True),
+                                                    record = cms.string("EcalPedestalsRcd"),
+                                                    Source = cms.PSet(BTransition = cms.PSet(CondDBConnection, #We write and read from the same DB
+                                                                                             runNumber = cms.uint64(conddb_init.options.runNumber),
+                                                                                             tagForRunInfo = cms.string(conddb_init.options.tagForRunInfo),
+                                                                                             tagForBOff = cms.string(conddb_init.options.tagForBOff),
+                                                                                             tagForBOn = cms.string(conddb_init.options.tagForBOn),
+                                                                                             currentThreshold = cms.untracked.double(conddb_init.options.currentThreshold)
+                                                                                             )
+                                                                      ),
+                                                    loggingOn = cms.untracked.bool(True),
+                                                    targetDBConnectionString = cms.untracked.string("")
+                                                    )
+
+process.p = cms.Path(process.popConEcalPedestals)

--- a/CondTools/Ecal/python/conddb_init.py
+++ b/CondTools/Ecal/python/conddb_init.py
@@ -1,14 +1,39 @@
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 options = VarParsing.VarParsing()
+options.register('runNumber',
+                1,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.int,
+                "the run number to be uploaded.")
 options.register('destinationDatabase',
                 '',
                 VarParsing.VarParsing.multiplicity.singleton,
                 VarParsing.VarParsing.varType.string,
-                "the destination database connection string")
+                "the destination database connection string.")
 options.register('destinationTag',
                 '',
                 VarParsing.VarParsing.multiplicity.singleton,
                 VarParsing.VarParsing.varType.string,
-                "the destination tag name")
+                "the destination tag name.")
+options.register('tagForRunInfo',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the RunInfo payload and the magnet current therein.")
+options.register('tagForBOff',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the reference payload for magnet off.")
+options.register('tagForBOn',
+                '',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the tag name used to retrieve the reference payload for magnet on.")
+options.register('currentThreshold',
+                7000.0,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.float,
+                "the threshold on the magnet current for considering a switch of the magnetic field.")
 options.parseArguments()

--- a/CondTools/Ecal/test/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py
+++ b/CondTools/Ecal/test/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py
@@ -1,0 +1,128 @@
+import socket
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from CondCore.CondDB.CondDB_cfi import *
+
+options = VarParsing.VarParsing()
+options.register( 'runNumber'
+                , 1 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number to be uploaded."
+                  )
+options.register( 'destinationConnection'
+                , 'sqlite_file:EcalIntercalibConstants_PopCon_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads will be possibly written."
+                  )
+options.register( 'targetConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the target DB:
+                     if not empty (default), this provides the latest IOV and payloads to compare;
+                     it is the DB where payloads should be finally uploaded."""
+                  )
+options.register( 'sourceConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the DB hosting tags for RunInfo and EcalIntercalibConstants.
+                     It defaults to the same as the target connection, i.e. empty.
+                     If target connection is also empty, it is set to be the same as destination connection."""
+                  )
+options.register( 'tag'
+                , 'EcalIntercalibConstants_PopCon_test'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag written in destinationConnection and finally appended in targetConnection."
+                  )
+options.register( 'tagForRunInfo'
+                , 'runInfo_31X_hlt'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the RunInfo payload and the magnet current therein."
+                  )
+options.register( 'tagForBOff'
+                , 'EcalIntercalibConstants_0T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalIntercalibConstants payload for magnet off."
+                  )
+options.register( 'tagForBOn'
+                , 'EcalIntercalibConstants_3.8T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalIntercalibConstants payload for magnet on."
+                  )
+options.register( 'currentThreshold'
+                , 7000.
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.float
+                , "The threshold on the magnet current for considering a switch of the magnetic field."
+                  )
+options.register( 'messageLevel'
+                , 0 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Message level; default to 0"
+                  )
+options.parseArguments()
+
+if not options.sourceConnection:
+    if options.targetConnection:
+        options.sourceConnection = options.targetConnection
+    else:
+        options.sourceConnection = options.destinationConnection
+
+CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
+CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+PopConConnection = CondDB.clone( connect = cms.string( options.sourceConnection ) )
+PopConConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+process = cms.Process( "EcalIntercalibConstantsPopulator" )
+
+process.MessageLogger = cms.Service( "MessageLogger"
+                                   , destinations = cms.untracked.vstring( 'cout' )
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
+                                     )
+
+if options.messageLevel == 3:
+    #enable LogDebug output: remember the USER_CXXFLAGS="-DEDM_ML_DEBUG" compilation flag!
+    process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string( 'DEBUG' ) )
+    process.MessageLogger.debugModules = cms.untracked.vstring( '*' )
+
+process.source = cms.Source( "EmptyIOVSource"
+                           , lastValue = cms.uint64( options.runNumber )
+                           , timetype = cms.string( 'runnumber' )
+                           , firstValue = cms.uint64( options.runNumber )
+                           , interval = cms.uint64( 1 )
+                             )
+
+process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
+                                         , CondDBConnection
+                                         , timetype = cms.untracked.string( 'runnumber' )
+                                         , toPut = cms.VPSet( cms.PSet( record = cms.string( 'EcalIntercalibConstantsRcd' )
+                                                                      , tag = cms.string( options.tag )
+                                                                        )
+                                                              )
+                                          )
+
+process.popConEcalIntercalibConstants = cms.EDAnalyzer( "EcalIntercalibConstantsPopConBTransitionAnalyzer"
+                                                   , SinceAppendMode = cms.bool( True )
+                                                   , record = cms.string( 'EcalIntercalibConstantsRcd' )
+                                                   , Source = cms.PSet( BTransition = cms.PSet( PopConConnection
+                                                                                              , runNumber = cms.uint64( options.runNumber )
+                                                                                              , tagForRunInfo = cms.string( options.tagForRunInfo )
+                                                                                              , tagForBOff = cms.string( options.tagForBOff )
+                                                                                              , tagForBOn = cms.string( options.tagForBOn )
+                                                                                              , currentThreshold = cms.untracked.double( options.currentThreshold )
+                                                                                                )
+                                                                        )
+                                                   , loggingOn = cms.untracked.bool( True )
+                                                   , targetDBConnectionString = cms.untracked.string( options.targetConnection )
+                                                     )
+
+process.p = cms.Path( process.popConEcalIntercalibConstants )

--- a/CondTools/Ecal/test/EcalPedestalsPopConBTransitionAnalyzer_test_express_cfg.py
+++ b/CondTools/Ecal/test/EcalPedestalsPopConBTransitionAnalyzer_test_express_cfg.py
@@ -1,0 +1,128 @@
+import socket
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from CondCore.CondDB.CondDB_cfi import *
+
+options = VarParsing.VarParsing()
+options.register( 'runNumber'
+                , 1 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number to be uploaded."
+                  )
+options.register( 'destinationConnection'
+                , 'sqlite_file:EcalPedestals_PopCon_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads will be possibly written."
+                  )
+options.register( 'targetConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the target DB:
+                     if not empty (default), this provides the latest IOV and payloads to compare;
+                     it is the DB where payloads should be finally uploaded."""
+                  )
+options.register( 'sourceConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the DB hosting tags for RunInfo and EcalPedestals.
+                     It defaults to the same as the target connection, i.e. empty.
+                     If target connection is also empty, it is set to be the same as destination connection."""
+                  )
+options.register( 'tag'
+                , 'EcalPedestals_PopCon_test_express'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag written in destinationConnection and finally appended in targetConnection."
+                  )
+options.register( 'tagForRunInfo'
+                , 'runInfo_31X_hlt'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the RunInfo payload and the magnet current therein."
+                  )
+options.register( 'tagForBOff'
+                , 'EcalPedestals_express_0T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalPedestals payload for magnet off."
+                  )
+options.register( 'tagForBOn'
+                , 'EcalPedestals_express_3.8T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalPedestals payload for magnet on."
+                  )
+options.register( 'currentThreshold'
+                , 7000.
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.float
+                , "The threshold on the magnet current for considering a switch of the magnetic field."
+                  )
+options.register( 'messageLevel'
+                , 0 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Message level; default to 0"
+                  )
+options.parseArguments()
+
+if not options.sourceConnection:
+    if options.targetConnection:
+        options.sourceConnection = options.targetConnection
+    else:
+        options.sourceConnection = options.destinationConnection
+
+CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
+CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+PopConConnection = CondDB.clone( connect = cms.string( options.sourceConnection ) )
+PopConConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+process = cms.Process( "EcalPedestalsPopulator" )
+
+process.MessageLogger = cms.Service( "MessageLogger"
+                                   , destinations = cms.untracked.vstring( 'cout' )
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
+                                     )
+
+if options.messageLevel == 3:
+    #enable LogDebug output: remember the USER_CXXFLAGS="-DEDM_ML_DEBUG" compilation flag!
+    process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string( 'DEBUG' ) )
+    process.MessageLogger.debugModules = cms.untracked.vstring( '*' )
+
+process.source = cms.Source( "EmptyIOVSource"
+                           , lastValue = cms.uint64( options.runNumber )
+                           , timetype = cms.string( 'runnumber' )
+                           , firstValue = cms.uint64( options.runNumber )
+                           , interval = cms.uint64( 1 )
+                             )
+
+process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
+                                         , CondDBConnection
+                                         , timetype = cms.untracked.string( 'runnumber' )
+                                         , toPut = cms.VPSet( cms.PSet( record = cms.string( 'EcalPedestalsRcd' )
+                                                                      , tag = cms.string( options.tag )
+                                                                        )
+                                                              )
+                                          )
+
+process.popConEcalPedestals = cms.EDAnalyzer( "EcalPedestalsPopConBTransitionAnalyzer"
+                                                   , SinceAppendMode = cms.bool( True )
+                                                   , record = cms.string( 'EcalPedestalsRcd' )
+                                                   , Source = cms.PSet( BTransition = cms.PSet( PopConConnection
+                                                                                              , runNumber = cms.uint64( options.runNumber )
+                                                                                              , tagForRunInfo = cms.string( options.tagForRunInfo )
+                                                                                              , tagForBOff = cms.string( options.tagForBOff )
+                                                                                              , tagForBOn = cms.string( options.tagForBOn )
+                                                                                              , currentThreshold = cms.untracked.double( options.currentThreshold )
+                                                                                                )
+                                                                        )
+                                                   , loggingOn = cms.untracked.bool( True )
+                                                   , targetDBConnectionString = cms.untracked.string( options.targetConnection )
+                                                     )
+
+process.p = cms.Path( process.popConEcalPedestals )

--- a/CondTools/Ecal/test/EcalPedestalsPopConBTransitionAnalyzer_test_hlt_cfg.py
+++ b/CondTools/Ecal/test/EcalPedestalsPopConBTransitionAnalyzer_test_hlt_cfg.py
@@ -1,0 +1,128 @@
+import socket
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from CondCore.CondDB.CondDB_cfi import *
+
+options = VarParsing.VarParsing()
+options.register( 'runNumber'
+                , 1 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number to be uploaded."
+                  )
+options.register( 'destinationConnection'
+                , 'sqlite_file:EcalPedestals_PopCon_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads will be possibly written."
+                  )
+options.register( 'targetConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the target DB:
+                     if not empty (default), this provides the latest IOV and payloads to compare;
+                     it is the DB where payloads should be finally uploaded."""
+                  )
+options.register( 'sourceConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the DB hosting tags for RunInfo and EcalPedestals.
+                     It defaults to the same as the target connection, i.e. empty.
+                     If target connection is also empty, it is set to be the same as destination connection."""
+                  )
+options.register( 'tag'
+                , 'EcalPedestals_PopCon_test_hlt'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag written in destinationConnection and finally appended in targetConnection."
+                  )
+options.register( 'tagForRunInfo'
+                , 'runInfo_31X_hlt'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the RunInfo payload and the magnet current therein."
+                  )
+options.register( 'tagForBOff'
+                , 'EcalPedestals_hlt_0T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalPedestals payload for magnet off."
+                  )
+options.register( 'tagForBOn'
+                , 'EcalPedestals_hlt_3.8T'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the EcalPedestals payload for magnet on."
+                  )
+options.register( 'currentThreshold'
+                , 7000.
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.float
+                , "The threshold on the magnet current for considering a switch of the magnetic field."
+                  )
+options.register( 'messageLevel'
+                , 0 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Message level; default to 0"
+                  )
+options.parseArguments()
+
+if not options.sourceConnection:
+    if options.targetConnection:
+        options.sourceConnection = options.targetConnection
+    else:
+        options.sourceConnection = options.destinationConnection
+
+CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
+CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+PopConConnection = CondDB.clone( connect = cms.string( options.sourceConnection ) )
+PopConConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+process = cms.Process( "EcalPedestalsPopulator" )
+
+process.MessageLogger = cms.Service( "MessageLogger"
+                                   , destinations = cms.untracked.vstring( 'cout' )
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
+                                     )
+
+if options.messageLevel == 3:
+    #enable LogDebug output: remember the USER_CXXFLAGS="-DEDM_ML_DEBUG" compilation flag!
+    process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string( 'DEBUG' ) )
+    process.MessageLogger.debugModules = cms.untracked.vstring( '*' )
+
+process.source = cms.Source( "EmptyIOVSource"
+                           , lastValue = cms.uint64( options.runNumber )
+                           , timetype = cms.string( 'runnumber' )
+                           , firstValue = cms.uint64( options.runNumber )
+                           , interval = cms.uint64( 1 )
+                             )
+
+process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
+                                         , CondDBConnection
+                                         , timetype = cms.untracked.string( 'runnumber' )
+                                         , toPut = cms.VPSet( cms.PSet( record = cms.string( 'EcalPedestalsRcd' )
+                                                                      , tag = cms.string( options.tag )
+                                                                        )
+                                                              )
+                                          )
+
+process.popConEcalPedestals = cms.EDAnalyzer( "EcalPedestalsPopConBTransitionAnalyzer"
+                                                   , SinceAppendMode = cms.bool( True )
+                                                   , record = cms.string( 'EcalPedestalsRcd' )
+                                                   , Source = cms.PSet( BTransition = cms.PSet( PopConConnection
+                                                                                              , runNumber = cms.uint64( options.runNumber )
+                                                                                              , tagForRunInfo = cms.string( options.tagForRunInfo )
+                                                                                              , tagForBOff = cms.string( options.tagForBOff )
+                                                                                              , tagForBOn = cms.string( options.tagForBOn )
+                                                                                              , currentThreshold = cms.untracked.double( options.currentThreshold )
+                                                                                                )
+                                                                        )
+                                                   , loggingOn = cms.untracked.bool( True )
+                                                   , targetDBConnectionString = cms.untracked.string( options.targetConnection )
+                                                     )
+
+process.p = cms.Path( process.popConEcalPedestals )


### PR DESCRIPTION
A new python configuration file `CondTools/Ecal/python/EcalADCToGeVConstantPopConBTransitionAnalyzer_cfg.py` is added: it targets the deployment of the new `PopCon` modules handling magnet current transitions into the production O2O workflow for the `EcalADCToGeVConstant` payloads.
The configuration has been recently tested by @depasse in the development Database.

New `PopCon` analyzers `EcalIntercalibConstantsPopConBTransitionAnalyzer.cc` and `EcalPedestalsPopConBTransitionAnalyzer.cc`, and corresponding sources handling magnetic field transitions for `EcalIntercalibConstants` and `EcalPedestals` are defined, and the corresponding test and O2O-tailored configurations are added.
The module and the configurations have been implemented and tested by @depasse in the development Database.

@franzoni @mmusich @arunhep this is something you might want to watch as well.