### PR TITLE
CaloOnlineTools-EcalTools fix clang warning about abs

### DIFF
--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -107,7 +107,7 @@ std::vector<std::string> split(std::string msg, std::string separator)
 double getEta(int ietaTower) 
 {
   // Paga: to be confirmed, specially in EE:
-  return 0.0174*fabs(ietaTower) ;
+  return 0.0174*std::abs(ietaTower) ;
 }
 
 


### PR DESCRIPTION
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp:110:17: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
warnings.txt:/scratch/gartung/CMSSW_9_0_CLANG_X_2016-12-06-1100/src/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp:110:17: note: use function 'std::abs' instead