### PR TITLE
Fireworks: fix clang warnings about abs

### DIFF
--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -353,14 +353,14 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	    {
 	       x = pt.x2(); // tubs radius
 	    }
-	    double halfOpeningAngle = asin( x / abs( r ))/deg;
+	    double halfOpeningAngle = asin( x / std::abs( r ))/deg;
 	    double displacement = 0;
 	    double startPhi = 0;
 	    /* calculate the displacement of the tubs w.r.t. to the trap,
 	       determine the opening angle of the tubs */
 	    double delta = sqrt( r * r - x * x );
 
-	    if( r < 0 && abs( r ) >= x )
+	    if( r < 0 && std::abs( r ) >= x )
 	    {
 	      intersec = true; // intersection solid
 	      h = pt.y1() < pt.y2() ? pt.y2() : pt.y1(); // tubs half height
@@ -376,7 +376,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 		startPhi = -90.- halfOpeningAngle;
 	      }
 	    }
-	    else if( r > 0 && abs( r ) >= x )
+	    else if( r > 0 && std::abs( r ) >= x )
 	    {
 	      if( atMinusZ )
 	      {
@@ -405,7 +405,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	      
 	    std::auto_ptr<TGeoShape> tubs( new TGeoTubeSeg( pt.name().name().c_str(),
 							    0.,
-							    abs(r)/cm, // radius cannot be negative!!!
+							    std::abs(r)/cm, // radius cannot be negative!!!
 							    h/cm,
 							    startPhi,
 							    startPhi + halfOpeningAngle * 2. ));


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libpng/1.6.16/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libjpeg-turbo/1.3.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/Fireworks/Geometry/src/FireworksGeometry/FWTGeoRecoGeometryRecord.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/FWTGeoRecoGeometryRecord.cc -o tmp/slc6_amd64_gcc530/src/Fireworks/Geometry/src/FireworksGeometry/FWTGeoRecoGeometryRecord.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:356:42: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
             double halfOpeningAngle = asin( x / abs( r ))/deg;
                                                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:356:42: note: use function 'std::abs' instead
            double halfOpeningAngle = asin( x / abs( r ))/deg;
                                                ^~~
                                                std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:363:19: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
             if( r < 0 && abs( r ) >= x )
                         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:363:19: note: use function 'std::abs' instead
            if( r < 0 && abs( r ) >= x )
                         ^~~
                         std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:379:24: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
             else if( r > 0 && abs( r ) >= x )
                              ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:379:24: note: use function 'std::abs' instead
            else if( r > 0 && abs( r ) >= x )
                              ^~~
                              std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:408:12: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
                                                             abs(r)/cm, // radius cannot be negative!!!
                                                            ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Fireworks/Geometry/src/TGeoMgrFromDdd.cc:408:12: note: use function 'std::abs' instead
                                                            abs(r)/cm, // radius cannot be negative!!!
                                                            ^~~
                                                            std::abs
