### PR TITLE
CalibTracker/SiPixelGainCalibration fix clang warning about abs

### DIFF
--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
@@ -213,7 +213,7 @@ SiPixelCalibDigiProducer::clear(){
 void 
 SiPixelCalibDigiProducer::setPattern(){
   //  edm::LogInfo("SiPixelCalibProducer") << "in setPattern()" << std::endl;
-  uint32_t patternnumber = abs(iEventCounter_-1)/pattern_repeat_;
+  uint32_t patternnumber = (iEventCounter_-1)/pattern_repeat_;
   uint32_t rowpatternnumber = patternnumber/calib_->nColumnPatterns();
   uint32_t colpatternnumber = patternnumber%calib_->nColumnPatterns();
   edm::LogInfo("SiPixelCalibDigiProducer") << " rowpatternnumbers = " << rowpatternnumber << " " << colpatternnumber << " " << patternnumber << std::endl;


### PR DESCRIPTION
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc:216:28: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
   uint32_t patternnumber = abs(iEventCounter_-1)/pattern_repeat_;
                           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc:216:28: note: remove the call to 'abs' since unsigned values cannot be negative
  uint32_t patternnumber = abs(iEventCounter_-1)/pattern_repeat_;
                           ^~~