### PR TITLE
HCAL digi simulation debugging tools

### DIFF
--- a/CalibFormats/CaloObjects/interface/CaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloSamples.h
@@ -82,4 +82,6 @@ private:
 
 std::ostream& operator<<(std::ostream& s, const CaloSamples& samps);
 
+typedef std::vector<CaloSamples> CaloSamplesCollection;
+
 #endif

--- a/CalibFormats/CaloObjects/src/classes.h
+++ b/CalibFormats/CaloObjects/src/classes.h
@@ -1,0 +1,10 @@
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+namespace CalibFormats_CaloObjects {
+  struct dictionary {
+    CaloSamples cs;
+    CaloSamplesCollection vcs;
+    edm::Wrapper<CaloSamplesCollection> wcvs;
+  };
+}

--- a/CalibFormats/CaloObjects/src/classes_def.xml
+++ b/CalibFormats/CaloObjects/src/classes_def.xml
@@ -1,0 +1,7 @@
+<lcgdict>
+  <class name="CaloSamples" ClassVersion="3">
+   <version ClassVersion="3" checksum="4242646275"/>
+  </class>
+  <class name="std::vector<CaloSamples>"/>
+  <class name="edm::Wrapper<std::vector<CaloSamples> >" splitLevel="0"/>
+</lcgdict>

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -121,6 +121,10 @@ public:
     storePrecise = sp;
   }
 
+  void setIgnoreGeantTime(bool gt) {
+    ignoreTime = gt;
+  }
+
 protected:
 
   AnalogSignalMap theAnalogSignalMap;
@@ -139,7 +143,7 @@ protected:
 
   double thePhaseShift_;
   bool storePrecise;
-
+  bool ignoreTime;
 };
 
 #endif

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -117,6 +117,10 @@ public:
     return(bunchCrossing >= theMinBunch && bunchCrossing <= theMaxBunch);
   }
 
+  void setStorePrecise(bool sp) {
+    storePrecise = sp;
+  }
+
 protected:
 
   AnalogSignalMap theAnalogSignalMap;
@@ -134,6 +138,7 @@ protected:
   int theMaxBunch;
 
   double thePhaseShift_;
+  bool storePrecise;
 
 };
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
@@ -108,6 +108,7 @@ public:
     int nDigisExpected = addNoise_ ? theDetIds->size() : theHitResponse->nSignals();
     output.reserve(nDigisExpected);
     if(debugCS_) {
+      csColl_.clear();
       csColl_.reserve(nDigisExpected);
       theHitResponse->setStorePrecise(true);
     }

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
@@ -107,7 +107,10 @@ public:
     // reserve space for how many digis we expect
     int nDigisExpected = addNoise_ ? theDetIds->size() : theHitResponse->nSignals();
     output.reserve(nDigisExpected);
-    if(debugCS_) csColl_.reserve(nDigisExpected);
+    if(debugCS_) {
+      csColl_.reserve(nDigisExpected);
+      theHitResponse->setStorePrecise(true);
+    }
 
     // make a raw digi for evey cell
     for(std::vector<DetId>::const_iterator idItr = theDetIds->begin();

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
@@ -49,7 +49,8 @@ public:
      theNoiseSignalGenerator(0),
      theElectronicsSim(electronicsSim),
      theDetIds(0),
-     addNoise_(addNoise)
+     addNoise_(addNoise),
+     debugCS_(false)
   {
   }
 
@@ -64,6 +65,14 @@ public:
   void setNoiseSignalGenerator(CaloVNoiseSignalGenerator * generator)
   {
     theNoiseSignalGenerator = generator;
+  }
+
+  void setDebugCaloSamples(bool debug){
+    debugCS_ = debug;
+  }
+
+  const CaloSamplesCollection& getCaloSamples() const {
+    return csColl_;
   }
 
   void add(const std::vector<PCaloHit> & hits, int bunchCrossing, CLHEP::HepRandomEngine* engine) {
@@ -98,12 +107,14 @@ public:
     // reserve space for how many digis we expect
     int nDigisExpected = addNoise_ ? theDetIds->size() : theHitResponse->nSignals();
     output.reserve(nDigisExpected);
+    if(debugCS_) csColl_.reserve(nDigisExpected);
 
     // make a raw digi for evey cell
     for(std::vector<DetId>::const_iterator idItr = theDetIds->begin();
         idItr != theDetIds->end(); ++idItr)
     {
        CaloSamples * analogSignal = theHitResponse->findSignal(*idItr);
+       if(analogSignal && debugCS_) csColl_.push_back(*analogSignal);
        bool needToDeleteSignal = false;
        // don't bother digitizing if no signal and no noise
        if(analogSignal == 0 && addNoise_) {
@@ -142,6 +153,8 @@ private:
   ElectronicsSim * theElectronicsSim;
   const std::vector<DetId>* theDetIds;
   bool addNoise_;
+  bool debugCS_;
+  CaloSamplesCollection csColl_;
 };
 
 #endif

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -119,10 +119,12 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit & hit, CLHEP::HepRa
   double signal = analogSignalAmplitude(detId, hit.energy(), parameters, engine);
 
   double time = hit.time();
+  double tof = timeOfFlight(detId);
+  if(ignoreTime) time = tof;
   if(theHitCorrection != 0) {
     time += theHitCorrection->delay(hit, engine);
   }
-  double jitter = hit.time() - timeOfFlight(detId);
+  double jitter = time - tof;
 
   const CaloVShape * shape = theShape;
   if(!shape) {

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -31,7 +31,8 @@ CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap * parametersMap,
   theMinBunch(-10), 
   theMaxBunch(10),
   thePhaseShift_(1.),
-  storePrecise(false) {}
+  storePrecise(false),
+  ignoreTime(false) {}
 
 CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap * parametersMap,
                                  const CaloShapes * shapes)
@@ -46,7 +47,8 @@ CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap * parametersMap,
   theMinBunch(-10),
   theMaxBunch(10),
   thePhaseShift_(1.),
-  storePrecise(false) {}
+  storePrecise(false),
+  ignoreTime(false) {}
 
 CaloHitResponse::~CaloHitResponse() {
 }
@@ -193,7 +195,7 @@ CaloSamples CaloHitResponse::makeBlankSignal(const DetId & detId) const {
   int preciseSize(storePrecise ? parameters.readoutFrameSize()*BUNCHSPACE : 0);
   CaloSamples result(detId, parameters.readoutFrameSize(),preciseSize);
   result.setPresamples(parameters.binOfMaximum()-1);
-  result.setPrecise(result.presamples()*BUNCHSPACE,1.0);
+  if(storePrecise) result.setPrecise(result.presamples()*BUNCHSPACE,1.0);
   return result;
 }
 

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -9,7 +9,8 @@ SimCalorimetryFEVTDEBUG = cms.PSet(
         'keep *_simHcalDigis_*_*', 
         'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
         'drop ZDCDataFramesSorted_mix_simHcalUnsuppressedDigis*_*',
-        'keep *_simHcalTriggerPrimitiveDigis_*_*')
+        'keep *_simHcalTriggerPrimitiveDigis_*_*',
+        'keep *_mix_HcalSamples_*')
 )
 SimCalorimetryRAW = cms.PSet(
     outputCommands = cms.untracked.vstring('keep EBSrFlagsSorted_simEcalDigis_*_*', 

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -10,7 +10,8 @@ SimCalorimetryFEVTDEBUG = cms.PSet(
         'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
         'drop ZDCDataFramesSorted_mix_simHcalUnsuppressedDigis*_*',
         'keep *_simHcalTriggerPrimitiveDigis_*_*',
-        'keep *_mix_HcalSamples_*')
+        'keep *_mix_HcalSamples_*',
+        'keep *_mix_HcalHits_*')
 )
 SimCalorimetryRAW = cms.PSet(
     outputCommands = cms.untracked.vstring('keep EBSrFlagsSorted_simEcalDigis_*_*', 

--- a/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
@@ -20,6 +20,8 @@ public:
 
   double fCtoGeV(const DetId & detId) const;
 
+  double samplingFactor() const;
+
 private:
   const HcalDbService * theDbService;
   double theSamplingFactor;

--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -3,12 +3,11 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
         process.mix.digitizers.hcal.debugCaloSamples = cms.bool(True)
-    if hasattr(process,'simHcalUnsuppressedDigis'):
-        process.simHcalUnsuppressedDigis.mix.append(cms.PSet(type = cms.string('CaloSampless')))
 
     from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlock
     process.CaloSamplesAnalyzer = cms.EDAnalyzer("CaloSamplesAnalyzer",
-        hcalSimBlock
+        hcalSimBlock,
+        CaloSamplesTag = cms.InputTag("mix","HcalSamples"),
     )
 
     process.TFileService = cms.Service("TFileService",

--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
+        process.mix.digitizers.hcal.debugCaloSamples = cms.bool(True)
+    if hasattr(process,'simHcalUnsuppressedDigis'):
+        process.simHcalUnsuppressedDigis.mix.append(cms.PSet(type = cms.string('CaloSampless')))
+
+    from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlock
+    process.CaloSamplesAnalyzer = cms.EDAnalyzer("CaloSamplesAnalyzer",
+        hcalSimBlock
+    )
+
+    process.TFileService = cms.Service("TFileService",
+        fileName = cms.string("debugcalosamples.root")
+    )
+    
+    process.debug_step = cms.Path(process.CaloSamplesAnalyzer)
+    process.schedule.extend([process.debug_step])
+    
+    return process

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -55,3 +55,7 @@ double HFSimParameters::fCtoGeV(const DetId & detId) const
 }
 
 
+double HFSimParameters::samplingFactor() const
+{
+  return theSamplingFactor;
+}

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -79,7 +79,9 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
       //divide out mean of crosstalk distribution 1/(1-lambda) = multiply by (1-lambda)
       double signal(analogSignalAmplitude(id, hit.energy(), pars, engine)*(1-pars.sipmCrossTalk(id)));
       unsigned int photons(signal + 0.5);
+      double tof( timeOfFlight(id) );
       double time( hit.time() );
+      if(ignoreTime) time = tof;
 
       if (photons > 0)
 	if (precisionTimedPhotons.find(id)==precisionTimedPhotons.end()) {
@@ -100,11 +102,11 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
 		<< " photons: " << photons 
 		<< " time: " << time;
       LogDebug("HcalSiPMHitResponse") << " timePhase: " << pars.timePhase()
-		<< " tof: " << timeOfFlight(id)
+		<< " tof: " << tof
 		<< " binOfMaximum: " << pars.binOfMaximum()
 		<< " phaseShift: " << thePhaseShift_;
       double tzero(0.0*Y11TIMETORISE + pars.timePhase() - 
-		   (hit.time() - timeOfFlight(id)) - 
+		   (time - tof) - 
 		   BUNCHSPACE*( pars.binOfMaximum() - thePhaseShift_));
       LogDebug("HcalSiPMHitResponse") << " tzero: " << tzero;
       double tzero_bin(-tzero/(theTDCParams.deltaT()/TIMEMULT));

--- a/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
+++ b/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="SimCalorimetry/HcalSimAlgos"/>
   <use name="SimDataFormats/CrossingFrame"/>
   <use name="CommonTools/UtilAlgos"/>
+  <use name="SimDataFormats/CaloTest"/>
   <bin file="HPDIonFeedbackTest.cpp"/>
   <bin file="HcalShapeIntegratorTest.cpp"/>
   <bin file="HcalTimeSlewTest.cpp"/>
@@ -11,5 +12,7 @@
   <library file="HcalDigitizerTest.cc" name="HcalDigitizerTest">
   </library>
   <library file="SiPMNonlinearityAnalyzer.cc" name="SiPMNonlinearityAnalyzer">
+  </library>
+  <library file="CaloSamplesAnalyzer.cc" name="CaloSamplesAnalyzer">
   </library>
 </environment>

--- a/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
@@ -1,0 +1,277 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+//ROOT headers
+#include <TTree.h>
+
+//calo headers
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameterMap.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "SimDataFormats/CaloTest/interface/HcalTestNumbering.h"
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h" 
+ 
+//STL headers 
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+//
+// class declaration
+//
+
+class CaloSamplesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+	public:
+		explicit CaloSamplesAnalyzer(const edm::ParameterSet&);
+		~CaloSamplesAnalyzer();
+	
+		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+		
+		struct CaloNtuple {
+			unsigned run = 0;
+			unsigned lumiblock = 0;
+			unsigned long long event = 0;
+			unsigned id = 0;
+			int subdet = 0;
+			int ieta = 0;
+			int iphi = 0;
+			int depth = 0;
+			double samplingFactor = 0.;
+			double fCtoGeV = 0.;
+			double photoelectronsToAnalog = 0.;
+			double simHitToPhotoelectrons = 0.;
+			double tof = 0.;
+			std::vector<double> energy;
+			std::vector<double> time;
+			std::vector<double> signalTot;
+			std::vector<double> signalTotPrecise;
+		};
+	
+	private:
+		void beginJob() override;
+		void doBeginRun_(const edm::Run&, const edm::EventSetup&) override;
+		void analyze(const edm::Event&, const edm::EventSetup&) override;
+		void doEndRun_(const edm::Run&, const edm::EventSetup&) override {}
+		void endJob() override {}
+		
+		// ----------member data ---------------------------
+		edm::Service<TFileService> fs;
+		TTree* tree;
+		const CaloGeometry* theGeometry;
+		const HcalDDDRecConstants * theRecNumber;
+		CaloHitResponse* theResponse;
+		HcalSimParameterMap * theParameterMap;
+		//for tree branches
+		CaloNtuple entry;
+		std::unordered_map<unsigned,CaloNtuple> treemap;
+		//misc. params
+		bool TestNumbering;
+		//tokens
+		edm::EDGetTokenT<std::vector<PCaloHit>> tok_sim;
+		edm::EDGetTokenT<std::vector<CaloSamples>> tok_calo;
+};
+
+//
+// constructors and destructor
+//
+CaloSamplesAnalyzer::CaloSamplesAnalyzer(const edm::ParameterSet& iConfig) :
+	tree(NULL), theGeometry(NULL), theRecNumber(NULL), theResponse(new CaloHitResponse(NULL,(CaloShapes*)NULL)), theParameterMap(new HcalSimParameterMap(iConfig)),
+	tok_sim(consumes<std::vector<PCaloHit>>(edm::InputTag(iConfig.getParameter<std::string>("hitsProducer"), "HcalHits"))),
+	tok_calo(consumes<std::vector<CaloSamples>>(edm::InputTag("simHcalUnsuppressedDigis")))
+{
+	usesResource("TFileService");
+}
+
+
+CaloSamplesAnalyzer::~CaloSamplesAnalyzer()
+{
+	delete theResponse;
+	delete theParameterMap;
+}
+
+
+//
+// member functions
+//
+
+void CaloSamplesAnalyzer::beginJob()
+{
+	tree = fs->make<TTree>("tree","tree");
+	
+	tree->Branch("run"                   , &entry.run                   , "run/i");
+	tree->Branch("lumiblock"             , &entry.lumiblock             , "lumiblock/i");
+	tree->Branch("event"                 , &entry.event                 , "event/l");
+	tree->Branch("id"                    , &entry.id                    , "id/i");
+	tree->Branch("subdet"                , &entry.subdet                , "subdet/I");
+	tree->Branch("ieta"                  , &entry.ieta                  , "ieta/I");
+	tree->Branch("iphi"                  , &entry.iphi                  , "iphi/I");
+	tree->Branch("depth"                 , &entry.depth                 , "depth/I");
+	tree->Branch("samplingFactor"        , &entry.samplingFactor        , "samplingFactor/D");
+	tree->Branch("fCtoGeV"               , &entry.fCtoGeV               , "fCtoGeV/D");
+	tree->Branch("photoelectronsToAnalog", &entry.photoelectronsToAnalog, "photoelectronsToAnalog/D");
+	tree->Branch("simHitToPhotoelectrons", &entry.simHitToPhotoelectrons, "simHitToPhotoelectrons/D");
+	tree->Branch("energy"                , "vector<double>"             , &entry.energy, 32000, 0);
+	tree->Branch("time"                  , "vector<double>"             , &entry.time, 32000, 0);
+	tree->Branch("tof"                   , &entry.tof                   , "tof/D");
+	tree->Branch("signalTot"             , "vector<double>"             , &entry.signalTot, 32000, 0);
+	tree->Branch("signalTotPrecise"      , "vector<double>"             , &entry.signalTotPrecise, 32000, 0);
+}
+
+void CaloSamplesAnalyzer::doBeginRun_(const edm::Run& iRun, const edm::EventSetup& iSetup)
+{
+	edm::ESHandle<CaloGeometry> geometry;
+	iSetup.get<CaloGeometryRecord>().get(geometry);
+	edm::ESHandle<HcalDDDRecConstants> pHRNDC;
+	iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
+
+	// See if it's been updated
+	if (&*geometry != theGeometry) {
+		theGeometry = &*geometry;
+		theRecNumber= &*pHRNDC;
+		theResponse->setGeometry(theGeometry);
+	}
+}
+
+// ------------ method called on each new Event  ------------
+void
+CaloSamplesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	treemap.clear();
+
+	//conditions
+	edm::ESHandle<HcalDbService> conditions;
+	iSetup.get<HcalDbRecord>().get(conditions);
+	theParameterMap->setDbService(conditions.product());
+	
+	// Event information
+	edm::EventAuxiliary aux = iEvent.eventAuxiliary();
+	unsigned run = aux.run();
+	unsigned lumiblock = aux.luminosityBlock();
+	unsigned long long event = aux.event();
+	
+	edm::Handle<std::vector<CaloSamples>> h_CS;
+	iEvent.getByToken(tok_calo,h_CS);
+	
+	//loop over CaloSamples, extract info per channel
+	for(const auto& iCS : *(h_CS.product())){
+		DetId did(iCS.id());
+		if(did.det()!=DetId::Hcal) continue;
+		HcalDetId hid(did);
+		CaloNtuple& ntup = treemap[hid.rawId()];
+		//check for existence of entry
+		if(ntup.id==0){
+			ntup.id = hid.rawId();
+			ntup.subdet = hid.subdet();
+			ntup.ieta = hid.ieta();
+			ntup.iphi = hid.iphi();
+			ntup.depth = hid.depth();
+			//get sim parameters
+			if(hid.subdet()==HcalForward){
+				const HFSimParameters& pars = dynamic_cast<const HFSimParameters&>(theParameterMap->simParameters(hid));
+				ntup.samplingFactor = pars.samplingFactor();
+				ntup.fCtoGeV = pars.fCtoGeV(hid);
+				ntup.photoelectronsToAnalog = pars.photoelectronsToAnalog(hid);
+				ntup.simHitToPhotoelectrons = pars.simHitToPhotoelectrons(hid);
+			}
+			else {
+				const HcalSimParameters& pars = dynamic_cast<const HcalSimParameters&>(theParameterMap->simParameters(hid));
+				ntup.samplingFactor = pars.samplingFactor(hid);
+				ntup.fCtoGeV = pars.fCtoGeV(hid);
+				ntup.photoelectronsToAnalog = pars.photoelectronsToAnalog(hid);
+				ntup.simHitToPhotoelectrons = pars.simHitToPhotoelectrons(hid);			
+			}
+			//get time of flight
+			ntup.tof = theResponse->timeOfFlight(hid);
+		}
+		//get pulse info every time
+		if(ntup.signalTot.size()==0) ntup.signalTot.resize(iCS.size(),0.0);
+		for(int i = 0; i < iCS.size(); ++i){
+			ntup.signalTot[i] += iCS[i];
+		}
+		if(ntup.signalTotPrecise.size()==0) ntup.signalTotPrecise.resize(iCS.preciseSize(),0.0);
+		for(int i = 0; i < iCS.preciseSize(); ++i){
+			ntup.signalTotPrecise[i] += iCS.preciseAt(i);
+		}
+	}
+	
+	edm::Handle<std::vector<PCaloHit>> h_SH;
+	iEvent.getByToken(tok_sim,h_SH);
+	
+	//loop over simhits, extract info per channel
+	for(const auto& iSH : *(h_SH.product())){
+		HcalDetId hid;
+		unsigned int id = iSH.id();
+		if(TestNumbering){
+			int subdet, z, depth, eta, phi, lay;
+			HcalTestNumbering::unpackHcalIndex(id, subdet, z, depth, eta, phi, lay);
+			int sign = (z==0) ? -1 : 1;
+			HcalDDDRecConstants::HcalID cid = theRecNumber->getHCID(subdet, eta, phi, lay, depth);
+			hid = HcalDetId((HcalSubdetector)subdet, sign*cid.eta, cid.phi, cid.depth);
+		}
+		else hid = HcalDetId(id);
+		auto ntupIt = treemap.find(hid.rawId());
+		if(ntupIt==treemap.end()) continue;
+		CaloNtuple& ntup = ntupIt->second;
+		//append simhit info
+		ntup.energy.push_back(iSH.energy());
+		ntup.time.push_back(iSH.time());
+	}
+	
+	//one tree entry per map entry
+	entry.run = run;
+	entry.lumiblock = lumiblock;
+	entry.event = event;
+	for(const auto& ntup : treemap){
+		entry.id = ntup.second.id;
+		entry.subdet = ntup.second.subdet;
+		entry.ieta = ntup.second.ieta;
+		entry.iphi = ntup.second.iphi;
+		entry.depth = ntup.second.depth;
+		entry.samplingFactor = ntup.second.samplingFactor;
+		entry.fCtoGeV = ntup.second.fCtoGeV;
+		entry.photoelectronsToAnalog = ntup.second.photoelectronsToAnalog;
+		entry.simHitToPhotoelectrons = ntup.second.simHitToPhotoelectrons;
+		entry.tof = ntup.second.tof;
+		entry.energy = ntup.second.energy;
+		entry.time = ntup.second.time;
+		entry.signalTot = ntup.second.signalTot;
+		entry.signalTotPrecise = ntup.second.signalTotPrecise;
+		tree->Fill();
+	}
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+CaloSamplesAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(CaloSamplesAnalyzer);

--- a/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
@@ -101,7 +101,7 @@ class CaloSamplesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResource
 CaloSamplesAnalyzer::CaloSamplesAnalyzer(const edm::ParameterSet& iConfig) :
 	tree(NULL), theGeometry(NULL), theRecNumber(NULL), theResponse(new CaloHitResponse(NULL,(CaloShapes*)NULL)), theParameterMap(new HcalSimParameterMap(iConfig)),
 	tok_sim(consumes<std::vector<PCaloHit>>(edm::InputTag(iConfig.getParameter<std::string>("hitsProducer"), "HcalHits"))),
-	tok_calo(consumes<std::vector<CaloSamples>>(edm::InputTag("simHcalUnsuppressedDigis")))
+	tok_calo(consumes<std::vector<CaloSamples>>(iConfig.getParameter<edm::InputTag>("CaloSamplesTag")))
 {
 	usesResource("TFileService");
 }

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -148,6 +148,7 @@ private:
   bool doHFWindow_;
   bool killHE_;
   bool debugCS_;
+  bool ignoreTime_;
 
   std::string hitsProducer_;
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/HcalCalibObjects/interface/HEDarkening.h"
 #include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 
 #include <vector>
 
@@ -25,7 +26,6 @@ class HcalElectronicsSim;
 class HcalTimeSlewSim;
 class HcalBaseSignalGenerator;
 class HcalShapes;
-class PCaloHit;
 class PileUpEventPrincipal;
 class HcalTopology;
 
@@ -149,6 +149,7 @@ private:
   bool killHE_;
   bool debugCS_;
   bool ignoreTime_;
+  bool injectTestHits_;
 
   std::string hitsProducer_;
 
@@ -157,6 +158,11 @@ private:
   double deliveredLumi;
   HEDarkening* m_HEDarkening;
   HFRecalibration* m_HFRecalibration;
+
+  std::vector<double> injectedHitsEnergy_;
+  std::vector<double> injectedHitsTime_;
+  std::vector<int> injectedHitsCells_;
+  std::vector<PCaloHit> injectedHits_;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -147,6 +147,7 @@ private:
   bool testNumbering_;
   bool doHFWindow_;
   bool killHE_;
+  bool debugCS_;
 
   std::string hitsProducer_;
 

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -25,6 +25,7 @@ hcalSimBlock = cms.PSet(
     HFDarkening = cms.bool(False),
     minFCToDelay=cms.double(5.), # old TC model! set to 5 for the new one
     debugCaloSamples=cms.bool(False),
+    ignoreGeantTime=cms.bool(False),
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -35,6 +35,8 @@ hcalSimBlock = cms.PSet(
     injectTestHitsTime = cms.vdouble(),
     # format for cells: subdet, ieta, iphi, depth
     # multiple quadruplets can be specified
+    # if instead only 1 value is given, 
+    # it will be interpreted as an entire subdetector
     injectTestHitsCells = cms.vint32()
 )
 

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -23,7 +23,8 @@ hcalSimBlock = cms.PSet(
     TestNumbering = cms.bool(False),
     HEDarkening = cms.bool(False),
     HFDarkening = cms.bool(False),
-    minFCToDelay=cms.double(5.) # old TC model! set to 5 for the new one
+    minFCToDelay=cms.double(5.), # old TC model! set to 5 for the new one
+    debugCaloSamples=cms.bool(False),
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -26,6 +26,16 @@ hcalSimBlock = cms.PSet(
     minFCToDelay=cms.double(5.), # old TC model! set to 5 for the new one
     debugCaloSamples=cms.bool(False),
     ignoreGeantTime=cms.bool(False),
+    # settings for SimHit test injection
+    injectTestHits = cms.bool(False),
+    # if no time is specified for injected hits, t = 0 will be used
+    # (recommendation: enable "ignoreGeantTime" in that case to set t = tof)
+    # otherwise, need 1 time value per energy value
+    injectTestHitsEnergy = cms.vdouble(),
+    injectTestHitsTime = cms.vdouble(),
+    # format for cells: subdet, ieta, iphi, depth
+    # multiple quadruplets can be specified
+    injectTestHitsCells = cms.vint32()
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -17,6 +17,9 @@ HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::E
   if(pset.getParameter<bool>("debugCaloSamples")){
     mixMod.produces<CaloSamplesCollection>("HcalSamples");
   }
+  if(pset.getParameter<bool>("injectTestHits")){
+    mixMod.produces<edm::PCaloHitContainer>("HcalHits");
+  }
 }
 
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -14,7 +14,9 @@ HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::E
   mixMod.produces<ZDCDigiCollection>();
   mixMod.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
   mixMod.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
-
+  if(pset.getParameter<bool>("debugCaloSamples")){
+    mixMod.produces<CaloSamplesCollection>();
+  }
 }
 
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -15,7 +15,7 @@ HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::E
   mixMod.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
   mixMod.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
   if(pset.getParameter<bool>("debugCaloSamples")){
-    mixMod.produces<CaloSamplesCollection>();
+    mixMod.produces<CaloSamplesCollection>("HcalSamples");
   }
 }
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -502,7 +502,7 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
     if(theHFDigitizer)        csResult->insert(csResult->end(),theHFDigitizer->getCaloSamples().begin(),theHFDigitizer->getCaloSamples().end());
     if(theHFQIE10Digitizer)   csResult->insert(csResult->end(),theHFQIE10Digitizer->getCaloSamples().begin(),theHFQIE10Digitizer->getCaloSamples().end());
     csResult->insert(csResult->end(),theZDCDigitizer->getCaloSamples().begin(),theZDCDigitizer->getCaloSamples().end());
-    e.put(std::move(csResult));
+    e.put(std::move(csResult),"HcalSamples");
   }
 
 #ifdef DebugLog

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -86,6 +86,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   doHFWindow_(ps.getParameter<bool>("doHFWindow")),
   killHE_(ps.getParameter<bool>("killHE")),
   debugCS_(ps.getParameter<bool>("debugCaloSamples")),
+  ignoreTime_(ps.getParameter<bool>("ignoreGeantTime")),
   hitsProducer_(ps.getParameter<std::string>("hitsProducer")),
   theHOSiPMCode(ps.getParameter<edm::ParameterSet>("ho").getParameter<int>("siPMCode")),
   deliveredLumi(0.),
@@ -192,6 +193,17 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
     if(theHFDigitizer)        theHFDigitizer->setDebugCaloSamples(true);
     if(theHFQIE10Digitizer)   theHFQIE10Digitizer->setDebugCaloSamples(true);
     theZDCDigitizer->setDebugCaloSamples(true);
+  }
+
+  //option to ignore Geant time distribution in SimHits, for debugging
+  if(ignoreTime_){
+    theHBHEResponse->setIgnoreGeantTime(ignoreTime_);
+    theHBHESiPMResponse->setIgnoreGeantTime(ignoreTime_);
+    theHOResponse->setIgnoreGeantTime(ignoreTime_);
+    theHOSiPMResponse->setIgnoreGeantTime(ignoreTime_);
+    theHFResponse->setIgnoreGeantTime(ignoreTime_);
+    theHFQIE10Response->setIgnoreGeantTime(ignoreTime_);
+    theZDCResponse->setIgnoreGeantTime(ignoreTime_);
   }
 
   if(agingFlagHE) m_HEDarkening = new HEDarkening();

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -594,14 +594,24 @@ void  HcalDigitizer::updateGeometry(const edm::EventSetup & eventSetup) {
   theZDCDigitizer->setDetIds(zdcCells);
 
   //fill test hits collection if desired and empty
-  if(injectTestHits_ && injectedHits_.size()==0 && injectedHitsCells_.size()>=4 && injectedHitsEnergy_.size()>0){
+  if(injectTestHits_ && injectedHits_.size()==0 && injectedHitsCells_.size()>0 && injectedHitsEnergy_.size()>0){
     //make list of specified cells if desired
-    std::vector<HcalDetId> testCells;
-    testCells.reserve(injectedHitsCells_.size()/4);
-    for(unsigned ic = 0; ic < injectedHitsCells_.size(); ic += 4){
-      if(ic+4 > injectedHitsCells_.size()) break;
-      testCells.emplace_back((HcalSubdetector)injectedHitsCells_[ic],injectedHitsCells_[ic+1],
-                          injectedHitsCells_[ic+2],injectedHitsCells_[ic+3]);
+    std::vector<DetId> testCells;
+    if(injectedHitsCells_.size()>=4){
+      testCells.reserve(injectedHitsCells_.size()/4);
+      for(unsigned ic = 0; ic < injectedHitsCells_.size(); ic += 4){
+        if(ic+4 > injectedHitsCells_.size()) break;
+        testCells.push_back(HcalDetId((HcalSubdetector)injectedHitsCells_[ic],injectedHitsCells_[ic+1],
+                            injectedHitsCells_[ic+2],injectedHitsCells_[ic+3]));
+      }
+    }
+    else{
+      int testSubdet = injectedHitsCells_[0];
+      if(testSubdet==HcalBarrel) testCells = hbCells;
+      else if(testSubdet==HcalEndcap) testCells = heCells;
+      else if(testSubdet==HcalForward) testCells = hfCells;
+      else if(testSubdet==HcalOuter) testCells = hoCells;
+      else throw cms::Exception("Configuration") << "Unknown subdet " << testSubdet << " for HCAL test hit injection";
     }
     bool useHitTimes = (injectedHitsTime_.size()==injectedHitsEnergy_.size());
     injectedHits_.reserve(testCells.size()*injectedHitsEnergy_.size());


### PR DESCRIPTION
This PR adds several tools for debugging the HCAL digitization simulation.
1. Ability to save the `CaloSamples` objects created by the different `CaloHitResponse`-derived classes as an event product.
2. If `CaloSamples` are saved as an event product, precise samples for the HPD simulation are generated with 1ns binning. (Otherwise, only the usual samples are generated.)
3. An option to ignore the `PCaloHit` time assigned by Geant4 in the `CaloHitResponse` classes, in order to study tails introduced by slow neutrons, etc.
4. An analyzer to create a simple tree, with one entry per channel per event (associating info from `CaloSamples` and `PCaloHit`). In order to take my own advice and avoid tracking test configs that immediately become outdated, this analyzer can be added to any `cmsDriver` command using `--customise=SimCalorimetry/HcalSimAlgos/AddCaloSamplesAnalyzer`. This customize automatically enables output of `CaloSamples`. The analyzer does not get access to all of the internals of the `CaloHitResponse` classes as I have done privately using mountains of debug printouts, but it is still quite useful to see the precise output pulses before any pedestal, etc. is added, and to be able to compare vs `PCaloHit` energy and time values.
5. An option to inject `PCaloHit`s of specified energy (and optionally time) into `HcalDigitizer`. The new `PCaloHit` collection is output as an event product when this option is enabled. The injection is specified on a per-cell basis (or alternatively for an entire subdetector). Users should keep in mind that `PCaloHit` energy is in units of sensitive layer energy, which is equivalent to "total" energy divided by the sampling factor (or photoelectrons for HF).

An example of running the analyzer (using a premade sample of 500 GeV pions):
```
cmsDriver.py step2 --conditions auto:phase1_2017_realistic -s DIGI --datatier GEN-SIM-DIGI-RAW -n 10 --geometry DB:Extended --era Run2_2017 --eventcontent FEVTDEBUGHLT --filein file:step1_SinglePiE500_10K.root --fileout file:step2.root --customise=SimCalorimetry/HcalSimAlgos/AddCaloSamplesAnalyzer
```
A flat tree is created in a file with default name `debugcalosamples.root`:
```
root -l debugcalosamples.root
CaloSamplesAnalyzer->cd()
tree->Draw("Iteration$*0.5>>htemp(250,0,250)","signalTotPrecise[]*(subdet==2)","hist");
```
produces the plot:
![plot_debugcalosamples](http://kjplanet.com/pr/plot_debugcalosamples.png)
similar to the plots that motivated #16825.

NB: because the new collections produced (`CaloSamples`, injected `PCaloHit`s) are optional, they can't be added to the `EDAlias` for `simHcalUnsuppressedDigis`, so their tag is just `mix`.

attn: @abdoulline, @mariadalfonso 