### PR TITLE
DQM: fix clang warnings about missing override keyword

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -32,12 +32,12 @@ class AlcaBeamMonitor : public edm::EDAnalyzer {
 
  protected:
 
-  void beginJob 	   (void);
-  void beginRun 	   (const edm::Run& iRun,  	       const edm::EventSetup& iSetup);
-  void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup);
-  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
-  void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
-  void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup);
+  void beginJob 	   (void) override;
+  void beginRun 	   (const edm::Run& iRun,  	       const edm::EventSetup& iSetup) override;
+  void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup) override;
   void endJob		   (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
   
  private:

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -28,12 +28,12 @@ class AlcaBeamMonitorClient : public edm::EDAnalyzer {
 
  protected:
 
-  void beginJob 	   (void);
-  void beginRun 	   (const edm::Run& iRun,  	       const edm::EventSetup& iSetup);
-  void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup);
-  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
-  void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
-  void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup);
+  void beginJob 	   (void) override;
+  void beginRun 	   (const edm::Run& iRun,  	       const edm::EventSetup& iSetup) override;
+  void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup) override;
   void endJob		   (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
   
  private:

--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -39,20 +39,20 @@ class BeamMonitor : public edm::EDAnalyzer {
   protected:
 
     // BeginJob
-    void beginJob();
+    void beginJob() override;
 
     // BeginRun
-    void beginRun(const edm::Run& r, const edm::EventSetup& c);
+    void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
-    void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
     void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-        const edm::EventSetup& context) ;
+        const edm::EventSetup& context) override;
 
     void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-        const edm::EventSetup& c);
+        const edm::EventSetup& c) override;
     // EndRun
-    void endRun(const edm::Run& r, const edm::EventSetup& c);
+    void endRun(const edm::Run& r, const edm::EventSetup& c) override;
     // Endjob
     void endJob(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
 

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -35,20 +35,20 @@ class BeamMonitorBx : public edm::EDAnalyzer {
  protected:
    
   // BeginJob
-  void beginJob();
+  void beginJob() override;
 
   // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c);
+  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
   
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-			    const edm::EventSetup& context) ;
+			    const edm::EventSetup& context) override;
   
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-			  const edm::EventSetup& c);
+			  const edm::EventSetup& c) override;
   // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c);
+  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
   // Endjob
   void endJob(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
   

--- a/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.h
@@ -41,17 +41,17 @@ class BeamSpotProblemMonitor : public edm::EDAnalyzer {
 
 
     // BeginJob
-    void beginJob();
+    void beginJob() override;
 
     // BeginRun
-    void beginRun(const edm::Run& r, const edm::EventSetup& c);
-    void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+    void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
     void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-        const edm::EventSetup& context) ;
+        const edm::EventSetup& context) override;
     void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-        const edm::EventSetup& c);
+        const edm::EventSetup& c) override;
     // EndRun
-    void endRun(const edm::Run& r, const edm::EventSetup& c);
+    void endRun(const edm::Run& r, const edm::EventSetup& c) override;
     // Endjob
     void endJob(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
 

--- a/DQM/BeamMonitor/plugins/TKStatus.h
+++ b/DQM/BeamMonitor/plugins/TKStatus.h
@@ -30,20 +30,20 @@ class TKStatus : public edm::EDAnalyzer {
  protected:
 
   // BeginJob
-  void beginJob();
+  void beginJob() override;
 
   // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c);
+  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-			    const edm::EventSetup& context) ;
+			    const edm::EventSetup& context) override ;
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-			  const edm::EventSetup& c);
+			  const edm::EventSetup& c) override;
   // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c);
+  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
   // Endjob
   void endJob(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
 

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
@@ -62,9 +62,9 @@ class Vx3DHLTAnalyzer : public DQMEDAnalyzer
   double Gauss3DFunc(const double* par);
 
  private:
-  void analyze              (const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  void beginLuminosityBlock (const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup);
-  void endLuminosityBlock   (const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup);
+  void analyze              (const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock (const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlock   (const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) override;
   void bookHistograms       (DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   unsigned int HitCounter (const edm::Event& iEvent);

--- a/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
+++ b/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
@@ -110,7 +110,7 @@ class CSCMonitorModule: public DQMEDAnalyzer, public cscdqm::MonitorObjectProvid
 
   public:
 
-    bool getCSCDetId(const unsigned int crateId, const unsigned int dmbId, CSCDetId& detId) const { 
+    bool getCSCDetId(const unsigned int crateId, const unsigned int dmbId, CSCDetId& detId) const override  {
       // Check parameter values
       if (crateId < MIN_CRATE_ID || crateId > MAX_CRATE_ID || dmbId < MIN_DMB_SLOT || dmbId > MAX_DMB_SLOT) {
         return false;
@@ -119,7 +119,7 @@ class CSCMonitorModule: public DQMEDAnalyzer, public cscdqm::MonitorObjectProvid
       return (detId.rawId() != 0);
     }
 
-    cscdqm::MonitorObject *bookMonitorObject (const cscdqm::HistoBookRequest& p_req); 
+    cscdqm::MonitorObject *bookMonitorObject (const cscdqm::HistoBookRequest& p_req) override;
 
   /** 
    * EDAnalyzer Implementation
@@ -130,9 +130,9 @@ class CSCMonitorModule: public DQMEDAnalyzer, public cscdqm::MonitorObjectProvid
     void beginJob() { }
     // void beginRun(const edm::Run& r, const edm::EventSetup& c);
     void setup() { }
-    void analyze(const edm::Event& e, const edm::EventSetup& c);
-    void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) { }
-    void endRun(const edm::Run& r, const edm::EventSetup& c) { }
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override  { }
+    void endRun(const edm::Run& r, const edm::EventSetup& c) override { }
     void endJob() { }
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQM/CSCMonitorModule/plugins/CSCOfflineClient.h
+++ b/DQM/CSCMonitorModule/plugins/CSCOfflineClient.h
@@ -89,8 +89,8 @@ class CSCOfflineClient: public DQMEDHarvester, public cscdqm::MonitorObjectProvi
 
   public:
 
-    bool getCSCDetId(const unsigned int crateId, const unsigned int dmbId, CSCDetId& detId) const { return false; }
-    cscdqm::MonitorObject *bookMonitorObject (const cscdqm::HistoBookRequest& p_req);
+    bool getCSCDetId(const unsigned int crateId, const unsigned int dmbId, CSCDetId& detId) const override{ return false; }
+    cscdqm::MonitorObject *bookMonitorObject (const cscdqm::HistoBookRequest& p_req) override;
 
   /** 
    * EDAnalyzer Implementation

--- a/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
@@ -34,10 +34,10 @@ class TotemDAQTriggerDQMSource: public DQMEDAnalyzer
   protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
     unsigned int verbosity;

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -45,10 +45,10 @@ class TotemRPDQMSource: public DQMEDAnalyzer
   protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
     unsigned int verbosity;

--- a/DQM/DTMonitorClient/src/DTChamberEfficiencyClient.h
+++ b/DQM/DTMonitorClient/src/DTChamberEfficiencyClient.h
@@ -51,13 +51,13 @@ public:
 
 protected:
 
-  void beginRun(const edm::Run& , const edm::EventSetup&);
+  void beginRun(const edm::Run& , const edm::EventSetup&) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
   /// book the report summary
 
   void bookHistos(DQMStore::IBooker &);
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 private:
 

--- a/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.h
+++ b/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.h
@@ -65,7 +65,7 @@ protected:
   std::string getMEName(std::string histoTag, const DTChamberId & chID);
 
   /// DQM Client Diagnostic
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 
 

--- a/DQM/DTMonitorClient/src/DTDCSSummary.h
+++ b/DQM/DTMonitorClient/src/DTDCSSummary.h
@@ -31,7 +31,7 @@ public:
   // Operations
 
   void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, 
-                               edm::LuminosityBlock const &, edm::EventSetup const &);
+                               edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.h
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.h
@@ -45,7 +45,7 @@ protected:
   void bookHistos(DQMStore::IBooker &, std::string histoType, int dduId);
 
   /// DQM Client Diagnostic
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 private:
   int readOutToGeometry(int dduId, int rosNumber, int& wheel, int& sector);

--- a/DQM/DTMonitorClient/src/DTOfflineSummaryClients.h
+++ b/DQM/DTMonitorClient/src/DTOfflineSummaryClients.h
@@ -33,10 +33,10 @@ public:
   virtual ~DTOfflineSummaryClients();
 
   /// BeginRun
-  void beginRun (const edm::Run& r, const edm::EventSetup& c);
+  void beginRun (const edm::Run& r, const edm::EventSetup& c) override;
 
   /// EndLumi
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
   /// EndJob
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;

--- a/DQM/DTMonitorClient/src/DTResolutionTest.h
+++ b/DQM/DTMonitorClient/src/DTResolutionTest.h
@@ -67,7 +67,7 @@ protected:
   std::string getMEName2D(const DTSuperLayerId & slID);
 
   /// DQM Client Diagnostic
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 
 private:

--- a/DQM/DTMonitorClient/src/DTRunConditionVarClient.h
+++ b/DQM/DTMonitorClient/src/DTRunConditionVarClient.h
@@ -55,7 +55,7 @@ class DTRunConditionVarClient: public DQMEDHarvester{
     /// Destructor
     virtual ~DTRunConditionVarClient();
 
-  void beginRun(const edm::Run& r, const edm::EventSetup& c);
+  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   protected:
 
@@ -67,7 +67,7 @@ class DTRunConditionVarClient: public DQMEDHarvester{
                          int wh, int nbins, float min, float max, bool isVDCorr=false);
 
     /// DQM Client Diagnostic
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 
   float varQuality(float var, float maxGood, float minBad);

--- a/DQM/DTMonitorClient/src/DTSummaryClients.h
+++ b/DQM/DTMonitorClient/src/DTSummaryClients.h
@@ -47,7 +47,7 @@ protected:
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 private:
 

--- a/DQM/DTMonitorModule/interface/DTDigiTask.h
+++ b/DQM/DTMonitorModule/interface/DTDigiTask.h
@@ -61,7 +61,7 @@ public:
 
 protected:
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   // Book the histograms
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
@@ -73,14 +73,14 @@ protected:
   void bookHistos(DQMStore::IBooker & ibooker, const int wheelId, std::string folder, std::string histoTag);
 
   /// To reset the MEs
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) ;
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context)  override;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup) override;
 
   /// To map real channels
   void channelsMap(const DTChamberId& dtCh, std::string histoTag);
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 
   /// get the L1A source

--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.h
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.h
@@ -68,8 +68,8 @@ class DTChamberEfficiency : public DQMEDAnalyzer
   ~DTChamberEfficiency() ;
 
   //Operations
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
  protected:
 // Book the histograms

--- a/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.h
@@ -49,13 +49,13 @@ public:
   virtual ~DTChamberEfficiencyTask();
 
   /// BeginRun
-  void dqmBeginRun(const edm::Run& run, const edm::EventSetup& setup);
+  void dqmBeginRun(const edm::Run& run, const edm::EventSetup& setup) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) ;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
  protected:
 // Book the histograms

--- a/DQM/DTMonitorModule/src/DTDCSByLumiTask.h
+++ b/DQM/DTMonitorModule/src/DTDCSByLumiTask.h
@@ -46,19 +46,19 @@ public:
 protected:
 
   /// Begin Run
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   // Book the histograms
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   /// By Lumi DCS DB Operation
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) ;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
 
   /// By Lumi DCS DB Operation
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup);
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup) override;
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/DQM/DTMonitorModule/src/DTEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTEfficiencyTask.h
@@ -44,15 +44,15 @@ public:
   virtual ~DTEfficiencyTask();
 
   /// To reset the MEs
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) ;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context)  override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
 protected:
 
   /// BeginRun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
 // Book the histograms
 void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
@@ -57,16 +57,16 @@ class DTLocalTriggerBaseTask: public DQMEDAnalyzer{
  protected:
 
   ///Beginrun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override;
 
   /// Perform trend plot operations
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context)  override;
 
  private:
 

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
@@ -56,16 +56,16 @@ class DTLocalTriggerLutTask: public DQMEDAnalyzer{
  protected:
 
   ///BeginRun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Find best (highest qual) TM trigger segments
   void searchDccBest(std::vector<L1MuDTChambPhDigi> const* trigs);
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override ;
 
  private:
 

--- a/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
@@ -64,13 +64,13 @@ class DTLocalTriggerSynchTask: public DQMEDAnalyzer{
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  ///Beginrun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Book the histograms
   void bookHistos(DQMStore::IBooker &, const DTChamberId& dtCh );
 
   /// Analyze
-  void analyze(const edm::Event& event, const edm::EventSetup& context);
+  void analyze(const edm::Event& event, const edm::EventSetup& context) override;
 
   std::string & baseDir() { return baseDirectory; }
 

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
@@ -60,7 +60,7 @@ class DTLocalTriggerTask: public DQMEDAnalyzer{
  protected:
 
   ///Beginrun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Book the histograms
 
@@ -90,10 +90,10 @@ class DTLocalTriggerTask: public DQMEDAnalyzer{
   void runDDUvsTMAnalysis(std::string& trigsrc);
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override ;
 
   /// Get the L1A source
   void triggerSource(const edm::Event& e);

--- a/DQM/DTMonitorModule/src/DTNoiseTask.h
+++ b/DQM/DTMonitorModule/src/DTNoiseTask.h
@@ -52,14 +52,14 @@ public:
 
 protected:
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock&  lumiSeg, const edm::EventSetup& context);
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup);
+  void beginLuminosityBlock(const edm::LuminosityBlock&  lumiSeg, const edm::EventSetup& context) override;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup) override;
 
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
@@ -43,13 +43,13 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   /// BeginRun
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) ;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
 
 protected:

--- a/DQM/DTMonitorModule/src/DTRunConditionVar.h
+++ b/DQM/DTMonitorModule/src/DTRunConditionVar.h
@@ -56,8 +56,8 @@ class DTRunConditionVar : public DQMEDAnalyzer
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
     //Operations
-    void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
-    void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+    void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+    void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   private:
 

--- a/DQM/DTMonitorModule/src/DTScalerInfoTask.h
+++ b/DQM/DTMonitorModule/src/DTScalerInfoTask.h
@@ -53,16 +53,16 @@ class DTScalerInfoTask: public DQMEDAnalyzer{
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   ///Beginrun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context)  override;
 
   /// Perform trend plot operations
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context)  override;
 
  private:
 

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -51,14 +51,14 @@ public:
   virtual ~DTSegmentAnalysisTask();
 
   /// BeginRun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
   /// Summary
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup);
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
 
 
 protected:

--- a/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.h
@@ -55,7 +55,7 @@ class DTTriggerEfficiencyTask: public DQMEDAnalyzer{
  protected:
 
   /// BeginRun
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
@@ -72,10 +72,10 @@ class DTTriggerEfficiencyTask: public DQMEDAnalyzer{
   std::string topFolder(std::string source) { return source=="TM" ? "DT/03-LocalTrigger-TM/" : "DT/04-LocalTrigger-DDU/"; }
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context)  override;
 
  private:
 

--- a/DQM/DataScouting/plugins/AlphaTVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/AlphaTVarAnalyzer.h
@@ -8,7 +8,7 @@ class AlphaTVarAnalyzer : public ScoutingAnalyzerBase {
     explicit AlphaTVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~AlphaTVarAnalyzer() ;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    virtual void analyze( const edm::Event & , const edm::EventSetup &  );
+    virtual void analyze( const edm::Event & , const edm::EventSetup &  ) override;
   private: 
     edm::InputTag m_jetCollectionTag;
     edm::InputTag m_alphaTVarCollectionTag;

--- a/DQM/DataScouting/plugins/DiJetVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/DiJetVarAnalyzer.h
@@ -16,7 +16,7 @@ class DiJetVarAnalyzer : public ScoutingAnalyzerBase {
     explicit DiJetVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~DiJetVarAnalyzer() ;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    virtual void analyze( const edm::Event & , const edm::EventSetup &  );
+    virtual void analyze( const edm::Event & , const edm::EventSetup &  ) override;
   private: 
     edm::InputTag jetCollectionTag_;
     edm::InputTag widejetsCollectionTag_;

--- a/DQM/DataScouting/plugins/ScoutingTestAnalyzer.h
+++ b/DQM/DataScouting/plugins/ScoutingTestAnalyzer.h
@@ -10,8 +10,8 @@ class ScoutingTestAnalyzer : public ScoutingAnalyzerBase {
     explicit ScoutingTestAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~ScoutingTestAnalyzer() ;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    virtual void analyze( const edm::Event & , const edm::EventSetup &  );
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ) ;
+    virtual void analyze( const edm::Event & , const edm::EventSetup &  ) override;
+    virtual void endRun( edm::Run const &, edm::EventSetup const & ) override ;
   private: 
     // histograms
     edm::InputTag m_pfJetsCollectionTag;

--- a/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
+++ b/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
@@ -20,7 +20,7 @@ namespace ecaldqm {
     void addDependencies(DependencySet&) override;
 
     bool analyze(void const*, Collections) override;
-    void endEvent(edm::Event const&, edm::EventSetup const&);
+    void endEvent(edm::Event const&, edm::EventSetup const&) override;
 
     void runOnRecHits(EcalRecHitCollection const&, Collections);
     void runOnReducedRecHits(EcalRecHitCollection const&, Collections);

--- a/DQM/HLTEvF/plugins/DQMCorrelationClient.h
+++ b/DQM/HLTEvF/plugins/DQMCorrelationClient.h
@@ -46,8 +46,8 @@ class DQMCorrelationClient: public DQMEDHarvester{
       
  protected:
 
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
   
  private:

--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -49,7 +49,7 @@ public:
 protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
 
 private:
 

--- a/DQM/HLTEvF/plugins/PSMonitor.h
+++ b/DQM/HLTEvF/plugins/PSMonitor.h
@@ -53,7 +53,7 @@ public:
 protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
 
 private:
 

--- a/DQM/HLXMonitor/interface/HLXMonitor.h
+++ b/DQM/HLXMonitor/interface/HLXMonitor.h
@@ -55,7 +55,7 @@ class HLXMonitor : public DQMEDAnalyzer {
  private:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void connectHLXTCP();
 

--- a/DQM/HcalCommon/interface/Container2D.h
+++ b/DQM/HcalCommon/interface/Container2D.h
@@ -42,140 +42,140 @@ namespace hcaldqm
 				int debug=0);
 
 			//	redeclare what to override
-			virtual void fill(HcalDetId const&);
-			virtual void fill(HcalDetId const&, int);
-			virtual void fill(HcalDetId const&, double);
-			virtual void fill(HcalDetId const&, int, double);
-			virtual void fill(HcalDetId const&, int, int);
-			virtual void fill(HcalDetId const&, double, double);
+			virtual void fill(HcalDetId const&) override ;
+			virtual void fill(HcalDetId const&, int) override;
+			virtual void fill(HcalDetId const&, double) override;
+			virtual void fill(HcalDetId const&, int, double) override;
+			virtual void fill(HcalDetId const&, int, int) override;
+			virtual void fill(HcalDetId const&, double, double) override;
 
-			virtual double getBinEntries(HcalDetId const&);
-			virtual double getBinEntries(HcalDetId const&, int);
-			virtual double getBinEntries(HcalDetId const&, double);
-			virtual double getBinEntries(HcalDetId const&, int, int);
-			virtual double getBinEntries(HcalDetId const&, int, double);
-			virtual double getBinEntries(HcalDetId const&, double, double);
+			virtual double getBinEntries(HcalDetId const&) override;
+			virtual double getBinEntries(HcalDetId const&, int) override;
+			virtual double getBinEntries(HcalDetId const&, double) override;
+			virtual double getBinEntries(HcalDetId const&, int, int) override;
+			virtual double getBinEntries(HcalDetId const&, int, double) override;
+			virtual double getBinEntries(HcalDetId const&, double, double) override;
 
-			virtual double getBinContent(HcalDetId const&);
-			virtual double getBinContent(HcalDetId const&, int);
-			virtual double getBinContent(HcalDetId const&, double);
-			virtual double getBinContent(HcalDetId const&, int, int);
-			virtual double getBinContent(HcalDetId const&, int, double);
-			virtual double getBinContent(HcalDetId const&, double, double);
+			virtual double getBinContent(HcalDetId const&) override;
+			virtual double getBinContent(HcalDetId const&, int) override;
+			virtual double getBinContent(HcalDetId const&, double) override;
+			virtual double getBinContent(HcalDetId const&, int, int) override;
+			virtual double getBinContent(HcalDetId const&, int, double) override;
+			virtual double getBinContent(HcalDetId const&, double, double) override;
 
-			virtual void setBinContent(HcalDetId const&, int);
-			virtual void setBinContent(HcalDetId const&, double);
-			virtual void setBinContent(HcalDetId const&, int, int);
-			virtual void setBinContent(HcalDetId const&, int, double);
-			virtual void setBinContent(HcalDetId const&, double, int);
-			virtual void setBinContent(HcalDetId const&, double, double);
-			virtual void setBinContent(HcalDetId const&, int, int, int);
-			virtual void setBinContent(HcalDetId const&, int, double, int);
-			virtual void setBinContent(HcalDetId const&, double, int, int);
-			virtual void setBinContent(HcalDetId const&, double, double, int);
-			virtual void setBinContent(HcalDetId const&, int, int, double);
-			virtual void setBinContent(HcalDetId const&, int, double, double);
-			virtual void setBinContent(HcalDetId const&, double, int, double);
+			virtual void setBinContent(HcalDetId const&, int) override;
+			virtual void setBinContent(HcalDetId const&, double) override;
+			virtual void setBinContent(HcalDetId const&, int, int) override;
+			virtual void setBinContent(HcalDetId const&, int, double) override;
+			virtual void setBinContent(HcalDetId const&, double, int) override;
+			virtual void setBinContent(HcalDetId const&, double, double) override;
+			virtual void setBinContent(HcalDetId const&, int, int, int) override;
+			virtual void setBinContent(HcalDetId const&, int, double, int) override;
+			virtual void setBinContent(HcalDetId const&, double, int, int) override;
+			virtual void setBinContent(HcalDetId const&, double, double, int) override;
+			virtual void setBinContent(HcalDetId const&, int, int, double) override;
+			virtual void setBinContent(HcalDetId const&, int, double, double) override;
+			virtual void setBinContent(HcalDetId const&, double, int, double) override;
 			virtual void setBinContent(HcalDetId const&, double, double, 
-				double);
+				double) override;
 
-			virtual void fill(HcalElectronicsId const&);
-			virtual void fill(HcalElectronicsId const&, int);
-			virtual void fill(HcalElectronicsId const&, double);
-			virtual void fill(HcalElectronicsId const&, int, double);
-			virtual void fill(HcalElectronicsId const&, int, int);
-			virtual void fill(HcalElectronicsId const&, double, double);
+			virtual void fill(HcalElectronicsId const&) override;
+			virtual void fill(HcalElectronicsId const&, int) override;
+			virtual void fill(HcalElectronicsId const&, double) override;
+			virtual void fill(HcalElectronicsId const&, int, double) override;
+			virtual void fill(HcalElectronicsId const&, int, int) override;
+			virtual void fill(HcalElectronicsId const&, double, double) override;
 
-			virtual double getBinEntries(HcalElectronicsId const&);
-			virtual double getBinEntries(HcalElectronicsId const&, int);
-			virtual double getBinEntries(HcalElectronicsId const&, double);
-			virtual double getBinEntries(HcalElectronicsId const&, int, int);
-			virtual double getBinEntries(HcalElectronicsId const&, int, double);
+			virtual double getBinEntries(HcalElectronicsId const&) override;
+			virtual double getBinEntries(HcalElectronicsId const&, int) override;
+			virtual double getBinEntries(HcalElectronicsId const&, double) override;
+			virtual double getBinEntries(HcalElectronicsId const&, int, int) override;
+			virtual double getBinEntries(HcalElectronicsId const&, int, double) override;
 			virtual double getBinEntries(HcalElectronicsId const&, double, 
-				double);
+				double) override;
 
-			virtual double getBinContent(HcalElectronicsId const&);
-			virtual double getBinContent(HcalElectronicsId const&, int);
-			virtual double getBinContent(HcalElectronicsId const&, double);
-			virtual double getBinContent(HcalElectronicsId const&, int, int);
-			virtual double getBinContent(HcalElectronicsId const&, int, double);
+			virtual double getBinContent(HcalElectronicsId const&) override;
+			virtual double getBinContent(HcalElectronicsId const&, int) override;
+			virtual double getBinContent(HcalElectronicsId const&, double) override;
+			virtual double getBinContent(HcalElectronicsId const&, int, int) override;
+			virtual double getBinContent(HcalElectronicsId const&, int, double) override;
 			virtual double getBinContent(HcalElectronicsId const&, double, 
-				double);
+				double) override;
 
-			virtual void setBinContent(HcalElectronicsId const&, int);
-			virtual void setBinContent(HcalElectronicsId const&, double);
-			virtual void setBinContent(HcalElectronicsId const&, int, int);
-			virtual void setBinContent(HcalElectronicsId const&, int, double);
-			virtual void setBinContent(HcalElectronicsId const&, double, int);
-			virtual void setBinContent(HcalElectronicsId const&, double, double);
-			virtual void setBinContent(HcalElectronicsId const&, int, int, int);
-			virtual void setBinContent(HcalElectronicsId const&, int, double, int);
-			virtual void setBinContent(HcalElectronicsId const&, double, int, int);
-			virtual void setBinContent(HcalElectronicsId const&, double, double, int);
-			virtual void setBinContent(HcalElectronicsId const&, int, int, double);
-			virtual void setBinContent(HcalElectronicsId const&, int, double, double);
-			virtual void setBinContent(HcalElectronicsId const&, double, int, double);
+			virtual void setBinContent(HcalElectronicsId const&, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, double) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, double) override;
+			virtual void setBinContent(HcalElectronicsId const&, double, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, double, double) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, int, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, double, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, double, int, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, double, double, int) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, int, double) override;
+			virtual void setBinContent(HcalElectronicsId const&, int, double, double) override;
+			virtual void setBinContent(HcalElectronicsId const&, double, int, double) override;
 			virtual void setBinContent(HcalElectronicsId const&, double, double, 
-				double);
+				double) override;
 
-			virtual void fill(HcalTrigTowerDetId const&);
-			virtual void fill(HcalTrigTowerDetId const&, int);
-			virtual void fill(HcalTrigTowerDetId const&, double);
-			virtual void fill(HcalTrigTowerDetId const&, int, int);
-			virtual void fill(HcalTrigTowerDetId const&, int, double);
-			virtual void fill(HcalTrigTowerDetId const&, double, double);
+			virtual void fill(HcalTrigTowerDetId const&) override;
+			virtual void fill(HcalTrigTowerDetId const&, int) override;
+			virtual void fill(HcalTrigTowerDetId const&, double) override;
+			virtual void fill(HcalTrigTowerDetId const&, int, int) override;
+			virtual void fill(HcalTrigTowerDetId const&, int, double) override;
+			virtual void fill(HcalTrigTowerDetId const&, double, double) override;
 
-			virtual double getBinEntries(HcalTrigTowerDetId const&);
-			virtual double getBinEntries(HcalTrigTowerDetId const&, int);
-			virtual double getBinEntries(HcalTrigTowerDetId const&, double);
-			virtual double getBinEntries(HcalTrigTowerDetId const&, int, int);
+			virtual double getBinEntries(HcalTrigTowerDetId const&) override;
+			virtual double getBinEntries(HcalTrigTowerDetId const&, int) override;
+			virtual double getBinEntries(HcalTrigTowerDetId const&, double) override;
+			virtual double getBinEntries(HcalTrigTowerDetId const&, int, int) override;
 			virtual double getBinEntries(HcalTrigTowerDetId const&, int, 
-				double);
+				double) override;
 			virtual double getBinEntries(HcalTrigTowerDetId const&, 
-				double, double);
+				double, double) override;
 
-			virtual double getBinContent(HcalTrigTowerDetId const&);
-			virtual double  getBinContent(HcalTrigTowerDetId const&, int);
-			virtual double getBinContent(HcalTrigTowerDetId const&, double);
-			virtual double getBinContent(HcalTrigTowerDetId const&, int, int);
-			virtual double getBinContent(HcalTrigTowerDetId const&, int, double);
+			virtual double getBinContent(HcalTrigTowerDetId const&) override;
+			virtual double  getBinContent(HcalTrigTowerDetId const&, int) override;
+			virtual double getBinContent(HcalTrigTowerDetId const&, double) override;
+			virtual double getBinContent(HcalTrigTowerDetId const&, int, int) override;
+			virtual double getBinContent(HcalTrigTowerDetId const&, int, double) override;
 			virtual double getBinContent(HcalTrigTowerDetId const&, 
-				double, double);
+				double, double) override;
 
-			virtual void setBinContent(HcalTrigTowerDetId const&, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, double);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double, double);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, int, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, double, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double, int, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double, double, int);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, int, double);
-			virtual void setBinContent(HcalTrigTowerDetId const&, int, double, double);
-			virtual void setBinContent(HcalTrigTowerDetId const&, double, int, double);
+			virtual void setBinContent(HcalTrigTowerDetId const&, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, double) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double, double) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, int, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, double, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double, int, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double, double, int) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, int, double) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, int, double, double) override;
+			virtual void setBinContent(HcalTrigTowerDetId const&, double, int, double) override;
 			virtual void setBinContent(HcalTrigTowerDetId const&, double, double, 
-				double);
+				double) override;
 
 			//	booking. see Container1D.h
 			virtual void book(DQMStore::IBooker&,
 				HcalElectronicsMap const*,
-				std::string subsystem="Hcal", std::string aux="");
+				std::string subsystem="Hcal", std::string aux="") override;
 			virtual void book(DQMStore::IBooker&,
 				HcalElectronicsMap const*, filter::HashFilter const&,
-				std::string subsystem="Hcal", std::string aux="");
+				std::string subsystem="Hcal", std::string aux="") override;
 			virtual void book(DQMStore*,
 				HcalElectronicsMap const*,
-				std::string subsystem="Hcal", std::string aux="");
+				std::string subsystem="Hcal", std::string aux="") override;
 			virtual void book(DQMStore*,
 				HcalElectronicsMap const*, filter::HashFilter const&,
-				std::string subsystem="Hcal", std::string aux="");
+				std::string subsystem="Hcal", std::string aux="") override;
 
 		protected:
 			Quantity	*_qz;
 
-			virtual void customize(MonitorElement*);
+			virtual void customize(MonitorElement*) override;
 	};
 }
 

--- a/DQM/HcalCommon/interface/ElectronicsQuantity.h
+++ b/DQM/HcalCommon/interface/ElectronicsQuantity.h
@@ -1,5 +1,5 @@
 #ifndef ElectronicsQuantity_h
-#define ElectronicsQauntity_h
+#define ElectronicsQuantity_h
 
 /**
  *	file:		ElectronicsQuantity.h

--- a/DQM/L1TMonitor/interface/BxTiming.h
+++ b/DQM/L1TMonitor/interface/BxTiming.h
@@ -40,8 +40,8 @@ class BxTiming : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
   
  private:

--- a/DQM/L1TMonitor/interface/L1ExtraDQM.h
+++ b/DQM/L1TMonitor/interface/L1ExtraDQM.h
@@ -168,10 +168,10 @@ protected:
     void analyzeL1ExtraHfRingEtSums(const edm::Event&, const edm::EventSetup&);
 
     virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endRun(const edm::Run& run, const edm::EventSetup& evSetup);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endRun(const edm::Run& run, const edm::EventSetup& evSetup) override;
 
 private:
 

--- a/DQM/L1TMonitor/interface/L1GtHwValidation.h
+++ b/DQM/L1TMonitor/interface/L1GtHwValidation.h
@@ -108,13 +108,13 @@ private:
     /// exclusion status for algorithm with bit i
     bool excludedAlgo(const int&) const;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 protected:
     
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     //virtual void analyze(DQMStore::IBooker &ibooker, const edm::Event&, const edm::EventSetup&);
 
 private:

--- a/DQM/L1TMonitor/interface/L1TBPTX.h
+++ b/DQM/L1TMonitor/interface/L1TBPTX.h
@@ -114,12 +114,12 @@ class L1TBPTX : public DQMEDAnalyzer {
 
   protected:
 
-    void analyze (const edm::Event& e, const edm::EventSetup& c);  // Analyze                         
+    void analyze (const edm::Event& e, const edm::EventSetup& c) override;  // Analyze
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
-    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
+    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
 
 
   // Private Methods

--- a/DQM/L1TMonitor/interface/L1TCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTPG.h
@@ -51,9 +51,9 @@ virtual ~L1TCSCTPG();
 
 protected:
 // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TCompare.h
+++ b/DQM/L1TMonitor/interface/L1TCompare.h
@@ -77,11 +77,11 @@ public:
 
 protected:
 // Analyze
- void analyze(const edm::Event& e, const edm::EventSetup& c);
+ void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 // BeginRun
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
 private:
   // ----------member data ---------------------------

--- a/DQM/L1TMonitor/interface/L1TDEMON.h
+++ b/DQM/L1TMonitor/interface/L1TDEMON.h
@@ -38,9 +38,9 @@ class L1TDEMON : public DQMEDAnalyzer {
 
   //virtual void beginJob(void) ;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
     
  private:
 

--- a/DQM/L1TMonitor/interface/L1TDTTF.h
+++ b/DQM/L1TMonitor/interface/L1TDTTF.h
@@ -40,11 +40,11 @@ class L1TDTTF : public DQMEDAnalyzer {
 
  protected:
   // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // BeginJob
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
 
  private:

--- a/DQM/L1TMonitor/interface/L1TDTTPG.h
+++ b/DQM/L1TMonitor/interface/L1TDTTPG.h
@@ -48,12 +48,12 @@ class L1TDTTPG : public DQMEDAnalyzer {
 
  protected:
   // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   
   // BeginRun
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 
  private:

--- a/DQM/L1TMonitor/interface/L1TFED.h
+++ b/DQM/L1TMonitor/interface/L1TFED.h
@@ -50,7 +50,7 @@ virtual ~L1TFED();
 
 protected:
 // Analyze
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 // BeginRun
 void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/DQM/L1TMonitor/interface/L1TGCT.h
+++ b/DQM/L1TMonitor/interface/L1TGCT.h
@@ -133,11 +133,11 @@ public:
 
 protected:
 // Analyze
- void analyze(const edm::Event& e, const edm::EventSetup& c);
+ void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
 private:
   // ----------member data ---------------------------

--- a/DQM/L1TMonitor/interface/L1THIonImp.h
+++ b/DQM/L1TMonitor/interface/L1THIonImp.h
@@ -28,11 +28,11 @@ public:
 
 protected:
 // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   //virtual std::vector<int> SortMinBiasBit(std::vector<int>, std::vector<int>);
   virtual std::vector<int> SortMinBiasBit(uint16_t, uint16_t);
   

--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -26,8 +26,8 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TPUM.h
+++ b/DQM/L1TMonitor/interface/L1TPUM.h
@@ -28,10 +28,10 @@ class L1TPUM : public DQMEDAnalyzer {
     virtual ~L1TPUM();
   
   protected:
-    void analyze(const edm::Event& e, const edm::EventSetup& c);
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   
   private:
     edm::EDGetTokenT<L1CaloRegionCollection> regionSource_;

--- a/DQM/L1TMonitor/interface/L1TRCT.h
+++ b/DQM/L1TMonitor/interface/L1TRCT.h
@@ -49,10 +49,10 @@ public:
 
 protected:
 // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
  
 private:

--- a/DQM/L1TMonitor/interface/L1TRPCTF.h
+++ b/DQM/L1TMonitor/interface/L1TRPCTF.h
@@ -52,14 +52,14 @@ public:
 
 protected:
 // Analyze
- void analyze(const edm::Event& e, const edm::EventSetup& c);
+ void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 // BeginJob
   virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
- virtual void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
- void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
+ virtual void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
+ void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
 
 
 private:

--- a/DQM/L1TMonitor/interface/L1TRPCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TRPCTPG.h
@@ -67,12 +67,12 @@ public:
 
 protected:
 // Analyze
- void analyze(const edm::Event& e, const edm::EventSetup& c);
+ void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 // BeginRun
  virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
- virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
- virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+ virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+ virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 private:
   // ----------member data ---------------------------

--- a/DQM/L1TMonitor/interface/L1TRate.h
+++ b/DQM/L1TMonitor/interface/L1TRate.h
@@ -55,14 +55,14 @@ class L1TRate : public DQMEDAnalyzer {
 
   protected:
 
-    void analyze (const edm::Event& e, const edm::EventSetup& c);      // Analyze
+    void analyze (const edm::Event& e, const edm::EventSetup& c) override;      // Analyze
     //void beginJob();                                                   // BeginJob
     //void endJob  ();                                                   // EndJob
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
     //void endRun  (const edm::Run& run, const edm::EventSetup& iSetup);
 
-    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
+    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
     virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
 
   // Private methods

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -64,11 +64,11 @@ class L1TStage2CaloLayer1 : public DQMEDAnalyzer {
     virtual ~L1TStage2CaloLayer1();
   
   protected:
-    void analyze(const edm::Event& e, const edm::EventSetup& c);
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-    void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+    void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   
   private:
     void updateMismatch(const edm::Event& e, int mismatchType);

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
@@ -27,10 +27,10 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
 
  protected:
 
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override ;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
  private:
 

--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -23,8 +23,8 @@ class L1TStage2EMTF : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -21,8 +21,8 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -21,8 +21,8 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -23,8 +23,8 @@ class L1TStage2uGMT : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGT.h
@@ -50,11 +50,11 @@ public:
    virtual ~L1TStage2uGT(); // destructor
 
 protected:
-   virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-   virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+   virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+   virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
    virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-   virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&); // end section
+   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+   virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override; // end section
 
 private:
    

--- a/DQM/L1TMonitor/interface/L1TSync.h
+++ b/DQM/L1TMonitor/interface/L1TSync.h
@@ -90,12 +90,12 @@ class L1TSync : public DQMEDAnalyzer {
 
   protected:
 
-    void analyze (const edm::Event& e, const edm::EventSetup& c);  // Analyze
+    void analyze (const edm::Event& e, const edm::EventSetup& c) override;  // Analyze
 
-    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
+    virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+    virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
 
   // Private Methods

--- a/DQM/L1TMonitor/interface/L1TdeCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTF.h
@@ -68,10 +68,10 @@ private:
 	
 
 protected:
-  void analyze(edm::Event const& e, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override;
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 public:
   explicit L1TdeCSCTF(edm::ParameterSet const& pset);

--- a/DQM/L1TMonitor/interface/L1TdeGCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeGCT.h
@@ -34,11 +34,11 @@ class L1TdeGCT : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
  
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -59,12 +59,12 @@ public:
 
 protected:
 // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 //For FED vector monitoring 
   virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void readFEDVector(MonitorElement*,const edm::EventSetup&); 
 
 private:

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -33,9 +33,9 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
   protected:
     void analyze(const edm::Event& e, const edm::EventSetup& c);
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-    void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+    void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   
   private:
     void updateMismatch(const edm::Event& e, int mismatchType);

--- a/DQM/L1TMonitor/interface/L1TdeStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2EMTF.h
@@ -20,8 +20,8 @@ class L1TdeStage2EMTF : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h
+++ b/DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h
@@ -28,7 +28,7 @@ public:
     virtual ~L1EmulatorErrorFlagClient();
 
 protected:
-    virtual void dqmEndLuminosityBlock(DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+    virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
     virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
     
 

--- a/DQM/L1TMonitorClient/interface/L1TCSCTFClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TCSCTFClient.h
@@ -22,7 +22,7 @@ public:
 
 protected:
 
-  void dqmEndLuminosityBlock(DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
 private:

--- a/DQM/L1TMonitorClient/interface/L1TDTTFClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TDTTFClient.h
@@ -30,7 +30,7 @@ public:
  
 protected:
 
-  void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
   void book(DQMStore::IBooker &ibooker);

--- a/DQM/L1TMonitorClient/interface/L1TEventInfoClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TEventInfoClient.h
@@ -51,7 +51,7 @@ public:
 protected:
     
     void
-    dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock&, const edm::EventSetup&);
+    dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
     /// end job
     void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)override;

--- a/DQM/L1TMonitorClient/interface/L1TGCTClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TGCTClient.h
@@ -28,7 +28,7 @@ class L1TGCTClient: public DQMEDHarvester {
  
  protected:
   virtual void dqmEndJob(DQMStore::IBooker &ibooker,DQMStore::IGetter &igetter) override;
-  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,DQMStore::IGetter &igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
+  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,DQMStore::IGetter &igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
 
  private:
 

--- a/DQM/L1TMonitorClient/interface/L1TGMTClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TGMTClient.h
@@ -23,7 +23,7 @@ public:
 protected:
 
     virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)override;
-    virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& evSetup);
+    virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& evSetup) override;
 
 private:
 

--- a/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
@@ -41,7 +41,7 @@ class L1TOccupancyClient: public DQMEDHarvester {
     
     void dqmEndJob  (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)override;
     void book   (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
-    void dqmEndLuminosityBlock  (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c);       // DQM Client Diagnostic
+    void dqmEndLuminosityBlock  (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override;       // DQM Client Diagnostic
   
     //DQM test routines
     double xySymmetry(const edm::ParameterSet& ps, 

--- a/DQM/L1TMonitorClient/interface/L1TRPCTFClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TRPCTFClient.h
@@ -31,7 +31,7 @@ public:
  
 protected:
 
-  void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
 

--- a/DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClient.h
@@ -16,7 +16,7 @@ class L1TStage2CaloLayer2DEClient: public DQMEDHarvester {
  protected:
   
   virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)override;
-  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,DQMStore::IGetter &igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
+  virtual void dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,DQMStore::IGetter &igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
   
  private:
   

--- a/DQM/L1TMonitorClient/interface/L1TTestsSummary.h
+++ b/DQM/L1TMonitorClient/interface/L1TTestsSummary.h
@@ -36,7 +36,7 @@ class L1TTestsSummary: public DQMEDHarvester {
  
   protected:
 
-    virtual void dqmEndLuminosityBlock  (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c);     // DQM Client Diagnostic
+    virtual void dqmEndLuminosityBlock  (DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override;     // DQM Client Diagnostic
 
     virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)override;
     virtual void book(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);

--- a/DQM/L1TMonitorClient/src/L1EmulatorErrorFlagClient.cc
+++ b/DQM/L1TMonitorClient/src/L1EmulatorErrorFlagClient.cc
@@ -102,7 +102,7 @@ void L1EmulatorErrorFlagClient::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore:
     }
 }
 
-void L1EmulatorErrorFlagClient::dqmEndLuminosityBlock(DQMStore::IGetter &igetter,
+void L1EmulatorErrorFlagClient::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker, DQMStore::IGetter &igetter,
         const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& evSetup) {
 
     // reset the summary content values

--- a/DQM/L1TMonitorClient/src/L1TCSCTFClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TCSCTFClient.cc
@@ -36,7 +36,7 @@ void L1TCSCTFClient::initialize(){
 
 }
 
-void L1TCSCTFClient::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c){
+void L1TCSCTFClient::dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &igetter, const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c){
 }
 
 //--------------------------------------------------------

--- a/DQM/Physics/src/B2GDQM.h
+++ b/DQM/Physics/src/B2GDQM.h
@@ -84,7 +84,7 @@ class B2GDQM : public DQMEDAnalyzer {
   virtual ~B2GDQM();
 
  protected:
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  virtual void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
   virtual void analyzeJets(edm::Event const& e, edm::EventSetup const& eSetup);
   virtual void analyzeSemiMu(edm::Event const& e,

--- a/DQM/Physics/src/BPhysicsOniaDQM.h
+++ b/DQM/Physics/src/BPhysicsOniaDQM.h
@@ -35,7 +35,7 @@ class BPhysicsOniaDQM : public DQMEDAnalyzer {
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
   /// Get the analysis
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   float computeMass(const math::XYZVector& vec1, const math::XYZVector& vec2);

--- a/DQM/Physics/src/EwkDQM.h
+++ b/DQM/Physics/src/EwkDQM.h
@@ -39,10 +39,10 @@ class EwkDQM : public DQMEDAnalyzer {
   //Book histograms
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// Get the analysis
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   double calcDeltaPhi(double phi1, double phi2);
 

--- a/DQM/Physics/src/EwkElecDQM.h
+++ b/DQM/Physics/src/EwkElecDQM.h
@@ -32,9 +32,9 @@ class EwkElecDQM : public DQMEDAnalyzer {
   //Book histograms
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
   double calcDeltaPhi(double phi1, double phi2);
 

--- a/DQM/Physics/src/EwkMuDQM.h
+++ b/DQM/Physics/src/EwkMuDQM.h
@@ -30,12 +30,12 @@ class MonitorElement;
 class EwkMuDQM : public DQMEDAnalyzer {
  public:
   EwkMuDQM(const edm::ParameterSet&);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   //Book histograms
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
   void init_histograms();
 

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.h
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.h
@@ -37,12 +37,12 @@ class MonitorElement;
 class EwkMuLumiMonitorDQM : public DQMEDAnalyzer {
  public:
   EwkMuLumiMonitorDQM(const edm::ParameterSet&);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   //Book histograms
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
   void init_histograms();
   double muIso(const reco::Muon&);

--- a/DQM/Physics/src/EwkTauDQM.h
+++ b/DQM/Physics/src/EwkTauDQM.h
@@ -31,8 +31,8 @@ class EwkTauDQM : public DQMEDAnalyzer {
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
-  void endRun(const edm::Run&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
 
  private:
   std::string dqmDirectory_;

--- a/DQM/Physics/src/ExoticaDQM.h
+++ b/DQM/Physics/src/ExoticaDQM.h
@@ -109,7 +109,7 @@ public:
 
 protected:
 
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  virtual void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
   //Resonances
   virtual void analyzeDiJets(edm::Event const& e);

--- a/DQM/Physics/src/HiggsDQM.h
+++ b/DQM/Physics/src/HiggsDQM.h
@@ -51,12 +51,12 @@ class HiggsDQM : public DQMEDAnalyzer {
   //Book histograms
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
   void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
-                            edm::EventSetup const& context);
+                            edm::EventSetup const& context) override;
   void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
-                          edm::EventSetup const& c);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+                          edm::EventSetup const& c) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
  private:
   double Distance(const reco::Candidate& c1, const reco::Candidate& c2);

--- a/DQM/Physics/src/QcdHighPtDQM.h
+++ b/DQM/Physics/src/QcdHighPtDQM.h
@@ -26,7 +26,7 @@ class QcdHighPtDQM : public DQMEDAnalyzer {
   virtual ~QcdHighPtDQM();
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   // input tags/Tokens for Jets/MET

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -119,13 +119,13 @@ class QcdLowPtDQM : public DQMEDAnalyzer {
 
   QcdLowPtDQM(const edm::ParameterSet &parameters);
   virtual ~QcdLowPtDQM();
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &);
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
-  void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup);
+  void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
   void endLuminosityBlock(const edm::LuminosityBlock &l,
-                          const edm::EventSetup &iSetup);
-  void endRun(const edm::Run &r, const edm::EventSetup &iSetup);
+                          const edm::EventSetup &iSetup) override;
+  void endRun(const edm::Run &r, const edm::EventSetup &iSetup) override;
 
  private:
   void book1D(DQMStore::IBooker &, std::vector<MonitorElement *> &mes, const std::string &name,

--- a/DQM/Physics/src/QcdPhotonsDQM.h
+++ b/DQM/Physics/src/QcdPhotonsDQM.h
@@ -38,7 +38,7 @@ class QcdPhotonsDQM : public DQMEDAnalyzer {
     edm::Run const &, edm::EventSetup const &) override;
 
   /// Get the analysis
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   // ----------member data ---------------------------

--- a/DQM/Physics/src/QcdUeDQM.h
+++ b/DQM/Physics/src/QcdUeDQM.h
@@ -55,10 +55,10 @@ class QcdUeDQM : public DQMEDAnalyzer {
  public:
   QcdUeDQM(const edm::ParameterSet &parameters);
   virtual ~QcdUeDQM();
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &);
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
-  void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup);
+  void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
  private:
   bool isHltConfigSuccessful_;  // to prevent processing in case of problems

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -303,7 +303,7 @@ class SingleTopTChannelLeptonDQM : public DQMEDAnalyzer {
   ~SingleTopTChannelLeptonDQM() {};
 
   /// do this during the event loop
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
  
  protected:
   //Book histograms

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
@@ -233,7 +233,7 @@ class SingleTopTChannelLeptonDQM_miniAOD : public DQMEDAnalyzer {
   ~SingleTopTChannelLeptonDQM_miniAOD() {};
 
   /// do this during the event loop
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
  
  protected:
   //Book histograms

--- a/DQM/Physics/src/SusyDQM.h
+++ b/DQM/Physics/src/SusyDQM.h
@@ -59,7 +59,7 @@ class SusyDQM : public DQMEDAnalyzer {
                       edm::EventSetup const&) override;
 
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual bool goodSusyElectron(const Ele*);
   virtual bool goodSusyMuon(const Mu*);
 

--- a/DQM/Physics/src/TopDiLeptonDQM.h
+++ b/DQM/Physics/src/TopDiLeptonDQM.h
@@ -45,7 +45,7 @@ class TopDiLeptonDQM : public DQMEDAnalyzer {
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleName_;
   std::string outputFile_;

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.h
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.h
@@ -328,7 +328,7 @@ class TopDiLeptonOfflineDQM : public DQMEDAnalyzer {
   ~TopDiLeptonOfflineDQM() {}
 
   /// do this during the event loop
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
  protected:
   //Book histograms

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -284,7 +284,7 @@ class TopSingleLeptonDQM : public DQMEDAnalyzer {
   ~TopSingleLeptonDQM() {};
 
   /// do this during the event loop
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
  
  protected:
   //Book histograms

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -212,7 +212,7 @@ class TopSingleLeptonDQM_miniAOD : public DQMEDAnalyzer {
   ~TopSingleLeptonDQM_miniAOD() {};
 
   /// do this during the event loop
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
  
  protected:
   //Book histograms

--- a/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
+++ b/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
@@ -37,7 +37,7 @@ class PhysicsObjectsMonitor : public DQMEDAnalyzer {
   // Operations
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
-  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup);
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
  private:
   std::string theSTAMuonLabel;

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.h
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.h
@@ -55,14 +55,14 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const&) override;
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&,
-                                    edm::EventSetup const&);
+                                    edm::EventSetup const&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&,
-                                  edm::EventSetup const&);
+                                  edm::EventSetup const&) override;
 
   // This is a kludge method to infer the filled bunches from the cluster count;  
   // notice that this cannot be used with random triggers.

--- a/DQM/RPCMonitorClient/interface/RPCChamberQuality.h
+++ b/DQM/RPCMonitorClient/interface/RPCChamberQuality.h
@@ -16,8 +16,8 @@ class RPCChamberQuality:public DQMEDHarvester{
   
   
  protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
  private:

--- a/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
+++ b/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
@@ -18,8 +18,8 @@ public:
   // Operations
 
 protected:
- void beginJob();
- void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+ void beginJob() override;
+ void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   

--- a/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
+++ b/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
@@ -18,8 +18,8 @@ public:
   ~RPCDaqInfo();
 
 protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
 private:

--- a/DQM/RPCMonitorClient/interface/RPCDataCertification.h
+++ b/DQM/RPCMonitorClient/interface/RPCDataCertification.h
@@ -17,8 +17,8 @@ public:
   virtual ~RPCDataCertification();
 
 protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
 

--- a/DQM/RPCMonitorClient/interface/RPCDcsInfoClient.h
+++ b/DQM/RPCMonitorClient/interface/RPCDcsInfoClient.h
@@ -14,8 +14,8 @@ public:
 
 protected:
 
- void beginJob();
- void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+ void beginJob() override;
+ void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
 

--- a/DQM/RPCMonitorClient/interface/RPCDqmClient.h
+++ b/DQM/RPCMonitorClient/interface/RPCDqmClient.h
@@ -22,8 +22,8 @@ class RPCDqmClient:public  DQMEDHarvester {
 
  protected:
 
- void beginJob();
- void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+ void beginJob() override;
+ void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   void makeClientMap(const edm::ParameterSet& parameters_);

--- a/DQM/RPCMonitorClient/interface/RPCEfficiencyPerRingLayer.h
+++ b/DQM/RPCMonitorClient/interface/RPCEfficiencyPerRingLayer.h
@@ -18,8 +18,8 @@ public:
 
   
  protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
 

--- a/DQM/RPCMonitorClient/interface/RPCEfficiencySecond.h
+++ b/DQM/RPCMonitorClient/interface/RPCEfficiencySecond.h
@@ -23,8 +23,8 @@ class RPCEfficiencySecond :public DQMEDHarvester{
       int rollY(std::string shortname,const std::vector<std::string>& rollNames);
   
  protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
  private:

--- a/DQM/RPCMonitorClient/interface/RPCEfficiencyShiftHisto.h
+++ b/DQM/RPCMonitorClient/interface/RPCEfficiencyShiftHisto.h
@@ -26,8 +26,8 @@ public:
   virtual ~RPCEfficiencyShiftHisto();
 
  protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   

--- a/DQM/RPCMonitorClient/interface/RPCEventSummary.h
+++ b/DQM/RPCMonitorClient/interface/RPCEventSummary.h
@@ -22,8 +22,8 @@ public:
 
 
  protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
  

--- a/DQM/RPCMonitorClient/interface/RPCFEDIntegrity.h
+++ b/DQM/RPCMonitorClient/interface/RPCFEDIntegrity.h
@@ -34,7 +34,7 @@ public:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// Analyze  
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& c) override;
   
     
  private:

--- a/DQM/RPCMonitorClient/interface/RPCMonitorLinkSynchro.h
+++ b/DQM/RPCMonitorClient/interface/RPCMonitorLinkSynchro.h
@@ -26,9 +26,9 @@ public:
   virtual ~RPCMonitorLinkSynchro();
  
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) ;
-  virtual void endLuminosityBlock(const edm::LuminosityBlock&,const edm::EventSetup&);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);  
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override ;
+  virtual void endLuminosityBlock(const edm::LuminosityBlock&,const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;  
   virtual  const RPCRawSynchro::ProdItem & select(const RPCRawSynchro::ProdItem &v, const edm::Event&, const edm::EventSetup&) { return v; };
  
 protected:

--- a/DQM/RPCMonitorClient/interface/RPCMonitorRaw.h
+++ b/DQM/RPCMonitorClient/interface/RPCMonitorRaw.h
@@ -25,7 +25,7 @@ public:
   explicit RPCMonitorRaw( const edm::ParameterSet& cfg);
   virtual ~RPCMonitorRaw();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 private:
 

--- a/DQM/RPCMonitorClient/interface/RPCRecHitProbabilityClient.h
+++ b/DQM/RPCMonitorClient/interface/RPCRecHitProbabilityClient.h
@@ -19,8 +19,8 @@ public:
   
   
 protected:
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
  

--- a/DQM/RPCMonitorDigi/interface/RPCDcsInfo.h
+++ b/DQM/RPCMonitorDigi/interface/RPCDcsInfo.h
@@ -28,9 +28,9 @@ public:
 protected:
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
+  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
 
 
 

--- a/DQM/RPCMonitorDigi/interface/RPCEfficiency.h
+++ b/DQM/RPCMonitorDigi/interface/RPCEfficiency.h
@@ -100,7 +100,7 @@ class RPCEfficiency : public DQMEDAnalyzer {
 
  protected:
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
       void bookDetUnitSeg(DQMStore::IBooker &, RPCDetId & detId,int nstrips, std::string folder, std::map<std::string, MonitorElement*> & );
       std::map<DTStationIndex,std::set<RPCDetId> > rollstoreDT;

--- a/DQM/RPCMonitorDigi/interface/RPCMonitorDigi.h
+++ b/DQM/RPCMonitorDigi/interface/RPCMonitorDigi.h
@@ -30,7 +30,7 @@ class RPCMonitorDigi : public DQMEDAnalyzer {
 
  protected:
 
-	virtual void analyze( const edm::Event&, const edm::EventSetup& );
+	virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
 	void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 	/// Booking of MonitoringElement for one RPCDetId (= roll)
 	void bookRollME(DQMStore::IBooker &,RPCDetId& , const edm::EventSetup&, const std::string &, std::map<std::string, MonitorElement*> &);

--- a/DQM/RPCMonitorDigi/interface/RPCRecHitProbability.h
+++ b/DQM/RPCMonitorDigi/interface/RPCRecHitProbability.h
@@ -25,7 +25,7 @@ class RPCRecHitProbability : public DQMEDAnalyzer {
   
  protected:
   
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
    
  private:

--- a/DQM/RPCMonitorDigi/interface/RPCTTUMonitor.h
+++ b/DQM/RPCMonitorDigi/interface/RPCTTUMonitor.h
@@ -56,7 +56,7 @@ public:
   
 protected:
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   
 

--- a/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
@@ -36,7 +36,7 @@ public:
 protected:
 
   void beginRun(edm::Run const& run, 
-                edm::EventSetup const& eSetup);
+                edm::EventSetup const& eSetup) override;
   void dqmEndLuminosityBlock(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter, edm::LuminosityBlock const& lumiSeg, 
                           edm::EventSetup const& c) override;
   void dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGetter & iGetter) override;

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -52,8 +52,8 @@
 
        typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
        
-       virtual void analyze(const edm::Event&, const edm::EventSetup&);
-       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) override;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
        virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -51,9 +51,9 @@
        explicit SiPixelHLTSource(const edm::ParameterSet& conf);
        ~SiPixelHLTSource();
 
-       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) override;
        virtual void bookMEs(DQMStore::IBooker &);
 
 

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -57,8 +57,8 @@
 
        typedef edm::DetSet<SiPixelRawDataError>::const_iterator    ErrorIterator;
        
-       virtual void analyze(const edm::Event&, const edm::EventSetup&);
-       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) override;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
        virtual void buildStructure(edm::EventSetup const&);

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -58,9 +58,9 @@ class SiPixelRecHitSource : public DQMEDAnalyzer {
 
 //       typedef edm::DetSet<PixelRecHit>::const_iterator    RecHitIterator;
        
-       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, const edm::EventSetup&) override;
-       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) override;
 
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &, const edm::EventSetup& iSetup);

--- a/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.h
@@ -52,7 +52,7 @@ class ClusterCount : public DQMEDAnalyzer {
    private:
       void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                           edm::EventSetup const&) override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
       // ----------member data ---------------------------
       //      edm::InputTag clusterLabel_;

--- a/DQM/SiStripMonitorDigi/interface/SiStripBaselineValidator.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripBaselineValidator.h
@@ -35,7 +35,7 @@ class SiStripBaselineValidator : public DQMEDAnalyzer
   explicit SiStripBaselineValidator(const edm::ParameterSet&);
   virtual ~SiStripBaselineValidator();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   private:

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -35,12 +35,12 @@ class SiStripMonitorDigi : public DQMEDAnalyzer {
  public:
   explicit SiStripMonitorDigi(const edm::ParameterSet&);
   ~SiStripMonitorDigi();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
-  virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c);
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   std::string topFolderName_;
 

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -75,7 +75,7 @@ class SiStripCMMonitorPlugin : public DQMEDAnalyzer
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) ;
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) override;
 
   //update the cabling if necessary
   void updateCabling(const edm::EventSetup& eventSetup);

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -60,7 +60,7 @@ class SiStripFEDCheckPlugin : public DQMEDAnalyzer
 
  private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endRun();
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
@@ -340,7 +340,7 @@ void SiStripFEDCheckPlugin::bookHistograms(DQMStore::IBooker & ibooker , const e
 
 // ------------ method called once each run just after ending the event loop  ------------
 void 
-SiStripFEDCheckPlugin::endRun()
+SiStripFEDCheckPlugin::endRun(edm::Run const&, edm::EventSetup const&)
 {
   updateHistograms();
 }

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -26,7 +26,7 @@ class SiStripFEDDumpPlugin : public DQMEDAnalyzer
   explicit SiStripFEDDumpPlugin(const edm::ParameterSet&);
   ~SiStripFEDDumpPlugin();
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   //tag of FEDRawData collection

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
@@ -60,7 +60,7 @@ class SiStripSpyMonitorModule : public DQMEDAnalyzer
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup& );
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) override;
 
 
   //check if contains pedsubtr data = 0

--- a/DQM/TrackingMonitorClient/interface/DQMScaleToClient.h
+++ b/DQM/TrackingMonitorClient/interface/DQMScaleToClient.h
@@ -38,8 +38,8 @@ class DQMScaleToClient: public DQMEDHarvester{
       
  protected:
 
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
   
  private:


### PR DESCRIPTION
This adds the keyword override where needed to remove clang warning:
overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
In 4 cases the function is changed to add unused parameters so the function parameters matches the overridden function parameters.