### PR TITLE
CondTool/DT fix clang warning  -Wabsolute-value

### DIFF
--- a/CondTools/DT/test/validate/DTRangeT0ValidateDBRead.cc
+++ b/CondTools/DT/test/validate/DTRangeT0ValidateDBRead.cc
@@ -76,8 +76,8 @@ void DTRangeT0ValidateDBRead::analyze(const edm::Event& e,
                           << tRId.sectorId  << " "
                           << tRId.slId      << " , status = "
                           << status << std::endl;
-    if ( ( fabs( tRData.t0min - t0min ) > 0.0001 ) ||
-         ( fabs( tRData.t0max - t0max ) > 0.0001 ) )
+    if ( ( std::abs( tRData.t0min - t0min ) > 0.0001 ) ||
+         ( std::abs( tRData.t0max - t0max ) > 0.0001 ) )
          logFile << "MISMATCH WHEN READING range T0"
                  << tRId.wheelId   << " "
                  << tRId.stationId << " "
@@ -101,8 +101,8 @@ void DTRangeT0ValidateDBRead::analyze(const edm::Event& e,
                       sec,
                       qua,
                       t0min, t0max );
-    if ( ( fabs( ckt0min - t0min ) > 0.0001 ) ||
-         ( fabs( ckt0max - t0max ) > 0.0001 ) )
+    if ( ( std::abs( ckt0min - t0min ) > 0.0001 ) ||
+         ( std::abs( ckt0max - t0max ) > 0.0001 ) )
          logFile << "MISMATCH IN WRITING AND READING range T0 "
                  << whe << " "
                  << sta << " "

--- a/CondTools/DT/test/validate/DTRangeT0ValidateHandler.cc
+++ b/CondTools/DT/test/validate/DTRangeT0ValidateHandler.cc
@@ -113,8 +113,8 @@ void DTRangeT0ValidateHandler::addNewObject( int runNumber ) {
                                     << sec << " "
                                     << qua << " , status = "
                                     << status << std::endl;
-              if ( ( fabs( ckt0min - t0min ) > 0.0001 ) ||
-                   ( fabs( ckt0max - t0max ) > 0.0001 ) )
+              if ( ( std::abs( ckt0min - t0min ) > 0.0001 ) ||
+                   ( std::abs( ckt0max - t0max ) > 0.0001 ) )
                    logFile << "MISMATCH WHEN WRITING range T0 "
                            << whe << " "
                            << sta << " "

--- a/CondTools/DT/test/validate/DTTPGParametersValidateDBRead.cc
+++ b/CondTools/DT/test/validate/DTTPGParametersValidateDBRead.cc
@@ -74,7 +74,7 @@ void DTTPGParametersValidateDBRead::analyze( const edm::Event& e,
                           << tpgId.sectorId  << " , status = "
                           << status << std::endl;
     if (       ( tpgData.nClock != nClock )            ||
-         ( fabs( tpgData.tPhase  - tPhase ) > 0.0001 ) )
+         ( std::abs( tpgData.tPhase  - tPhase ) > 0.0001 ) )
          logFile << "MISMATCH WHEN READING cell TPGParameters "
                  << tpgId.wheelId   << " "
                  << tpgId.stationId << " "
@@ -93,8 +93,8 @@ void DTTPGParametersValidateDBRead::analyze( const edm::Event& e,
                        sta,
                        sec,
                        nClock, tPhase, DTTimeUnits::counts );
-    if ( ( fabs( ckclock - nClock ) > 0.0001 ) ||
-         ( fabs( ckphase - tPhase ) > 0.0001 ) )
+    if ( ( std::abs( ckclock - nClock ) > 0.0001 ) ||
+         ( std::abs( ckphase - tPhase ) > 0.0001 ) )
          logFile << "MISMATCH IN WRITING AND READING cell TPGParameters "
                  << whe << " "
                  << sta << " "

--- a/CondTools/DT/test/validate/DTTPGParametersValidateHandler.cc
+++ b/CondTools/DT/test/validate/DTTPGParametersValidateHandler.cc
@@ -103,8 +103,8 @@ void DTTPGParametersValidateHandler::addNewObject( int runNumber ) {
                               << sta << " "
                               << sec << " , status = "
                               << status << std::endl;
-        if ( ( fabs( ckclock - nClock ) > 0.0001 ) ||
-             ( fabs( ckphase - tPhase ) > 0.0001 ) )
+        if ( ( std::abs( ckclock - nClock ) > 0.0001 ) ||
+             ( std::abs( ckphase - tPhase ) > 0.0001 ) )
              logFile << "MISMATCH WHEN WRITING cell TPGParameters "
                      << whe << " "
                      << sta << " "


### PR DESCRIPTION
>> Compiling edm plugin /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondTools/DT/test/validate/DTDeadFlagValidateDBRead.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/CondTools/DT/test/CondToolsDTValidate/validate/DTDeadFlagValidateDBRead.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondTools/DT/test/validate/DTDeadFlagValidateDBRead.cc -o tmp/slc6_amd64_gcc530/src/CondTools/DT/test/CondToolsDTValidate/validate/DTDeadFlagValidateDBRead.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondTools/DT/test/validate/DTTPGParametersValidateHandler.cc:106:16: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
         if ( ( fabs( ckclock - nClock ) > 0.0001 ) ||
               ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondTools/DT/test/validate/DTTPGParametersValidateHandler.cc:106:16: note: use function 'std::abs' instead
        if ( ( fabs( ckclock - nClock ) > 0.0001 ) ||
               ^~~~
               std::abs