### PR TITLE
Set useClusterTPAssociation=False for HI tracking validation

### DIFF
--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 # track associator settings
 import SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi
-trackAssociatorByHitsRecoDenom = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone()
+trackAssociatorByHitsRecoDenom = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone(
+    useClusterTPAssociation = False # to do the track<->TP association with TrackerHitAssociator
+)
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff import *
 
 # reco track quality cuts


### PR DESCRIPTION
#16833 accidentally broke HI tracking validation: `QuickTrackAssociatorByHits` parameter `useClusterTPAssociation` was set to `True`, but `ClusterTPAssociationProducer` is not included in the configuration so `QuickTrackAssociatorByHits` used previously `TrackerHitAssociator`, and now throws an exception.

The proposed fix here is to restore the pre-#16833 behaviour, i.e. the use of `TrackerHitAssociator` (I leave it to HI experts to decide whether they would prefer `ClusterTPAssociation` instead).


Tested in CMSSW_9_0_X_2016-12-03-1100, the currently failing workflows `140.1,140.2,140.4,145.0,300,301,302` should run again.