### PR TITLE
Ignore track<->vertex links for non-generalTracks input in TrackingNtuple

### DIFF
--- a/Validation/RecoTrack/README.md
+++ b/Validation/RecoTrack/README.md
@@ -99,3 +99,10 @@ cases where a track is matched to TrackingParticle (by
 `QuickTrackAssociatorByHits`), but redoing the association by hits in
 the ntuple fails, because delta ray SimHit induced a RecHit that was
 included in the track.
+
+#### Vertex <-> track links
+
+If the input track collection is different from the one used for
+vertex reconstruction, the vertex <-> track links are not created.
+Possible use case is making ntuple of the tracks from a single
+iteration (without going through `generalTracks`).

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -369,7 +369,8 @@ private:
                              const std::vector<TPHitIndex>& tpHitList
                              );
 
-  void fillVertices(const reco::VertexCollection& vertices);
+  void fillVertices(const reco::VertexCollection& vertices,
+                    const edm::RefToBaseVector<reco::Track>& tracks);
 
   void fillTrackingVertices(const TrackingVertexRefVector& trackingVertices,
                             const TrackingParticleRefKeyToIndex& tpKeyToIndex
@@ -1357,7 +1358,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   // vertices
   edm::Handle<reco::VertexCollection> vertices;
   iEvent.getByToken(vertexToken_, vertices);
-  fillVertices(*vertices);
+  fillVertices(*vertices, trackRefs);
 
   // tracking vertices
   fillTrackingVertices(tvRefs, tpKeyToIndex);
@@ -2286,7 +2287,8 @@ void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::
   }
 }
 
-void TrackingNtuple::fillVertices(const reco::VertexCollection& vertices) {
+void TrackingNtuple::fillVertices(const reco::VertexCollection& vertices,
+                                  const edm::RefToBaseVector<reco::Track>& tracks) {
   for(size_t iVertex=0, size=vertices.size(); iVertex<size; ++iVertex) {
     const reco::Vertex& vertex = vertices[iVertex];
     vtx_x.push_back(vertex.x());
@@ -2302,6 +2304,10 @@ void TrackingNtuple::fillVertices(const reco::VertexCollection& vertices) {
 
     std::vector<int> trkIdx;
     for(auto iTrack = vertex.tracks_begin(); iTrack != vertex.tracks_end(); ++iTrack) {
+      // Ignore link if vertex was fit from a track collection different from the input
+      if(iTrack->id() != tracks.id())
+        continue;
+
       trkIdx.push_back(iTrack->key());
 
       if(trk_vtxIdx[iTrack->key()] != -1) {


### PR DESCRIPTION
This PR disables the creation of track<->vertex links in TrackingNtuple if the input track collection is different from the ones used for vertex reconstruction (as in that case the links make no sense).

Use case: give tracks of a single iteration (or something else not derived from generalTracks) as an input.

Tested in 8_1_0_pre16, no effect on standard workflows.

@rovere @VinInn 