### PR TITLE
GeneratorInterface: fix clang warnings about abs

### DIFF
--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
@@ -277,10 +277,10 @@ void JetMatchingMGFastJet::beforeHadronisation( const lhef::LHEEvent* lhee )
 										  // we only take those that descent
 										  // directly from "incoming partons"
       idx = 2;
-      if ( hepeup.IDUP[i] == ID_GLUON || (fabs(hepeup.IDUP[i]) <= nQmatch) ) // light jet
+      if ( hepeup.IDUP[i] == ID_GLUON || (std::abs(hepeup.IDUP[i]) <= nQmatch) ) // light jet
          // light jet
 	 idx = 0;
-      else if ( fabs(hepeup.IDUP[i]) > nQmatch && fabs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
+      else if ( std::abs(hepeup.IDUP[i]) > nQmatch && std::abs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
          idx = 1;
       // Store
       typeIdx[idx].push_back(i); 

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -67,11 +67,11 @@ bool Py8PtGun::generatePartonsAndHadronize()
       double pz = pp * cos(the);
 
       if ( !((fMasterGen->particleData).isParticle( particleID )) ){
-         particleID = std::fabs(particleID) ;
+         particleID = std::std::abs(particleID) ;
       }
-      if( 1<= fabs(particleID) && fabs(particleID) <= 6) // quarks
+      if( 1<= std::abs(particleID) && std::abs(particleID) <= 6) // quarks
 	(fMasterGen->event).append( particleID, 23, 101, 0, px, py, pz, ee, mass ); 
-      else if (fabs(particleID) == 21)                   // gluons
+      else if (std::abs(particleID) == 21)                   // gluons
 	(fMasterGen->event).append( 21, 23, 101, 102, px, py, pz, ee, mass );
                                                          // other
       else {
@@ -87,9 +87,9 @@ bool Py8PtGun::generatePartonsAndHadronize()
 // (for example, gamma)
 //
       if ( fAddAntiParticle ) {
-         if( 1 <= fabs(particleID) && fabs(particleID) <= 6){ // quarks
+         if( 1 <= std::abs(particleID) && std::abs(particleID) <= 6){ // quarks
 	  (fMasterGen->event).append( -particleID, 23, 0, 101, -px, -py, -pz, ee, mass );
-         } else if (fabs(particleID) == 21){                   // gluons
+         } else if (std::abs(particleID) == 21){                   // gluons
 	  (fMasterGen->event).append( 21, 23, 102, 101, -px, -py, -pz, ee, mass );
          } else {
 	   if ( (fMasterGen->particleData).isParticle( -particleID ) ) {

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -67,7 +67,7 @@ bool Py8PtGun::generatePartonsAndHadronize()
       double pz = pp * cos(the);
 
       if ( !((fMasterGen->particleData).isParticle( particleID )) ){
-         particleID = std::std::abs(particleID) ;
+         particleID = std::abs(particleID) ;
       }
       if( 1<= std::abs(particleID) && std::abs(particleID) <= 6) // quarks
 	(fMasterGen->event).append( particleID, 23, 101, 0, px, py, pz, ee, mass ); 


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gcc/5.3.0/bin/gfortran -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pythia8/219-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/lhapdf/6.1.6-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/yaml-cpp/0.5.1-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libhepml/0.2.1/interface -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pythia6/426/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -fno-second-underscore -Wunused -Wuninitialized -O2 -cpp -fno-second-underscore -Wunused -Wuninitialized -O2 -cpp -O2 -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/GeneratorInterface/PartonShowerVeto/src/GeneratorInterfacePartonShowerVeto/ktclusdble.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/ktclusdble.f -o tmp/slc6_amd64_gcc530/src/GeneratorInterface/PartonShowerVeto/src/GeneratorInterfacePartonShowerVeto/ktclusdble.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:280:43: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if ( hepeup.IDUP[i] == ID_GLUON || (fabs(hepeup.IDUP[i]) <= nQmatch) ) // light jet
                                          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:280:43: note: use function 'std::abs' instead
      if ( hepeup.IDUP[i] == ID_GLUON || (fabs(hepeup.IDUP[i]) <= nQmatch) ) // light jet
                                          ^~~~
                                          std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:283:17: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       else if ( fabs(hepeup.IDUP[i]) > nQmatch && fabs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:283:17: note: use function 'std::abs' instead
      else if ( fabs(hepeup.IDUP[i]) > nQmatch && fabs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
                ^~~~
                std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:283:51: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       else if ( fabs(hepeup.IDUP[i]) > nQmatch && fabs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
                                                  ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc:283:51: note: use function 'std::abs' instead
      else if ( fabs(hepeup.IDUP[i]) > nQmatch && fabs(hepeup.IDUP[i]) <= ID_TOP) // heavy jet
                                                  ^~~~
                                                  std::abs