### PR TITLE
[80X] Update data run2 Global Tags with Sept 2016 conditions and add L1TGlobalPrescalesVetosRcd

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,19 +22,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '80X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_Candidate_2016_09_02_10_26_48',
+    'run1_data'         :   '80X_dataRun2_v19',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_Candidate_2016_09_02_10_26_48',
+    'run2_data'         :   '80X_dataRun2_v19',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v17',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v18',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
+    'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v14',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v13',
+    'run2_hlt'          :   '80X_dataRun2_HLT_frozen_v14',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v13',
+    'run2_hlt_relval'   :   '80X_dataRun2_HLT_relval_v14',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v10',
+    'run2_hlt_hi'       :   '80X_dataRun2_HLTHI_frozen_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '80X_upgrade2017_design_v18',
     # GlobalTag for MC production with realistic conditions for for Phase1 2017 detector


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII data 
 
   * **RunII Offline processing** : [80X_dataRun2_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v19) as [80X_dataRun2_Candidate_2016_09_02_10_26_48](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_Candidate_2016_09_02_10_26_48) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_v19/80X_dataRun2_Candidate_2016_09_02_10_26_48): 
      * all conditions updates as in the Sept2016 data-rereco (see [PdmVDataReprocessing8020Run2016BCDEFG](https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDataReprocessing8020Run2016BCDEFG))
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLTHI processing** : [80X_dataRun2_HLTHI_frozen_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v11) as [80X_dataRun2_HLTHI_frozen_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLTHI_frozen_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLTHI_frozen_v11/80X_dataRun2_HLTHI_frozen_v10): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT relval processing** : [80X_dataRun2_HLT_relval_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v14) as [80X_dataRun2_HLT_relval_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_relval_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_relval_v14/80X_dataRun2_HLT_relval_v13): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII HLT processing** : [80X_dataRun2_HLT_frozen_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v14) as [80X_dataRun2_HLT_frozen_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_HLT_frozen_v13) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_HLT_frozen_v14/80X_dataRun2_HLT_frozen_v13): 
      * added `L1TGlobalPrescalesVetosRcd`
 
   * **RunII Offline relval processing** : [80X_dataRun2_relval_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v18) as [80X_dataRun2_relval_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v18/80X_dataRun2_relval_v17): 
      * all conditions updates as in the Sept2016 data-rereco (see [PdmVDataReprocessing8020Run2016BCDEFG](https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDataReprocessing8020Run2016BCDEFG))
      * added `L1TGlobalPrescalesVetosRcd`
