### PR TITLE
FastSimulation: fix clang warnings about abs

### DIFF
--- a/FastSimulation/BaseParticlePropagator/src/BaseParticlePropagator.cc
+++ b/FastSimulation/BaseParticlePropagator/src/BaseParticlePropagator.cc
@@ -596,7 +596,7 @@ BaseParticlePropagator::propagateToHOLayer(bool first) {
   bool done = propagate();
   propDir = 1;
   
-  if ( done && abs(Z()) > 700.25) success = 0;
+  if ( done && std::abs(Z()) > 700.25) success = 0;
   
   return done;
 }

--- a/FastSimulation/Event/src/FBaseSimEvent.cc
+++ b/FastSimulation/Event/src/FBaseSimEvent.cc
@@ -200,7 +200,7 @@ FBaseSimEvent::fill(const std::vector<SimTrack>& simTracks,
     int motherType = motherId == -1 ? 0 : simTracks[motherId].type();
 
     bool notBremInDetector =
-      (abs(motherType) != 11 && abs(motherType) != 13) ||
+      (abs(motherType) != 11 && std::abs(motherType) != 13) ||
       motherType != track.type() ||
       position.Perp2() < lateVertexPosition ;
 
@@ -394,7 +394,7 @@ FBaseSimEvent::addParticles(const HepMC::GenEvent& myGenEvent) {
       unsigned productionMother = productionVertex->particles_in_size();
       if ( productionMother ) {
 	unsigned motherId = (*(productionVertex->particles_in_const_begin()))->pdg_id();
-	if ( abs(motherId) < 1000000 ) 
+	if ( std::abs(motherId) < 1000000 ) 
 	  productionVertexPosition = 
 	    XYZTLorentzVector(productionVertex->position().x()/10.,
 			      productionVertex->position().y()/10.,
@@ -404,7 +404,7 @@ FBaseSimEvent::addParticles(const HepMC::GenEvent& myGenEvent) {
     }
     if ( !myFilter->acceptVertex(productionVertexPosition) ) continue;
 
-    int abspdgId = abs(p->pdg_id());
+    int abspdgId = std::abs(p->pdg_id());
     HepMC::GenVertex* endVertex = p->end_vertex();
 
     // Keep only: 

--- a/FastSimulation/Event/src/FBaseSimEvent.cc
+++ b/FastSimulation/Event/src/FBaseSimEvent.cc
@@ -394,7 +394,7 @@ FBaseSimEvent::addParticles(const HepMC::GenEvent& myGenEvent) {
       unsigned productionMother = productionVertex->particles_in_size();
       if ( productionMother ) {
 	unsigned motherId = (*(productionVertex->particles_in_const_begin()))->pdg_id();
-	if ( std::abs(motherId) < 1000000 ) 
+	if ( motherId < 1000000 ) 
 	  productionVertexPosition = 
 	    XYZTLorentzVector(productionVertex->position().x()/10.,
 			      productionVertex->position().y()/10.,


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/FastSimulation/BaseParticlePropagator/src/FastSimulationBaseParticlePropagator/BaseParticlePropagator.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/BaseParticlePropagator/src/BaseParticlePropagator.cc -o tmp/slc6_amd64_gcc530/src/FastSimulation/BaseParticlePropagator/src/FastSimulationBaseParticlePropagator/BaseParticlePropagator.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/BaseParticlePropagator/src/BaseParticlePropagator.cc:599:16: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   if ( done && abs(Z()) > 700.25) success = 0;
               ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/BaseParticlePropagator/src/BaseParticlePropagator.cc:599:16: note: use function 'std::abs' instead
  if ( done && abs(Z()) > 700.25) success = 0;
               ^~~
               std::abs/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/FastSimulation/Event/src/FastSimulationEvent/FBaseSimEvent.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/Event/src/FBaseSimEvent.cc -o tmp/slc6_amd64_gcc530/src/FastSimulation/Event/src/FastSimulationEvent/FBaseSimEvent.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/Event/src/FSimVertex.cc:12:66: warning: all paths through this function will call itself [-Winfinite-recursion]
 std::ostream& operator <<(std::ostream& o , const FSimVertex& t) {
                                                                 ^
1 warning generated.
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/Event/src/FBaseSimEvent.cc:397:7: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
         if ( abs(motherId) < 1000000 ) 
             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/FastSimulation/Event/src/FBaseSimEvent.cc:397:7: note: remove the call to 'abs' since unsigned values cannot be negative
        if ( abs(motherId) < 1000000 ) 
             ^~~
1 warning generated.