### PR TITLE
Fix PFTrackAlgoTools memory corruption

### DIFF
--- a/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
@@ -8,7 +8,7 @@ hgcalTrackCollection = cms.EDProducer(
 
     useIterativeTracking = cms.bool(True),
     DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,10.0,10.0,5.0),
-    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3),
+    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,32700), # the last value is nonsense
 
     # From HGCClusterizer
     hgcalGeometryNames = cms.PSet( HGC_ECAL  = cms.string('HGCalEESensitive'),

--- a/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
@@ -7,9 +7,8 @@ hgcalTrackCollection = cms.EDProducer(
     # From GeneralTracksImporter
 
     useIterativeTracking = cms.bool(True),
-    DPtOverPtCuts_byTrackAlgo = cms.vdouble(-1.0,-1.0,-1.0,
-                                             1.0,1.0),
-    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3),
+    DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,10.0,10.0,5.0),
+    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3),
 
     # From HGCClusterizer
     hgcalGeometryNames = cms.PSet( HGC_ECAL  = cms.string('HGCalEESensitive'),

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -24,7 +24,7 @@ namespace PFTrackAlgoTools {
       return cuts[4];
     case reco::TrackBase::muonSeededStepInOut:
     case reco::TrackBase::muonSeededStepOutIn:
-      return cuts[5];
+      return cuts.back(); //usually [5]
     case reco::TrackBase::hltIter0:
     case reco::TrackBase::hltIter1:
     case reco::TrackBase::hltIter2:
@@ -36,7 +36,7 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::hltIterX:
       return  cuts[0];
     default:
-      return hltIterativeTracking ? cuts[6]:cuts[0];
+      return hltIterativeTracking ? cuts.back():cuts[0];
 
     }
   }
@@ -65,7 +65,7 @@ namespace PFTrackAlgoTools {
       return cuts[4];
     case reco::TrackBase::muonSeededStepInOut:
     case reco::TrackBase::muonSeededStepOutIn:
-      return cuts[5];
+      return cuts.back(); //usually [5]
     case reco::TrackBase::hltIter0:
     case reco::TrackBase::hltIter1:
     case reco::TrackBase::hltIter2:
@@ -77,7 +77,7 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::hltIterX:
       return  cuts[0];
     default:
-      return hltIterativeTracking ? cuts[6]:cuts[0];
+      return hltIterativeTracking ? cuts.back():cuts[0];
 
     }
   }

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -24,7 +24,7 @@ namespace PFTrackAlgoTools {
       return cuts[4];
     case reco::TrackBase::muonSeededStepInOut:
     case reco::TrackBase::muonSeededStepOutIn:
-      return cuts.back(); //usually [5]
+      return cuts.at(5);
     case reco::TrackBase::hltIter0:
     case reco::TrackBase::hltIter1:
     case reco::TrackBase::hltIter2:
@@ -36,7 +36,7 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::hltIterX:
       return  cuts[0];
     default:
-      return hltIterativeTracking ? cuts.back():cuts[0];
+      return hltIterativeTracking ? cuts.at(5):cuts[0];
 
     }
   }
@@ -65,7 +65,7 @@ namespace PFTrackAlgoTools {
       return cuts[4];
     case reco::TrackBase::muonSeededStepInOut:
     case reco::TrackBase::muonSeededStepOutIn:
-      return cuts.back(); //usually [5]
+      return cuts.at(5);
     case reco::TrackBase::hltIter0:
     case reco::TrackBase::hltIter1:
     case reco::TrackBase::hltIter2:
@@ -77,7 +77,7 @@ namespace PFTrackAlgoTools {
     case reco::TrackBase::hltIterX:
       return  cuts[0];
     default:
-      return hltIterativeTracking ? cuts.back():cuts[0];
+      return hltIterativeTracking ? cuts.at(5):cuts[0];
 
     }
   }


### PR DESCRIPTION
A memory corruption issue in `PFTrackAlgoTools` was identified in #16493. Two functions in this namespace referenced indices [5] and [6] from an input vector of cut values. However, [5] only exists sometimes and [6] never exists:
https://cmssdt.cern.ch/lxr/search?_filestring=&_string=NHitCuts_byTrackAlgo
https://cmssdt.cern.ch/lxr/search?_filestring=&_string=DPtOverPtCuts_byTrackAlgo

@bachtis suggested just using `back()` for all cases that reference [5] or [6]. This indeed fixes the memory corruption issue (checked with valgrind).

This PR will be backported to 81X.