### PR TITLE
DQMOffline-Ecal fix clang warnings about abs

### DIFF
--- a/DQMOffline/Ecal/plugins/EcalZmassClient.cc
+++ b/DQMOffline/Ecal/plugins/EcalZmassClient.cc
@@ -138,8 +138,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	  {
 
 	    B->Fit ("mygauss", "QR");
-	    mean = fabs (func->GetParameter (1));
-	    sigma = fabs (func->GetParError (1));
+	    mean = std::abs (func->GetParameter (1));
+	    sigma = std::abs (func->GetParError (1));
 	  }
 
 	if (N == 0 || mean < 50 || mean > 100 || sigma <= 0 || sigma > 20)
@@ -197,8 +197,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	  {
 
 	    Bbis->Fit ("mygauss", "QR");
-	    rms = fabs (func->GetParameter (2));
-	    rmsErr = fabs (func->GetParError (2));
+	    rms = std::abs (func->GetParameter (2));
+	    rmsErr = std::abs (func->GetParError (2));
 	  }
 
 	if (N == 0 || rms < 0 || rms > 50 || rmsErr <= 0 || rmsErr > 50)
@@ -256,8 +256,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	if (N != 0)
 	  {
 	    E->Fit ("mygauss", "QR");
-	    mean = fabs (func->GetParameter (1));
-	    sigma = fabs (func->GetParError (1));
+	    mean = std::abs (func->GetParameter (1));
+	    sigma = std::abs (func->GetParError (1));
 	  }
 
 	if (N == 0 || mean < 50 || mean > 100 || sigma <= 0 || sigma > 20)
@@ -317,8 +317,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	  {
 
 	    Ebis->Fit ("mygauss", "QR");
-	    rms = fabs (func->GetParameter (2));
-	    rmsErr = fabs (func->GetParError (2));
+	    rms = std::abs (func->GetParameter (2));
+	    rmsErr = std::abs (func->GetParError (2));
 	  }
 
 	if (N == 0 || rms < 0 || rms > 50 || rmsErr <= 0 || rmsErr > 50)
@@ -378,8 +378,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	  {
 
 	    M->Fit ("mygauss", "QR");
-	    mean = fabs (func->GetParameter (1));
-	    sigma = fabs (func->GetParError (1));
+	    mean = std::abs (func->GetParameter (1));
+	    sigma = std::abs (func->GetParError (1));
 	  }
 	if (N == 0 || mean < 50 || mean > 100 || sigma <= 0 || sigma > 20)
 	  {
@@ -437,8 +437,8 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	  {
 
 	    Mbis->Fit ("mygauss", "QR");
-	    rms = fabs (func->GetParameter (2));
-	    rmsErr = fabs (func->GetParError (2));
+	    rms = std::abs (func->GetParameter (2));
+	    rmsErr = std::abs (func->GetParError (2));
 	  }
 
 	if (N == 0 || rms < 0 || rms > 50 || rmsErr <= 0 || rmsErr > 50)
@@ -500,7 +500,7 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	    C1->Fit ("mygauss", "QR");
 	    if ((func->GetNDF () != 0))
 	      {
-		Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
+		Chi2 = std::abs (func->GetChisquare ()) / std::abs (func->GetNDF ());
 		NDF = 0.1;
 	      }
 	  }
@@ -562,7 +562,7 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	    C2->Fit ("mygauss", "QR");
 	    if (func->GetNDF () != 0)
 	      {
-		Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
+		Chi2 = std::abs (func->GetChisquare ()) / std::abs (func->GetNDF ());
 		NDF = 0.1;
 	      }
 	  }
@@ -623,7 +623,7 @@ EcalZmassClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _iget
 	    C3->Fit ("mygauss", "QR");
 	    if ((func->GetNDF () != 0))
 	      {
-		Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
+		Chi2 = std::abs (func->GetChisquare ()) / std::abs (func->GetNDF ());
 		NDF = 0.1;
 	      }
 	  }


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/DQMOffline/Ecal/plugins/DQMOfflineEcalPlugins/EcalZmassClient.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc -o tmp/slc6_amd64_gcc530/src/DQMOffline/Ecal/plugins/DQMOfflineEcalPlugins/EcalZmassClient.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:503:41: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
                 Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:503:41: note: use function 'std::abs' instead
                Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^~~~
                                                      std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:565:41: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
                 Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:565:41: note: use function 'std::abs' instead
                Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^~~~
                                                      std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:626:41: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
                 Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DQMOffline/Ecal/plugins/EcalZmassClient.cc:626:41: note: use function 'std::abs' instead
                Chi2 = fabs (func->GetChisquare ()) / fabs (func->GetNDF ());
                                                      ^~~~
                                                      std::abs
3 warnings generated.