### PR TITLE
Add cms_ prefix to float<BITS>x<ELEM_NUM>_t typedefs

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -9,21 +9,21 @@
 #define VECTOR_EXT(N) __attribute__( ( vector_size( N ) ) )
 #endif
 
-typedef float  VECTOR_EXT(  8 ) float32x2_t;
-typedef float  VECTOR_EXT( 16 ) float32x4_t;
-typedef float  VECTOR_EXT( 32 ) float32x8_t;
-typedef double VECTOR_EXT( 16 ) float64x2_t;
-typedef double VECTOR_EXT( 32 ) float64x4_t;
-typedef double VECTOR_EXT( 64 ) float64x8_t;
+typedef float  VECTOR_EXT(  8 ) cms_float32x2_t;
+typedef float  VECTOR_EXT( 16 ) cms_float32x4_t;
+typedef float  VECTOR_EXT( 32 ) cms_float32x8_t;
+typedef double VECTOR_EXT( 16 ) cms_float64x2_t;
+typedef double VECTOR_EXT( 32 ) cms_float64x4_t;
+typedef double VECTOR_EXT( 64 ) cms_float64x8_t;
 
 // Enable only for AArch64 for now as this would ICE GCC on
 // x86_64.
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
 // XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491
 #if defined(__aarch64__) || defined(__powerpc64__) || defined(__PPC64__) || defined(__powerpc__)
-typedef long double VECTOR_EXT( 32 ) float128x2_t;
-typedef long double VECTOR_EXT( 64 ) float128x4_t;
-typedef long double VECTOR_EXT( 128 ) float128x8_t;
+typedef long double VECTOR_EXT( 32 ) cms_float128x2_t;
+typedef long double VECTOR_EXT( 64 ) cms_float128x4_t;
+typedef long double VECTOR_EXT( 128 ) cms_float128x8_t;
 #endif
 
 // template<typename T, int N> using ExtVec =  T __attribute__( ( vector_size( N*sizeof(T) ) ) );

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -230,8 +230,8 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
   }
 
 #ifdef USE_VECTORS_HERE 
-  float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
-  float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
+  cms_float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
+  cms_float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
   auto phis = f_asin07f(num/den);
   phis = phis*dLayer/(rLayer*cosCross);
   auto deltaPhi = std::abs(phis[0]-phis[1]);


### PR DESCRIPTION
We have recently moved to Eigen 3.3 with

- Many ARM NEON improvements, including support for ARMv8 (64-bit code),
  VFPv4 (fused-multiply-accumulate instruction), and correct tuning of
  the target number of vector registers.

Internally Eigen loads `arm_neon.h` on AArch64 target to use ARM NEON
intrinsics. The header defines extra system types:

    float<BITS>x<ELEM_NUM>_t

Let's add `cms_` prefix to our types to avoid conflicts with system
types, which lead to compilation errors.

NOTE: these types are not directly used within CMSSW.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>