### PR TITLE
bug fix in clone constructor of GsfElectron. 

### DIFF
--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -81,6 +81,7 @@ GsfElectron::GsfElectron
    //closestCtfTrack_(electron.closestCtfTrack_),
    fiducialFlags_(electron.fiducialFlags_),
    showerShape_(electron.showerShape_),
+   full5x5_showerShape_(electron.full5x5_showerShape_),
    dr03_(electron.dr03_), dr04_(electron.dr04_),
    conversionRejection_(electron.conversionRejection_),
    pfIso_(electron.pfIso_),

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -33,7 +33,8 @@ class SCEnergyCorrectorSemiParm {
   ~SCEnergyCorrectorSemiParm(); 
   
   void setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc);
-  
+
+  std::pair<double,double> getCorrections(const reco::SuperCluster &sc) const;
   void modifyObject(reco::SuperCluster &sc);
   
   void setEventSetup(const edm::EventSetup &es);

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -299,8 +299,7 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
       ecor = mean*eval[6]+sc.preshowerEnergy();
 
 	p.first  = ecor;
-	p.second = 0.;
-
+	//p.second unchanged 
   }
 
   return p;
@@ -310,9 +309,9 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
 void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
   
 	std::pair<double, double> cor = getCorrections(sc);
-	if(cor.first<0 || cor.second < 0) return;
+	if(cor.first<0) return;
 	sc.setEnergy(cor.first);
 	sc.setCorrectedEnergy(cor.first);
-	sc.setCorrectedEnergyUncertainty(cor.second);
+	if(! isHLT_ && cor.second>=0.) sc.setCorrectedEnergyUncertainty(cor.second);
 }
 

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -97,10 +97,13 @@ void SCEnergyCorrectorSemiParm::setEvent(const edm::Event &e) {
 }
 
 //--------------------------------------------------------------------------------------------------
-void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
-  
+std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::SuperCluster &sc) const {
+  std::pair<double, double> p;
+  p.first=-1;
+  p.second=-1;
+
   // protect against HGCal, don't mod the object
-  if( sc.seed()->seed().det() == DetId::Forward ) return;
+  if( sc.seed()->seed().det() == DetId::Forward ) return p;
 
   const reco::CaloCluster &seedCluster = *(sc.seed());
   const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;
@@ -240,9 +243,9 @@ void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
     double ecor = mean*(eval[1]);
     const double sigmacor = sigma*ecor;
     
-    sc.setEnergy(ecor);
-    sc.setCorrectedEnergy(ecor);
-    sc.setCorrectedEnergyUncertainty(sigmacor);
+	p.first  = ecor;
+	p.second = sigmacor;
+
   } else {
 
     std::array<float, 7> eval;  
@@ -294,9 +297,22 @@ void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
     double ecor = mean*eval[6];
     if (!iseb)  
       ecor = mean*eval[6]+sc.preshowerEnergy();
+
+	p.first  = ecor;
+	p.second = 0.;
+
+  }
+
+  return p;
+}
    
-    sc.setEnergy(ecor);
-    sc.setCorrectedEnergy(ecor);
-  }  
+//--------------------------------------------------------------------------------------------------
+void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
+  
+	std::pair<double, double> cor = getCorrections(sc);
+	if(cor.first<0 || cor.second < 0) return;
+	sc.setEnergy(cor.first);
+	sc.setCorrectedEnergy(cor.first);
+	sc.setCorrectedEnergyUncertainty(cor.second);
 }
 


### PR DESCRIPTION
New method to get regression correction without modifying the object, this method is needed in the ECALELF framework