### PR TITLE
Split cluster charge & S/N MEs for thin and thick sensors (81X)

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -104,7 +104,7 @@ private:
 		const SiStripRecHit1D*          hit1D,
 		      LocalVector               localMomentum,
 		const bool                      track_ok);
-  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs);	
+  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs , const TrackerTopology* tTopo);	
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&, bool ok);
 
   // fill monitorables 
@@ -137,7 +137,7 @@ private:
   struct ModMEs{  
     MonitorElement* ClusterStoNCorr;
     MonitorElement* ClusterCharge;
-    MonitorElement* ClusterChargeCorr; 
+    MonitorElement* ClusterChargeCorr;
     MonitorElement* ClusterWidth;
     MonitorElement* ClusterPos;
     MonitorElement* ClusterPGV;
@@ -147,7 +147,11 @@ private:
 
   struct LayerMEs{
     MonitorElement* ClusterStoNCorrOnTrack;
+    MonitorElement* ClusterStoNCorrThinOnTrack;
+    MonitorElement* ClusterStoNCorrThickOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
+    MonitorElement* ClusterChargeCorrThinOnTrack;
+    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterNoiseOnTrack;
@@ -162,7 +166,11 @@ private:
   };
   struct RingMEs{
     MonitorElement* ClusterStoNCorrOnTrack;
+    MonitorElement* ClusterStoNCorrThinOnTrack;
+    MonitorElement* ClusterStoNCorrThickOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
+    MonitorElement* ClusterChargeCorrThinOnTrack;
+    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterNoiseOnTrack;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -147,11 +147,7 @@ private:
 
   struct LayerMEs{
     MonitorElement* ClusterStoNCorrOnTrack;
-    MonitorElement* ClusterStoNCorrThinOnTrack;
-    MonitorElement* ClusterStoNCorrThickOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
-    MonitorElement* ClusterChargeCorrThinOnTrack;
-    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterNoiseOnTrack;
@@ -166,11 +162,7 @@ private:
   };
   struct RingMEs{
     MonitorElement* ClusterStoNCorrOnTrack;
-    MonitorElement* ClusterStoNCorrThinOnTrack;
-    MonitorElement* ClusterStoNCorrThickOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
-    MonitorElement* ClusterChargeCorrThinOnTrack;
-    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterNoiseOnTrack;
@@ -191,6 +183,11 @@ private:
     MonitorElement* nClustersOffTrack;
     MonitorElement* nClustersTrendOffTrack;
     MonitorElement* ClusterStoNCorrOnTrack;
+    MonitorElement* ClusterStoNCorrThinOnTrack;
+    MonitorElement* ClusterStoNCorrThickOnTrack;
+    MonitorElement* ClusterChargeCorrOnTrack;
+    MonitorElement* ClusterChargeCorrThinOnTrack;
+    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterStoNOffTrack;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -346,11 +346,7 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
 
   LayerMEs theLayerMEs;
   theLayerMEs.ClusterStoNCorrOnTrack               = 0;
-  theLayerMEs.ClusterStoNCorrThinOnTrack           = 0;
-  theLayerMEs.ClusterStoNCorrThickOnTrack          = 0;
   theLayerMEs.ClusterChargeCorrOnTrack             = 0;
-  theLayerMEs.ClusterChargeCorrThinOnTrack         = 0;
-  theLayerMEs.ClusterChargeCorrThickOnTrack        = 0;
   theLayerMEs.ClusterChargeOnTrack                 = 0;
   theLayerMEs.ClusterChargeOffTrack                = 0;
   theLayerMEs.ClusterNoiseOnTrack                  = 0;
@@ -368,26 +364,10 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
   hpar  = "TH1ClusterStoNCorr";
   theLayerMEs.ClusterStoNCorrOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
 
-  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThin",name,layer_id,"OnTrack");
-  hpar  = "TH1ClusterStoNCorr";
-  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterStoNCorrThinOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThick",name,layer_id,"OnTrack");
-  hpar  = "TH1ClusterStoNCorr";
-  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterStoNCorrThickOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
-
   // Cluster Charge Corrected
   hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorr",name,layer_id,"OnTrack");
   hpar = "TH1ClusterChargeCorr";
   theLayerMEs.ClusterChargeCorrOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThin",name,layer_id,"OnTrack");
-  hpar = "TH1ClusterChargeCorr";
-  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterChargeCorrThinOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThick",name,layer_id,"OnTrack");
-  hpar = "TH1ClusterChargeCorr";
-  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterChargeCorrThickOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
 
   // Cluster Charge (On and Off Track)
   hname = hidmanager.createHistoLayer("Summary_ClusterCharge",name,layer_id,"OnTrack");
@@ -457,11 +437,7 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32
 
   RingMEs theRingMEs;
   theRingMEs.ClusterStoNCorrOnTrack               = 0;
-  theRingMEs.ClusterStoNCorrThinOnTrack           = 0;
-  theRingMEs.ClusterStoNCorrThickOnTrack          = 0;
   theRingMEs.ClusterChargeCorrOnTrack             = 0;
-  theRingMEs.ClusterChargeCorrThinOnTrack         = 0;
-  theRingMEs.ClusterChargeCorrThickOnTrack        = 0;
   theRingMEs.ClusterChargeOnTrack                 = 0;
   theRingMEs.ClusterChargeOffTrack                = 0;
   theRingMEs.ClusterNoiseOnTrack                  = 0;
@@ -478,26 +454,10 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32
   hpar  = "TH1ClusterStoNCorr";
   theRingMEs.ClusterStoNCorrOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
 
-  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThin",name,ring_id,"OnTrack");
-  hpar  = "TH1ClusterStoNCorr";
-  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterStoNCorrThinOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThick",name,ring_id,"OnTrack");
-  hpar  = "TH1ClusterStoNCorr";
-  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterStoNCorrThickOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
-
   // Cluster Charge Corrected
   hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorr",name,ring_id,"OnTrack");
   hpar = "TH1ClusterChargeCorr";
   theRingMEs.ClusterChargeCorrOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThin",name,ring_id,"OnTrack");
-  hpar = "TH1ClusterChargeCorr";
-  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterChargeCorrThinOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
-
-  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThick",name,ring_id,"OnTrack");
-  hpar = "TH1ClusterChargeCorr";
-  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterChargeCorrThickOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
 
   // Cluster Charge (On and Off Track)
   hname = hidmanager.createHistoLayer("Summary_ClusterCharge",name,ring_id,"OnTrack");
@@ -574,6 +534,11 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
   theSubDetMEs.nClustersOffTrack                    = 0;
   theSubDetMEs.nClustersTrendOffTrack               = 0;
   theSubDetMEs.ClusterStoNCorrOnTrack               = 0;
+  theSubDetMEs.ClusterStoNCorrThinOnTrack           = 0;
+  theSubDetMEs.ClusterStoNCorrThickOnTrack          = 0;
+  theSubDetMEs.ClusterChargeCorrOnTrack             = 0;
+  theSubDetMEs.ClusterChargeCorrThinOnTrack         = 0;
+  theSubDetMEs.ClusterChargeCorrThickOnTrack        = 0;
   theSubDetMEs.ClusterChargeOnTrack                 = 0;
   theSubDetMEs.ClusterChargeOffTrack                = 0;
   theSubDetMEs.ClusterStoNOffTrack                  = 0;
@@ -598,6 +563,22 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
   // Cluster StoN On Track
   completeName = "Summary_ClusterStoNCorr_OnTrack"  + subdet_tag;
   theSubDetMEs.ClusterStoNCorrOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterStoNCorrThin_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterStoNCorrThinOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterStoNCorrThick_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterStoNCorrThickOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  // Cluster Charge Corrected
+  completeName = "Summary_ClusterChargeCorr_OnTrack"  + subdet_tag;
+  theSubDetMEs.ClusterChargeCorrOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterChargeCorrThin_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterChargeCorrThinOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterChargeCorrThick_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterChargeCorrThickOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
 
   // Cluster Charge On Track
   completeName = "Summary_ClusterCharge_OnTrack" + subdet_tag;
@@ -1173,13 +1154,6 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7 ) {
-        if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
-        fillME(MEs.iLayer->ClusterChargeCorrThickOnTrack, charge*cosRZ);
-      } else  {
-        if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
-        fillME(MEs.iLayer->ClusterChargeCorrThinOnTrack, charge*cosRZ);
-      }
     }
     // ringMEs
     if (MEs.iRing != nullptr) {
@@ -1192,20 +1166,21 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iRing->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
-        if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
-        fillME(MEs.iRing->ClusterChargeCorrThickOnTrack, charge*cosRZ);
-      } else  {
-        if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
-        fillME(MEs.iRing->ClusterChargeCorrThinOnTrack, charge*cosRZ);
-      }
     }
     // subdetMEs
     if(MEs.iSubdet != nullptr){
       fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
       if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cosRZ);
+      fillME(MEs.iSubdet->ClusterChargeCorrOnTrack, charge*cosRZ);
       if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
       if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
+      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
+        if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
+        fillME(MEs.iSubdet->ClusterChargeCorrThickOnTrack, charge*cosRZ);
+      } else  {
+        if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
+        fillME(MEs.iSubdet->ClusterChargeCorrThinOnTrack, charge*cosRZ);
+      }
     }
     //******** TkHistoMaps
     if (TkHistoMap_On_) {

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -1173,8 +1173,6 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-      //---------ATTENTION -- DELETE LATER---------//
-      //-------------------------------------------//
       if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7 ) {
         if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
         fillME(MEs.iLayer->ClusterChargeCorrThickOnTrack, charge*cosRZ);
@@ -1182,8 +1180,6 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
         if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
         fillME(MEs.iLayer->ClusterChargeCorrThinOnTrack, charge*cosRZ);
       }
-      //---------ATTENTION -- DELETE LATER---------//
-      //-------------------------------------------//
     }
     // ringMEs
     if (MEs.iRing != nullptr) {
@@ -1196,8 +1192,6 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iRing->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-      //---------ATTENTION -- DELETE LATER---------//
-      //-------------------------------------------//
       if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
         if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
         fillME(MEs.iRing->ClusterChargeCorrThickOnTrack, charge*cosRZ);
@@ -1205,8 +1199,6 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
         if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
         fillME(MEs.iRing->ClusterChargeCorrThinOnTrack, charge*cosRZ);
       }
-      //---------ATTENTION -- DELETE LATER---------//
-      //-------------------------------------------//
     }
     // subdetMEs
     if(MEs.iSubdet != nullptr){

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -346,7 +346,11 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
 
   LayerMEs theLayerMEs;
   theLayerMEs.ClusterStoNCorrOnTrack               = 0;
+  theLayerMEs.ClusterStoNCorrThinOnTrack           = 0;
+  theLayerMEs.ClusterStoNCorrThickOnTrack          = 0;
   theLayerMEs.ClusterChargeCorrOnTrack             = 0;
+  theLayerMEs.ClusterChargeCorrThinOnTrack         = 0;
+  theLayerMEs.ClusterChargeCorrThickOnTrack        = 0;
   theLayerMEs.ClusterChargeOnTrack                 = 0;
   theLayerMEs.ClusterChargeOffTrack                = 0;
   theLayerMEs.ClusterNoiseOnTrack                  = 0;
@@ -364,10 +368,26 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
   hpar  = "TH1ClusterStoNCorr";
   theLayerMEs.ClusterStoNCorrOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
 
+  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThin",name,layer_id,"OnTrack");
+  hpar  = "TH1ClusterStoNCorr";
+  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterStoNCorrThinOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThick",name,layer_id,"OnTrack");
+  hpar  = "TH1ClusterStoNCorr";
+  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterStoNCorrThickOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
+
   // Cluster Charge Corrected
   hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorr",name,layer_id,"OnTrack");
   hpar = "TH1ClusterChargeCorr";
   theLayerMEs.ClusterChargeCorrOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThin",name,layer_id,"OnTrack");
+  hpar = "TH1ClusterChargeCorr";
+  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterChargeCorrThinOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThick",name,layer_id,"OnTrack");
+  hpar = "TH1ClusterChargeCorr";
+  if ( layer_id.find("TEC") != std::string::npos ) theLayerMEs.ClusterChargeCorrThickOnTrack = handleBookMEs(ibooker,view,layer_id,hpar,hname);
 
   // Cluster Charge (On and Off Track)
   hname = hidmanager.createHistoLayer("Summary_ClusterCharge",name,layer_id,"OnTrack");
@@ -437,7 +457,11 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32
 
   RingMEs theRingMEs;
   theRingMEs.ClusterStoNCorrOnTrack               = 0;
+  theRingMEs.ClusterStoNCorrThinOnTrack           = 0;
+  theRingMEs.ClusterStoNCorrThickOnTrack          = 0;
   theRingMEs.ClusterChargeCorrOnTrack             = 0;
+  theRingMEs.ClusterChargeCorrThinOnTrack         = 0;
+  theRingMEs.ClusterChargeCorrThickOnTrack        = 0;
   theRingMEs.ClusterChargeOnTrack                 = 0;
   theRingMEs.ClusterChargeOffTrack                = 0;
   theRingMEs.ClusterNoiseOnTrack                  = 0;
@@ -454,10 +478,26 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32
   hpar  = "TH1ClusterStoNCorr";
   theRingMEs.ClusterStoNCorrOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
 
+  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThin",name,ring_id,"OnTrack");
+  hpar  = "TH1ClusterStoNCorr";
+  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterStoNCorrThinOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterStoNCorrThick",name,ring_id,"OnTrack");
+  hpar  = "TH1ClusterStoNCorr";
+  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterStoNCorrThickOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
+
   // Cluster Charge Corrected
   hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorr",name,ring_id,"OnTrack");
   hpar = "TH1ClusterChargeCorr";
   theRingMEs.ClusterChargeCorrOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThin",name,ring_id,"OnTrack");
+  hpar = "TH1ClusterChargeCorr";
+  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterChargeCorrThinOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
+
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargeCorrThick",name,ring_id,"OnTrack");
+  hpar = "TH1ClusterChargeCorr";
+  if ( ring_id.find("TEC") != std::string::npos ) theRingMEs.ClusterChargeCorrThickOnTrack = handleBookMEs(ibooker,view,ring_id,hpar,hname);
 
   // Cluster Charge (On and Off Track)
   hname = hidmanager.createHistoLayer("Summary_ClusterCharge",name,ring_id,"OnTrack");
@@ -995,7 +1035,7 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
       SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,detid);
 
       const Det2MEs MEs = findMEs(tTopo, detid);
-      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, track_ok, LV, MEs))
+      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, track_ok, LV, MEs, tTopo))
       {
         vPSiStripCluster.insert(SiStripCluster_);
       }
@@ -1033,7 +1073,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter,es,detid);
-          clusterInfos(&SiStripClusterInfo_,detid,OffTrack, /*track_ok*/ false,LV,MEs);
+          clusterInfos(&SiStripClusterInfo_,detid,OffTrack, /*track_ok*/ false,LV,MEs , tTopo);
         }
       }
     }
@@ -1076,7 +1116,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
 //------------------------------------------------------------------------
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
-bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, bool track_ok, const LocalVector LV, const Det2MEs& MEs)
+bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, bool track_ok, const LocalVector LV, const Det2MEs& MEs , const TrackerTopology* tTopo)
 {
 
   if (cluster==NULL) return false;
@@ -1133,6 +1173,17 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      //---------ATTENTION -- DELETE LATER---------//
+      //-------------------------------------------//
+      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7 ) {
+        if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
+        fillME(MEs.iLayer->ClusterChargeCorrThickOnTrack, charge*cosRZ);
+      } else  {
+        if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
+        fillME(MEs.iLayer->ClusterChargeCorrThinOnTrack, charge*cosRZ);
+      }
+      //---------ATTENTION -- DELETE LATER---------//
+      //-------------------------------------------//
     }
     // ringMEs
     if (MEs.iRing != nullptr) {
@@ -1145,6 +1196,17 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
       fillME(MEs.iRing->ClusterPosOnTrack, position);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if(track_ok) fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      //---------ATTENTION -- DELETE LATER---------//
+      //-------------------------------------------//
+      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
+        if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
+        fillME(MEs.iRing->ClusterChargeCorrThickOnTrack, charge*cosRZ);
+      } else  {
+        if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
+        fillME(MEs.iRing->ClusterChargeCorrThinOnTrack, charge*cosRZ);
+      }
+      //---------ATTENTION -- DELETE LATER---------//
+      //-------------------------------------------//
     }
     // subdetMEs
     if(MEs.iSubdet != nullptr){


### PR DESCRIPTION
The strip tracker contains thin and thick sensors. While the other partitions consist completely out of thin/thick sensors, the tracker endcap contains a mix. The thickness of the sensors influences the cluster charge and S/N, so the MEs for these are separated for thin and thick sensors in the TEC.

A PR for 90X is being prepared. Should there also be one for 80X?