### PR TITLE
Geometry: fix clang warnings about abs

### DIFF
--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -217,7 +217,7 @@ CaloGeometryAnalyzer::cmpset( const CaloSubdetectorGeometry* geom ,
    }
    else
    {
-      if( 2 < std::abs( base.size() - over.size() ) ) 
+      if( 2 < std::abs( (long)(base.size()) - (long)(over.size()) ) ) 
       {
       DetSet inBaseNotOver ;
       DetSet inOverNotBase ;

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -217,7 +217,7 @@ CaloGeometryAnalyzer::cmpset( const CaloSubdetectorGeometry* geom ,
    }
    else
    {
-      if( 2 < abs( base.size() - over.size() ) ) 
+      if( 2 < std::abs( base.size() - over.size() ) ) 
       {
       DetSet inBaseNotOver ;
       DetSet inOverNotBase ;
@@ -366,7 +366,7 @@ CaloGeometryAnalyzer::ovrTst( const CaloGeometry& cg      ,
 {
    static const GlobalPoint origin (0,0,0) ;
    const int ieta ( id.ieta() ) ;
-   if( 85 == abs( ieta ) )
+   if( 85 == std::abs( ieta ) )
    {
       const EcalBarrelGeometry* ebG ( dynamic_cast<const EcalBarrelGeometry*>( geom ) );
       const CaloCellGeometry* cell ( geom->getGeometry(id) ) ;

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -217,7 +217,7 @@ CaloGeometryAnalyzer::cmpset( const CaloSubdetectorGeometry* geom ,
    }
    else
    {
-      if( 2 < std::abs( (long)(base.size()) - (long)(over.size()) ) ) 
+      if( 2 < std::abs( (int)(base.size()) - (int)(over.size()) ) ) 
       {
       DetSet inBaseNotOver ;
       DetSet inOverNotBase ;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc
@@ -67,12 +67,12 @@ DDHGCalNoTaperEndcap::createQuarter( DDCompactView& cpv, int xQuadrant, int yQua
 #ifdef EDM_ML_DEBUG
   int rowmax(0), column(0);
 #endif
-  while (abs(offsetX) < m_rMax) {
+  while (std::abs(offsetX) < m_rMax) {
 #ifdef EDM_ML_DEBUG
     column++;
     int row(0);
 #endif
-    while (abs(offsetY) < m_rMax) {
+    while (std::abs(offsetY) < m_rMax) {
 #ifdef EDM_ML_DEBUG
       row++;
 #endif


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/Geometry/CaloEventSetup/test/testCaloGeometryESProducer/CaloGeometryAnalyzer.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc -o tmp/slc6_amd64_gcc530/src/Geometry/CaloEventSetup/test/testCaloGeometryESProducer/CaloGeometryAnalyzer.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc:220:15: warning: taking the absolute value of unsigned type 'unsigned long' has no effect [-Wabsolute-value]
       if( 2 < abs( base.size() - over.size() ) ) 
              ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc:220:15: note: remove the call to 'abs' since unsigned values cannot be negative
      if( 2 < abs( base.size() - over.size() ) ) 
              ^~~/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/Geometry/HGCalCommonData/plugins/GeometryHGCalCommonDataPlugin/DDHGCalWaferAlgo.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/HGCalCommonData/plugins/DDHGCalWaferAlgo.cc -o tmp/slc6_amd64_gcc530/src/Geometry/HGCalCommonData/plugins/GeometryHGCalCommonDataPlugin/DDHGCalWaferAlgo.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc:70:10: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   while (abs(offsetX) < m_rMax) {
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc:70:10: note: use function 'std::abs' instead
  while (abs(offsetX) < m_rMax) {
         ^~~
         std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc:75:12: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     while (abs(offsetY) < m_rMax) {
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc:75:12: note: use function 'std::abs' instead
    while (abs(offsetY) < m_rMax) {
           ^~~
           std::abs
