### PR TITLE
fix clang warnings about missing override keyword

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -21,16 +21,16 @@ public:
                         const std::string& decompressionFile="");
   virtual ~CaloTPGTranscoderULUT();
   virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, int fineGrain) const override;
-  virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
+  virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const override;
 
   virtual void rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
-				   unsigned int& et, bool& egVecto, bool& activity) const;
+				   unsigned int& et, bool& egVecto, bool& activity) const override;
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
-				   unsigned int& et) const;
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const;
-  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
+				   unsigned int& et) const override;
+  virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const override;
+  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const override;
   virtual bool HTvalid(const int ieta, const int iphi, const int version) const;
   virtual const std::vector<unsigned int> getCompressionLUT(const HcalTrigTowerDetId& id) const;
   virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&, int, int);

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -38,10 +38,10 @@ public:
   virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
   virtual void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
   virtual void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const override;
-  virtual void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const;
-  virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const;
-  virtual float getLUTPedestal(HcalDetId id) const;
-  virtual float getLUTGain(HcalDetId id) const;
+  virtual void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const override;
+  virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const override;
+  virtual float getLUTPedestal(HcalDetId id) const override;
+  virtual float getLUTGain(HcalDetId id) const override;
 
   void update(const HcalDbService& conditions);
   void update(const char* filename, bool appendMSB = false);

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
@@ -28,7 +28,7 @@ namespace pos{
     PixelCalibBase();
     virtual ~PixelCalibBase();
     virtual std::string mode() const {return mode_;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
+    virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
@@ -28,7 +28,7 @@ namespace pos{
     PixelCalibBase();
     virtual ~PixelCalibBase();
     virtual std::string mode() const {return mode_;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey key, 
+    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
@@ -156,7 +156,7 @@ namespace pos{
     const std::set <PixelModuleName>& moduleList() const {assert(rocAndModuleListsBuilt_); return modules_;}
     const std::set <PixelChannel>& channelList() const {assert( objectsDependingOnTheNameTranslationBuilt_ ); return channels_;}
 
-    std::string mode() const {return mode_;}
+    std::string mode() const override {return mode_;}
 
     bool singleROC() const {return singleROC_;}
 
@@ -172,22 +172,22 @@ namespace pos{
 
     friend std::ostream& pos::operator<<(std::ostream& s, const PixelCalibConfiguration& calib);
 
-    virtual void writeASCII(std::string dir="") const;
-    void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const {;}
+    virtual void writeASCII(std::string dir="") const override;
+    void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const override{;}
     virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,
 				  std::ofstream *out1 = NULL,
 				  std::ofstream *out2 = NULL
-				  ) const ;
+				  ) const override;
     virtual void writeXML(        std::ofstream *out,			                                    
 			   	  std::ofstream *out1 = NULL ,
-			   	  std::ofstream *out2 = NULL ) const ;
+			   	  std::ofstream *out2 = NULL ) const override;
     virtual void writeXMLTrailer( std::ofstream *out, 
 				  std::ofstream *out1 = NULL,
 				  std::ofstream *out2 = NULL
-				  ) const ;
+				  ) const override;
 
 
   private:

--- a/CalibFormats/SiPixelObjects/interface/PixelDelay25Calib.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelDelay25Calib.h
@@ -29,22 +29,22 @@ namespace pos{
     PixelDelay25Calib(std::vector<std::vector<std::string> > &);
     ~PixelDelay25Calib();
 
-    virtual void writeASCII(std::string dir="") const;
-    void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const {;}
+    virtual void writeASCII(std::string dir="") const override;
+    void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const override {;}
     virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,
 				  std::ofstream *out1 = NULL,
 				  std::ofstream *out2 = NULL
-				  ) const ;
+				  ) const override;
     virtual void writeXML( 	  std::ofstream *out,			     	   			    
 			   	  std::ofstream *out1 = NULL ,
-			   	  std::ofstream *out2 = NULL ) const ;
+			   	  std::ofstream *out2 = NULL ) const override;
     virtual void writeXMLTrailer( std::ofstream *out, 
 				  std::ofstream *out1 = NULL,
 				  std::ofstream *out2 = NULL
-				  ) const ;
+				  ) const override;
 
     std::set<std::string>& portcardList() {return portcardNames_;}
     bool allPortcards() {return allPortcards_;}

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -30,10 +30,10 @@ public:
   virtual ~FakeTTrig();
 
   // Operations
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup ) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
-  virtual void endJob();
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup)override {}
+  virtual void endJob() override;
 
   // TOF computation
   double tofComputation(const DTSuperLayer* superlayer);

--- a/Calibration/HcalCalibAlgos/plugins/AnalyzerMinbias.cc
+++ b/Calibration/HcalCalibAlgos/plugins/AnalyzerMinbias.cc
@@ -70,8 +70,8 @@ public:
   ~AnalyzerMinbias();
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void beginJob() ;
-  virtual void endJob() ;
+  virtual void beginJob() override;
+  virtual void endJob() override;
   
 private:
     

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
@@ -80,7 +80,7 @@ public:
 
 private:
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginJob() ;
+  virtual void beginJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);

--- a/Calibration/HcalCalibAlgos/test/RecAnalyzerMinbias.cc
+++ b/Calibration/HcalCalibAlgos/test/RecAnalyzerMinbias.cc
@@ -51,8 +51,8 @@ public:
 
 private:
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginJob() ;
-  virtual void endJob();
+  virtual void beginJob() override;
+  virtual void endJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
@@ -81,7 +81,7 @@ public:
 
 private:
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginJob() ;
+  virtual void beginJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);

--- a/Calibration/IsolatedParticles/plugins/StudyHLT.cc
+++ b/Calibration/IsolatedParticles/plugins/StudyHLT.cc
@@ -71,7 +71,7 @@ public:
 
 private:
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginJob() ;
+  virtual void beginJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);

--- a/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjetsXml.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjetsXml.cc
@@ -51,8 +51,8 @@ public:
 
 private:
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override {}
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
 
   // ----------member data ---------------------------
   std::string tagname_;

--- a/CommonTools/TriggerUtils/interface/CandidateTriggerObjectProducer.h
+++ b/CommonTools/TriggerUtils/interface/CandidateTriggerObjectProducer.h
@@ -28,9 +28,9 @@ class CandidateTriggerObjectProducer : public edm::EDProducer {
 
  private:
   virtual void beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
-  virtual void beginJob() {} ;
+  virtual void beginJob() override {} ;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() {} ;
+  virtual void endJob() override {} ;
 
   /// module config parameters
   edm::InputTag triggerResultsTag_;

--- a/CondTools/Hcal/interface/StreamOutFormatTarget.h
+++ b/CondTools/Hcal/interface/StreamOutFormatTarget.h
@@ -43,7 +43,7 @@ public:
 			    const XMLSize_t count,
 			    XMLFormatter* const  formatter) override;
 
-    virtual void flush();
+    virtual void flush() override;
 
 private:
     std::ostream* mStream;

--- a/DPGAnalysis/Skims/interface/CSCSkim.h
+++ b/DPGAnalysis/Skims/interface/CSCSkim.h
@@ -79,9 +79,9 @@ class CSCSkim : public edm::EDFilter {
   ~CSCSkim();
      
   // Analysis routines
-  virtual void beginJob() ;
+  virtual void beginJob() override;
   virtual bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override;
-  virtual void endJob() ;
+  virtual void endJob() override;
        
 protected:
        

--- a/DPGAnalysis/Skims/interface/EcalTangentFilter.h
+++ b/DPGAnalysis/Skims/interface/EcalTangentFilter.h
@@ -25,9 +25,9 @@ class EcalTangentFilter : public edm::EDFilter {
       ~EcalTangentFilter();
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override;
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override;
       
       // ----------member data ---------------------------
 		int fNgood, fNtot, fEvt;

--- a/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
+++ b/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
@@ -37,9 +37,9 @@ class MatchedProbeMaker : public edm::EDProducer
       ~MatchedProbeMaker();
       
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override;
       
       // ----------member data ---------------------------
       edm::InputTag m_candidateSource;

--- a/DPGAnalysis/Skims/interface/TagProbeMassEDMFilter.h
+++ b/DPGAnalysis/Skims/interface/TagProbeMassEDMFilter.h
@@ -42,9 +42,9 @@ class TagProbeMassEDMFilter : public edm::EDFilter
       ~TagProbeMassEDMFilter();
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override;
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override;
       
       // ----------member data ---------------------------
       std::string tpMapName;

--- a/DPGAnalysis/Skims/interface/TagProbeMassProducer.h
+++ b/DPGAnalysis/Skims/interface/TagProbeMassProducer.h
@@ -38,9 +38,9 @@ class TagProbeMassProducer : public edm::EDProducer
       ~TagProbeMassProducer();
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override;
 
       bool isPassingProbe (const unsigned int iprobe) const;
 

--- a/DPGAnalysis/Skims/interface/TriggerMatchProducer.h
+++ b/DPGAnalysis/Skims/interface/TriggerMatchProducer.h
@@ -28,9 +28,9 @@ class TriggerMatchProducer : public edm::EDProducer
 
  private:
   virtual void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
-  virtual void beginJob() ;
+  virtual void beginJob() override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override;
 
   // ----------member data --------------------------
     

--- a/DQM/DataScouting/plugins/RazorVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/RazorVarAnalyzer.h
@@ -12,7 +12,7 @@ class RazorVarAnalyzer : public ScoutingAnalyzerBase {
     explicit RazorVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~RazorVarAnalyzer() ;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    virtual void analyze( const edm::Event & , const edm::EventSetup &  );
+    virtual void analyze( const edm::Event & , const edm::EventSetup &  ) override;
   private: 
     edm::InputTag m_eleCollectionTag;    
     edm::InputTag m_jetCollectionTag;

--- a/DQM/EcalMonitorTasks/interface/LedTask.h
+++ b/DQM/EcalMonitorTasks/interface/LedTask.h
@@ -33,7 +33,7 @@ namespace ecaldqm {
 
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   private:
-    void setParams(edm::ParameterSet const&);
+    void setParams(edm::ParameterSet const&) override;
 
     std::map<int, unsigned> wlToME_;
 

--- a/DQM/L1TMonitor/interface/L1TCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTF.h
@@ -67,8 +67,8 @@ class L1TCSCTF : public thread_unsafe::DQMEDAnalyzer {
 
  protected:
   // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   //virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
 

--- a/DQM/L1TMonitor/interface/L1TGT.h
+++ b/DQM/L1TMonitor/interface/L1TGT.h
@@ -60,13 +60,13 @@ public:
 protected:
 
     //virtual void beginJob();
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
     virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     /// end section
-    virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
 
 private:

--- a/DQM/L1TMonitor/interface/L1TRate.h
+++ b/DQM/L1TMonitor/interface/L1TRate.h
@@ -63,7 +63,7 @@ class L1TRate : public DQMEDAnalyzer {
 
     virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
     virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
-    virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+    virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
   // Private methods
   private:

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -31,7 +31,7 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
     virtual ~L1TdeStage2CaloLayer1();
   
   protected:
-    void analyze(const edm::Event& e, const edm::EventSetup& c);
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
     virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
     virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;

--- a/DQM/RCTMonitor/interface/RCTMonitor.h
+++ b/DQM/RCTMonitor/interface/RCTMonitor.h
@@ -77,7 +77,7 @@ class RCTMonitor : public DQMEDAnalyzer {
   ~RCTMonitor();
   void bookHistograms(DQMStore::IBooker&, edm::Run const&,
                       edm::EventSetup const&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void FillRCT(const edm::Event&, const edm::EventSetup&);
 
  private:

--- a/DQM/SiStripMonitorCluster/interface/MonitorLTC.h
+++ b/DQM/SiStripMonitorCluster/interface/MonitorLTC.h
@@ -30,7 +30,7 @@ class MonitorLTC : public DQMEDAnalyzer {
    public:
       explicit MonitorLTC(const edm::ParameterSet&);
       ~MonitorLTC(){};
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
    private:
        DQMStore* dqmStore_;

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -40,9 +40,9 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
  public:
   explicit SiStripMonitorCluster(const edm::ParameterSet&);
   ~SiStripMonitorCluster();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) ;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   
   struct ModMEs{ // MEs for one single detector module
 

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorFilter.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorFilter.h
@@ -27,7 +27,7 @@ class SiStripMonitorFilter : public DQMEDAnalyzer {
       explicit SiStripMonitorFilter(const edm::ParameterSet&);
       ~SiStripMonitorFilter(){};
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
    private:

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
@@ -27,7 +27,7 @@ class SiStripMonitorHLT : public DQMEDAnalyzer {
       explicit SiStripMonitorHLT(const edm::ParameterSet&);
       ~SiStripMonitorHLT(){};
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
        void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
    private:

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
@@ -59,9 +59,9 @@ class SiStripMonitorPedestals : public DQMEDAnalyzer {
   ~SiStripMonitorPedestals();
   
   virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
-  virtual void endJob() ;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+  virtual void endJob();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
    
  private:

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -50,8 +50,8 @@ class SiStripMonitorQuality : public DQMEDAnalyzer {
   
   virtual void beginJob() ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
   virtual void endJob() ;
   
   

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -50,8 +50,8 @@ class SiStripMonitorRawData : public DQMEDAnalyzer {
   
   virtual void beginJob() ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
   virtual void endJob() ;
   
   

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -64,8 +64,8 @@ public:
   enum RecHitType { Single=0, Matched=1, Projected=2, Null=3};
   explicit SiStripMonitorTrack(const edm::ParameterSet&);
   ~SiStripMonitorTrack();
-  void dqmBeginRun(const edm::Run& run, const edm::EventSetup& es) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& run, const edm::EventSetup& es)  override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -39,8 +39,8 @@ class MonitorTrackResidualsBase : public DQMEDAnalyzer {
   // constructors and EDAnalyzer Methods
   explicit MonitorTrackResidualsBase(const edm::ParameterSet&);
   ~MonitorTrackResidualsBase();
-  void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) override ;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
  private:
 

--- a/DQM/TrackingMonitor/interface/LogMessageMonitor.h
+++ b/DQM/TrackingMonitor/interface/LogMessageMonitor.h
@@ -60,13 +60,13 @@ class LogMessageMonitor : public DQMEDAnalyzer {
 
    private:
   //      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() ;
 
   //      virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-      virtual void endRun(edm::Run const&, edm::EventSetup const&);
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+      virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
@@ -48,7 +48,7 @@ class TrackEfficiencyMonitor : public DQMEDAnalyzer {
       ~TrackEfficiencyMonitor();
       virtual void beginJob(void);
       virtual void endJob(void);
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -56,11 +56,11 @@ class TrackingMonitor : public DQMEDAnalyzer
 	virtual void setMaxMinBin(std::vector<double> & ,std::vector<double> &  ,std::vector<int> &  ,double, double, int, double, double, int);
 	virtual void setNclus(const edm::Event&, std::vector<int> & );
 
-        virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&  eSetup);
-        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+        virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&  eSetup) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 	void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 	//        virtual void beginRun(const edm::Run&, const edm::EventSetup&); 
-        virtual void endRun(const edm::Run&, const edm::EventSetup&);
+        virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
     private:
         void doProfileX(TH2 * th2, MonitorElement* me);

--- a/DQM/TrackingMonitor/interface/V0Monitor.h
+++ b/DQM/TrackingMonitor/interface/V0Monitor.h
@@ -48,7 +48,7 @@ protected:
   MonitorElement* bookHisto1D(DQMStore::IBooker & ibooker,std::string name, std::string title, std::string xaxis, std::string yaxis, MEbinning binning);
   MonitorElement* bookHisto2D(DQMStore::IBooker & ibooker,std::string name, std::string title, std::string xaxis, std::string yaxis, MEbinning xbinning, MEbinning ybinning);
   MonitorElement* bookProfile(DQMStore::IBooker & ibooker,std::string name, std::string title, std::string xaxis, std::string yaxis, MEbinning xbinning, MEbinning ybinning);
-  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
 
 private:
 

--- a/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
@@ -40,14 +40,14 @@ class dEdxAnalyzer : public DQMEDAnalyzer {
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   virtual void beginJob();
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   virtual void endJob() ;
 
   double mass(double P, double I);
   
   //  virtual void beginRun(const edm::Run&, const edm::EventSetup&); 
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   

--- a/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
@@ -39,10 +39,10 @@ class dEdxHitAnalyzer : public DQMEDAnalyzer {
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   double harmonic2(const reco::DeDxHitInfo* dedxHits);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &);
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   
  private:
   // ----------member data ---------------------------

--- a/DQM/TrackingMonitorSource/interface/StandaloneTrackMonitor.h
+++ b/DQM/TrackingMonitorSource/interface/StandaloneTrackMonitor.h
@@ -35,7 +35,7 @@ protected:
   void processHit(const TrackingRecHit& recHit, edm::EventSetup const& iSetup, const TrackerGeometry& tkGeom, double wfac=1);
   void processClusters(edm::Event const& iEvent, edm::EventSetup const& iSetup, const TrackerGeometry& tkGeom, double wfac=1);
   void addClusterToMap(uint32_t detid, const SiStripCluster* cluster);
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
 

--- a/DQM/TrackingMonitorSource/interface/TrackTypeMonitor.h
+++ b/DQM/TrackingMonitorSource/interface/TrackTypeMonitor.h
@@ -31,7 +31,7 @@ protected:
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
   void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
 

--- a/DQM/TrigXMonitor/interface/HLTScalers.h
+++ b/DQM/TrigXMonitor/interface/HLTScalers.h
@@ -68,16 +68,16 @@ class HLTScalers : public DQMEDAnalyzer {
   HLTScalers(const edm::ParameterSet &ps);
   virtual ~HLTScalers(){};
   void beginJob(void);
-  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c);
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
   void beginLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                            const edm::EventSetup &c);
-  void analyze(const edm::Event &e, const edm::EventSetup &c);
+                            const edm::EventSetup &c) override;
+  void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   /// DQM Client Diagnostic should be performed here:
   void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                          const edm::EventSetup &c);
-  void endRun(const edm::Run &run, const edm::EventSetup &c);
+                          const edm::EventSetup &c) override;
+  void endRun(const edm::Run &run, const edm::EventSetup &c) override;
 
  private:
   HLTConfigProvider hltConfig_;

--- a/DQM/TrigXMonitor/interface/HLTSeedL1LogicScalers.h
+++ b/DQM/TrigXMonitor/interface/HLTSeedL1LogicScalers.h
@@ -49,10 +49,10 @@ class HLTSeedL1LogicScalers : public DQMEDAnalyzer {
   ~HLTSeedL1LogicScalers();
 
  private:
-  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c);
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   bool analyzeL1GtUtils(const edm::Event&, const edm::EventSetup&,
                         const std::string&);

--- a/DQM/TrigXMonitor/interface/L1Scalers.h
+++ b/DQM/TrigXMonitor/interface/L1Scalers.h
@@ -20,10 +20,10 @@ class L1Scalers : public DQMEDAnalyzer {
   virtual ~L1Scalers(){};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
-  void analyze(const edm::Event &e, const edm::EventSetup &c);
+  void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   /// DQM Client Diagnostic should be performed here:
   void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                          const edm::EventSetup &c);
+                          const edm::EventSetup &c) override;
 
  private:
   int nev_;  // Number of events processed

--- a/DQM/TrigXMonitor/interface/L1TScalersSCAL.h
+++ b/DQM/TrigXMonitor/interface/L1TScalersSCAL.h
@@ -21,7 +21,7 @@ class L1TScalersSCAL : public DQMEDAnalyzer {
   virtual ~L1TScalersSCAL();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
  private:
   edm::EDGetTokenT<Level1TriggerScalersCollection> l1triggerscalers_;
   edm::EDGetTokenT<LumiScalersCollection> lumiscalers_;

--- a/DQMOffline/CalibCalo/interface/DQMSourceEleCalib.h
+++ b/DQMOffline/CalibCalo/interface/DQMSourceEleCalib.h
@@ -38,13 +38,13 @@ protected:
    
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) ;
+                            const edm::EventSetup& context)  override;
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
+                          const edm::EventSetup& c) override;
 
 
 private:

--- a/DQMOffline/CalibCalo/src/DQMHOAlCaRecoStream.h
+++ b/DQMOffline/CalibCalo/src/DQMHOAlCaRecoStream.h
@@ -15,7 +15,7 @@ class DQMHOAlCaRecoStream : public DQMEDAnalyzer {
    private:
 
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 

--- a/DQMOffline/CalibCalo/src/DQMHcalDiJetsAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalDiJetsAlCaReco.h
@@ -35,10 +35,10 @@ protected:
    
 
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) ;
+                            const edm::EventSetup& context) override ;
 
 private:
  

--- a/DQMOffline/CalibCalo/src/DQMHcalIsolatedBunchAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalIsolatedBunchAlCaReco.h
@@ -33,15 +33,15 @@ public:
 protected:
    
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) { }
+                            const edm::EventSetup& context) override { }
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c) { }
+                          const edm::EventSetup& c) override { }
 
-  void endRun(const edm::Run& r, const edm::EventSetup& c) { }
+  void endRun(const edm::Run& r, const edm::EventSetup& c) override { }
 
 private:
       

--- a/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
@@ -32,15 +32,15 @@ protected:
    
 //  void beginRun(const edm::Run& r, const edm::EventSetup& c);
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) ;
+                            const edm::EventSetup& context) override ;
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
+                          const edm::EventSetup& c) override;
 
-  void endRun(const edm::Run& r, const edm::EventSetup& c);
+  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 
 private:

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.h
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.h
@@ -54,15 +54,15 @@ protected:
 
 //  void beginRun(const edm::Run& r, const edm::EventSetup& c);
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) ;
+                            const edm::EventSetup& context)  override;
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
+                          const edm::EventSetup& c) override;
 
-  void endRun(const edm::Run& r, const edm::EventSetup& c);
+  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   void endJob();
 

--- a/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
@@ -25,13 +25,13 @@ class ElectronDqmAnalyzerBase : public DQMEDAnalyzer
     virtual ~ElectronDqmAnalyzerBase() ;
 
     // specific implementation of EDAnalyzer
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ) ; 
-    virtual void endLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) ; 
-	virtual void dqmBeginRun( edm::Run const & , edm::EventSetup const & ) ;
+    virtual void endRun( edm::Run const &, edm::EventSetup const & )  override; 
+    virtual void endLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) override ; 
+	virtual void dqmBeginRun( edm::Run const & , edm::EventSetup const & )  override;
     void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
     // interface to implement in derived classes
-    virtual void analyze( const edm::Event & e, const edm::EventSetup & c ) {}
+    virtual void analyze( const edm::Event & e, const edm::EventSetup & c ) override {}
 
     // utility methods
     bool finalStepDone() { return finalDone_ ; }

--- a/DQMOffline/EGamma/interface/ElectronDqmHarvesterBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmHarvesterBase.h
@@ -25,8 +25,8 @@ class ElectronDqmHarvesterBase : public DQMEDHarvester
     virtual ~ElectronDqmHarvesterBase() ;
 
     // specific implementation of EDAnalyzer
-    void beginJob() ; // prepare DQM, open input field if declared, and call book() below
-    void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+    void beginJob() override ; // prepare DQM, open input field if declared, and call book() below
+    void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
     void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
     // interface to implement in derived classes

--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.h
@@ -104,7 +104,7 @@ class PhotonAnalyzer : public DQMEDAnalyzer
   explicit PhotonAnalyzer( const edm::ParameterSet& );
   virtual ~PhotonAnalyzer();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;      
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
  
  private:
   void bookHistogramsForHistogramCounts(DQMStore::IBooker &);

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
@@ -81,7 +81,7 @@ class PiZeroAnalyzer : public DQMEDAnalyzer
   explicit PiZeroAnalyzer( const edm::ParameterSet& ) ;
   virtual ~PiZeroAnalyzer();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze( const edm::Event&, const edm::EventSetup& ) ;
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override ;
  
  private:
   void makePizero(const edm::EventSetup& es, const edm::Handle<EcalRecHitCollection> eb, const edm::Handle<EcalRecHitCollection> ee ); 

--- a/DQMOffline/EGamma/plugins/ZToMuMuGammaAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/ZToMuMuGammaAnalyzer.h
@@ -103,7 +103,7 @@ class ZToMuMuGammaAnalyzer : public DQMEDAnalyzer
   explicit ZToMuMuGammaAnalyzer(const edm::ParameterSet&);
   virtual ~ZToMuMuGammaAnalyzer();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;                                
-  virtual void analyze( const edm::Event&, const edm::EventSetup&);
+  virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
 
  private:
   edm::EDGetTokenT<std::vector<reco::Photon> > photon_token_;

--- a/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
+++ b/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
@@ -34,7 +34,7 @@ class CaloTowersAnalyzer : public DQMEDAnalyzer {
    CaloTowersAnalyzer(edm::ParameterSet const& conf);
   ~CaloTowersAnalyzer();
   
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+  virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
   virtual void beginJob() ;
   virtual void endJob() ;
   virtual void beginRun() ;

--- a/DQMOffline/Hcal/interface/CaloTowersDQMClient.h
+++ b/DQMOffline/Hcal/interface/CaloTowersDQMClient.h
@@ -54,9 +54,9 @@ class CaloTowersDQMClient : public DQMEDHarvester {
   explicit CaloTowersDQMClient(const edm::ParameterSet& );
   virtual ~CaloTowersDQMClient();
   
-  virtual void beginJob(void);
+  virtual void beginJob(void) override;
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
 
   int CaloTowersEndjob(const std::vector<MonitorElement*> &hcalMEs);
 

--- a/DQMOffline/Hcal/interface/HcalNoiseRates.h
+++ b/DQMOffline/Hcal/interface/HcalNoiseRates.h
@@ -50,7 +50,7 @@ class HcalNoiseRates : public DQMEDAnalyzer {
   
  private:
   virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endJob();
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/Hcal/interface/HcalNoiseRatesClient.h
+++ b/DQMOffline/Hcal/interface/HcalNoiseRatesClient.h
@@ -55,9 +55,9 @@ class HcalNoiseRatesClient : public DQMEDHarvester {
   explicit HcalNoiseRatesClient(const edm::ParameterSet& );
   virtual ~HcalNoiseRatesClient();
   
-  virtual void beginJob(void);
+  virtual void beginJob(void) override;
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
 
   int NoiseRatesEndjob(const std::vector<MonitorElement*> &hcalMEs);
 

--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -62,7 +62,7 @@ class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
   virtual void analyze(edm::Event const& ev, edm::EventSetup const& c) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   //virtual void beginRun(edm::Run const& run, edm::EventSetup const& c) override;
-  virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& c);
+  virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& c) override;
  private:
   
   virtual void fillRecHitsTmp(int subdet_, edm::Event const& ev);

--- a/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsDQMClient.h
@@ -68,8 +68,8 @@ class HcalRecHitsDQMClient : public DQMEDHarvester {
   explicit HcalRecHitsDQMClient(const edm::ParameterSet& );
   virtual ~HcalRecHitsDQMClient();
   
-  virtual void beginJob(void);
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginJob(void) override;
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   int HcalRecHitsEndjob(const std::vector<MonitorElement*> &hcalMEs);

--- a/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
+++ b/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
@@ -159,7 +159,7 @@ class BeamHaloAnalyzer: public DQMEDAnalyzer {
  private:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event& , const edm::EventSetup&);
+  virtual void analyze(const edm::Event& , const edm::EventSetup&) override;
 
   edm::InputTag IT_L1MuGMTReadout;
 

--- a/DQMOffline/JetMET/interface/CaloTowerAnalyzer.h
+++ b/DQMOffline/JetMET/interface/CaloTowerAnalyzer.h
@@ -26,7 +26,7 @@ public:
 
   explicit CaloTowerAnalyzer(const edm::ParameterSet&);
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void dqmbeginRun(const edm::Run& ,const edm::EventSetup&);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
@@ -85,7 +85,7 @@ public:
   ECALRecHitAnalyzer(const edm::ParameterSet&);
   //~ECALRecHitAnalyzer();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   //  virtual void beginJob(void) ;
   virtual void dqmbeginRun(const edm::Run&, const edm::EventSetup&) ;
 

--- a/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
@@ -28,11 +28,11 @@ class HCALRecHitAnalyzer: public DQMEDAnalyzer {
 
   explicit HCALRecHitAnalyzer(const edm::ParameterSet&);
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   //  virtual void beginJob(void);
   //  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) ;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override ;
  private:
 
 

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -94,14 +94,14 @@ class JetAnalyzer : public DQMEDAnalyzer {
 //  void beginJob(void);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// Get the analysis
- void analyze(const edm::Event&, const edm::EventSetup&);
+ void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 
   /// Initialize run-based parameters
-  void dqmBeginRun(const edm::Run&,  const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&,  const edm::EventSetup&) override;
 
   /// Finish up a run
-  void endRun(const edm::Run&,  const edm::EventSetup&);
+  void endRun(const edm::Run&,  const edm::EventSetup&) override;
 
 
  private:

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -108,13 +108,13 @@ class METAnalyzer : public DQMEDAnalyzer{
   //void bookMonitorElement(std::string, bool);
 
   /// Get the analysis
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   /// Initialize run-based parameters
-  void dqmBeginRun(const edm::Run&,  const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&,  const edm::EventSetup&) override;
 
   /// Finish up a run
-  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
+  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   //  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
   // Fill MonitorElements
   void fillMESet(const edm::Event&, std::string, const reco::MET&, const pat::MET&, const reco::PFMET&, const reco::CaloMET&, const reco::Candidate::PolarLorentzVector&, std::map<std::string,MonitorElement*>&,std::vector<bool>,std::vector<bool>);

--- a/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
+++ b/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
@@ -28,7 +28,7 @@ class SUSYDQMAnalyzer: public DQMEDAnalyzer {
   edm::ParameterSet iConfig;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event& , const edm::EventSetup&);
+  virtual void analyze(const edm::Event& , const edm::EventSetup&) override;
 
   edm::EDGetTokenT<reco::PFMETCollection> thePFMETCollectionToken;
   edm::EDGetTokenT<std::vector<reco::PFJet> > thePFJetCollectionToken;

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyMuons_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyMuons_Offline.h
@@ -117,16 +117,16 @@ class L1TEfficiencyMuons_Offline : public DQMEDAnalyzer {
 
     protected:
    // Luminosity Block
-        virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
+        virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
         virtual void dqmEndLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-        virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup);
+        virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
         virtual void bookControlHistos(DQMStore::IBooker &);
         virtual void bookEfficiencyHistos(DQMStore::IBooker &ibooker, int ptCut);
         virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& run, const edm::EventSetup& iSetup) override;
        //virtual void analyze (const edm::Event& e, const edm::EventSetup& c);
 
     private:
-        void analyze (const edm::Event& e, const edm::EventSetup& c);
+        void analyze (const edm::Event& e, const edm::EventSetup& c) override;
 
         // Helper Functions
         const reco::Vertex getPrimaryVertex(edm::Handle<reco::VertexCollection> & vertex,edm::Handle<reco::BeamSpot> & beamSpot);

--- a/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
@@ -59,12 +59,12 @@ public:
 
 protected:
 
-  void analyze (const edm::Event& e, const edm::EventSetup& c);      // Analyze
+  void analyze (const edm::Event& e, const edm::EventSetup& c) override;      // Analyze
   virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& run, const edm::EventSetup& iSetup) override;
 
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
 // Private methods
 //private:

--- a/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
@@ -107,9 +107,9 @@ class L1TSync_Offline : public DQMEDAnalyzer {
     
   protected:
 
-  void analyze (const edm::Event& e, const edm::EventSetup& c);  // Analyze
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void analyze (const edm::Event& e, const edm::EventSetup& c) override;  // Analyze
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
 // no lumi block //    virtual void endLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
 

--- a/DQMOffline/Muon/interface/CSCOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/CSCOfflineMonitor.h
@@ -81,7 +81,7 @@ public:
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
 private: 
 

--- a/DQMOffline/Muon/interface/DTSegmentsTask.h
+++ b/DQMOffline/Muon/interface/DTSegmentsTask.h
@@ -33,7 +33,7 @@ public:
   virtual ~DTSegmentsTask();
 
   /// book the histos
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 protected:

--- a/DQMOffline/Muon/interface/DiMuonHistograms.h
+++ b/DQMOffline/Muon/interface/DiMuonHistograms.h
@@ -39,7 +39,7 @@ class DiMuonHistograms : public DQMEDAnalyzer {
   virtual ~DiMuonHistograms() ;
   
   /* Operations */ 
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   
  private:

--- a/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
@@ -43,7 +43,7 @@ class EfficiencyAnalyzer : public DQMEDAnalyzer {
   virtual ~EfficiencyAnalyzer() ;
 
   /* Operations */ 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
@@ -39,7 +39,7 @@ class MuonEnergyDepositAnalyzer : public DQMEDAnalyzer{
   virtual ~MuonEnergyDepositAnalyzer();
   
   /* Operations */
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   
  private:

--- a/DQMOffline/Muon/interface/MuonIdDQM.h
+++ b/DQMOffline/Muon/interface/MuonIdDQM.h
@@ -53,7 +53,7 @@ class MuonIdDQM : public DQMEDAnalyzer {
       ~MuonIdDQM();
 
       /* Operations */
-      void analyze(const edm::Event&, const edm::EventSetup&);
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
    private:

--- a/DQMOffline/Muon/interface/MuonIsolationDQM.h
+++ b/DQMOffline/Muon/interface/MuonIsolationDQM.h
@@ -69,7 +69,7 @@ public:
   explicit MuonIsolationDQM(const edm::ParameterSet&);
   ~MuonIsolationDQM();
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
@@ -40,7 +40,7 @@ class MuonKinVsEtaAnalyzer : public DQMEDAnalyzer {
   /// Destructor
   ~MuonKinVsEtaAnalyzer();
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/DQMOffline/Muon/interface/MuonMiniAOD.h
+++ b/DQMOffline/Muon/interface/MuonMiniAOD.h
@@ -36,7 +36,7 @@ class MuonMiniAOD : public DQMEDAnalyzer {
   virtual ~MuonMiniAOD();
 
   /// Inizialize parameters for histo binning
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
  
 

--- a/DQMOffline/Muon/interface/MuonPFAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonPFAnalyzer.h
@@ -44,7 +44,7 @@ public:
   /// Destructor
   ~MuonPFAnalyzer();
 
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   
 private:

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -36,7 +36,7 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
   virtual ~MuonRecoAnalyzer();
 
   /// Inizialize parameters for histo binning
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
  
   //calculate residual & pull:

--- a/DQMOffline/Muon/interface/MuonRecoOneHLT.h
+++ b/DQMOffline/Muon/interface/MuonRecoOneHLT.h
@@ -53,7 +53,7 @@ class MuonRecoOneHLT : public DQMEDAnalyzer {
   /// Destructor
   ~MuonRecoOneHLT();
 
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
@@ -38,7 +38,7 @@ class MuonSeedsAnalyzer : public  DQMEDAnalyzer {
   /// Destructor
   virtual ~MuonSeedsAnalyzer();
 
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   
   private:

--- a/DQMOffline/Muon/interface/SegmentTrackAnalyzer.h
+++ b/DQMOffline/Muon/interface/SegmentTrackAnalyzer.h
@@ -41,7 +41,7 @@ class SegmentTrackAnalyzer : public DQMEDAnalyzer {
     delete theSegmentsAssociator;
   };
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/DQMOffline/PFTau/plugins/CandidateBenchmarkAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/CandidateBenchmarkAnalyzer.h
@@ -15,7 +15,7 @@ class CandidateBenchmarkAnalyzer: public BenchmarkAnalyzer, public CandidateBenc
   
   CandidateBenchmarkAnalyzer(const edm::ParameterSet& parameterSet);
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/METBenchmarkAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/METBenchmarkAnalyzer.h
@@ -14,7 +14,7 @@ class METBenchmarkAnalyzer: public BenchmarkAnalyzer, public METBenchmark {
   
   METBenchmarkAnalyzer(const edm::ParameterSet& parameterSet);
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h
@@ -13,7 +13,7 @@ class MatchMETBenchmarkAnalyzer: public BenchmarkAnalyzer, public MatchMETBenchm
   
   MatchMETBenchmarkAnalyzer(const edm::ParameterSet& parameterSet);
 
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginJob(){};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFCandidateBenchmarkAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFCandidateBenchmarkAnalyzer.h
@@ -14,7 +14,7 @@ class PFCandidateBenchmarkAnalyzer: public BenchmarkAnalyzer, public PFCandidate
   
   PFCandidateBenchmarkAnalyzer(const edm::ParameterSet& parameterSet);
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFCandidateDQMAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFCandidateDQMAnalyzer.h
@@ -18,7 +18,7 @@ class PFCandidateDQMAnalyzer: public DQMEDAnalyzer {
   PFCandidateDQMAnalyzer(const edm::ParameterSet& parameterSet);
   
  private:
-  void analyze(edm::Event const&, edm::EventSetup const&);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFCandidateManagerAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFCandidateManagerAnalyzer.h
@@ -14,7 +14,7 @@ class PFCandidateManagerAnalyzer: public BenchmarkAnalyzer, public PFCandidateMa
   
   PFCandidateManagerAnalyzer(const edm::ParameterSet& parameterSet);
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFJetDQMAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFJetDQMAnalyzer.h
@@ -18,7 +18,7 @@ class PFJetDQMAnalyzer: public DQMEDAnalyzer {
   PFJetDQMAnalyzer(const edm::ParameterSet& parameterSet);
   
  private:
-  void analyze(edm::Event const&, edm::EventSetup const&);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFMETDQMAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFMETDQMAnalyzer.h
@@ -18,7 +18,7 @@ class PFMETDQMAnalyzer: public DQMEDAnalyzer {
   PFMETDQMAnalyzer(const edm::ParameterSet& parameterSet);
   
  private:
-  void analyze(edm::Event const&, edm::EventSetup const&);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/PFTau/plugins/PFMuonDQMAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/PFMuonDQMAnalyzer.h
@@ -18,7 +18,7 @@ class PFMuonDQMAnalyzer: public DQMEDAnalyzer {
   PFMuonDQMAnalyzer(const edm::ParameterSet& parameterSet);
   
  private:
-  void analyze(edm::Event const&, edm::EventSetup const&);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
@@ -23,7 +23,7 @@ class BTagPerformanceAnalyzerOnData : public DQMEDAnalyzer {
 
       ~BTagPerformanceAnalyzerOnData();
 
-      virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+      virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 
    private:

--- a/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
@@ -50,7 +50,7 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
   ~BTVHLTOfflineSource();
 
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const & run, edm::EventSetup const & c) override;
   virtual void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override;
 

--- a/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
@@ -85,7 +85,7 @@ class EgHLTOfflineClient : public DQMEDHarvester {
   // virtual void beginJob();
   // virtual void analyze(const edm::Event&, const edm::EventSetup&); //dummy
   // virtual void endJob();
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
   // virtual void endRun(const edm::Run& run, const edm::EventSetup& c);
 
   // virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& context){}
@@ -93,7 +93,7 @@ class EgHLTOfflineClient : public DQMEDHarvester {
   // virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c);
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
   void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &,
-      edm::LuminosityBlock const &, edm::EventSetup const&); //performed in the endLumi
+      edm::LuminosityBlock const &, edm::EventSetup const&) override; //performed in the endLumi
 
   //at somepoint these all may migrate to a helper class
   void createN1EffHists(const std::string& filterName, const std::string& baseName,

--- a/DQMOffline/Trigger/interface/EventShapeDQM.h
+++ b/DQMOffline/Trigger/interface/EventShapeDQM.h
@@ -27,7 +27,7 @@ public:
 
 protected:
 	void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-	void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+	void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
 private:
 	edm::EDGetTokenT<edm::TriggerResults> triggerResults_;

--- a/DQMOffline/Trigger/interface/HeavyIonUCCDQM.h
+++ b/DQMOffline/Trigger/interface/HeavyIonUCCDQM.h
@@ -30,7 +30,7 @@ public:
 
 protected:
 	void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-	void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+	void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
 private:
 	edm::EDGetTokenT<edm::TriggerResults> triggerResults_;

--- a/DQMOffline/Trigger/interface/HotlineDQM.h
+++ b/DQMOffline/Trigger/interface/HotlineDQM.h
@@ -46,7 +46,7 @@ class HotlineDQM: public DQMEDAnalyzer{
 
   protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
   private:
   //variables from config file

--- a/DQMOffline/Trigger/interface/JetMETHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/JetMETHLTOfflineSource.h
@@ -70,7 +70,7 @@ class JetMETHLTOfflineSource : public DQMEDAnalyzer {
   ~JetMETHLTOfflineSource();
 
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const & run, edm::EventSetup const & c) override;
   virtual void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override;
 

--- a/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
@@ -260,8 +260,8 @@ class TopDiLeptonHLTOfflineDQM : public DQMEDAnalyzer  {
     }
 
     /// do this during the event loop
-    virtual void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c);
-    virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+    virtual void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
+    virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
     void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
 
   private:

--- a/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
@@ -238,8 +238,8 @@ class TopSingleLeptonHLTOfflineDQM : public DQMEDAnalyzer  {
     };
 
     /// do this during the event loop
-    virtual void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c);
-    virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
+    virtual void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
+    virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
     void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
 
   private:

--- a/DQMOffline/Trigger/src/HLTMuonCertSummary.cc
+++ b/DQMOffline/Trigger/src/HLTMuonCertSummary.cc
@@ -63,7 +63,7 @@ class HLTMuonCertSummary : public DQMEDHarvester {
       ~HLTMuonCertSummary();
 
 
-      virtual void beginJob();
+      virtual void beginJob() override;
       virtual void beginRun(const edm::Run&, const edm::EventSetup&) override ;
       virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override ;
 

--- a/DQMServices/Components/src/DQMDcsInfo.h
+++ b/DQMServices/Components/src/DQMDcsInfo.h
@@ -35,9 +35,9 @@ public:
 protected:
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
+  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
 
 private:
 

--- a/DQMServices/Components/src/DQMEventInfo.h
+++ b/DQMServices/Components/src/DQMEventInfo.h
@@ -42,9 +42,9 @@ public:
 protected:
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
+  void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
 
 private:
 

--- a/DQMServices/Components/src/DQMProvInfo.h
+++ b/DQMServices/Components/src/DQMProvInfo.h
@@ -28,13 +28,13 @@ class DQMProvInfo : public DQMEDAnalyzer {
   virtual ~DQMProvInfo();
 
  protected:
-  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) ;
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void beginLuminosityBlock(const edm::LuminosityBlock& l,
-                            const edm::EventSetup& c);
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+                            const edm::EventSetup& c) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void endLuminosityBlock(const edm::LuminosityBlock& l,
-                          const edm::EventSetup& c);
+                          const edm::EventSetup& c) override;
 
  private:
   void bookHistogramsLhcInfo(DQMStore::IBooker &);

--- a/DQMServices/Components/src/DQMScalInfo.h
+++ b/DQMServices/Components/src/DQMScalInfo.h
@@ -43,7 +43,7 @@ public:
 protected:
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
@@ -147,14 +147,14 @@ class DummyBookFillDQMStoreMultiThread :  public DQMEDAnalyzer {
 
  private:
   virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endJob();
 
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&,
-                                    edm::EventSetup const&);
+                                    edm::EventSetup const&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&,
-                                  edm::EventSetup const&);
+                                  edm::EventSetup const&) override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void fillerDispose();

--- a/DQMServices/Core/test/DQMTestMultiThread.cc
+++ b/DQMServices/Core/test/DQMTestMultiThread.cc
@@ -14,7 +14,7 @@ class DQMTestMultiThread
  public:
   explicit DQMTestMultiThread(const edm::ParameterSet&);
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   virtual void bookHistograms(DQMStore::IBooker&,
                               edm::Run const &,

--- a/DQMServices/Examples/interface/DQMExample_Step1.h
+++ b/DQMServices/Examples/interface/DQMExample_Step1.h
@@ -56,10 +56,10 @@ protected:
 
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override ;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
   //histos booking function

--- a/DQMServices/Examples/interface/DQMExample_Step2.h
+++ b/DQMServices/Examples/interface/DQMExample_Step2.h
@@ -20,8 +20,8 @@ public:
   
 protected:
 
-  void beginJob();
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&);  //performed in the endLumi
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
 private:

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.h
@@ -62,7 +62,7 @@ class DQMFileSaverBase
   virtual void globalEndRun(const edm::Run &, const edm::EventSetup &) const override final;
 
   virtual void postForkReacquireResources(unsigned int childIndex,
-                                          unsigned int numberOfChildren);
+                                          unsigned int numberOfChildren) override;
 
   // these method (and only these) should be overriden
   // so we need to call all file savers

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -43,7 +43,7 @@ public:
 
       virtual void getThinnedProducts(edm::ProductID const& pid,
                                       std::vector<edm::WrapperBase const*>& foundContainers,
-                                      std::vector<unsigned int>& keys) const {
+                                      std::vector<unsigned int>& keys) const override {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
@@ -88,7 +88,7 @@ protected:
   virtual uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
-                                     const uint32_t eventId) const;
+                                     const uint32_t eventId) const override;
 
 
 private:

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.h
@@ -13,7 +13,7 @@ class HcalLaserEventFiltProducer2012 : public edm::EDProducer {
   virtual ~HcalLaserEventFiltProducer2012(){
     delete hcalLaserEventFilter2012;
 } 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
   virtual void endJob() override;

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTriggerMenuLiteProducer.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTriggerMenuLiteProducer.h
@@ -61,7 +61,7 @@ private:
 
     virtual void produce(edm::Event&, const edm::EventSetup&) override final;
 
-    virtual void endJob();
+    virtual void endJob() override;
 
 private:
     

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
@@ -31,7 +31,7 @@ public:
 
 
   /// dummy end of job 
-  virtual void endJob() {}
+  virtual void endJob() override {}
 
   /// get data, convert to raw event, attach again to Event
   virtual void produce( edm::Event&, const edm::EventSetup& ) override;

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -39,10 +39,10 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
   explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~RecoTrackAccumulator();
   
-  virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);
-  virtual void accumulate(edm::Event const& e, edm::EventSetup const& c);
+  virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
+  virtual void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
   virtual void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
-  virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c);
+  virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
 
   
  private:

--- a/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
@@ -46,7 +46,7 @@ public:
    virtual void buildViewType(const reco::GsfElectron& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type , const FWViewContext*) override;
 
    using FWSimpleProxyBuilderTemplate<reco::GsfElectron>::setItem;
-   virtual void setItem(const FWEventItem* iItem);
+   virtual void setItem(const FWEventItem* iItem) override;
 
    REGISTER_PROXYBUILDER_METHODS();
 

--- a/Fireworks/FWInterface/interface/FWFFLooper.h
+++ b/Fireworks/FWInterface/interface/FWFFLooper.h
@@ -53,7 +53,7 @@ public:
 
    // ---------- member functions ---------------------------
 
-   virtual void attachTo(edm::ActivityRegistry &);
+   virtual void attachTo(edm::ActivityRegistry &) override;
    void postBeginJob();
    void postEndJob();
 
@@ -64,13 +64,13 @@ public:
    TEveMagField* getMagField();
    void          setupFieldForPropagator(TEveTrackPropagator* prop);
 
-   virtual void checkPosition();
-   virtual void stopPlaying();
-   virtual void autoLoadNewEvent();
+   virtual void checkPosition() override;
+   virtual void stopPlaying() override ;
+   virtual void autoLoadNewEvent() override;
 
    void showPathsGUI(const TGWindow *p);
 
-   void quit();
+   void quit() override;
 
    virtual void startingNewLoop(unsigned int) override;
    virtual edm::EDLooperBase::Status endOfLoop(const edm::EventSetup&, unsigned int) override;

--- a/Fireworks/Muons/plugins/FWMuonProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonProxyBuilder.cc
@@ -23,7 +23,7 @@ public:
    FWMuonProxyBuilder( void ) {}
    virtual ~FWMuonProxyBuilder( void ) {}
 
-   virtual void setItem(const FWEventItem* iItem);
+   virtual void setItem(const FWEventItem* iItem) override;
 
    REGISTER_PROXYBUILDER_METHODS();
 

--- a/Fireworks/Muons/plugins/FWMuonRhoPhiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonRhoPhiProxyBuilder.cc
@@ -17,7 +17,7 @@ public:
    FWMuonRhoPhiProxyBuilder( void ) {}
    virtual ~FWMuonRhoPhiProxyBuilder( void ) {}
 
-   virtual void setItem(const FWEventItem* iItem);
+   virtual void setItem(const FWEventItem* iItem) override;
 
    REGISTER_PROXYBUILDER_METHODS();
 

--- a/Fireworks/Tracks/plugins/FWSiStripClusterProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiStripClusterProxyBuilder.cc
@@ -23,7 +23,7 @@ public:
    REGISTER_PROXYBUILDER_METHODS();
 
     //    virtual void cleanLocal();
-   virtual void itemBeingDestroyed(const FWEventItem*);
+   virtual void itemBeingDestroyed(const FWEventItem*) override;
 
 protected:
    using FWProxyBuilderBase::build;

--- a/Fireworks/Tracks/plugins/FWTrackProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrackProxyBuilder.cc
@@ -31,7 +31,7 @@ public:
 
    REGISTER_PROXYBUILDER_METHODS();
   
-   virtual void setItem(const FWEventItem* iItem);
+   virtual void setItem(const FWEventItem* iItem) override;
 private:
    FWTrackProxyBuilder(const FWTrackProxyBuilder&); // stop default
 

--- a/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
@@ -89,8 +89,8 @@ namespace gen
   
     void SetVolEff(double value) {fVolEff = value;}
     double GetVolEff() {return fVolEff;}
-    virtual bool RunDecays() {return (fDecay>0 ? kTRUE : kFALSE);}
-    virtual double GetWeakDecayLimit() {return fWeakDecay;}  
+    virtual bool RunDecays() override {return (fDecay>0 ? kTRUE : kFALSE);}
+    virtual double GetWeakDecayLimit() override {return fWeakDecay;}  
 
     bool IniOfThFreezeoutParameters();
  

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -42,7 +42,7 @@ class LHERunInfoProduct;
 	virtual void readRun_(edm::RunPrincipal& runPrincipal) override;
 	virtual void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) override;
 	virtual void readEvent_(edm::EventPrincipal& eventPrincipal) override;
-        virtual void produce(edm::Event&) {}
+        virtual void produce(edm::Event&) override {}
 
 	void nextEvent();
 

--- a/GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h
+++ b/GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h
@@ -43,7 +43,7 @@ namespace gen
     bool initializeForInternalPartons();
     bool declareStableParticles( const std::vector<int>& );
     bool declareSpecialSettings( const std::vector<std::string>& ) { return true; }
-    virtual bool select(HepMC::GenEvent* evtTry) const { return selector_->filter(evtTry); }
+    virtual bool select(HepMC::GenEvent* evtTry) const override { return selector_->filter(evtTry); }
     void finalizeEvent();
     void statistics();
     const char* classname() const;

--- a/GeneratorInterface/Pythia8Interface/interface/MultiUserHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/MultiUserHook.h
@@ -351,7 +351,7 @@ public:
   }
 
   // Possibility to veto an MPI.
-  bool canVetoMPIEmission() {
+  bool canVetoMPIEmission() override {
     bool test = false;
     for (Pythia8::UserHooks *hook : hooks_) {
       test |= hook->canVetoMPIEmission();

--- a/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
@@ -54,7 +54,7 @@ public:
   virtual void beginRun(edm::Run const&, edm::EventSetup const&){}
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {};
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {};
-  virtual void endRunProduce(edm::Run&, edm::EventSetup const&){};
+  virtual void endRunProduce(edm::Run&, edm::EventSetup const&) override{};
   virtual void produce( edm::Event&, const edm::EventSetup&) override final;
   virtual void beginJob() override final;
   virtual void endRun( const edm::Run&, const edm::EventSetup& ){};

--- a/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
+++ b/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
@@ -65,7 +65,7 @@ class IdealCastorTrapezoid: public CaloCellGeometry
       using CaloCellGeometry::vocalCorners;
       virtual void vocalCorners( Pt3DVec&        vec ,
 				 const CCGFloat* pv  ,
-				 Pt3D&           ref  ) const ;
+				 Pt3D&           ref  ) const override ;
 
       static void localCorners( Pt3DVec&        vec ,
 				const CCGFloat* pv  , 

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
@@ -15,9 +15,9 @@ class HLTDisplacedmumuFilter : public HLTFilter {
     explicit HLTDisplacedmumuFilter(const edm::ParameterSet&);
     ~HLTDisplacedmumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
-    virtual void beginJob() ;
+    virtual void beginJob() override ;
     virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() ;
+    virtual void endJob() override ;
 
   private:
     bool fastAccept_;

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
@@ -15,9 +15,9 @@ class HLTDisplacedmumumuFilter : public HLTFilter {
     explicit HLTDisplacedmumumuFilter(const edm::ParameterSet&);
     ~HLTDisplacedmumumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual void beginJob() ;
+    virtual void beginJob() override ;
     virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() ;
+    virtual void endJob() override ;
 
   private:
     bool fastAccept_;

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
@@ -15,9 +15,9 @@ class HLTDisplacedtktkFilter : public HLTFilter {
     explicit HLTDisplacedtktkFilter(const edm::ParameterSet&);
     ~HLTDisplacedtktkFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
-    virtual void beginJob() ;
+    virtual void beginJob() override ;
     virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() ;
+    virtual void endJob() override ;
 
   private:
     bool fastAccept_;

--- a/HLTrigger/btau/src/HLTmmkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkFilter.h
@@ -46,9 +46,9 @@ class HLTmmkFilter : public HLTFilter {
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
-  virtual void beginJob() ;
+  virtual void beginJob() override ;
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-  virtual void endJob();
+  virtual void endJob() override;
 
   static int overlap(const reco::Candidate&, const reco::Candidate&);
   static FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);

--- a/HLTrigger/btau/src/HLTmmkkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkkFilter.h
@@ -45,9 +45,9 @@ class HLTmmkkFilter : public HLTFilter {
   ~HLTmmkkFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
  private:
-  virtual void beginJob();
+  virtual void beginJob() override;
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-  virtual void endJob();
+  virtual void endJob() override;
 
   static int overlap(const reco::Candidate&, const reco::Candidate&);
   static FreeTrajectoryState initialFreeState(const reco::Track &, const MagneticField *);

--- a/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
+++ b/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
@@ -58,9 +58,9 @@ class HLTRPCTrigNoSyncFilter : public HLTFilter{
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override ;
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
       edm::InputTag m_GMTInputTag;
       edm::InputTag rpcRecHitsLabel;
       edm::EDGetTokenT<L1MuGMTReadoutCollection> m_GMTInputToken;

--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -43,10 +43,10 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 		public:
 			explicit HLTBTagPerformanceAnalyzer(const edm::ParameterSet&);
 			~HLTBTagPerformanceAnalyzer();
-			void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
+			void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 
 		private:
-			virtual void analyze(const edm::Event&, const edm::EventSetup&);
+			virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 			void bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & iRun,edm::EventSetup const &  iSetup ) override;
 
 		struct JetRefCompare :

--- a/HLTriggerOffline/Btag/interface/HLTVertexPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTVertexPerformanceAnalyzer.h
@@ -34,10 +34,10 @@ class HLTVertexPerformanceAnalyzer : public DQMEDAnalyzer {
 	public:
 		explicit HLTVertexPerformanceAnalyzer(const edm::ParameterSet&);
 		~HLTVertexPerformanceAnalyzer();
-			void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup);
+			void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 
 	private:
-		virtual void analyze(const edm::Event&, const edm::EventSetup&);
+		virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 		void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 		// variables from python configuration

--- a/HLTriggerOffline/Egamma/interface/EmDQM.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQM.h
@@ -75,13 +75,13 @@ public:
 
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup&);
+  void analyze(const edm::Event & event, const edm::EventSetup&) override;
   void beginJob();
   void endJob();
 
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void endRun(edm::Run const&, edm::EventSetup const&);
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
 
 private:
   // interface to DQM framework

--- a/HLTriggerOffline/Egamma/interface/EmDQMReco.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMReco.h
@@ -91,10 +91,10 @@ public:
 
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup&);
+  void analyze(const edm::Event & event, const edm::EventSetup&) override;
   void beginJob();
   void endJob();
-  void dqmBeginRun( const edm::Run&, const edm::EventSetup& );
+  void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
@@ -48,10 +48,10 @@ protected:
 private:
     virtual void beginJob();
     /// Method called by the framework just before dqmBeginRun()
-    virtual void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup & iSetup);
+    virtual void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup & iSetup) override;
     /// Method called for each event.
-    virtual void analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup);
-    virtual void endRun(const edm::Run & iRun, const edm::EventSetup & iSetup);
+    virtual void analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    virtual void endRun(const edm::Run & iRun, const edm::EventSetup & iSetup) override;
     virtual void endJob();
 
     /// Copy (to be modified) of the input ParameterSet from configuration file.

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -55,7 +55,7 @@ class HeavyFlavorValidation : public DQMEDAnalyzer {
     explicit HeavyFlavorValidation(const edm::ParameterSet&);
     ~HeavyFlavorValidation();
   protected:
-    void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+    void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   private:

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DiJet_MET.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DiJet_MET.h
@@ -45,10 +45,10 @@ class SUSY_HLT_DiJet_MET: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleEle_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleEle_Hadronic.h
@@ -41,10 +41,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleMuon_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleMuon_Hadronic.h
@@ -38,10 +38,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override ;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_ElecFakes.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_ElecFakes.h
@@ -45,10 +45,10 @@ class SUSY_HLT_ElecFakes: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Electron_BJet.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Electron_BJet.h
@@ -41,10 +41,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override ;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_InclusiveHT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_InclusiveHT.h
@@ -34,10 +34,10 @@ class SUSY_HLT_InclusiveHT: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuEle_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuEle_Hadronic.h
@@ -45,10 +45,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuonFakes.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuonFakes.h
@@ -45,10 +45,10 @@ class SUSY_HLT_MuonFakes: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_BJet.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_BJet.h
@@ -38,10 +38,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_Hadronic.h
@@ -45,10 +45,10 @@ class SUSY_HLT_Muon_Hadronic: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonHT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonHT.h
@@ -36,10 +36,10 @@ class SUSY_HLT_PhotonHT: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override ;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
@@ -36,10 +36,10 @@ public:
 protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Razor.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Razor.h
@@ -46,10 +46,10 @@ class SUSY_HLT_Razor: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
@@ -56,10 +56,10 @@ public:
 protected:
   void dqmBeginRun(const edm::Run &run, const edm::EventSetup &e) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup) ;
-  void analyze(const edm::Event &e, const edm::EventSetup &eSetup);
-  void endLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup);
-  void endRun(const edm::Run &run, const edm::EventSetup &eSetup);
+  void beginLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup)  override;
+  void analyze(const edm::Event &e, const edm::EventSetup &eSetup) override;
+  void endLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup) override;
+  void endRun(const edm::Run &run, const edm::EventSetup &eSetup) override;
 
 private:
   //variables from config file

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_VBF_Mu.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_VBF_Mu.h
@@ -45,10 +45,10 @@ public:
 protected:
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-    void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+    void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+    void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+    void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
     
 private:
     //histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
@@ -44,10 +44,10 @@ class SUSY_HLT_alphaT: public DQMEDAnalyzer{
   protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) ;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup)  override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
   private:
   //histos booking function

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -37,9 +37,9 @@ public:
 
   /// return a new event vertex
   //virtual CLHEP::Hep3Vector * newVertex();
-  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) ;
+  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) override ;
 
-  virtual TMatrixD* GetInvLorentzBoost();
+  virtual TMatrixD* GetInvLorentzBoost() override;
 
     
   /// set resolution in Z in cm

--- a/IOMC/EventVertexGenerators/test/BoostTester.h
+++ b/IOMC/EventVertexGenerators/test/BoostTester.h
@@ -22,8 +22,8 @@ class BoostTester : public edm::EDAnalyzer
       virtual ~BoostTester() {}
       
       virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
-      virtual void beginJob() ;
-      virtual void endJob() ;
+      virtual void beginJob() override ;
+      virtual void endJob() override ;
 
    private:
    

--- a/IOMC/EventVertexGenerators/test/VtxTester.h
+++ b/IOMC/EventVertexGenerators/test/VtxTester.h
@@ -18,8 +18,8 @@ class VtxTester : public edm::EDAnalyzer
       virtual ~VtxTester() {}
       
       virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
-      virtual void beginJob() ;
-      virtual void endJob() ;
+      virtual void beginJob() override ;
+      virtual void endJob() override ;
 
    private:
    

--- a/IOMC/ParticleGuns/interface/FlatEGunASCIIWriter.h
+++ b/IOMC/ParticleGuns/interface/FlatEGunASCIIWriter.h
@@ -44,7 +44,7 @@ namespace edm
      virtual ~FlatEGunASCIIWriter() ;
      
      virtual void analyze(  const edm::Event&, const edm::EventSetup&) override;
-	 virtual void beginJob() ;
+	 virtual void beginJob() override ;
 	 virtual void beginRun(const edm::Run&, const EventSetup&) override;
      
    private:

--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -33,7 +33,7 @@ namespace edm
       if(pr_.get() != nullptr) pr_->closeFile();
     }
 
-    virtual bool checkNextEvent();
+    virtual bool checkNextEvent() override;
 
     //ProductRegistry const* prod_reg_;
     edm::propagate_const<std::unique_ptr<Producer>> pr_;

--- a/L1Trigger/DTTrigger/interface/DTTrigProd.h
+++ b/L1Trigger/DTTrigger/interface/DTTrigProd.h
@@ -38,7 +38,7 @@ public:
   void beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
   
   //! Producer: process every event and generates trigger data
-  void produce(edm::Event & iEvent, const edm::EventSetup& iEventSetup);
+  void produce(edm::Event & iEvent, const edm::EventSetup& iEventSetup) override;
   
 private:
 

--- a/L1Trigger/HardwareValidation/interface/L1Comparator.h
+++ b/L1Trigger/HardwareValidation/interface/L1Comparator.h
@@ -47,10 +47,10 @@ public:
   
 private:
 
-  virtual void beginJob(void);
+  virtual void beginJob(void) override;
   virtual void beginRun(edm::Run const&, const edm::EventSetup&) override final;
-   virtual void produce (edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+   virtual void produce (edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
   template <class T> 
     void process( T const*, T const*, const int, const int);

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
@@ -75,8 +75,8 @@ private:
   
   //virtual void beginJob() ;
   virtual void beginRun(edm::Run const&, const edm::EventSetup&) override final;
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
   //...........................................................................
   

--- a/PhysicsTools/HepMCCandAlgos/interface/FlavorHistoryFilter.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/FlavorHistoryFilter.h
@@ -83,7 +83,7 @@ class FlavorHistoryFilter : public edm::EDFilter {
 
    private:
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
 
       // ----------member data ---------------------------
       edm::EDGetTokenT<reco::FlavorHistoryEvent>   bsrcToken_;           // Input b flavor history collection name

--- a/PhysicsTools/HepMCCandAlgos/interface/HFFilter.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/HFFilter.h
@@ -48,7 +48,7 @@ class HFFilter : public edm::EDFilter {
       ~HFFilter();
 
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
 
    private:
       // ----------member data ---------------------------

--- a/PhysicsTools/HepMCCandAlgos/interface/ModelFilter.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/ModelFilter.h
@@ -30,9 +30,9 @@ namespace edm {
 	typedef std::vector<std::string>::const_iterator comments_const_iterator;
 
   private:
-	virtual void beginJob() ;
+	virtual void beginJob() override ;
 	virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-	virtual void endJob() ;
+	virtual void endJob() override ;
 
 	edm::EDGetTokenT<LHEEventProduct> tokenSource_;
 	std::string modelTag_;

--- a/PhysicsTools/HepMCCandAlgos/test/HZZ4muAnalyzer.h
+++ b/PhysicsTools/HepMCCandAlgos/test/HZZ4muAnalyzer.h
@@ -20,8 +20,8 @@ class HZZ4muAnalyzer : public edm::EDAnalyzer
                                    // as it'll be deleted upon closing TFile
 
       virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
-      virtual void beginJob() ;
-      virtual void endJob() ;
+      virtual void beginJob() override ;
+      virtual void endJob() override ;
 
    private:
 

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -28,7 +28,7 @@ namespace pat {
       explicit PATJetSlimmer(const edm::ParameterSet & iConfig);
       virtual ~PATJetSlimmer() { }
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
       virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
 
     private:

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -27,7 +27,7 @@ namespace pat {
     explicit PATMuonSlimmer(const edm::ParameterSet & iConfig);
     virtual ~PATMuonSlimmer() { }
     
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
     
   private:

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -30,7 +30,7 @@ namespace pat {
       explicit PATPhotonSlimmer(const edm::ParameterSet & iConfig);
       virtual ~PATPhotonSlimmer() { }
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
       virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
 
     private:

--- a/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
@@ -22,7 +22,7 @@ namespace pat {
     explicit PATTauSlimmer(const edm::ParameterSet & iConfig);
     virtual ~PATTauSlimmer() { }
     
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
     
   private:

--- a/PhysicsTools/TagAndProbe/interface/ElectronMatchedCandidateProducer.h
+++ b/PhysicsTools/TagAndProbe/interface/ElectronMatchedCandidateProducer.h
@@ -22,9 +22,9 @@ class ElectronMatchedCandidateProducer : public edm::EDProducer
   ~ElectronMatchedCandidateProducer();
 
  private:
-  virtual void beginJob() ;
+  virtual void beginJob() override ;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob()  override;
 
   // ----------member data ---------------------------
 

--- a/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.h
+++ b/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.h
@@ -29,9 +29,9 @@ class TriggerCandProducer : public edm::EDProducer
 
  private:
   virtual void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
-  virtual void beginJob() ;
+  virtual void beginJob()  override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob()  override;
 
   // ----------member data --------------------------
 

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
@@ -50,7 +50,7 @@ class InterestingDetIdCollectionProducer : public edm::stream::EDProducer<> {
       explicit InterestingDetIdCollectionProducer(const edm::ParameterSet&);
       virtual void beginRun (edm::Run const&, const edm::EventSetup&) override final;
       //! producer
-      virtual void produce(edm::Event &, const edm::EventSetup&);
+      virtual void produce(edm::Event &, const edm::EventSetup&) override;
 
    private:
       // ----------member data ---------------------------

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
@@ -50,7 +50,7 @@ class InterestingDetIdFromSuperClusterProducer : public edm::stream::EDProducer<
       explicit InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet&);
       virtual void beginRun (edm::Run const&, const edm::EventSetup&) override final;
       //! producer
-      virtual void produce(edm::Event &, const edm::EventSetup&);
+      virtual void produce(edm::Event &, const edm::EventSetup&) override;
 
    private:
       // ----------member data ---------------------------

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
@@ -28,7 +28,7 @@ class ReducedESRecHitCollectionProducer : public edm::stream::EDProducer<> {
   ReducedESRecHitCollectionProducer(const edm::ParameterSet& pset);
   virtual ~ReducedESRecHitCollectionProducer();
   virtual void beginRun (edm::Run const&, const edm::EventSetup&) override final;
-  void produce(edm::Event & e, const edm::EventSetup& c);
+  void produce(edm::Event & e, const edm::EventSetup& c) override;
   void collectIds(const ESDetId strip1, const ESDetId strip2, const int & row=0);
   
  private :

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.h
@@ -18,7 +18,7 @@ class GsfElectronFull5x5Filler : public edm::stream::EDProducer<>
 
     explicit GsfElectronFull5x5Filler( const edm::ParameterSet & ) ;
     virtual ~GsfElectronFull5x5Filler() ;
-    virtual void produce( edm::Event &, const edm::EventSetup & ) ;
+    virtual void produce( edm::Event &, const edm::EventSetup & ) override ;
     void calculateShowerShape_full5x5(const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape);
 
     void beginLuminosityBlock(edm::LuminosityBlock const&, 

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
@@ -15,7 +15,7 @@
 class HFEMClusterProducer : public edm::stream::EDProducer<> {
 public:
   explicit HFEMClusterProducer(edm::ParameterSet const& conf);
-  virtual void produce(edm::Event& e, edm::EventSetup const& iSetup);
+  virtual void produce(edm::Event& e, edm::EventSetup const& iSetup) override;
   virtual void beginRun(edm::Run const &, edm::EventSetup const&) override final { algo_.resetForRun(); }
 private:
   edm::EDGetToken hfreco_;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.h
@@ -45,7 +45,7 @@ public:
   explicit EgammaIsoESDetIdCollectionProducer(const edm::ParameterSet&);
   virtual void beginRun (edm::Run const&, const edm::EventSetup&) override final;
   //! producer
-  virtual void produce(edm::Event &, const edm::EventSetup&);
+  virtual void produce(edm::Event &, const edm::EventSetup&) override;
 
 private:
   void addDetIds(const reco::SuperCluster& superClus,reco::PFClusterCollection clusters,const reco::PFCluster::EEtoPSAssociation& eeClusToESMap,std::vector<DetId>& detIdsToStore);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.h
@@ -47,7 +47,7 @@ public:
   explicit EgammaIsoHcalDetIdCollectionProducer(const edm::ParameterSet&);
   virtual void beginRun (edm::Run const&, const edm::EventSetup&) override final;
   //! producer
-  virtual void produce(edm::Event &, const edm::EventSetup&);
+  virtual void produce(edm::Event &, const edm::EventSetup&) override;
 
 private:
   void addDetIds(const reco::SuperCluster& superClus,const HBHERecHitCollection& recHits,std::vector<DetId>& detIdsToStore);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
@@ -24,7 +24,7 @@ class ParticleBasedIsoProducer : public edm::stream::EDProducer<>
   
   virtual void beginRun (edm::Run const& r, edm::EventSetup const & es) override;
   virtual void endRun(edm::Run const&,  edm::EventSetup const&) override;
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
    
  private:
  

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
@@ -55,7 +55,7 @@ public:
   ElectronPFIsolationWithConeVeto(const ElectronPFIsolationWithConeVeto&) = delete;
   ElectronPFIsolationWithConeVeto& operator=(const ElectronPFIsolationWithConeVeto&) =delete;
   
-  void setConsumes(edm::ConsumesCollector) {}
+  void setConsumes(edm::ConsumesCollector) override {}
 
   bool isInIsolationCone(const reco::CandidatePtr& physob,
 			 const reco::CandidatePtr& other) const override final;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithMapBasedVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithMapBasedVeto.cc
@@ -84,14 +84,14 @@ public:
  edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationMap;			 
  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken_;
  
- virtual void getEventInfo(const edm::Event& iEvent)
+ virtual void getEventInfo(const edm::Event& iEvent) override
   {
       iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap); 
   };			 
   
   
   //As far as I understand now, the object particleBasedIsolationMap should be fixed, so we don't configure the name
-  void setConsumes(edm::ConsumesCollector iC)
+  void setConsumes(edm::ConsumesCollector iC) override
   {
       particleBasedIsolationToken_ = iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(edm::InputTag("particleBasedIsolation", "gedGsfElectrons"));
   }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithConeVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithConeVeto.cc
@@ -56,7 +56,7 @@ public:
   PhotonPFIsolationWithConeVeto(const PhotonPFIsolationWithConeVeto&) = delete;
   PhotonPFIsolationWithConeVeto& operator=(const PhotonPFIsolationWithConeVeto&) =delete;
   
-  void setConsumes(edm::ConsumesCollector) {}
+  void setConsumes(edm::ConsumesCollector) override {}
 
   bool isInIsolationCone(const reco::CandidatePtr& photon,
 			 const reco::CandidatePtr& pfCandidate) const override final;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithMapBasedVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithMapBasedVeto.cc
@@ -86,14 +86,14 @@ public:
  edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationMap;			 
  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken_;
  
- virtual void getEventInfo(const edm::Event& iEvent)
+ virtual void getEventInfo(const edm::Event& iEvent) override
   {
       iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap); 
   };			 
   
   
   //As far as I understand now, the object particleBasedIsolationMap should be fixed, so we don't configure the name
-  void setConsumes(edm::ConsumesCollector iC)
+  void setConsumes(edm::ConsumesCollector iC) override
   {
       particleBasedIsolationToken_ = iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(_particleBasedIsolation);
   }

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
@@ -39,7 +39,7 @@ class ConvertedPhotonProducer : public edm::stream::EDProducer<> {
   virtual ~ConvertedPhotonProducer();
 
   virtual void beginRun(edm::Run const&, const edm::EventSetup &es) override final;
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
  private:
   

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -48,7 +48,7 @@ class GEDPhotonProducer : public edm::stream::EDProducer<> {
 
   virtual void beginRun (edm::Run const& r, edm::EventSetup const & es) override final;
   virtual void endRun(edm::Run const&,  edm::EventSetup const&) override final;
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
  private:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
@@ -43,7 +43,7 @@ class PhotonProducer : public edm::stream::EDProducer<> {
 
   virtual void beginRun (edm::Run const& r, edm::EventSetup const & es) override final;
   virtual void endRun(edm::Run const&,  edm::EventSetup const&) override final;
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
  private:
 

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.h
@@ -70,7 +70,7 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   ~ElectronMVAEstimatorRun2Phys14NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& evt) const;
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& evt) const override;
  
   // Utility functions
   std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
@@ -82,8 +82,8 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
-  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
+  int findCategory(const edm::Ptr<reco::Candidate>& particle) const override;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
   void constrainMVAVariables(AllVariables& vars) const;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.h
@@ -63,7 +63,7 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   ~PhotonMVAEstimatorRun2Phys14NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  float mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
  
   // Utility functions
   std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
@@ -76,7 +76,7 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
   std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
-  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
+  int findCategory(const edm::Ptr<reco::Candidate>& particle) const override;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
   void constrainMVAVariables(AllVariables& vars) const;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.h
@@ -63,12 +63,12 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   ~PhotonMVAEstimatorRun2Spring15NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
  
   // Utility functions
   std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
   
-  virtual int getNCategories() const { return nCategories; }
+  virtual int getNCategories() const override { return nCategories; }
   bool isEndcapCategory( int category ) const;
   virtual const std::string& getName() const override final { return _name; }
   virtual const std::string& getTag() const override final { return _tag; }

--- a/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
@@ -15,7 +15,7 @@ public:
 	HIPixelTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
 	virtual ~HIPixelTrackFilter();
 	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits,
-				 const TrackerTopology *tTopo) const;
+				 const TrackerTopology *tTopo) const override;
 	virtual void update(const edm::Event& ev, const edm::EventSetup& es) override;
 private:
 	double theTIPMax, theNSigmaTipMaxTolerance;

--- a/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
@@ -14,7 +14,7 @@ class HIProtoTrackFilter : public PixelTrackFilter {
 public:
 	HIProtoTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
 	virtual ~HIProtoTrackFilter();
-	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits) const;
+	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits) const override;
 	virtual void update(const edm::Event& ev, const edm::EventSetup& es) override;
 private:
 	double theTIPMax;

--- a/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.h
+++ b/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.h
@@ -17,7 +17,7 @@ public:
 	virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
 	
 private:
-	void beginJob(){};
+	void beginJob() override{};
 	
 	edm::EDGetTokenT<reco::TrackCollection> theTrackCollection;
 	double thePtMin;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -48,7 +48,7 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 void set(const edm::Event& evt) override;
                 bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) override;
 	public:	
-		edm::ParameterSetDescription getAlgoDescription();
+		edm::ParameterSetDescription getAlgoDescription() override;
         private:
 
                 edm::ESHandle<EcalPedestals> peds;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
@@ -30,7 +30,7 @@ class HGCalUncalibRecHitWorkerWeights : public HGCalUncalibRecHitWorkerBaseClass
   HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet&);
   virtual ~HGCalUncalibRecHitWorkerWeights() {};
   
-  void set(const edm::EventSetup& es);
+  void set(const edm::EventSetup& es) override;
   bool run1(const edm::Event& evt, const HGCEEDigiCollection::const_iterator & digi, HGCeeUncalibratedRecHitCollection & result) override;
   bool run2(const edm::Event& evt, const HGCHEDigiCollection::const_iterator & digi, HGChefUncalibratedRecHitCollection & result) override;
   bool run3(const edm::Event& evt, const HGCBHDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) override;

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
@@ -26,7 +26,7 @@
       virtual ~ZdcSimpleReconstructor();
       virtual void beginRun(edm::Run const&r, edm::EventSetup const & es) override final;
       virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
-      virtual void produce(edm::Event& e, const edm::EventSetup& c);
+      virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
     private:      
       ZdcSimpleRecAlgo reco_;
       DetId::Detector det_;

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -14,7 +14,7 @@ class ThreeThresholdAlgorithm final : public StripClusterizerAlgorithm {
   void clusterizeDetUnit(const    edm::DetSet<SiStripDigi> &, output_t::TSFastFiller &) const override;
   void clusterizeDetUnit(const edmNew::DetSet<SiStripDigi> &, output_t::TSFastFiller &) const override;
 
-  Det stripByStripBegin(uint32_t id) const;
+  Det stripByStripBegin(uint32_t id) const override;
 
   // LazyGetter interface
   void stripByStripAdd(State & state, uint16_t strip, uint8_t adc, std::vector<SiStripCluster>& out) const override;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
@@ -27,7 +27,7 @@ public:
 	    const SiStripBackPlaneCorrection&,
 	    const SiStripConfObject&,
 	    const SiStripLatency&);    
-  LocalVector driftDirection(const StripGeomDetUnit* det) const;
+  LocalVector driftDirection(const StripGeomDetUnit* det) const override;
 
  struct Param {
     Param() : topology(nullptr) {}

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
@@ -71,7 +71,7 @@ public:
                               const TrajectoryStateOnSurface& firstPredTsos) const;
 
 
-  virtual void setHitCloner(TkCloner const * hc) {}
+  virtual void setHitCloner(TkCloner const * hc) override {}
 
 private:
   std::vector<Trajectory> smooth(const std::vector<Trajectory>& ) const;

--- a/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
@@ -14,7 +14,7 @@ class MuonCkfTrajectoryBuilder : public CkfTrajectoryBuilder {
 
   void collectMeasurement(const DetLayer * layer, const std::vector<const DetLayer*>& nl,const TrajectoryStateOnSurface & currentState, std::vector<TM>& result,int& invalidHits,const Propagator *) const;
 
-  virtual void findCompatibleMeasurements(const TrajectorySeed&seed, const TempTrajectory& traj, std::vector<TrajectoryMeasurement> & result) const;
+  virtual void findCompatibleMeasurements(const TrajectorySeed&seed, const TempTrajectory& traj, std::vector<TrajectoryMeasurement> & result) const override;
   
   //and other fields
   bool theUseSeedLayer;

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -25,7 +25,7 @@ public:
   MuonPFIsolationWithConeVeto(const MuonPFIsolationWithConeVeto&) = delete;
   MuonPFIsolationWithConeVeto& operator=(const MuonPFIsolationWithConeVeto&) =delete;
 
-  void setConsumes(edm::ConsumesCollector) {}
+  void setConsumes(edm::ConsumesCollector) override {}
 
   bool isInIsolationCone(const reco::CandidatePtr& physob,
 			 const reco::CandidatePtr& other) const override final;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -41,7 +41,7 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
 				    const edm::EventSetup & es) override;
   
   void produce(edm::Event& iEvent, 
-	       const edm::EventSetup& iSetup);
+	       const edm::EventSetup& iSetup) override;
 
 
   reco::PFRecHit*  createHcalRecHit( const DetId& detid, 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
@@ -23,7 +23,7 @@ class GenericSimClusterMapper : public InitialClusteringStepBase {
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
 		     const std::vector<bool>&,
 		     const std::vector<bool>&, 
-		     reco::PFClusterCollection&);
+		     reco::PFClusterCollection&) override;
   
  private:  
   edm::EDGetTokenT<SimClusterCollection> _simClusterToken;

--- a/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
+++ b/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
@@ -69,9 +69,9 @@ private:
 	/* 
 	 * The usual EDAnalyzer methods
 	 */
-	virtual void beginJob();
+	virtual void beginJob() override;
 	virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-	virtual void endJob();
+	virtual void endJob() override;
 
 	/*
 	 * Called for each particle in the event to fill the tree and

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
@@ -33,7 +33,7 @@ class ClusterShapeTrackFilter : public PixelTrackFilter
   void update(const edm::Event& ev, const edm::EventSetup& es) override;
   virtual bool operator()
     (const reco::Track*, const std::vector<const TrackingRecHit *> &hits, 
-     const TrackerTopology *tTopo) const;
+     const TrackerTopology *tTopo) const override;
 
  private:
   float areaParallelogram(const Global2DVector & a,

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
@@ -23,13 +23,13 @@ class ClusterShapeTrajectoryFilter : public TrajectoryFilter {
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  virtual bool qualityFilter(const TempTrajectory&) const;
-  virtual bool qualityFilter(const Trajectory&) const;
+  virtual bool qualityFilter(const TempTrajectory&) const override;
+  virtual bool qualityFilter(const Trajectory&) const override;
  
-  virtual bool toBeContinued(TempTrajectory&) const;
-  virtual bool toBeContinued(Trajectory&) const;
+  virtual bool toBeContinued(TempTrajectory&) const override;
+  virtual bool toBeContinued(Trajectory&) const override;
 
-  virtual std::string name() const { return "ClusterShapeTrajectoryFilter"; }
+  virtual std::string name() const override { return "ClusterShapeTrajectoryFilter"; }
 
  private:
   edm::EDGetTokenT<SiPixelClusterShapeCache> theCacheToken;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -79,7 +79,7 @@ class StripSubClusterShapeTrajectoryFilter: public StripSubClusterShapeFilterBas
         virtual bool toBeContinued(TempTrajectory&) const override;
         virtual bool toBeContinued(Trajectory&) const override;
 
-        virtual std::string name() const { return "StripSubClusterShapeTrajectoryFilter"; }
+        virtual std::string name() const override { return "StripSubClusterShapeTrajectoryFilter"; }
 
         virtual void setEvent(const edm::Event & e, const edm::EventSetup & es) override {
             setEventBase(e,es);
@@ -100,10 +100,10 @@ class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, pub
             setEventBase(ev,es);
         }
         // implemented
-        virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const ;
+        virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const override ;
         // not implemented 
-        virtual bool compatible(const SeedingHitSet &hits) const { return true; }
-        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const ;
+        virtual bool compatible(const SeedingHitSet &hits) const override { return true; }
+        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const override ;
 
     protected:
         bool filterAtHelixStage_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
@@ -25,7 +25,7 @@ public:
   void update(const edm::Event& ev, const edm::EventSetup& es) override;
   virtual bool operator()(const reco::Track * track,
                           const std::vector<const TrackingRecHit *>& recHits,
-			  const TrackerTopology *tTopo) const;
+			  const TrackerTopology *tTopo) const override;
 
 private:
   int getLayer(const TrackingRecHit & recHit, const TrackerTopology *tTopo) const;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
@@ -12,8 +12,8 @@ public:
   PixelTrackFilterByKinematics(double ptmin = 0.9, double tipmax = 0.1, double chi2max = 100.);
   virtual ~PixelTrackFilterByKinematics();
   void update(const edm::Event&, const edm::EventSetup&) override;
-  virtual bool operator()(const reco::Track*) const;
-  virtual bool operator()(const reco::Track*, const PixelTrackFilter::Hits & hits) const;
+  virtual bool operator()(const reco::Track*) const override;
+  virtual bool operator()(const reco::Track*, const PixelTrackFilter::Hits & hits) const override;
 private:
   float theoPtMin, theNSigmaInvPtTolerance; 
   float theTIPMax, theNSigmaTipMaxTolerance;

--- a/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
+++ b/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
@@ -32,9 +32,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob() ;
+  virtual void beginJob()  override;
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  virtual void endJob() ;
+  virtual void endJob()  override;
       
   // ----------member data ---------------------------
 

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
@@ -98,7 +98,7 @@ class TauDiscriminationAgainstCaloMuon final : public TauDiscriminationProducerB
   ~TauDiscriminationAgainstCaloMuon() {} 
 
   // called at the beginning of every event
-  void beginEvent(const edm::Event&, const edm::EventSetup&);
+  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
   double discriminate(const TauRef&) const override;
 

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
@@ -33,7 +33,7 @@ class TauDiscriminationAgainstMuon final : public TauDiscriminationProducerBase<
   ~TauDiscriminationAgainstMuon() {} 
 
   // called at the beginning of every event
-  void beginEvent(const edm::Event&, const edm::EventSetup&);
+  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
   double discriminate(const TauRef&) const override;
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -44,18 +44,18 @@ public:
   ~CkfTrajectoryBuilder() {}
 
   /// trajectories building starting from a seed
-  virtual TrajectoryContainer trajectories(const TrajectorySeed& seed) const;
+  virtual TrajectoryContainer trajectories(const TrajectorySeed& seed) const override;
   /// trajectories building starting from a seed
-  virtual void trajectories(const TrajectorySeed& seed, TrajectoryContainer &ret) const;
+  virtual void trajectories(const TrajectorySeed& seed, TrajectoryContainer &ret) const override;
 
   // new interface returning the start Trajectory...
   TempTrajectory buildTrajectories (const TrajectorySeed&,
 				    TrajectoryContainer &ret,
-				    const TrajectoryFilter*) const;
+				    const TrajectoryFilter*) const override;
   
   
   void  rebuildTrajectories(TempTrajectory const& startingTraj, const TrajectorySeed&,
-			    TrajectoryContainer& result) const {}
+			    TrajectoryContainer& result) const override {}
 
   /// set Event for the internal MeasurementTracker data member
   //  virtual void setEvent(const edm::Event& event) const;

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -34,10 +34,10 @@ class dso_internal GroupedCkfTrajectoryBuilder final : public BaseCkfTrajectoryB
   //  virtual void setEvent(const edm::Event& event) const;
 
   /// trajectories building starting from a seed
-  TrajectoryContainer trajectories(const TrajectorySeed&) const;
+  TrajectoryContainer trajectories(const TrajectorySeed&) const override;
 
   /// trajectories building starting from a seed, return in an already allocated vector
-  void trajectories(const TrajectorySeed&, TrajectoryContainer &ret) const;
+  void trajectories(const TrajectorySeed&, TrajectoryContainer &ret) const override;
 
   /// trajectories building starting from a seed with a region
   TrajectoryContainer trajectories(const TrajectorySeed&, const TrackingRegion&) const;
@@ -49,7 +49,7 @@ class dso_internal GroupedCkfTrajectoryBuilder final : public BaseCkfTrajectoryB
   // also new interface returning the start Trajectory...
   TempTrajectory buildTrajectories (const TrajectorySeed&seed,
 				    TrajectoryContainer &ret,
-				    const TrajectoryFilter*) const;
+				    const TrajectoryFilter*) const override;
 
 
 
@@ -60,11 +60,11 @@ class dso_internal GroupedCkfTrajectoryBuilder final : public BaseCkfTrajectoryB
       collection.
   **/
   void  rebuildSeedingRegion(const TrajectorySeed&,
-			     TrajectoryContainer& result) const ;
+			     TrajectoryContainer& result) const override ;
  
   // same as above using the precomputed startingTraj..
   void  rebuildTrajectories(TempTrajectory const & startingTraj, const TrajectorySeed&,
-			     TrajectoryContainer& result) const ;  
+			     TrajectoryContainer& result) const override ;  
 
 
   // Access to lower level components

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -19,7 +19,7 @@ namespace cms {
     }
 
     virtual void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
-    virtual void endJob() {delete dbg; }
+    virtual void endJob() override {delete dbg; }
 
   private:
     virtual TrajectorySeedCollection::const_iterator 
@@ -33,9 +33,9 @@ namespace cms {
 	//theTrajectoryBuilder->setDebugger( dbg);
     };
     
-    void printHitsDebugger(edm::Event& e){dbg->printSimHits(e);};
-    void countSeedsDebugger(){dbg->countSeed();};
-    void deleteAssocDebugger(){dbg->deleteHitAssociator();};
+    void printHitsDebugger(edm::Event& e) override{dbg->printSimHits(e);};
+    void countSeedsDebugger() override{dbg->countSeed();};
+    void deleteAssocDebugger() override{dbg->deleteHitAssociator();};
     void deleteDebugger(){delete dbg;};
     CkfDebugger *  dbg;
     const CkfDebugTrajectoryBuilder* myTrajectoryBuilder;

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -45,7 +45,7 @@ public:
                  const MeasurementEstimator::OpaquePayload  & opay) const override;
 
 
-  virtual Chi2ChargeMeasurementEstimator* clone() const {
+  virtual Chi2ChargeMeasurementEstimator* clone() const override {
     return new Chi2ChargeMeasurementEstimator(*this);
   }
 private:

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearTrackCorrector.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearTrackCorrector.h
@@ -86,7 +86,7 @@ public:
 
    private:
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
 
       /// check if the trajectory has to be refitted and get the new trajectory
       bool newTrajNeeded(Trajectory& newtrajectory, const TrajectoryRef& trajRef, const reco::NuclearInteraction& ni);

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -97,11 +97,11 @@ public:
       const Hit & outerHit,
       const edm::EventSetup& iSetup, 
       const DetLayer* outerlayer=0,
-      float lr=0, float gz=0, float dr=0, float dz=0) const {return 0; }
+      float lr=0, float gz=0, float dr=0, float dz=0) const override {return 0; }
    
-   CosmicTrackingRegion * clone() const {     return new CosmicTrackingRegion(*this);  }
+   CosmicTrackingRegion * clone() const override {     return new CosmicTrackingRegion(*this);  }
    
-   std::string name() const { return "CosmicTrackingRegion"; }
+   std::string name() const override { return "CosmicTrackingRegion"; }
 
 private:
   template <typename T>

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
@@ -33,7 +33,7 @@ public:
 
   /// from base class
   virtual void hitSets( const TrackingRegion& reg, OrderedMultiHits & result,
-      const edm::Event & ev,  const edm::EventSetup& es);
+      const edm::Event & ev,  const edm::EventSetup& es) override;
 
   virtual void clear() override {
     MultiHitGenerator::clear();

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -42,7 +42,7 @@ public:
   virtual void hitSets( const TrackingRegion& region, OrderedMultiHits & trs, 
                         const edm::Event & ev, const edm::EventSetup& es,
                         SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers);
+                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
 
   void hitSets(const TrackingRegion& region, OrderedMultiHits& trs,
                const edm::Event& ev, const edm::EventSetup& es,

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
@@ -16,7 +16,7 @@ namespace ctfseeding {
     HitExtractorPIX( SeedingLayer::Side & side, int idLayer, const std::string & hitProducer, edm::ConsumesCollector& iC);
     virtual ~HitExtractorPIX(){}
     virtual HitExtractor::Hits hits(const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup& ) const override;
-    virtual HitExtractorPIX * clone() const { return new HitExtractorPIX(*this); }
+    virtual HitExtractorPIX * clone() const override { return new HitExtractorPIX(*this); }
     
   private:
     typedef edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > SkipClustersCollection;

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
@@ -28,7 +28,7 @@ public:
   virtual ~HitExtractorSTRP(){}
 
   virtual HitExtractor::Hits hits( const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup&) const override;
-  virtual HitExtractorSTRP * clone() const { return new HitExtractorSTRP(*this); }
+  virtual HitExtractorSTRP * clone() const override { return new HitExtractorSTRP(*this); }
 
   void useMatchedHits( const edm::InputTag & m, edm::ConsumesCollector& iC) { hasMatchedHits = true; theMatchedHits = iC.consumes<SiStripMatchedRecHit2DCollection>(m); }
   void useRPhiHits(    const edm::InputTag & m, edm::ConsumesCollector& iC) { hasRPhiHits    = true; theRPhiHits = iC.consumes<SiStripRecHit2DCollection>(m); }

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -42,14 +42,14 @@ public:
 				       const Hit &  outerHit,
 				       const edm::EventSetup& iSetup,
 				       const DetLayer* outerlayer=0,
-				       float lr=0, float gz=0, float dr=0, float dz=0) const ;
+				       float lr=0, float gz=0, float dr=0, float dz=0) const  override;
 
-  virtual GlobalTrackingRegion* clone() const { 
+  virtual GlobalTrackingRegion* clone() const override { 
     return new GlobalTrackingRegion(*this);
   }
 
-  virtual std::string name() const { return "GlobalTrackingRegion"; }
-  virtual std::string print() const;
+  virtual std::string name() const override { return "GlobalTrackingRegion"; }
+  virtual std::string print() const override;
 
 private:
   bool  thePrecise=false;

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -164,15 +164,15 @@ public:
 				       const Hit &  outerHit,
 				       const edm::EventSetup&iSetup,
 				       const DetLayer* outerlayer=nullptr,
-				       float lr=0, float gz=0, float dr=0, float dz=0) const
+				       float lr=0, float gz=0, float dr=0, float dz=0) const override
   { return checkRZOld(layer,outerHit,iSetup, outerlayer); }
 
-  virtual RectangularEtaPhiTrackingRegion* clone() const { 
+  virtual RectangularEtaPhiTrackingRegion* clone() const override { 
     return new RectangularEtaPhiTrackingRegion(*this);
   }
 
-  virtual std::string name() const { return "RectangularEtaPhiTrackingRegion"; }
-  virtual std::string print() const;
+  virtual std::string name() const override { return "RectangularEtaPhiTrackingRegion"; }
+  virtual std::string print() const override;
 
 private:
   HitRZCompatibility* checkRZOld(

--- a/RecoTracker/TrackProducer/test/GsfVertexConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/test/GsfVertexConstraintProducer.cc
@@ -25,7 +25,7 @@ public:
 
 private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override ;
       
   // ----------member data ---------------------------
   const edm::ParameterSet iConfig_;

--- a/RecoTracker/TrackProducer/test/MomentumConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/test/MomentumConstraintProducer.cc
@@ -45,7 +45,7 @@ public:
 
 private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override ;
 
   // ----------member data ---------------------------
   const edm::InputTag srcTag_;

--- a/RecoTracker/TrackProducer/test/TwoBodyDecayConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/test/TwoBodyDecayConstraintProducer.cc
@@ -47,7 +47,7 @@ public:
 private:
 
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override ;
 
   std::pair<bool, TrajectoryStateOnSurface> innermostState( const reco::TransientTrack& ttrack ) const;
   bool match( const TrajectoryStateOnSurface& newTsos, const TrajectoryStateOnSurface& oldTsos ) const;

--- a/RecoTracker/TrackProducer/test/TwoBodyDecayMomConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/test/TwoBodyDecayMomConstraintProducer.cc
@@ -48,7 +48,7 @@ public:
 private:
 
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override ;
 
   std::pair<double, double> momentaAtVertex( const TwoBodyDecay& tbd ) const;
 

--- a/RecoTracker/TrackProducer/test/VertexConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/test/VertexConstraintProducer.cc
@@ -47,7 +47,7 @@ public:
 
 private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endJob() override ;
       
   // ----------member data ---------------------------
   const edm::ParameterSet iConfig_;

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
@@ -11,29 +11,29 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
 
   virtual ~TRecHit1DMomConstraint() {}
 
-  virtual AlgebraicVector parameters() const {
+  virtual AlgebraicVector parameters() const override {
     AlgebraicVector result(1);
     result[0] = charge_/fabs(mom_);
     return result;
   }
   
-  virtual AlgebraicSymMatrix parametersError() const {
+  virtual AlgebraicSymMatrix parametersError() const override {
     AlgebraicSymMatrix m(1);
     m[0][0] = err_/(mom_*mom_);//parametersErrors are squared
     m[0][0] *= m[0][0];
     return m;
   }
 
-  virtual AlgebraicMatrix projectionMatrix() const {
+  virtual AlgebraicMatrix projectionMatrix() const override {
     AlgebraicMatrix theProjectionMatrix;
     theProjectionMatrix = AlgebraicMatrix( 1, 5, 0);
     theProjectionMatrix[0][0] = 1;
     return theProjectionMatrix;
   }
-  virtual int dimension() const {return 1;}
+  virtual int dimension() const override {return 1;}
 
-  virtual LocalPoint localPosition() const {return LocalPoint(0,0,0);}
-  virtual LocalError localPositionError() const {return LocalError(0,0,0);}
+  virtual LocalPoint localPosition() const override {return LocalPoint(0,0,0);}
+  virtual LocalError localPositionError() const override {return LocalError(0,0,0);}
 
   double mom() const {return mom_;}
   double err() const {return err_;}
@@ -41,11 +41,11 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
 
 
   virtual const TrackingRecHit * hit() const override {return 0;}//fixme return invalid
-  virtual TrackingRecHit * cloneHit() const { return 0;}
+  virtual TrackingRecHit * cloneHit() const override { return 0;}
 
-  virtual std::vector<const TrackingRecHit*> recHits() const { return std::vector<const TrackingRecHit*>(); }
-  virtual std::vector<TrackingRecHit*> recHits() { return std::vector<TrackingRecHit*>(); }
-  virtual bool sharesInput( const TrackingRecHit*, SharedInputType) const { return false;}
+  virtual std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
+  virtual std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
+  virtual bool sharesInput( const TrackingRecHit*, SharedInputType) const override { return false;}
 
   virtual bool canImproveWithTrack() const override {return false;}
 
@@ -62,11 +62,11 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
 
   virtual const Surface * surface() const override {return surface_;}
 
-  virtual GlobalPoint globalPosition() const { return GlobalPoint();  }
-  virtual GlobalError globalPositionError() const { return GlobalError();}
-  virtual float errorGlobalR() const { return 0;}
-  virtual float errorGlobalZ() const { return 0; }
-  virtual float errorGlobalRPhi() const { return 0; }
+  virtual GlobalPoint globalPosition() const override { return GlobalPoint();  }
+  virtual GlobalError globalPositionError() const override { return GlobalError();}
+  virtual float errorGlobalR() const override { return 0;}
+  virtual float errorGlobalZ() const override { return 0; }
+  virtual float errorGlobalRPhi() const override { return 0; }
 
 
  private:
@@ -84,7 +84,7 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
   TRecHit1DMomConstraint( const TRecHit1DMomConstraint& other ):
     charge_( other.charge() ), mom_( other.mom() ),err_( other.err() ), surface_((other.surface())) {}
   
-  virtual TRecHit1DMomConstraint * clone() const {
+  virtual TRecHit1DMomConstraint * clone() const override {
     return new TRecHit1DMomConstraint(*this);
   }
 

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.h
@@ -40,7 +40,7 @@ class EcalTPInputAnalyzer : public edm::EDAnalyzer {
       ~EcalTPInputAnalyzer();
 
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob();
+      void endJob() override;
 
    private:
 

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.h
@@ -42,7 +42,7 @@ class EcalTrigPrimAnalyzer : public edm::one::EDAnalyzer<> {
 
 
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob();
+  virtual void endJob() override;
    private:
 
   // for histos of nr of hits

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -34,7 +34,7 @@ public:
   typedef std::vector<unsigned int> photonTimeHist;
   typedef std::map< DetId, photonTimeHist > photonTimeMap;
 
-  virtual void initializeHits();
+  virtual void initializeHits() override;
 
   virtual void finalizeHits(CLHEP::HepRandomEngine*) override;
 

--- a/SimG4CMS/HGCalTestBeam/plugins/HGCalTBAnalyzer.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCalTBAnalyzer.cc
@@ -55,7 +55,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob() ;
+  virtual void beginJob() override ;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/SimG4Core/Application/test/SimHitCaloHitDumper.h
+++ b/SimG4Core/Application/test/SimHitCaloHitDumper.h
@@ -18,8 +18,8 @@ class SimHitCaloHitDumper : public edm::EDAnalyzer{
   virtual ~SimHitCaloHitDumper() {};
   
   virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
-  virtual void beginJob(){};
-  virtual void endJob(){};
+  virtual void beginJob() override{};
+  virtual void endJob() override{};
   
  private:
   std::string processName;

--- a/SimG4Core/Application/test/SimTrackSimVertexDumper.h
+++ b/SimG4Core/Application/test/SimTrackSimVertexDumper.h
@@ -19,8 +19,8 @@ class SimTrackSimVertexDumper : public edm::EDAnalyzer{
   virtual ~SimTrackSimVertexDumper() {};
   
   virtual void analyze( const edm::Event&, const edm::EventSetup&) override;
-  virtual void beginJob(){};
-  virtual void endJob(){};
+  virtual void beginJob() override{};
+  virtual void endJob() override{};
  private:
   edm::InputTag HepMCLabel;
   edm::InputTag SimTkLabel;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -60,13 +60,13 @@ namespace edm {
 
       // copies, with EventSetup
       virtual void checkSignal(const edm::Event &e) override {}; 
-      virtual void createnewEDProduct() {}
-      virtual void addSignals(const edm::Event &e, const edm::EventSetup& ES); 
+      virtual void createnewEDProduct() override {}
+      virtual void addSignals(const edm::Event &e, const edm::EventSetup& ES) override; 
       virtual void doPileUp(edm::Event &e,const edm::EventSetup& ES) override;
-      virtual void put(edm::Event &e,const edm::EventSetup& ES) ;
+      virtual void put(edm::Event &e,const edm::EventSetup& ES) override ;
 
-      virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& eventSetup);
-      void beginRun(edm::Run const& run, edm::EventSetup const& eventSetup);
+      virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& eventSetup) override;
+      void beginRun(edm::Run const& run, edm::EventSetup const& eventSetup) override;
       void pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
       //virtual void beginJob();
       //virtual void endJob();

--- a/SimGeneral/MixingModule/plugins/InputAnalyzer.h
+++ b/SimGeneral/MixingModule/plugins/InputAnalyzer.h
@@ -38,9 +38,9 @@ namespace edm
       virtual ~InputAnalyzer();
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
 
       // ----------member data ---------------------------
       

--- a/SimGeneral/MixingModule/plugins/Mixing2DB.h
+++ b/SimGeneral/MixingModule/plugins/Mixing2DB.h
@@ -43,9 +43,9 @@ class Mixing2DB : public edm::one::EDAnalyzer<> {
 
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob()  override;
 
 
       // ----------member data ---------------------------

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -66,22 +66,22 @@ namespace edm {
 
       virtual void endLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) override;
 
-      void initializeEvent(Event const& event, EventSetup const& setup);
+      void initializeEvent(Event const& event, EventSetup const& setup) override;
 
       void accumulateEvent(Event const& event, EventSetup const& setup);
 
       void accumulateEvent(PileUpEventPrincipal const& event, EventSetup const& setup, edm::StreamID const&);
 
-      void finalizeEvent(Event& event, EventSetup const& setup);
+      void finalizeEvent(Event& event, EventSetup const& setup) override;
 
-      virtual void reload(const edm::EventSetup &);
+      virtual void reload(const edm::EventSetup &) override;
  
     private:
       virtual void branchesActivate(const std::string &friendlyName, const std::string &subdet, InputTag &tag, std::string &label);
-      virtual void put(edm::Event &e,const edm::EventSetup& es);
-      virtual void createnewEDProduct();
-      virtual void checkSignal(const edm::Event &e);
-      virtual void addSignals(const edm::Event &e, const edm::EventSetup& es); 
+      virtual void put(edm::Event &e,const edm::EventSetup& es) override;
+      virtual void createnewEDProduct() override;
+      virtual void checkSignal(const edm::Event &e) override;
+      virtual void addSignals(const edm::Event &e, const edm::EventSetup& es) override; 
       virtual void doPileUp(edm::Event &e, const edm::EventSetup& es) override;
       void pileAllWorkers(EventPrincipal const& ep, ModuleCallingContext const*, int bcr, int id, int& offset,
 			  const edm::EventSetup& setup, edm::StreamID const&);

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
@@ -48,9 +48,9 @@ namespace edm {
     virtual void dummyFunction(EventPrincipal const& ep) {}
 
   private:
-    virtual void beginJob() ;
+    virtual void beginJob() override ;
     virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() ;
+    virtual void endJob() override ;
 
     // ----------member data ---------------------------
     int minBunch_;

--- a/SimGeneral/MixingModule/plugins/TestMixedSource.h
+++ b/SimGeneral/MixingModule/plugins/TestMixedSource.h
@@ -48,9 +48,9 @@ namespace edm
       ~TestMixedSource();
 
    private:
-      virtual void beginJob() ;
+      virtual void beginJob() override ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      virtual void endJob() override ;
 
       // ----------member data ---------------------------
       std::ofstream outputFile;

--- a/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.h
+++ b/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.h
@@ -47,11 +47,11 @@ public:
  
 private:
   /// initialization for each layer
-  void initParameters();
+  void initParameters() override;
 
-  virtual int readoutElement(int strip) const;
+  virtual int readoutElement(int strip) const override;
 
-  float calculateAmpResponse(float t) const;
+  float calculateAmpResponse(float t) const override;
   CSCStripAmpResponse theAmpResponse;
 
   void runComparator(std::vector<CSCComparatorDigi> & result, CLHEP::HepRandomEngine*);

--- a/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
@@ -27,7 +27,7 @@ public:
 
   ~GEMSimpleModel();
 
-  void setup();
+  void setup() override;
 
   void simulateSignal(const GEMEtaPartition*, const edm::PSimHitContainer&, CLHEP::HepRandomEngine*) override;
 

--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
@@ -26,7 +26,7 @@ public:
   void simulateSignal(const ME0EtaPartition*, const edm::PSimHitContainer&, CLHEP::HepRandomEngine*) override;
   void simulateNoise(const ME0EtaPartition*, CLHEP::HepRandomEngine*) override;
   double correctSigmaU(const ME0EtaPartition*, double);
-  void setup() {}
+  void setup() override {}
 
 private:
   double sigma_t;

--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoNoSmearModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoNoSmearModel.h
@@ -23,7 +23,7 @@ public:
 
   void simulateNoise(const ME0EtaPartition*, CLHEP::HepRandomEngine*) override;
 
-  void setup() {}
+  void setup() override {}
 
 private:
 };

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
@@ -52,9 +52,9 @@ class SeedToTrackProducer : public edm::one::EDProducer<> {
       ~SeedToTrackProducer();
 
    private:
-      virtual void beginJob();
+      virtual void beginJob() override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob();
+      virtual void endJob() override;
       virtual TrajectoryStateOnSurface seedTransientState(const TrajectorySeed&);
       // ----------member data ---------------------------
     

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
@@ -45,7 +45,7 @@ class RPCSimAsymmetricCls : public RPCSim
   unsigned int slice(float posX); //??? CLHEP::HepRandomEngine*);
 
  private:
-  void init(){};
+  void init() override{};
  private:
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverage.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverage.h
@@ -41,7 +41,7 @@ class RPCSimAverage : public RPCSim
   int getClSize(float posX, CLHEP::HepRandomEngine*);
 
  private:
-  void init(){};
+  void init() override{};
  private:
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.h
@@ -41,7 +41,7 @@ class RPCSimAverageNoise : public RPCSim
   int getClSize(float posX, CLHEP::HepRandomEngine*);
 
  private:
-  void init(){};
+  void init() override{};
  private:
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.h
@@ -42,7 +42,7 @@ class RPCSimAverageNoiseEff : public RPCSim
   int getClSize(float posX, CLHEP::HepRandomEngine*);
 
  private:
-  void init(){};
+  void init() override{};
  private:
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
@@ -44,7 +44,7 @@ class RPCSimAverageNoiseEffCls : public RPCSim
 
 // private:
  protected:
-  void init(){};
+  void init() override{};
   
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimModelTiming.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimModelTiming.h
@@ -41,7 +41,7 @@ class RPCSimModelTiming : public RPCSim
   int getClSize(uint32_t id,float posX, CLHEP::HepRandomEngine*);
 
  protected:
-  void init(){};
+  void init() override{};
   
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimParam.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimParam.h
@@ -31,7 +31,7 @@ class RPCSimParam : public RPCSim
                      CLHEP::HepRandomEngine*) override;
 
  private:
-  void init(){};
+  void init() override{};
  private:
   double aveEff;
   double aveCls;

--- a/SimMuon/RPCDigitizer/src/RPCSimSimple.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimSimple.h
@@ -29,7 +29,7 @@ class RPCSimSimple : public RPCSim
   void simulateNoise(const RPCRoll*, CLHEP::HepRandomEngine*) override;
 
  private:
-  void init(){};
+  void init() override{};
 
   RPCSynchronizer* _rpcSync;
   int N_hits;

--- a/SimMuon/RPCDigitizer/src/RPCSimTriv.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimTriv.h
@@ -30,7 +30,7 @@ class RPCSimTriv : public RPCSim
                      CLHEP::HepRandomEngine*) override;
 
  private:
-  void init(){};
+  void init() override{};
 
   RPCSynchronizer* _rpcSync;
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -63,11 +63,11 @@ namespace cms {
     virtual void StorePileupInformation( std::vector<int> &numInteractionList,
 					 std::vector<int> &bunchCrossingList,
 					 std::vector<float> &TrueInteractionList, 
-					 std::vector<edm::EventID> &eventInfoList, int bunchSpacing){
+					 std::vector<edm::EventID> &eventInfoList, int bunchSpacing) override{
       PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
     }
 
-    virtual PileupMixingContent* getEventPileupInfo() { return PileupInfo_; }
+    virtual PileupMixingContent* getEventPileupInfo() override { return PileupInfo_; }
 
   private:
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >,

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -57,11 +57,11 @@ public:
   virtual void StorePileupInformation( std::vector<int> &numInteractionList,
 				       std::vector<int> &bunchCrossingList,
 				       std::vector<float> &TrueInteractionList,
-				       std::vector<edm::EventID> &eventInfoList, int bunchSpacing){
+				       std::vector<edm::EventID> &eventInfoList, int bunchSpacing) override{
     PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
   } 
 
-  virtual PileupMixingContent* getEventPileupInfo() { return PileupInfo_; } 
+  virtual PileupMixingContent* getEventPileupInfo() override { return PileupInfo_; } 
 
   
 private:

--- a/TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h
+++ b/TrackingTools/GsfTools/interface/BasicMultiTrajectoryState.h
@@ -38,13 +38,13 @@ public:
   }
 
   using	Components = BasicTrajectoryState::Components;
-  Components const & components() const {
+  Components const & components() const override {
     return theStates;
   }
   bool singleState() const override { return false;}
 
 
-  virtual bool canUpdateLocalParameters() const { return false; }
+  virtual bool canUpdateLocalParameters() const override { return false; }
   virtual void update( const LocalTrajectoryParameters& p,
                        const Surface& aSurface,
                        const MagneticField* field,

--- a/TrackingTools/GsfTools/interface/GsfPropagatorAdapter.h
+++ b/TrackingTools/GsfTools/interface/GsfPropagatorAdapter.h
@@ -48,7 +48,7 @@ public:
 
 public:
 
-  virtual bool setMaxDirectionChange( float phiMax) {
+  virtual bool setMaxDirectionChange( float phiMax) override {
     return thePropagator->setMaxDirectionChange(phiMax);
   }
 
@@ -60,12 +60,12 @@ public:
     return *thePropagator;
   }
 
-  virtual GsfPropagatorAdapter* clone() const
+  virtual GsfPropagatorAdapter* clone() const override 
   {
     return new GsfPropagatorAdapter(*thePropagator);
   }
 
-  virtual const MagneticField* magneticField() const {
+  virtual const MagneticField* magneticField() const override {
     return thePropagator->magneticField();
   }
 

--- a/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.h
+++ b/TrackingTools/GsfTools/interface/KullbackLeiblerDistance.h
@@ -15,7 +15,7 @@ public:
  double operator() (const SingleGaussianState<N>&, 
 			     const SingleGaussianState<N>&) const override;
 
-  virtual KullbackLeiblerDistance<N>* clone() const
+  virtual KullbackLeiblerDistance<N>* clone() const override
   {  
     return new KullbackLeiblerDistance<N>(*this);
   }

--- a/TrackingTools/GsfTracking/interface/GsfPropagatorWithMaterial.h
+++ b/TrackingTools/GsfTracking/interface/GsfPropagatorWithMaterial.h
@@ -67,7 +67,7 @@ class GsfPropagatorWithMaterial : public Propagator {
 
 
 
-  virtual bool setMaxDirectionChange( float phiMax) {
+  virtual bool setMaxDirectionChange( float phiMax) override {
     return theGeometricalPropagator->setMaxDirectionChange(phiMax);
   }
 
@@ -94,12 +94,12 @@ class GsfPropagatorWithMaterial : public Propagator {
     return *theConvolutor;
   }
 
-  virtual GsfPropagatorWithMaterial* clone() const
+  virtual GsfPropagatorWithMaterial* clone() const override
   {
     return new GsfPropagatorWithMaterial(*theGeometricalPropagator,*theConvolutor);
   }
 
-  const MagneticField* magneticField() const {return theGeometricalPropagator->magneticField();}
+  const MagneticField* magneticField() const override {return theGeometricalPropagator->magneticField();}
 
 private:
 //   /// Definition of timers (temporary)

--- a/TrackingTools/GsfTracking/interface/GsfTrajectoryFitter.h
+++ b/TrackingTools/GsfTracking/interface/GsfTrajectoryFitter.h
@@ -36,12 +36,12 @@ public:
 
   virtual ~GsfTrajectoryFitter();
 
-  Trajectory fitOne(const Trajectory& t, fitType type) const;
+  Trajectory fitOne(const Trajectory& t, fitType type) const override;
   Trajectory fitOne(const TrajectorySeed& aSeed,
 		    const RecHitContainer& hits,
-		    const TrajectoryStateOnSurface& firstPredTsos, fitType type) const;
+		    const TrajectoryStateOnSurface& firstPredTsos, fitType type) const override;
   Trajectory fitOne(const TrajectorySeed& aSeed,
-		    const RecHitContainer& hits, fitType type) const;
+		    const RecHitContainer& hits, fitType type) const override;
 
 
 
@@ -61,7 +61,7 @@ public:
                                 theGeometry));
   }
 
-  virtual void setHitCloner(TkCloner const * hc) {
+  virtual void setHitCloner(TkCloner const * hc) override {
      theHitCloner = hc;
   }
 

--- a/TrackingTools/GsfTracking/interface/GsfTrajectorySmoother.h
+++ b/TrackingTools/GsfTracking/interface/GsfTrajectorySmoother.h
@@ -51,7 +51,7 @@ public:
 				     *theMerger,theErrorRescaling,theMatBeforeUpdate,theGeometry);
   }
 
-  virtual void setHitCloner(TkCloner const * hc) {
+  virtual void setHitCloner(TkCloner const * hc)  override{
   }
 
 

--- a/TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h
+++ b/TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h
@@ -62,7 +62,7 @@ private:
 
 public:
   /// Limit on change in azimuthal angle
-  virtual bool setMaxDirectionChange( float phiMax) {
+  virtual bool setMaxDirectionChange( float phiMax)  override{
     return theGeometricalPropagator->setMaxDirectionChange(phiMax);
   }
   /// Propagation direction
@@ -89,10 +89,10 @@ public:
     return *theMEUpdator;
   }
 
-  virtual const MagneticField* magneticField() const {return field;}
+  virtual const MagneticField* magneticField() const override {return field;}
 
 
-  virtual PropagatorWithMaterial* clone() const
+  virtual PropagatorWithMaterial* clone() const override
     {
       return new PropagatorWithMaterial(*this);
     }

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
@@ -31,7 +31,7 @@ class EcalDetIdAssociator: public CaloDetIdAssociator{
  protected:
 
    virtual const unsigned int getNumberOfSubdetectors() const override { return 2;}
-   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const {
+   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const  override{
      if ( subDetectorIndex == 0 )
        validIds = geometry_->getValidDetIds(DetId::Ecal, EcalBarrel);//EB
      else

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
@@ -34,7 +34,7 @@ class HcalDetIdAssociator: public CaloDetIdAssociator{
     
    int hcalReg_;
    virtual const unsigned int getNumberOfSubdetectors() const override { return hcalReg_;}
-   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const {
+   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
      if ( subDetectorIndex == 0 )
        validIds = geometry_->getValidDetIds(DetId::Hcal, HcalBarrel);//HB
      else

--- a/TrackingTools/TrackFitters/interface/KFSplittingFitter.h
+++ b/TrackingTools/TrackFitters/interface/KFSplittingFitter.h
@@ -42,16 +42,16 @@ public:
   }
 
   Trajectory fitOne(const Trajectory& aTraj,
-		    fitType type) const;
+		    fitType type) const override;
   Trajectory fitOne(const TrajectorySeed& aSeed,
 		    const RecHitContainer& hits,
-		    fitType type) const;
+		    fitType type) const override;
  Trajectory fitOne(const TrajectorySeed& aSeed,
 		    const RecHitContainer& hits,
 		    const TSOS& firstPredTsos,
-		    fitType type) const;
+		    fitType type) const override;
 
-  virtual void setHitCloner(TkCloner const * hc) {
+  virtual void setHitCloner(TkCloner const * hc)  override{
         fitter.setHitCloner(hc);
   }
 

--- a/TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h
+++ b/TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h
@@ -74,13 +74,13 @@ public:
     }
   }
 
-  Trajectory fitOne(const Trajectory& aTraj,fitType) const;
+  Trajectory fitOne(const Trajectory& aTraj,fitType) const override;
   Trajectory fitOne(const TrajectorySeed& aSeed,
-		    const RecHitContainer& hits,fitType) const;
+		    const RecHitContainer& hits,fitType) const override;
 
   Trajectory fitOne(const TrajectorySeed& aSeed,
 		    const RecHitContainer& hits,
-		    const TSOS& firstPredTsos,fitType) const;
+		    const TSOS& firstPredTsos,fitType) const override;
 
   const Propagator* propagator() const {return thePropagator;}
   const TrajectoryStateUpdator* updator() const {return theUpdator;}
@@ -101,7 +101,7 @@ public:
   }
 
  // FIXME a prototype:	final inplementaiton may differ 
-  virtual void setHitCloner(TkCloner const * hc) {  theHitCloner = hc;}
+  virtual void setHitCloner(TkCloner const * hc) override {  theHitCloner = hc;}
 
 
 private:

--- a/TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h
+++ b/TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h
@@ -88,7 +88,7 @@ public:
   }
 
  // FIXME a prototype:  final inplementaiton may differ
-  virtual void setHitCloner(TkCloner const * hc) {  theHitCloner =	hc;}
+  virtual void setHitCloner(TkCloner const * hc) override {  theHitCloner =	hc;}
 
 
 private:

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -44,13 +44,13 @@ public:
     theMaxCCCLostHitsTrajectoryFilter->setEvent(iEvent, iSetup);
   }
 
-  virtual bool qualityFilter( const Trajectory& traj) const {return QF<Trajectory>(traj);}
-  virtual bool qualityFilter( const TempTrajectory& traj) const {return QF<TempTrajectory>(traj);}
+  virtual bool qualityFilter( const Trajectory& traj) const override {return QF<Trajectory>(traj);}
+  virtual bool qualityFilter( const TempTrajectory& traj) const override {return QF<TempTrajectory>(traj);}
  
-  virtual bool toBeContinued( Trajectory& traj) const {return TBC<Trajectory>(traj);}
-  virtual bool toBeContinued( TempTrajectory& traj) const {return TBC<TempTrajectory>(traj);}
+  virtual bool toBeContinued( Trajectory& traj) const override {return TBC<Trajectory>(traj);}
+  virtual bool toBeContinued( TempTrajectory& traj) const override {return TBC<TempTrajectory>(traj);}
 
-  virtual  std::string name() const { return "CkfBaseTrajectoryFilter";}
+  virtual  std::string name() const override { return "CkfBaseTrajectoryFilter";}
 
   inline edm::ParameterSetDescription getFilledConfigurationDescription() {
     edm::ParameterSetDescription descLooper           = theLooperTrajectoryFilter->getFilledConfigurationDescription();

--- a/TrackingTools/TrajectoryFiltering/interface/CompositeLogicalTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CompositeLogicalTrajectoryFilter.h
@@ -40,13 +40,13 @@ public:
     }
   }
 
-  virtual bool qualityFilter( const Trajectory& traj) const { return QF<Trajectory>(traj);}
-  virtual bool qualityFilter( const TempTrajectory& traj) const { return QF<TempTrajectory>(traj);}
+  virtual bool qualityFilter( const Trajectory& traj) const override { return QF<Trajectory>(traj);}
+  virtual bool qualityFilter( const TempTrajectory& traj) const override { return QF<TempTrajectory>(traj);}
  
-  virtual bool toBeContinued( Trajectory& traj) const { return TBC<Trajectory>(traj);}
-  virtual bool toBeContinued( TempTrajectory& traj) const { return TBC<TempTrajectory>(traj);}
+  virtual bool toBeContinued( Trajectory& traj) const override { return TBC<Trajectory>(traj);}
+  virtual bool toBeContinued( TempTrajectory& traj) const override { return TBC<TempTrajectory>(traj);}
   
-  virtual std::string name() const {return "CompositeLogicalTrajectoryFilter";}
+  virtual std::string name() const override {return "CompositeLogicalTrajectoryFilter";}
 
 protected:
   template <class T> bool TBC( T& traj)const{

--- a/TrackingTools/TrajectoryFiltering/interface/CompositeTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CompositeTrajectoryFilter.h
@@ -33,13 +33,13 @@ public:
     }
   }
 
-  virtual bool qualityFilter( const Trajectory& traj) const { return QF<Trajectory>(traj);}
-  virtual bool qualityFilter( const TempTrajectory& traj) const { return QF<TempTrajectory>(traj);}
+  virtual bool qualityFilter( const Trajectory& traj) const  override{ return QF<Trajectory>(traj);}
+  virtual bool qualityFilter( const TempTrajectory& traj) const  override{ return QF<TempTrajectory>(traj);}
  
-  virtual bool toBeContinued( Trajectory& traj) const { return TBC<Trajectory>(traj);}
-  virtual bool toBeContinued( TempTrajectory& traj) const { return TBC<TempTrajectory>(traj);}
+  virtual bool toBeContinued( Trajectory& traj) const  override{ return TBC<Trajectory>(traj);}
+  virtual bool toBeContinued( TempTrajectory& traj) const  override{ return TBC<TempTrajectory>(traj);}
   
-  virtual std::string name() const { std::string rname="CompositeTrajectoryFilter";
+  virtual std::string name() const  override{ std::string rname="CompositeTrajectoryFilter";
     unsigned int i=0;
     unsigned int n=filters.size();
     for (;i<n;i++){ rname+="_"+filters[i]->name();}

--- a/TrackingTools/TransientTrackingRecHit/interface/GenericTransientTrackingRecHit.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/GenericTransientTrackingRecHit.h
@@ -10,10 +10,10 @@ public:
 
   virtual ~GenericTransientTrackingRecHit() {delete trackingRecHit_;}
 
-  virtual AlgebraicVector parameters() const {return trackingRecHit_->parameters();}
-  virtual AlgebraicSymMatrix parametersError() const {return trackingRecHit_->parametersError();}
-  virtual AlgebraicMatrix projectionMatrix() const {return trackingRecHit_->projectionMatrix();}
-  virtual int dimension() const {return trackingRecHit_->dimension();}
+  virtual AlgebraicVector parameters() const override {return trackingRecHit_->parameters();}
+  virtual AlgebraicSymMatrix parametersError() const override {return trackingRecHit_->parametersError();}
+  virtual AlgebraicMatrix projectionMatrix() const override {return trackingRecHit_->projectionMatrix();}
+  virtual int dimension() const override {return trackingRecHit_->dimension();}
 
   // virtual void getKfComponents( KfComponentsHolder & holder ) const  override { trackingRecHit_->getKfComponents(holder); }
   // NO, because someone might specialize parametersError, projectionMatrix or parameters in the transient rechit
@@ -24,8 +24,8 @@ public:
 
   virtual bool canImproveWithTrack() const override {return false;}
 
-  virtual const TrackingRecHit * hit() const {return trackingRecHit_;}
-  TrackingRecHit * cloneHit() const { return hit()->clone();}
+  virtual const TrackingRecHit * hit() const override {return trackingRecHit_;}
+  TrackingRecHit * cloneHit() const override { return hit()->clone();}
 
   virtual std::vector<const TrackingRecHit*> recHits() const override {
     return ((const TrackingRecHit *)(trackingRecHit_))->recHits();

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.h
@@ -23,7 +23,7 @@ public:
   explicit CSCRecHitValidation(const edm::ParameterSet&);
   ~CSCRecHitValidation();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   PSimHitMap theSimHitMap;

--- a/Validation/CaloTowers/interface/CaloTowersClient.h
+++ b/Validation/CaloTowers/interface/CaloTowersClient.h
@@ -52,7 +52,7 @@ class CaloTowersClient : public DQMEDHarvester {
   explicit CaloTowersClient(const edm::ParameterSet& );
   virtual ~CaloTowersClient();
   
-  virtual void beginJob(void);
+  virtual void beginJob(void) override;
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
 
   int CaloTowersEndjob(const std::vector<MonitorElement*> &hcalMEs);

--- a/Validation/CaloTowers/interface/CaloTowersValidation.h
+++ b/Validation/CaloTowers/interface/CaloTowersValidation.h
@@ -34,9 +34,9 @@ class CaloTowersValidation : public DQMEDAnalyzer {
  public:
    CaloTowersValidation(edm::ParameterSet const& conf);
   ~CaloTowersValidation();
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-  virtual void beginRun() ;
-  virtual void endRun() ;
+  virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  virtual void beginRun();
+  virtual void endRun();
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/Validation/EcalDigis/interface/EcalDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalDigisValidation.h
@@ -62,7 +62,7 @@ void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const
 protected:
 
 /// Analyze
-void analyze(edm::Event const & e, edm::EventSetup const & c);
+void analyze(edm::Event const & e, edm::EventSetup const & c) override;
 void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override; 
 
 private:

--- a/Validation/EcalDigis/interface/EcalEndcapDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalEndcapDigisValidation.h
@@ -50,7 +50,7 @@ virtual void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSet
 protected:
 
 /// Analyze
-void analyze(edm::Event const & e, edm::EventSetup const & c);
+void analyze(edm::Event const & e, edm::EventSetup const & c) override;
 
 void checkCalibrations(edm::EventSetup const & c);
 

--- a/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
+++ b/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
@@ -89,12 +89,12 @@ void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const
 protected:
 
 /// Analyze
-void analyze(edm::Event const & e, edm::EventSetup const & c);
+void analyze(edm::Event const & e, edm::EventSetup const & c) override;
 
 void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
 // EndRun
-void endRun(const edm::Run& r, const edm::EventSetup& c);
+void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 
 private:

--- a/Validation/EcalDigis/interface/EcalPreshowerDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalPreshowerDigisValidation.h
@@ -46,7 +46,7 @@ void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const
 protected:
 
 /// Analyze
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/Validation/EcalDigis/interface/EcalPreshowerNoiseDistrib.h
+++ b/Validation/EcalDigis/interface/EcalPreshowerNoiseDistrib.h
@@ -39,7 +39,7 @@ void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const
 protected:
 
 /// Analyze
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
@@ -49,7 +49,7 @@ protected:
 
 /// Analyze
 void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
@@ -50,7 +50,7 @@ protected:
 void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
 
 /// Analyze
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 

--- a/Validation/EcalRecHits/interface/EcalPreshowerRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalPreshowerRecHitsValidation.h
@@ -46,7 +46,7 @@ class EcalPreshowerRecHitsValidation: public DQMEDAnalyzer{
  
   void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override; 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   
  private:
   

--- a/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
@@ -57,7 +57,7 @@ protected:
 
 void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
 /// Analyze
-void analyze(const edm::Event& e, const edm::EventSetup& c);
+void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  uint32_t getUnitWithMaxEnergy(MapType& themap);
  void     findBarrelMatrix(int nCellInEta, int nCellInPhi,

--- a/Validation/EcalRecHits/interface/EcalTBValidation.h
+++ b/Validation/EcalRecHits/interface/EcalTBValidation.h
@@ -24,7 +24,7 @@ class EcalTBValidation : public DQMEDAnalyzer {
   ~EcalTBValidation();
   
   void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
   
  private:
 

--- a/Validation/GlobalDigis/interface/GlobalDigisAnalyzer.h
+++ b/Validation/GlobalDigis/interface/GlobalDigisAnalyzer.h
@@ -116,7 +116,7 @@ class GlobalDigisAnalyzer : public DQMEDAnalyzer
 
   explicit GlobalDigisAnalyzer(const edm::ParameterSet&);
   virtual ~GlobalDigisAnalyzer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/Validation/GlobalDigis/interface/GlobalDigisHistogrammer.h
+++ b/Validation/GlobalDigis/interface/GlobalDigisHistogrammer.h
@@ -60,7 +60,7 @@ class GlobalDigisHistogrammer : public DQMEDAnalyzer {
 
   explicit GlobalDigisHistogrammer(const edm::ParameterSet&);
   virtual ~GlobalDigisHistogrammer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &,
       edm::Run const &, edm::EventSetup const &) override;
   

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -80,7 +80,7 @@ class GlobalHitsAnalyzer : public DQMEDAnalyzer
 
   explicit GlobalHitsAnalyzer(const edm::ParameterSet&);
   virtual ~GlobalHitsAnalyzer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
@@ -79,7 +79,7 @@ class GlobalHitsHistogrammer : public DQMEDAnalyzer {
 
   explicit GlobalHitsHistogrammer(const edm::ParameterSet&);
   virtual ~GlobalHitsHistogrammer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &,
       edm::Run const &, edm::EventSetup const &) override;
 

--- a/Validation/GlobalHits/interface/GlobalHitsProducer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProducer.h
@@ -81,8 +81,8 @@ class GlobalHitsProducer : public edm::EDProducer
 
   explicit GlobalHitsProducer(const edm::ParameterSet&);
   virtual ~GlobalHitsProducer();
-  virtual void beginJob( void );
-  virtual void endJob();  
+  virtual void beginJob( void ) override;
+  virtual void endJob() override;  
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
   
  private:

--- a/Validation/GlobalHits/interface/GlobalHitsTester.h
+++ b/Validation/GlobalHits/interface/GlobalHitsTester.h
@@ -80,7 +80,7 @@ class GlobalHitsTester : public DQMEDAnalyzer
 
   explicit GlobalHitsTester(const edm::ParameterSet&);
   virtual ~GlobalHitsTester();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
   

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -148,7 +148,7 @@ class GlobalRecHitsAnalyzer : public DQMEDAnalyzer
 
   explicit GlobalRecHitsAnalyzer(const edm::ParameterSet&);
   virtual ~GlobalRecHitsAnalyzer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsHistogrammer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsHistogrammer.h
@@ -62,7 +62,7 @@ class GlobalRecHitsHistogrammer : public DQMEDAnalyzer
 
   explicit GlobalRecHitsHistogrammer(const edm::ParameterSet&);
   virtual ~GlobalRecHitsHistogrammer();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
 

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -47,9 +47,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::EDGetTokenT<PHGCalValidInfo> g4Token_;

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.h
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.h
@@ -56,9 +56,9 @@ public:
   ~HGCalDigiValidation();
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   void fillDigiInfo(digiInfo&   hinfo);

--- a/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
@@ -68,9 +68,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   typedef std::tuple<float,float,float,float> HGCHitTuple;

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.h
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.h
@@ -63,9 +63,9 @@ public:
   ~HGCalRecHitValidation();
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   
 private:
   template<class T1, class T2>

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.h
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.h
@@ -78,9 +78,9 @@ public:
 
 protected:
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   
 private:
 

--- a/Validation/HGCalValidation/test/FTSimHitTest.cc
+++ b/Validation/HGCalValidation/test/FTSimHitTest.cc
@@ -42,7 +42,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  virtual void beginJob() {}
+  virtual void beginJob() override {}
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Validation/HGCalValidation/test/HGCGeometryCheck.cc
+++ b/Validation/HGCalValidation/test/HGCGeometryCheck.cc
@@ -40,7 +40,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  virtual void beginJob();
+  virtual void beginJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}

--- a/Validation/HGCalValidation/test/HGCHitValidation.cc
+++ b/Validation/HGCalValidation/test/HGCHitValidation.cc
@@ -83,8 +83,8 @@ public:
 private:
   typedef std::tuple<float,float,float,float> HGCHitTuple;
 
-  virtual void beginJob();
-  virtual void endJob();
+  virtual void beginJob() override;
+  virtual void endJob() override;
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}

--- a/Validation/HGCalValidation/test/HGCalBHValidation.cc
+++ b/Validation/HGCalValidation/test/HGCalBHValidation.cc
@@ -44,7 +44,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  virtual void beginJob() {}
+  virtual void beginJob() override {}
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Validation/HcalHits/test/HcalHitValidation.h
+++ b/Validation/HcalHits/test/HcalHitValidation.h
@@ -34,7 +34,7 @@ public:
 
 protected:
 
-  void analyze  (const edm::Event& e, const edm::EventSetup& c);
+  void analyze  (const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &,
     edm::Run const &, edm::EventSetup const &) override;
 

--- a/Validation/Mixing/interface/GlobalTest.h
+++ b/Validation/Mixing/interface/GlobalTest.h
@@ -50,7 +50,7 @@ class GlobalTest : public DQMEDAnalyzer {
 
   void bookHistograms(DQMStore::IBooker &,
       edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   std::string filename_;

--- a/Validation/Mixing/interface/MixCollectionValidation.h
+++ b/Validation/Mixing/interface/MixCollectionValidation.h
@@ -36,7 +36,7 @@ public:
   explicit MixCollectionValidation(const edm::ParameterSet&);
   ~MixCollectionValidation();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   

--- a/Validation/MuonCSCDigis/src/CSCDigiValidation.h
+++ b/Validation/MuonCSCDigis/src/CSCDigiValidation.h
@@ -23,7 +23,7 @@ public:
   explicit CSCDigiValidation(const edm::ParameterSet&);
   ~CSCDigiValidation();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   bool doSim_;

--- a/Validation/MuonDTDigis/src/MuonDTDigis.h
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.h
@@ -59,7 +59,7 @@ class MuonDTDigis : public DQMEDAnalyzer{
  protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   // Analysis
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
   hDigis* WheelHistos(int wheel);
 

--- a/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.h
+++ b/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.h
@@ -69,7 +69,7 @@ class MuonSimHitsValidAnalyzer : public DQMEDAnalyzer
   explicit MuonSimHitsValidAnalyzer(const edm::ParameterSet&);
   virtual ~MuonSimHitsValidAnalyzer();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
  private:
   void fillDT(const edm::Event&, const edm::EventSetup&);

--- a/Validation/MuonIdentification/interface/MuonIdVal.h
+++ b/Validation/MuonIdentification/interface/MuonIdVal.h
@@ -62,7 +62,7 @@ class MuonIdVal : public DQMEDAnalyzer {
    private:
       virtual void beginJob();
       void bookHistograms(DQMStore::IBooker &,  edm::Run const &, edm::EventSetup const &) override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       virtual void endJob();
       virtual void Fill(MonitorElement*, float);
 

--- a/Validation/MuonIsolation/interface/MuIsoValidation.h
+++ b/Validation/MuonIsolation/interface/MuIsoValidation.h
@@ -71,7 +71,7 @@ public:
   
 private:
   //---------methods----------------------------
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void InitStatics();
   void RecordData(MuonIterator muon);//Fills Histograms with info from single muon
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -23,7 +23,7 @@ public:
   ~RPCDigiValid();
 
 protected:
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/Validation/Performance/interface/PerformanceAnalyzer.h
+++ b/Validation/Performance/interface/PerformanceAnalyzer.h
@@ -16,7 +16,7 @@ public:
   explicit PerformanceAnalyzer(const edm::ParameterSet&);
   ~PerformanceAnalyzer();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::EDGetTokenT<edm::EventTime> eventTime_Token_;

--- a/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
+++ b/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
@@ -22,7 +22,7 @@ public:
   RPCPointVsRecHit(const edm::ParameterSet& pset);
   ~RPCPointVsRecHit() {};
 
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/Validation/RPCRecHits/interface/RPCRecHitValid.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValid.h
@@ -27,7 +27,7 @@ public:
   RPCRecHitValid(const edm::ParameterSet& pset);
   ~RPCRecHitValid() {};
 
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -30,7 +30,7 @@ class BTagPerformanceAnalyzerMC : public DQMEDAnalyzer {
 
       ~BTagPerformanceAnalyzerMC();
 
-      virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+      virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
    private:
 

--- a/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.h
@@ -49,7 +49,7 @@ class ElectronConversionRejectionValidator : public DQMEDAnalyzer
   virtual ~ElectronConversionRejectionValidator();
 
 
-  virtual void analyze( const edm::Event&, const edm::EventSetup& ) ;
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override ;
   void bookHistograms(DQMStore::IBooker& bei, edm::Run const&,
       edm::EventSetup const&) override;
 

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -23,7 +23,7 @@ class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
       bool isAncestor(const reco::Candidate * ancestor, const reco::Candidate * particle);
 
    private:
-      virtual void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) ;
+      virtual void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
       // ----------member data ---------------------------

--- a/Validation/RecoEgamma/plugins/TkConvValidator.h
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.h
@@ -58,9 +58,9 @@ class TkConvValidator : public DQMEDAnalyzer
   virtual ~TkConvValidator();
 
 
-  virtual void analyze( const edm::Event&, const edm::EventSetup& ) ;
+  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override ;
   void  bookHistograms( DQMStore::IBooker&, edm::Run const &, edm::EventSetup const &) override; 
-  virtual void dqmBeginRun( edm::Run const & r, edm::EventSetup const & theEventSetup) ;
+  virtual void dqmBeginRun( edm::Run const & r, edm::EventSetup const & theEventSetup) override ;
   virtual void endRun (edm::Run& r, edm::EventSetup const & es);
   virtual void endJob() ;
 

--- a/Validation/RecoHI/plugins/HiBasicGenTest.h
+++ b/Validation/RecoHI/plugins/HiBasicGenTest.h
@@ -23,8 +23,8 @@ class HiBasicGenTest : public DQMEDAnalyzer
  public:
   explicit HiBasicGenTest(const edm::ParameterSet&);
   virtual ~HiBasicGenTest();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker &,
       edm::Run const &, edm::EventSetup const &) override;
 

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -46,7 +46,7 @@ class JetTester : public DQMEDAnalyzer {
   JetTester (const edm::ParameterSet&);
   ~JetTester();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -55,7 +55,7 @@ public:
 
   explicit METTester(const edm::ParameterSet&);
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 

--- a/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
+++ b/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
@@ -52,7 +52,7 @@ class GlobalMuonMatchAnalyzer : public DQMEDAnalyzer {
    private:
       virtual void beginJob() ;
       //      virtual void beginRun(const edm::Run&, const edm::EventSetup&) ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
       virtual void endJob() ;
       virtual void endRun() ;

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.h
@@ -58,7 +58,7 @@ class MuonTrackAnalyzer: public DQMEDAnalyzer {
 
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
   void tracksAnalysis(const edm::Event & event, const edm::EventSetup& eventSetup,
 		      edm::Handle<edm::SimTrackContainer> simTracks);
   void seedsAnalysis(const edm::Event & event, const edm::EventSetup& eventSetup,

--- a/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
@@ -58,7 +58,7 @@ public:
   
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
   virtual void beginJob() ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/Validation/RecoMuon/src/RecoMuonValidator.h
+++ b/Validation/RecoMuon/src/RecoMuonValidator.h
@@ -36,10 +36,10 @@ class RecoMuonValidator : public DQMEDAnalyzer
   RecoMuonValidator(const edm::ParameterSet& pset);
   ~RecoMuonValidator();
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup& eventSetup);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup& eventSetup) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   virtual void endRun();
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   virtual int countMuonHits(const reco::Track& track) const;
   virtual int countTrackerHits(const reco::Track& track) const;
 

--- a/Validation/RecoTau/interface/TauTagValidation.h
+++ b/Validation/RecoTau/interface/TauTagValidation.h
@@ -76,8 +76,8 @@ public:
   ~TauTagValidation();
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   /// label of the current module


### PR DESCRIPTION
Adds override keyword where needed to remove clang warning.

One function signature change in CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
-    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
+    virtual void writeXMLHeader(  pos::PixelConfigKey key, 
The parameter key is not modified so pass by copy is OK. The derived classes did not use pass by reference which caused shadowed warnings.