### PR TITLE
put in failsafe to not run PreMixing and HIP simulation simultaneously

### DIFF
--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -77,6 +77,7 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
   else LogDebug("SiStripDigitizerAlgorithm")<<" SingleStripNoise: OFF";
   if(CommonModeNoise) LogDebug("SiStripDigitizerAlgorithm")<<" CommonModeNoise: ON";
   else LogDebug("SiStripDigitizerAlgorithm")<<" CommonModeNoise: OFF";
+  if(PreMixing_ && APVSaturationFromHIP) throw cms::Exception("PreMixing does not work with HIP loss simulation yet");
   if(APVSaturationFromHIP){  
     std::string line; 
     APVProbaFile.open((APVProbabilityFile.fullPath()).c_str());


### PR DESCRIPTION
This is preventing to run premixing when switching on the HIP simulation 

Forward port of the last commit from  @mdhildreth in the 80X PR #15458 , keeping all release cycles  in synch 