### PR TITLE
HGCal EGamma Fake Control - Cluster Hadronic Energy Fraction Cut

### DIFF
--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -66,8 +66,8 @@ class ElectronSeed : public TrajectorySeed
        float dPhi1 =std::numeric_limits<float>::infinity() ) ;
 
     //! Accessors
-    CtfTrackRef ctfTrack() const { return ctfTrack_ ; }
-    CaloClusterRef caloCluster() const { return caloCluster_ ; }
+    const CtfTrackRef& ctfTrack() const { return ctfTrack_ ; }
+    const CaloClusterRef& caloCluster() const { return caloCluster_ ; }
     unsigned char hitsMask() const { return hitsMask_ ; }
     int subDet2() const { return subDet2_ ; }
     float dRz2() const { return dRz2_ ; }

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -201,7 +201,7 @@ public:
     }
 
     /// direction of how the hits were sorted in the original seed
-    PropagationDirection seedDirection() const {
+    const PropagationDirection& seedDirection() const {
         return extra_->seedDirection();
     }
 
@@ -210,7 +210,7 @@ public:
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    edm::RefToBase<TrajectorySeed> seedRef() const {
+    const edm::RefToBase<TrajectorySeed>& seedRef() const {
         return extra_->seedRef();
     }
 

--- a/DataFormats/TrackReco/interface/TrackExtra.h
+++ b/DataFormats/TrackReco/interface/TrackExtra.h
@@ -160,7 +160,7 @@ public:
         return innerDetId_;
     }
     // direction how the hits were sorted in the original seed
-    PropagationDirection seedDirection() const {
+    const PropagationDirection& seedDirection() const {
         return seedDir_;
     }
 
@@ -169,7 +169,7 @@ public:
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    edm::RefToBase<TrajectorySeed> seedRef() const {
+    const edm::RefToBase<TrajectorySeed>& seedRef() const {
         return seedRef_;
     }
     void setSeedRef(const edm::RefToBase<TrajectorySeed> &r) {

--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -25,6 +25,7 @@
 <use   name="RecoTracker/TrackProducer"/>
 <use   name="DataFormats/HcalRecHit"/>
 <use   name="RecoCaloTools/Selectors"/>
+<use   name="RecoLocalCalo/HGCalRecAlgos"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="RecoEgamma/EgammaIsolationAlgos"/>

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -487,7 +487,7 @@ void ElectronSeedGenerator::addSeed
    reco::ElectronSeedCollection & out )
  {
   if (!info)
-   { out.push_back(seed) ; return ; }
+    { out.emplace_back(seed) ; return ; }
 
   if (positron)
    { seed.setPosAttributes(info->dRz2(),info->dPhi2(),info->dRz1(),info->dPhi1()) ; }
@@ -496,7 +496,7 @@ void ElectronSeedGenerator::addSeed
   reco::ElectronSeedCollection::iterator resItr ;
   for ( resItr=out.begin() ; resItr!=out.end() ; ++resItr )
    {
-    if ( (seed.caloCluster()==resItr->caloCluster()) &&
+    if ( (seed.caloCluster().key()==resItr->caloCluster().key()) &&
          (seed.hitsMask()==resItr->hitsMask()) &&
          equivalent(seed,*resItr) )
      {
@@ -578,7 +578,7 @@ void ElectronSeedGenerator::addSeed
      }
    }
 
-  out.push_back(seed) ;
+  out.emplace_back(seed) ;
  }
 
 bool ElectronSeedGenerator::prepareElTrackSeed

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -36,6 +36,7 @@ namespace edm
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
 class ElectronSeedProducer : public edm::stream::EDProducer<>
@@ -104,6 +105,8 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
 
     bool fromTrackerSeeds_;
     bool prefilteredSeeds_;
+
+    std::unique_ptr<hgcal::ClusterTools> hgcClusterTools_;
 
  } ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -106,6 +106,7 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     bool fromTrackerSeeds_;
     bool prefilteredSeeds_;
 
+    bool allowHGCal_;
     std::unique_ptr<hgcal::ClusterTools> hgcClusterTools_;
 
  } ;

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -22,6 +22,12 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     # H/E
     applyHOverECut = cms.bool(True),
     hOverEConeSize = cms.double(0.15),
+    # H/E equivalent for HGCal
+    HGCalConfig = cms.PSet(
+        HGCEEInput = cms.InputTag('HGCalRecHit:HGCEERecHits'),
+        HGCFHInput = cms.InputTag('HGCalRecHit:HGCHEFRecHits'),
+        HGCBHInput = cms.InputTag('HGCalRecHit:HGCHEBRecHits')
+        ),
     #maxHOverE = cms.double(0.1),
     maxHOverEBarrel = cms.double(0.15),
     maxHOverEEndcaps = cms.double(0.15),

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -23,6 +23,7 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     applyHOverECut = cms.bool(True),
     hOverEConeSize = cms.double(0.15),
     # H/E equivalent for HGCal
+    allowHGCal = cms.bool(False),
     HGCalConfig = cms.PSet(
         HGCEEInput = cms.InputTag('HGCalRecHit:HGCEERecHits'),
         HGCFHInput = cms.InputTag('HGCalRecHit:HGCHEFRecHits'),

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cfi.py
@@ -36,5 +36,9 @@ phase2_hgcal.toModify(
     ecalDrivenElectronSeeds,
     endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCal')
 )
+phase2_hgcal.toModify(
+    ecalDrivenElectronSeeds.SeedConfiguration,
+    allowHGCal = cms.bool(True)
+)
 
 

--- a/RecoEgamma/EgammaPhotonProducers/python/allConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/allConversions_cfi.py
@@ -61,3 +61,6 @@ allConversions = cms.EDProducer('ConversionProducer',
     AllowSingleLeg = cms.bool(False), #Allow single track conversion
     AllowRightBC = cms.bool(False) #Require second leg matching basic cluster
 )
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify( allConversions, bypassPreselGsf = cms.bool(False) )

--- a/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
@@ -1,0 +1,42 @@
+#ifndef __RecoLocalCalo_HGCalRecAlgos_ClusterTools_h__
+#define __RecoLocalCalo_HGCalRecAlgos_ClusterTools_h__
+
+#include <array>
+#include <cmath>
+
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+
+class HGCalGeometry;
+class HGCalDDDConstants;
+class DetId;
+
+namespace edm {
+  class Event;
+  class EventSetup;
+}
+
+namespace hgcal {
+  class ClusterTools {    
+  public:
+    ClusterTools(const edm::ParameterSet&, edm::ConsumesCollector&);
+    ~ClusterTools() {}
+
+    void getEvent(const edm::Event&);
+    void getEventSetup(const edm::EventSetup&);
+    
+    float getClusterHadronFraction(const reco::CaloCluster&) const;
+
+  private:
+    RecHitTools rhtools_;
+    const edm::EDGetTokenT<HGCRecHitCollection> eetok, fhtok, bhtok;
+    const HGCRecHitCollection *eerh_, *fhrh_, *bhrh_;
+  };
+}
+
+#endif

--- a/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
@@ -1,0 +1,76 @@
+#include "RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+using namespace hgcal;
+
+ClusterTools::ClusterTools(const edm::ParameterSet& conf, 
+                           edm::ConsumesCollector& sumes):
+  eetok( sumes.consumes<HGCRecHitCollection>(conf.getParameter<edm::InputTag>("HGCEEInput")) ),
+  fhtok( sumes.consumes<HGCRecHitCollection>(conf.getParameter<edm::InputTag>("HGCFHInput")) ),
+  bhtok( sumes.consumes<HGCRecHitCollection>(conf.getParameter<edm::InputTag>("HGCBHInput")) ) {
+}
+
+void ClusterTools::getEvent(const edm::Event& ev) {
+  rhtools_.getEvent(ev);
+  edm::Handle<HGCRecHitCollection> temp;
+  ev.getByToken(eetok, temp);
+  eerh_ = temp.product();
+  ev.getByToken(fhtok, temp);
+  fhrh_ = temp.product();
+  ev.getByToken(bhtok, temp);
+  bhrh_ = temp.product();
+}
+
+void ClusterTools::getEventSetup(const edm::EventSetup& es) {
+  rhtools_.getEventSetup(es);
+}
+
+float ClusterTools::getClusterHadronFraction(const reco::CaloCluster& clus) const {
+  float energy=0.f, energyHad=0.f;
+  const auto& hits = clus.hitsAndFractions();
+  for( const auto& hit : hits ) {
+    const auto& id = hit.first;
+    const float fraction = hit.second;
+    if( id.det() == DetId::Forward ) {
+      switch( id.subdetId() ) {
+      case HGCEE:
+        energy += eerh_->find(id)->energy()*fraction;
+        break;
+      case HGCHEF:
+        {
+          const float temp = fhrh_->find(id)->energy();
+          energy += temp*fraction;
+          energyHad += temp*fraction;
+        }
+        break;
+      default:
+        throw cms::Exception("HGCalClusterTools")
+          << " Cluster contains hits that are not from HGCal! " << std::endl;
+      }
+    } else if ( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap ) {
+      const float temp = bhrh_->find(id)->energy();
+      energy += temp*fraction;
+      energyHad += temp*fraction;
+    } else {
+      throw cms::Exception("HGCalClusterTools")
+        << " Cluster contains hits that are not from HGCal! " << std::endl;
+    }    
+  }
+  float fraction = -1.f;
+  if( energy > 0.f ) {
+    fraction = energyHad/energy;
+  }
+  return fraction;
+}
+
+

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -43,6 +43,7 @@ class ConvBremPFTrackFinder;
  and transform them in PFGsfRecTracks.
 */
 
+#include <unordered_map>
 
 
 class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<convbremhelpers::HeavyObjectCache> > {
@@ -164,6 +165,9 @@ class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<c
       std::string path_mvaWeightFileConvBremBarrelHighPt_;
       std::string path_mvaWeightFileConvBremEndcapsLowPt_;
       std::string path_mvaWeightFileConvBremEndcapsHighPt_;
-      
+  
+      // cache for multitrajectory states
+      std::vector<double> gsfInnerMomentumCache_;
+
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -169,6 +169,16 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   vector<reco::GsfPFRecTrack> primaryGsfPFRecTracks;
   std::map<unsigned int, std::vector<reco::GsfPFRecTrack> >  GsfPFMap;
   
+  for( unsigned igsf = 0; igsf < gsftracks.size(); igsf++ ) {
+    GsfTrackRef trackRef(gsftrackscoll, igsf);
+    gsfInnerMomentumCache_.push_back(trackRef->pMode());
+    TrajectoryStateOnSurface i_inTSOS = mtsTransform_.innerStateOnSurface((*trackRef));
+    GlobalVector i_innMom;
+    if(i_inTSOS.isValid()){
+      mtsMode_->momentumFromModeCartesian(i_inTSOS,i_innMom);  
+      gsfInnerMomentumCache_.back() = i_innMom.mag();
+    }
+  }
 
   for (unsigned int igsf=0; igsf<gsftracks.size();igsf++) {
     
@@ -194,7 +204,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	  isTrackerDriven = false;
 	}
 	else {
-	  auto const& SeedFromRef= dynamic_cast<ElectronSeed const&>(*(trackRef->extra()->seedRef()) );
+	  auto const& SeedFromRef= static_cast<ElectronSeed const&>(*(trackRef->extra()->seedRef()) );
 	  if(SeedFromRef.caloCluster().isNull())
 	    isEcalDriven = false;
 	  if(SeedFromRef.ctfTrack().isNull())
@@ -361,6 +371,8 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   selGsfPFRecTracks.clear();
   GsfPFMap.clear();
   primaryGsfPFRecTracks.clear();
+
+  std::vector<double>().swap(gsfInnerMomentumCache_);
 }
   
 // create the secondary GsfPFRecTracks Ref
@@ -390,7 +402,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 
 
   if (&(*gsftk.seedRef())==0) return -1;
-  auto const &  ElSeedFromRef=dynamic_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
+  auto const &  ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
   //CASE 1 ELECTRONSEED DOES NOT HAVE A REF TO THE CKFTRACK
   if (ElSeedFromRef.ctfTrack().isNull()){
     reco::PFRecTrackCollection::const_iterator pft=PfRTkColl.begin();
@@ -471,12 +483,12 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 bool 
 PFElecTkProducer::applySelection(const reco::GsfTrack& gsftk) {
   if (&(*gsftk.seedRef())==0) return false;
-  auto const& ElSeedFromRef=dynamic_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
+  auto const& ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
 
   bool passCut = false;
   if (ElSeedFromRef.ctfTrack().isNull()){
     if(ElSeedFromRef.caloCluster().isNull()) return passCut;
-    auto const* scRef = dynamic_cast<SuperCluster const*>(ElSeedFromRef.caloCluster().get());
+    auto const* scRef = static_cast<SuperCluster const*>(ElSeedFromRef.caloCluster().get());
     //do this just to know if exist a SC? 
     if(scRef) {
       float caloEne = scRef->energy();
@@ -501,12 +513,12 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
   bool debugCleaning = debugGsfCleaning_;
   bool n_keepGsf = true;
 
-  reco::GsfTrackRef nGsfTrack = GsfPFVec[ngsf].gsfTrackRef();
+  const reco::GsfTrackRef& nGsfTrack = GsfPFVec[ngsf].gsfTrackRef();
   
   if (&(*nGsfTrack->seedRef())==0) return false;    
-  auto const& nElSeedFromRef=dynamic_cast<ElectronSeed const&>( *(nGsfTrack->extra()->seedRef()) );
-
-
+  auto const& nElSeedFromRef=static_cast<ElectronSeed const&>( *(nGsfTrack->extra()->seedRef()) );
+  
+  /* // now gotten from cache below
   TrajectoryStateOnSurface inTSOS = mtsTransform_.innerStateOnSurface((*nGsfTrack));
   GlobalVector ninnMom;
   float nPin =  nGsfTrack->pMode();
@@ -514,6 +526,8 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
     mtsMode_->momentumFromModeCartesian(inTSOS,ninnMom);
     nPin = ninnMom.mag();
   }
+  */
+  float nPin = gsfInnerMomentumCache_[nGsfTrack.key()];
 
   float neta = nGsfTrack->innerMomentum().eta();
   float nphi = nGsfTrack->innerMomentum().phi();
@@ -546,6 +560,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
 	if(debugCleaning)
 	  cout << " Entering angular superloose preselection " << endl;
 	
+        /* //now taken from cache below
 	TrajectoryStateOnSurface i_inTSOS = mtsTransform_.innerStateOnSurface((*iGsfTrack));
 	GlobalVector i_innMom;
 	float iPin = iGsfTrack->pMode();
@@ -553,9 +568,11 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
 	  mtsMode_->momentumFromModeCartesian(i_inTSOS,i_innMom);  
 	  iPin = i_innMom.mag();
 	}
+        */
+        float iPin = gsfInnerMomentumCache_[iGsfTrack.key()];
 
 	if (&(*iGsfTrack->seedRef())==0) continue;   
-	auto const& iElSeedFromRef=dynamic_cast<ElectronSeed const&>( *(iGsfTrack->extra()->seedRef()) );
+	auto const& iElSeedFromRef=static_cast<ElectronSeed const&>( *(iGsfTrack->extra()->seedRef()) );
 
 	float SCEnergy = -1.;
 	// Check if two tracks match the same SC     
@@ -816,8 +833,8 @@ PFElecTkProducer::isSameEgSC(const reco::ElectronSeed& nSeed,
   bool isSameSC = false;
 
   if(nSeed.caloCluster().isNonnull() && iSeed.caloCluster().isNonnull()) {
-    auto const* nscRef = dynamic_cast<SuperCluster const*>(nSeed.caloCluster().get());
-    auto const* iscRef = dynamic_cast<SuperCluster const*>(iSeed.caloCluster().get());
+    auto const* nscRef = static_cast<SuperCluster const*>(nSeed.caloCluster().get());
+    auto const* iscRef = static_cast<SuperCluster const*>(iSeed.caloCluster().get());
 
     if(nscRef && iscRef) {
       bothGsfEcalDriven = true;
@@ -850,14 +867,14 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
   GsfPFRecTrack gsfPfTrack;
 
   if(nSeed.caloCluster().isNonnull()) {
-    scRef = dynamic_cast<SuperCluster const*>(nSeed.caloCluster().get());
+    scRef = static_cast<SuperCluster const*>(nSeed.caloCluster().get());
     assert(scRef);
     nEnergy = scRef->energy();
     nEcalDriven = true;
     gsfPfTrack = iGsfPFRecTrack;
   }
   else if(iSeed.caloCluster().isNonnull()){
-    scRef = dynamic_cast<SuperCluster const*>(iSeed.caloCluster().get());
+    scRef = static_cast<SuperCluster const*>(iSeed.caloCluster().get());
     assert(scRef);
     iEnergy = scRef->energy();
     iEcalDriven = true;


### PR DESCRIPTION
Adds a cut for ECAL driven electron seeds that requires the fraction of the seed cluster energy that's in the hadron sections of the HGCal to not exceed 0.15.

This causes a significant reduction in the number of GSF tracks that are seeded by the HGCal.
Timing measurements are in progress.