### PR TITLE
Let cling parse the full TrackingRegion class to avoid errors in root6.08 IBs

### DIFF
--- a/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
@@ -11,7 +11,6 @@
 
 class DetLayer;
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 /**
  * Class to store TransientTrackingRecHits, names, and DetLayer
  * pointers of each ctfseeding::SeedingLayer as they come from
@@ -260,6 +259,5 @@ private:
   std::vector<BaseTrackerRecHit const*> rechits_;
 
 };
-#endif
 
 #endif

--- a/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
@@ -249,15 +249,4 @@ private:
   OwnedHits rechits_;
 };
 
-
-#else
-class SeedingLayerSetsHits {
-private:
-  SeedingLayerSetsHits(SeedingLayerSetsHits const&){} 
-  SeedingLayerSetsHits& operator=(SeedingLayerSetsHits const&){return *this;}
-
-  std::vector<BaseTrackerRecHit const*> rechits_;
-
-};
-
 #endif


### PR DESCRIPTION
90X ROOT6 IBs failing to build with error
```
.../src/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h:46:33: error: no type named 'ConstRecHitPointer' in 'SeedingLayerSetsHits'
  typedef SeedingLayerSetsHits::ConstRecHitPointer Hit;
          ~~~~~~~~~~~~~~~~~~~~~~^
.../src/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h:47:33: error: no type named 'Hits' in 'SeedingLayerSetsHits'
  typedef SeedingLayerSetsHits::Hits Hits;
          ~~~~~~~~~~~~~~~~~~~~~~^
.../src/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h:100:35: error: no type named 'SeedingLayer' in 'SeedingLayerSetsHits'
                    const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
```
Chris suggested that we let cling parse the full classes