### PR TITLE
Update MIP timing resolution to 30ps

### DIFF
--- a/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
@@ -8,6 +8,6 @@ trackTimeValueMapProducer = cms.EDProducer(
     trackingVertexSrc = cms.InputTag('mix:MergedTrackTruth'),
     associators = cms.VInputTag(cms.InputTag('quickTrackAssociatorByHits')),
     resolutionModels = cms.VPSet( cms.PSet( modelName = cms.string('ConfigurableFlatResolutionModel'),
-                                            resolutionInNs = cms.double(0.020) ),
+                                            resolutionInNs = cms.double(0.030) ),
                                   cms.PSet( modelName = cms.string('PerfectResolutionModel') ) )
     )


### PR DESCRIPTION
Change MIP timing resolution to a flat 30ps, instead of 20ps, to reflect a conservative estimate of present technologies.

