### PR TITLE
remove Trajectory in Event for GSF

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackProducer_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackProducer_cfi.py
@@ -4,7 +4,7 @@ conversionTrackProducer = cms.EDProducer("ConversionTrackProducer",
                                          #input collection of tracks or gsf tracks
                                          TrackProducer = cms.string(''),
                                          #control whether to get ref to Trajectory (only available in reco job)
-                                         useTrajectory = cms.bool(True),
+                                         useTrajectory = cms.bool(False),
                                          #control which flags are set in output collection
                                          setTrackerOnly = cms.bool(False),
                                          setArbitratedEcalSeeded = cms.bool(False),

--- a/TrackingTools/GsfTracking/python/GsfElectronGsfFit_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronGsfFit_cff.py
@@ -9,5 +9,5 @@ electronGsfTracks.src = 'electronCkfTrackCandidates'
 electronGsfTracks.Propagator = 'fwdGsfElectronPropagator'
 electronGsfTracks.Fitter = 'GsfElectronFittingSmoother'
 electronGsfTracks.TTRHBuilder = 'WithTrackAngle'
-electronGsfTracks.TrajectoryInEvent = True
+electronGsfTracks.TrajectoryInEvent = False
 


### PR DESCRIPTION
reduces memory by ~1GB at PU200 with 4 threads

tested with
```
[1]    Done                          runTheMatrix.py --useInput=all --list=limited >& lim.log
[innocent@cmsco01 matrix]$ 
[innocent@cmsco01 matrix]$ cat runall-report-step123-.log 
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:15:58 2016-date Wed Dec  7 11:12:04 2016; exit: 0 0 0 0 0
5.1_TTbar+TTbarFS+HARVESTFS Step0-PASSED Step1-PASSED  - time date Wed Dec  7 11:15:36 2016-date Wed Dec  7 11:12:05 2016; exit: 0 0
8.0_BeamHalo+BeamHaloINPUT+DIGICOS+RECOCOS+ALCABH+HARVESTCOS Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:17:22 2016-date Wed Dec  7 11:12:08 2016; exit: 0 0 0 0 0
25.0_TTbar+TTbarINPUT+DIGI+RECOAlCaCalo+HARVEST+ALCATT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:23:35 2016-date Wed Dec  7 11:12:13 2016; exit: 0 0 0 0 0
135.4_ZEE_13+ZEEFS_13+HARVESTUP15FS+MINIAODMCUP15FS Step0-PASSED Step1-PASSED Step2-PASSED  - time date Wed Dec  7 11:26:15 2016-date Wed Dec  7 11:15:44 2016; exit: 0 0 0
136.731_RunSinglePh2016B+RunSinglePh2016B+HLTDR2_2016+RECODR2_2016reHLT_skimSinglePh_HIPM+HARVESTDR2 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  7 11:38:08 2016-date Wed Dec  7 11:15:59 2016; exit: 0 0 0 0
140.53_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI Step0-PASSED Step1-PASSED Step2-PASSED  - time date Wed Dec  7 11:24:51 2016-date Wed Dec  7 11:17:25 2016; exit: 0 0 0
1330.0_ZMM_13+ZMM_13INPUT+DIGIUP15+RECOUP15+HARVESTUP15 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  7 11:31:12 2016-date Wed Dec  7 11:23:40 2016; exit: 0 0 0 0
1000.0_RunMinBias2011A+RunMinBias2011A+TIER0+SKIMD+HARVESTDfst2+ALCASPLIT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:33:03 2016-date Wed Dec  7 11:24:54 2016; exit: 0 0 0 0 0
1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED Step6-PASSED Step7-PASSED  - time date Wed Dec  7 11:33:23 2016-date Wed Dec  7 11:26:17 2016; exit: 0 0 0 0 0 0 0 0
10021.0_TenMuE_0_200+TenMuE_0_200_pythia8_2017_GenSimFullINPUT+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:41:11 2016-date Wed Dec  7 11:31:21 2016; exit: 0 0 0 0 0
10024.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017_GenSimFullINPUT+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Dec  7 11:44:21 2016-date Wed Dec  7 11:33:03 2016; exit: 0 0 0 0 0
20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D1_GenSimHLBeamSpotFull14+DigiFull_2023D1+RecoFullGlobal_2023D1+HARVESTFullGlobal_2023D1 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  7 11:45:10 2016-date Wed Dec  7 11:33:24 2016; exit: 0 0 0 0
21234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D4_GenSimHLBeamSpotFull14+DigiFull_2023D4+RecoFullGlobal_2023D4+HARVESTFullGlobal_2023D4 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  7 12:19:32 2016-date Wed Dec  7 11:38:08 2016; exit: 0 0 0 0
23234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D5_GenSimHLBeamSpotFull14+DigiFull_2023D5+RecoFullGlobal_2023D5+HARVESTFullGlobal_2023D5 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  7 12:22:39 2016-date Wed Dec  7 11:41:13 2016; exit: 0 0 0 0
15 15 14 12 7 1 1 1 tests passed, 0 0 0 0 0 0 0 0 failed
```