### PR TITLE
Phase2Digitizer package updated

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
@@ -14,60 +14,29 @@
 namespace DigitizerUtility {
   class Amplitude {
   public:
-    Amplitude() : _amp(0.0)
-    {}
-    Amplitude(float amp, float frac) :
-      _amp(amp), _frac(1, frac), _hitInfo() 
-    {
-      // in case of digi from noisypixels
-      // the MC information are removed
-      if (_frac[0] < -0.5)
-	_frac.pop_back();
+    Amplitude() : _amp(0.0) {}
+    Amplitude(float amp) : _amp(amp) {}
+    Amplitude( float amp, const PSimHit* hitp, size_t hitIndex, unsigned int tofBin, float frac) :
+      _amp(amp) {
+      if (frac > -0.5) _simInfoList.push_back({frac,new SimHitInfoForLinks(hitp,hitIndex,tofBin)});
     }
 
-    Amplitude( float amp, const PSimHit* hitp, size_t hitIndex, unsigned int tofBin, float frac) :
-    _amp(amp), _frac(1, frac), _hitInfo(new SimHitInfoForLinks(hitp, hitIndex, tofBin)) {
-      // in case of digi from noisypixels
-      // the MC information are removed
-      if (_frac[0] < -0.5) {
-	_frac.pop_back();
-	_hitInfo->trackIds().pop_back();
-      }
+    Amplitude( float amp, float frac) :
+      _amp(amp) {
+      if (frac > -0.5) _simInfoList.push_back({frac,0});
     }
 
     // can be used as a float by convers.
     operator float() const {return _amp;}
     float ampl() const {return _amp;}
-    const std::vector<float>& individualampl() const {return _frac;}
-    const std::vector<unsigned int>& trackIds() const {return _hitInfo->trackIds();}
-    const std::shared_ptr<SimHitInfoForLinks>& hitInfo() const {return _hitInfo;}
+    const std::vector<std::pair<float,SimHitInfoForLinks*> >& simInfoList() const {return _simInfoList;}
 
     void operator+= (const Amplitude& other) {
       _amp += other._amp;
-
-      // in case of contribution of noise to the digi
-      // the MC information are removed
-      if (other._frac.size() > 0 && other._frac[0] > -0.5) {
-        if (other._hitInfo) {
-          const std::vector<unsigned int>& otherTrackIds = other._hitInfo->trackIds();
-          if (_hitInfo) {
-            std::vector<unsigned int>& trackIds = _hitInfo->trackIds();
-	    trackIds.insert(trackIds.end(), otherTrackIds.begin(), otherTrackIds.end());
-          } 
-	  else 
-            _hitInfo.reset(new SimHitInfoForLinks(*other._hitInfo));
-        }
-	_frac.insert(_frac.end(), other._frac.begin(), other._frac.end());
+      // in case of digi from the noise, the MC information need not be there
+      for (auto const & ic : other.simInfoList()) {
+	if (ic.first > -0.5) _simInfoList.push_back({ic.first, ic.second});
       }
-    }
-    const EncodedEventId& eventId() const {
-      return _hitInfo->eventId();
-    }
-    const unsigned int hitIndex() const {
-      return _hitInfo->hitIndex();
-    }
-    const unsigned int tofBin() const {
-      return _hitInfo->tofBin();
     }
     void operator+= (const float& amp) {
       _amp += amp;
@@ -81,8 +50,7 @@ namespace DigitizerUtility {
 
   private:
     float _amp;
-    std::vector<float> _frac;
-    std::shared_ptr<SimHitInfoForLinks> _hitInfo;
+    std::vector<std::pair<float,SimHitInfoForLinks*> > _simInfoList;
   };
 
   //*********************************************************
@@ -142,10 +110,7 @@ namespace DigitizerUtility {
   struct DigiSimInfo {
     int sig_tot;
     bool ot_bit;
-    std::map<unsigned int, float> track_map;
-    unsigned int hit_counter;
-    unsigned int tof_bin; 
-    EncodedEventId event_id;
+    std::vector<std::pair<float, SimHitInfoForLinks*> > simInfoList;
   };
 }
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -584,7 +584,8 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(const PSimHit& hit,
   // Fill the global map with all hit pixels from this event
   for (auto const & hit_s : hit_signal) {
     int chan =  hit_s.first;
-    theSignal[chan] += (makeDigiSimLinks_ ? DigitizerUtility::Amplitude( hit_s.second, &hit, hitIndex, tofBin, hit_s.second) : DigitizerUtility::Amplitude( hit_s.second, hit_s.second) ) ;
+    theSignal[chan] += (makeDigiSimLinks_ ? DigitizerUtility::Amplitude( hit_s.second, &hit, hitIndex, tofBin, hit_s.second) 
+			                  : DigitizerUtility::Amplitude( hit_s.second, hit_s.second) ) ;
   }
 }
 // ======================================================================
@@ -636,10 +637,11 @@ void Phase2TrackerDigitizerAlgorithm::add_noise(const Phase2TrackerGeomDetUnit* 
     for (auto const & l : signalNew) {
       int chan = l.first;
       auto iter = theSignal.find(chan);
-      if (iter != theSignal.end())
+      if (iter != theSignal.end()) {
 	theSignal[chan] += l.second.ampl();
-      else 
-        theSignal.insert(std::pair<int,DigitizerUtility::Amplitude>(chan, DigitizerUtility::Amplitude(l.second.ampl(),-1.0)));
+      }  else {
+        theSignal.insert(std::pair<int,DigitizerUtility::Amplitude>(chan, DigitizerUtility::Amplitude(l.second.ampl(), -1.0)));
+      }
     } 
   } 
   if (!addNoisyPixels)  // Option to skip noise in non-hit pixels
@@ -909,7 +911,7 @@ void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* p
   auto it = _signal.find(detID);
   if (it == _signal.end()) return;
 
-  const signal_map_type& theSignal = _signal[detID]; // ** please check detID exists!!!
+  const signal_map_type& theSignal = _signal[detID];
 
 
   unsigned int Sub_detid = DetId(detID).subdetId();
@@ -927,9 +929,8 @@ void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* p
     theHIPThresholdInE = theHIPThresholdInE_Endcap;
   }
 
-
   if (addNoise) add_noise(pixdet, theThresholdInE/theNoiseInElectrons);  // generate noise
-
+  
   // Do only if needed
   if (AddPixelInefficiency && theSignal.size() > 0) {
     if (use_ineff_from_db_) 
@@ -944,27 +945,23 @@ void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* p
       module_killing_conf(detID);
   }
 
-  // DDigitize if the signal is greater than threshold
+  // Digitize if the signal is greater than threshold
   for (auto const & s : theSignal) {
     DigitizerUtility::Amplitude sig_data = s.second;  
     float signalInElectrons  = sig_data.ampl();
     int adc;
     if (signalInElectrons >= theThresholdInE) { // check threshold
-
       if (doDigitalReadout) adc = theAdcFullScale;
       else adc = std::min( int(signalInElectrons / theElectronPerADC), theAdcFullScale );
-
       DigitizerUtility::DigiSimInfo info;
       info.sig_tot     = adc;
       info.ot_bit      = ( signalInElectrons  > theHIPThresholdInE ? true : false);
-      if (makeDigiSimLinks_ && sig_data.hitInfo() != 0) {
-	info.hit_counter = sig_data.hitIndex();
-	info.tof_bin     = sig_data.tofBin();
-	info.event_id    = sig_data.eventId();
-	for (unsigned int j = 0; j != sig_data.trackIds().size(); ++j) {
-	  unsigned int tkid = sig_data.trackIds()[j];
-	  float  charge_frac = sig_data.individualampl()[j]/adc;
-	  info.track_map.insert({tkid, charge_frac});
+      if (makeDigiSimLinks_ ) {
+        int j = 0;
+	for (auto l : sig_data.simInfoList()) {
+          j++;
+	  float  charge_frac = l.first/signalInElectrons;
+          if (l.first > -5.0)  info.simInfoList.push_back({charge_frac,l.second});
 	}
       }
       digi_map.insert({s.first, info});

--- a/SimTracker/SiPhase2Digitizer/python/Phase2TrackerMonitorDigi_cff.py
+++ b/SimTracker/SiPhase2Digitizer/python/Phase2TrackerMonitorDigi_cff.py
@@ -5,6 +5,13 @@ from SimTracker.SiPhase2Digitizer.Phase2TrackerMonitorDigi_cfi import *
 pixDigiMon = digiMon.clone()
 pixDigiMon.PixelPlotFillingFlag = cms.bool(True)
 pixDigiMon.TopFolderName = cms.string("Ph2TkPixelDigi")
+pixDigiMon.PositionOfPixDigisH = cms.PSet(
+    Nxbins = cms.int32(1350),
+    xmin   = cms.double(0.5),
+    xmax   = cms.double(1350.5),
+    Nybins = cms.int32(450),
+    ymin   = cms.double(0.5),
+    ymax   = cms.double(450.5))
 
 otDigiMon = digiMon.clone()
 otDigiMon.PixelPlotFillingFlag = cms.bool(False)

--- a/SimTracker/SiPhase2Digitizer/python/Phase2TrackerMonitorDigi_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/Phase2TrackerMonitorDigi_cfi.py
@@ -23,18 +23,28 @@ digiMon = cms.EDAnalyzer("Phase2TrackerMonitorDigi",
            xmax = cms.double(0.005)
     ),
     PositionOfDigisH = cms.PSet(
-           Nxbins = cms.int32(260),
+           Nxbins = cms.int32(1016),
            xmin   = cms.double(0.5),
-           xmax   = cms.double(260.5),
-           Nybins = cms.int32(2),
+           xmax   = cms.double(1016.5),
+           Nybins = cms.int32(10),
            ymin   = cms.double(0.5),
-           ymax   = cms.double(2.5)
+           ymax   = cms.double(10.5)
     ),
     DigiChargeH = cms.PSet(
       Nbins = cms.int32(261),
       xmin   = cms.double(0.5),
       xmax   = cms.double(260.5)
     ), 
+    TotalNumberOfDigisPerLayerH = cms.PSet(
+      Nbins = cms.int32(1000),
+      xmin   = cms.double(-0.5),
+      xmax   = cms.double(999.5)
+    ),
+    NumberOfHitDetsPerLayerH = cms.PSet(
+      Nbins = cms.int32(200),
+      xmin   = cms.double(-0.5),
+      xmax   = cms.double(199.5)
+    ),
     NumberOfClustersH = cms.PSet(
            Nbins = cms.int32(51),
            xmin = cms.double(-0.5),

--- a/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
@@ -31,9 +31,9 @@ digiValid = cms.EDAnalyzer("Phase2TrackerValidateDigi",
         xmax   = cms.double(100.0)
     ),
     TrackEtaH = cms.PSet(
-        Nbins  = cms.int32(35),
-        xmin   = cms.double(-3.5),
-        xmax   = cms.double(3.5),
+        Nbins  = cms.int32(45),
+        xmin   = cms.double(-4.5),
+        xmax   = cms.double(4.5)
     ),
     TrackPhiH = cms.PSet(
         Nbins  = cms.int32(64),
@@ -45,13 +45,28 @@ digiValid = cms.EDAnalyzer("Phase2TrackerValidateDigi",
         xmin   = cms.double(0.0),
         xmax   = cms.double(100000.0)
     ),  
+    SimHitDxH = cms.PSet(
+        Nbins  = cms.int32(1000),
+        xmin   = cms.double(0.0),
+        xmax   = cms.double(0.1)
+    ),
+    SimHitDyH = cms.PSet(
+        Nbins  = cms.int32(1000),
+        xmin   = cms.double(0.0),
+        xmax   = cms.double(0.1)
+    ),
+    SimHitDzH = cms.PSet(
+        Nbins  = cms.int32(150),
+        xmin   = cms.double(0.0),
+        xmax   = cms.double(0.03)
+    ),
     XYPositionMapH = cms.PSet(
-           Nxbins = cms.int32(1200),
-           xmin   = cms.double(-120.),
-           xmax   = cms.double(120.),
-           Nybins = cms.int32(1200),
-           ymin   = cms.double(-120.),
-           ymax   = cms.double(120.)
+        Nxbins = cms.int32(1200),
+        xmin   = cms.double(-120.),
+        xmax   = cms.double(120.),
+        Nybins = cms.int32(1200),
+        ymin   = cms.double(-120.),
+        ymax   = cms.double(120.)
     ),
     RZPositionMapH = cms.PSet(
            Nxbins = cms.int32(3000),
@@ -60,5 +75,37 @@ digiValid = cms.EDAnalyzer("Phase2TrackerValidateDigi",
            Nybins = cms.int32(1200),
            ymin   = cms.double(0.),
            ymax   = cms.double(120.)
+    ),
+   TOFEtaMapH = cms.PSet(
+           Nxbins = cms.int32(45),
+           xmin   = cms.double(-4.5),
+           xmax   = cms.double(4.5),
+           Nybins = cms.int32(200),
+           ymin   = cms.double(0.),
+           ymax   = cms.double(40.)
+    ),
+   TOFPhiMapH = cms.PSet(
+           Nxbins = cms.int32(64),
+           xmin   = cms.double(-3.2),
+           xmax   = cms.double(3.2),
+           Nybins = cms.int32(200),
+           ymin   = cms.double(0.),
+           ymax   = cms.double(40.)
+    ),
+   TOFZMapH = cms.PSet(
+           Nxbins = cms.int32(3000),
+           xmin   = cms.double(-300.),
+           xmax   = cms.double(300.),
+           Nybins = cms.int32(200),
+           ymin   = cms.double(0.),
+           ymax   = cms.double(40.)
+    ),
+    TOFRMapH = cms.PSet(
+           Nxbins = cms.int32(1200),
+           xmin   = cms.double(0.),
+           xmax   = cms.double(120.),
+           Nybins = cms.int32(200),
+           ymin   = cms.double(0.),
+           ymax   = cms.double(40.)
     )
 )

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
@@ -120,7 +120,10 @@ void Phase2TrackerMonitorDigi::fillITPixelDigiHistos(const edm::Handle<edm::DetS
     int nColumns  = tkDetUnit->specificTopology().ncolumns();
     if (nRows*nColumns == 0) continue;  
 
-    DigiMEs local_mes = pos->second;
+    DigiMEs& local_mes = pos->second;
+
+    local_mes.nHitDetsPerLayer++;
+
     int nDigi = 0; 
     int row_last = -1;
     int col_last = -1;
@@ -130,6 +133,7 @@ void Phase2TrackerMonitorDigi::fillITPixelDigiHistos(const edm::Handle<edm::DetS
     for (typename edm::DetSet< PixelDigi >::const_iterator di = DSViter->begin(); di != DSViter->end(); di++) {
       int col = di->column(); // column
       int row = di->row();    // row
+      int adc = di->adc();    // digi charge 
       if (geomDet) {
         MeasurementPoint mp( row + 0.5, col + 0.5 );
         GlobalPoint pdPos = geomDet->surface().toGlobal( gDetUnit->topology().localPosition( mp ) ) ;
@@ -140,7 +144,7 @@ void Phase2TrackerMonitorDigi::fillITPixelDigiHistos(const edm::Handle<edm::DetS
       edm::LogInfo("Phase2TrackerMonitorDigi")<< "  column " << col << " row " << row  <<
         std::dec  << std::endl;
       local_mes.PositionOfDigis->Fill(row+1, col+1);
-
+      if (local_mes.ChargeOfDigis) local_mes.ChargeOfDigis->Fill(adc);
       if (row_last == -1 ) {
         position = row+1;
         nclus++; 
@@ -163,15 +167,24 @@ void Phase2TrackerMonitorDigi::fillITPixelDigiHistos(const edm::Handle<edm::DetS
     }
     local_mes.NumberOfClusters->Fill(nclus);  
     local_mes.NumberOfDigis->Fill(nDigi);
+    local_mes.nDigiPerLayer += nDigi;
     float occupancy = 1.0;
     if (nRows*nColumns > 0) occupancy = nDigi*1.0/(nRows*nColumns);
     if (geomDet) {
       GlobalPoint gp = geomDet->surface().toGlobal( gDetUnit->topology().localPosition( MeasurementPoint(0.0,0.0))) ;
       XYOccupancyMap->Fill(gp.x(), gp.y(), occupancy);
-      RZOccupancyMap->Fill(gp.z(), gp.z(), std::hypot(gp.x(),gp.y()), occupancy);  
+      RZOccupancyMap->Fill(gp.z(), std::hypot(gp.x(),gp.y()), occupancy);  
       local_mes.EtaOccupancyProfP->Fill(gp.eta(), occupancy);
     }
     local_mes.DigiOccupancyP->Fill(occupancy);
+  }
+  // Fill histograms after loop over digis are complete
+  for (auto & ilayer : layerMEs) {
+    DigiMEs& local_mes = ilayer.second;
+    local_mes.TotalNumberOfDigis->Fill(local_mes.nDigiPerLayer);
+    local_mes.NumberOfHitDetectors->Fill(local_mes.nHitDetsPerLayer);
+    local_mes.nDigiPerLayer = 0;
+    local_mes.nHitDetsPerLayer = 0;
   }
 }
 void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVector<Phase2TrackerDigi>>  handle, const edm::ESHandle<TrackerGeometry> gHandle) {
@@ -187,8 +200,9 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
     if (layer < 0) continue;
     std::map<uint32_t, DigiMEs >::iterator pos = layerMEs.find(layer);
     if (pos == layerMEs.end()) continue;
-    DigiMEs local_mes = pos->second;
+    DigiMEs& local_mes = pos->second;
 
+    local_mes.nHitDetsPerLayer++;
     if (DetId(detId).det() != DetId::Detector::Tracker) continue;
   
     const GeomDetUnit* gDetUnit = gHandle->idToDetUnit(detId);
@@ -246,6 +260,7 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
     }
     local_mes.NumberOfClusters->Fill(nclus);  
     local_mes.NumberOfDigis->Fill(nDigi);
+    local_mes.nDigiPerLayer += nDigi;
      
     if (nDigi) frac_ot /= nDigi;
     if (local_mes.FractionOfOTBits) local_mes.FractionOfOTBits->Fill(frac_ot);
@@ -254,7 +269,7 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
     if (geomDet) {
       GlobalPoint gp = geomDet->surface().toGlobal( gDetUnit->topology().localPosition( MeasurementPoint(0.0,0.0))) ;
       XYOccupancyMap->Fill(gp.x(), gp.y(), occupancy);
-      RZOccupancyMap->Fill(gp.z(), gp.z(), std::hypot(gp.x(),gp.y()), occupancy);  
+      RZOccupancyMap->Fill(gp.z(), std::hypot(gp.x(),gp.y()), occupancy);  
       if (nColumns > 2) {
 	if (local_mes.DigiOccupancyP) local_mes.DigiOccupancyP->Fill(occupancy);
 	if (local_mes.EtaOccupancyProfP) local_mes.EtaOccupancyProfP->Fill(gp.eta(), occupancy);
@@ -263,6 +278,14 @@ void Phase2TrackerMonitorDigi::fillOTDigiHistos(const edm::Handle<edm::DetSetVec
 	local_mes.EtaOccupancyProfS->Fill(gp.eta(), occupancy);
       }
     }
+  }
+  // Fill histograms after loop over digis are complete
+  for (auto & ilayer : layerMEs) {
+    DigiMEs& local_mes = ilayer.second;
+    local_mes.TotalNumberOfDigis->Fill(local_mes.nDigiPerLayer);
+    local_mes.NumberOfHitDetectors->Fill(local_mes.nHitDetsPerLayer);
+    local_mes.nDigiPerLayer = 0;
+    local_mes.nHitDetsPerLayer = 0;
   }
 }
 //
@@ -284,7 +307,7 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker & ibooker,
     iSetup.get<TrackerDigiGeometryRecord>().get(geomType_, geom_handle);
     for (auto const & det_u : geom_handle->detUnits()) {
       unsigned int detId_raw = det_u->geographicalId().rawId();
-      bookLayerHistos(ibooker,detId_raw, tTopo, pixelFlag_); 
+      bookLayerHistos(ibooker,detId_raw, tTopo); 
     }
   }
   ibooker.cd();
@@ -312,7 +335,7 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker & ibooker,
 					 ParametersOcc.getParameter<double>("xmax"));
 
   Parameters =  config_.getParameter<edm::ParameterSet>("RZPositionMapH");  
-  RZPositionMap = ibooker.book2D("DigiRPosVszPos","DigiRPosVsZPos",
+  RZPositionMap = ibooker.book2D("DigiRPosVsZPos","DigiRPosVsZPos",
 				 Parameters.getParameter<int32_t>("Nxbins"),
 				 Parameters.getParameter<double>("xmin"),
 				 Parameters.getParameter<double>("xmax"),
@@ -332,10 +355,11 @@ void Phase2TrackerMonitorDigi::bookHistograms(DQMStore::IBooker & ibooker,
 //
 // -- Book Layer Histograms
 //
-void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsigned int det_id, const TrackerTopology* tTopo, bool flag){ 
+void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsigned int det_id, const TrackerTopology* tTopo){ 
 
+  
   int layer;
-  if (flag) layer = tTopo->getITPixelLayerNumber(det_id);
+  if (pixelFlag_) layer = tTopo->getITPixelLayerNumber(det_id);
   else layer = tTopo->getOTLayerNumber(det_id);
 
   if (layer < 0) return;
@@ -344,6 +368,8 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 
     std::string top_folder = config_.getParameter<std::string>("TopFolderName");
     std::stringstream folder_name;
+
+    // initialise Histograms
 
     std::ostringstream fname1, fname2, tag;
     if (layer < 100) { 
@@ -365,9 +391,13 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
     std::ostringstream HistoName;
 
     DigiMEs local_mes;
+
+    local_mes.nDigiPerLayer = 0;
+    local_mes.nHitDetsPerLayer = 0;
+
     edm::ParameterSet Parameters =  config_.getParameter<edm::ParameterSet>("NumbeOfDigisH");
     HistoName.str("");
-    HistoName << "NumberOfDigis_" << fname2.str();
+    HistoName << "NumberOfDigisPerDet_" << fname2.str();
     local_mes.NumberOfDigis = ibooker.book1D(HistoName.str(), HistoName.str(),
 					     Parameters.getParameter<int32_t>("Nbins"),
 					     Parameters.getParameter<double>("xmin"),
@@ -381,24 +411,10 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 					     Parameters.getParameter<double>("xmin"),
 					     Parameters.getParameter<double>("xmax"));
     HistoName.str("");
-    HistoName << "DigiOcupancyVsEtaP_" << fname2.str();
+    HistoName << "DigiOccupancyVsEtaP_" << fname2.str();
     local_mes.EtaOccupancyProfP = ibooker.bookProfile(HistoName.str(), HistoName.str(),
-            35,-3.5,3.5,Parameters.getParameter<double>("xmin"),Parameters.getParameter<double>("xmax"),"");
+            45,-4.5,4.5,Parameters.getParameter<double>("xmin"),Parameters.getParameter<double>("xmax"),"");
 
-    if (!flag) {
-      Parameters =  config_.getParameter<edm::ParameterSet>("DigiOccupancySH");
-      HistoName.str("");
-      HistoName << "DigiOccupancyS_" << fname2.str();
-      local_mes.DigiOccupancyS = ibooker.book1D(HistoName.str(), HistoName.str(),
-						Parameters.getParameter<int32_t>("Nbins"),
-						Parameters.getParameter<double>("xmin"),
-						Parameters.getParameter<double>("xmax"));
-      
-      HistoName.str("");
-      HistoName << "DigiOcupancyVsEtaS_" << fname2.str();
-      local_mes.EtaOccupancyProfS = ibooker.bookProfile(HistoName.str(), HistoName.str(),
-		35,-3.5,3.5,Parameters.getParameter<double>("xmin"),Parameters.getParameter<double>("xmax"),"");
-    }
     Parameters =  config_.getParameter<edm::ParameterSet>("PositionOfDigisH");
     HistoName.str("");
     HistoName << "PositionOfDigis_" << fname2.str().c_str();
@@ -410,6 +426,23 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 					       Parameters.getParameter<double>("ymin"),
 					       Parameters.getParameter<double>("ymax"));
 
+    Parameters =  config_.getParameter<edm::ParameterSet>("TotalNumberOfDigisPerLayerH");
+    HistoName.str("");
+    HistoName << "TotalNumberOfDigis_" << fname2.str();
+    local_mes.TotalNumberOfDigis = ibooker.book1D(HistoName.str(), HistoName.str(),
+					     Parameters.getParameter<int32_t>("Nbins"),
+					     Parameters.getParameter<double>("xmin"),
+					     Parameters.getParameter<double>("xmax"));
+
+
+    Parameters =  config_.getParameter<edm::ParameterSet>("NumberOfHitDetsPerLayerH");
+    HistoName.str("");
+    HistoName << "NumberOfHitDetectors_" << fname2.str();
+    local_mes.NumberOfHitDetectors = ibooker.book1D(HistoName.str(), HistoName.str(),
+					     Parameters.getParameter<int32_t>("Nbins"),
+					     Parameters.getParameter<double>("xmin"),
+					     Parameters.getParameter<double>("xmax"));
+
     Parameters =  config_.getParameter<edm::ParameterSet>("NumberOfClustersH");
     HistoName.str("");
     HistoName << "NumberOfClusters_" << fname2.str();
@@ -417,6 +450,7 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 					     Parameters.getParameter<int32_t>("Nbins"),
 					     Parameters.getParameter<double>("xmin"),
 					     Parameters.getParameter<double>("xmax"));
+
     Parameters =  config_.getParameter<edm::ParameterSet>("ClusterWidthH");
     HistoName.str("");
     HistoName << "ClusterWidth_" << fname2.str();
@@ -433,9 +467,33 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 					     Parameters.getParameter<double>("xmax"));
    
     if (!pixelFlag_) {
+
+      Parameters =  config_.getParameter<edm::ParameterSet>("DigiOccupancySH");
+      HistoName.str("");
+      HistoName << "DigiOccupancyS_" << fname2.str();
+      local_mes.DigiOccupancyS = ibooker.book1D(HistoName.str(), HistoName.str(),
+						Parameters.getParameter<int32_t>("Nbins"),
+						Parameters.getParameter<double>("xmin"),
+						Parameters.getParameter<double>("xmax"));
+      
+      HistoName.str("");
+      HistoName << "DigiOcupancyVsEtaS_" << fname2.str();
+      local_mes.EtaOccupancyProfS = ibooker.bookProfile(HistoName.str(), HistoName.str(),
+	    45,-4.5,4.5,Parameters.getParameter<double>("xmin"),Parameters.getParameter<double>("xmax"),"");
+
       HistoName.str("");
       HistoName << "FractionOfOverThresholdDigis_" << fname2.str();
       local_mes.FractionOfOTBits= ibooker.book1D(HistoName.str(), HistoName.str(),11, -0.05, 1.05);
+
+    } else {
+
+      Parameters =  config_.getParameter<edm::ParameterSet>("DigiChargeH");
+      HistoName.str("");
+      HistoName << "ChargeOfDigis_" << fname2.str();   
+      local_mes.ChargeOfDigis = ibooker.book1D(HistoName.str(),HistoName.str(),
+					       Parameters.getParameter<int32_t>("Nbins"),
+					       Parameters.getParameter<double>("xmin"),
+					       Parameters.getParameter<double>("xmax"));
     }
 
     layerMEs.insert(std::make_pair(layer, local_mes)); 

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.h
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.h
@@ -34,12 +34,17 @@ public:
     MonitorElement* DigiOccupancyP;
     MonitorElement* DigiOccupancyS;
     MonitorElement* PositionOfDigis;
+    MonitorElement* ChargeOfDigis;
+    MonitorElement* TotalNumberOfDigis;
+    MonitorElement* NumberOfHitDetectors;
     MonitorElement* NumberOfClusters;
     MonitorElement* ClusterWidth;
     MonitorElement* ClusterPosition;
     MonitorElement* FractionOfOTBits;
     MonitorElement* EtaOccupancyProfP;
     MonitorElement* EtaOccupancyProfS;
+    unsigned int nDigiPerLayer; 
+    unsigned int nHitDetsPerLayer; 
   };
 
   MonitorElement* XYPositionMap;
@@ -48,7 +53,7 @@ public:
   MonitorElement* RZOccupancyMap;
 
 private:
-  void bookLayerHistos(DQMStore::IBooker & ibooker, unsigned int det_id, const TrackerTopology* tTopo, bool iflag); 
+  void bookLayerHistos(DQMStore::IBooker & ibooker, unsigned int det_id, const TrackerTopology* tTopo); 
   void fillITPixelDigiHistos(const edm::Handle<edm::DetSetVector<PixelDigi>>  handle, const edm::ESHandle<TrackerGeometry> gHandle);
   void fillOTDigiHistos(const edm::Handle<edm::DetSetVector<Phase2TrackerDigi>>  handle, const edm::ESHandle<TrackerGeometry> gHandle);
 

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.cc
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.cc
@@ -198,6 +198,15 @@ int Phase2TrackerValidateDigi::fillSimHitInfo(const edm::Event& iEvent, unsigned
       if (nColumns <= 2) local_mes.SimHitElossS->Fill((*isim).energyLoss()/GeVperElectron);
       else local_mes.SimHitElossP->Fill((*isim).energyLoss()/GeVperElectron);
       
+      local_mes.SimHitDx->Fill(std::fabs((*isim).entryPoint().x()-(*isim).exitPoint().x()));
+      local_mes.SimHitDy->Fill(std::fabs((*isim).entryPoint().y()-(*isim).exitPoint().y()));
+      local_mes.SimHitDz->Fill(std::fabs((*isim).entryPoint().z()-(*isim).exitPoint().z()));
+      
+      SimulatedTOFEtaMap->Fill(pdPos.eta(),(*isim).timeOfFlight());
+      SimulatedTOFPhiMap->Fill(pdPos.phi(),(*isim).timeOfFlight());
+      SimulatedTOFRMap->Fill(std::hypot(pdPos.x(),pdPos.y()),(*isim).timeOfFlight());
+      SimulatedTOFZMap->Fill(pdPos.z(),(*isim).timeOfFlight());
+
       if (fabs(eta) <  etaCut_) fillHistogram(local_mes.SimTrackPt, local_mes.SimTrackPtP, local_mes.SimTrackPtS, pt, type);
       if (pt > ptCut_) fillHistogram(local_mes.SimTrackEta, local_mes.SimTrackEtaP, local_mes.SimTrackEtaS, eta, type);
       if ( fabs(eta) < etaCut_ && pt > ptCut_) fillHistogram(local_mes.SimTrackPhi, local_mes.SimTrackPhiP, local_mes.SimTrackPhiS, phi, type);
@@ -370,6 +379,51 @@ void Phase2TrackerValidateDigi::bookHistograms(DQMStore::IBooker & ibooker,
 				 Parameters.getParameter<int32_t>("Nybins"),
 				 Parameters.getParameter<double>("ymin"),
 				 Parameters.getParameter<double>("ymax"));
+
+  //add TOF maps
+  Parameters =  config_.getParameter<edm::ParameterSet>("TOFEtaMapH");
+  HistoName.str("");
+  HistoName << "SimulatedTOFVsEta";
+  SimulatedTOFEtaMap = ibooker.book2D(HistoName.str(), HistoName.str(),
+					  Parameters.getParameter<int32_t>("Nxbins"),
+					  Parameters.getParameter<double>("xmin"),
+					  Parameters.getParameter<double>("xmax"),
+					  Parameters.getParameter<int32_t>("Nybins"),
+					  Parameters.getParameter<double>("ymin"),
+					  Parameters.getParameter<double>("ymax"));
+
+  Parameters =  config_.getParameter<edm::ParameterSet>("TOFPhiMapH");
+  HistoName.str("");
+  HistoName << "SimulatedTOFVsPhi";
+  SimulatedTOFPhiMap = ibooker.book2D(HistoName.str(), HistoName.str(),
+				      Parameters.getParameter<int32_t>("Nxbins"),
+				      Parameters.getParameter<double>("xmin"),
+				      Parameters.getParameter<double>("xmax"),
+				      Parameters.getParameter<int32_t>("Nybins"),
+				      Parameters.getParameter<double>("ymin"),
+				      Parameters.getParameter<double>("ymax"));
+  
+  Parameters =  config_.getParameter<edm::ParameterSet>("TOFRMapH");
+  HistoName.str("");
+  HistoName << "SimulatedTOFVsR";
+  SimulatedTOFRMap = ibooker.book2D(HistoName.str(), HistoName.str(),
+                                      Parameters.getParameter<int32_t>("Nxbins"),
+                                      Parameters.getParameter<double>("xmin"),
+                                      Parameters.getParameter<double>("xmax"),
+                                      Parameters.getParameter<int32_t>("Nybins"),
+                                      Parameters.getParameter<double>("ymin"),
+                                      Parameters.getParameter<double>("ymax"));
+
+  Parameters =  config_.getParameter<edm::ParameterSet>("TOFZMapH");
+  HistoName.str("");
+  HistoName << "SimulatedTOFVsZ";
+  SimulatedTOFZMap = ibooker.book2D(HistoName.str(), HistoName.str(),
+                                      Parameters.getParameter<int32_t>("Nxbins"),
+                                      Parameters.getParameter<double>("xmin"),
+                                      Parameters.getParameter<double>("xmax"),
+                                      Parameters.getParameter<int32_t>("Nybins"),
+                                      Parameters.getParameter<double>("ymin"),
+                                      Parameters.getParameter<double>("ymax"));
 
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
 
@@ -580,6 +634,31 @@ void Phase2TrackerValidateDigi::bookLayerHistos(DQMStore::IBooker & ibooker, uns
 						Parameters.getParameter<int32_t>("Nbins"),
 						Parameters.getParameter<double>("xmin"),
 						Parameters.getParameter<double>("xmax"));
+
+    Parameters =  config_.getParameter<edm::ParameterSet>("SimHitDxH");
+    HistoName.str("");
+    HistoName << "SimHitDx_" << fname2.str();
+    local_mes.SimHitDx = ibooker.book1D(HistoName.str(),HistoName.str(),
+					Parameters.getParameter<int32_t>("Nbins"),
+					Parameters.getParameter<double>("xmin"),
+					Parameters.getParameter<double>("xmax"));
+    
+    Parameters =  config_.getParameter<edm::ParameterSet>("SimHitDyH");
+    HistoName.str("");
+    HistoName << "SimHitDy_" << fname2.str();
+    local_mes.SimHitDy = ibooker.book1D(HistoName.str(),HistoName.str(),
+					 Parameters.getParameter<int32_t>("Nbins"),
+					 Parameters.getParameter<double>("xmin"),
+					 Parameters.getParameter<double>("xmax"));
+
+    Parameters =  config_.getParameter<edm::ParameterSet>("SimHitDzH");
+    HistoName.str("");
+    HistoName << "SimHitDz_" << fname2.str();
+    local_mes.SimHitDz = ibooker.book1D(HistoName.str(),HistoName.str(),
+					 Parameters.getParameter<int32_t>("Nbins"),
+					 Parameters.getParameter<double>("xmin"),
+					 Parameters.getParameter<double>("xmax"));
+
     layerMEs.insert(std::make_pair(layer, local_mes)); 
   }  
 }

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.h
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.h
@@ -57,6 +57,9 @@ public:
     MonitorElement* MatchedTrackEtaS;
     MonitorElement* SimHitElossP;  
     MonitorElement* SimHitElossS;  
+    MonitorElement* SimHitDx;
+    MonitorElement* SimHitDy;
+    MonitorElement* SimHitDz;
   };
 
 private:
@@ -79,6 +82,11 @@ private:
    
   MonitorElement* MatchedXYPositionMap;
   MonitorElement* MatchedRZPositionMap;
+
+  MonitorElement* SimulatedTOFEtaMap;
+  MonitorElement* SimulatedTOFPhiMap;
+  MonitorElement* SimulatedTOFRMap;
+  MonitorElement* SimulatedTOFZMap;
 
   float etaCut_;
   float ptCut_;


### PR DESCRIPTION
Updated DigitizerUtility::Amplitude object to store the EncodedEventId properly for individual SimHit contributions to the Digi. There was a subtle bug that only the first EncodedEventId was stored. Another bug has also been fixed where the fraction of individual contribution to the digi was calculated wrongly. A few new histograms are added in the validation suite and a few minor bugs corrected.

Detailed description of the update reported in Tracker Phase2 Simulation meeting can be found here
https://indico.cern.ch/event/536892/contributions/2385404/attachments/1379749/2096939/DigiStudy_Status_Nov29_2016.pdf

@delaere @atricomi @boudoul @emiglior 