### PR TITLE
Split cluster charge & S/N MEs for thin and thick sensors (90X)

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -104,7 +104,7 @@ private:
 		const SiStripRecHit1D*          hit1D,
 		      LocalVector               localMomentum,
 		const bool                      track_ok);
-  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs);	
+  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs , const TrackerTopology* tTopo);	
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&, bool ok);
 
   // fill monitorables 
@@ -137,7 +137,7 @@ private:
   struct ModMEs{  
     MonitorElement* ClusterStoNCorr;
     MonitorElement* ClusterCharge;
-    MonitorElement* ClusterChargeCorr; 
+    MonitorElement* ClusterChargeCorr;
     MonitorElement* ClusterWidth;
     MonitorElement* ClusterPos;
     MonitorElement* ClusterPGV;
@@ -183,6 +183,11 @@ private:
     MonitorElement* nClustersOffTrack;
     MonitorElement* nClustersTrendOffTrack;
     MonitorElement* ClusterStoNCorrOnTrack;
+    MonitorElement* ClusterStoNCorrThinOnTrack;
+    MonitorElement* ClusterStoNCorrThickOnTrack;
+    MonitorElement* ClusterChargeCorrOnTrack;
+    MonitorElement* ClusterChargeCorrThinOnTrack;
+    MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterStoNOffTrack;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -534,6 +534,11 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
   theSubDetMEs.nClustersOffTrack                    = 0;
   theSubDetMEs.nClustersTrendOffTrack               = 0;
   theSubDetMEs.ClusterStoNCorrOnTrack               = 0;
+  theSubDetMEs.ClusterStoNCorrThinOnTrack           = 0;
+  theSubDetMEs.ClusterStoNCorrThickOnTrack          = 0;
+  theSubDetMEs.ClusterChargeCorrOnTrack             = 0;
+  theSubDetMEs.ClusterChargeCorrThinOnTrack         = 0;
+  theSubDetMEs.ClusterChargeCorrThickOnTrack        = 0;
   theSubDetMEs.ClusterChargeOnTrack                 = 0;
   theSubDetMEs.ClusterChargeOffTrack                = 0;
   theSubDetMEs.ClusterStoNOffTrack                  = 0;
@@ -558,6 +563,22 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
   // Cluster StoN On Track
   completeName = "Summary_ClusterStoNCorr_OnTrack"  + subdet_tag;
   theSubDetMEs.ClusterStoNCorrOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterStoNCorrThin_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterStoNCorrThinOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterStoNCorrThick_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterStoNCorrThickOnTrack = bookME1D(ibooker , "TH1ClusterStoNCorr", completeName.c_str());
+
+  // Cluster Charge Corrected
+  completeName = "Summary_ClusterChargeCorr_OnTrack"  + subdet_tag;
+  theSubDetMEs.ClusterChargeCorrOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterChargeCorrThin_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterChargeCorrThinOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
+
+  completeName = "Summary_ClusterChargeCorrThick_OnTrack"  + subdet_tag;
+  if ( subdet_tag.find("TEC") != std::string::npos ) theSubDetMEs.ClusterChargeCorrThickOnTrack = bookME1D(ibooker , "TH1ClusterChargeCorr", completeName.c_str());
 
   // Cluster Charge On Track
   completeName = "Summary_ClusterCharge_OnTrack" + subdet_tag;
@@ -995,7 +1016,7 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
       SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,detid);
 
       const Det2MEs MEs = findMEs(tTopo, detid);
-      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, track_ok, LV, MEs))
+      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, track_ok, LV, MEs, tTopo))
       {
         vPSiStripCluster.insert(SiStripCluster_);
       }
@@ -1033,7 +1054,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter,es,detid);
-          clusterInfos(&SiStripClusterInfo_,detid,OffTrack, /*track_ok*/ false,LV,MEs);
+          clusterInfos(&SiStripClusterInfo_,detid,OffTrack, /*track_ok*/ false,LV,MEs, tTopo);
         }
       }
     }
@@ -1076,7 +1097,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
 //------------------------------------------------------------------------
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
-bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, bool track_ok, const LocalVector LV, const Det2MEs& MEs)
+bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, bool track_ok, const LocalVector LV, const Det2MEs& MEs , const TrackerTopology* tTopo)
 {
 
   if (cluster==NULL) return false;
@@ -1150,8 +1171,16 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
     if(MEs.iSubdet != nullptr){
       fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
       if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cosRZ);
+      fillME(MEs.iSubdet->ClusterChargeCorrOnTrack, charge*cosRZ);
       if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
       if(track_ok) fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
+      if( tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 || tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
+        if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrThickOnTrack, StoN*cosRZ);
+        fillME(MEs.iSubdet->ClusterChargeCorrThickOnTrack, charge*cosRZ);
+      } else  {
+        if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrThinOnTrack, StoN*cosRZ);
+        fillME(MEs.iSubdet->ClusterChargeCorrThinOnTrack, charge*cosRZ);
+      }
     }
     //******** TkHistoMaps
     if (TkHistoMap_On_) {


### PR DESCRIPTION
The strip tracker contains thin and thick sensors. While the other partitions consist completely out of thin/thick sensors, the tracker endcap contains a mix. The thickness of the sensors influences the cluster charge and S/N, so the MEs for these are separated for thin and thick sensors in the TEC.

PR for 81X: #16722 