### PR TITLE
EgammaAnalysis-ElectronTools fix clang warnings about abs

### DIFF
--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc
@@ -309,7 +309,7 @@ double ElectronEnergyRegressionEvaluate::calculateRegressionEnergy(const reco::G
               ele->trackMomentumError(),
               ele->correctedEcalEnergyError(),
               ele->classification(),     
-              fmin(fabs(ele->deltaEtaSuperClusterTrackAtVtx()), 0.6),
+              fmin(std::abs(ele->deltaEtaSuperClusterTrackAtVtx()), 0.6),
               ele->deltaPhiSuperClusterTrackAtVtx(),
               ele->deltaEtaSeedClusterTrackAtCalo(),
               ele->deltaPhiSeedClusterTrackAtCalo(),
@@ -584,7 +584,7 @@ double ElectronEnergyRegressionEvaluate::calculateRegressionEnergyUncertainty(co
               ele->trackMomentumError(),
               ele->correctedEcalEnergyError(),
               ele->classification(),     
-              fmin(fabs(ele->deltaEtaSuperClusterTrackAtVtx()), 0.6),
+              fmin(std::abs(ele->deltaEtaSuperClusterTrackAtVtx()), 0.6),
               ele->deltaPhiSuperClusterTrackAtVtx(),
               ele->deltaEtaSeedClusterTrackAtCalo(),
               ele->deltaPhiSeedClusterTrackAtCalo(),
@@ -653,8 +653,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVar(
     assert(forestCorrection_ee);
 
   // Now applying regression according to version and (endcap/barrel)
-  float *vals = (fabs(scEta) <= 1.479) ? new float[38] : new float[31];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[38] : new float[31];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -689,7 +689,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVar(
     vals[31] = IPhiSeed;
     vals[32] = ((int) IEtaSeed)%5;
     vals[33] = ((int) IPhiSeed)%2;
-    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[34] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[35] = ((int) IPhiSeed)%20;
     vals[36] = EtaCrySeed;
     vals[37] = PhiCrySeed;
@@ -733,7 +733,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVar(
   Int_t BinIndex = -1;
 
   if (fVersionType == kNoTrkVar) {
-    if (fabs(scEta) <= 1.479) { 
+    if (std::abs(scEta) <= 1.479) { 
       regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals); 
       BinIndex = 0;
     }
@@ -745,7 +745,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVar(
 
   //print debug
   if (printDebug) {    
-    if ( fabs(scEta) <= 1.479) {
+    if ( std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 38; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -816,8 +816,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVar(
   }
 
   // Now applying regression according to version and (endcap/barrel)
-  float *vals = (fabs(scEta) <= 1.479) ? new float[38] : new float[31];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[38] : new float[31];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -852,7 +852,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVar(
     vals[31] = IPhiSeed;
     vals[32] = ((int) IEtaSeed)%5;
     vals[33] = ((int) IPhiSeed)%2;
-    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[34] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[35] = ((int) IPhiSeed)%20;
     vals[36] = EtaCrySeed;
     vals[37] = PhiCrySeed;
@@ -896,7 +896,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVar(
   Int_t BinIndex = -1;
 
   if (fVersionType == kNoTrkVar) {
-    if (fabs(scEta) <= 1.479) { 
+    if (std::abs(scEta) <= 1.479) { 
       regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals); 
       BinIndex = 0;
     }
@@ -908,7 +908,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVar(
 
   //print debug
   if (printDebug) {    
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 38; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -983,8 +983,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVarV1(
   }
 
   // Now applying regression according to version and (endcap/barrel)
-  float *vals = (fabs(scEta) <= 1.479) ? new float[39] : new float[32];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[39] : new float[32];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1020,7 +1020,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVarV1(
     vals[32] = IPhiSeed;
     vals[33] = ((int) IEtaSeed)%5;
     vals[34] = ((int) IPhiSeed)%2;
-    vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[35] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[36] = ((int) IPhiSeed)%20;
     vals[37] = EtaCrySeed;
     vals[38] = PhiCrySeed;
@@ -1065,7 +1065,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVarV1(
   Int_t BinIndex = -1;
 
   if (fVersionType == kNoTrkVarV1) {
-    if (fabs(scEta) <= 1.479) { 
+    if (std::abs(scEta) <= 1.479) { 
       regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals); 
       BinIndex = 0;
     }
@@ -1077,7 +1077,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueNoTrkVarV1(
 
   //print debug
   if (printDebug) {    
-    if ( fabs(scEta) <= 1.479) {
+    if ( std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 39; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -1149,8 +1149,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVarV1(
   }
 
   // Now applying regression according to version and (endcap/barrel)
-  float *vals = (fabs(scEta) <= 1.479) ? new float[39] : new float[32];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[39] : new float[32];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1186,7 +1186,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVarV1(
     vals[32] = IPhiSeed;
     vals[33] = ((int) IEtaSeed)%5;
     vals[34] = ((int) IPhiSeed)%2;
-    vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[35] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[36] = ((int) IPhiSeed)%20;
     vals[37] = EtaCrySeed;
     vals[38] = PhiCrySeed;
@@ -1231,7 +1231,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVarV1(
   Int_t BinIndex = -1;
 
   if (fVersionType == kNoTrkVarV1) {
-    if (fabs(scEta) <= 1.479) { 
+    if (std::abs(scEta) <= 1.479) { 
       regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals); 
       BinIndex = 0;
     }
@@ -1243,7 +1243,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyNoTrkVarV1(
 
   //print debug
   if (printDebug) {    
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 39; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -1320,8 +1320,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVar(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVar);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[43] : new float[36];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[43] : new float[36];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1361,7 +1361,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVar(
     vals[36] = IPhiSeed;
     vals[37] = ((int) IEtaSeed)%5;
     vals[38] = ((int) IPhiSeed)%2;
-    vals[39] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[39] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[40] = ((int) IPhiSeed)%20;
     vals[41] = EtaCrySeed;
     vals[42] = PhiCrySeed;
@@ -1410,7 +1410,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVar(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVar) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestCorrection_ee->GetResponse(vals);
   }
 
@@ -1493,8 +1493,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVar(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVar);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[43] : new float[36];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[43] : new float[36];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1534,7 +1534,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVar(
     vals[36] = IPhiSeed;
     vals[37] = ((int) IEtaSeed)%5;
     vals[38] = ((int) IPhiSeed)%2;
-    vals[39] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[39] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[40] = ((int) IPhiSeed)%20;
     vals[41] = EtaCrySeed;
     vals[42] = PhiCrySeed;
@@ -1583,7 +1583,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVar(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVar) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestUncertainty_ee->GetResponse(vals);
   }
 
@@ -1666,8 +1666,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVarV1);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[46] : new float[39];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[46] : new float[39];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1710,7 +1710,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(
     vals[39] = IPhiSeed;
     vals[40] = ((int) IEtaSeed)%5;
     vals[41] = ((int) IPhiSeed)%2;
-    vals[42] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[42] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[43] = ((int) IPhiSeed)%20;
     vals[44] = EtaCrySeed;
     vals[45] = PhiCrySeed;
@@ -1762,14 +1762,14 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV1) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestCorrection_ee->GetResponse(vals);
   }
 
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 46; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -1845,8 +1845,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVarV1);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[46] : new float[39];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[46] : new float[39];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -1889,7 +1889,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(
     vals[39] = IPhiSeed;
     vals[40] = ((int) IEtaSeed)%5;
     vals[41] = ((int) IPhiSeed)%2;
-    vals[42] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[42] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[43] = ((int) IPhiSeed)%20;
     vals[44] = EtaCrySeed;
     vals[45] = PhiCrySeed;
@@ -1941,13 +1941,13 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV1) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestUncertainty_ee->GetResponse(vals);
   }
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 46; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -2029,8 +2029,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(std::vector
   double EcalEnergyError  = inputvars[40];
   int    Classification  = inputvars[41]; 
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[46] : new float[39];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[46] : new float[39];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -2073,7 +2073,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(std::vector
     vals[39] = IPhiSeed;
     vals[40] = ((int) IEtaSeed)%5;
     vals[41] = ((int) IPhiSeed)%2;
-    vals[42] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[42] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[43] = ((int) IPhiSeed)%20;
     vals[44] = EtaCrySeed;
     vals[45] = PhiCrySeed;
@@ -2125,14 +2125,14 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV1(std::vector
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV1) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestCorrection_ee->GetResponse(vals);
   }
 
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 46; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -2213,8 +2213,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(std::
   int    Classification  = inputvars[41]; 
 
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[46] : new float[39];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[46] : new float[39];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -2257,7 +2257,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(std::
     vals[39] = IPhiSeed;
     vals[40] = ((int) IEtaSeed)%5;
     vals[41] = ((int) IPhiSeed)%2;
-    vals[42] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[42] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[43] = ((int) IPhiSeed)%20;
     vals[44] = EtaCrySeed;
     vals[45] = PhiCrySeed;
@@ -2309,13 +2309,13 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV1(std::
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV1) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestUncertainty_ee->GetResponse(vals);
   }
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 46; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -2398,8 +2398,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVarV2);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[53] : new float[46];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[53] : new float[46];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -2449,7 +2449,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(
     vals[46] = IPhiSeed;
     vals[47] = ((int) IEtaSeed)%5;
     vals[48] = ((int) IPhiSeed)%2;
-    vals[49] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[49] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[50] = ((int) IPhiSeed)%20;
     vals[51] = EtaCrySeed;
     vals[52] = PhiCrySeed;
@@ -2508,14 +2508,14 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV2) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestCorrection_ee->GetResponse(vals);
   }
 
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 53; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -2598,8 +2598,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(
   // Checking if fVersionType is correct
   assert(fVersionType == kWithTrkVarV2);
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[53] : new float[46];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[53] : new float[46];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -2649,7 +2649,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(
     vals[46] = IPhiSeed;
     vals[47] = ((int) IEtaSeed)%5;
     vals[48] = ((int) IPhiSeed)%2;
-    vals[49] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[49] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[50] = ((int) IPhiSeed)%20;
     vals[51] = EtaCrySeed;
     vals[52] = PhiCrySeed;
@@ -2708,13 +2708,13 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV2) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestUncertainty_ee->GetResponse(vals);
   }
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 53; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -2802,8 +2802,8 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(std::vector
   double KFTrackNLayers  = inputvars[47];
   double ElectronEnergyOverPout  = inputvars[48];
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[53] : new float[46];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[53] : new float[46];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -2853,7 +2853,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(std::vector
     vals[46] = IPhiSeed;
     vals[47] = ((int) IEtaSeed)%5;
     vals[48] = ((int) IPhiSeed)%2;
-    vals[49] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[49] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[50] = ((int) IPhiSeed)%20;
     vals[51] = EtaCrySeed;
     vals[52] = PhiCrySeed;
@@ -2912,14 +2912,14 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithTrkVarV2(std::vector
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV2) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestCorrection_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestCorrection_ee->GetResponse(vals);
   }
 
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 53; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -3006,8 +3006,8 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(std::
   double KFTrackNLayers  = inputvars[47];
   double ElectronEnergyOverPout  = inputvars[48];
 
-  float *vals = (fabs(scEta) <= 1.479) ? new float[53] : new float[46];
-  if (fabs(scEta) <= 1.479) {		// Barrel
+  float *vals = (std::abs(scEta) <= 1.479) ? new float[53] : new float[46];
+  if (std::abs(scEta) <= 1.479) {		// Barrel
     vals[0]  = SCRawEnergy;
     vals[1]  = scEta;
     vals[2]  = scPhi;
@@ -3057,7 +3057,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(std::
     vals[46] = IPhiSeed;
     vals[47] = ((int) IEtaSeed)%5;
     vals[48] = ((int) IPhiSeed)%2;
-    vals[49] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[49] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[50] = ((int) IPhiSeed)%20;
     vals[51] = EtaCrySeed;
     vals[52] = PhiCrySeed;
@@ -3116,13 +3116,13 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithTrkVarV2(std::
   double regressionResult = 0;
 
   if (fVersionType == kWithTrkVarV2) {
-    if (fabs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
+    if (std::abs(scEta) <= 1.479) regressionResult = SCRawEnergy * forestUncertainty_eb->GetResponse(vals);
     else regressionResult = (SCRawEnergy*(1+PreShowerOverRaw)) * forestUncertainty_ee->GetResponse(vals);
   }
 
   //print debug
   if (printDebug) {
-    if (fabs(scEta) <= 1.479) {
+    if (std::abs(scEta) <= 1.479) {
       std::cout << "Barrel :";
       for (unsigned int v=0; v < 53; ++v) std::cout << vals[v] << ", ";
       std::cout << "\n";
@@ -3284,7 +3284,7 @@ double ElectronEnergyRegressionEvaluate::regressionValueWithSubClusters(
     vals[52] = (NClusters<=3 ? 0.   : E3x3Sub3/ESub3);
     vals[53] = IEtaSeed;
     vals[54] = ((int) IEtaSeed)%5;
-    vals[55] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[55] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[56] = IPhiSeed;
     vals[57] = ((int) IPhiSeed)%2;
     vals[58] = ((int) IPhiSeed)%20;
@@ -3537,7 +3537,7 @@ double ElectronEnergyRegressionEvaluate::regressionUncertaintyWithSubClusters(
     vals[52] = (NClusters<=3 ? 0.   : E3x3Sub3/ESub3);
     vals[53] = IEtaSeed;
     vals[54] = ((int) IEtaSeed)%5;
-    vals[55] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
+    vals[55] = (std::abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (std::abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*std::abs(IEtaSeed)/IEtaSeed))%20);
     vals[56] = IPhiSeed;
     vals[57] = ((int) IPhiSeed)%2;
     vals[58] = ((int) IPhiSeed)%20;

--- a/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc
@@ -230,7 +230,7 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::PFCa
   fVy =  pfCandidate->vy();
   fVz =  pfCandidate->vz();
 
-  pivotInBarrel = fabs(pfCandidate->positionAtECALEntrance().eta())<1.479;
+  pivotInBarrel = std::abs(pfCandidate->positionAtECALEntrance().eta())<1.479;
 
   for(unsigned iPF=0; iPF<pfParticlesColl->size(); iPF++) {
 
@@ -246,7 +246,7 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::PFCa
 	fIsolationInRingsPhoton[isoBin]  = fIsolationInRingsPhoton[isoBin] + pfParticle.pt();
       }
       
-    }else if(abs(pfParticle.pdgId())==130){
+    }else if(std::abs(pfParticle.pdgId())==130){
         
       if(isNeutralParticleVetoed(  &pfParticle)>=0.){
        	isoBin = (int)(fDeltaR/fRingSize);
@@ -254,8 +254,8 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::PFCa
       }
     
 
-      //}else if(abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || abs(pfParticle.pdgId()) == 211){
-    }else if(abs(pfParticle.pdgId()) == 211){
+      //}else if(std::abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || std::abs(pfParticle.pdgId()) == 211){
+    }else if(std::abs(pfParticle.pdgId()) == 211){
       if(isChargedParticleVetoed( &pfParticle, vtx, vertices)>=0.){
 	isoBin = (int)(fDeltaR/fRingSize);
 	fIsolationInRingsCharged[isoBin]  = fIsolationInRingsCharged[isoBin] + pfParticle.pt();
@@ -299,7 +299,7 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::Phot
   iMissHits = 0;
 
   refSC = photon->superCluster();
-  pivotInBarrel = fabs((refSC->position().eta()))<1.479;
+  pivotInBarrel = std::abs((refSC->position().eta()))<1.479;
 
   for(unsigned iPF=0; iPF<pfParticlesColl->size(); iPF++) {
 
@@ -328,7 +328,7 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::Phot
 	fIsolationInRingsPhoton[isoBin]  = fIsolationInRingsPhoton[isoBin] + pfParticle.pt();
       }
       
-    }else if(abs(pfParticle.pdgId())==130){
+    }else if(std::abs(pfParticle.pdgId())==130){
        
        // Set the vertex of reco::Photon to the first PV
       math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - pfParticle.vx(), 
@@ -346,8 +346,8 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::Phot
 	fIsolationInRingsNeutral[isoBin]  = fIsolationInRingsNeutral[isoBin] + pfParticle.pt();
       }
 
-      //}else if(abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || abs(pfParticle.pdgId()) == 211){
-    }else if(abs(pfParticle.pdgId()) == 211){
+      //}else if(std::abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || std::abs(pfParticle.pdgId()) == 211){
+    }else if(std::abs(pfParticle.pdgId()) == 211){
  
       // Set the vertex of reco::Photon to the first PV
       math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - (*vtx).x(),
@@ -414,7 +414,7 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::GsfE
   
   //  if(electron->ecalDrivenSeed())
   refSC = electron->superCluster();
-  pivotInBarrel = fabs((refSC->position().eta()))<1.479;
+  pivotInBarrel = std::abs((refSC->position().eta()))<1.479;
 
   for(unsigned iPF=0; iPF<pfParticlesColl->size(); iPF++) {
 
@@ -429,15 +429,15 @@ std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::GsfE
 
       }
       
-    }else if(abs(pfParticle.pdgId())==130){
+    }else if(std::abs(pfParticle.pdgId())==130){
         
       if(isNeutralParticleVetoed( &pfParticle)>=0.){
        	isoBin = (int)(fDeltaR/fRingSize);
 	fIsolationInRingsNeutral[isoBin]  = fIsolationInRingsNeutral[isoBin] + pfParticle.pt();
       }
 
-      //}else if(abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || abs(pfParticle.pdgId()) == 211){
-    }else if(abs(pfParticle.pdgId()) == 211){
+      //}else if(std::abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || std::abs(pfParticle.pdgId()) == 211){
+    }else if(std::abs(pfParticle.pdgId()) == 211){
       if(isChargedParticleVetoed(  &pfParticle, vtx, vertices)>=0.){
 	isoBin = (int)(fDeltaR/fRingSize);
 	
@@ -491,13 +491,13 @@ float  PFIsolationEstimator::isPhotonParticleVetoed( const reco::PFCandidate* pf
     }
     
     if(bRectangleVetoBarrel){
-      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
+      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
 	return -999.;
       }
     }
   }else{
     if (bUseCrystalSize == true) {
-      fDeltaRVetoEndcapPhotons = 0.00864*fabs(sinh(refSC->position().eta()))*fNumberOfCrystalEndcapPhotons;
+      fDeltaRVetoEndcapPhotons = 0.00864*std::abs(sinh(refSC->position().eta()))*fNumberOfCrystalEndcapPhotons;
     }
 
     if(bDeltaRVetoEndcap){
@@ -505,7 +505,7 @@ float  PFIsolationEstimator::isPhotonParticleVetoed( const reco::PFCandidate* pf
 	return -999.;
     }
     if(bRectangleVetoEndcap){
-      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
+      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
 	 return -999.;
       }
     }
@@ -540,7 +540,7 @@ float  PFIsolationEstimator::isNeutralParticleVetoed( const reco::PFCandidate* p
 	  return -999.;
       }
       if(bRectangleVetoBarrel){
-	if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
+	if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
 	    return -999.;
 	}
       }
@@ -554,7 +554,7 @@ float  PFIsolationEstimator::isNeutralParticleVetoed( const reco::PFCandidate* p
 	  return -999.;
       }
       if(bRectangleVetoEndcap){
-	if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
+	if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
 	  return -999.;
 	}
       }
@@ -591,34 +591,34 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
   if(bApplyDzDxyVeto) {
     if(iParticleType==kPhoton){
       
-      float dz = fabs( pfIsoCand->trackRef()->dz( (*vtxMain).position() ) );
+      float dz = std::abs( pfIsoCand->trackRef()->dz( (*vtxMain).position() ) );
       if (dz > 0.2)
         return -999.;
 	
       double dxy = pfIsoCand->trackRef()->dxy( (*vtxMain).position() );  
-      if (fabs(dxy) > 0.1)
+      if (std::abs(dxy) > 0.1)
         return -999.;
       
       /*
-      float dz = fabs(vtx->z() - fVtxMainZ);
+      float dz = std::abs(vtx->z() - fVtxMainZ);
       if (dz > 1.)
 	return -999.;
       
       
       double dxy = ( -(vtx->x() - fVtxMainX)*pfIsoCand->py() + (vtx->y() - fVtxMainY)*pfIsoCand->px()) / pfIsoCand->pt();
       
-      if(fabs(dxy) > 0.2)
+      if(std::abs(dxy) > 0.2)
 	return -999.;
       */
     }else{
       
       
-      float dz = fabs(vtx->z() - fVtxMainZ);
+      float dz = std::abs(vtx->z() - fVtxMainZ);
       if (dz > 1.)
 	return -999.;
       
       double dxy = ( -(vtx->x() - fVx)*pfIsoCand->py() + (vtx->y() - fVy)*pfIsoCand->px()) / pfIsoCand->pt();
-      if(fabs(dxy) > 0.1)
+      if(std::abs(dxy) > 0.1)
 	return -999.;
     }
   }    
@@ -652,7 +652,7 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
 	  return -999.;
       }
       if(bRectangleVetoBarrel){
-	if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
+	if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
 	    return -999.;
 	}
       }
@@ -666,7 +666,7 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
 	  return -999.;
       }
       if(bRectangleVetoEndcap){
-	if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
+	if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
 	  return -999.;
 	}
       }
@@ -736,7 +736,7 @@ reco::VertexRef  PFIsolationEstimator::chargedHadronVertex(  edm::Handle< reco::
     index = 0;
     for( reco::VertexCollection::const_iterator  iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
 
-      double dz = fabs(ztrack - iv->z());
+      double dz = std::abs(ztrack - iv->z());
       if(dz<dzmin) {
         dzmin = dz;
         iVertex = index;

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -349,7 +349,7 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     if(abs(genPtcl.pdgId())==11 &&
        genPtcl.status()==1       &&
        ptmc > 10.               &&
-       fabs(etamc) < 2.5 ){
+       std::abs(etamc) < 2.5 ){
 
 
       for (unsigned int j=0; j<theEGamma.size();j++) {
@@ -519,7 +519,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
   myMVAVar_phiwidth        =  ele.superCluster()->phiWidth();
   myMVAVar_e1x5e5x5        =  (ele.e5x5()) !=0. ? 1.-(ele.e1x5()/ele.e5x5()) : -1. ;
   myMVAVar_R9              =  myEcalCluster.e3x3(*(ele.superCluster()->seed())) / ele.superCluster()->rawEnergy();
-  myMVAVar_nbrems          =  fabs(ele.numberOfBrems());
+  myMVAVar_nbrems          =  std::abs(ele.numberOfBrems());
 
   myMVAVar_HoE             =  ele.hadronicOverEm();
   myMVAVar_EoP             =  ele.eSuperClusterOverP();
@@ -598,12 +598,12 @@ void ElectronTestAnalyzer::myBindVariables() {
   if(myMVAVar_fbrem < -1.)
     myMVAVar_fbrem = -1.;
 
-  myMVAVar_deta = fabs(myMVAVar_deta);
+  myMVAVar_deta = std::abs(myMVAVar_deta);
   if(myMVAVar_deta > 0.06)
     myMVAVar_deta = 0.06;
 
 
-  myMVAVar_dphi = fabs(myMVAVar_dphi);
+  myMVAVar_dphi = std::abs(myMVAVar_dphi);
   if(myMVAVar_dphi > 0.6)
     myMVAVar_dphi = 0.6;
 
@@ -618,12 +618,12 @@ void ElectronTestAnalyzer::myBindVariables() {
     myMVAVar_eleEoPout = 20.;
 
 
-  myMVAVar_detacalo = fabs(myMVAVar_detacalo);
+  myMVAVar_detacalo = std::abs(myMVAVar_detacalo);
   if(myMVAVar_detacalo > 0.2)
     myMVAVar_detacalo = 0.2;
 
 
-  myMVAVar_dphicalo = fabs(myMVAVar_dphicalo);
+  myMVAVar_dphicalo = std::abs(myMVAVar_dphicalo);
   if(myMVAVar_dphicalo > 0.4)
     myMVAVar_dphicalo = 0.4;
 
@@ -657,7 +657,7 @@ void ElectronTestAnalyzer::myBindVariables() {
 bool ElectronTestAnalyzer::trainTrigPresel(const reco::GsfElectron& ele) {
 
   bool myTrigPresel = false;
-  if(fabs(ele.superCluster()->eta()) < 1.479) {
+  if(std::abs(ele.superCluster()->eta()) < 1.479) {
     if(ele.sigmaIetaIeta() < 0.014 &&
        ele.hadronicOverEm() < 0.15 &&
        ele.dr03TkSumPt()/ele.pt() < 0.2 &&
@@ -731,30 +731,30 @@ ElectronTestAnalyzer::evaluate_mvas(const edm::Event& iEvent, const edm::EventSe
     } else if (iE->closestCtfTrackRef().isNonnull()) {
       electronTrackZ = iE->closestCtfTrackRef()->dz(pvCol->at(0).position());
     }
-    if(fabs(electronTrackZ) > 0.2)  continue;
+    if(std::abs(electronTrackZ) > 0.2)  continue;
 
 
-    if(fabs(iE->superCluster()->eta())<1.479) {
+    if(std::abs(iE->superCluster()->eta())<1.479) {
       if(iE->pt() > 20) {
         if(iE->sigmaIetaIeta()       > 0.01)  continue;
-        if(fabs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.007) continue;
-        if(fabs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
+        if(std::abs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.007) continue;
+        if(std::abs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
         if(iE->hadronicOverEm()       > 0.15)  continue;
       } else {
         if(iE->sigmaIetaIeta()       > 0.012)  continue;
-        if(fabs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.007) continue;
-        if(fabs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
+        if(std::abs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.007) continue;
+        if(std::abs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
         if(iE->hadronicOverEm()       > 0.15) continue;
       }
     } else {
       if(iE->pt() > 20) {
         if(iE->sigmaIetaIeta()       > 0.03)  continue;
-        if(fabs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.010) continue;
-        if(fabs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
+        if(std::abs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.010) continue;
+        if(std::abs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
       } else {
         if(iE->sigmaIetaIeta()       > 0.032)  continue;
-        if(fabs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.010) continue;
-        if(fabs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
+        if(std::abs(iE->deltaEtaSuperClusterTrackAtVtx()) > 0.010) continue;
+        if(std::abs(iE->deltaPhiSuperClusterTrackAtVtx()) > 0.8)  continue;
       }
     }
     IdentifiedElectrons.push_back(*iE);


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/EgammaAnalysis/ElectronTools/src/EgammaAnalysisElectronTools/EGammaMvaEleEstimatorCSA14.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc -o tmp/slc6_amd64_gcc530/src/EgammaAnalysis/ElectronTools/src/EgammaAnalysisElectronTools/EGammaMvaEleEstimatorCSA14.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:494:10: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
       if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:494:10: note: use function 'std::abs' instead
      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
         ^~~
         std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:494:66: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
       if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
                                                                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:494:66: note: use function 'std::abs' instead
      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons){
                                                                 ^~~
                                                                 std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:508:10: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
       if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:508:10: note: use function 'std::abs' instead
      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
         ^~~
         std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:508:66: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
       if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
                                                                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:508:66: note: use function 'std::abs' instead
      if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons){
                                                                 ^~~
                                                                 std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:543:5: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:543:5: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
           ^~~
           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:543:62: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
                                                                    ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:543:62: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals){
                                                                    ^~~
                                                                    std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:557:5: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:557:5: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
           ^~~
           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:557:62: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
                                                                    ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:557:62: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals){
                                                                    ^~~
                                                                    std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:655:5: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:655:5: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
           ^~~
           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:655:61: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
                                                                   ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:655:61: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged){
                                                                   ^~~
                                                                   std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:669:5: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:669:5: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
           ^~~
           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:669:61: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
                                                                   ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc:669:61: note: use function 'std::abs' instead
        if(abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged && abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged){
                                                                   ^~~
                                                                   std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:17: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:17: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^~~
                std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:60: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:60: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^~~
                                                           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:99: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                                                                  ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:692:99: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                                                                  ^~~
                                                                                                  std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:17: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:17: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^~~
                std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:60: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:60: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^~~
                                                           std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:99: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                                                                  ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:855:99: note: use function 'std::abs' instead
    vals[34] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                                                                  ^~~
                                                                                                  std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:1023:17: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:1023:17: note: use function 'std::abs' instead
    vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                ^~~
                std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:1023:60: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/EgammaAnalysis/ElectronTools/src/ElectronEnergyRegressionEvaluate.cc:1023:60: note: use function 'std::abs' instead
    vals[35] = (abs(IEtaSeed)<=25)*(((int)IEtaSeed)%25) + (abs(IEtaSeed)>25)*(((int) (IEtaSeed-25*abs(IEtaSeed)/IEtaSeed))%20);
                                                           ^~~
                                                           std::abs
