### PR TITLE
QuickTrackAssociatorByHitsProducer throws for missing ClusterTPAssociation input

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
@@ -168,14 +168,9 @@ QuickTrackAssociatorByHitsProducer::produce(edm::StreamID, edm::Event& iEvent, c
    if(useClusterTPAssociation_)  {
      edm::Handle<ClusterTPAssociation> clusterAssocHandle;
      iEvent.getByToken(cluster2TPToken_,clusterAssocHandle);
-
-     if(clusterAssocHandle.isValid()) {
-       clusterAssoc = clusterAssocHandle.product();
-     } else {
-       edm::LogInfo( "TrackAssociator" ) << "ClusterTPAssociation not found. Using DigiSimLink based associator";
-     }
+     clusterAssoc = clusterAssocHandle.product();
    }
-   if(not clusterAssoc) {
+   else {
      // If control got this far then either useClusterTPAssociation_ was false or getting the cluster
      // to TrackingParticle association from the event failed. Either way I need to create a hit associator.
      trackAssoc = std::make_unique<TrackerHitAssociator>(iEvent, trackerHitAssociatorConfig_);


### PR DESCRIPTION
The effectively-silent fallback has bitten me many times. I think it is a configuration error if `useClusterTPAssociation=True` and the `ClusterTPAssociation` collection is missing. In this case I'd prefer to fix my configuration instead of silently falling back to `TrackerHitAssociator` (not only the latter is slow, but apparently can give different results; I trust `ClusterTPAssociation` more).

Tested in CMSSW_9_0_X_2016-11-24-2300, no changes expected in standard workflows.

@rovere @VinInn 