### PR TITLE
fix memoryleak in NuclearInteractionSimulator

### DIFF
--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -183,8 +183,18 @@ NuclearInteractionSimulator::~NuclearInteractionSimulator() {
   // without crashing, while trying to close these files from outside
   for ( unsigned ifile=0; ifile<theFiles.size(); ++ifile ) { 
     for ( unsigned iene=0; iene<theFiles[ifile].size(); ++iene ) {
+      auto file = theFiles[ifile][iene];
+      if(file) {
       // std::cout << "Closing file " << iene << " with name " << theFileNames[ifile][iene] << std::endl;
-      theFiles[ifile][iene]->Close(); 
+        file->Close();
+        delete file;
+      }
+    }
+  }
+
+  for(auto& vEvents: theNUEvents) {
+    for(auto evtPtr: vEvents) {
+      delete evtPtr;
     }
   }
 


### PR DESCRIPTION
This fixes a 92MB memory leak found by valgrind