### PR TITLE
update RECO  & SIM phase-1 geometry (81X)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,11 +36,11 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v9',
+    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v25',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_v26',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v8',
+    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunII simulation

   * **PhaseI realistic scenario** : [81X_upgrade2017_realistic_v25](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v25) as [81X_upgrade2017_realistic_v26](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v26) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_realistic_v25/81X_upgrade2017_realistic_v26):
      * **RECO geom**: un-do the assignment of passive material outside the TK volume to the last layer of TK
      * **SIM geom**: Fix overlaps in Pixel support structure. Subtraction with Union solid replacement in ES support structure (no changes in sensitive volumes) . Pixel support structure material density has been corrected to compensate for the (very minimal) shape changes.

   * **PhaseI design scenario** : [81X_upgrade2017_design_IdealBS_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v9) as [81X_upgrade2017_design_IdealBS_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017_design_IdealBS_v9/81X_upgrade2017_design_IdealBS_v10):
      * **RECO geom**: un-do the assignment of passive material outside the TK volume to the last layer of TK
      * **SIM geom**: Fix overlaps in Pixel support structure. Subtraction with Union solid replacement in ES support structure (no changes in sensitive volumes) . Pixel support structure material density has been corrected to compensate for the (very minimal) shape changes.

   * **PhaseI cosmics scenario** : [81X_upgrade2017cosmics_realistic_peak_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017cosmics_realistic_peak_v8) as [81X_upgrade2017cosmics_realistic_peak_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017cosmics_realistic_peak_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_upgrade2017cosmics_realistic_peak_v8/81X_upgrade2017cosmics_realistic_peak_v9):
      * **RECO geom**: un-do the assignment of passive material outside the TK volume to the last layer of TK
      * **SIM geom**: Fix overlaps in Pixel support structure. Subtraction with Union solid replacement in ES support structure (no changes in sensitive volumes) . Pixel support structure material density has been corrected to compensate for the (very minimal) shape changes.