### PR TITLE
Extended maximum allowed span for Phase2 Inner Tracker pixel clusters

### DIFF
--- a/DataFormats/Phase2ITPixelCluster/interface/Phase2ITPixelCluster.h
+++ b/DataFormats/Phase2ITPixelCluster/interface/Phase2ITPixelCluster.h
@@ -65,7 +65,7 @@ public:
     
   static constexpr unsigned int POSBITS=20;
   static constexpr unsigned int SPANBITS=12;
-  static constexpr unsigned int MAXSPAN=127;
+  static constexpr unsigned int MAXSPAN=255;
   static constexpr unsigned int MAXPOS=2047;
   
   /** Construct from a range of digis that form a cluster and from 


### PR DESCRIPTION
This PR extends the maximum allowed span for Phase2 Inner Tracker pixel clusters from 127 to 255 to stay in sync with #16393.

Note that the DataFormat would actually allow the maximum to go above 255. However, given the fact that pixel clusters are limited to containing a maximum of 256 pixels, setting the maximum allowed span to 255 is sufficient.

@emiglior @atricomi @ebrondol
