### PR TITLE
Use make_shared in core software

### DIFF
--- a/DataFormats/Common/test/DetSetNewTS_t.cpp
+++ b/DataFormats/Common/test/DetSetNewTS_t.cpp
@@ -246,7 +246,7 @@ void TestDetSet::fillSeq() {
 
 void TestDetSet::fillPar() {
   std::cout << std::endl;
-  std::shared_ptr<Getter> pg(new Getter(this));
+  auto pg = std::make_shared<Getter>(this);
   Getter & g = *pg;
   int maxDet=100*nth;
   std::vector<unsigned int> v(maxDet); int k=20;for (auto &i:v) i=k++;

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -518,10 +518,8 @@ Event::throwProductNotFoundException(std::type_info const& iType, char const* iM
 fwlite::LuminosityBlock const& Event::getLuminosityBlock() const {
   if (not lumi_) {
     // Branch map pointer not really being shared, owned by event, have to trick Lumi
-    lumi_ = std::shared_ptr<fwlite::LuminosityBlock> (
-             new fwlite::LuminosityBlock(std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
-             runFactory_)
-          );
+    lumi_ = std::make_shared<fwlite::LuminosityBlock> (std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
+             runFactory_);
   }
   edm::RunNumber_t             run  = eventAuxiliary().run();
   edm::LuminosityBlockNumber_t lumi = eventAuxiliary().luminosityBlock();

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -284,7 +284,7 @@ XrdFile::readv (IOPosBuffer *into, IOSize n)
     return read(into[0].data(), into[0].size(), into[0].offset());
   }
 
-  std::shared_ptr<std::vector<IOPosBuffer> >cl(new std::vector<IOPosBuffer>);
+  auto cl = std::make_shared<std::vector<IOPosBuffer>>();
 
   // CMSSW may issue large readv's; Xrootd is only able to handle
   // 1024.  Further, the splitting algorithm may slightly increase

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -233,7 +233,7 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
   timespec ts;
   GET_CLOCK_MONOTONIC(ts);
 
-  std::shared_ptr<Source> source(new Source(ts, std::move(file), excludeString));
+  auto source = std::make_shared<Source>(ts, std::move(file), excludeString);
   {
     std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
     auto oldList = m_activeSources;
@@ -700,7 +700,7 @@ XrdAdaptor::RequestManager::handle(std::shared_ptr<std::vector<IOPosBuffer> > io
 
     if (activeSources.size() == 1)
     {
-        std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr(new XrdAdaptor::ClientRequest(*this, iolist));
+        auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
         checkSources(now, c_ptr->getSize(), activeSources,inactiveSources);
         activeSources[0]->handle(c_ptr);
         return c_ptr->get_future();
@@ -719,15 +719,15 @@ XrdAdaptor::RequestManager::handle(std::shared_ptr<std::vector<IOPosBuffer> > io
     }
 
     assert(iolist.get());
-    std::shared_ptr<std::vector<IOPosBuffer> > req1(new std::vector<IOPosBuffer>);
-    std::shared_ptr<std::vector<IOPosBuffer> > req2(new std::vector<IOPosBuffer>);
+    auto req1 = std::make_shared<std::vector<IOPosBuffer>>();
+    auto req2 = std::make_shared<std::vector<IOPosBuffer>>();
     splitClientRequest(*iolist, *req1, *req2, activeSources);
 
     checkSources(now, req1->size() + req2->size(), activeSources, inactiveSources);
     // CheckSources may have removed a source
     if (activeSources.size() == 1)
     {
-        std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr(new XrdAdaptor::ClientRequest(*this, iolist));
+        auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
         activeSources[0]->handle(c_ptr);
         return c_ptr->get_future();
     }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -62,7 +62,7 @@ public:
      */
     std::future<IOSize> handle(void * into, IOSize size, IOOffset off)
     {
-        std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr(new XrdAdaptor::ClientRequest(*this, into, size, off));
+        auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, into, size, off);
         return handle(c_ptr);
     }
 


### PR DESCRIPTION
"auto thePtr = std::make_shared&lt;MyClass&gt;(...)" is preferred to "shared_ptr thePtr(new MyClass(...)) " because it saves a memory allocation. It allocates the shared_ptr and the pointee in the same allocation.
This PR changes the very few places in core software that did it the suboptimal way.
Note: make_shared requires that the pointee class has a public constructor. There were two cases where the pointee class had a private constructor, so I did not change those cases.