### PR TITLE
Fix typo in the name of GlobalTrackingRegionFromBeamSpotEDProducer

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
@@ -17,8 +17,8 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, PointSeededTrackingRegionsProdu
 
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
-using GlobalTrackinRegionFromBeamSpotEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionProducerFromBeamSpot>;
-DEFINE_FWK_MODULE(GlobalTrackinRegionFromBeamSpotEDProducer);
+using GlobalTrackingRegionFromBeamSpotEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionProducerFromBeamSpot>;
+DEFINE_FWK_MODULE(GlobalTrackingRegionFromBeamSpotEDProducer);
 
 using GlobalTrackingRegionWithVerticesEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionWithVerticesProducer>;
 DEFINE_FWK_MODULE(GlobalTrackingRegionWithVerticesEDProducer);


### PR DESCRIPTION
This PR fixes a typo of an EDProducer in a typedef introduced in #16635 (`Trackin` -> `Tracking`).

Tested in CMSSW_9_0_X_2016-11-24-2300, no changes expected.

@rovere @VinInn @mtosi 