### PR TITLE
Calibration/EcalCalibAlgos fix clang warning about abs

### DIFF
--- a/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc
+++ b/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc
@@ -257,7 +257,7 @@ EcalEleCalibLooper::duringLoop (const edm::Event& iEvent,
      double pTk = 0 ;
      std::map<int , double> xtlMap;
      DetId Max =0;
-     if (fabs(eleIt->eta()<1.49))
+     if (std::abs(eleIt->eta())<1.49)
 	     Max = EcalClusterTools::getMaximum(eleIt->superCluster()->hitsAndFractions(),barrelHitsCollection).first;
      else 
 	     Max = EcalClusterTools::getMaximum(eleIt->superCluster()->hitsAndFractions(),endcapHitsCollection).first;

--- a/Calibration/EcalCalibAlgos/src/InvRingCalib.cc
+++ b/Calibration/EcalCalibAlgos/src/InvRingCalib.cc
@@ -315,7 +315,7 @@ InvRingCalib::duringLoop (const edm::Event& iEvent,
       pTk=eleIt->trackMomentumAtVtx().R();
       std::map<int , double> xtlMap;
       DetId Max=0; 
-      if (fabs(eleIt->eta()<1.49))
+      if (std::abs(eleIt->eta())<1.49)
 	     Max = EcalClusterTools::getMaximum(eleIt->superCluster()->hitsAndFractions(),barrelHitsCollection).first;
       else 
 	     Max = EcalClusterTools::getMaximum(eleIt->superCluster()->hitsAndFractions(),endcapHitsCollection).first;


### PR DESCRIPTION
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc:260:10: warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc:260:10: note: remove the call to 'fabs' since unsigned values cannot be negative
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/InvRingCalib.cc:318:11: warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/InvRingCalib.cc:318:11: note: remove the call to 'fabs' since unsigned values cannot be negative
warnings.txt.unique:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc:260:10: warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
warnings.txt.unique:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/Calibration/EcalCalibAlgos/src/InvRingCalib.cc:318:11: warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
