### PR TITLE
CommonTools-PileupAlgos fix clang warnings about abs and hides overloaded virtual

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -82,7 +82,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    int npv = 0;
    const reco::VertexCollection::const_iterator vtxEnd = pvCol->end();
    for (reco::VertexCollection::const_iterator vtxIter = pvCol->begin(); vtxEnd != vtxIter; ++vtxIter) {
-      if (!vtxIter->isFake() && vtxIter->ndof()>=fVtxNdofCut && fabs(vtxIter->z())<=fVtxZCut)
+      if (!vtxIter->isFake() && vtxIter->ndof()>=fVtxNdofCut && std::abs(vtxIter->z())<=fVtxZCut)
          npv++;
    }
 
@@ -125,8 +125,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         double tmpdz = 99999;
         if      ( pPF->trackRef().isNonnull()    ) tmpdz = pPF->trackRef()   ->dz(iV->position());
         else if ( pPF->gsfTrackRef().isNonnull() ) tmpdz = pPF->gsfTrackRef()->dz(iV->position());
-        if (fabs(tmpdz) < curdz){
-          curdz = fabs(tmpdz);
+        if (std::abs(tmpdz) < curdz){
+          curdz = std::abs(tmpdz);
           closestVtxForUnassociateds = pVtxId;
         }
         pVtxId++;
@@ -134,21 +134,21 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
       int tmpFromPV = 0;  
       // mocking the miniAOD definitions
-      if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId > 0) tmpFromPV = 0;
-      if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId == 0) tmpFromPV = 3;
-      if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds == 0) tmpFromPV = 2;
-      if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds != 0) tmpFromPV = 1;
+      if (closestVtx != 0 && std::abs(pReco.charge) > 0 && pVtxId > 0) tmpFromPV = 0;
+      if (closestVtx != 0 && std::abs(pReco.charge) > 0 && pVtxId == 0) tmpFromPV = 3;
+      if (closestVtx == 0 && std::abs(pReco.charge) > 0 && closestVtxForUnassociateds == 0) tmpFromPV = 2;
+      if (closestVtx == 0 && std::abs(pReco.charge) > 0 && closestVtxForUnassociateds != 0) tmpFromPV = 1;
       pReco.dZ      = pDZ;
       pReco.d0      = pD0;
       pReco.id = 0; 
-      if (fabs(pReco.charge) == 0){ pReco.id = 0; }
+      if (std::abs(pReco.charge) == 0){ pReco.id = 0; }
       else{
         if (tmpFromPV == 0){ pReco.id = 2; } // 0 is associated to PU vertex
         if (tmpFromPV == 3){ pReco.id = 1; }
         if (tmpFromPV == 1 || tmpFromPV == 2){ 
           pReco.id = 0;
-          if (!fPuppiForLeptons && fUseDZ && (fabs(pDZ) < fDZCut)) pReco.id = 1;
-          if (!fPuppiForLeptons && fUseDZ && (fabs(pDZ) > fDZCut)) pReco.id = 2;
+          if (!fPuppiForLeptons && fUseDZ && (std::abs(pDZ) < fDZCut)) pReco.id = 1;
+          if (!fPuppiForLeptons && fUseDZ && (std::abs(pDZ) > fDZCut)) pReco.id = 2;
           if (fPuppiForLeptons && tmpFromPV == 1) pReco.id = 2;
           if (fPuppiForLeptons && tmpFromPV == 2) pReco.id = 1;
         }
@@ -161,14 +161,14 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       pReco.d0      = pD0;
   
       pReco.id = 0; 
-      if (fabs(pReco.charge) == 0){ pReco.id = 0; }
-      if (fabs(pReco.charge) > 0){
+      if (std::abs(pReco.charge) == 0){ pReco.id = 0; }
+      if (std::abs(pReco.charge) > 0){
         if (lPack->fromPV() == 0){ pReco.id = 2; } // 0 is associated to PU vertex
         if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)){ pReco.id = 1; }
         if (lPack->fromPV() == (pat::PackedCandidate::PVTight) || lPack->fromPV() == (pat::PackedCandidate::PVLoose)){ 
           pReco.id = 0;
-          if (!fPuppiForLeptons && fUseDZ && (fabs(pDZ) < fDZCut)) pReco.id = 1;
-          if (!fPuppiForLeptons && fUseDZ && (fabs(pDZ) > fDZCut)) pReco.id = 2;
+          if (!fPuppiForLeptons && fUseDZ && (std::abs(pDZ) < fDZCut)) pReco.id = 1;
+          if (!fPuppiForLeptons && fUseDZ && (std::abs(pDZ) > fDZCut)) pReco.id = 2;
           if (fPuppiForLeptons && lPack->fromPV() == (pat::PackedCandidate::PVLoose)) pReco.id = 2;
           if (fPuppiForLeptons && lPack->fromPV() == (pat::PackedCandidate::PVTight)) pReco.id = 1;
         }
@@ -323,18 +323,6 @@ void PuppiProducer::beginJob() {
 }
 // ------------------------------------------------------------------------------------------
 void PuppiProducer::endJob() {
-}
-// ------------------------------------------------------------------------------------------
-void PuppiProducer::beginRun(edm::Run&, edm::EventSetup const&) {
-}
-// ------------------------------------------------------------------------------------------
-void PuppiProducer::endRun(edm::Run&, edm::EventSetup const&) {
-}
-// ------------------------------------------------------------------------------------------
-void PuppiProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&) {
-}
-// ------------------------------------------------------------------------------------------
-void PuppiProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&) {
 }
 // ------------------------------------------------------------------------------------------
 void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -37,11 +37,6 @@ private:
 	virtual void produce(edm::Event&, const edm::EventSetup&);
 	virtual void endJob() ;
       
-	virtual void beginRun(edm::Run&, edm::EventSetup const&);
-	virtual void endRun(edm::Run&, edm::EventSetup const&);
-	virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-	virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-
 	edm::EDGetTokenT< CandidateView > tokenPFCandidates_;
 	edm::EDGetTokenT< VertexCollection > tokenVertices_;
 	std::string     fPuppiName;


### PR DESCRIPTION
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:26:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.h:40:15: warning: 'PuppiProducer::beginRun' hides overloaded virtual function [-Woverloaded-virtual]
         virtual void beginRun(edm::Run&, edm::EventSetup const&);
                     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FWCore/Framework/interface/stream/EDProducerBase.h:67:20: note: hidden overloaded virtual function 'edm::stream::EDProducerBase::beginRun' declared here: type mismatch at 1st parameter ('const edm::Run &' vs 'edm::Run &')
      virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
                   ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:26:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.h:41:15: warning: 'PuppiProducer::endRun' hides overloaded virtual function [-Woverloaded-virtual]
         virtual void endRun(edm::Run&, edm::EventSetup const&);
                     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FWCore/Framework/interface/stream/EDProducerBase.h:71:20: note: hidden overloaded virtual function 'edm::stream::EDProducerBase::endRun' declared here: type mismatch at 1st parameter ('const edm::Run &' vs 'edm::Run &')
      virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
                   ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:26:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.h:42:15: warning: 'PuppiProducer::beginLuminosityBlock' hides overloaded virtual function [-Woverloaded-virtual]
         virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
                     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FWCore/Framework/interface/stream/EDProducerBase.h:68:20: note: hidden overloaded virtual function 'edm::stream::EDProducerBase::beginLuminosityBlock' declared here: type mismatch at 1st parameter ('const edm::LuminosityBlock &' vs 'edm::LuminosityBlock &')
      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
                   ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:26:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.h:43:15: warning: 'PuppiProducer::endLuminosityBlock' hides overloaded virtual function [-Woverloaded-virtual]
         virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
                     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FWCore/Framework/interface/stream/EDProducerBase.h:70:20: note: hidden overloaded virtual function 'edm::stream::EDProducerBase::endLuminosityBlock' declared here: type mismatch at 1st parameter ('const edm::LuminosityBlock &' vs 'edm::LuminosityBlock &')
      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
                   ^
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:137:30: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId > 0) tmpFromPV = 0;
                             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:137:30: note: use function 'std::abs' instead
      if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId > 0) tmpFromPV = 0;
                             ^~~~
                             std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:138:30: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId == 0) tmpFromPV = 3;
                             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:138:30: note: use function 'std::abs' instead
      if (closestVtx != 0 && fabs(pReco.charge) > 0 && pVtxId == 0) tmpFromPV = 3;
                             ^~~~
                             std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:139:30: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds == 0) tmpFromPV = 2;
                             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:139:30: note: use function 'std::abs' instead
      if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds == 0) tmpFromPV = 2;
                             ^~~~
                             std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:140:30: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds != 0) tmpFromPV = 1;
                             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:140:30: note: use function 'std::abs' instead
      if (closestVtx == 0 && fabs(pReco.charge) > 0 && closestVtxForUnassociateds != 0) tmpFromPV = 1;
                             ^~~~
                             std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:144:11: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (fabs(pReco.charge) == 0){ pReco.id = 0; }
          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:144:11: note: use function 'std::abs' instead
      if (fabs(pReco.charge) == 0){ pReco.id = 0; }
          ^~~~
          std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:164:11: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (fabs(pReco.charge) == 0){ pReco.id = 0; }
          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:164:11: note: use function 'std::abs' instead
      if (fabs(pReco.charge) == 0){ pReco.id = 0; }
          ^~~~
          std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:165:11: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (fabs(pReco.charge) > 0){
          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CommonTools/PileupAlgos/plugins/PuppiProducer.cc:165:11: note: use function 'std::abs' instead
      if (fabs(pReco.charge) > 0){
          ^~~~
          std::abs