### PR TITLE
Use make_shared in visualization

### DIFF
--- a/Fireworks/Core/interface/CmsShowCommonPopup.h
+++ b/Fireworks/Core/interface/CmsShowCommonPopup.h
@@ -2,7 +2,7 @@
 #define Fireworks_Core_CmsShowCommonPopup_h
 
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #endif
 #include "GuiTypes.h"
 #include "TGFrame.h"
@@ -64,7 +64,7 @@ private:
    FWColorSelect* m_colorSelectWidget[kFWGeomColorSize];
    FWColorSelect* m_colorRnrCtxHighlightWidget;   
    FWColorSelect* m_colorRnrCtxSelectWidget;
-   std::vector<boost::shared_ptr<FWParameterSetterBase> > m_setters;
+   std::vector<std::shared_ptr<FWParameterSetterBase> > m_setters;
 #endif
    TGComboBox     *m_combo;  
 };

--- a/Fireworks/Core/interface/CmsShowViewPopup.h
+++ b/Fireworks/Core/interface/CmsShowViewPopup.h
@@ -21,7 +21,7 @@
 // system include files
 #include <vector>
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <sigc++/sigc++.h>
 #endif
 #include "TGFrame.h"
@@ -66,7 +66,7 @@ private:
    TGTab*      m_tab;
    std::string m_selectedTabName;
 #ifndef __CINT__
-   std::vector<boost::shared_ptr<FWParameterSetterBase> > m_setters;
+   std::vector<std::shared_ptr<FWParameterSetterBase> > m_setters;
 #endif
 }; 
 

--- a/Fireworks/Core/interface/FWEvePtr.h
+++ b/Fireworks/Core/interface/FWEvePtr.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "TEveElement.h"
 
 // user include files
@@ -76,7 +76,7 @@ private:
    //const FWEvePtr& operator=(const FWEvePtr&); // stop default
 
    // ---------- member data --------------------------------
-   boost::shared_ptr<TEveElement> m_container;
+   std::shared_ptr<TEveElement> m_container;
 };
 
 

--- a/Fireworks/Core/interface/FWEveView.h
+++ b/Fireworks/Core/interface/FWEveView.h
@@ -145,7 +145,7 @@ private:
    FWBoolParameter   m_showCameraGuide;
    FWBoolParameter   m_useGlobalEnergyScale;
 
-   boost::shared_ptr<FWViewContextMenuHandlerGL>   m_viewContextMenu;
+   std::shared_ptr<FWViewContextMenuHandlerGL>   m_viewContextMenu;
    std::auto_ptr<FWViewContext> m_viewContext;
    std::auto_ptr<FWViewEnergyScale> m_localEnergyScale;
 

--- a/Fireworks/Core/interface/FWEveViewManager.h
+++ b/Fireworks/Core/interface/FWEveViewManager.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <map>
 #include <set>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 #include "Fireworks/Core/interface/FWViewManagerBase.h"
@@ -88,7 +88,7 @@ private:
    const FWEveViewManager& operator=(const FWEveViewManager&); // stop default
 
    FWViewBase* buildView(TEveWindowSlot* iParent, const std::string& type);
-   FWEveView*  finishViewCreate     (boost::shared_ptr<FWEveView>);
+   FWEveView*  finishViewCreate     (std::shared_ptr<FWEveView>);
 
    void beingDestroyed(const FWViewBase*);
    void modelChanges(const FWModelIds& iIds);
@@ -99,9 +99,9 @@ private:
    // ---------- member data --------------------------------
    
    typedef std::map<std::string,  std::vector<BuilderInfo> >  TypeToBuilder;
-   typedef std::vector<boost::shared_ptr<FWProxyBuilderBase> >  BuilderVec;   
+   typedef std::vector<std::shared_ptr<FWProxyBuilderBase> >  BuilderVec;   
    typedef BuilderVec::iterator BuilderVec_it;
-   typedef std::vector<boost::shared_ptr<FWEveView > >::iterator EveViewVec_it;
+   typedef std::vector<std::shared_ptr<FWEveView > >::iterator EveViewVec_it;
    
    TypeToBuilder            m_typeToBuilder;
 
@@ -109,7 +109,7 @@ private:
 
    std::map<int, BuilderVec> m_builders; // key is viewer bit
 
-   std::vector< std::vector<boost::shared_ptr<FWEveView> > >  m_views;
+   std::vector< std::vector<std::shared_ptr<FWEveView> > >  m_views;
 
    std::map<const FWEventItem*,FWInteractionList*>  m_interactionLists;
 };

--- a/Fireworks/Core/interface/FWEventItem.h
+++ b/Fireworks/Core/interface/FWEventItem.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 #include "FWCore/Utilities/interface/TypeWithDict.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <sigc++/connection.h>
 
 // user include files
@@ -75,7 +75,7 @@ public:
 
    FWEventItem(fireworks::Context* iContext,
                unsigned int iItemId,
-               boost::shared_ptr<FWItemAccessorBase> iAccessor,
+               std::shared_ptr<FWItemAccessorBase> iAccessor,
                const FWPhysicsObjectDesc& iDesc,  const FWConfiguration* pbConf = 0);
    virtual ~FWEventItem();
 
@@ -231,7 +231,7 @@ private:
    std::string m_name;
    const TClass* m_type;
    std::string m_purpose;
-   boost::shared_ptr<FWItemAccessorBase> m_accessor;
+   std::shared_ptr<FWItemAccessorBase> m_accessor;
    FWDisplayProperties m_displayProperties;
    int m_layer;
    mutable std::vector<ModelInfo> m_itemInfos;

--- a/Fireworks/Core/interface/FWEventItemsManager.h
+++ b/Fireworks/Core/interface/FWEventItemsManager.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "sigc++/signal.h"
 
 // user include files
@@ -86,7 +86,7 @@ private:
    fireworks::Context* m_context;
 
    const edm::EventBase* m_event;
-   boost::shared_ptr<FWItemAccessorFactory> m_accessorFactory;
+   std::shared_ptr<FWItemAccessorFactory> m_accessorFactory;
 };
 
 

--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -21,7 +21,6 @@
 // system include files
 #include <map>
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 #include <sigc++/sigc++.h>
 #include "Rtypes.h"
 #include "GuiTypes.h"

--- a/Fireworks/Core/interface/FWGeometryTableViewBase.h
+++ b/Fireworks/Core/interface/FWGeometryTableViewBase.h
@@ -2,7 +2,7 @@
 #define Fireworks_Core_FWGeometryTableViewBase_h
 
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #endif
 
 
@@ -140,7 +140,7 @@ protected:
    TEveScene*    m_eveScene;
 
 #ifndef __CINT__
-   // std::vector<boost::shared_ptr<FWParameterSetterBase> > m_setters;
+   // std::vector<std::shared_ptr<FWParameterSetterBase> > m_setters;
 #endif
    //   void resetSetters();
    //   void makeSetter(TGCompositeFrame* frame, FWParameterBase* param);

--- a/Fireworks/Core/interface/FWGeometryTableViewManager.h
+++ b/Fireworks/Core/interface/FWGeometryTableViewManager.h
@@ -50,7 +50,7 @@ protected:
    virtual void modelChangesComing() {}
    virtual void modelChangesDone() {}
 
-   std::vector<boost::shared_ptr<FWGeometryTableViewBase> > m_views;
+   std::vector<std::shared_ptr<FWGeometryTableViewBase> > m_views;
 
 private:
    FWGeometryTableViewManager(const FWGeometryTableViewManager&); // stop default

--- a/Fireworks/Core/interface/FWHLTValidator.h
+++ b/Fireworks/Core/interface/FWHLTValidator.h
@@ -20,7 +20,7 @@ public:
 
    void setProcess(const char* x) { m_process = x; m_triggerNames.clear(); }
    virtual void fillOptions(const char* iBegin, const char* iEnd,
-                            std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const;
+                            std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const;
 private:
    FWHLTValidator(const FWHLTValidator&); // stop default
    const FWHLTValidator& operator=(const FWHLTValidator&); // stop default

--- a/Fireworks/Core/interface/FWItemAccessorFactory.h
+++ b/Fireworks/Core/interface/FWItemAccessorFactory.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 // user include files
@@ -35,7 +35,7 @@ public:
    virtual ~FWItemAccessorFactory();
 
    // ---------- const member functions ---------------------
-   boost::shared_ptr<FWItemAccessorBase> accessorFor(const TClass*) const;
+   std::shared_ptr<FWItemAccessorBase> accessorFor(const TClass*) const;
    static bool hasAccessor(const TClass *iClass, std::string &result);
    static bool hasTVirtualCollectionProxy(const TClass *iClass);
    static bool hasMemberTVirtualCollectionProxy(const TClass *iClass,

--- a/Fireworks/Core/interface/FWParameterSetterBase.h
+++ b/Fireworks/Core/interface/FWParameterSetterBase.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -38,7 +38,7 @@ public:
 
    // ---------- static member functions --------------------
 
-   static boost::shared_ptr<FWParameterSetterBase> makeSetterFor(FWParameterBase*);
+   static std::shared_ptr<FWParameterSetterBase> makeSetterFor(FWParameterBase*);
 
    // ---------- member functions ---------------------------
 

--- a/Fireworks/Core/interface/FWProxyBuilderConfiguration.h
+++ b/Fireworks/Core/interface/FWProxyBuilderConfiguration.h
@@ -28,7 +28,7 @@
 #include "Fireworks/Core/interface/FWGenericParameterWithRange.h"
 
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <sigc++/sigc++.h>
 #endif
 
@@ -64,7 +64,7 @@ private:
    const FWEventItem*      m_item;
 
 #ifndef __CINT__
-   std::vector<boost::shared_ptr<FWParameterSetterBase> > m_setters;
+   std::vector<std::shared_ptr<FWParameterSetterBase> > m_setters;
 #endif
 
 };

--- a/Fireworks/Core/interface/FWTableViewManager.h
+++ b/Fireworks/Core/interface/FWTableViewManager.h
@@ -88,7 +88,7 @@ protected:
    virtual void colorsChanged();
    void dataChanged ();
 
-   typedef std::vector<boost::shared_ptr<FWTableView> >    Views;
+   typedef std::vector<std::shared_ptr<FWTableView> >    Views;
 
    Views       m_views;
    Items       m_items;

--- a/Fireworks/Core/interface/FWTriggerTableViewManager.h
+++ b/Fireworks/Core/interface/FWTriggerTableViewManager.h
@@ -48,7 +48,7 @@ protected:
 
    void updateProcessList();
 
-   std::vector<boost::shared_ptr<FWTriggerTableView> > m_views;
+   std::vector<std::shared_ptr<FWTriggerTableView> > m_views;
 
 private:
    FWTriggerTableViewManager(const FWTriggerTableViewManager&);      // stop default

--- a/Fireworks/Core/interface/FWTypeToRepresentations.h
+++ b/Fireworks/Core/interface/FWTypeToRepresentations.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 #include "Fireworks/Core/interface/FWRepresentationInfo.h"
@@ -42,7 +42,7 @@ public:
    // ---------- static member functions --------------------
 
    // ---------- member functions ---------------------------
-   void add( boost::shared_ptr<FWRepresentationCheckerBase> iChecker);
+   void add( std::shared_ptr<FWRepresentationCheckerBase> iChecker);
    void insert( const FWTypeToRepresentations& );
 
 private:
@@ -52,7 +52,7 @@ private:
 
    // ---------- member data --------------------------------
    mutable std::map<std::string, std::vector<FWRepresentationInfo> > m_typeToReps;
-   std::vector<boost::shared_ptr<FWRepresentationCheckerBase> > m_checkers;
+   std::vector<std::shared_ptr<FWRepresentationCheckerBase> > m_checkers;
 };
 
 

--- a/Fireworks/Core/interface/FWViewEnergyScaleEditor.h
+++ b/Fireworks/Core/interface/FWViewEnergyScaleEditor.h
@@ -22,7 +22,7 @@
 
 // user include files
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #endif
 #include "TGFrame.h"
 #include "Fireworks/Core/interface/FWParameterSetterEditorBase.h"
@@ -61,7 +61,7 @@ private:
    bool               m_enabled;
 
 #ifndef __CINT__
-   std::vector<boost::shared_ptr<FWParameterSetterBase> > m_setters;
+   std::vector<std::shared_ptr<FWParameterSetterBase> > m_setters;
 #endif
 };
 

--- a/Fireworks/Core/interface/FWViewManagerManager.h
+++ b/Fireworks/Core/interface/FWViewManagerManager.h
@@ -21,7 +21,7 @@
 // system include files
 #include <vector>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 #include <string>
 
@@ -47,7 +47,7 @@ public:
    // ---------- static member functions --------------------
 
    // ---------- member functions ---------------------------
-   void add( boost::shared_ptr<FWViewManagerBase>);
+   void add( std::shared_ptr<FWViewManagerBase>);
    void registerEventItem(const FWEventItem*iItem);
    void removeEventItem(const FWEventItem*iItem);
    void eventBegin();
@@ -59,7 +59,7 @@ private:
    const FWViewManagerManager& operator=(const FWViewManagerManager&);    // stop default
 
    // ---------- member data --------------------------------
-   std::vector<boost::shared_ptr<FWViewManagerBase> > m_viewManagers;
+   std::vector<std::shared_ptr<FWViewManagerBase> > m_viewManagers;
    FWModelChangeManager* m_changeManager;
    FWColorManager* m_colorManager;
    std::map<std::string, const FWEventItem*> m_typeToItems;    //use this to tell view managers registered after the item

--- a/Fireworks/Core/src/CmsShowCommonPopup.cc
+++ b/Fireworks/Core/src/CmsShowCommonPopup.cc
@@ -337,7 +337,7 @@ void CmsShowCommonPopup::getColorSetColors (int& hci, int& sci)
 TGFrame*
 CmsShowCommonPopup::makeSetter(TGCompositeFrame* frame, FWParameterBase* param) 
 {
-   boost::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(param) );
+   std::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(param) );
    ptr->attach(param, this);
  
    TGFrame* pframe = ptr->build(frame);

--- a/Fireworks/Core/src/CmsShowMain.h
+++ b/Fireworks/Core/src/CmsShowMain.h
@@ -26,7 +26,6 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include <boost/shared_ptr.hpp>
 #include "Rtypes.h"
 
 

--- a/Fireworks/Core/src/CmsShowMainBase.cc
+++ b/Fireworks/Core/src/CmsShowMainBase.cc
@@ -111,22 +111,22 @@ CmsShowMainBase::setupViewManagers()
 {
    guiManager()->updateStatus("Setting up view manager...");
 
-   boost::shared_ptr<FWViewManagerBase> eveViewManager(new FWEveViewManager(guiManager()));
+   std::shared_ptr<FWViewManagerBase> eveViewManager = std::make_shared<FWEveViewManager>(guiManager());
    eveViewManager->setContext(m_contextPtr);
    viewManager()->add(eveViewManager);
 
-   boost::shared_ptr<FWTableViewManager> tableViewManager(new FWTableViewManager(guiManager()));
+   auto tableViewManager = std::make_shared<FWTableViewManager>(guiManager());
    configurationManager()->add(std::string("Tables"), tableViewManager.get());
    viewManager()->add(tableViewManager);
    eiManager()->goingToClearItems_.connect(boost::bind(&FWTableViewManager::removeAllItems, tableViewManager.get()));
 
-   boost::shared_ptr<FWTriggerTableViewManager> triggerTableViewManager(new FWTriggerTableViewManager(guiManager()));
+   auto triggerTableViewManager = std::make_shared<FWTriggerTableViewManager>(guiManager());
    configurationManager()->add(std::string("TriggerTables"), triggerTableViewManager.get());
    configurationManager()->add(std::string("L1TriggerTables"), triggerTableViewManager.get()); // AMT: added for backward compatibilty
    triggerTableViewManager->setContext(m_contextPtr);
    viewManager()->add(triggerTableViewManager);
 
-   boost::shared_ptr<FWGeometryTableViewManager> geoTableViewManager(new FWGeometryTableViewManager(guiManager(),  m_simGeometryFilename));
+   auto geoTableViewManager = std::make_shared<FWGeometryTableViewManager>(guiManager(),  m_simGeometryFilename);
    geoTableViewManager->setContext(m_contextPtr);
    viewManager()->add(geoTableViewManager);
 

--- a/Fireworks/Core/src/CmsShowViewPopup.cc
+++ b/Fireworks/Core/src/CmsShowViewPopup.cc
@@ -245,7 +245,7 @@ ViewerParameterGUI::requestTab(const char* name)
 ViewerParameterGUI&
 ViewerParameterGUI::addParam( const FWParameterBase* param)
 {
-   boost::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor((FWParameterBase*)param) );
+   std::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor((FWParameterBase*)param) );
    ptr->attach((FWParameterBase*)param, this);
    TGCompositeFrame* parent = m_tab->GetCurrentContainer();
 

--- a/Fireworks/Core/src/FWCollectionSummaryTableManager.h
+++ b/Fireworks/Core/src/FWCollectionSummaryTableManager.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 #include "Fireworks/TableWidget/interface/FWTableManagerBase.h"

--- a/Fireworks/Core/src/FWColorManager.cc
+++ b/Fireworks/Core/src/FWColorManager.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <iostream>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "TColor.h"
 #include "TROOT.h"
 #include "TMath.h"
@@ -325,7 +325,7 @@ FWColorManager::geomColor(FWGeomColorIndex iIndex) const
 }
 
 
-static boost::shared_ptr<std::map<Color_t,Color_t> > m_oldColorToIndexMap;
+static std::shared_ptr<std::map<Color_t,Color_t> > m_oldColorToIndexMap;
 
 Color_t
 FWColorManager::oldColorToIndex(Color_t iColor, int version) const
@@ -343,7 +343,7 @@ FWColorManager::oldColorToIndex(Color_t iColor, int version) const
    if (version < 3)
    {
       if(0==m_oldColorToIndexMap.get()) {
-         m_oldColorToIndexMap = boost::shared_ptr<std::map<Color_t,Color_t> >(new std::map<Color_t,Color_t>());
+         m_oldColorToIndexMap = std::make_shared<std::map<Color_t,Color_t> >();
          (*m_oldColorToIndexMap)[kRed]=kFWRed;
          (*m_oldColorToIndexMap)[kBlue]=kFWBlue;
          (*m_oldColorToIndexMap)[kYellow]=kFWYellow;

--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -241,7 +241,7 @@ FWEveViewManager::newItem(const FWEventItem* iItem)
       // 2.
       // printf("FWEveViewManager::makeProxyBuilderFor NEW builder %s \n", builderName.c_str());
       
-      boost::shared_ptr<FWProxyBuilderBase> pB(builder);
+      std::shared_ptr<FWProxyBuilderBase> pB(builder);
       builder->setItem(iItem);
       iItem->changed_.connect(boost::bind(&FWEveViewManager::modelChanges,this,_1));
       iItem->goingToBeDestroyed_.connect(boost::bind(&FWEveViewManager::removeItem,this,_1));
@@ -310,7 +310,7 @@ FWEveViewManager::buildView(TEveWindowSlot* iParent, const std::string& viewName
       }
    }
 
-   boost::shared_ptr<FWEveView> view;
+   std::shared_ptr<FWEveView> view;
    switch(type)
    {
       case FWViewType::k3D:
@@ -338,12 +338,12 @@ FWEveViewManager::buildView(TEveWindowSlot* iParent, const std::string& viewName
          break;
    }
 
-   m_views[type].push_back(boost::shared_ptr<FWEveView> (view));
+   m_views[type].push_back(std::shared_ptr<FWEveView> (view));
    return finishViewCreate(m_views[type].back());
 }
 
 FWEveView*
-FWEveViewManager::finishViewCreate(boost::shared_ptr<FWEveView> view)
+FWEveViewManager::finishViewCreate(std::shared_ptr<FWEveView> view)
 {
    // printf("new view %s added \n", view->typeName().c_str());
    gEve->DisableRedraw();
@@ -804,11 +804,11 @@ FWEveViewManager::supportedTypesAndRepresentations() const
          info.classType(name, isSimple);
          if(isSimple) 
          {
-            returnValue.add(boost::shared_ptr<FWRepresentationCheckerBase>(new FWSimpleRepresentationChecker(name, it->first,bitPackedViews,representsSubPart, FFOnly)) );
+            returnValue.add(std::make_shared<FWSimpleRepresentationChecker>(name, it->first,bitPackedViews,representsSubPart, FFOnly) );
          }
          else
          {
-            returnValue.add(boost::shared_ptr<FWRepresentationCheckerBase>(new FWEDProductRepresentationChecker(name, it->first,bitPackedViews,representsSubPart, FFOnly)) );
+            returnValue.add(std::make_shared<FWEDProductRepresentationChecker>(name, it->first,bitPackedViews,representsSubPart, FFOnly) );
          }
       }
    }

--- a/Fireworks/Core/src/FWEventItem.cc
+++ b/Fireworks/Core/src/FWEventItem.cc
@@ -51,7 +51,7 @@ int FWEventItem::maxLayerValue()
 //
 FWEventItem::FWEventItem(fireworks::Context* iContext,
                          unsigned int iId,
-                         boost::shared_ptr<FWItemAccessorBase> iAccessor,
+                         std::shared_ptr<FWItemAccessorBase> iAccessor,
                          const FWPhysicsObjectDesc& iDesc,  const FWConfiguration* pbc) :
    m_context(iContext),
    m_id(iId),

--- a/Fireworks/Core/src/FWExpressionValidator.cc
+++ b/Fireworks/Core/src/FWExpressionValidator.cc
@@ -25,7 +25,7 @@
 //
 // constants, enums and typedefs
 //
-typedef std::vector<boost::shared_ptr<fireworks::OptionNode> > Options;
+typedef std::vector<std::shared_ptr<fireworks::OptionNode> > Options;
 
 namespace fireworks {
    template< class T>
@@ -60,14 +60,14 @@ public:
       unsigned long substitutionEnd() const {
          return m_endOfName;
       }
-      const std::vector<boost::shared_ptr<OptionNode> >& options() const {
+      const std::vector<std::shared_ptr<OptionNode> >& options() const {
          if(m_hasSubOptions && m_subOptions.empty()) {
             fillOptionForType(m_type, m_subOptions);
             std::sort(m_subOptions.begin(),m_subOptions.end(),
-                      fireworks::OptionNodePtrCompare<boost::shared_ptr<OptionNode> >());
-            std::vector<boost::shared_ptr<OptionNode> >::iterator it=
+                      fireworks::OptionNodePtrCompare<std::shared_ptr<OptionNode> >());
+            std::vector<std::shared_ptr<OptionNode> >::iterator it=
                std::unique(m_subOptions.begin(),m_subOptions.end(),
-                           fireworks::OptionNodePtrEqual<boost::shared_ptr<OptionNode> >());
+                           fireworks::OptionNodePtrEqual<std::shared_ptr<OptionNode> >());
             m_subOptions.erase(it,  m_subOptions.end());
 
             m_hasSubOptions = !m_subOptions.empty();
@@ -80,12 +80,12 @@ public:
       }
 
       static void fillOptionForType( const edm::TypeWithDict&,
-                                     std::vector<boost::shared_ptr<OptionNode> >& );
+                                     std::vector<std::shared_ptr<OptionNode> >& );
 private:
       edm::TypeWithDict m_type;
       mutable std::string m_description;
       mutable std::string::size_type m_endOfName;
-      mutable std::vector<boost::shared_ptr<OptionNode> > m_subOptions;
+      mutable std::vector<std::shared_ptr<OptionNode> > m_subOptions;
       mutable bool m_hasSubOptions;
       static bool typeHasOptions(const edm::TypeWithDict& iType);
    };
@@ -124,7 +124,7 @@ private:
 
 
    void OptionNode::fillOptionForType( const edm::TypeWithDict& iType,
-                                       std::vector<boost::shared_ptr<OptionNode> >& oOptions)
+                                       std::vector<std::shared_ptr<OptionNode> >& oOptions)
    {
       edm::TypeWithDict type = iType;
       if(type.isPointer()) {
@@ -141,7 +141,7 @@ private:
             m.isOperator() ||
             !m.isPublic() ||
             m.name().substr(0,2)=="__") {continue;}
-         oOptions.push_back(boost::shared_ptr<OptionNode>(new OptionNode(m)));
+         oOptions.push_back(std::make_shared<OptionNode>(m));
       }
 
       edm::TypeBases bases(type);
@@ -164,10 +164,10 @@ private:
 // constructors and destructor
 //
 #define FUN1(_fun_) \
-   m_builtins.push_back(boost::shared_ptr<OptionNode>( new OptionNode( # _fun_ "(float):float", strlen( # _fun_ )+1,s_float)))
+   m_builtins.push_back(std::make_shared<OptionNode>( # _fun_ "(float):float", strlen( # _fun_ )+1,s_float))
 
 #define FUN2(_fun_) \
-   m_builtins.push_back(boost::shared_ptr<OptionNode>( new OptionNode( # _fun_ "(float,float):float", strlen( # _fun_ )+1,s_float)))
+   m_builtins.push_back(std::make_shared<OptionNode>( # _fun_ "(float,float):float", strlen( # _fun_ )+1,s_float))
 
 FWExpressionValidator::FWExpressionValidator()
 {
@@ -193,7 +193,7 @@ FWExpressionValidator::FWExpressionValidator()
    FUN2(min);
    FUN2(max);
    std::sort(m_builtins.begin(),m_builtins.end(),
-             fireworks::OptionNodePtrCompare<boost::shared_ptr<OptionNode> >());
+             fireworks::OptionNodePtrCompare<std::shared_ptr<OptionNode> >());
 
 }
 
@@ -230,10 +230,10 @@ FWExpressionValidator::setType(const edm::TypeWithDict& iType)
    m_options=m_builtins;
    OptionNode::fillOptionForType(iType, m_options);
    std::sort(m_options.begin(),m_options.end(),
-             fireworks::OptionNodePtrCompare<boost::shared_ptr<OptionNode> >());
-   std::vector<boost::shared_ptr<OptionNode> >::iterator it=
+             fireworks::OptionNodePtrCompare<std::shared_ptr<OptionNode> >());
+   std::vector<std::shared_ptr<OptionNode> >::iterator it=
       std::unique(m_options.begin(),m_options.end(),
-                  fireworks::OptionNodePtrEqual<boost::shared_ptr<OptionNode> >());
+                  fireworks::OptionNodePtrEqual<std::shared_ptr<OptionNode> >());
    m_options.erase(it,  m_options.end());
 }
 
@@ -272,7 +272,7 @@ namespace {
 
 void
 FWExpressionValidator::fillOptions(const char* iBegin, const char* iEnd,
-                                   std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const
+                                   std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const
 {
    using fireworks::OptionNode;
    oOptions.clear();
@@ -287,11 +287,11 @@ FWExpressionValidator::fillOptions(const char* iBegin, const char* iEnd,
                       *it-begin,
                       edm::TypeWithDict());
 
-      boost::shared_ptr<OptionNode> comp(&temp, dummyDelete);
+      std::shared_ptr<OptionNode> comp(&temp, dummyDelete);
       Options::const_iterator itFind =std::lower_bound(nodes->begin(),
                                                        nodes->end(),
                                                        comp,
-                                                       fireworks::OptionNodePtrCompare<boost::shared_ptr<OptionNode> >());
+                                                       fireworks::OptionNodePtrCompare<std::shared_ptr<OptionNode> >());
 
       if(itFind == nodes->end() ||  *comp < *(*itFind) ) {
          //no match so we have an error
@@ -308,7 +308,7 @@ FWExpressionValidator::fillOptions(const char* iBegin, const char* iEnd,
        it != itEnd;
        ++it) {
       if(part == (*it)->description().substr(0,part_size) ) {
-         oOptions.push_back(std::make_pair(boost::shared_ptr<std::string>(const_cast<std::string*>(&((*it)->description())), dummyDelete),
+         oOptions.push_back(std::make_pair(std::shared_ptr<std::string>(const_cast<std::string*>(&((*it)->description())), dummyDelete),
                                            (*it)->description().substr(part_size,(*it)->substitutionEnd()-part_size)));
       }
    }

--- a/Fireworks/Core/src/FWExpressionValidator.h
+++ b/Fireworks/Core/src/FWExpressionValidator.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
 // user include files
@@ -39,7 +39,7 @@ public:
 
    // ---------- const member functions ---------------------
    virtual void fillOptions(const char* iBegin, const char* iEnd,
-                            std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const;
+                            std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const;
 
    // ---------- static member functions --------------------
 
@@ -53,8 +53,8 @@ private:
 
    // ---------- member data --------------------------------
    edm::TypeWithDict m_type;
-   std::vector<boost::shared_ptr<fireworks::OptionNode> > m_options;
-   std::vector<boost::shared_ptr<fireworks::OptionNode> > m_builtins;
+   std::vector<std::shared_ptr<fireworks::OptionNode> > m_options;
+   std::vector<std::shared_ptr<fireworks::OptionNode> > m_builtins;
 
 };
 

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
@@ -165,7 +165,7 @@ FWGUIValidatingTextEntry::showOptions() {
       std::string subText(text,text+GetCursorPosition());
       //std::cout <<subText<<std::endl;
 
-      typedef std::vector<std::pair<boost::shared_ptr<std::string>, std::string> > Options;
+      typedef std::vector<std::pair<std::shared_ptr<std::string>, std::string> > Options;
       m_validator->fillOptions(text, text+GetCursorPosition(), m_options);
       if(m_options.empty()) { return;}
       if(m_options.size()==1) {

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.h
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <string>
 #ifndef __CINT__
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #endif
 // user include files
 #include "TGTextEntry.h"
@@ -70,7 +70,7 @@ private:
 
    UInt_t           m_listHeight;
 #ifndef __CINT__
-   std::vector<std::pair<boost::shared_ptr<std::string>, std::string> > m_options;
+   std::vector<std::pair<std::shared_ptr<std::string>, std::string> > m_options;
 #endif
 };
 

--- a/Fireworks/Core/src/FWGeometryTableView.cc
+++ b/Fireworks/Core/src/FWGeometryTableView.cc
@@ -87,7 +87,7 @@ public:
 
   }
 
-   virtual void fillOptions(const char* iBegin, const char* iEnd, std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const override 
+   virtual void fillOptions(const char* iBegin, const char* iEnd, std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const override 
    {
       oOptions.clear();
       m_list.clear();
@@ -105,14 +105,14 @@ public:
     unsigned int part_size = part.size();
       std::string h = "";
   // int cnt = 0;  
-    oOptions.push_back(std::make_pair(boost::shared_ptr<std::string>(new std::string(*m_list.begin())), h));
+    oOptions.push_back(std::make_pair(std::make_shared<std::string>(*m_list.begin()), h));
     std::vector<const char*>::iterator startIt = m_list.begin();  startIt++;
     for (std::vector<const char*>::iterator i = startIt; i!=m_list.end(); ++i)
       {
     //      std::cout << *i << " " << cnt++ << std::endl;
       if ((strlen(*i) >= part_size) && strncmp(*i, part.c_str(), part_size ) == 0)
          {
-        oOptions.push_back(std::make_pair(boost::shared_ptr<std::string>(new std::string((*i))),&((*i)[part_size]) ));
+        oOptions.push_back(std::make_pair(std::make_shared<std::string>((*i)),&((*i)[part_size]) ));
          }
       }
    }
@@ -183,7 +183,7 @@ FWGeometryTableView::FWGeometryTableView(TEveWindowSlot* iParent, FWColorManager
       m_filterType.addEntry(kFilterShapeName,      "ShapeName");
       m_filterType.addEntry(kFilterShapeClassName, "ShapeClassName");
 
-      boost::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor((FWParameterBase*)&m_filterType) );
+      std::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor((FWParameterBase*)&m_filterType) );
       ptr->attach((FWParameterBase*)&m_filterType, this);
 
       TGFrame* pframe = ptr->build(hp, false);

--- a/Fireworks/Core/src/FWGeometryTableView.h
+++ b/Fireworks/Core/src/FWGeometryTableView.h
@@ -88,7 +88,7 @@ private:
    FWEnumParameter         m_proximityAlgo;
    
    
-   boost::shared_ptr<FWParameterSetterBase> m_filterTypeSetter;
+   std::shared_ptr<FWParameterSetterBase> m_filterTypeSetter;
 
 #endif  
 

--- a/Fireworks/Core/src/FWGeometryTableViewManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewManager.cc
@@ -49,7 +49,7 @@ FWViewBase*
 FWGeometryTableViewManager::buildView(TEveWindowSlot* iParent, const std::string& type)
 {
    if (!s_geoManager) setGeoManagerFromFile();
-   boost::shared_ptr<FWGeometryTableViewBase> view;
+   std::shared_ptr<FWGeometryTableViewBase> view;
 
    FWViewType::EType typeId = (type == FWViewType::sName[FWViewType::kGeometryTable]) ?  FWViewType::kGeometryTable : FWViewType::kOverlapTable;
    if (typeId == FWViewType::kGeometryTable)
@@ -58,7 +58,7 @@ FWGeometryTableViewManager::buildView(TEveWindowSlot* iParent, const std::string
       view.reset( new FWOverlapTableView(iParent, &colorManager()));
 
    view->setBackgroundColor();
-   m_views.push_back(boost::shared_ptr<FWGeometryTableViewBase> (view));
+   m_views.push_back(std::shared_ptr<FWGeometryTableViewBase> (view));
    view->beingDestroyed_.connect(boost::bind(&FWGeometryTableViewManager::beingDestroyed, this,_1));
                                             
    return view.get();
@@ -68,7 +68,7 @@ FWGeometryTableViewManager::buildView(TEveWindowSlot* iParent, const std::string
 void
 FWGeometryTableViewManager::beingDestroyed(const FWViewBase* iView)
 {
-   for(std::vector<boost::shared_ptr<FWGeometryTableViewBase> >::iterator it=m_views.begin(); it != m_views.end(); ++it) {
+   for(std::vector<std::shared_ptr<FWGeometryTableViewBase> >::iterator it=m_views.begin(); it != m_views.end(); ++it) {
       if(it->get() == iView) {
          m_views.erase(it);
          return;
@@ -79,7 +79,7 @@ FWGeometryTableViewManager::beingDestroyed(const FWViewBase* iView)
 void
 FWGeometryTableViewManager::colorsChanged()
 {
-  for(std::vector<boost::shared_ptr<FWGeometryTableViewBase> >::iterator it=m_views.begin(); it != m_views.end(); ++it)
+  for(std::vector<std::shared_ptr<FWGeometryTableViewBase> >::iterator it=m_views.begin(); it != m_views.end(); ++it)
       (*it)->setBackgroundColor();
 }
 

--- a/Fireworks/Core/src/FWHLTValidator.cc
+++ b/Fireworks/Core/src/FWHLTValidator.cc
@@ -22,7 +22,7 @@
 
 void
 FWHLTValidator::fillOptions(const char* iBegin, const char* iEnd,
-			    std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const
+			    std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const
 {
    oOptions.clear();
    std::string part(iBegin,iEnd);
@@ -51,7 +51,7 @@ FWHLTValidator::fillOptions(const char* iBegin, const char* iEnd,
    for(std::vector<std::string>::const_iterator trigger = m_triggerNames.begin();
        trigger != m_triggerNames.end(); ++trigger)
      if(part == trigger->substr(0,part_size) ) {
-       oOptions.push_back(std::make_pair(boost::shared_ptr<std::string>(new std::string(*trigger)),
+       oOptions.push_back(std::make_pair(std::make_shared<std::string>(*trigger),
 					 trigger->substr(part_size,trigger->size()-part_size)));
      }
 }

--- a/Fireworks/Core/src/FWItemAccessorFactory.cc
+++ b/Fireworks/Core/src/FWItemAccessorFactory.cc
@@ -90,7 +90,7 @@ FWItemAccessorFactory::~FWItemAccessorFactory()
     mean that the product associated to @a iClass will not show up in the
     "Add Collection" table.
  */
-boost::shared_ptr<FWItemAccessorBase>
+std::shared_ptr<FWItemAccessorBase>
 FWItemAccessorFactory::accessorFor(const TClass* iClass) const
 {
    static const bool debug = false;
@@ -103,9 +103,8 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
       if (debug)
          fwLog(fwlog::kDebug) << "class " << iClass->GetName()
                               << " uses FWItemTVirtualCollectionProxyAccessor." << std::endl;
-      return boost::shared_ptr<FWItemAccessorBase>(
-         new FWItemTVirtualCollectionProxyAccessor(iClass,
-            boost::shared_ptr<TVirtualCollectionProxy>(iClass->GetCollectionProxy()->Generate())));
+      return std::make_shared<FWItemTVirtualCollectionProxyAccessor>(iClass,
+            std::shared_ptr<TVirtualCollectionProxy>(iClass->GetCollectionProxy()->Generate()));
    } 
    
    // Iterate on the available plugins and use the one which handles 
@@ -121,7 +120,7 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
       if (debug)
          fwLog(fwlog::kDebug) << "class " << iClass->GetName() << " uses " 
                               << accessorName << "." << std::endl;
-      return boost::shared_ptr<FWItemAccessorBase>(FWItemAccessorRegistry::get()->create(accessorName, iClass));
+      return std::shared_ptr<FWItemAccessorBase>(FWItemAccessorRegistry::get()->create(accessorName, iClass));
    }
    
    if (hasMemberTVirtualCollectionProxy(iClass, member,offset)) 
@@ -132,13 +131,12 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
                               << " which uses FWItemTVirtualCollectionProxyAccessor."
                               << std::endl;
    	   
-      return boost::shared_ptr<FWItemAccessorBase>(
-         new FWItemTVirtualCollectionProxyAccessor(iClass,
-            boost::shared_ptr<TVirtualCollectionProxy>(member->GetCollectionProxy()->Generate()),
-                                                   offset));
+      return std::make_shared<FWItemTVirtualCollectionProxyAccessor>(iClass,
+            std::shared_ptr<TVirtualCollectionProxy>(member->GetCollectionProxy()->Generate()),
+                                                   offset);
    }
 
-   return boost::shared_ptr<FWItemAccessorBase>(new FWItemSingleAccessor(iClass));
+   return std::make_shared<FWItemSingleAccessor>(iClass);
 }
 
 /** Helper method which @return true if the passes @a iClass can be accessed via

--- a/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.cc
+++ b/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.cc
@@ -33,7 +33,7 @@
 //
 FWItemTVirtualCollectionProxyAccessor::FWItemTVirtualCollectionProxyAccessor(
    const TClass* iType,
-   boost::shared_ptr<TVirtualCollectionProxy> iProxy,
+   std::shared_ptr<TVirtualCollectionProxy> iProxy,
    size_t iOffset)
    : m_type(iType),
      m_colProxy(iProxy),

--- a/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.h
+++ b/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 // user include files
 #include "Fireworks/Core/interface/FWItemAccessorBase.h"
@@ -31,7 +31,7 @@ class FWItemTVirtualCollectionProxyAccessor : public FWItemAccessorBase {
 
 public:
    FWItemTVirtualCollectionProxyAccessor(const TClass* iType,
-                                         boost::shared_ptr<TVirtualCollectionProxy> iProxy,
+                                         std::shared_ptr<TVirtualCollectionProxy> iProxy,
                                          size_t iOffset=0);
    virtual ~FWItemTVirtualCollectionProxyAccessor();
 
@@ -57,7 +57,7 @@ private:
 
    // ---------- member data --------------------------------
    const TClass* m_type;
-   boost::shared_ptr<TVirtualCollectionProxy> m_colProxy; //should be something other than shared_ptr
+   std::shared_ptr<TVirtualCollectionProxy> m_colProxy; //should be something other than shared_ptr
    mutable const void * m_data;
    size_t m_offset;
 };

--- a/Fireworks/Core/src/FWModelChangeManager.cc
+++ b/Fireworks/Core/src/FWModelChangeManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <cassert>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <exception>
 
 // user include files
@@ -108,7 +108,7 @@ FWModelChangeManager::endChanges()
           itChanges != m_itemChanges.end();
           ++itChanges,++index) {
          if( !guard ) {
-            // boost::shared_ptr<FWModelChangeManager> done(this, &sendChangeSignalsAreDone);
+            // std::shared_ptr<FWModelChangeManager> done(this, &sendChangeSignalsAreDone);
             guard = true;
             changeSignalsAreComing_();
          }
@@ -141,7 +141,7 @@ FWModelChangeManager::endChanges()
          {
             if (!guard) 
             {
-               // boost::shared_ptr<FWModelChangeManager> done(this, &sendChangeSignalsAreDone);
+               // std::shared_ptr<FWModelChangeManager> done(this, &sendChangeSignalsAreDone);
                guard = true;
                changeSignalsAreComing_();
             }

--- a/Fireworks/Core/src/FWParameterSetterBase.cc
+++ b/Fireworks/Core/src/FWParameterSetterBase.cc
@@ -90,7 +90,7 @@ FWParameterSetterBase::update() const
 // static member functions
 //
 
-boost::shared_ptr<FWParameterSetterBase>
+std::shared_ptr<FWParameterSetterBase>
 FWParameterSetterBase::makeSetterFor(FWParameterBase* iParam)
 {
    static std::map<edm::TypeID,edm::TypeWithDict> s_paramToSetterMap;
@@ -145,7 +145,7 @@ FWParameterSetterBase::makeSetterFor(FWParameterBase* iParam)
    //make it into the base class
    FWParameterSetterBase* p = static_cast<FWParameterSetterBase*>(setterObj.address());
    //Make a shared pointer to the base class that uses a destructor for the derived class, in order to match the above construct call.
-   boost::shared_ptr<FWParameterSetterBase> ptr(p, boost::bind(&edm::TypeWithDict::destruct,itFind->second,setterObj.address(),true));
+   std::shared_ptr<FWParameterSetterBase> ptr(p, boost::bind(&edm::TypeWithDict::destruct,itFind->second,setterObj.address(),true));
    return ptr;
 }
 

--- a/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
+++ b/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
@@ -72,7 +72,7 @@ FWProxyBuilderConfiguration::makeSetter(TGCompositeFrame* frame, FWParameterBase
 {
    //  std::cout << "make setter " << pb->name() << std::endl;
 
-   boost::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(pb) );
+   std::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(pb) );
    ptr->attach(pb, this); 
    TGFrame* tmpFrame = ptr->build(frame, false);
    frame->AddFrame(tmpFrame, new TGLayoutHints(kLHintsExpandX));

--- a/Fireworks/Core/src/FWRPZView.cc
+++ b/Fireworks/Core/src/FWRPZView.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <stdexcept>
 #include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "TGLViewer.h"
 #include "TGLScenePad.h"
@@ -300,7 +300,7 @@ FWRPZView::importElements(TEveElement* iChildren, float iLayer, TEveElement* iPr
    float oldLayer = m_projMgr->GetCurrentDepth();
    m_projMgr->SetCurrentDepth(iLayer);
    //make sure current depth is reset even if an exception is thrown
-   boost::shared_ptr<TEveProjectionManager> sentry(m_projMgr,
+   std::shared_ptr<TEveProjectionManager> sentry(m_projMgr,
                                                    boost::bind(&TEveProjectionManager::SetCurrentDepth,
                                                                _1,oldLayer));
    m_projMgr->ImportElements(iChildren,iProjectedParent);

--- a/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
+++ b/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
@@ -111,7 +111,7 @@ FWSimpleRepresentationChecker::infoFor(const std::string& iTypeName) const
    if(0==clss || 0==clss->GetTypeInfo()) {
       return FWRepresentationInfo();
    }
-   boost::shared_ptr<FWItemAccessorBase> accessor = factory.accessorFor(clss);
+   std::shared_ptr<FWItemAccessorBase> accessor = factory.accessorFor(clss);
 
    const TClass* modelClass = accessor->modelType();
    //std::cout <<"   "<<modelClass->GetName()<<" "<< bool(modelClass == clss)<< std::endl;

--- a/Fireworks/Core/src/FWTableView.cc
+++ b/Fireworks/Core/src/FWTableView.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <stdlib.h>
 #include <algorithm>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -368,7 +368,7 @@ class FWViewBase*
 FWTableViewManager::buildView(TEveWindowSlot* iParent, const std::string& /*type*/)
 {
    TEveManager::TRedrawDisabler disableRedraw(gEve);
-   boost::shared_ptr<FWTableView> view(new FWTableView(iParent, this));
+   auto view = std::make_shared<FWTableView>(iParent, this);
    view->setBackgroundColor(colorManager().background());
    m_views.push_back(view);
    view->beingDestroyed_.connect(boost::bind(&FWTableViewManager::beingDestroyed,

--- a/Fireworks/Core/src/FWTriggerTableViewManager.cc
+++ b/Fireworks/Core/src/FWTriggerTableViewManager.cc
@@ -44,7 +44,7 @@ FWTriggerTableViewManager::~FWTriggerTableViewManager()
 class FWViewBase*
 FWTriggerTableViewManager::buildView(TEveWindowSlot* iParent, const std::string& type)
 {
-   boost::shared_ptr<FWTriggerTableView> view;
+   std::shared_ptr<FWTriggerTableView> view;
    
    if (type == FWViewType::sName[FWViewType::kTableHLT])
       view.reset( new FWHLTTriggerTableView(iParent));
@@ -54,7 +54,7 @@ FWTriggerTableViewManager::buildView(TEveWindowSlot* iParent, const std::string&
    view->setProcessList(&(context().metadataManager()->processNamesInJob()));   
  
    view->setBackgroundColor(colorManager().background());
-   m_views.push_back(boost::shared_ptr<FWTriggerTableView> (view));
+   m_views.push_back(std::shared_ptr<FWTriggerTableView> (view));
    view->beingDestroyed_.connect(boost::bind(&FWTriggerTableViewManager::beingDestroyed,
                                              this,_1));
    return view.get();
@@ -63,7 +63,7 @@ FWTriggerTableViewManager::buildView(TEveWindowSlot* iParent, const std::string&
 void
 FWTriggerTableViewManager::beingDestroyed(const FWViewBase* iView)
 {
-   for(std::vector<boost::shared_ptr<FWTriggerTableView> >::iterator it=
+   for(std::vector<std::shared_ptr<FWTriggerTableView> >::iterator it=
           m_views.begin(), itEnd = m_views.end();
        it != itEnd;
        ++it) {
@@ -77,7 +77,7 @@ FWTriggerTableViewManager::beingDestroyed(const FWViewBase* iView)
 void
 FWTriggerTableViewManager::colorsChanged()
 {
-   for(std::vector<boost::shared_ptr<FWTriggerTableView> >::iterator it=
+   for(std::vector<std::shared_ptr<FWTriggerTableView> >::iterator it=
           m_views.begin(), itEnd = m_views.end();
        it != itEnd;
        ++it) {
@@ -88,7 +88,7 @@ FWTriggerTableViewManager::colorsChanged()
 void
 FWTriggerTableViewManager::eventEnd()
 {
-   for(std::vector<boost::shared_ptr<FWTriggerTableView> >::iterator it=
+   for(std::vector<std::shared_ptr<FWTriggerTableView> >::iterator it=
           m_views.begin(), itEnd = m_views.end();
        it != itEnd;
        ++it) {
@@ -100,7 +100,7 @@ void
 FWTriggerTableViewManager::updateProcessList()
 { 
    // printf("FWTriggerTableViewManager::updateProcessLi\n");
-   for(std::vector<boost::shared_ptr<FWTriggerTableView> >::iterator it=
+   for(std::vector<std::shared_ptr<FWTriggerTableView> >::iterator it=
           m_views.begin(), itEnd = m_views.end();
        it != itEnd;
        ++it) {

--- a/Fireworks/Core/src/FWTypeToRepresentations.cc
+++ b/Fireworks/Core/src/FWTypeToRepresentations.cc
@@ -58,7 +58,7 @@ FWTypeToRepresentations::~FWTypeToRepresentations()
 // member functions
 //
 void
-FWTypeToRepresentations::add( boost::shared_ptr<FWRepresentationCheckerBase> iChecker)
+FWTypeToRepresentations::add( std::shared_ptr<FWRepresentationCheckerBase> iChecker)
 {
    m_checkers.push_back(iChecker);
    if(m_typeToReps.size()) {
@@ -78,7 +78,7 @@ void
 FWTypeToRepresentations::insert( const FWTypeToRepresentations& iOther)
 {
    m_typeToReps.clear();
-   for(std::vector<boost::shared_ptr<FWRepresentationCheckerBase> >::const_iterator it =iOther.m_checkers.begin(),
+   for(std::vector<std::shared_ptr<FWRepresentationCheckerBase> >::const_iterator it =iOther.m_checkers.begin(),
                                                                                     itEnd = iOther.m_checkers.end();
        it != itEnd;
        ++it) {
@@ -96,7 +96,7 @@ FWTypeToRepresentations::representationsForType(const std::string& iTypeName) co
    if(itFound == m_typeToReps.end()) {
       std::vector<FWRepresentationInfo> reps;
       //check all reps
-      for(std::vector<boost::shared_ptr<FWRepresentationCheckerBase> >::const_iterator it = m_checkers.begin(),
+      for(std::vector<std::shared_ptr<FWRepresentationCheckerBase> >::const_iterator it = m_checkers.begin(),
              itEnd = m_checkers.end();
           it != itEnd;
           ++it) {

--- a/Fireworks/Core/src/FWValidatorBase.h
+++ b/Fireworks/Core/src/FWValidatorBase.h
@@ -21,7 +21,7 @@
 // system include files
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 
@@ -40,7 +40,7 @@ public:
    // first: the full details about the substitution
    // second: exactly what should be inserted into the expression to complete the option
    virtual void fillOptions(const char* iBegin, const char* iEnd,
-                            std::vector<std::pair<boost::shared_ptr<std::string>, std::string> >& oOptions) const = 0;
+                            std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const = 0;
 
    // ---------- static member functions --------------------
 

--- a/Fireworks/Core/src/FWViewEnergyScaleEditor.cc
+++ b/Fireworks/Core/src/FWViewEnergyScaleEditor.cc
@@ -57,7 +57,7 @@ void
 FWViewEnergyScaleEditor::setEnabled(bool x)
 {
    m_enabled =x;
-   typedef  std::vector<boost::shared_ptr<FWParameterSetterBase> > sList;
+   typedef  std::vector<std::shared_ptr<FWParameterSetterBase> > sList;
    for (sList::iterator i = m_setters.begin(); i!=m_setters.end(); ++i)
    {
       (*i)->setEnabled(m_enabled);
@@ -75,7 +75,7 @@ FWViewEnergyScaleEditor::addParam(FWParameterBase* param, const char* title)
       leftPad *= 2;
    }
    
-   boost::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(param) );
+   std::shared_ptr<FWParameterSetterBase> ptr( FWParameterSetterBase::makeSetterFor(param) );
    ptr->attach((FWParameterBase*)param, this);
    TGFrame* pframe = ptr->build(this);
    AddFrame(pframe, new TGLayoutHints(kLHintsLeft, leftPad, 0, 0, 0));

--- a/Fireworks/Core/src/FWViewManagerManager.cc
+++ b/Fireworks/Core/src/FWViewManagerManager.cc
@@ -64,7 +64,7 @@ FWViewManagerManager::~FWViewManagerManager()
 // member functions
 //
 void
-FWViewManagerManager::add( boost::shared_ptr<FWViewManagerBase> iManager)
+FWViewManagerManager::add( std::shared_ptr<FWViewManagerBase> iManager)
 {
    m_viewManagers.push_back(iManager);
    iManager->setChangeManager(m_changeManager);
@@ -88,7 +88,7 @@ FWViewManagerManager::registerEventItem(const FWEventItem*iItem)
    iItem->goingToBeDestroyed_.connect(boost::bind(&FWViewManagerManager::removeEventItem,this,_1));
 
    //std::map<std::string, std::vector<std::string> >::iterator itFind = m_typeToBuilders.find(iItem->name());
-   for(std::vector<boost::shared_ptr<FWViewManagerBase> >::iterator itVM = m_viewManagers.begin();
+   for(std::vector<std::shared_ptr<FWViewManagerBase> >::iterator itVM = m_viewManagers.begin();
        itVM != m_viewManagers.end();
        ++itVM) {
       (*itVM)->newItem(iItem);
@@ -111,7 +111,7 @@ FWTypeToRepresentations
 FWViewManagerManager::supportedTypesAndRepresentations() const
 {
    FWTypeToRepresentations returnValue;
-   for(std::vector<boost::shared_ptr<FWViewManagerBase> >::const_iterator itVM = m_viewManagers.begin();
+   for(std::vector<std::shared_ptr<FWViewManagerBase> >::const_iterator itVM = m_viewManagers.begin();
        itVM != m_viewManagers.end();
        ++itVM) {
       FWTypeToRepresentations v = (*itVM)->supportedTypesAndRepresentations();

--- a/Fireworks/Core/test/unittest_changemanager.cc
+++ b/Fireworks/Core/test/unittest_changemanager.cc
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE( changemanager )
    
    fireworks::Context context(&cm,0,0,0,0);
    
-   boost::shared_ptr<FWItemAccessorBase> accessor( new TestAccessor(&fVector));
+   auto accessor = std::make_shared<TestAccessor>(&fVector);
    FWPhysicsObjectDesc pObj("Tracks",cls,"Tracks");
    
    FWEventItem item(&context, 0,accessor,pObj);

--- a/Fireworks/Core/test/unittest_modelexpressionselector.cc
+++ b/Fireworks/Core/test/unittest_modelexpressionselector.cc
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( modelexpressionselector )
 
    fireworks::Context context(&cm,&sm,0,0,0);
    
-   boost::shared_ptr<FWItemAccessorBase> accessor( new TestAccessor(&fVector));
+   auto accessor = std::make_shared<TestAccessor>(&fVector);
    FWPhysicsObjectDesc pObj("Tracks",cls,"Tracks");
    
    FWEventItem item(&context, 0,accessor,pObj);

--- a/Fireworks/Core/test/unittest_modelfilter.cc
+++ b/Fireworks/Core/test/unittest_modelfilter.cc
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE( itemfilter )
    
    fireworks::Context context(&cm,&sm,0,0,0);
    
-   boost::shared_ptr<FWItemAccessorBase> accessor( new TestAccessor(&fVector));
+   auto accessor = std::make_shared<TestAccessor>(&fVector);
    FWPhysicsObjectDesc pObj("Tracks",cls,"Tracks");
    FWEventItem item(&context, 0,accessor,pObj);
 

--- a/Fireworks/Core/test/unittest_selectionmanager.cc
+++ b/Fireworks/Core/test/unittest_selectionmanager.cc
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE( selectionmanager )
    
    fireworks::Context context(&cm,&sm,0,0,0);
    
-   boost::shared_ptr<FWItemAccessorBase> accessor( new TestAccessor(&fVector));
+   auto accessor = std::make_shared<TestAccessor>(&fVector);
    FWPhysicsObjectDesc pObj("Tracks",cls,"Tracks");
    
    FWEventItem item(&context, 0,accessor,pObj);


### PR DESCRIPTION
"auto thePtr = std::make_shared&lt;MyClass&gt;(...)" is preferred to "shared_ptr thePtr(new MyClass(...))" because it saves a memory allocation. It allocates the shared_ptr and the pointee in the same allocation.
This PR changes the places in visualization that did it the suboptimal way. To do this, it was necessary to replace the use of boost::shared_ptr with std::shared_ptr, which was done throughout visualization.