### PR TITLE
Use make_shared in simulation

### DIFF
--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -177,8 +177,7 @@ namespace edm {
     for (size_t makeIdx = 0; makeIdx < maxNbSources_; makeIdx++ ) {
       if (globalConf->inputConfigs_[makeIdx]) {
       	const edm::ParameterSet & psin=pset.getParameter<edm::ParameterSet>(globalConf->inputConfigs_[makeIdx]->sourcename_);
-        std::shared_ptr<PileUp> p(new PileUp(psin, globalConf->inputConfigs_[makeIdx]));
-        inputSources_.push_back(p);
+        inputSources_.push_back(std::make_shared<PileUp>(psin, globalConf->inputConfigs_[makeIdx]));
         inputSources_.back()->input(makeIdx);
       } else {
         inputSources_.push_back(nullptr);

--- a/SimG4Core/Watcher/interface/SimWatcherMaker.h
+++ b/SimG4Core/Watcher/interface/SimWatcherMaker.h
@@ -41,7 +41,7 @@ class SimWatcherMaker : public SimWatcherMakerBase
 			std::shared_ptr<SimProducer>& oProd
 	 ) const
       {
-	std::shared_ptr<T> returnValue(new T(p));
+	auto returnValue = std::make_shared<T>(p);
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 	oWatcher = returnValue;
 

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -64,7 +64,7 @@ SecSourceAnalyzer::SecSourceAnalyzer(const edm::ParameterSet& iConfig)
    std::unique_ptr<TH1F> histoName(new TH1F("h","",10,0,10));
    bool playback = false;
    
-   std::shared_ptr<PileUpConfig> conf(new PileUpConfig("input",averageNumber,histoName,playback));
+   auto conf = std::make_shared<PileUpConfig>("input",averageNumber,histoName,playback);
    input_.reset(new edm::PileUp(iConfig.getParameter<edm::ParameterSet>("input"),conf));
       
    dataStep2_ = iConfig.getParameter<bool>("dataStep2");


### PR DESCRIPTION
"auto thePtr = std::make_shared&lt;MyClass&gt;(...)" is preferred to "shared_ptr thePtr(new MyClass(...)) " because it saves a memory allocation. It allocates the shared_ptr and the pointee in the same allocation.
This PR changes the very few places in full simulation that did it the suboptimal way.