### PR TITLE
DQM-EcalMonitorClient fix clang warnings about abs

### DIFF
--- a/DQM/EcalMonitorClient/src/LaserClient.cc
+++ b/DQM/EcalMonitorClient/src/LaserClient.cc
@@ -165,7 +165,7 @@ namespace ecaldqm
         if(intensity < toleranceAmplitudeLo_
             || intensity > toleranceAmplitudeHi_
             || aRms > aMean * toleranceAmpRMSRatio_
-            || abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ /*|| tRms > toleranceTimRMS_*/)
+            || std::abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ /*|| tRms > toleranceTimRMS_*/)
           qItr->setBinContent(doMask ? kMBad : kBad);
         else
           qItr->setBinContent(doMask ? kMGood : kGood);

--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -159,7 +159,7 @@ namespace ecaldqm
 
         float aRmsThr( sqrt(pow(aMean*toleranceAmpRMSRatio_,2) + pow(3.,2)) );
         if(intensity < toleranceAmplitude_ || aRms > aRmsThr ||
-           abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ || tRms > toleranceTimRMS_)
+           std::abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ || tRms > toleranceTimRMS_)
           qItr->setBinContent(doMask ? kMBad : kBad);
         else
           qItr->setBinContent(doMask ? kMGood : kGood);

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -132,7 +132,7 @@ namespace ecaldqm
         meFwdvBkwd.fill(id, mean, posTime);
       }
 
-      if(abs(mean) > meanThresh || rms > rmsThresh)
+      if(std::abs(mean) > meanThresh || rms > rmsThresh)
         qItr->setBinContent(doMask ? kMBad : kBad);
       else
         qItr->setBinContent(doMask ? kMGood : kGood);
@@ -164,12 +164,12 @@ namespace ecaldqm
     MESet& meTrendMean(MEs_.at("TrendMean"));
     MESet& meTrendRMS(MEs_.at("TrendRMS"));
     if ( EBentries > 0. ) {
-      if ( abs(EBmean) > 0. ) meTrendMean.fill( EcalBarrel, double(timestamp_.iLumi), EBmean/EBentries );
-      if ( abs(EBrms ) > 0. ) meTrendRMS.fill ( EcalBarrel, double(timestamp_.iLumi), EBrms/EBentries  );
+      if ( std::abs(EBmean) > 0. ) meTrendMean.fill( EcalBarrel, double(timestamp_.iLumi), EBmean/EBentries );
+      if ( std::abs(EBrms ) > 0. ) meTrendRMS.fill ( EcalBarrel, double(timestamp_.iLumi), EBrms/EBentries  );
     }
     if ( EEentries > 0. ) {
-      if ( abs(EEmean) > 0. ) meTrendMean.fill( EcalEndcap, double(timestamp_.iLumi), EEmean/EEentries );
-      if ( abs(EErms ) > 0. ) meTrendRMS.fill ( EcalEndcap, double(timestamp_.iLumi), EErms/EEentries  );
+      if ( std::abs(EEmean) > 0. ) meTrendMean.fill( EcalEndcap, double(timestamp_.iLumi), EEmean/EEentries );
+      if ( std::abs(EErms ) > 0. ) meTrendRMS.fill ( EcalEndcap, double(timestamp_.iLumi), EErms/EEentries  );
     }
 
     MESet::iterator qsEnd(meQualitySummary.end());
@@ -230,7 +230,7 @@ namespace ecaldqm
 
           float towerRMS(sqrt(towerMean2 - towerMean * towerMean));
 
-          if(abs(towerMean) > meanThresh || towerRMS > rmsThresh)
+          if(std::abs(towerMean) > meanThresh || towerRMS > rmsThresh)
             quality = doMask ? kMBad : kBad;
           else
             quality = doMask ? kMGood : kGood;

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -142,8 +142,8 @@ namespace ecaldqm
     }
     meanFEDEB /= float( nFEDEB ); rmsFEDEB /= float( nFEDEB );
     meanFEDEE /= float( nFEDEE ); rmsFEDEE /= float( nFEDEE );
-    rmsFEDEB   = sqrt( abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
-    rmsFEDEE   = sqrt( abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
+    rmsFEDEB   = sqrt( std::abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
+    rmsFEDEE   = sqrt( std::abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
     // Analyze FED statistics
     float meanFED(0.), rmsFED(0.), nRMS(5.);
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++){


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DQM/EcalMonitorClient/src/DQMEcalMonitorClient/TestPulseClient.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/TestPulseClient.cc -o tmp/slc6_amd64_gcc530/src/DQM/EcalMonitorClient/src/DQMEcalMonitorClient/TestPulseClient.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/LedClient.cc:162:12: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
            abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ || tRms > toleranceTimRMS_)
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/LedClient.cc:162:12: note: use function 'std::abs' instead
           abs(tMean - expectedTiming_[wlItr->second]) > toleranceTiming_ || tRms > toleranceTimRMS_)
           ^~~
           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/TrigPrimClient.cc:145:24: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     rmsFEDEB   = sqrt( abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
                       ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/TrigPrimClient.cc:145:24: note: use function 'std::abs' instead
    rmsFEDEB   = sqrt( abs(rmsFEDEB - meanFEDEB*meanFEDEB) );
                       ^~~
                       std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/TrigPrimClient.cc:146:24: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     rmsFEDEE   = sqrt( abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
                       ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQM/EcalMonitorClient/src/TrigPrimClient.cc:146:24: note: use function 'std::abs' instead
    rmsFEDEE   = sqrt( abs(rmsFEDEE - meanFEDEE*meanFEDEE) );
                       ^~~
                       std::abs