### PR TITLE
Update SecondaryEventProvider to match framework change

### DIFF
--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -59,8 +59,7 @@ namespace edm {
   }
 
   void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>, StreamContext >(ep, setup, ep.streamID(),
-                                                                                                                   &sContext, &sContext);
+    workerManager_.setupOnDemandSystem(ep, setup);
   }
   void SecondaryEventProvider::beginStream(edm::StreamID iID, StreamContext& sContext) {
     workerManager_.beginStream(iID, sContext);


### PR DESCRIPTION
The phase 2 change of the threaded framework no longer uses
WorkerManger::processOneOccurrence for handling Events. The
SecondaryEventProvider now uses the setupUnscheduledSystem call
just like the framework.