### PR TITLE
Phase 2 seeding quadruplets: from merging triplets to propagation

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -23,7 +23,7 @@ trackingPhase1.toModify(detachedQuadStepSeedLayers,
 )
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(detachedQuadStepSeedLayers, 
-    layerList = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.layerList.value()
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 
 # TrackingRegion
@@ -113,9 +113,6 @@ _detachedQuadStepHitQuadrupletsMerging.SeedComparitorPSet = detachedQuadStepSeed
 trackingPhase1PU70.toModify(detachedQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
 trackingPhase1PU70.toReplaceWith(detachedQuadStepHitQuadruplets, _detachedQuadStepHitQuadrupletsMerging)
 trackingPhase1PU70.toModify(detachedQuadStepSeeds, SeedComparitorPSet=cms.PSet(ComponentName=cms.string("none")))
-trackingPhase2PU140.toModify(detachedQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
-trackingPhase2PU140.toReplaceWith(detachedQuadStepHitQuadruplets, _detachedQuadStepHitQuadrupletsMerging)
-trackingPhase2PU140.toModify(detachedQuadStepSeeds, SeedComparitorPSet=cms.PSet(ComponentName=cms.string("none")))
 
 
 # QUALITY CUTS DURING TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -55,7 +55,7 @@ initialStepHitTriplets = _pixelTripletHLTEDProducer.clone(
 )
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
+_initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
     triplets = "initialStepHitTriplets",
     layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
 )
@@ -90,7 +90,7 @@ trackingPhase2PU140.toModify(initialStepHitTriplets,
 trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
 
 # temporary...
-initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
+_initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     ComponentName = cms.string("SeedFromConsecutiveHitsCreator"),
     MinOneOverPtError = initialStepSeeds.MinOneOverPtError,
     OriginTransverseErrorMultiplier = initialStepSeeds.OriginTransverseErrorMultiplier,
@@ -101,9 +101,10 @@ initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     propagator = initialStepSeeds.propagator,
 
 )
-initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
+_initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
 
-trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadrupletsMerging")
+trackingPhase1PU70.toReplaceWith(initialStepHitQuadruplets, _initialStepHitQuadrupletsMerging) 
+trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
 
 
 # building

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -9,6 +9,7 @@ from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayers,
@@ -19,6 +20,9 @@ trackingPhase1.toModify(initialStepSeedLayers,
         'BPix1+FPix1_pos+FPix2_pos',
         'BPix1+FPix1_neg+FPix2_neg'
     ]
+)
+trackingPhase2PU140.toModify(initialStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 
 # TrackingRegion
@@ -51,7 +55,7 @@ initialStepHitTriplets = _pixelTripletHLTEDProducer.clone(
 )
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-initialStepHitQuadruplets = _pixelQuadrupletMergerEDProducer.clone(
+initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
     triplets = "initialStepHitTriplets",
     layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
 )
@@ -59,8 +63,34 @@ from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_
 initialStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = "initialStepHitTriplets",
 )
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+initialStepHitQuadruplets = _pixelQuadrupletEDProducer.clone(
+    triplets = "initialStepHitTriplets",
+    extraHitRZtolerance = initialStepHitTriplets.extraHitRZtolerance,
+    extraHitRPhitolerance = initialStepHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 200, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.6, pt2    = 1,
+        value1 = 0.15, value2 = 0.1,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet
+)
+trackingPhase2PU140.toModify(initialStepHitTriplets,
+    produceSeedingHitSets = False,
+    produceIntermediateHitTriplets = True,
+)
+trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
+
 # temporary...
-initialStepHitQuadruplets.SeedCreatorPSet = cms.PSet(
+initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     ComponentName = cms.string("SeedFromConsecutiveHitsCreator"),
     MinOneOverPtError = initialStepSeeds.MinOneOverPtError,
     OriginTransverseErrorMultiplier = initialStepSeeds.OriginTransverseErrorMultiplier,
@@ -71,10 +101,9 @@ initialStepHitQuadruplets.SeedCreatorPSet = cms.PSet(
     propagator = initialStepSeeds.propagator,
 
 )
-initialStepHitQuadruplets.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
+initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
 
-trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
-trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
+trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadrupletsMerging")
 
 
 # building
@@ -337,4 +366,6 @@ trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)
 _InitialStep_Phase1PU70 = _InitialStep_LowPU.copy()
 _InitialStep_Phase1PU70.replace(initialStepHitTriplets, initialStepHitTriplets+initialStepHitQuadruplets)
 trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)
-trackingPhase2PU140.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)
+_InitialStep_trackingPhase2 = _InitialStep_LowPU.copy()
+_InitialStep_trackingPhase2.replace(initialStepHitTriplets, initialStepHitTriplets*initialStepHitQuadruplets)
+trackingPhase2PU140.toReplaceWith(InitialStep, _InitialStep_trackingPhase2)

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -18,6 +18,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(lowPtQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase2PU140.toModify(lowPtQuadStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
@@ -26,7 +30,6 @@ lowPtQuadStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSe
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
-from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptMin = 0.35))
 
 
@@ -92,8 +95,6 @@ _lowPtQuadStepHitQuadrupletsMerging.SeedComparitorPSet = lowPtQuadStepSeeds.Seed
 
 trackingPhase1PU70.toModify(lowPtQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
 trackingPhase1PU70.toReplaceWith(lowPtQuadStepHitQuadruplets, _lowPtQuadStepHitQuadrupletsMerging)
-trackingPhase2PU140.toModify(lowPtQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
-trackingPhase2PU140.toReplaceWith(lowPtQuadStepHitQuadruplets, _lowPtQuadStepHitQuadrupletsMerging)
 
 
 # QUALITY CUTS DURING TRACK BUILDING


### PR DESCRIPTION
Before this PR, the Phase 2 quadruplets was using the merging triplets approach, now we move in line with Phase 1 where the quadruplets are created propagating the triplets. This new algorithm has been already extensively discussed in #14327.
Performance without PU on 1000 events ttbar, D4 geometry:
- About the eff/fakes performance, the results have been produced [here](https://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/ph2_movingQuadSeeding/TTbar_1000ev_ph2_movingQuadSeeding/). We recover something at low pT without getting more fakes. In particular I think because the efficiency of the seeding itself with the new algorithm is increasing both eff and fake, but then in the track reconstruction itself, the fakes are rejected pretty good. I suppose it can be consider a pretty good result.
![pr16858](https://cloud.githubusercontent.com/assets/5331004/20923181/a007a630-bbab-11e6-8581-a740174a00d5.png)

- About timing and memory, the baseline results have been produced [here](https://ebrondol.web.cern.ch/ebrondol/cgi-bin/igprof-navigator/90X-2016-11-30-1100/TTbar_14TeV_step3_tkOnly_1000ev_baseline_CMSSW_9_0_X_2016-11-30-2300/24) while including the PR can be found [here](https://ebrondol.web.cern.ch/ebrondol/cgi-bin/igprof-navigator/90X-2016-11-30-1100/TTbar_14TeV_step3_tkOnly_1000ev_ph2_movingQuadSeeding_CMSSW_9_0_X_2016-11-30-2300/24). Thankfully, we can see that the PixelQuadrupletMergerEDProducer::produce(edm::Event&, edm::EventSetup const&) goes down quite a bit in positions. So everything seem to work pretty as expected. I am not sure that the absolute comparison is correct - maybe I messed up with some machines - but if we take the MuonId as reference, in the ph2_movingQuadSeeding version should be ~17 counts where instead is ~3.

For higher PU, this is the report from @VinInn:
full job, ttbar 200PU,  tracking only incl validation&dqm  (step3)
vinavx2 (3.5GHz, 4thread)
91x out-of-the-box      TimeReport       event loop CPU/event = 406.026545
+git cms-merge-topic ebrondol:ph2_movingQuadSeeding   TimeReport       event loop CPU/event = 291.797381
and is even more efficient at low-pt
http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_newQuad/plots_highPurity/effandfake1.pdf

This PR is considered from the TRK POG a prority not only for the much better performance, but also because of further developments expected for Phase 1 by @makortel . Best in the next pre-release.

Informing @boudoul @atricomi @delaere 