### PR TITLE
Fix memory leak in L1TGlobalProducer

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -180,7 +180,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet) :
 
 
     // create new uGt Board
-    m_uGtBrd = new GlobalBoard();
+    m_uGtBrd = std::make_unique<GlobalBoard>();
     m_uGtBrd->setVerbosity(m_verbosity);
 
     // initialize cached IDs
@@ -232,9 +232,6 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet) :
 // destructor
 L1TGlobalProducer::~L1TGlobalProducer()
 {
-
-    delete m_uGtBrd;
-
 }
 
 // member functions
@@ -322,7 +319,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 	gtParser.parseCondFormats(utml1GtMenu); 
         
     // transfer the condition map and algorithm map from parser to L1uGtTriggerMenu
-        m_l1GtMenu  =  new TriggerMenu(gtParser.gtTriggerMenuName(), data->numberChips(), 
+        m_l1GtMenu  =  std::make_unique<TriggerMenu>(gtParser.gtTriggerMenuName(), data->numberChips(), 
                         gtParser.vecMuonTemplate(),
                         gtParser.vecCaloTemplate(),
                         gtParser.vecEnergySumTemplate(),
@@ -333,16 +330,16 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
                         gtParser.corEnergySumTemplate()) ;
 
  
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtTriggerMenuInterface(gtParser.gtTriggerMenuInterface());
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtTriggerMenuImplementation(gtParser.gtTriggerMenuImplementation());
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtScaleDbKey(gtParser.gtScaleDbKey());
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtScales(gtParser.gtScales());
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtTriggerMenuUUID(gtParser.gtTriggerMenuUUID());
+	m_l1GtMenu->setGtTriggerMenuInterface(gtParser.gtTriggerMenuInterface());
+	m_l1GtMenu->setGtTriggerMenuImplementation(gtParser.gtTriggerMenuImplementation());
+	m_l1GtMenu->setGtScaleDbKey(gtParser.gtScaleDbKey());
+	m_l1GtMenu->setGtScales(gtParser.gtScales());
+	m_l1GtMenu->setGtTriggerMenuUUID(gtParser.gtTriggerMenuUUID());
 
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtAlgorithmMap(gtParser.gtAlgorithmMap());
-	(const_cast<TriggerMenu*>(m_l1GtMenu))->setGtAlgorithmAliasMap(gtParser.gtAlgorithmAliasMap());	        
+	m_l1GtMenu->setGtAlgorithmMap(gtParser.gtAlgorithmMap());
+	m_l1GtMenu->setGtAlgorithmAliasMap(gtParser.gtAlgorithmAliasMap());	        
 
-        (const_cast<TriggerMenu*>(m_l1GtMenu))->buildGtConditionMap();
+        m_l1GtMenu->buildGtConditionMap();
         
 	int printV = 2;
         if(m_printL1Menu) m_l1GtMenu->print(std::cout, printV);
@@ -587,7 +584,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
 
 //  Run the GTL for this BX
-        m_uGtBrd->runGTL(iEvent, evSetup, m_l1GtMenu,
+        m_uGtBrd->runGTL(iEvent, evSetup, m_l1GtMenu.get(),
             m_produceL1GtObjectMapRecord, iBxInEvent, gtObjectMapRecord,
             m_numberPhysTriggers,
             m_nrL1Mu,

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -56,7 +56,7 @@ private:
     unsigned long long m_l1GtParCacheID;
 
     // trigger menu
-    const TriggerMenu* m_l1GtMenu;
+    std::unique_ptr<TriggerMenu> m_l1GtMenu;
     unsigned long long m_l1GtMenuCacheID;
 
     // number of physics triggers
@@ -112,7 +112,7 @@ private:
     const std::vector<int>* m_triggerMaskVetoAlgoTrig;
     std::vector<int> m_initialTriggerMaskVetoAlgoTrig;
 
-    l1t::GlobalBoard* m_uGtBrd;
+    std::unique_ptr<l1t::GlobalBoard> m_uGtBrd;
 
     /// input tag for muon collection from GMT
     edm::InputTag m_muInputTag;


### PR DESCRIPTION
Fixed a multi-megabyte leak which could happen during event processing if
an IOV is crossed.