### PR TITLE
Fixing static analyzer warnings in ElectronEnergyCorrector.cc, GEDPhotonProducer.cc and PhotonMIPHaloTagger.cc

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -73,7 +73,7 @@ void ElectronEnergyCorrector::classBasedParameterizationEnergy
   float corr = 1.;
   float corr2 = 1.;
   float energy = electron.superCluster()->energy() ;
-  float newEnergy = energy;
+  float newEnergy;
 
   //int subdet = electron.superCluster()->seed()->hitsAndFractions()[0].first.subdetId();
 

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -73,7 +73,6 @@ void ElectronEnergyCorrector::classBasedParameterizationEnergy
   float corr = 1.;
   float corr2 = 1.;
   float energy = electron.superCluster()->energy() ;
-  float newEnergy;
 
   //int subdet = electron.superCluster()->seed()->hitsAndFractions()[0].first.subdetId();
 
@@ -98,7 +97,7 @@ void ElectronEnergyCorrector::classBasedParameterizationEnergy
   else if (electron.isEE()) { corr2 = corr * fEnergy(energy/corr, 1,elClass) ; }
   else { edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")<<"nor barrel neither endcap electron !" ; }
 
-  newEnergy = energy/corr2;
+  float newEnergy = energy/corr2;
 
   // cracks
   double crackcor = 1. ;

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -269,7 +269,6 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   const EcalRecHitCollection dummyEB;
   theEvent.getByToken(barrelEcalHits_, barrelHitHandle);
   if (!barrelHitHandle.isValid()) {
-    validEcalRecHits=false; 
     throw cms::Exception("GEDPhotonProducer") 
       << "Error! Can't get the barrelEcalHits";
   }
@@ -279,7 +278,6 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   theEvent.getByToken(endcapEcalHits_, endcapHitHandle);
   const EcalRecHitCollection dummyEE;
   if (!endcapHitHandle.isValid()) {
-    validEcalRecHits=false; 
     throw cms::Exception("GEDPhotonProducer") 
       << "Error! Can't get the endcapEcalHits";
   }
@@ -290,7 +288,6 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   theEvent.getByToken(preshowerHits_, preshowerHitHandle);
   EcalRecHitCollection preshowerRecHits;
   if (!preshowerHitHandle.isValid()) {
-    validPreshowerRecHits=false; 
     throw cms::Exception("GEDPhotonProducer") 
       << "Error! Can't get the preshowerEcalHits";
   }
@@ -347,7 +344,6 @@ void GEDPhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   if ( usePrimaryVertex_ ) {
     theEvent.getByToken(vertexProducer_, vertexHandle);
     if (!vertexHandle.isValid()) {
-      validVertex=false;
       throw cms::Exception("GEDPhotonProducer") 
 	<< "Error! Can't get the product primary Vertex Collection";
     }

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -290,17 +290,11 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
            
 
         //Lets Initialize them first for each iteration 
-        res    = 0.0;
-        res_sq = 0.0;
-        wt     = 0.0; 
         sx     = 0.0;
         sy     = 0.0; 
         ss     = 0.0;
         sxx    = 0.0;
         sxy    = 0.0;
-        delt   = 0.0; 
-        a1     = 0.0;
-        b1     = 0.0;
         m_chi2 = 0.0;
         etot_cell=0.0;
      
@@ -362,7 +356,6 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
    if(debug_)std::cout<<" eTot ="<<eT<<"     Rounness = "<<Roundness_<<"    Angle_  "<<Angle_ <<std::endl; 
 
      //get the halo disc variable
-     halo_disc_ = 0.;
      halo_disc_ = eT/(Roundness_* Angle_);
 
 

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -259,17 +259,13 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
      if(debug_)std::cout<<" starting npoing = "<<Npoints<<std::endl;
 
      //defined some variable for iterative fitting the mip trail line  
-        double  res    = 0.0;                            
-        double  res_sq = 0.0;                            
-        double  wt     = 0.0;                            
         double  sx     = 0.0;    
         double  sy     = 0.0;                                   
         double  ss     = 0.0;                            
         double  sxx    = 0.0;                            
-        double  sxy    = 0.0;                            
-        double  delt   = 0.0;
+        double  sxy    = 0.0;
         double  a1     = 0.0;
-        double  b1     = 0.0;                            
+        double  b1     = 0.0;                             
         double  m_chi2 = 0.0;                            
         double  etot_cell=0.0;   
 
@@ -302,7 +298,7 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
             //Fit the line to trail 
            for(int j=0; j<Npoints; j++)
             {  
-               wt = 1.0;
+               double wt = 1.0;
                ss += wt;
                sx += ieta_cell[j]*wt;                               
                sy += iphi_cell[j]; 
@@ -310,9 +306,9 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
                sxy += ieta_cell[j]*iphi_cell[j]*wt;
             }
        
-            delt =  ss*sxx - (sx*sx);
-              a1 = ((sxx*sy)-(sx*sxy))/delt;   // INTERCEPT
-              b1 = ((ss*sxy)-(sx*sy))/delt;    // SLOPE
+            double delt =  ss*sxx - (sx*sx);
+            a1 = ((sxx*sy)-(sx*sxy))/delt;   // INTERCEPT
+            b1 = ((ss*sxy)-(sx*sy))/delt;    // SLOPE
 
 
           double highest_res   = 0.;
@@ -321,8 +317,8 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
 
             for(int j=0; j<Npoints; j++)
                {                
-                    res = 1.0*iphi_cell[j] - a1 - b1*ieta_cell[j];
-                    res_sq = res*res;
+                    double res = 1.0*iphi_cell[j] - a1 - b1*ieta_cell[j];
+                    double res_sq = res*res;
 
                     if(TMath::Abs(res) > highest_res)
                        {             


### PR DESCRIPTION
In all three files, dead assignment errors raised by static analyzer are fixed by deleting these assignments. These preliminary fixes pass all tests, however some deliberation is needed for the file PhotonMIPHaloTagger.cc which has other similar "dead assignments" which are not pointed out by the static analyzer. Or perhaps, I misunderstand the intention of the code. @slava77 and @cvuosalo you requested to watch this.