### PR TITLE
remove IN_DICTBUILD with __CLING__ to control the visibility of standard math vs sse

### DIFF
--- a/DataFormats/GeometrySurface/test/OldFrameTransformTest.cpp
+++ b/DataFormats/GeometrySurface/test/OldFrameTransformTest.cpp
@@ -1,6 +1,4 @@
 #include <iostream>
-// force standard math
-#define IN_DICTBUILD
 #include "DataFormats/GeometrySurface/interface/TkRotation.h"
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"

--- a/DataFormats/GeometryVector/interface/oldBasic2DVector.h
+++ b/DataFormats/GeometryVector/interface/oldBasic2DVector.h
@@ -4,7 +4,7 @@
 #include "DataFormats/GeometryVector/interface/Phi.h"
 #include "DataFormats/GeometryVector/interface/PreciseFloatType.h"
 #include "DataFormats/GeometryVector/interface/CoordinateSets.h"
-#if (!defined(IN_DICTBUILD))
+#if (!defined(__CLING__))
 #include "DataFormats/Math/interface/SIMDVec.h"
 #endif
 

--- a/DataFormats/GeometryVector/interface/oldBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/oldBasic3DVector.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_oldBasic3DVector_h
 #define GeometryVector_oldBasic3DVector_h
-#if ( defined(IN_DICTBUILD) || defined(__CINT__) )  && !defined(__REFLEX__)
+#if ( defined(__CLING__) || defined(__CINT__) )  && !defined(__REFLEX__)
 #define __REFLEX__
 #endif
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"

--- a/DataFormats/GeometryVector/src/classes.h
+++ b/DataFormats/GeometryVector/src/classes.h
@@ -1,5 +1,3 @@
-// use old stile (no sse vector buildin) class...
-#define IN_DICTBUILD
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
 //
 

--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -1,7 +1,7 @@
 #ifndef DataFormat_Math_SIMDVec_H
 #define DataFormat_Math_SIMDVec_H
 
-#if ( defined(IN_DICTBUILD) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
+#if ( defined(__CLING__) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
 #elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #  if defined(__x86_64__) && defined(__SSE__)
 #    define USE_SSEVECT

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -11,7 +11,7 @@
   \author Lindsey Gray
 */
 
-#if ( !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__) ) || defined(__ROOTCLING__)
+#if ( !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__) && !defined(__CLING__) )
 
 #define REGULAR_CPLUSPLUS 1
 #define CINT_GUARD(CODE) CODE

--- a/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h
@@ -11,7 +11,6 @@
 
 class DetLayer;
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 /**
  * Class to store TransientTrackingRecHits, names, and DetLayer
  * pointers of each ctfseeding::SeedingLayer as they come from
@@ -249,17 +248,5 @@ private:
    */
   OwnedHits rechits_;
 };
-
-
-#else
-class SeedingLayerSetsHits {
-private:
-  SeedingLayerSetsHits(SeedingLayerSetsHits const&){} 
-  SeedingLayerSetsHits& operator=(SeedingLayerSetsHits const&){return *this;}
-
-  std::vector<BaseTrackerRecHit const*> rechits_;
-
-};
-#endif
 
 #endif


### PR DESCRIPTION
backport of #16440

As reported in #16291 , root sees inconsistents sse headers. This PR should avoid the use of internal IN_DICTBUILD and use ```__CLING__```