### PR TITLE
Fix clang compiler warning and replace boost::mpl::if_c with std::conditional

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -1,7 +1,7 @@
 #ifndef DPGAnalysis_SiStripTools_Multiplicities_H
 #define DPGAnalysis_SiStripTools_Multiplicities_H
 
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -34,7 +34,7 @@ class ClusterSummarySingleMultiplicity {
 
  public:
   ClusterSummarySingleMultiplicity();
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
   ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC);
   ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC);
 #endif
@@ -43,34 +43,34 @@ class ClusterSummarySingleMultiplicity {
   int mult() const;
 
  private:
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
   edm::EDGetTokenT<ClusterSummary> m_collection;
 #endif
   ClusterSummary::CMSTracker m_subdetenum;
   ClusterSummary::VariablePlacement m_varenum;
   int m_mult;
-    
+
 };
 
 
 
 template <class T>
 class SingleMultiplicity {
-  
+
  public:
   SingleMultiplicity();
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
   SingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC);
   SingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC);
-#endif  
-  
+#endif
+
   void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   int mult() const;
   //  int mult;
-  
+
  private:
-  
-#ifndef __GCCXML__
+
+#ifndef __ROOTCLING__
   edm::EDGetTokenT<T> m_collection;
 #endif
   int m_modthr;
@@ -81,15 +81,15 @@ class SingleMultiplicity {
 
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity():
-  //  mult(0), 
-#ifndef __GCCXML__
-m_collection(), 
+  //  mult(0),
+#ifndef __ROOTCLING__
+m_collection(),
 #endif
     m_modthr(-1), m_useQuality(false),  m_qualityLabel(),
   m_mult(0)
 { }
 
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC):
   //  mult(0),
@@ -110,7 +110,7 @@ m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"
 { }
 #endif
 
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
 template <class T>
 void
 SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -131,8 +131,8 @@ SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventSetup&
 
      if(!m_useQuality || !qualityHandle->IsModuleBad(it->detId()) ) {
        if(m_modthr < 0 || int(it->size()) < m_modthr ) {
-	 m_mult += it->size();
-	 //	 mult += it->size();
+         m_mult += it->size();
+         //      mult += it->size();
        }
      }
    }
@@ -145,34 +145,34 @@ int SingleMultiplicity<T>::mult() const { return m_mult; }
 
 template <class T1, class T2>
   class MultiplicityPair {
-    
+
  public:
     MultiplicityPair();
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
     MultiplicityPair(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC);
     MultiplicityPair(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC);
 #endif
-    
+
     void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
     int mult1() const;
     int mult2() const;
     //    int mult1;
     //    int mult2;
-    
+
  private:
-    
+
     T1 m_multiplicity1;
     T2 m_multiplicity2;
-    
+
   };
 
 template <class T1, class T2>
   MultiplicityPair<T1,T2>::MultiplicityPair():
-    //    mult1(0),mult2(0),  
+    //    mult1(0),mult2(0),
     m_multiplicity1(),  m_multiplicity2()
 { }
 
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
 template <class T1, class T2>
       MultiplicityPair<T1,T2>::MultiplicityPair(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC):
     //    mult1(0),mult2(0),
@@ -190,13 +190,13 @@ template <class T1, class T2>
 template <class T1, class T2>
   void
   MultiplicityPair<T1,T2>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
+
   m_multiplicity1.getEvent(iEvent,iSetup);
   m_multiplicity2.getEvent(iEvent,iSetup);
 
   //  mult1=m_multiplicity1.mult;
   //  mult2=m_multiplicity2.mult;
-  
+
 }
 
 template<class T1, class T2>
@@ -208,9 +208,9 @@ template<class T1, class T2>
 typedef SingleMultiplicity<edm::DetSetVector<SiStripDigi> > SingleSiStripDigiMultiplicity;
 typedef SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > SingleSiStripClusterMultiplicity;
 typedef SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > SingleSiPixelClusterMultiplicity;
-typedef MultiplicityPair<SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > ,SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > > 
-SiPixelClusterSiStripClusterMultiplicityPair; 
-typedef MultiplicityPair<ClusterSummarySingleMultiplicity,ClusterSummarySingleMultiplicity> ClusterSummaryMultiplicityPair; 
+typedef MultiplicityPair<SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > ,SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > >
+SiPixelClusterSiStripClusterMultiplicityPair;
+typedef MultiplicityPair<ClusterSummarySingleMultiplicity,ClusterSummarySingleMultiplicity> ClusterSummaryMultiplicityPair;
 
 
 #endif // DPGAnalysis_SiStripTools_Multiplicities_H

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -43,7 +43,7 @@ public:
 
       virtual void getThinnedProducts(edm::ProductID const& pid,
                                       std::vector<edm::WrapperBase const*>& foundContainers,
-                                      std::vector<unsigned int>& keys) const {
+                                      std::vector<unsigned int>& keys) const override {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
@@ -69,8 +69,8 @@ private:
 // constructors and destructor
 //
   MultiChainEvent::MultiChainEvent(std::vector<std::string> const& iFileNames1,
-				   std::vector<std::string> const& iFileNames2,
-				   bool useSecFileMapSorted)
+                                   std::vector<std::string> const& iFileNames2,
+                                   bool useSecFileMapSorted)
 {
   event1_ = std::make_shared<ChainEvent>(iFileNames1);
   event2_ = std::make_shared<ChainEvent>(iFileNames2);
@@ -123,28 +123,28 @@ private:
     bool foundAny = false;
 
     for(event2_->toBegin();
-	 ! event2_->atEnd();
-	 ++(*event2_)) {
+         ! event2_->atEnd();
+         ++(*event2_)) {
       // if we have a new file, cache the "first"
       if (lastFile != event2_->getTFile()) {
 
-	// if this is not the first file, we have an entry.
-	// Add it to the list.
-	if (!firstFile) {
-	  foundAny = true;
-	  event_id_range toAdd = eventRange.first;
-	  secFileMapSorted_[ toAdd ] = eventRange.second;
-	}
-	// always add the "first" event id to the cached event range
-	eventRange.first.first = event2_->event()->id();
-	lastFile = event2_->getTFile();
+        // if this is not the first file, we have an entry.
+        // Add it to the list.
+        if (!firstFile) {
+          foundAny = true;
+          event_id_range toAdd = eventRange.first;
+          secFileMapSorted_[ toAdd ] = eventRange.second;
+        }
+        // always add the "first" event id to the cached event range
+        eventRange.first.first = event2_->event()->id();
+        lastFile = event2_->getTFile();
       }
       // otherwise, cache the "second" event id in the cached event range.
       // Upon the discovery of a new file, this will be used as the
       // "last" event id in the cached event range.
       else {
-	eventRange.first.second = event2_->event()->id();
-	eventRange.second = event2_->eventIndex();
+        eventRange.first.second = event2_->event()->id();
+        eventRange.second = event2_->eventIndex();
       }
       firstFile = false;
     }
@@ -156,17 +156,17 @@ private:
     }
 //     std::cout << "Dumping run range to event id list:" << std::endl;
 //     for (sec_file_range_index_map::const_iterator mBegin = secFileMapSorted_.begin(),
-// 	    mEnd = secFileMapSorted_.end(),
-// 	    mit = mBegin;
-// 	  mit != mEnd; ++mit) {
+//          mEnd = secFileMapSorted_.end(),
+//          mit = mBegin;
+//        mit != mEnd; ++mit) {
 //       char buff[1000];
 //       event2_->to(mit->second);
 //       sprintf(buff, "[%10d,%10d - %10d,%10d] ---> %10d",
-// 	      mit->first.first.run(),
-// 	      mit->first.first.event(),
-// 	      mit->first.second.run(),
-// 	      mit->first.second.event(),
-// 	      mit->second);
+//            mit->first.first.run(),
+//            mit->first.first.event(),
+//            mit->first.second.run(),
+//            mit->first.second.event(),
+//            mit->second);
 //       std::cout << buff << std::endl;
 //     }
   }

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -36,7 +36,7 @@ namespace edm {
   class ModuleCallingContext;
   class ProducerBase;
   class SharedResourcesAcquirer;
-  
+
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
   }
@@ -54,7 +54,7 @@ namespace edm {
     /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
      */
     LuminosityBlockIndex index() const;
-    
+
     /**If you are caching data from the LuminosityBlock, you should also keep
      this number.  If this number changes then you know that
      the data you have cached is invalid.
@@ -64,10 +64,10 @@ namespace edm {
     typedef unsigned long CacheIdentifier_t;
     CacheIdentifier_t
     cacheIdentifier() const;
-    
+
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
-    
+
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
 
     template <typename PROD>
@@ -84,11 +84,11 @@ namespace edm {
     template <typename PROD>
     bool
     getByLabel(InputTag const& tag, Handle<PROD>& result) const;
-    
+
     template<typename PROD>
     bool
     getByToken(EDGetToken token, Handle<PROD>& result) const;
-    
+
     template<typename PROD>
     bool
     getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
@@ -170,9 +170,9 @@ namespace edm {
 
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    typename boost::mpl::if_c<detail::has_postinsert<PROD>::value,
-      DoPostInsert<PROD>,
-      DoNotPostInsert<PROD> >::type maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value,
+                       DoPostInsert<PROD>,
+                       DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
 
     BranchDescription const& desc =
@@ -223,7 +223,7 @@ namespace edm {
     }
     return true;
   }
-  
+
   template<typename PROD>
   bool
   LuminosityBlock::getByToken(EDGetToken token, Handle<PROD>& result) const {
@@ -238,7 +238,7 @@ namespace edm {
     }
     return true;
   }
-  
+
   template<typename PROD>
   bool
   LuminosityBlock::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -34,7 +34,7 @@ namespace edm {
   class ModuleCallingContext;
   class ProducerBase;
   class SharedResourcesAcquirer;
-  
+
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
   }
@@ -49,7 +49,7 @@ namespace edm {
     void setConsumer(EDConsumerBase const* iConsumer) {
       provRecorder_.setConsumer(iConsumer);
     }
-    
+
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
       provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
     }
@@ -77,7 +77,7 @@ namespace edm {
     CacheIdentifier_t
     cacheIdentifier() const;
 
-    
+
     template <typename PROD>
     bool
     getByLabel(std::string const& label, Handle<PROD>& result) const;
@@ -96,7 +96,7 @@ namespace edm {
     template<typename PROD>
     bool
     getByToken(EDGetToken token, Handle<PROD>& result) const;
-    
+
     template<typename PROD>
     bool
     getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
@@ -181,9 +181,9 @@ namespace edm {
 
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    typename boost::mpl::if_c<detail::has_postinsert<PROD>::value,
-      DoPostInsert<PROD>,
-      DoNotPostInsert<PROD> >::type maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value,
+                       DoPostInsert<PROD>,
+                       DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
 
     BranchDescription const& desc =
@@ -249,7 +249,7 @@ namespace edm {
     }
     return true;
   }
-  
+
   template<typename PROD>
   bool
   Run::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     moduleAbilities
-// 
+//
 /**\file moduleAbilities moduleAbilities.h "FWCore/Framework/interface/moduleAbilities.h"
 
  Description: Template arguments for stream::{Module}, global::{Module}, one::{Module} classes
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include "boost/mpl/if.hpp"
+#include <type_traits>
 
 // user include files
 #include "FWCore/Framework/interface/moduleAbilityEnums.h"
@@ -31,43 +31,43 @@ namespace edm {
     //Used in the case where ability is not available
     struct Empty{};
   }
-  
+
   template<typename T>
   struct GlobalCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kGlobalCache;
     typedef T Type;
   };
-  
+
   template<typename T>
   struct StreamCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kStreamCache;
     typedef T Type;
   };
-  
+
   template<typename T>
   struct RunCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kRunCache;
     typedef T Type;
   };
-  
+
   template<typename T>
   struct LuminosityBlockCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kLuminosityBlockCache;
     typedef T Type;
   };
-  
+
   template<typename T>
   struct RunSummaryCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kRunSummaryCache;
     typedef T Type;
   };
-  
+
   template<typename T>
   struct LuminosityBlockSummaryCache {
     static constexpr module::Abilities kAbilities=module::Abilities::kLuminosityBlockSummaryCache;
     typedef T Type;
   };
-  
+
   struct BeginRunProducer {
     static constexpr module::Abilities kAbilities=module::Abilities::kBeginRunProducer;
     typedef module::Empty Type;
@@ -82,7 +82,7 @@ namespace edm {
     static constexpr module::Abilities kAbilities=module::Abilities::kBeginLuminosityBlockProducer;
     typedef module::Empty Type;
   };
-  
+
   struct EndLuminosityBlockProducer {
     static constexpr module::Abilities kAbilities=module::Abilities::kEndLuminosityBlockProducer;
     typedef module::Empty Type;
@@ -92,18 +92,18 @@ namespace edm {
     static constexpr module::Abilities kAbilities=module::Abilities::kWatchInputFiles;
     typedef module::Empty Type;
   };
-  
+
   //Recursively checks VArgs template arguments looking for the ABILITY
   template<module::Abilities ABILITY, typename... VArgs> struct CheckAbility;
-  
+
   template<module::Abilities ABILITY, typename T, typename... VArgs>
   struct CheckAbility<ABILITY,T,VArgs...> {
     static constexpr bool kHasIt = (T::kAbilities==ABILITY) | CheckAbility<ABILITY,VArgs...>::kHasIt;
-    typedef typename boost::mpl::if_c<(T::kAbilities==ABILITY),
-    typename T::Type,
-    typename CheckAbility<ABILITY,VArgs...>::Type>::type Type;
+    typedef std::conditional_t<(T::kAbilities==ABILITY),
+                               typename T::Type,
+                               typename CheckAbility<ABILITY,VArgs...>::Type> Type;
   };
-  
+
   //End of the recursion
   template<module::Abilities ABILITY>
   struct CheckAbility<ABILITY> {

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ESProxyFactoryProducer
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -71,7 +71,7 @@ ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
    typedef Record2Factories::iterator Iterator;
    std::pair< Iterator, Iterator > range = record2Factories_.equal_range(iRecord);
    for(Iterator it = range.first; it != range.second; ++it) {
-      
+
       std::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
       if(nullptr != proxy.get()) {
          iProxies.push_back(KeyedProxies::value_type((*it).second.key_,
@@ -89,13 +89,13 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
       assert(false && "Factor pointer was null");
       ::exit(1);
    }
-   
+
    usingRecordWithKey(iRecord);
-   
+
    std::shared_ptr<ProxyFactoryBase> temp(iFactory.release());
    FactoryInfo info(temp->makeKey(iLabel),
                     temp);
-   
+
    //has this already been registered?
    std::pair<Record2Factories::const_iterator,Record2Factories::const_iterator> range =
       record2Factories_.equal_range(iRecord);
@@ -109,12 +109,12 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
       throw cms::Exception("IdenticalProducts")<<"Producer has been asked to produce "<<info.key_.type().name()
       <<" \""<<info.key_.name().value()<<"\" multiple times.\n Please modify the code.";
    }
-                                               
+
    record2Factories_.insert(Record2Factories::value_type(iRecord,
                                                          std::move(info)));
 }
 
-void 
+void
 ESProxyFactoryProducer::newInterval(const EventSetupRecordKey& iRecordType,
                                    const ValidityInterval& /*iInterval*/)
 {

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -1,4 +1,3 @@
-
 /*----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 
@@ -14,25 +13,25 @@
 #include "FWCore/Framework/src/OutputModuleCommunicatorT.h"
 
 namespace edm {
-  
+
   template<typename T>
   void
   OutputModuleCommunicatorT<T>::closeFile() {
     module().doCloseFile();
   }
-  
+
   template<typename T>
   bool
   OutputModuleCommunicatorT<T>::shouldWeCloseFile() const {
     return module().shouldWeCloseFile();
   }
-  
+
   template<typename T>
   void
   OutputModuleCommunicatorT<T>::openNewFileIfNeeded() {
     module().maybeOpenFile();
   }
-  
+
   template<typename T>
   void
   OutputModuleCommunicatorT<T>::openFile(edm::FileBlock const& fb) {
@@ -71,23 +70,23 @@ namespace edm {
 
   template<typename T>
   bool OutputModuleCommunicatorT<T>::wantAllEvents() const {return module().wantAllEvents();}
-  
+
   template<typename T>
   bool OutputModuleCommunicatorT<T>::limitReached() const {return module().limitReached();}
-  
+
   template<typename T>
   void OutputModuleCommunicatorT<T>::configure(OutputModuleDescription const& desc) {module().configure(desc);}
-  
+
   template<typename T>
   edm::SelectedProductsForBranchType const& OutputModuleCommunicatorT<T>::keptProducts() const {
     return module().keptProducts();
   }
-  
+
   template<typename T>
   void OutputModuleCommunicatorT<T>::selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const& helper) {
     module().selectProducts(preg, helper);
   }
-  
+
   template<typename T>
   void OutputModuleCommunicatorT<T>::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                                     bool anyProductProduced) {
@@ -98,7 +97,7 @@ namespace edm {
   ModuleDescription const& OutputModuleCommunicatorT<T>::description() const {
     return module().description();
   }
-  
+
   namespace impl {
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void *) {
       return std::unique_ptr<edm::OutputModuleCommunicator>{};

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -31,7 +31,7 @@ namespace edm {
   class UnscheduledAuxiliary;
   class Worker;
   class ServiceToken;
-  
+
   class DataManagingProductResolver : public ProductResolverBase {
   public:
     enum class ProductStatus {
@@ -41,16 +41,16 @@ namespace edm {
       ResolveNotRun,
       ProductDeleted
     };
-    
+
     DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd,ProductStatus iDefaultStatus): ProductResolverBase(),
     productData_(bd),
     theStatus_(iDefaultStatus),
     defaultStatus_(iDefaultStatus){}
-    
+
     virtual void connectTo(ProductResolverBase const&, Principal const*) override final;
 
     void resetStatus() {theStatus_ = defaultStatus_;}
-    
+
     //Give AliasProductResolver access
     virtual void resetProductData_(bool deleteEarly) override;
 
@@ -62,7 +62,7 @@ namespace edm {
     //Handle the boilerplate code needed for resolveProduct_
     template <bool callResolver, typename FUNC>
     Resolution resolveProductImpl( FUNC resolver) const;
-    
+
   private:
 
     void throwProductDeletedException() const;
@@ -105,7 +105,7 @@ namespace edm {
     private:
       virtual bool isFromCurrentProcess() const override final;
 
-    
+
       virtual Resolution resolveProduct_(Principal const& principal,
                                          bool skipCurrentProcess,
                                          SharedResourcesAcquirer* sra,
@@ -116,11 +116,11 @@ namespace edm {
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    
+
       virtual void retrieveAndMerge_(Principal const& principal) const override;
 
       virtual bool unscheduledWasNotRun_() const override final {return false;}
-    
+
       virtual void resetProductData_(bool deleteEarly) override;
 
       mutable std::atomic<bool> m_prefetchRequested;
@@ -140,7 +140,7 @@ namespace edm {
       virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
     private:
       virtual bool isFromCurrentProcess() const override final;
-    
+
   };
 
   class PuttableProductResolver : public ProducedProductResolver {
@@ -160,7 +160,7 @@ namespace edm {
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
     virtual bool unscheduledWasNotRun_() const override {return false;}
-    
+
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
     virtual void resetProductData_(bool deleteEarly) override;
 
@@ -169,14 +169,14 @@ namespace edm {
     mutable std::atomic<bool> prefetchRequested_;
 
   };
-  
+
   class UnscheduledProductResolver : public ProducedProductResolver {
     public:
       explicit UnscheduledProductResolver(std::shared_ptr<BranchDescription const> bd) :
        ProducedProductResolver(bd,ProductStatus::ResolveNotRun),
        aux_(nullptr),
        prefetchRequested_(false){}
-    
+
       virtual void setupUnscheduled(UnscheduledConfigurator const&) override final;
 
     private:
@@ -192,7 +192,7 @@ namespace edm {
       virtual bool unscheduledWasNotRun_() const override {return status() == ProductStatus::ResolveNotRun;}
 
       virtual void resetProductData_(bool deleteEarly) override;
-    
+
       mutable WaitingTaskList waitingTasks_;
       UnscheduledAuxiliary const* aux_;
       Worker* worker_;
@@ -203,7 +203,7 @@ namespace edm {
     public:
       typedef ProducedProductResolver::ProductStatus ProductStatus;
       explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct) : ProductResolverBase(), realProduct_(realProduct), bd_(bd) {}
-    
+
       virtual void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) override final {
         realProduct_.connectTo(iOther, iParentPrincipal );
       };
@@ -251,12 +251,12 @@ namespace edm {
   public:
     typedef ProducedProductResolver::ProductStatus ProductStatus;
     explicit ParentProcessProductResolver(std::shared_ptr<BranchDescription const> bd) : ProductResolverBase(), realProduct_(nullptr), bd_(bd), provRetriever_(nullptr), parentPrincipal_(nullptr) {}
-    
+
     virtual void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) override final {
       realProduct_ = &iOther;
       parentPrincipal_ = iParentPrincipal;
     };
-    
+
   private:
     virtual Resolution resolveProduct_(Principal const& principal,
                                        bool skipCurrentProcess,
@@ -288,7 +288,7 @@ namespace edm {
     virtual ProductProvenance const* productProvenancePtr_() const override;
     virtual void resetProductData_(bool deleteEarly) override;
     virtual bool singleProduct_() const override;
-    
+
     ProductResolverBase const* realProduct_;
     std::shared_ptr<BranchDescription const> bd_;
     ProductProvenanceRetriever const* provRetriever_;
@@ -300,7 +300,7 @@ namespace edm {
       typedef ProducedProductResolver::ProductStatus ProductStatus;
       NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
                              std::vector<bool> const& ambiguous);
-    
+
     virtual void connectTo(ProductResolverBase const& iOther, Principal const*) override final ;
 
     void tryPrefetchResolverAsync(unsigned int iProcessingIndex,
@@ -309,11 +309,11 @@ namespace edm {
                                   SharedResourcesAcquirer* sra,
                                   ModuleCallingContext const* mcc,
                                   ServiceToken token) const;
-    
+
     bool dataValidFromResolver(unsigned int iProcessingIndex,
                                Principal const& principal,
                                bool iSkipCurrentProcess) const;
-    
+
     void prefetchFailed(unsigned int iProcessingIndex,
                         Principal const& principal,
                         bool iSkipCurrentProcess,
@@ -347,7 +347,7 @@ namespace edm {
       virtual ProductProvenance const* productProvenancePtr_() const override;
       virtual void resetProductData_(bool deleteEarly) override;
       virtual bool singleProduct_() const override;
-    
+
       Resolution tryResolver(unsigned int index,
                              Principal const& principal,
                              bool skipCurrentProcess,
@@ -371,9 +371,9 @@ namespace edm {
     typedef ProducedProductResolver::ProductStatus ProductStatus;
     SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice):
     ProductResolverBase(), realResolverIndex_(iChoice) {}
-    
+
     virtual void connectTo(ProductResolverBase const& iOther, Principal const*) override final ;
-    
+
   private:
     virtual Resolution resolveProduct_(Principal const& principal,
                                        bool skipCurrentProcess,
@@ -395,14 +395,14 @@ namespace edm {
     virtual BranchDescription const& branchDescription_() const override;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
     virtual Provenance const* provenance_() const override;
-    
+
     virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
     virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
     virtual void setProcessHistory_(ProcessHistory const& ph) override;
     virtual ProductProvenance const* productProvenancePtr_() const override;
     virtual void resetProductData_(bool deleteEarly) override;
     virtual bool singleProduct_() const override;
-    
+
     ProductResolverIndex realResolverIndex_;
   };
 

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -4,13 +4,13 @@
 //
 // Package:     ParameterSet
 // Class  :     ParameterSetDescriptionFiller
-// 
+//
 /**\class ParameterSetDescriptionFiller ParameterSetDescriptionFiller.h FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
 
  Description: A concrete ParameterSetDescription filler which calls a static function of the template argument
 
  Usage:
-    This is an ParameterSetDescription filler adapter class which calls the 
+    This is an ParameterSetDescription filler adapter class which calls the
 
 void fillDescription(edm::ParameterSetDescription&)
 
@@ -138,24 +138,24 @@ namespace edm {
         descriptions.addDefault(desc);
       }
     };
-    
+
     template <typename T, void (*)(ConfigurationDescriptions &)>  struct prevalidate_function;
     template <typename T> no_tag  has_prevalidate_helper(...);
     template <typename T> yes_tag has_prevalidate_helper(fillDescriptions_function<T, &T::prevalidate> * dummy);
-    
+
     template<typename T>
     struct has_prevalidate_function {
       static bool const value =
       sizeof(has_prevalidate_helper<T>(0)) == sizeof(yes_tag);
     };
-    
+
     template <typename T>
     struct DoPrevalidate {
       void operator()(ConfigurationDescriptions & descriptions) {
         T::prevalidate(descriptions);
       }
     };
-    
+
     template <typename T>
     struct DoNothing {
       void operator()(ConfigurationDescriptions & descriptions) {
@@ -166,7 +166,7 @@ namespace edm {
 
   // Not needed at the moment
   //void prevalidateService(ConfigurationDescriptions &);
-  
+
   template< typename T>
   class DescriptionFillerForServices : public ParameterSetDescriptionFillerBase
   {
@@ -176,9 +176,9 @@ namespace edm {
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
     virtual void fill(ConfigurationDescriptions & descriptions) const {
-      typename boost::mpl::if_c<edm::fillDetails::has_fillDescriptions_function<T>::value,
-                                edm::fillDetails::DoFillDescriptions<T>,
-                                edm::fillDetails::DoFillAsUnknown<T> >::type fill_descriptions;
+      std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
+                         edm::fillDetails::DoFillDescriptions<T>,
+                         edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
       fill_descriptions(descriptions);
       //we don't have a need for prevalidation of services at the moment, so this is a placeholder
       // Probably the best package to declare this in would be FWCore/ServiceRegistry
@@ -208,14 +208,14 @@ namespace edm {
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
     virtual void fill(ConfigurationDescriptions & descriptions) const {
-      typename boost::mpl::if_c<edm::fillDetails::has_fillDescriptions_function<T>::value,
-                                edm::fillDetails::DoFillDescriptions<T>,
-                                edm::fillDetails::DoFillAsUnknown<T> >::type fill_descriptions;
+      std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
+                         edm::fillDetails::DoFillDescriptions<T>,
+                         edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
       fill_descriptions(descriptions);
-      
-      typename boost::mpl::if_c<edm::fillDetails::has_prevalidate_function<T>::value,
-      edm::fillDetails::DoPrevalidate<T>,
-      edm::fillDetails::DoNothing<T> >::type prevalidate;
+
+      std::conditional_t<edm::fillDetails::has_prevalidate_function<T>::value,
+                         edm::fillDetails::DoPrevalidate<T>,
+                         edm::fillDetails::DoNothing<T>> prevalidate;
       prevalidate(descriptions);
     }
 
@@ -241,14 +241,14 @@ namespace edm {
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
     virtual void fill(ConfigurationDescriptions & descriptions) const {
-      typename boost::mpl::if_c<edm::fillDetails::has_fillDescriptions_function<T>::value,
-                                edm::fillDetails::DoFillDescriptions<T>,
-                                edm::fillDetails::DoFillAsUnknown<T> >::type fill_descriptions;
+      std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
+                         edm::fillDetails::DoFillDescriptions<T>,
+                         edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
       fill_descriptions(descriptions);
-      
-      typename boost::mpl::if_c<edm::fillDetails::has_prevalidate_function<T>::value,
-      edm::fillDetails::DoPrevalidate<T>,
-      edm::fillDetails::DoNothing<T> >::type prevalidate;
+
+      std::conditional_t<edm::fillDetails::has_prevalidate_function<T>::value,
+                         edm::fillDetails::DoPrevalidate<T>,
+                         edm::fillDetails::DoNothing<T>> prevalidate;
       prevalidate(descriptions);
     }
 

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Services
 // Class  :     CPU
-// 
+//
 // Implementation:
 //
 // Original Author:  Natalia Garcia
@@ -34,13 +34,13 @@
 #endif
 
 namespace edm {
-  
+
   namespace service {
     class CPU : public CPUServiceBase {
     public:
       CPU(ParameterSet const&, ActivityRegistry&);
       ~CPU();
-      
+
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
       virtual bool cpuInfo(std::string &models, double &avgSpeed) override;
@@ -54,7 +54,7 @@ namespace edm {
       double getAverageSpeed(const std::vector<std::pair<std::string, std::string>> & info);
       void postEndJob();
     };
-    
+
     inline
     bool isProcessWideService(CPU const*) {
       return true;
@@ -67,19 +67,19 @@ namespace edm {
     namespace {
 
       std::string i2str(int i){
-	std::ostringstream t;
-	t << i;
-	return t.str();
+        std::ostringstream t;
+        t << i;
+        return t.str();
       }
 
       std::string d2str(double d){
-	std::ostringstream t;
-	t << d;
-	return t.str();
+        std::ostringstream t;
+        t << d;
+        return t.str();
       }
 
       double str2d(std::string s){
-	return atof(s.c_str());
+        return atof(s.c_str());
       }
 
       void trim(std::string& s, const std::string& drop = " \t") {
@@ -91,22 +91,22 @@ namespace edm {
       }
 
       std::string eraseExtraSpaces(std::string s) {
-	bool founded = false; 
-	std::string aux;
+        bool founded = false;
+        std::string aux;
         for(std::string::const_iterator iter = s.begin(); iter != s.end(); iter++){
-		if(founded){
+                if(founded){
                         if(*iter == ' ') founded = true;
                         else{
                                 aux += " "; aux += *iter;
-				founded = false;
-			}
-		}
-		else{
-			if(*iter == ' ') founded = true;
-			else aux += *iter;
-		}
-	}
-	return aux;
+                                founded = false;
+                        }
+                }
+                else{
+                        if(*iter == ' ') founded = true;
+                        else aux += *iter;
+                }
+        }
+        return aux;
       }
 
       // Determine the CPU set size; if this can be successfully determined, then this
@@ -142,9 +142,9 @@ namespace edm {
 
 
     CPU::CPU(const ParameterSet& iPS, ActivityRegistry&iRegistry):
-	reportCPUProperties_(iPS.getUntrackedParameter<bool>("reportCPUProperties"))
+        reportCPUProperties_(iPS.getUntrackedParameter<bool>("reportCPUProperties"))
     {
-	iRegistry.watchPostEndJob(this,&CPU::postEndJob);
+        iRegistry.watchPostEndJob(this,&CPU::postEndJob);
     }
 
 
@@ -195,7 +195,7 @@ namespace edm {
             {"totalCPUs",        i2str(totalNumberCPUs)},
             {"averageCoreSpeed", d2str(avgSpeed)},
             {"CPUModels",        models}
-        };       
+        };
         unsigned set_size = -1;
         if (getCpuSetSize(set_size)) {
           reportCPUProperties.insert(std::make_pair("cpusetCount", i2str(set_size)));
@@ -294,5 +294,3 @@ namespace edm {
 using edm::service::CPU;
 typedef edm::serviceregistry::AllArgsMaker<edm::CPUServiceBase,CPU> CPUMaker;
 DEFINE_FWK_SERVICE_MAKER(CPU, CPUMaker);
-
-

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -55,7 +55,7 @@ namespace edm {
     virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
     virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) override;
     virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) override;
-    
+
     RootServiceChecker rootServiceChecker_;
 
     unsigned int nStreams_;
@@ -67,7 +67,7 @@ namespace edm {
 
     InputFileCatalog catalog_;
     edm::propagate_const<std::unique_ptr<RootEmbeddedFileSequence>> fileSequence_;
-    
+
   }; // class EmbeddedRootSource
 }
 #endif

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -91,7 +91,7 @@ namespace edm {
     auto resources = SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader();
     resourceSharedWithDelayedReaderPtr_ = std::make_unique<SharedResourcesAcquirer>(std::move(resources.first));
     mutexSharedWithDelayedReader_ = resources.second;
-    
+
     if (secondaryCatalog_.empty() && pset.getUntrackedParameter<bool>("needSecondaryFileNames", false)) {
       throw Exception(errors::Configuration, "PoolSource") << "'secondaryFileNames' must be specified\n";
     }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -116,11 +116,11 @@ namespace edm {
                processingMode, runHelper,
                false, productSelectorRules, inputType, branchIDListHelper,
                thinnedAssociationsHelper, associationsFromSecondary,
-               nullptr, dropDescendantsOfDroppedProducts, processHistoryRegistry,  
+               nullptr, dropDescendantsOfDroppedProducts, processHistoryRegistry,
                indexesIntoFiles, currentIndexIntoFile, orderedProcessHistoryIDs,
                bypassVersionCheck, labelRawDataLikeMC,
                false, enablePrefetching) {}
-               
+
     RootFile(std::string const& fileName,
              ProcessConfiguration const& processConfiguration,
              std::string const& logicalFileName,
@@ -141,11 +141,11 @@ namespace edm {
                nullptr, false, -1, -1, nStreams, treeCacheSize, treeMaxVirtualSize,
                InputSource::RunsLumisAndEvents, runHelper,
                false, productSelectorRules, inputType, nullptr, nullptr,
-               nullptr, nullptr, false, processHistoryRegistry,  
+               nullptr, nullptr, false, processHistoryRegistry,
                indexesIntoFiles, currentIndexIntoFile, orderedProcessHistoryIDs,
                bypassVersionCheck, false,
                false, enablePrefetching) {}
-               
+
     ~RootFile();
 
     RootFile(RootFile const&) = delete; // Disallow copying and moving

--- a/IOPool/Output/interface/TimeoutPoolOutputModule.h
+++ b/IOPool/Output/interface/TimeoutPoolOutputModule.h
@@ -3,7 +3,7 @@
 
 //////////////////////////////////////////////////////////////////////
 //
-// Class TimeoutPoolOutputModule. Output module to POOL file with file 
+// Class TimeoutPoolOutputModule. Output module to POOL file with file
 // closure based on timeout. First file has only one event, second
 // file is closed after 15 seconds if at least one event was processed.
 // Then timeout is increased to 30 seconds and 60 seconds. After that

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -45,4 +45,3 @@ namespace edm {
 } //end-of-namespace-def
 
 #endif
-


### PR DESCRIPTION
Fixed some clang compiler warnings.
Also replaced several uses of `boost::mpl::if_c` with `std::conditional`.