### PR TITLE
PhaseII: optimize seeding, reduce cpu-timing

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -40,10 +40,12 @@ _layerListForPhase2 = ['BPix1+BPix2+BPix3+BPix4',
                        'BPix1+BPix2+BPix3+FPix1_pos','BPix1+BPix2+BPix3+FPix1_neg',
                        'BPix1+BPix2+FPix1_pos+FPix2_pos', 'BPix1+BPix2+FPix1_neg+FPix2_neg',
                        'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix2_neg+FPix3_neg',
+# removed as redundant in current geometry (here for documentation)
 #                       'FPix1_pos+FPix2_pos+FPix3_pos+FPix4_pos', 'FPix1_neg+FPix2_neg+FPix3_neg+FPix4_neg',
                        'FPix2_pos+FPix3_pos+FPix4_pos+FPix5_pos', 'FPix2_neg+FPix3_neg+FPix4_neg+FPix5_neg',
                        'FPix3_pos+FPix4_pos+FPix5_pos+FPix6_pos', 'FPix3_neg+FPix4_neg+FPix5_neg+FPix6_pos',
                        'FPix4_pos+FPix5_pos+FPix6_pos+FPix7_pos', 'FPix4_neg+FPix5_neg+FPix6_neg+FPix7_neg',
+#  removed as redunant and covering effectively only eta>4   (here for documentation, to be optimized after TDR)
 #                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix8_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix8_neg',
 #                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix9_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix9_neg',
 #                       'FPix6_pos+FPix7_pos+FPix8_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix8_neg+FPix9_neg'

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -40,13 +40,14 @@ _layerListForPhase2 = ['BPix1+BPix2+BPix3+BPix4',
                        'BPix1+BPix2+BPix3+FPix1_pos','BPix1+BPix2+BPix3+FPix1_neg',
                        'BPix1+BPix2+FPix1_pos+FPix2_pos', 'BPix1+BPix2+FPix1_neg+FPix2_neg',
                        'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix2_neg+FPix3_neg',
-                       'FPix1_pos+FPix2_pos+FPix3_pos+FPix4_pos', 'FPix1_neg+FPix2_neg+FPix3_neg+FPix4_neg',
+#                       'FPix1_pos+FPix2_pos+FPix3_pos+FPix4_pos', 'FPix1_neg+FPix2_neg+FPix3_neg+FPix4_neg',
                        'FPix2_pos+FPix3_pos+FPix4_pos+FPix5_pos', 'FPix2_neg+FPix3_neg+FPix4_neg+FPix5_neg',
                        'FPix3_pos+FPix4_pos+FPix5_pos+FPix6_pos', 'FPix3_neg+FPix4_neg+FPix5_neg+FPix6_pos',
                        'FPix4_pos+FPix5_pos+FPix6_pos+FPix7_pos', 'FPix4_neg+FPix5_neg+FPix6_neg+FPix7_neg',
-                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix8_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix8_neg',
-                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix9_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix9_neg',
-                       'FPix6_pos+FPix7_pos+FPix8_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix8_neg+FPix9_neg']
+#                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix8_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix8_neg',
+#                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix9_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix9_neg',
+#                       'FPix6_pos+FPix7_pos+FPix8_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix8_neg+FPix9_neg'
+]
 
 # Needed to have pixelTracks to not to look like depending
 # siPixelRecHits (that is inserted in reco sequences in

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -31,9 +31,9 @@ trackingPhase2PU140.toReplaceWith(convClusters, _phase2trackClusterRemover.clone
     phase2OTClusters                         = "siPhase2Clusters",
     TrackQuality                             = 'highPurity',
     minNumberOfLayersWithMeasBeforeFiltering = 0,
-    trajectories                             = cms.InputTag("pixelPairStepTracks"),
-    oldClusterRemovalInfo                    = cms.InputTag("pixelPairStepClusters"),
-    overrideTrkQuals                         = cms.InputTag("pixelPairStepSelector","pixelPairStep"),
+    trajectories                             = cms.InputTag("detachedQuadStepTracks"),
+    oldClusterRemovalInfo                    = cms.InputTag("detachedQuadStepClusters"),
+    overrideTrkQuals                         = cms.InputTag("detachedQuadStepSelector","detachedQuadStepTrk"),
     )
 )
 

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -105,7 +105,6 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
                      'lowPtQuadStepTracks',
                      'lowPtTripletStepTracks',
                      'detachedQuadStepTracks',
-#                     'pixelPairStepTracks'
                     ],
     hasSelector = [1,1,1,1,1],
     indivShareFrac = [1.0,0.16,0.095,0.09,0.09,0.09],
@@ -114,7 +113,6 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
                                        cms.InputTag("lowPtQuadStepSelector","lowPtQuadStep"),
                                        cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
                                        cms.InputTag("detachedQuadStep"),
-#                                       cms.InputTag("pixelPairStepSelector","pixelPairStep")
                                        ),
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4), pQual=cms.bool(True) )
                              ),

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -105,17 +105,18 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
                      'lowPtQuadStepTracks',
                      'lowPtTripletStepTracks',
                      'detachedQuadStepTracks',
-                     'pixelPairStepTracks'],
-    hasSelector = [1,1,1,1,1,1],
+#                     'pixelPairStepTracks'
+                    ],
+    hasSelector = [1,1,1,1,1],
     indivShareFrac = [1.0,0.16,0.095,0.09,0.09,0.09],
     selectedTrackQuals = cms.VInputTag(cms.InputTag("initialStepSelector","initialStep"),
                                        cms.InputTag("highPtTripletStepSelector","highPtTripletStep"),
                                        cms.InputTag("lowPtQuadStepSelector","lowPtQuadStep"),
                                        cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
                                        cms.InputTag("detachedQuadStep"),
-                                       cms.InputTag("pixelPairStepSelector","pixelPairStep")
+#                                       cms.InputTag("pixelPairStepSelector","pixelPairStep")
                                        ),
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) )
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4), pQual=cms.bool(True) )
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -23,7 +23,7 @@ trackingPhase1.toModify(detachedQuadStepSeedLayers,
 )
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(detachedQuadStepSeedLayers, 
-    layerList = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.layerList.value()
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 
 # TrackingRegion
@@ -113,9 +113,6 @@ _detachedQuadStepHitQuadrupletsMerging.SeedComparitorPSet = detachedQuadStepSeed
 trackingPhase1PU70.toModify(detachedQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
 trackingPhase1PU70.toReplaceWith(detachedQuadStepHitQuadruplets, _detachedQuadStepHitQuadrupletsMerging)
 trackingPhase1PU70.toModify(detachedQuadStepSeeds, SeedComparitorPSet=cms.PSet(ComponentName=cms.string("none")))
-trackingPhase2PU140.toModify(detachedQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
-trackingPhase2PU140.toReplaceWith(detachedQuadStepHitQuadruplets, _detachedQuadStepHitQuadrupletsMerging)
-trackingPhase2PU140.toModify(detachedQuadStepSeeds, SeedComparitorPSet=cms.PSet(ComponentName=cms.string("none")))
 
 
 # QUALITY CUTS DURING TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -303,7 +303,7 @@ trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
 trackingPhase2PU140.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*
     highPtTripletStepSeedClusterMask*
-    pixelPairStepSeedClusterMask*
+#    pixelPairStepSeedClusterMask*
     tripletElectronSeedLayers*
     tripletElectronTrackingRegions*
     tripletElectronHitDoublets*

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -32,7 +32,7 @@ trackingPhase2PU140.toReplaceWith(highPtTripletStepSeedClusterMask, seedClusterR
     )
 )
 trackingPhase2PU140.toReplaceWith(pixelPairStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag("pixelPairStepSeeds"),
+    trajectories = cms.InputTag("detachedQuadStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("highPtTripletStepSeedClusterMask")
     )
 )
@@ -263,7 +263,7 @@ trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
 trackingPhase2PU140.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
-    'pixelPairStepSeeds',
+#    'pixelPairStepSeeds',
     'tripletElectronSeeds'
 ])
 
@@ -303,7 +303,7 @@ trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
 trackingPhase2PU140.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*
     highPtTripletStepSeedClusterMask*
-#    pixelPairStepSeedClusterMask*
+    pixelPairStepSeedClusterMask*
     tripletElectronSeedLayers*
     tripletElectronTrackingRegions*
     tripletElectronHitDoublets*

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -263,7 +263,6 @@ trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
 trackingPhase2PU140.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
-#    'pixelPairStepSeeds',
     'tripletElectronSeeds'
 ])
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -32,7 +32,8 @@ highPtTripletStepSeedLayers = _PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
 )
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(highPtTripletStepSeedLayers, 
+trackingPhase2PU140.toModify(highPtTripletStepSeedLayers,
+# combination with gap removed as only source of fakes in current geometry (kept for doc) 
     layerList = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
 #                 'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
                  'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
@@ -47,6 +48,7 @@ trackingPhase2PU140.toModify(highPtTripletStepSeedLayers,
                  'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
                  'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
                  'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
+#  removed as redunant and covering effectively only eta>4   (here for documentation, to be optimized after TDR)
 #                 'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg',
 #                 'FPix6_pos+FPix7_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix9_neg']
      ]

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -34,23 +34,23 @@ highPtTripletStepSeedLayers = _PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(highPtTripletStepSeedLayers, 
     layerList = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
-                 'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+#                 'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
                  'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
                  'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
                  'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
                  'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
-                 'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+#                 'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
                  'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
                  'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
-                 'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg',
+#                 'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg',
                  'FPix2_pos+FPix3_pos+FPix4_pos', 'FPix2_neg+FPix3_neg+FPix4_neg',
                  'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
                  'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
                  'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
-                 'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg',
-                 'FPix6_pos+FPix7_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix9_neg']
+#                 'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg',
+#                 'FPix6_pos+FPix7_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix9_neg']
+     ]
 )
-
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 highPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -55,7 +55,7 @@ initialStepHitTriplets = _pixelTripletHLTEDProducer.clone(
 )
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
+_initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
     triplets = "initialStepHitTriplets",
     layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
 )
@@ -90,7 +90,7 @@ trackingPhase2PU140.toModify(initialStepHitTriplets,
 trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
 
 # temporary...
-initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
+_initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     ComponentName = cms.string("SeedFromConsecutiveHitsCreator"),
     MinOneOverPtError = initialStepSeeds.MinOneOverPtError,
     OriginTransverseErrorMultiplier = initialStepSeeds.OriginTransverseErrorMultiplier,
@@ -101,9 +101,10 @@ initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     propagator = initialStepSeeds.propagator,
 
 )
-initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
+_initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
 
-trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadrupletsMerging")
+trackingPhase1PU70.toReplaceWith(initialStepHitQuadruplets, _initialStepHitQuadrupletsMerging) 
+trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
 
 
 # building

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -9,6 +9,7 @@ from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayers,
@@ -19,6 +20,9 @@ trackingPhase1.toModify(initialStepSeedLayers,
         'BPix1+FPix1_pos+FPix2_pos',
         'BPix1+FPix1_neg+FPix2_neg'
     ]
+)
+trackingPhase2PU140.toModify(initialStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 
 # TrackingRegion
@@ -51,7 +55,7 @@ initialStepHitTriplets = _pixelTripletHLTEDProducer.clone(
 )
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-initialStepHitQuadruplets = _pixelQuadrupletMergerEDProducer.clone(
+initialStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
     triplets = "initialStepHitTriplets",
     layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
 )
@@ -59,8 +63,34 @@ from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_
 initialStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = "initialStepHitTriplets",
 )
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+initialStepHitQuadruplets = _pixelQuadrupletEDProducer.clone(
+    triplets = "initialStepHitTriplets",
+    extraHitRZtolerance = initialStepHitTriplets.extraHitRZtolerance,
+    extraHitRPhitolerance = initialStepHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 200, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.6, pt2    = 1,
+        value1 = 0.15, value2 = 0.1,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet
+)
+trackingPhase2PU140.toModify(initialStepHitTriplets,
+    produceSeedingHitSets = False,
+    produceIntermediateHitTriplets = True,
+)
+trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
+
 # temporary...
-initialStepHitQuadruplets.SeedCreatorPSet = cms.PSet(
+initialStepHitQuadrupletsMerging.SeedCreatorPSet = cms.PSet(
     ComponentName = cms.string("SeedFromConsecutiveHitsCreator"),
     MinOneOverPtError = initialStepSeeds.MinOneOverPtError,
     OriginTransverseErrorMultiplier = initialStepSeeds.OriginTransverseErrorMultiplier,
@@ -71,10 +101,9 @@ initialStepHitQuadruplets.SeedCreatorPSet = cms.PSet(
     propagator = initialStepSeeds.propagator,
 
 )
-initialStepHitQuadruplets.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
+initialStepHitQuadrupletsMerging.SeedComparitorPSet = initialStepSeeds.SeedComparitorPSet
 
-trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
-trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadruplets")
+trackingPhase1PU70.toModify(initialStepSeeds, seedingHitSets="initialStepHitQuadrupletsMerging")
 
 
 # building
@@ -337,4 +366,6 @@ trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)
 _InitialStep_Phase1PU70 = _InitialStep_LowPU.copy()
 _InitialStep_Phase1PU70.replace(initialStepHitTriplets, initialStepHitTriplets+initialStepHitQuadruplets)
 trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)
-trackingPhase2PU140.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)
+_InitialStep_trackingPhase2 = _InitialStep_LowPU.copy()
+_InitialStep_trackingPhase2.replace(initialStepHitTriplets, initialStepHitTriplets*initialStepHitQuadruplets)
+trackingPhase2PU140.toReplaceWith(InitialStep, _InitialStep_trackingPhase2)

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -18,6 +18,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(lowPtQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase2PU140.toModify(lowPtQuadStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
@@ -26,7 +30,6 @@ lowPtQuadStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSe
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
-from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptMin = 0.35))
 
 
@@ -92,8 +95,6 @@ _lowPtQuadStepHitQuadrupletsMerging.SeedComparitorPSet = lowPtQuadStepSeeds.Seed
 
 trackingPhase1PU70.toModify(lowPtQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
 trackingPhase1PU70.toReplaceWith(lowPtQuadStepHitQuadruplets, _lowPtQuadStepHitQuadrupletsMerging)
-trackingPhase2PU140.toModify(lowPtQuadStepHitTriplets, produceIntermediateHitTriplets=False, produceSeedingHitSets=True)
-trackingPhase2PU140.toReplaceWith(lowPtQuadStepHitQuadruplets, _lowPtQuadStepHitQuadrupletsMerging)
 
 
 # QUALITY CUTS DURING TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -31,17 +31,17 @@ trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPha
 trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 
 _layerListForPhase2 = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
-                       'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+#                       'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
                        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
                        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
-                       'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+#                       'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
                        'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
-                       'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg',
+#                       'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg',
                        'FPix2_pos+FPix3_pos+FPix4_pos', 'FPix2_neg+FPix3_neg+FPix4_neg',
                        'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
                        'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
-                       'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
-                       'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg'
+#                       'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
+#                       'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg'
 ]
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase2)

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -30,6 +30,7 @@ from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU7
 trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 
+# combination with gap removed as only source of fakes in current geometry (kept for doc,=)
 _layerListForPhase2 = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
 #                       'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
                        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
@@ -40,6 +41,7 @@ _layerListForPhase2 = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
                        'FPix2_pos+FPix3_pos+FPix4_pos', 'FPix2_neg+FPix3_neg+FPix4_neg',
                        'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
                        'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
+#  removed as redunant and covering effectively only eta>4   (here for documentation, to be optimized after TDR)
 #                       'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
 #                       'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg'
 ]

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -63,7 +63,6 @@ _iterations_trackingPhase2PU140 = [
     "LowPtQuadStep",
     "LowPtTripletStep",
     "DetachedQuadStep",
-#    "PixelPairStep",
 ]
 _iterations_muonSeeded = [
     "MuonSeededStepInOut",

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -63,7 +63,7 @@ _iterations_trackingPhase2PU140 = [
     "LowPtQuadStep",
     "LowPtTripletStep",
     "DetachedQuadStep",
-    "PixelPairStep",
+#    "PixelPairStep",
 ]
 _iterations_muonSeeded = [
     "MuonSeededStepInOut",


### PR DESCRIPTION
This PR builds upon #16858 and
1) remove PIxelPair seeding
  makes PhaseII consistent with PhaseI
2) remove redundant Layers combinations w/o affecting physics performance
  a) Triplets with gaps
 b)  very-forward conbinations
 c) an intermediate FPIX combination

Timing for ttbar 200PU TkOnly wf is reduced from 406 seconds to 169 seconds (on 3.5GHz Haswell)
see details in
https://twiki.cern.ch/twiki/bin/viewauth/CMS/ViTkPerfPhase21216?sortcol=3;table=1;up=1#sorted_table

physics performance are even better than those in #16858
http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_9pre2/

http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_9pre2/plots_highPurity/effandfake1.pdf
please note also
http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_9pre2/plots_highPurity/hitsAndPt.pdf
http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_9pre2/plots_selectedOfflinePrimaryVertices/recovsgen.pdf
http://innocent.home.cern.ch/innocent/RelVal/tkRecoD4_9pre2/plots_selectedOfflinePrimaryVertices/pvtagging.pdf

 