### PR TITLE
RecoPixelVertexing/PixelTriplets: add *::minLayers variables

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -37,6 +37,8 @@ namespace
 using namespace std;
 using namespace ctfseeding;
 
+constexpr unsigned int CAHitQuadrupletGenerator::minLayers;
+
 CAHitQuadrupletGenerator::CAHitQuadrupletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC, bool needSeedingLayerSetsHits) :
 extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")), //extra window in ThirdHitPredictionFromCircle range (divide by R to get phi)
 maxChi2(cfg.getParameter<edm::ParameterSet>("maxChi2")),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -31,6 +31,8 @@ T sqr(T x)
 using namespace std;
 using namespace ctfseeding;
 
+constexpr unsigned int CAHitTripletGenerator::minLayers;
+
 CAHitTripletGenerator::CAHitTripletGenerator(const edm::ParameterSet& cfg,
                                              edm::ConsumesCollector& iC,
                                              bool needSeedingLayerSetsHits) :


### PR DESCRIPTION
The patch resolves issue with Clang compiler.
N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.
```
  In function AHitNtupletEDProducerT<CAHitQuadrupletGenerator>::produce(edm::Event&, edm::EventSetup const&)':
  RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc: undefined reference to AHitQuadrupletGenerator::minLayers'
  RecoPixelVertexingPixelTripletsPlugins/CAHitNtupletEDProducerT.o: In function AHitNtupletEDProducerT<CAHitTripletGenerator>::produce(edm::Event&, edm::EventSetup const&)':
  RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc: undefined reference to AHitTripletGenerator::minLayers'
```
Started with CMSSW_9_0_CLANG_X_2016-11-24-2300.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>