### PR TITLE
CondFormats-SiPixelObjects fix clang warnings about abs and mismatched tags

### DIFF
--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 
 short SiPixelCalibConfiguration::vcalIndexForEvent(const uint32_t & eventnumber) const{
-  uint32_t relative_event = (eventnumber-1)%patternSize();
+  uint32_t relative_event = std::abs((int32_t)eventnumber-1)%patternSize();
   short relative_pattern = relative_event/getNTriggers();
   return relative_pattern; 
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 
 short SiPixelCalibConfiguration::vcalIndexForEvent(const uint32_t & eventnumber) const{
-  uint32_t relative_event = abs(eventnumber-1)%patternSize();
+  uint32_t relative_event = (eventnumber-1)%patternSize();
   short relative_pattern = relative_event/getNTriggers();
   return relative_pattern; 
 }

--- a/CondFormats/SiPixelObjects/src/classes.h
+++ b/CondFormats/SiPixelObjects/src/classes.h
@@ -17,9 +17,9 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 #include "CondFormats/SiPixelObjects/interface/PixelDCSObject.h"
 
-template class PixelDCSObject<bool>;
-template class PixelDCSObject<float>;
-template class PixelDCSObject<CaenChannel>;
+template struct PixelDCSObject<bool>;
+template struct PixelDCSObject<float>;
+template struct PixelDCSObject<CaenChannel>;
 
 namespace CondFormats_SiPixelObjects {
   struct dictionary {


### PR DESCRIPTION
In file included from CondFormatsSiPixelObjects/a/CondFormatsSiPixelObjects_xr.cc:41:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:20:10: warning: class template 'PixelDCSObject' was previously declared as a struct template [-Wmismatched-tags]
 template class PixelDCSObject<bool>;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/interface/PixelDCSObject.h:22:8: note: previous use is here
struct PixelDCSObject
       ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:20:10: note: did you mean struct here?
template class PixelDCSObject<bool>;
         ^~~~~
         struct
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:21:10: warning: class template 'PixelDCSObject' was previously declared as a struct template [-Wmismatched-tags]
 template class PixelDCSObject<float>;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/interface/PixelDCSObject.h:22:8: note: previous use is here
struct PixelDCSObject
       ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:21:10: note: did you mean struct here?
template class PixelDCSObject<float>;
         ^~~~~
         struct
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:22:10: warning: class template 'PixelDCSObject' was previously declared as a struct template [-Wmismatched-tags]
 template class PixelDCSObject<CaenChannel>;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/interface/PixelDCSObject.h:22:8: note: previous use is here
struct PixelDCSObject
       ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/classes.h:22:10: note: did you mean struct here?
template class PixelDCSObject<CaenChannel>;
         ^~~~~
         struct

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc:6:29: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
   uint32_t relative_event = abs(eventnumber-1)%patternSize();
                            ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc:6:29: note: remove the call to 'abs' since unsigned values cannot be negative
  uint32_t relative_event = abs(eventnumber-1)%patternSize();
                            ^~~