### PR TITLE
Updating L1TO2O with extra HI CaloParams

### DIFF
--- a/L1Trigger/L1TCommon/interface/Tools.h
+++ b/L1Trigger/L1TCommon/interface/Tools.h
@@ -25,7 +25,7 @@ template <class varType> varType convertVariable(const std::string& aVar)
 	catch (std::exception& e)
 	{
 		std::map<std::string, int> hexnums;
-        	std::string strHexNums("0123456789ABCDEF");
+        	std::string strHexNums("0123456789ABCDEFabcdef");
 	       	for(unsigned int i=0; i<strHexNums.size(); i++)
 	                hexnums[strHexNums.substr(i,1)] = i;
 		if ( aVar.substr(0,2) == "0x" && aVar.substr(2,aVar.size()).find_first_not_of(strHexNums) == std::string::npos)

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #from L1Trigger.L1TCalorimeter.caloStage2Params_cfi import *
-from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_towEta27_cfi import *
+from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_cfi import *
 
 L1TCaloParamsOnlineProd = cms.ESProducer("L1TCaloParamsOnlineProd",
     onlineAuthentication = cms.string('.'),

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #from L1Trigger.L1TCalorimeter.caloStage2Params_cfi import *
-from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_2_cfi import *
+from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_HI_towEta27_cfi import *
 
 L1TCaloParamsOnlineProd = cms.ESProducer("L1TCaloParamsOnlineProd",
     onlineAuthentication = cms.string('.'),

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -74,8 +74,16 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
     "tauMaxEta",
     "tauEnergyCalibLUT",
     "tauIsoLUT1",
-    "tauIsoLUT2"
-  };
+    "tauIsoLUT2",
+    "towerCountThreshold",
+    "towerCountMaxEta",
+    "ET_towerThreshold",
+    "MET_towerThreshold",
+    "jetBypassPileUpSub",
+    "egammaBypassCuts",
+    "egammaHOverECut_iEtaLT15",
+    "egammaHOverECut_iEtaGTEq15"
+ };
   for (const auto param : expectedParams) {
     if ( conf.find(param) == conf.end() ) {
       std::cerr << "Unable to locate expected CaloLayer2 parameter: " << param << " in L1 settings payload!";
@@ -88,6 +96,11 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
   paramsHelper.setEgNeighbourThreshold((conf["leptonTowerThreshold"].getValue<int>())/2);
   paramsHelper.setTauNeighbourThreshold((conf["leptonTowerThreshold"].getValue<int>())/2);
   paramsHelper.setJetSeedThreshold((conf["jetSeedThreshold"].getValue<int>())/2);
+  paramsHelper.setJetBypassPUS(conf["jetBypassPileUpSub"].getValue<unsigned>()); //these are bools in onlineDB
+  paramsHelper.setEgBypassEGVetos(conf["egammaBypassCuts"].getValue<unsigned>()); //these are bools in onlineDB
+  paramsHelper.setEgHOverEcutBarrel(conf["egammaHOverECut_iEtaLT15"].getValue<int>());
+  paramsHelper.setEgHOverEcutEndcap(conf["egammaHOverECut_iEtaGTEq15"].getValue<int>());
+
 
   // Currently not used // paramsHelper.setEgPileupTowerThresh((conf["pileUpTowerThreshold"].getValue<int>())); 
   // Currently not used // paramsHelper.setTauPileupTowerThresh((conf["pileUpTowerThreshold"].getValue<int>())); 
@@ -100,13 +113,15 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
   etSumEtaMax.push_back(conf["HTMHT_maxJetEta"].getValue<int>());
   etSumEtaMax.push_back(conf["ETMET_maxTowerEta"].getValue<int>());
   etSumEtaMax.push_back(conf["HTMHT_maxJetEta"].getValue<int>());
+  etSumEtaMax.push_back(conf["towerCountMaxEta"].getValue<int>());
   
-  etSumEtThresh.push_back(0); // ETT tower threshold
+  etSumEtThresh.push_back(conf["ET_towerThreshold"].getValue<int>()); // ETT tower threshold
   etSumEtThresh.push_back(conf["HT_jetThreshold"].getValue<int>());
-  etSumEtThresh.push_back(0); // ETM tower threshold
+  etSumEtThresh.push_back(conf["MET_towerThreshold"].getValue<int>()); // ETM tower threshold
   etSumEtThresh.push_back(conf["MHT_jetThreshold"].getValue<int>());
+  etSumEtThresh.push_back(conf["ET_towerThreshold"].getValue<int>());
 
-  for (uint i=0; i<4; ++i) {
+  for (uint i=0; i<5; ++i) {
     paramsHelper.setEtSumEtaMax(i, etSumEtaMax.at(i));
     paramsHelper.setEtSumEtThreshold(i, etSumEtThresh.at(i));
   }


### PR DESCRIPTION
This is a patch including additional 9 CaloLayer2 parameters required for running the emulator (e.g. in DQM) with real configuration at p5.