### PR TITLE
Cleaning up Phase-2 tracker local reco sequence

### DIFF
--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
@@ -24,8 +24,6 @@ RecoLocalTrackerAOD = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(RecoLocalTrackerFEVT, outputCommands = RecoLocalTrackerFEVT.outputCommands + ['keep *_siPhase2Clusters_*_*',
-                                                                                                           'keep *_phase2ITPixelClusters_*_*'] )
-phase2_tracker.toModify(RecoLocalTrackerRECO, outputCommands = RecoLocalTrackerRECO.outputCommands + ['keep *_siPhase2Clusters_*_*',
-                                                                                                           'keep *_phase2ITPixelClusters_*_*'] )
+phase2_tracker.toModify(RecoLocalTrackerFEVT, outputCommands = RecoLocalTrackerFEVT.outputCommands + ['keep *_siPhase2Clusters_*_*'] )
+phase2_tracker.toModify(RecoLocalTrackerRECO, outputCommands = RecoLocalTrackerRECO.outputCommands + ['keep *_siPhase2Clusters_*_*'] )
 

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
@@ -25,8 +25,16 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toReplaceWith(pixeltrackerlocalreco,
   cms.Sequence(
           siPhase2Clusters +
-          phase2ITPixelClusters +
           siPixelClustersPreSplitting +
           siPixelRecHitsPreSplitting
+  )
+)
+phase2_tracker.toModify(clusterSummaryProducer,
+  doStrips = False,
+  stripClusters = ''
+)
+phase2_tracker.toReplaceWith(trackerlocalreco,
+  cms.Sequence(
+          pixeltrackerlocalreco*clusterSummaryProducer
   )
 )


### PR DESCRIPTION
In order to improve the time/memory performance, I have removed part of the local reco(phase2ITPixelClusters and striptrackerlocalreco) which is not needed for Phase-2 tracker/ing.
Since no modules are affected by this changes, the performance should be the same. I produced comparisons for [D1](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/cleaningTkLocalReco/20161129_TTbar_D1/) and [D4](http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/cleaningTkLocalReco/20161128_TTbar_D4/)

Informing @kpedro88 @delaere @boudoul @atricomi