### PR TITLE
use cern.ch/cmsbuild to provide data for davix http tests

### DIFF
--- a/Utilities/DavixAdaptor/test/davixread.cpp
+++ b/Utilities/DavixAdaptor/test/davixread.cpp
@@ -10,7 +10,7 @@ int main(int, char ** /*argv*/) try {
   IOSize size = 1024;
   char buf[size];
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://opendata.cern.ch/eos/opendata/cms/Run2011A/PhotonHad/AOD"
+      "http://cern.ch/cmsbuild/cms/Run2011A/PhotonHad/AOD"
       "/12Oct2013-v1/00000/024938EB-3445-E311-A72B-002590593920.root");
   assert(s);
 

--- a/Utilities/DavixAdaptor/test/davixreadfilenotfound.cpp
+++ b/Utilities/DavixAdaptor/test/davixreadfilenotfound.cpp
@@ -8,7 +8,7 @@ int main(int, char ** /*argv*/) try {
 
   char buf[1024];
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://opendata.cern.ch/eos/opendata/cms/mc/this/file/does/not/exist.root");
+      "http://cern.ch/cmsbuild/cms/mc/this/file/does/not/exist.root");
   assert(s);
 
   s->read(buf, sizeof(buf));

--- a/Utilities/DavixAdaptor/test/davixreadv.cpp
+++ b/Utilities/DavixAdaptor/test/davixreadv.cpp
@@ -7,7 +7,7 @@ int main(int, char ** /*argv*/) try {
   initTest();
 
   std::unique_ptr<Storage> s = StorageFactory::get()->open(
-      "http://opendata.cern.ch/eos/opendata/cms/Run2011A/PhotonHad/AOD"
+      "http://cern.ch/cmsbuild/cms/Run2011A/PhotonHad/AOD"
       "/12Oct2013-v1/00000/024938EB-3445-E311-A72B-002590593920.root");
   assert(s);
 


### PR DESCRIPTION
backport of #16827

