### PR TITLE
bugfix in all in one validation tool

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -135,7 +135,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
                                 knownSimpleOptions = ["levels", "dbOutput","moduleList","modulesToPlot","useDefaultRange","plotOnlyGlobal","plotPng",
                                                       "dx_min","dx_max","dy_min","dy_max","dz_min","dz_max","dr_min","dr_max","rdphi_min","rdphi_max",
                                                       "dalpha_min","dalpha_max","dbeta_min","dbeta_max","dgamma_min","dgamma_max",
-                                                      "jobmode", "3DSubdetector1", "3Dubdetector2", "3DTranslationalScaleFactor"])
+                                                      "jobmode", "3DSubdetector1", "3Dubdetector2", "3DTranslationalScaleFactor", "jobid"])
                 levels = self.get( section, "levels" )
                 dbOutput = self.get( section, "dbOutput" )
                 compares[section.split(":")[1]] = ( levels, dbOutput )

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -23,9 +23,11 @@ class GenericValidation:
         self.filesToCompare = {}
         self.config = config
 
-        defaults = {"jobmode":      self.general["jobmode"],
+        defaults = {
+                    "jobmode":      self.general["jobmode"],
                     "cmssw":        os.environ['CMSSW_BASE'],
-                    "parallelJobs": "1"
+                    "parallelJobs": "1",
+                    "jobid":        "",
                    }
         defaults.update(addDefaults)
         mandatories = []
@@ -46,6 +48,14 @@ class GenericValidation:
             msg = ("Maximum allowed number of parallel jobs "
                    +str(maximumNumberJobs)+" exceeded!!!")
             raise AllInOneError(msg)
+
+        self.jobid = self.general["jobid"]
+        if self.jobid:
+            try:  #make sure it's actually a valid jobid
+                output = getCommandOutput2("bjobs %(jobid)s 2>&1"%self.general)
+                if "is not found" in output: raise RuntimeError
+            except RuntimeError:
+                raise AllInOneError("%s is not a valid jobid.\nMaybe it finished already?"%self.jobid)
 
         self.cmssw = self.general["cmssw"]
         badcharacters = r"\'"

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -20,7 +20,7 @@ class PreexistingValidation(GenericValidation):
         self.config = config
         self.filesToCompare = {}
 
-        defaults = {"title": self.name, "jobid": ""}
+        defaults = {"title": self.name}
         defaults.update(addDefaults)
         mandatories = ["file", "color", "style"]
         mandatories += addMandatories
@@ -34,14 +34,6 @@ class PreexistingValidation(GenericValidation):
         if "|" in self.title or "," in self.title or '"' in self.title:
             msg = "The characters '|', '\"', and ',' cannot be used in the alignment title!"
             raise AllInOneError(msg)
-
-        self.jobid = self.general["jobid"]
-        if self.jobid:
-            try:  #make sure it's actually a valid jobid
-                output = getCommandOutput2("bjobs %(jobid)s 2>&1"%self.general)
-                if "is not found" in output: raise RuntimeError
-            except RuntimeError:
-                raise AllInOneError("%s is not a valid jobid.\nMaybe it finished already?"%self.jobid)
 
         self.filesToCompare[GenericValidationData.defaultReferenceName] = \
             self.general["file"]

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -169,6 +169,9 @@ class ValidationJob:
             log = ">             " + self.validation.name + " is already validated."
             print log
             return log
+        else:
+            if self.validation.jobid:
+                print "jobid {} will be ignored, since the validation {} is not preexisting".format(self.validation.jobid, self.validation.name)
 
         general = self.__config.getGeneral()
         log = ""


### PR DESCRIPTION
Backport of #16817

Fix the *offline syntax, which wasn't working because of a stupid mistake.