### PR TITLE
Update all queues to 90X version. Add to run2 data Global Tag record for L1TGlobalPrescalesVetosRcd

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,49 +2,49 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '81X_mcRun1_design_v5',
+    'run1_design'       :   '90X_mcRun1_design_v0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '81X_mcRun1_realistic_v5',
+    'run1_mc'           :   '90X_mcRun1_realistic_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '81X_mcRun1_HeavyIon_v5',
+    'run1_mc_hi'        :   '90X_mcRun1_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '81X_mcRun1_pA_v5',
+    'run1_mc_pa'        :   '90X_mcRun1_pA_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '81X_mcRun2_design_v11',
+    'run2_design'       :   '90X_mcRun2_design_v0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '81X_mcRun2_startup_v13',
+    'run2_mc_50ns'      :   '90X_mcRun2_startup_v0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '81X_mcRun2_asymptotic_v12',
+    'run2_mc'           :   '90X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '81X_mcRun2cosmics_startup_peak_v11',
+    'run2_mc_cosmics'   :   '90X_mcRun2cosmics_startup_peak_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '81X_mcRun2_HeavyIon_v11',
+    'run2_mc_hi'        :   '90X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '81X_mcRun2_pA_v7',
+    'run2_mc_pa'        :   '90X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v11',
+    'run1_data'         :   '90X_dataRun2_v0',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v11',
+    'run2_data'         :   '90X_dataRun2_v0',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v14',
+    'run2_data_relval'  :   '90X_dataRun2_relval_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
+    'run1_hlt'          :   '90X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '90X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v0',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v4',
+    'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v10',
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v26',
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v0',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '81X_upgrade2017cosmics_realistic_peak_v9',
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '81X_upgrade2023_realistic_v4'
+    'phase2_realistic'     : '90X_upgrade2023_realistic_v0'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Ideal scenario** : [90X_mcRun1_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_design_v0) as [81X_mcRun1_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_design_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_design_v0/81X_mcRun1_design_v5): 
      * no change in content: open Queue for 90X
 
   * **RunI Heavy Ions scenario** : [90X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_HeavyIon_v0) as [81X_mcRun1_HeavyIon_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_HeavyIon_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_HeavyIon_v0/81X_mcRun1_HeavyIon_v5): 
      * no change in content: open Queue for 90X
 
   * **RunI Realistic scenario** : [90X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_realistic_v0) as [81X_mcRun1_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_realistic_v0/81X_mcRun1_realistic_v5): 
      * no change in content: open Queue for 90X
 
   * **RunI Proton-Lead scenario** : [90X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_pA_v0) as [81X_mcRun1_pA_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun1_pA_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_pA_v0/81X_mcRun1_pA_v5): 
      * no change in content: open Queue for 90X
 
## RunII simulation 
 
   * **RunII Ideal scenario** : [90X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_design_v0) as [81X_mcRun2_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_design_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_design_v0/81X_mcRun2_design_v11): 
      * no change in content: open Queue for 90X
 
   * **RunII Asymptotic scenario** : [90X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_asymptotic_v0) as [81X_mcRun2_asymptotic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_asymptotic_v12) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_asymptotic_v0/81X_mcRun2_asymptotic_v12): 
      * no change in content: open Queue for 90X
 
   * **RunII Startup scenario** : [90X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_startup_v0) as [81X_mcRun2_startup_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_startup_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_startup_v0/81X_mcRun2_startup_v13): 
      * no change in content: open Queue for 90X
 
   * **RunII Proton-Lead scenario** : [90X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_pA_v0) as [81X_mcRun2_pA_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_pA_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_pA_v0/81X_mcRun2_pA_v7): 
      * no change in content: open Queue for 90X
 
   * **RunII CRAFT scenario** : [90X_mcRun2cosmics_startup_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2cosmics_startup_peak_v0) as [81X_mcRun2cosmics_startup_peak_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2cosmics_startup_peak_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2cosmics_startup_peak_v0/81X_mcRun2cosmics_startup_peak_v11): 
      * no change in content: open Queue for 90X
 
   * **RunII Heavy Ions scenario** : [90X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_HeavyIon_v0) as [81X_mcRun2_HeavyIon_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_mcRun2_HeavyIon_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_HeavyIon_v0/81X_mcRun2_HeavyIon_v11): 
      * no change in content: open Queue for 90X
 
## RunII data 
 
   * **RunII Offline processing** : [90X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_v0) as [81X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_v0/81X_dataRun2_v11): 
      * added record for `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLTHI processing** : [90X_dataRun2_HLTHI_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_HLTHI_frozen_v0) as [81X_dataRun2_HLTHI_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_HLTHI_frozen_v0/81X_dataRun2_HLTHI_frozen_v4): 
      * added record for `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT relval processing** : [90X_dataRun2_HLT_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_HLT_relval_v0) as [81X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_HLT_relval_v0/81X_dataRun2_HLT_relval_v7): 
      * added record for `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT processing** : [90X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_HLT_frozen_v0) as [81X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_HLT_frozen_v0/81X_dataRun2_HLT_frozen_v4): 
      * added record for `L1TGlobalPrescalesVetosRcd`
 
   * **RunII Offline relval processing** : [90X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_relval_v0) as [81X_dataRun2_relval_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v14) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_relval_v0/81X_dataRun2_relval_v14): 
      * added record for `L1TGlobalPrescalesVetosRcd`
 
## Upgrade 
 
   * **PhaseI realistic scenario** : [90X_upgrade2017_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v0) as [81X_upgrade2017_realistic_v26](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_realistic_v26) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_realistic_v0/81X_upgrade2017_realistic_v26): 
      * no change in content: open Queue for 90X
 
   * **PhaseI design scenario** : [90X_upgrade2017_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v0) as [81X_upgrade2017_design_IdealBS_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017_design_IdealBS_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_design_IdealBS_v0/81X_upgrade2017_design_IdealBS_v10): 
      * no change in content: open Queue for 90X
 
   * **PhaseI cosmics scenario** : [90X_upgrade2017cosmics_realistic_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v0) as [81X_upgrade2017cosmics_realistic_peak_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2017cosmics_realistic_peak_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v0/81X_upgrade2017cosmics_realistic_peak_v9): 
      * no change in content: open Queue for 90X
 
   * **PhaseII realistic scenario** : [90X_upgrade2023_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v0) as [81X_upgrade2023_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_upgrade2023_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2023_realistic_v0/81X_upgrade2023_realistic_v4): 
      * no change in content: open Queue for 90X
 
