### PR TITLE
add missing dictionary std::vector<edm::Ref<std::vector<reco::PFMET> > >

### DIFF
--- a/DataFormats/METReco/src/classes.h
+++ b/DataFormats/METReco/src/classes.h
@@ -81,6 +81,7 @@ namespace DataFormats_METReco {
     edm::Wrapper<reco::PFMETCollection> dummy19;
     edm::Wrapper< std::vector<reco::PFMET> > dummy20;
     std::vector<reco::PFMET> dummy21;
+    std::vector<edm::Ref<std::vector<reco::PFMET> > > dummy211;
     edm::reftobase::Holder<reco::Candidate,reco::PFMETRef> rtb4;
 
     reco::PFClusterMETRef r5;

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -75,6 +75,7 @@
   <class name="edm::Wrapper<reco::PFMET>"/>
   <class name="edm::Wrapper<std::vector<reco::PFMET> >"/>
   <class name="std::vector<reco::PFMET>"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::PFMET> > >"/>
 
   <class name="reco::PFClusterMET" ClassVersion="12">
    <version ClassVersion="12" checksum="3688821779"/>


### PR DESCRIPTION
We are testing it in ROOT6 IBs first