### PR TITLE
Change the isolation in the reco::Photon to the value computed by CITK

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -40,6 +40,8 @@ namespace citk {
 			      const edm::EventSetup&) override final;
 
     void produce(edm::Event&, const edm::EventSetup&) override final;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
   private:  
     // datamembers
@@ -170,6 +172,35 @@ namespace citk {
 	ev.put(std::move(the_product),_product_names[i][j]);
       }
     }
+  }
+
+// ParameterSet description for module
+void PFIsolationSumProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {  
+    edm::ParameterSetDescription iDesc;
+    iDesc.setComment("isolation sum producer");
+
+    iDesc.add<edm::InputTag>("srcToIsolate", edm::InputTag("no default"))->setComment("calculate isolation for this collection");
+    iDesc.add<edm::InputTag>("srcForIsolationCone", edm::InputTag("no default"))->setComment("collection for the isolation calculation: like particleFlow ");
+
+    edm::ParameterSetDescription descIsoConeDefinitions;
+    descIsoConeDefinitions.add<std::string>("isolationAlgo", "no default");
+    descIsoConeDefinitions.add<double>("coneSize", 0.3);
+    descIsoConeDefinitions.add<std::string>("isolateAgainst", "no default");
+    descIsoConeDefinitions.add<std::vector<unsigned>>("miniAODVertexCodes", {2,3});
+    descIsoConeDefinitions.addOptional<double>("VetoConeSizeBarrel", 0.0);
+    descIsoConeDefinitions.addOptional<double>("VetoConeSizeEndcaps", 0.0);
+    descIsoConeDefinitions.addOptional<int>("vertexIndex",0);
+    descIsoConeDefinitions.addOptional<edm::InputTag>("particleBasedIsolation",edm::InputTag("no default"))->setComment("map for footprint removal that is used for photons");
+
+
+    std::vector<edm::ParameterSet> isolationConeDefinitions;
+    edm::ParameterSet chargedHadrons, neutralHadrons,photons;
+    isolationConeDefinitions.push_back(chargedHadrons);
+    isolationConeDefinitions.push_back(neutralHadrons);
+    isolationConeDefinitions.push_back(photons);
+    iDesc.addVPSet("isolationConeDefinitions", descIsoConeDefinitions, isolationConeDefinitions);
+
+    descriptions.add("CITKPFIsolationSumProducer", iDesc);
   }
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmIsoConeDefinitions_cfi.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmIsoConeDefinitions_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+IsoConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h+'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+
+                                    ),
+                               cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h0'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+                                    ),
+                               cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('gamma'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+                                    )
+    )

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from CommonTools.ParticleFlow.pfNoPileUpIso_cff import * 
 from CommonTools.ParticleFlow.pfParticleSelection_cff import * 
-from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import IsoConeDefinitions
+from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions
 
 pfNoPileUpCandidates = pfAllChargedHadrons.clone()
 pfNoPileUpCandidates.pdgId.extend(pfAllNeutralHadronsAndPhotons.pdgId)
@@ -14,28 +14,7 @@ src = cms.InputTag('particleFlow')
 egmPhotonIsolationAOD = cms.EDProducer( "CITKPFIsolationSumProducer",
 			  srcToIsolate = cms.InputTag("gedPhotons"),
 			  srcForIsolationCone = cms.InputTag('pfNoPileUpCandidates'),
-			  isolationConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h+'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-                                    ),
-                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h0'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-                                    ),
-                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('gamma'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-                                    )
-    )
+			  isolationConeDefinitions = IsoConeDefinitions
   )	
 
 egmPhotonIsolationAODSequence = cms.Sequence(particleFlowTmpPtrs + pfParticleSelectionSequence + pfNoPileUpCandidates + egmPhotonIsolationAOD)

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
@@ -14,7 +14,28 @@ src = cms.InputTag('particleFlow')
 egmPhotonIsolationAOD = cms.EDProducer( "CITKPFIsolationSumProducer",
 			  srcToIsolate = cms.InputTag("gedPhotons"),
 			  srcForIsolationCone = cms.InputTag('pfNoPileUpCandidates'),
-			  isolationConeDefinitions = IsoConeDefinitions
+			  isolationConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h+'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+                                    ),
+                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h0'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+                                    ),
+                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('gamma'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
+                                    )
+    )
   )	
 
 egmPhotonIsolationAODSequence = cms.Sequence(particleFlowTmpPtrs + pfParticleSelectionSequence + pfNoPileUpCandidates + egmPhotonIsolationAOD)

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationMiniAOD_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationMiniAOD_cff.py
@@ -1,28 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-IsoConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h+'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-
-                                    ),
-                               cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h0'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-                                    ),
-                               cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('gamma'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolation", "gedPhotons"),
-                                    )
-    )
+from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions
 
 egmPhotonIsolationMiniAOD = cms.EDProducer( "CITKPFIsolationSumProducer",
 			  srcToIsolate = cms.InputTag("slimmedPhotons"),

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -37,6 +37,7 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
+
 // GEDPhotonProducer inherits from EDProducer, so it can be a module:
 class GEDPhotonProducer : public edm::stream::EDProducer<> {
 
@@ -72,7 +73,7 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
 			   edm::ValueMap<reco::PhotonRef>  pfEGCandToPhotonMap,
 			   edm::Handle< reco::VertexCollection >&  pvVertices,
 			   reco::PhotonCollection & outputCollection,
-			   int& iSC, edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > >& particleBasedIsolationMap_);
+			   int& iSC, const edm::Handle<edm::ValueMap<float>>& chargedHadrons_, const edm::Handle<edm::ValueMap<float>>& neutralHadrons_, const edm::Handle<edm::ValueMap<float>>& photons_);
 
 
  // std::string PhotonCoreCollection_;
@@ -90,6 +91,10 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
  edm::EDGetTokenT<reco::VertexCollection> vertexProducer_;
  //for isolation with map-based veto
  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken;
+  //photon isolation sums
+  edm::EDGetTokenT<edm::ValueMap<float> > phoChargedIsolationToken_CITK; 
+  edm::EDGetTokenT<edm::ValueMap<float> > phoNeutralHadronIsolationToken_CITK; 
+  edm::EDGetTokenT<edm::ValueMap<float> > phoPhotonIsolationToken_CITK; 
  
   std::string conversionProducer_;
   std::string conversionCollection_;

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -72,7 +72,7 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
 			   edm::ValueMap<reco::PhotonRef>  pfEGCandToPhotonMap,
 			   edm::Handle< reco::VertexCollection >&  pvVertices,
 			   reco::PhotonCollection & outputCollection,
-			   int& iSC);
+			   int& iSC, edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > >& particleBasedIsolationMap_);
 
 
  // std::string PhotonCoreCollection_;
@@ -88,6 +88,8 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_;
  edm::EDGetTokenT<CaloTowerCollection> hcalTowers_;
  edm::EDGetTokenT<reco::VertexCollection> vertexProducer_;
+ //for isolation with map-based veto
+ edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken;
  
   std::string conversionProducer_;
   std::string conversionCollection_;

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -100,7 +100,6 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
   std::string conversionCollection_;
   std::string valueMapPFCandPhoton_;
 
-  PFPhotonIsolationCalculator* thePFBasedIsolationCalculator_;
   PhotonIsolationCalculator* thePhotonIsolationCalculator_;
 
   //AA

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
@@ -22,6 +22,9 @@ gedPhotons = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone()
 gedPhotons.photonProducer = cms.InputTag("gedPhotonsTmp")
 gedPhotons.outputPhotonCollection = cms.string("")
 gedPhotons.reconstructionStep = cms.string("final")
+gedPhotons.chargedHadronIsolation = cms.InputTag("egmPhotonIsolationCITK:h+-DR030-")
+gedPhotons.neutralHadronIsolation = cms.InputTag("egmPhotonIsolationCITK:h0-DR030-")
+gedPhotons.photonIsolation = cms.InputTag("egmPhotonIsolationCITK:gamma-DR030-")
 gedPhotonSequence    = cms.Sequence(gedPhotons)
 
 

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -218,21 +218,13 @@ GEDPhotonProducer::~GEDPhotonProducer()
 
 void  GEDPhotonProducer::beginRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
 
- if ( reconstructionStep_ == "final" ) { 
-    thePFBasedIsolationCalculator_ = new PFPhotonIsolationCalculator();
-    edm::ParameterSet pfIsolationCalculatorSet = conf_.getParameter<edm::ParameterSet>("PFIsolationCalculatorSet"); 
-    thePFBasedIsolationCalculator_->setup(pfIsolationCalculatorSet);
- }else{ 
+ if ( reconstructionStep_ != "final" ) { 
     thePhotonEnergyCorrector_ -> init(theEventSetup); 
   }
 
 }
 
 void  GEDPhotonProducer::endRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
-
-  if ( reconstructionStep_ == "final" ) { 
-    delete thePFBasedIsolationCalculator_;
-  }
 }
 
 
@@ -267,7 +259,6 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     } else {
       throw cms::Exception("GEDPhotonProducer") << "Error! Can't get the product " <<   photonProducer_.label() << "\n";
     }
-    //theEvent.getByToken(particleBasedIsolationToken, particleBasedIsolationMap); 
   } else {
     
     theEvent.getByToken(photonCoreProducerT_,photonCoreHandle);
@@ -756,6 +747,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
   // Calculate the PF isolation and ID - for the time being there is no calculation. Only the setting
     reco::Photon::PflowIsolationVariables pfIso;
     reco::Photon::PflowIDVariables pfID;
+  
     //get the pointer for the photon object
     edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
 
@@ -789,14 +781,6 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     //std::cout << " type " <<newCandidate.getCandidateP4type() <<  " standard p4 after " << newCandidate.p4() << " energy " << newCandidate.energy() << std::endl;
     //std::cout << " final p4 " << newCandidate.p4() << " energy " << newCandidate.energy() <<  std::endl;
 
-    //edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
-    //std::cout << " Start the test by Ivan .... " << std::endl;
-    //std::cout << reconstructionStep_ << std::endl;
-    //for ( auto itr = (*particleBasedIsolationMap_)[photonPtr].begin(); itr != (*particleBasedIsolationMap_)[photonPtr].end(); ++itr ) 
-   // {
-    //     std::cout << itr->key();
-    //}
-    //std::cout << " end the test by Ivan .... " << std::endl;
     outputPhotonCollection.push_back(newCandidate);        
     
   }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -68,7 +68,7 @@ GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config) :
     pfCandidates_      = 
       consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfCandidates"));
     particleBasedIsolationToken   = 
-       consumes<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolationTmp"));
+       consumes<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolationTmp", "gedPhotons"));
 
   } else {
 
@@ -775,11 +775,12 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
 
     edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
     std::cout << " Start the test by Ivan .... " << std::endl;
-    /*for ( auto itr = (*particleBasedIsolationMap_)[photonPtr].begin(); itr != (*particleBasedIsolationMap_)[photonPtr].end(); ++itr ) 
+    std::cout << reconstructionStep_ << std::endl;
+    for ( auto itr = (*particleBasedIsolationMap_)[photonPtr].begin(); itr != (*particleBasedIsolationMap_)[photonPtr].end(); ++itr ) 
     {
          std::cout << itr->key();
     }
-    std::cout << " end the test by Ivan .... " << std::endl;*/
+    std::cout << " end the test by Ivan .... " << std::endl;
     outputPhotonCollection.push_back(newCandidate);        
     
   }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -256,7 +256,7 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     } else {
       throw cms::Exception("GEDPhotonProducer") << "Error! Can't get the product " <<   photonProducer_.label() << "\n";
     }
-    //theEvent.getByToken(particleBasedIsolationToken, particleBasedIsolationMap); 
+    theEvent.getByToken(particleBasedIsolationToken, particleBasedIsolationMap); 
   } else {
     
     theEvent.getByToken(photonCoreProducerT_,photonCoreHandle);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -67,8 +67,13 @@ GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config) :
       consumes<reco::PhotonCollection>(photonProducer_);
     pfCandidates_      = 
       consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfCandidates"));
-    particleBasedIsolationToken   = 
-       consumes<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"));
+
+    phoChargedIsolationToken_CITK      = 
+      consumes<edm::ValueMap<float>>(conf_.getParameter<edm::InputTag>("chargedHadronIsolation"));
+    phoNeutralHadronIsolationToken_CITK      = 
+      consumes<edm::ValueMap<float>>(conf_.getParameter<edm::InputTag>("neutralHadronIsolation"));
+    phoPhotonIsolationToken_CITK      = 
+      consumes<edm::ValueMap<float>>(conf_.getParameter<edm::InputTag>("photonIsolation"));   
 
   } else {
 
@@ -246,17 +251,23 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   Handle<reco::PhotonCoreCollection> photonCoreHandle;
   bool validPhotonHandle= false;
   Handle<reco::PhotonCollection> photonHandle;
-  //this are changes done to test photon isolation with map-based footprint
-  Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationMap;  
+  //value maps for isolation
+  edm::Handle<edm::ValueMap<float> > phoChargedIsolationMap_CITK;
+  edm::Handle<edm::ValueMap<float> > phoNeutralHadronIsolationMap_CITK;
+  edm::Handle<edm::ValueMap<float> > phoPhotonIsolationMap_CITK;
 
   if ( reconstructionStep_ == "final" ) { 
     theEvent.getByToken(photonProducerT_,photonHandle);
+    //get isolation objects
+    theEvent.getByToken(phoChargedIsolationToken_CITK,phoChargedIsolationMap_CITK);
+    theEvent.getByToken(phoNeutralHadronIsolationToken_CITK,phoNeutralHadronIsolationMap_CITK);
+    theEvent.getByToken(phoPhotonIsolationToken_CITK,phoPhotonIsolationMap_CITK);
     if ( photonHandle.isValid()) {
       validPhotonHandle=true;  
     } else {
       throw cms::Exception("GEDPhotonProducer") << "Error! Can't get the product " <<   photonProducer_.label() << "\n";
     }
-    theEvent.getByToken(particleBasedIsolationToken, particleBasedIsolationMap); 
+    //theEvent.getByToken(particleBasedIsolationToken, particleBasedIsolationMap); 
   } else {
     
     theEvent.getByToken(photonCoreProducerT_,photonCoreHandle);
@@ -397,7 +408,9 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 			 vertexHandle,
 			 outputPhotonCollection,
 			 iSC,
-       particleBasedIsolationMap);
+       phoChargedIsolationMap_CITK,
+       phoNeutralHadronIsolationMap_CITK,
+       phoPhotonIsolationMap_CITK);
 
 
 
@@ -708,7 +721,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
 					     const edm::Handle<reco::PFCandidateCollection> pfEGCandidateHandle,
 					     edm::ValueMap<reco::PhotonRef> pfEGCandToPhotonMap,
 					     edm::Handle< reco::VertexCollection >  & vertexHandle,
-					     reco::PhotonCollection & outputPhotonCollection, int& iSC, edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > >& particleBasedIsolationMap_) {
+					     reco::PhotonCollection & outputPhotonCollection, int& iSC, const edm::Handle<edm::ValueMap<float>>& chargedHadrons_, const edm::Handle<edm::ValueMap<float>>& neutralHadrons_, const edm::Handle<edm::ValueMap<float>>& photons_) {
 
   
  
@@ -743,9 +756,12 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
   // Calculate the PF isolation and ID - for the time being there is no calculation. Only the setting
     reco::Photon::PflowIsolationVariables pfIso;
     reco::Photon::PflowIDVariables pfID;
-    if( thedet != DetId::Forward  ) {
-      thePFBasedIsolationCalculator_->calculate (&newCandidate, pfCandidateHandle, vertexHandle, evt, es, pfIso );
-    }
+    //get the pointer for the photon object
+    edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
+
+    pfIso.chargedHadronIso = (*chargedHadrons_)[photonPtr] ;
+    pfIso.neutralHadronIso = (*neutralHadrons_)[photonPtr];
+    pfIso.photonIso        = (*photons_)[photonPtr];
     newCandidate.setPflowIsolationVariables(pfIso);
     newCandidate.setPflowIDVariables(pfID);
 
@@ -773,14 +789,14 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     //std::cout << " type " <<newCandidate.getCandidateP4type() <<  " standard p4 after " << newCandidate.p4() << " energy " << newCandidate.energy() << std::endl;
     //std::cout << " final p4 " << newCandidate.p4() << " energy " << newCandidate.energy() <<  std::endl;
 
-    edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
-    std::cout << " Start the test by Ivan .... " << std::endl;
-    std::cout << reconstructionStep_ << std::endl;
-    for ( auto itr = (*particleBasedIsolationMap_)[photonPtr].begin(); itr != (*particleBasedIsolationMap_)[photonPtr].end(); ++itr ) 
-    {
-         std::cout << itr->key();
-    }
-    std::cout << " end the test by Ivan .... " << std::endl;
+    //edm::Ptr<reco::Photon> photonPtr(photonHandle, lSC);
+    //std::cout << " Start the test by Ivan .... " << std::endl;
+    //std::cout << reconstructionStep_ << std::endl;
+    //for ( auto itr = (*particleBasedIsolationMap_)[photonPtr].begin(); itr != (*particleBasedIsolationMap_)[photonPtr].end(); ++itr ) 
+   // {
+    //     std::cout << itr->key();
+    //}
+    //std::cout << " end the test by Ivan .... " << std::endl;
     outputPhotonCollection.push_back(newCandidate);        
     
   }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -68,7 +68,7 @@ GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config) :
     pfCandidates_      = 
       consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfCandidates"));
     particleBasedIsolationToken   = 
-       consumes<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolationTmp", "gedPhotons"));
+       consumes<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"));
 
   } else {
 

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -8,20 +8,43 @@ from RecoParticleFlow.PFProducer.particleFlowEGamma_cfi import *
 from RecoEgamma.EgammaPhotonProducers.gedPhotonSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.gedGsfElectronSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.pfBasedElectronIso_cff import *
-from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import *
-from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import *
+from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import particleBasedIsolation as _particleBasedIsolation
+from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import egmPhotonIsolationAOD as _egmPhotonIsolationAOD
 
-particleBasedIsolationTmp = particleBasedIsolation.clone()
+particleBasedIsolationTmp = _particleBasedIsolation.clone()
 particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
 particleBasedIsolationTmp.electronProducer = cms.InputTag("gedGsfElectronsTmp")
 particleBasedIsolationTmp.pfCandidates = cms.InputTag("particleFlowTmp")
-particleBasedIsolationTmp.valueMapPhoPFblockIso = cms.string("gedPhotons")
-particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectrons")
+particleBasedIsolationTmp.valueMapPhoPFblockIso = cms.string("gedPhotonsTmp")
+particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectronsTmp")
 
-egmPhotonIsolationCITK = egmPhotonIsolationAOD.clone()
+egmPhotonIsolationCITK = _egmPhotonIsolationAOD.clone()
+
+isolationConeDefinitionsTmp = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h+'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
+                                    ),
+                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('h0'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
+                                    ),
+                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
+                                      coneSize = cms.double(0.3),
+                                      isolateAgainst = cms.string('gamma'),
+                                      miniAODVertexCodes = cms.vuint32(2,3),
+                                      vertexIndex = cms.int32(0),
+                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
+                                    )
+    )
 egmPhotonIsolationCITK.srcToIsolate = cms.InputTag("gedPhotonsTmp")
 egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("particleFlowTmp")
-egmPhotonIsolationCITK.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotons")
+egmPhotonIsolationCITK.isolationConeDefinitions = isolationConeDefinitionsTmp
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
-particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*gedPhotonSequence*gedElectronPFIsoSequence)
+particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -8,6 +8,14 @@ from RecoParticleFlow.PFProducer.particleFlowEGamma_cfi import *
 from RecoEgamma.EgammaPhotonProducers.gedPhotonSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.gedGsfElectronSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.pfBasedElectronIso_cff import *
+from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import *
+
+particleBasedIsolationTmp = particleBasedIsolation.clone()
+particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
+particleBasedIsolationTmp.electronProducer = cms.InputTag("gedGsfElectronsTmp")
+particleBasedIsolationTmp.pfCandidates = cms.InputTag("particleFlowTmp")
+particleBasedIsolationTmp.valueMapPhoPFblockIso = cms.string("gedPhotons")
+particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectrons")
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
-particleFlowEGammaFinal = cms.Sequence(gedPhotonSequence*gedElectronPFIsoSequence)
+particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -9,6 +9,7 @@ from RecoEgamma.EgammaPhotonProducers.gedPhotonSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.gedGsfElectronSequence_cff import *
 from RecoEgamma.EgammaElectronProducers.pfBasedElectronIso_cff import *
 from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import *
+from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import *
 
 particleBasedIsolationTmp = particleBasedIsolation.clone()
 particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
@@ -16,6 +17,11 @@ particleBasedIsolationTmp.electronProducer = cms.InputTag("gedGsfElectronsTmp")
 particleBasedIsolationTmp.pfCandidates = cms.InputTag("particleFlowTmp")
 particleBasedIsolationTmp.valueMapPhoPFblockIso = cms.string("gedPhotons")
 particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectrons")
+
+egmPhotonIsolationCITK = egmPhotonIsolationAOD.clone()
+egmPhotonIsolationCITK.srcToIsolate = cms.InputTag("gedPhotonsTmp")
+egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("particleFlowTmp")
+egmPhotonIsolationCITK.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotons")
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
 particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -11,8 +11,7 @@ from RecoEgamma.EgammaElectronProducers.pfBasedElectronIso_cff import *
 from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import particleBasedIsolation as _particleBasedIsolation
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import egmPhotonIsolationAOD as _egmPhotonIsolationAOD
 
-from CommonTools.ParticleFlow.pfNoPileUpIso_cff import * 
-from CommonTools.ParticleFlow.pfParticleSelection_cff import * 
+from CommonTools.ParticleFlow.pfNoPileUpIso_cff import pfPileUpIso, pfNoPileUpIso, pfNoPileUpIsoSequence
 from RecoEgamma.EgammaIsolationAlgos.egmIsolationDefinitions_cff import pfNoPileUpCandidates
 from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions  as IsoConeDefinitionsTmp
 
@@ -34,4 +33,4 @@ egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("pfNoPileUpCandidates"
 egmPhotonIsolationCITK.isolationConeDefinitions = IsoConeDefinitionsTmp
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
-particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfParticleSelectionSequence*pfNoPileUpCandidates*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)
+particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfNoPileUpIsoSequence*pfNoPileUpCandidates*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -11,6 +11,10 @@ from RecoEgamma.EgammaElectronProducers.pfBasedElectronIso_cff import *
 from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cfi import particleBasedIsolation as _particleBasedIsolation
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import egmPhotonIsolationAOD as _egmPhotonIsolationAOD
 
+from CommonTools.ParticleFlow.pfNoPileUpIso_cff import * 
+from CommonTools.ParticleFlow.pfParticleSelection_cff import * 
+from RecoEgamma.EgammaIsolationAlgos.egmIsolationDefinitions_cff import pfNoPileUpCandidates
+
 particleBasedIsolationTmp = _particleBasedIsolation.clone()
 particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
 particleBasedIsolationTmp.electronProducer = cms.InputTag("gedGsfElectronsTmp")
@@ -47,4 +51,4 @@ egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("particleFlowTmp")
 egmPhotonIsolationCITK.isolationConeDefinitions = isolationConeDefinitionsTmp
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
-particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)
+particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*egmPhotonIsolationCITK*pfParticleSelectionSequence*pfNoPileUpCandidates*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -14,6 +14,7 @@ from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationAOD_cff import egmPhotonI
 from CommonTools.ParticleFlow.pfNoPileUpIso_cff import * 
 from CommonTools.ParticleFlow.pfParticleSelection_cff import * 
 from RecoEgamma.EgammaIsolationAlgos.egmIsolationDefinitions_cff import pfNoPileUpCandidates
+from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions  as IsoConeDefinitionsTmp
 
 particleBasedIsolationTmp = _particleBasedIsolation.clone()
 particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
@@ -24,31 +25,13 @@ particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectronsTmp
 
 egmPhotonIsolationCITK = _egmPhotonIsolationAOD.clone()
 
-isolationConeDefinitionsTmp = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h+'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
-                                    ),
-                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('h0'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
-                                    ),
-                              		 cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
-                                      coneSize = cms.double(0.3),
-                                      isolateAgainst = cms.string('gamma'),
-                                      miniAODVertexCodes = cms.vuint32(2,3),
-                                      vertexIndex = cms.int32(0),
-                                      particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp"),
-                                    )
-    )
+for iPSet in IsoConeDefinitionsTmp:
+  iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp")
+
+
 egmPhotonIsolationCITK.srcToIsolate = cms.InputTag("gedPhotonsTmp")
 egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("pfNoPileUpCandidates")
-egmPhotonIsolationCITK.isolationConeDefinitions = isolationConeDefinitionsTmp
+egmPhotonIsolationCITK.isolationConeDefinitions = IsoConeDefinitionsTmp
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
 particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfParticleSelectionSequence*pfNoPileUpCandidates*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -47,8 +47,8 @@ isolationConeDefinitionsTmp = cms.VPSet(cms.PSet( isolationAlgo = cms.string('Ph
                                     )
     )
 egmPhotonIsolationCITK.srcToIsolate = cms.InputTag("gedPhotonsTmp")
-egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("particleFlowTmp")
+egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("pfNoPileUpCandidates")
 egmPhotonIsolationCITK.isolationConeDefinitions = isolationConeDefinitionsTmp
 
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp)
-particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*egmPhotonIsolationCITK*pfParticleSelectionSequence*pfNoPileUpCandidates*gedPhotonSequence*gedElectronPFIsoSequence)
+particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfParticleSelectionSequence*pfNoPileUpCandidates*egmPhotonIsolationCITK*gedPhotonSequence*gedElectronPFIsoSequence)


### PR DESCRIPTION
This PR changes the isolation in the reco::Photon object to the value computed by CITK as presented here:
https://indico.cern.ch/event/589257/contributions/2376119/attachments/1376717/2090803/Shvetsov_23November2016.pdf

Following changes are done the particleFlowEGammaFinal sequence:
- creation particleBasedIsolationTmp object
- add pfNoPileUpCandidates to the 
- CITK module to compute isolation

Additional minor changes in CITK:
- isolation cone definitions is move to a standalone file RecoEgamma/EgammaIsolationAlgos/python/egmIsoConeDefinitions_cfi.py
- fillDescriptions() function is added to PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc


include @gzevi , @ikrav, @fcouderc 
