### PR TITLE
set decay time in the right place for the antiparticle in Pythia8PtGun

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -91,16 +91,18 @@ bool Py8PtGun::generatePartonsAndHadronize()
 	  (fMasterGen->event).append( -particleID, 23, 0, 101, -px, -py, -pz, ee, mass );
          } else if (fabs(particleID) == 21){                   // gluons
 	  (fMasterGen->event).append( 21, 23, 102, 101, -px, -py, -pz, ee, mass );
-         } else if ( (fMasterGen->particleData).isParticle( -particleID ) ) {
-	    (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
          } else {
-	    (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-        int eventSize = (fMasterGen->event).size()-1;
-        // -log(flat) = exponential distribution
-        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-        (fMasterGen->event)[eventSize].tau( tauTmp );
+	   if ( (fMasterGen->particleData).isParticle( -particleID ) ) {
+	     (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	   } else {
+	     (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	   }
+	   int eventSize = (fMasterGen->event).size()-1;
+	   // -log(flat) = exponential distribution
+	   double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+	   (fMasterGen->event)[eventSize].tau( tauTmp );
          }
-	  }
+      }
    }
    
    if ( !fMasterGen->next() ) return false;


### PR DESCRIPTION

oddly enough, before this fix the not only the anti-particle doesn't decay,
but also the decaying particle comes out with ctau=0 (prompt decays).

K-gun with decays allowed:
Before:
```
eo->Scan("recoGenParticles_genParticles__GEN.obj.pdgId():recoGenParticles_genParticles__GEN.obj.vx():recoGenParticles_genParticles__GEN.obj.vy():recoGenParticles_genParticles__GEN.obj.vz():recoGenParticles_genParticles__GEN.obj.pt()")
***********************************************************************************
*    Row   * Instance * recoGenPa * recoGenPa * recoGenPa * recoGenPa * recoGenPa *
***********************************************************************************
*        0 *        0 *      -321 * 0.1056949 * 0.1692507 * 1.3009399 * 60.489666 *
*        0 *        1 *       321 * 0.1056949 * 0.1692507 * 1.3009399 * 60.489666 *
*        0 *        2 *       -13 * 0.1056949 * 0.1692507 * 1.3009399 * 26.971918 *
*        0 *        3 *        14 * 0.1056949 * 0.1692507 * 1.3009399 * 33.517959 *
```

After:
```
e->Scan("recoGenParticles_genParticles__GEN.obj.pdgId():recoGenParticles_genParticles__GEN.obj.vx():recoGenParticles_genParticles__GEN.obj.vy():recoGenParticles_genParticles__GEN***********************************************************************************
*    Row   * Instance * recoGenPa * recoGenPa * recoGenPa * recoGenPa * recoGenPa *
***********************************************************************************
*        0 *        0 *      -321 * 0.1052539 * 0.1674712 * -4.651619 * 52.327102 *
*        0 *        1 *       321 * 0.1052539 * 0.1674712 * -4.651619 * 52.327102 *
*        0 *        2 *       -13 * 14.896501 * -98.68802 * 8.3533515 * 36.057064 *
*        0 *        3 *        14 * 14.896501 * -98.68802 * 8.3533515 * 16.271556 *
```

note vx,vy,vz for muons
(both +13 and -13 show up).

