### PR TITLE
[81X] Update data run2 Global Tags adding L1TGlobalPrescalesVetosRcd

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,19 +22,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '81X_mcRun2_pA_v7',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '81X_dataRun2_v11',
+    'run1_data'         :   '81X_dataRun2_v12',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '81X_dataRun2_v11',
+    'run2_data'         :   '81X_dataRun2_v12',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '81X_dataRun2_relval_v14',
+    'run2_data_relval'  :   '81X_dataRun2_relval_v15',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
+    'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '81X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '81X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v4',
+    'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
     'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII data 
 
   * **RunII Offline processing** : [81X_dataRun2_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v12) as [81X_dataRun2_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_v11) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_v12/81X_dataRun2_v11): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLTHI processing** : [81X_dataRun2_HLTHI_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v5) as [81X_dataRun2_HLTHI_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLTHI_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLTHI_frozen_v5/81X_dataRun2_HLTHI_frozen_v4): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT relval processing** : [81X_dataRun2_HLT_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v8) as [81X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_relval_v8/81X_dataRun2_HLT_relval_v7): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT processing** : [81X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v5) as [81X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_HLT_frozen_v5/81X_dataRun2_HLT_frozen_v4): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII Offline relval processing** : [81X_dataRun2_relval_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v15) as [81X_dataRun2_relval_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/81X_dataRun2_relval_v14) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/81X_dataRun2_relval_v15/81X_dataRun2_relval_v14): 
      * added `L1TGlobalPrescalesVetosRcd`