### PR TITLE
Replace trackingPhase1PU70 workflows with CA seeding

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 
-Run2_2017 = cms.ModifierChain(run2_2017_core, trackingPhase1)
+Run2_2017 = cms.ModifierChain(run2_2017_core, trackingPhase1QuadProp)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -1,11 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
-from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 
 Run2_2017 = cms.ModifierChain(run2_2017_core, trackingPhase1)
 

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1CA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1CA_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+
+Run2_2017_trackingPhase1CA = cms.ModifierChain(run2_2017_core, trackingPhase1)

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1PU70_cff.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
-from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
-
-Run2_2017_trackingPhase1PU70 = cms.ModifierChain(run2_2017_core, trackingPhase1PU70)
-

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+
+Run2_2017_trackingPhase1QuadProp = cms.ModifierChain(run2_2017_core, trackingPhase1QuadProp)
+

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-
-Run2_2017_trackingPhase1QuadProp = cms.ModifierChain(run2_2017_core, trackingPhase1QuadProp)
-

--- a/Configuration/Eras/python/Era_Run2_2017_trackingQuadProp_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingQuadProp_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+
+Run2_2017_trackingPhase1QuadProp = cms.ModifierChain(run2_2017_core, trackingPhase1)
+

--- a/Configuration/Eras/python/Era_Run2_2017_trackingQuadProp_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingQuadProp_cff.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.ModifierChain_run2_2017_core_cff import run2_2017_core
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-
-Run2_2017_trackingPhase1QuadProp = cms.ModifierChain(run2_2017_core, trackingPhase1)
-

--- a/Configuration/Eras/python/ModifierChain_run2_2017_core_cff.py
+++ b/Configuration/Eras/python/ModifierChain_run2_2017_core_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017

--- a/Configuration/Eras/python/Modifier_trackingPhase1QuadProp_cff.py
+++ b/Configuration/Eras/python/Modifier_trackingPhase1QuadProp_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+trackingPhase1QuadProp =  cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -53,6 +53,19 @@ def _trackingRun2(stepList):
             continue
         res.append(s)
     return res
+def _trackingPhase1QuadProp(stepList):
+    res = []
+    for step in stepList:
+        s = step
+        if 'RecoFull' in step:
+            if 'trackingOnly' in step:
+                s = s.replace('Only', 'OnlyPhase1QuadProp')
+            else:
+                s = s.replace('Full', 'Full_trackingPhase1QuadProp')
+        if 'ALCA' in s:
+            continue
+        res.append(s)
+    return res
 
 # compose and adding tracking specific workflows in the IB test. 
 # NB. those workflows are expected to be only used forIB test.
@@ -60,3 +73,5 @@ def _trackingRun2(stepList):
 workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1]) ]
 workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
+workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1QuadProp(workflows[10024.0][1]) ]
+workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1QuadProp(workflows[10024.1][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -53,19 +53,6 @@ def _trackingRun2(stepList):
             continue
         res.append(s)
     return res
-def _trackingPhase1PU70(stepList):
-    res = []
-    for step in stepList:
-        s = step
-        if 'RecoFull' in step:
-            if 'trackingOnly' in step:
-                s = s.replace('Only', 'OnlyPhase1PU70')
-            else:
-                s = s.replace('Full', 'Full_trackingPhase1PU70')
-        if 'ALCA' in s:
-            continue
-        res.append(s)
-    return res
 
 # compose and adding tracking specific workflows in the IB test. 
 # NB. those workflows are expected to be only used forIB test.
@@ -73,5 +60,3 @@ def _trackingPhase1PU70(stepList):
 workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1]) ]
 workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
-workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1PU70(workflows[10024.0][1]) ]
-workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1PU70(workflows[10024.1][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -53,15 +53,15 @@ def _trackingRun2(stepList):
             continue
         res.append(s)
     return res
-def _trackingPhase1QuadProp(stepList):
+def _trackingPhase1CA(stepList):
     res = []
     for step in stepList:
         s = step
         if 'RecoFull' in step:
             if 'trackingOnly' in step:
-                s = s.replace('Only', 'OnlyPhase1QuadProp')
+                s = s.replace('Only', 'OnlyPhase1CA')
             else:
-                s = s.replace('Full', 'Full_trackingPhase1QuadProp')
+                s = s.replace('Full', 'Full_trackingPhase1CA')
         if 'ALCA' in s:
             continue
         res.append(s)
@@ -73,5 +73,5 @@ def _trackingPhase1QuadProp(stepList):
 workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1]) ]
 workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
-workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1QuadProp(workflows[10024.0][1]) ]
-workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1QuadProp(workflows[10024.1][1]) ]
+workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1CA(workflows[10024.0][1]) ]
+workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1CA(workflows[10024.1][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1937,5 +1937,5 @@ for step in upgradeSteps:
 # 2017 tracking specific eras
 steps['RecoFull_trackingRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_2017']])
 steps['RecoFull_trackingOnlyRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_trackingOnly_2017']])
-steps['RecoFull_trackingPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_2017']])
-steps['RecoFull_trackingOnlyPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_trackingOnly_2017']])
+steps['RecoFull_trackingPhase1CA_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1CA'}, steps['RecoFull_2017']])
+steps['RecoFull_trackingOnlyPhase1CA_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1CA'}, steps['RecoFull_trackingOnly_2017']])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1937,3 +1937,5 @@ for step in upgradeSteps:
 # 2017 tracking specific eras
 steps['RecoFull_trackingRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_2017']])
 steps['RecoFull_trackingOnlyRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_trackingOnly_2017']])
+steps['RecoFull_trackingPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_2017']])
+steps['RecoFull_trackingOnlyPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_trackingOnly_2017']])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1937,5 +1937,3 @@ for step in upgradeSteps:
 # 2017 tracking specific eras
 steps['RecoFull_trackingRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_2017']])
 steps['RecoFull_trackingOnlyRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_trackingOnly_2017']])
-steps['RecoFull_trackingPhase1PU70_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1PU70'}, steps['RecoFull_2017']])
-steps['RecoFull_trackingOnlyPhase1PU70_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1PU70'}, steps['RecoFull_trackingOnly_2017']])

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,7 +21,7 @@ class Eras (object):
                  'Run2_2016_pA',
                  'Run2_2017',
                  'Run2_2017_trackingRun2',
-                 'Run2_2017_trackingPhase1QuadProp',
+                 'Run2_2017_trackingPhase1CA',
                  'Run3',
                  'Phase2C1',
                  'Phase2C2',

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,6 +21,7 @@ class Eras (object):
                  'Run2_2016_pA',
                  'Run2_2017',
                  'Run2_2017_trackingRun2',
+                 'Run2_2017_trackingPhase1QuadProp',
                  'Run3',
                  'Phase2C1',
                  'Phase2C2',
@@ -39,7 +40,7 @@ class Eras (object):
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
                            'phase2_timing_layer','phase2_hcal',
-                           'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140',
+                           'trackingLowPU', 'trackingPhase1', 'trackingPhase1QuadProp', 'ctpps_2016', 'trackingPhase2PU140',
                            'tracker_apv_vfp30_2016']
         internalUseModChains = ['run2_2017_core']
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,7 +21,6 @@ class Eras (object):
                  'Run2_2016_pA',
                  'Run2_2017',
                  'Run2_2017_trackingRun2',
-                 'Run2_2017_trackingPhase1PU70',
                  'Run3',
                  'Phase2C1',
                  'Phase2C2',
@@ -40,7 +39,7 @@ class Eras (object):
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
                            'phase2_timing_layer','phase2_hcal',
-                           'trackingLowPU', 'trackingPhase1', 'trackingPhase1PU70', 'ctpps_2016', 'trackingPhase2PU140',
+                           'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140',
                            'tracker_apv_vfp30_2016']
         internalUseModChains = ['run2_2017_core']
 

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -62,6 +62,8 @@ _forPhase1 = dict(
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(PixelSeedMergerQuadruplets, **_forPhase1)
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(PixelSeedMergerQuadruplets, **_forPhase1)
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
 trackingPhase1PU70.toModify(PixelSeedMergerQuadruplets, **_forPhase1)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -43,8 +43,8 @@ trackingLowPU.toModify(earlyGeneralTracks,
     ]
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(
-    earlyGeneralTracks,
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+_forPhase1 = dict(
     trackProducers = [
         'initialStepTracks',
         'highPtTripletStepTracks',
@@ -70,6 +70,8 @@ trackingPhase1.toModify(
         "tobTecStep"
     ],
 )
+trackingPhase1.toModify(earlyGeneralTracks, **_forPhase1)
+trackingPhase1QuadProp.toModify(earlyGeneralTracks, **_forPhase1)
 
 # For Phase1PU70
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -83,6 +83,22 @@ detachedQuadStepHitQuadruplets = _pixelQuadrupletEDProducer.clone(
     fitFastCircle = True,
     fitFastCircleChi2Cut = True,
 )
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+trackingPhase1.toModify(detachedQuadStepHitDoublets, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
+trackingPhase1.toReplaceWith(detachedQuadStepHitQuadruplets, _caHitQuadrupletEDProducer.clone(
+    doublets = "detachedQuadStepHitDoublets",
+    extraHitRPhitolerance = detachedQuadStepHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 500, value2 = 100,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0011,
+    CAPhiCut = 0,
+))
+
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
 _detachedQuadStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
@@ -445,6 +461,7 @@ DetachedQuadStep = cms.Sequence(detachedQuadStepClusters*
                                 detachedQuadStepTracks*
                                 detachedQuadStepClassifier1*detachedQuadStepClassifier2*
                                 detachedQuadStep)
+trackingPhase1.toReplaceWith(DetachedQuadStep, DetachedQuadStep.copyAndExclude([detachedQuadStepHitTriplets]))
 _DetachedQuadStep_Phase1PU70 = DetachedQuadStep.copyAndExclude([detachedQuadStepClassifier1])
 _DetachedQuadStep_Phase1PU70.replace(detachedQuadStepClassifier2, detachedQuadStepSelector)
 trackingPhase1PU70.toReplaceWith(DetachedQuadStep, _DetachedQuadStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -21,6 +21,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(detachedQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(detachedQuadStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(detachedQuadStepSeedLayers, 
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -16,9 +16,7 @@ import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 detachedTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 detachedTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
 detachedTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(detachedTripletStepSeedLayers,
-    layerList = [
+_phase1LayerList = [
         'BPix1+BPix2+BPix3',
         'BPix2+BPix3+BPix4',
 #        'BPix1+BPix3+BPix4', # has "hole", not tested
@@ -33,7 +31,10 @@ trackingPhase1.toModify(detachedTripletStepSeedLayers,
 #        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',  # has "hole", not tested
 #        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'  # has "hole", not tested
     ]
-)
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(detachedTripletStepSeedLayers, layerList=_phase1LayerList)
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(detachedTripletStepSeedLayers, layerList=_phase1LayerList)
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -43,6 +43,7 @@ detachedTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clo
     originHalfLength = 15.0,
     originRadius = 1.5
 ))
+trackingPhase1.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.25))
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
@@ -70,6 +71,21 @@ detachedTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDPro
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     ),
 )
+
+from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+trackingPhase1.toModify(detachedTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
+trackingPhase1.toReplaceWith(detachedTripletStepHitTriplets, _caHitTripletEDProducer.clone(
+    doublets = "detachedTripletStepHitDoublets",
+    extraHitRPhitolerance = detachedTripletStepHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 300 , value2 = 10,
+    ),
+    useBendingCorrection = True,
+    CAThetaCut = 0.001,
+    CAPhiCut = 0,
+    CAHardPtCut = 0.2,
+))
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -250,7 +250,7 @@ newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCom
       cms.InputTag('stripPairElectronSeeds')
       )
 )
-trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
+_seedCollections_Phase1 = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
     'mixedTripletStepSeeds',
@@ -258,16 +258,9 @@ trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
     'tripletElectronSeeds',
     'pixelPairElectronSeeds',
     'stripPairElectronSeeds'
-])
-trackingPhase1QuadProp.toModify(newCombinedSeeds, seedCollections = [
-    'initialStepSeeds',
-    'highPtTripletStepSeeds',
-    'mixedTripletStepSeeds',
-    'pixelLessStepSeeds',
-    'tripletElectronSeeds',
-    'pixelPairElectronSeeds',
-    'stripPairElectronSeeds'
-])
+]
+trackingPhase1.toModify(newCombinedSeeds, seedCollections = _seedCollections_Phase1)
+trackingPhase1QuadProp.toModify(newCombinedSeeds, seedCollections = _seedCollections_Phase1)
 trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -50,6 +50,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(mixedTripletStepSeedClusterMask,
     oldClusterRemovalInfo = "detachedTripletStepSeedClusterMask"
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(mixedTripletStepSeedClusterMask,
+    oldClusterRemovalInfo = "detachedTripletStepSeedClusterMask"
+)
 pixelLessStepSeedClusterMask = seedClusterRemover.clone(
     trajectories = cms.InputTag("pixelLessStepSeeds"),
     oldClusterRemovalInfo = cms.InputTag("mixedTripletStepSeedClusterMask")
@@ -84,6 +88,7 @@ _layerListForPhase1 = [
     'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
 ]
 trackingPhase1.toModify(tripletElectronSeedLayers, layerList = _layerListForPhase1)
+trackingPhase1QuadProp.toModify(tripletElectronSeedLayers, layerList = _layerListForPhase1)
 trackingPhase1PU70.toModify(tripletElectronSeedLayers,
     layerList = _layerListForPhase1,
     BPix = dict(skipClusters = 'pixelPairStepSeedClusterMask'),
@@ -154,8 +159,7 @@ pixelPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     skipClusters = cms.InputTag('tripletElectronClusterMask')
     )
 )
-trackingPhase1.toModify(pixelPairElectronSeedLayers,
-    layerList = [
+_layerListForPhase1 = [
         'BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4',
         'BPix2+BPix3', 'BPix2+BPix4',
         'BPix3+BPix4',
@@ -166,7 +170,8 @@ trackingPhase1.toModify(pixelPairElectronSeedLayers,
         'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
         'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg' 
     ]
-)
+trackingPhase1.toModify(pixelPairElectronSeedLayers, layerList = _layerListForPhase1)
+trackingPhase1QuadProp.toModify(pixelPairElectronSeedLayers, layerList = _layerListForPhase1)
 
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 pixelPairElectronTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet = dict(
@@ -254,6 +259,15 @@ trackingPhase1.toModify(newCombinedSeeds, seedCollections = [
     'pixelPairElectronSeeds',
     'stripPairElectronSeeds'
 ])
+trackingPhase1QuadProp.toModify(newCombinedSeeds, seedCollections = [
+    'initialStepSeeds',
+    'highPtTripletStepSeeds',
+    'mixedTripletStepSeeds',
+    'pixelLessStepSeeds',
+    'tripletElectronSeeds',
+    'pixelPairElectronSeeds',
+    'stripPairElectronSeeds'
+])
 trackingPhase1PU70.toModify(newCombinedSeeds, seedCollections = [
     'initialStepSeeds',
     'highPtTripletStepSeeds',
@@ -288,6 +302,7 @@ electronSeedsSeq = cms.Sequence( initialStepSeedClusterMask*
 _electronSeedsSeq_Phase1 = electronSeedsSeq.copy()
 _electronSeedsSeq_Phase1.replace(pixelPairStepSeedClusterMask, detachedTripletStepSeedClusterMask)
 trackingPhase1.toReplaceWith(electronSeedsSeq, _electronSeedsSeq_Phase1)
+trackingPhase1QuadProp.toReplaceWith(electronSeedsSeq, _electronSeedsSeq_Phase1)
 trackingPhase1PU70.toReplaceWith(electronSeedsSeq, cms.Sequence(
     initialStepSeedClusterMask*
     highPtTripletStepSeedClusterMask*

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -60,6 +60,8 @@ highPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(Regio
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(highPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.55))
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
 trackingPhase1PU70.toModify(highPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.7))
 trackingPhase2PU140.toModify(highPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.9, originRadius = 0.03))
@@ -84,6 +86,22 @@ from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_
 highPtTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = "highPtTripletStepHitTriplets",
 )
+
+from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+trackingPhase1.toModify(highPtTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
+trackingPhase1.toReplaceWith(highPtTripletStepHitTriplets, _caHitTripletEDProducer.clone(
+    doublets = "highPtTripletStepHitDoublets",
+    extraHitRPhitolerance = highPtTripletStepHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = highPtTripletStepHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 8,
+        value1 = 100, value2 = 6,
+    ),
+    useBendingCorrection = True,
+    CAThetaCut = 0.004,
+    CAPhiCut = 0.07,
+    CAHardPtCut = 0.3,
+))
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -22,6 +22,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayersPreSplitting,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(initialStepSeedLayersPreSplitting,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
@@ -78,7 +82,12 @@ trackingPhase1.toModify(initialStepHitTripletsPreSplitting,
     produceSeedingHitSets = False,
     produceIntermediateHitTriplets = True,
 )
+trackingPhase1QuadProp.toModify(initialStepHitTripletsPreSplitting,
+    produceSeedingHitSets = False,
+    produceIntermediateHitTriplets = True,
+)
 trackingPhase1.toModify(initialStepSeedsPreSplitting, seedingHitSets = "initialStepHitQuadrupletsPreSplitting")
+trackingPhase1QuadProp.toModify(initialStepSeedsPreSplitting, seedingHitSets = "initialStepHitQuadrupletsPreSplitting")
 
 
 # building
@@ -201,6 +210,7 @@ InitialStepPreSplitting = cms.Sequence(trackerClusterCheckPreSplitting*
 _InitialStepPreSplitting_trackingPhase1 = InitialStepPreSplitting.copy()
 _InitialStepPreSplitting_trackingPhase1.replace(initialStepHitTripletsPreSplitting, initialStepHitTripletsPreSplitting*initialStepHitQuadrupletsPreSplitting)
 trackingPhase1.toReplaceWith(InitialStepPreSplitting, _InitialStepPreSplitting_trackingPhase1)
+trackingPhase1QuadProp.toReplaceWith(InitialStepPreSplitting, _InitialStepPreSplitting_trackingPhase1)
 
 # Although InitialStepPreSplitting is not really part of LowPU/Run1/Phase1PU70
 # tracking, we use it to get siPixelClusters and siPixelRecHits

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -21,6 +21,16 @@ trackingPhase1.toModify(initialStepSeedLayers,
         'BPix1+FPix1_neg+FPix2_neg'
     ]
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(initialStepSeedLayers,
+    layerList = [
+        'BPix1+BPix2+BPix3',
+        'BPix1+BPix2+FPix1_pos',
+        'BPix1+BPix2+FPix1_neg',
+        'BPix1+FPix1_pos+FPix2_pos',
+        'BPix1+FPix1_neg+FPix2_neg'
+    ]
+)
 trackingPhase2PU140.toModify(initialStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
@@ -175,6 +185,10 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     )
 trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
 trackingPhase1.toModify(initialStepTrajectoryBuilder,
+    inOutTrajectoryFilter = dict(refToPSet_ = "initialStepTrajectoryFilterInOut"),
+    useSameTrajFilter = False
+)
+trackingPhase1QuadProp.toModify(initialStepTrajectoryBuilder,
     inOutTrajectoryFilter = dict(refToPSet_ = "initialStepTrajectoryFilterInOut"),
     useSameTrajFilter = False
 )

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -13,13 +13,7 @@ import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayers,
-    layerList = [
-        'BPix1+BPix2+BPix3',
-        'BPix1+BPix2+FPix1_pos',
-        'BPix1+BPix2+FPix1_neg',
-        'BPix1+FPix1_pos+FPix2_pos',
-        'BPix1+FPix1_neg+FPix2_neg'
-    ]
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1QuadProp.toModify(initialStepSeedLayers,
@@ -44,6 +38,7 @@ initialStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet 
 ))
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+trackingPhase1.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.5))
 trackingPhase1PU70.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.7))
 trackingPhase2PU140.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.8))
 
@@ -93,10 +88,27 @@ initialStepHitQuadruplets = _pixelQuadrupletEDProducer.clone(
     fitFastCircleChi2Cut = True,
     SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet
 )
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+trackingPhase1.toModify(initialStepHitDoublets, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
+trackingPhase1.toReplaceWith(initialStepHitQuadruplets, _caHitQuadrupletEDProducer.clone(
+    doublets = "initialStepHitDoublets",
+    extraHitRPhitolerance = initialStepHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.7, pt2    = 2,
+        value1 = 200, value2 = 50,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0012,
+    CAPhiCut = 0.2,
+))
 trackingPhase2PU140.toModify(initialStepHitTriplets,
     produceSeedingHitSets = False,
     produceIntermediateHitTriplets = True,
 )
+trackingPhase1.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
 trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
 
 # temporary...
@@ -184,10 +196,6 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxPtForLooperReconstruction = cms.double(0.7)
     )
 trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
-trackingPhase1.toModify(initialStepTrajectoryBuilder,
-    inOutTrajectoryFilter = dict(refToPSet_ = "initialStepTrajectoryFilterInOut"),
-    useSameTrajFilter = False
-)
 trackingPhase1QuadProp.toModify(initialStepTrajectoryBuilder,
     inOutTrajectoryFilter = dict(refToPSet_ = "initialStepTrajectoryFilterInOut"),
     useSameTrajFilter = False
@@ -379,6 +387,9 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
 _InitialStep_LowPU = InitialStep.copyAndExclude([firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
 _InitialStep_LowPU.replace(initialStep, initialStepSelector)
 trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)
+_InitialStep_Phase1 = InitialStep.copy()
+_InitialStep_Phase1.replace(initialStepHitTriplets, initialStepHitQuadruplets)
+trackingPhase1.toReplaceWith(InitialStep, _InitialStep_Phase1)
 _InitialStep_Phase1PU70 = _InitialStep_LowPU.copy()
 _InitialStep_Phase1PU70.replace(initialStepHitTriplets, initialStepHitTriplets+initialStepHitQuadruplets)
 trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -48,8 +48,8 @@ jetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     )
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(jetCoreRegionalStepSeedLayers,
-    layerList = [
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+_layerListForPhase1 = [
         'BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4',
         'BPix2+BPix3', 'BPix2+BPix4',
         'BPix3+BPix4',
@@ -61,7 +61,8 @@ trackingPhase1.toModify(jetCoreRegionalStepSeedLayers,
         #'BPix3+TIB1','BPix3+TIB2'
         'BPix4+TIB1','BPix4+TIB2'
     ]
-)
+trackingPhase1.toModify(jetCoreRegionalStepSeedLayers, layerList = _layerListForPhase1)
+trackingPhase1QuadProp.toModify(jetCoreRegionalStepSeedLayers, layerList = _layerListForPhase1)
 
 # TrackingRegion
 from RecoTauTag.HLTProducers.tauRegionalPixelSeedTrackingRegions_cfi import tauRegionalPixelSeedTrackingRegions as _tauRegionalPixelSeedTrackingRegions

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -18,6 +18,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(lowPtQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(lowPtQuadStepSeedLayers,
+    layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
+)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(lowPtQuadStepSeedLayers,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -34,6 +34,7 @@ lowPtQuadStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSe
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
+trackingPhase1.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptMin = 0.15))
 trackingPhase2PU140.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptMin = 0.35))
 
 
@@ -73,6 +74,23 @@ lowPtQuadStepHitQuadruplets = _pixelQuadrupletEDProducer.clone(
     fitFastCircleChi2Cut = True,
     SeedComparitorPSet = lowPtQuadStepHitTriplets.SeedComparitorPSet,
 )
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+trackingPhase1.toModify(lowPtQuadStepHitDoublets, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
+trackingPhase1.toReplaceWith(lowPtQuadStepHitQuadruplets, _caHitQuadrupletEDProducer.clone(
+    doublets = "lowPtQuadStepHitDoublets",
+    extraHitRPhitolerance = lowPtQuadStepHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = lowPtQuadStepHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.7, pt2    = 2,
+        value1 = 1000, value2 = 150,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0017,
+    CAPhiCut = 0.3,
+))
+
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
 from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
 _lowPtQuadStepHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
@@ -300,6 +318,7 @@ LowPtQuadStep = cms.Sequence(lowPtQuadStepClusters*
                              lowPtQuadStepTrackCandidates*
                              lowPtQuadStepTracks*
                              lowPtQuadStep)
+trackingPhase1.toReplaceWith(LowPtQuadStep, LowPtQuadStep.copyAndExclude([lowPtQuadStepHitTriplets]))
 _LowPtQuadStep_Phase1PU70 = LowPtQuadStep.copy()
 _LowPtQuadStep_Phase1PU70.replace(lowPtQuadStep, lowPtQuadStepSelector)
 trackingPhase1PU70.toReplaceWith(LowPtQuadStep, _LowPtQuadStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -26,8 +26,10 @@ _layerListForPhase1 = [
     'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'
 ]
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
 trackingPhase1.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
+trackingPhase1QuadProp.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 trackingPhase1PU70.toModify(lowPtTripletStepSeedLayers, layerList = _layerListForPhase1)
 
 # combination with gap removed as only source of fakes in current geometry (kept for doc,=)
@@ -56,6 +58,7 @@ lowPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(Region
     nSigmaZ = 4.0
 ))
 trackingPhase1.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35)) # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
+trackingPhase1QuadProp.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35)) # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
 trackingPhase1PU70.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35, originRadius = 0.015))
 trackingPhase2PU140.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.45))
 
@@ -191,7 +194,7 @@ lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 # For Phase1
 # MVA selection to be enabled after re-training, for time being we go with cut-based selector
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier as _TrackCutClassifier
-trackingPhase1.toReplaceWith(lowPtTripletStep, _TrackCutClassifier.clone(
+_cutClassifierForPhase1 = _TrackCutClassifier.clone(
     src = "lowPtTripletStepTracks",
     vertices = "firstStepPrimaryVertices",
     mva = dict (
@@ -213,7 +216,9 @@ trackingPhase1.toReplaceWith(lowPtTripletStep, _TrackCutClassifier.clone(
             d0err_par = [0.002,0.002,0.001],
         ),
     )
-))
+)
+trackingPhase1.toReplaceWith(lowPtTripletStep, _cutClassifierForPhase1)
+trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, _cutClassifierForPhase1)
 
 # For LowPU and Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -57,7 +57,7 @@ lowPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(Region
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
-trackingPhase1.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35)) # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
+trackingPhase1.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.2))
 trackingPhase1QuadProp.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35)) # FIXME: Phase1PU70 value, let's see if we can lower it to Run2 value (0.2)
 trackingPhase1PU70.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.35, originRadius = 0.015))
 trackingPhase2PU140.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.45))
@@ -82,6 +82,21 @@ from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_
 lowPtTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = "lowPtTripletStepHitTriplets",
 )
+
+from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+trackingPhase1.toModify(lowPtTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
+trackingPhase1.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDProducer.clone(
+    doublets = "lowPtTripletStepHitDoublets",
+    extraHitRPhitolerance = lowPtTripletStepHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = lowPtTripletStepHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 70 , value2 = 8,
+    ),
+    useBendingCorrection = True,
+    CAThetaCut = 0.002,
+    CAPhiCut = 0.05,
+))
 
 
 # QUALITY CUTS DURING TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -21,6 +21,9 @@ for _eraName, _postfix, _era in _cfg.nonDefaultEras():
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(chargeCut2069Clusters, oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value())
 trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo="chargeCut2069Clusters")
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(chargeCut2069Clusters, oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value())
+trackingPhase1QuadProp.toModify(mixedTripletStepClusters, oldClusterRemovalInfo="chargeCut2069Clusters")
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
@@ -145,6 +148,7 @@ trackingLowPU.toModify(mixedTripletStepSeedLayersB,
     TIB = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
 trackingPhase1.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+TIB1'])
+trackingPhase1QuadProp.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+TIB1'])
 trackingPhase1PU70.toModify(mixedTripletStepSeedLayersB,
     layerList = [
         'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4','BPix1+BPix2+BPix4', 'BPix1+BPix3+BPix4'

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -4,7 +4,7 @@
 import FWCore.ParameterSet.Config as cms
 
 _defaultEraName = ""
-_nonDefaultEraNames = ["trackingLowPU", "trackingPhase1", "trackingPhase1PU70", "trackingPhase2PU140"]
+_nonDefaultEraNames = ["trackingLowPU", "trackingPhase1", "trackingPhase1QuadProp", "trackingPhase1PU70", "trackingPhase2PU140"]
 
 # name, postfix, era
 _defaultEra = (_defaultEraName, "", None)
@@ -47,6 +47,7 @@ _iterations_trackingPhase1 = [
     "TobTecStep",
     "JetCoreRegionalStep",
 ]
+_iterations_trackingPhase1QuadProp = _iterations_trackingPhase1
 _iterations_trackingPhase1PU70 = [
     "InitialStep",
     "HighPtTripletStep",
@@ -80,6 +81,7 @@ _multipleSeedProducers_trackingLowPU = {
     "MixedTripletStep": ["A", "B"],
 }
 _multipleSeedProducers_trackingPhase1 = _multipleSeedProducers
+_multipleSeedProducers_trackingPhase1QuadProp = _multipleSeedProducers_trackingPhase1
 _multipleSeedProducers_trackingPhase1PU70 = _multipleSeedProducers_trackingLowPU
 _multipleSeedProducers_trackingPhase2PU140 = {}
 _oldStyleHasSelector = set([

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -36,6 +36,8 @@ _layersForPhase1 = [
 ]
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(PixelLayerTriplets, layerList=_layersForPhase1)
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(PixelLayerTriplets, layerList=_layersForPhase1)
 from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
 trackingPhase1PU70.toModify(PixelLayerTriplets, layerList=_layersForPhase1)
 

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -54,15 +54,17 @@ def _filterForNtuple(lst):
     return ret
 _seedProducers = _filterForNtuple(_TrackValidation_cff._seedProducers)
 _seedProducers_trackingPhase1 = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase1)
+_seedProducers_trackingPhase1QuadProp = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase1QuadProp)
 
 (_seedSelectors, trackingNtupleSeedSelectors) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
 (_seedSelectors_trackingPhase1, _trackingNtupleSeedSelectors_trackingPhase1) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase1, globals())
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1)
-
-trackingNtuple.seedTracks = _seedSelectors
+(_seedSelectors_trackingPhase1QuadProp, _trackingNtupleSeedSelectors_trackingPhase1QuadProp) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase1QuadProp, globals())
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1)
+trackingPhase1QuadProp.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1QuadProp)
+
+trackingNtuple.seedTracks = _seedSelectors
 trackingPhase1.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
 trackingPhase1QuadProp.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
 

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -62,7 +62,9 @@ phase1Pixel.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelect
 
 trackingNtuple.seedTracks = _seedSelectors
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
+trackingPhase1QuadProp.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
 
 trackingNtupleSequence = cms.Sequence()
 # reproduce hits because they're not stored in RECO


### PR DESCRIPTION
~~This PR switches the default phase1 pixel seeding to cellular automaton (tuning by @felicepantaleo). The workflows of `trackingPhase1PU70` are replaced with workflows of the previous seeding (`trackingPhase1QuadProp`, suggestions for better name are welcome) to be kept as a reference for some time.~~ This PR replaces the `trackingPhase1PU70` workflows with CA seeding (tuning by @felicepantaleo). The goal is to switch the default phase1 tracking to CA seeding once the duplicate rate increase is better understood (and fixed/mitigated), therefore the "CA seeding" is already implemented under `trackingPhase1` sub-era, and the default trackign under `trackingPhase1QuadProp` era (suggestions for better name are welcome). Full cleanup of `trackingPhase1PU70` will come later (after the pre2 dust settles).

Here are MTV plots for 1000 ttbar+35PU events in 900pre1 (using 810pre16 DIGI-RAW as an input) comparing the CA seeding to the default.
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_0_pre1_caseeding/
Timing decreases by ~5 % for the full trackingOnly reco job (becomes ~10 % when excluding most expensive other-than-iterative-tracking modules, mostly validation).

~~The previous seeding is kept workflows 10024.[45] (full/trackingOnly), so there should be no changes between old 10024.[01] and new 10024.[45].~~ 

~~To minimize merge conflicts the developments are based on @ebrondol's #16858 (in the hope of getting this in pre2).~~

Tested in CMSSW_9_0_X_2016-11-30-2300 (rebased on top of CMSSW_9_0_X after IB CMSSW_9_0_X_2016-12-09-1100 and before the next). No changes expected in standard workflows (special 10024.[45] show the changes from `trackingPhase1PU70` to CA). ~~for phase0, phase1 changes are described above.~~ ~~and for phase2 there are changes because of #16858 (but no changes on top of that).~~

@rovere @VinInn @felicepantaleo @ebrondol @mtosi 