### PR TITLE
update the pA simulation GT to take latest L1T menu and HLT JECs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v11',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v5',
+    'run2_mc_pa'        :   '81X_mcRun2_pA_v7',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '81X_dataRun2_v11',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII simulation 
 
   * **RunII Proton-Lead scenario** : [81X_mcRun2_pA_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v7) as [81X_mcRun2_pA_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_mcRun2_pA_v7/81X_mcRun2_pA_v5): 
      * Updated L1 menu to `L1Menu_HeavyIons2016_v3_m2_xml` 
      * Updated HLT Jet Energy Corrections with new L2L3Residual step for 8 TeV pPb HLT where L1FastJet L2Relative and L3Absolute are taken from `JetCorrectorParametersCollection_HLT_BX25_V11_MC_AK4PFHLT` and `JetCorrectorParametersCollection_HLT_BX25_V11_MC_AK4CaloHLT`

solves issue reported at https://github.com/cms-sw/cmssw/pull/16606#issuecomment-262253173 

tested with: `runTheMatrix.py -l 281.0`

attn: @Martin-Grunewald @silviodonato 