### PR TITLE
Fix L1 fat event filters

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -39,6 +39,8 @@ Implementation:
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
+#include "EventFilter/FEDInterface/interface/FED1024.h"
+
 
 //
 // class declaration
@@ -102,12 +104,13 @@ L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSet
     return false;
   }
 
-  const FEDRawData& l1tRcd = feds->FEDData(1024);
+  const FEDRawData& tcdsRcd = feds->FEDData(1024);
+  const unsigned char *data = tcdsRcd.data();
 
-  const unsigned char *data = l1tRcd.data();
   FEDHeader header(data);
+  evf::evtn::TCDSRecord record((unsigned char *) data);
 
-  bool fatEvent = (header.lvl1ID() % period_ == 0 );
+  bool fatEvent = (record.getHeader().getData().header.triggerCount % period_ == 0 );
 
   return fatEvent;
 

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -55,6 +55,8 @@ private:
   const int fedId_;
   /// if invert_=true, invert that event accept decision
   const bool invert_;
+  /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11
+  const bool useTCDS_;
 };
 
 #endif

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -56,7 +56,7 @@ private:
   /// if invert_=true, invert that event accept decision
   const bool invert_;
   /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11
-  const bool useTCDS_;
+  bool useTCDS_;
 };
 
 #endif

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -42,6 +42,10 @@ HLTL1NumberFilter::HLTL1NumberFilter(const edm::ParameterSet& config) :
   invert_( config.getParameter<bool>("invert") ),
   useTCDS_( config.getParameter<bool>("useTCDSEventNumber") )
 {
+
+  // only try and use TCDS event number if the FED ID 1024 is selected
+  if (fedId_!=1024) useTCDS_ = false;
+
 }
 
 


### PR DESCRIPTION
Fixes for two filters used to select L1T "fat events", to use of the 64-bit event number from TCDS FED word 11 (https://twiki.cern.ch/twiki/bin/viewauth/CMS/TcdsEventRecord#TCDS_Data_Block_Definition_curre) instead of the 24-bit event number from common DAQ header.

In the case of HLTL1NumberFilter, use of the common DAQ header (ie. existing functionality) is maintained as default.


