### PR TITLE
SimHit vs. RecHit Validation

### DIFF
--- a/Validation/HcalRecHits/BuildFile.xml
+++ b/Validation/HcalRecHits/BuildFile.xml
@@ -11,6 +11,9 @@
 <use   name="Geometry/CaloGeometry"/>
 <use   name="Geometry/CaloTopology"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="SimDataFormats/CaloHit"/>
+<use   name="SimDataFormats/CaloTest"/>
+<use   name="SimDataFormats/ValidationFormats"/>
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/HcalObjects"/>

--- a/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
@@ -74,8 +74,7 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   std::string eventype_;
   std::string sign_;
   std::string mc_;
-  bool        famos_;
-  bool        useAllHistos_;
+  bool testNumber_;
 
   //RecHit Collection input tags
   edm::EDGetTokenT<edm::HepMCProduct> tok_evt_;

--- a/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
@@ -93,178 +93,14 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   int iz;
   int imc;
 
-  // for checking the status of ECAL and HCAL channels stored in the DB 
-  const HcalChannelQuality* theHcalChStatus;
-  // calculator of severety level for HCAL
-  const HcalSeverityLevelComputer* theHcalSevLvlComputer;
-  int hcalSevLvl(const CaloRecHit* hit);
-
-  std::vector<int> hcalHBSevLvlVec, hcalHESevLvlVec, hcalHFSevLvlVec, hcalHOSevLvlVec;
-
-  MonitorElement* sevLvl_HB;
-  MonitorElement* sevLvl_HE;
-  MonitorElement* sevLvl_HF;
-  MonitorElement* sevLvl_HO; 
-
-  // RecHits counters
-  MonitorElement* Nhb;
-  MonitorElement* Nhe;
-  MonitorElement* Nho;
-  MonitorElement* Nhf;
-
-  // ZS-specific
-
-  MonitorElement* map_depth1;
-  MonitorElement* map_depth2;
-  MonitorElement* map_depth3;
-  MonitorElement* map_depth4;
-
-  MonitorElement* ZS_HB1;
-  MonitorElement* ZS_HB2;
-  MonitorElement* ZS_HE1;
-  MonitorElement* ZS_HE2;
-  MonitorElement* ZS_HE3;
-  MonitorElement* ZS_HO;
-  MonitorElement* ZS_HF1;
-  MonitorElement* ZS_HF2;
-
-  MonitorElement* ZS_nHB1;
-  MonitorElement* ZS_nHB2;
-  MonitorElement* ZS_nHE1;
-  MonitorElement* ZS_nHE2;
-  MonitorElement* ZS_nHE3;
-  MonitorElement* ZS_nHO;
-  MonitorElement* ZS_nHF1;
-  MonitorElement* ZS_nHF2;
-
-  MonitorElement* ZS_seqHB1;
-  MonitorElement* ZS_seqHB2;
-  MonitorElement* ZS_seqHE1;
-  MonitorElement* ZS_seqHE2;
-  MonitorElement* ZS_seqHE3;
-  MonitorElement* ZS_seqHO;
-  MonitorElement* ZS_seqHF1;
-  MonitorElement* ZS_seqHF2;
-
   // In ALL other cases : 2D ieta-iphi maps 
   // without and with cuts (a la "Scheme B") on energy
   // - only in the cone around particle for single-part samples (mc = "yes")
   // - for all calls in milti-particle samples (mc = "no")
 
-  MonitorElement* map_ecal;
-
-  MonitorElement* emap_depth1;
-  MonitorElement* emap_depth2;
-  MonitorElement* emap_depth3;
-  MonitorElement* emap_depth4;
-
-  MonitorElement* emean_vs_ieta_HB1;
-  MonitorElement* emean_vs_ieta_HB2;
-  MonitorElement* emean_vs_ieta_HE1;
-  MonitorElement* emean_vs_ieta_HE2;
-  MonitorElement* emean_vs_ieta_HE3;
-  MonitorElement* emean_vs_ieta_HO;
-  MonitorElement* emean_vs_ieta_HF1;
-  MonitorElement* emean_vs_ieta_HF2;
-
-  MonitorElement* RMS_vs_ieta_HB1;
-  MonitorElement* RMS_vs_ieta_HB2;
-  MonitorElement* RMS_vs_ieta_HE1;
-  MonitorElement* RMS_vs_ieta_HE2;
-  MonitorElement* RMS_vs_ieta_HE3;
-  MonitorElement* RMS_vs_ieta_HO;
-  MonitorElement* RMS_vs_ieta_HF1;
-  MonitorElement* RMS_vs_ieta_HF2;
-
-  MonitorElement* emean_seqHB1;
-  MonitorElement* emean_seqHB2;
-  MonitorElement* emean_seqHE1;
-  MonitorElement* emean_seqHE2;
-  MonitorElement* emean_seqHE3;
-  MonitorElement* emean_seqHO;
-  MonitorElement* emean_seqHF1;
-  MonitorElement* emean_seqHF2;
-
-  MonitorElement* RMS_seq_HB1;
-  MonitorElement* RMS_seq_HB2;
-  MonitorElement* RMS_seq_HE1;
-  MonitorElement* RMS_seq_HE2;
-  MonitorElement* RMS_seq_HE3;
-  MonitorElement* RMS_seq_HO;
-  MonitorElement* RMS_seq_HF1;
-  MonitorElement* RMS_seq_HF2;
-
-  MonitorElement* occupancy_map_HB1;
-  MonitorElement* occupancy_map_HB2;
-  MonitorElement* occupancy_map_HE1;
-  MonitorElement* occupancy_map_HE2;
-  MonitorElement* occupancy_map_HE3;
-  MonitorElement* occupancy_map_HO;
-  MonitorElement* occupancy_map_HF1;
-  MonitorElement* occupancy_map_HF2;
-
-  MonitorElement* occupancy_vs_ieta_HB1;
-  MonitorElement* occupancy_vs_ieta_HB2;
-  MonitorElement* occupancy_vs_ieta_HE1;
-  MonitorElement* occupancy_vs_ieta_HE2;
-  MonitorElement* occupancy_vs_ieta_HE3;
-  MonitorElement* occupancy_vs_ieta_HO;
-  MonitorElement* occupancy_vs_ieta_HF1;
-  MonitorElement* occupancy_vs_ieta_HF2;
-
-  MonitorElement* occupancy_seqHB1;
-  MonitorElement* occupancy_seqHB2;
-  MonitorElement* occupancy_seqHE1;
-  MonitorElement* occupancy_seqHE2;
-  MonitorElement* occupancy_seqHE3;
-  MonitorElement* occupancy_seqHO;
-  MonitorElement* occupancy_seqHF1;
-  MonitorElement* occupancy_seqHF2;
-
-
-  // also - energy in the cone around MC particle
-  MonitorElement* map_econe_depth1;
-  MonitorElement* map_econe_depth2;
-  MonitorElement* map_econe_depth3;
-  MonitorElement* map_econe_depth4;
- 
-  // for single monoenergetic particles - cone collection profile vs ieta.
-  MonitorElement* meEnConeEtaProfile_depth1;
-  MonitorElement* meEnConeEtaProfile_depth2;
-  MonitorElement* meEnConeEtaProfile_depth3;
-  MonitorElement* meEnConeEtaProfile_depth4;
   MonitorElement* meEnConeEtaProfile;
   MonitorElement* meEnConeEtaProfile_E;
   MonitorElement* meEnConeEtaProfile_EH;
-  // Single particles - deviation of cluster from MC truth
-  MonitorElement* meDeltaPhi;
-  MonitorElement* meDeltaEta;
-  MonitorElement* meDeltaPhiS;  // simcluster
-  MonitorElement* meDeltaEtaS;  // simculster
-
-  //----------- NOISE case
-  MonitorElement* e_hb;
-  MonitorElement* e_he;
-  MonitorElement* e_ho;
-  MonitorElement* e_hfl;
-  MonitorElement* e_hfs;
-
-  // number of rechits above threshold 1GEV
-  MonitorElement* meNumRecHitsThreshHB;
-  MonitorElement* meNumRecHitsThreshHE;
-  MonitorElement* meNumRecHitsThreshHO;
-
-  // number of rechits in the cone
-  MonitorElement* meNumRecHitsConeHB;
-  MonitorElement* meNumRecHitsConeHE;
-  MonitorElement* meNumRecHitsConeHO;
-  MonitorElement* meNumRecHitsConeHF;
-
-  // time?
-  MonitorElement* meTimeHB;
-  MonitorElement* meTimeHE;
-  MonitorElement* meTimeHO;
-  MonitorElement* meTimeHF;
 
   // energy of rechits
   MonitorElement* meRecHitsEnergyHB;
@@ -272,57 +108,20 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   MonitorElement* meRecHitsEnergyHO;
   MonitorElement* meRecHitsEnergyHF;
 
-  MonitorElement* meTE_Low_HB;
-  MonitorElement* meTE_HB;
-  MonitorElement* meTE_High_HB;
-  MonitorElement* meTE_HB1;
-  MonitorElement* meTE_HB2;
   MonitorElement* meTEprofileHB_Low;
   MonitorElement* meTEprofileHB;
   MonitorElement* meTEprofileHB_High;
 
-  MonitorElement* meTE_Low_HE;
-  MonitorElement* meTE_HE;
-  MonitorElement* meTE_HE1;
-  MonitorElement* meTE_HE2;
   MonitorElement* meTEprofileHE_Low;
   MonitorElement* meTEprofileHE;
 
-  MonitorElement* meTE_HO;
-  MonitorElement* meTE_High_HO;
   MonitorElement* meTEprofileHO;
   MonitorElement* meTEprofileHO_High;
 
-  MonitorElement* meTE_Low_HF;
-  MonitorElement* meTE_HF;
-  MonitorElement* meTE_HFL;
-  MonitorElement* meTE_HFS;
   MonitorElement* meTEprofileHF_Low;
   MonitorElement* meTEprofileHF;
 
 
-  MonitorElement* meSumRecHitsEnergyHB;
-  MonitorElement* meSumRecHitsEnergyHE;
-  MonitorElement* meSumRecHitsEnergyHO;
-  MonitorElement* meSumRecHitsEnergyHF;
-
-
-  MonitorElement* meSumRecHitsEnergyConeHB;
-  MonitorElement* meSumRecHitsEnergyConeHE;
-  MonitorElement* meSumRecHitsEnergyConeHO;
-  MonitorElement* meSumRecHitsEnergyConeHF;
-  MonitorElement* meSumRecHitsEnergyConeHFL;
-  MonitorElement* meSumRecHitsEnergyConeHFS;
-
-
-  MonitorElement* meEcalHcalEnergyHB;
-  MonitorElement* meEcalHcalEnergyHE;
-   
-  MonitorElement* meEcalHcalEnergyConeHB; 
-  MonitorElement* meEcalHcalEnergyConeHE; 
-  MonitorElement* meEcalHcalEnergyConeHO; 
-  MonitorElement* meEcalHcalEnergyConeHF; 
- 
   // Histo (2D plot) for sum of RecHits vs SimHits (hcal only)
   MonitorElement* meRecHitSimHitHB;
   MonitorElement* meRecHitSimHitHE;
@@ -342,31 +141,9 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   MonitorElement* meEnergyHcalVsEcalHB;
   MonitorElement* meEnergyHcalVsEcalHE;
   
-  // number of ECAL's rechits in cone 0.3 
-  MonitorElement* meNumEcalRecHitsConeHB;
-  MonitorElement* meNumEcalRecHitsConeHE;
 
   edm::ESHandle<CaloGeometry> geometry ;
 
-  //Status word histos
-  MonitorElement* RecHit_StatusWord_HB;
-  MonitorElement* RecHit_StatusWord_HE;
-  MonitorElement* RecHit_StatusWord_HF;
-  MonitorElement* RecHit_StatusWord_HF67;
-  MonitorElement* RecHit_StatusWord_HO;
-
-  //Status word correlation
-  MonitorElement* RecHit_StatusWordCorr_HB;
-  MonitorElement* RecHit_StatusWordCorr_HE;
-
-  MonitorElement* RecHit_StatusWordCorrAll_HB;
-  MonitorElement* RecHit_StatusWordCorrAll_HE;
-
-  //Aux Status word histos
-  MonitorElement* RecHit_Aux_StatusWord_HB;
-  MonitorElement* RecHit_Aux_StatusWord_HE;
-  MonitorElement* RecHit_Aux_StatusWord_HF;
-  MonitorElement* RecHit_Aux_StatusWord_HO;
 
  // Filling vectors with essential RecHits data
   std::vector<int>      csub;
@@ -380,9 +157,6 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   std::vector<double>   cz;
   std::vector<uint32_t> cstwd;
   std::vector<uint32_t> cauxstwd;
-
-  // array or min. e-values  ieta x iphi x depth x subdet
-  double emap_min[82][72][4][4];
 
   // counter
   int nevtot;

--- a/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
@@ -71,7 +71,6 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   std::string outputFile_;
   std::string hcalselector_;
   std::string ecalselector_;
-  std::string eventype_;
   std::string sign_;
   std::string mc_;
   bool testNumber_;
@@ -89,7 +88,6 @@ class HcalRecHitsValidation : public DQMEDAnalyzer {
   int subdet_;
 
   // single/multi-particle sample (1/2)
-  int etype_;
   int iz;
   int imc;
 

--- a/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
@@ -10,7 +10,9 @@ hcalRecoAnalyzer = cms.EDAnalyzer("HcalRecHitsValidation",
     eventype                  = cms.untracked.string('multi'),
     ecalselector              = cms.untracked.string('yes'),
     hcalselector              = cms.untracked.string('all'),
-    mc                        = cms.untracked.string('no')
+    mc                        = cms.untracked.string('no'),
+
+    TestNumber                = cms.bool(False)
 )
 
 hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
@@ -20,3 +22,6 @@ hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
     minHitEnergy = cms.untracked.double(1.5),
     noiselabel   = cms.InputTag('hcalnoise')
 )
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify( hcalSimHitStudy, TestNumber = cms.bool(True) )

--- a/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
@@ -24,4 +24,4 @@ hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
 )
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify( hcalSimHitStudy, TestNumber = cms.bool(True) )
+phase2_hcal.toModify( hcalRecoAnalyzer, TestNumber = cms.bool(True) )

--- a/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
@@ -7,7 +7,6 @@ hcalRecoAnalyzer = cms.EDAnalyzer("HcalRecHitsValidation",
     HFRecHitCollectionLabel   = cms.untracked.InputTag("hfreco"),
     HORecHitCollectionLabel   = cms.untracked.InputTag("horeco"),
 
-    eventype                  = cms.untracked.string('multi'),
     ecalselector              = cms.untracked.string('yes'),
     hcalselector              = cms.untracked.string('all'),
     mc                        = cms.untracked.string('no'),

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -93,6 +93,13 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_High_HB" ) ;
       meTEprofileHB_High = ib.bookProfile(histo, histo, 150, -5., 295., 70, -48., 92.); 
 
+      if(imc != 0) {
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HB");
+        meRecHitSimHitHB = ib.book2D(histo, histo, 120, 0., 1.2,  300, 0., 150.);
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HB");
+        meRecHitSimHitProfileHB = ib.bookProfile(histo, histo, 120, 0., 1.2, 500, 0., 500.);  
+      } 
+
     }
     
     // ********************** HE ************************************
@@ -107,6 +114,13 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HE" ) ;
       meTEprofileHE = ib.bookProfile(histo, histo, 200, -5., 2995., 70, -48., 92.); 
       
+      if(imc != 0) {
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HE");
+        meRecHitSimHitHE = ib.book2D(histo, histo, 120, 0., 0.6,  300, 0., 150.);
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HE");
+        meRecHitSimHitProfileHE = ib.bookProfile(histo, histo, 120, 0., 0.6, 500, 0., 500.);  
+      }
+
     }
 
     // ************** HO ****************************************
@@ -121,6 +135,13 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_High_HO" ) ;
       meTEprofileHO_High = ib.bookProfile(histo, histo, 100, -5., 995.,  70, -48., 92.); 
       
+      if(imc != 0) {
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HO");
+        meRecHitSimHitHO = ib.book2D(histo, histo, 150, 0., 1.5,  350, 0., 350.);
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HO");
+        meRecHitSimHitProfileHO = ib.bookProfile(histo, histo, 150, 0., 1.5, 500, 0., 500.);  
+      }
+
     }   
   
     // ********************** HF ************************************
@@ -134,6 +155,21 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HF" ) ;
       meTEprofileHF = ib.bookProfile(histo, histo, 200, -5., 995., 70, -48., 92.); 
+
+      if(imc != 0) {
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HF");
+        meRecHitSimHitHF  = ib.book2D(histo, histo, 50, 0., 50., 150, 0., 150.);      
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HFL");
+        meRecHitSimHitHFL = ib.book2D(histo, histo, 50, 0., 50., 150, 0., 150.);      
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HFS");
+        meRecHitSimHitHFS = ib.book2D(histo, histo, 50, 0., 50., 150, 0., 150.);
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HF");
+        meRecHitSimHitProfileHF  = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFL");
+        meRecHitSimHitProfileHFL = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+        sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFS");
+        meRecHitSimHitProfileHFS = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+      }
 
     }
 

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -443,6 +443,8 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
         depth        = cell.depth();
       }
 
+      if(sub != subdet_ && subdet_ != 5) continue; //If we are not looking at all of the subdetectors and the simhit doesn't come from the specific subdetector of interest, then we won't do any thing with it 
+
       const CaloCellGeometry* cellGeometry =
 	geometry->getSubdetectorGeometry (cell)->getGeometry (cell) ;
       double etaS = cellGeometry->getPosition().eta () ;
@@ -452,6 +454,7 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
       double r  = dR(eta_MC, phi_MC, etaS, phiS);
        
       if ( r < partR ){ // just energy in the small cone
+ 
 	enSimHits += en;
 	if(sub == static_cast<int>(HcalBarrel)) enSimHitsHB += en; 
 	if(sub == static_cast<int>(HcalEndcap)) enSimHitsHE += en; 

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -69,13 +69,13 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
     //Histograms drawn for single pion scan
     if(subdet_ != 0 && imc != 0) { // just not for noise  
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths");
-      meEnConeEtaProfile = ib.bookProfile(histo, histo, 82, -41., 41.,        2100, -100., 2000.);  
+      meEnConeEtaProfile = ib.bookProfile(histo, histo, 82, -41., 41., -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_E");
-      meEnConeEtaProfile_E = ib.bookProfile(histo, histo, 82, -41., 41.,      2100, -100., 2000.);  
+      meEnConeEtaProfile_E = ib.bookProfile(histo, histo, 82, -41., 41., -100., 2000., " ");  
       
       sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_EH");
-      meEnConeEtaProfile_EH = ib.bookProfile(histo, histo, 82, -41., 41.,     2100, -100., 2000.);  
+      meEnConeEtaProfile_EH = ib.bookProfile(histo, histo, 82, -41., 41., -100., 2000., " ");  
     }
 
     // ************** HB **********************************
@@ -85,19 +85,19 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       meRecHitsEnergyHB = ib.book1D(histo, histo, 2010 , -10. , 2000.); 
       
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HB" ) ;
-      meTEprofileHB = ib.bookProfile(histo, histo, 150, -5., 295., 70, -48., 92.); 
+      meTEprofileHB = ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HB" ) ;
-      meTEprofileHB_Low = ib.bookProfile(histo, histo, 150, -5., 295., 70, -48., 92.); 
+      meTEprofileHB_Low = ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_High_HB" ) ;
-      meTEprofileHB_High = ib.bookProfile(histo, histo, 150, -5., 295., 70, -48., 92.); 
+      meTEprofileHB_High = ib.bookProfile(histo, histo, 150, -5., 295., 48., 92., " "); 
 
       if(imc != 0) {
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HB");
         meRecHitSimHitHB = ib.book2D(histo, histo, 120, 0., 1.2,  300, 0., 150.);
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HB");
-        meRecHitSimHitProfileHB = ib.bookProfile(histo, histo, 120, 0., 1.2, 500, 0., 500.);  
+        meRecHitSimHitProfileHB = ib.bookProfile(histo, histo, 120, 0., 1.2, 0., 500., " ");  
       } 
 
     }
@@ -109,16 +109,16 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       meRecHitsEnergyHE = ib.book1D(histo, histo, 2010, -10., 2000.);
       
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HE" ) ;
-      meTEprofileHE_Low = ib.bookProfile(histo, histo, 80, -5., 75., 70, -48., 92.); 
+      meTEprofileHE_Low = ib.bookProfile(histo, histo, 80, -5., 75., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HE" ) ;
-      meTEprofileHE = ib.bookProfile(histo, histo, 200, -5., 2995., 70, -48., 92.); 
+      meTEprofileHE = ib.bookProfile(histo, histo, 200, -5., 2995., -48., 92., " "); 
       
       if(imc != 0) {
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HE");
         meRecHitSimHitHE = ib.book2D(histo, histo, 120, 0., 0.6,  300, 0., 150.);
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HE");
-        meRecHitSimHitProfileHE = ib.bookProfile(histo, histo, 120, 0., 0.6, 500, 0., 500.);  
+        meRecHitSimHitProfileHE = ib.bookProfile(histo, histo, 120, 0., 0.6, 0., 500., " ");  
       }
 
     }
@@ -130,16 +130,16 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       meRecHitsEnergyHO = ib.book1D(histo, histo, 2010 , -10. , 2000.);
       
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HO" ) ;
-      meTEprofileHO = ib.bookProfile(histo, histo, 60, -5., 55.,  70, -48., 92.); 
+      meTEprofileHO = ib.bookProfile(histo, histo, 60, -5., 55., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_High_HO" ) ;
-      meTEprofileHO_High = ib.bookProfile(histo, histo, 100, -5., 995.,  70, -48., 92.); 
+      meTEprofileHO_High = ib.bookProfile(histo, histo, 100, -5., 995., -48., 92., " "); 
       
       if(imc != 0) {
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HO");
         meRecHitSimHitHO = ib.book2D(histo, histo, 150, 0., 1.5,  350, 0., 350.);
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HO");
-        meRecHitSimHitProfileHO = ib.bookProfile(histo, histo, 150, 0., 1.5, 500, 0., 500.);  
+        meRecHitSimHitProfileHO = ib.bookProfile(histo, histo, 150, 0., 1.5, 0., 500., " ");  
       }
 
     }   
@@ -151,10 +151,10 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
       meRecHitsEnergyHF = ib.book1D(histo, histo, 2010 , -10. , 2000.); 
       
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HF" ) ;
-      meTEprofileHF_Low = ib.bookProfile(histo, histo, 100, -5., 195., 70, -48., 92.); 
+      meTEprofileHF_Low = ib.bookProfile(histo, histo, 100, -5., 195., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_HF" ) ;
-      meTEprofileHF = ib.bookProfile(histo, histo, 200, -5., 995., 70, -48., 92.); 
+      meTEprofileHF = ib.bookProfile(histo, histo, 200, -5., 995., -48., 92., " "); 
 
       if(imc != 0) {
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HF");
@@ -164,11 +164,11 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HFS");
         meRecHitSimHitHFS = ib.book2D(histo, histo, 50, 0., 50., 150, 0., 150.);
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HF");
-        meRecHitSimHitProfileHF  = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+        meRecHitSimHitProfileHF  = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");  
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFL");
-        meRecHitSimHitProfileHFL = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+        meRecHitSimHitProfileHFL = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");  
         sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFS");
-        meRecHitSimHitProfileHFS = ib.bookProfile(histo, histo, 50, 0., 50., 500, 0., 500.);  
+        meRecHitSimHitProfileHFS = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");  
       }
 
     }

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -17,7 +17,6 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
   
   hcalselector_ = conf.getUntrackedParameter<std::string>("hcalselector", "all");
   ecalselector_ = conf.getUntrackedParameter<std::string>("ecalselector", "yes");
-  eventype_     = conf.getUntrackedParameter<std::string>("eventype", "single");
   sign_         = conf.getUntrackedParameter<std::string>("sign", "*");
   mc_           = conf.getUntrackedParameter<std::string>("mc", "yes");
   testNumber_   = conf.getParameter<bool>("TestNumber");
@@ -41,9 +40,6 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
   if (hcalselector_ == "HF"   ) subdet_ = 4;
   if (hcalselector_ == "all"  ) subdet_ = 5;
   if (hcalselector_ == "ZS"   ) subdet_ = 6;
-
-  etype_ = 1;
-  if (eventype_ == "multi") etype_ = 2;
 
   iz = 1;
   if(sign_ == "-") iz = -1;


### PR DESCRIPTION
Restores SimHit vs. RecHit comparisons removed from Validation/HcalRecHits/HcalRecHitsValidation in PR #PR. It adds support for testNumber in SimHit collection which is currently being used in 2023 workflows.