### PR TITLE
Making Puppi optional for PATPackedCandidate producer : 80X

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -148,7 +148,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
       }
     }  
     std::vector<int> mappingPuppi(usePuppi_ ? puppiCands->size() : 0);
-    auto const puppiCandsNoLepV = usePuppi_ ? puppiCandsNoLep.product() : nullptr;
 
     edm::Handle<reco::VertexCollection> PVOrigs;
     iEvent.getByToken( PVOrigs_, PVOrigs );
@@ -270,7 +269,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
            
            float puppiWeightVal = (*puppiWeight)[pkref];
            float puppiWeightNoLepVal = 0.0;
-
            // Check the "no lepton" puppi weights. 
            // If present, then it is not a lepton, use stored weight
            // If absent, it is a lepton, so set the weight to 1.0
@@ -282,7 +280,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
              for ( size_t ipcnl = 0; ipcnl < puppiCandsNoLepPtrs.size(); ipcnl++){
               if (puppiCandsNoLepPtrs[ipcnl] == pkrefPtr){
                 foundNoLep = true;
-                  puppiWeightNoLepVal = puppiCandsNoLepV->at(ipcnl).pt()/cand.pt(); // a hack for now, should use the value map
+                  puppiWeightNoLepVal = puppiCandsNoLep->at(ipcnl).pt()/cand.pt(); // a hack for now, should use the value map
                   break;
                 }
               }

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -77,6 +77,10 @@ namespace pat {
             std::vector< edm::EDGetTokenT<edm::View<reco::CompositePtrCandidate> > > SVWhiteLists_;
 
             const double minPtForTrackProperties_;
+            //if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
+            //otherwise assumes that if they are set, you wanted to use puppi and will throw an exception
+            //if the puppis are not found
+            const bool usePuppi_;  
             // for debugging
             float calcDxy(float dx, float dy, float phi) const {
                 return - dx * std::sin(phi) + dy * std::cos(phi);
@@ -99,7 +103,9 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   PuppiCands_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   PuppiCandsNoLep_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))),
-  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
+  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
+  usePuppi_(!iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() || 
+	    !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc").encode().empty())
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -129,7 +135,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     iEvent.getByToken( PuppiCandsMap_, puppiCandsMap );
     edm::Handle<std::vector< reco::PFCandidate > > puppiCands;
     iEvent.getByToken( PuppiCands_, puppiCands );
-    std::vector<int> mappingPuppi(puppiCands.isValid() ? puppiCands->size() : 0);
+    std::vector<int> mappingPuppi(usePuppi_ ? puppiCands->size() : 0);
 
     edm::Handle< edm::ValueMap<float> > puppiWeightNoLep;
     iEvent.getByToken( PuppiWeightNoLep_, puppiWeightNoLep );
@@ -142,7 +148,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
         puppiCandsNoLepPtrs.push_back(pup.sourceCandidatePtr(0));
       }
     }
-    auto const puppiCandsNoLepV = puppiCandsNoLep.isValid() ? puppiCandsNoLep.product() : nullptr;
+    auto const puppiCandsNoLepV = usePuppi_ ? puppiCandsNoLep.product() : nullptr;
 
     edm::Handle<reco::VertexCollection> PVOrigs;
     iEvent.getByToken( PVOrigs_, PVOrigs );
@@ -326,7 +332,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     pc2pfFiller.insert(oh   , order.begin(), order.end());
     // include also the mapping track -> packed PFCand
     pf2pcFiller.insert(TKOrigs, mappingTk.begin(), mappingTk.end());
-    if(puppiCands.isValid()) pf2pcFiller.insert(puppiCands, mappingPuppi.begin(), mappingPuppi.end());
+    if(usePuppi_) pf2pcFiller.insert(puppiCands, mappingPuppi.begin(), mappingPuppi.end());
 
     pf2pcFiller.fill();
     pc2pfFiller.fill();

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -62,7 +62,12 @@ namespace pat {
               return idx;
            }
 
-        private:
+        private: 
+            //if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
+            //otherwise assumes that if they are set, you wanted to use puppi and will throw an exception
+            //if the puppis are not found
+            const bool usePuppi_;  
+            
             const edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
             const edm::EDGetTokenT<reco::VertexCollection>         PVs_;
             const edm::EDGetTokenT<edm::Association<reco::VertexCollection> > PVAsso_;
@@ -77,10 +82,7 @@ namespace pat {
             std::vector< edm::EDGetTokenT<edm::View<reco::CompositePtrCandidate> > > SVWhiteLists_;
 
             const double minPtForTrackProperties_;
-            //if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
-            //otherwise assumes that if they are set, you wanted to use puppi and will throw an exception
-            //if the puppis are not found
-            const bool usePuppi_;  
+           
             // for debugging
             float calcDxy(float dx, float dy, float phi) const {
                 return - dx * std::sin(phi) + dy * std::cos(phi);
@@ -92,20 +94,20 @@ namespace pat {
 }
 
 pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::ParameterSet& iConfig) :
+  usePuppi_(!iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() || 
+	    !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc").encode().empty()),
   Cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCollection"))),
   PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("inputVertices"))),
   PVAsso_(consumes<edm::Association<reco::VertexCollection> >(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
   PVAssoQuality_(consumes<edm::ValueMap<int> >(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
   PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
   TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
-  PuppiWeight_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
-  PuppiWeightNoLep_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))),
-  PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
-  PuppiCands_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
-  PuppiCandsNoLep_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))),
-  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
-  usePuppi_(!iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() || 
-	    !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc").encode().empty())
+  PuppiWeight_(usePuppi_ ? consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT< edm::ValueMap<float> >()),
+  PuppiWeightNoLep_(usePuppi_ ? consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")) : edm::EDGetTokenT< edm::ValueMap<float> >()),
+  PuppiCandsMap_(usePuppi_ ? consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >() ),
+  PuppiCands_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >() ),
+  PuppiCandsNoLep_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >()),
+  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -129,25 +131,23 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     iEvent.getByToken( Cands_, cands );
     std::vector<reco::Candidate>::const_iterator cand;
 
-    edm::Handle< edm::ValueMap<float> > puppiWeight;
-    iEvent.getByToken( PuppiWeight_, puppiWeight );
+    edm::Handle<edm::ValueMap<float> > puppiWeight;
     edm::Handle<edm::ValueMap<reco::CandidatePtr> > puppiCandsMap;
-    iEvent.getByToken( PuppiCandsMap_, puppiCandsMap );
     edm::Handle<std::vector< reco::PFCandidate > > puppiCands;
-    iEvent.getByToken( PuppiCands_, puppiCands );
-    std::vector<int> mappingPuppi(usePuppi_ ? puppiCands->size() : 0);
-
-    edm::Handle< edm::ValueMap<float> > puppiWeightNoLep;
-    iEvent.getByToken( PuppiWeightNoLep_, puppiWeightNoLep );
+    edm::Handle<edm::ValueMap<float> > puppiWeightNoLep;
     edm::Handle<std::vector< reco::PFCandidate > > puppiCandsNoLep;
-    iEvent.getByToken( PuppiCandsNoLep_, puppiCandsNoLep );  
-
     std::vector<reco::CandidatePtr> puppiCandsNoLepPtrs;
-    if (puppiCandsNoLep.isValid()){
+    if(usePuppi_){
+      iEvent.getByToken( PuppiWeight_, puppiWeight );
+      iEvent.getByToken( PuppiCandsMap_, puppiCandsMap );
+      iEvent.getByToken( PuppiCands_, puppiCands );
+      iEvent.getByToken( PuppiWeightNoLep_, puppiWeightNoLep );
+      iEvent.getByToken( PuppiCandsNoLep_, puppiCandsNoLep );  
       for (auto pup : *puppiCandsNoLep){
         puppiCandsNoLepPtrs.push_back(pup.sourceCandidatePtr(0));
       }
-    }
+    }  
+    std::vector<int> mappingPuppi(usePuppi_ ? puppiCands->size() : 0);
     auto const puppiCandsNoLepV = usePuppi_ ? puppiCandsNoLep.product() : nullptr;
 
     edm::Handle<reco::VertexCollection> PVOrigs;
@@ -264,7 +264,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	}
 	
        
-        if (puppiWeight.isValid()){
+        if (usePuppi_){
            reco::PFCandidateRef pkref( cands, ic );
                  // outPtrP->back().setPuppiWeight( (*puppiWeight)[pkref]);
            

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -129,7 +129,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     iEvent.getByToken( PuppiCandsMap_, puppiCandsMap );
     edm::Handle<std::vector< reco::PFCandidate > > puppiCands;
     iEvent.getByToken( PuppiCands_, puppiCands );
-    std::vector<int> mappingPuppi(puppiCands->size());
+    std::vector<int> mappingPuppi(puppiCands.isValid() ? puppiCands->size() : 0);
 
     edm::Handle< edm::ValueMap<float> > puppiWeightNoLep;
     iEvent.getByToken( PuppiWeightNoLep_, puppiWeightNoLep );
@@ -142,7 +142,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
         puppiCandsNoLepPtrs.push_back(pup.sourceCandidatePtr(0));
       }
     }
-    auto const& puppiCandsNoLepV = puppiCandsNoLep.product();
+    auto const puppiCandsNoLepV = puppiCandsNoLep.isValid() ? puppiCandsNoLep.product() : nullptr;
 
     edm::Handle<reco::VertexCollection> PVOrigs;
     iEvent.getByToken( PVOrigs_, PVOrigs );
@@ -326,7 +326,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     pc2pfFiller.insert(oh   , order.begin(), order.end());
     // include also the mapping track -> packed PFCand
     pf2pcFiller.insert(TKOrigs, mappingTk.begin(), mappingTk.end());
-    pf2pcFiller.insert(puppiCands, mappingPuppi.begin(), mappingPuppi.end());
+    if(puppiCands.isValid()) pf2pcFiller.insert(puppiCands, mappingPuppi.begin(), mappingPuppi.end());
 
     pf2pcFiller.fill();
     pc2pfFiller.fill();


### PR DESCRIPTION
This commit makes puppi inputs optional for PATPackedCandidateProducer. If the puppi related input tags are both empty, it disables accessing puppi. If the input tags not empty, the behaviour is identical to before, thereby protecting against simple typos. 

This is helpful to remake the PFPackedCandidates without running all of miniAOD. The use case which prompts this is the new HEEP V7.0 uses PFPackedCandidates for tracker isolation and therefore needs to produce these in AOD. 

81X and 90X PRs following shortly. 
