### PR TITLE
Fix hit eff hit pattern phase I

### DIFF
--- a/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
@@ -90,4 +90,24 @@ trackingEffFromHitPattern = cms.EDAnalyzer("DQMGenericClient",
                                            verbose = cms.untracked.uint32(5),
                                            outputFileName = cms.untracked.string(""),
                                            )
+def __extendEfficiencyForPixels(dets):
+    """Inject the efficiency computation for the additional layers in the
+    PhaseI detectors wrt Run2. The input list is cloned and modified
+    rather than updated in place. The substitution add another layer
+    by replacing flat '3' -> '4' for the barrel case and '2' -> '3'
+    for the forward case.
+    """
+    from re import match
+    ret = []
+    for d in dets:
+        ret.append(d)
+        if match('.*PXB3.*', d):
+            ret.append(d.replace('3', '4'))
+        elif match('.*PXF2.*', d):
+            ret.append(d.replace('2', '3'))
+    return ret
 
+
+# Use additional pixel layers in PhaseI geometry.
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(trackingEffFromHitPattern, efficiency = __extendEfficiencyForPixels(trackingEffFromHitPattern.efficiency))

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -21,7 +21,7 @@ namespace trackerHitRTTI {
   inline bool isUndef(TrackingRecHit const & hit) { return rtti(hit)==undef;}
   inline bool isSingle(TrackingRecHit const & hit)  { return rtti(hit)==single || rtti(hit)==fastSingle;}
   inline bool isProjMono(TrackingRecHit const & hit)  { return rtti(hit)==projMono || rtti(hit)==fastProjMono;}
-  inline bool isProjStereo(TrackingRecHit const & hit)  { return rtti(hit)==projStereo || fastProjStereo;}
+  inline bool isProjStereo(TrackingRecHit const & hit)  { return rtti(hit)==projStereo || rtti(hit)==fastProjStereo;}
   inline bool isProjected(TrackingRecHit const & hit)  { return ((rtti(hit)==projMono) | (rtti(hit)==projStereo)) || (rtti(hit)==fastProjMono) | (rtti(hit)==fastProjStereo);}
   inline bool isMatched(TrackingRecHit const & hit)  { return rtti(hit)==match || rtti(hit)==fastMatch;}
   inline bool isMulti(TrackingRecHit const & hit)  { return rtti(hit)==multi;}
@@ -58,7 +58,7 @@ public:
   bool isMatched() const { return trackerHitRTTI::isMatched(*this);}
   bool isProjected() const { return trackerHitRTTI::isProjected(*this);}
   bool isProjMono() const { return trackerHitRTTI::isProjMono(*this);}
-  bool isProjSterep() const { return trackerHitRTTI::isProjStereo(*this);}
+  bool isProjStereo() const { return trackerHitRTTI::isProjStereo(*this);}
   bool isMulti() const { return trackerHitRTTI::isMulti(*this);}
 
   virtual bool isPixel() const { return false;}


### PR DESCRIPTION
Add the fourth barrel layer and third fwd disk to the computation of the hit efficiencies from hit-patter for the phaseI case.
Also a minor bug fix.
No changes expected (except for the new efficiencies)