### PR TITLE
HLTrigger: fix clang warnings about abs

### DIFF
--- a/HLTrigger/HLTanalyzers/src/HLTJets.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTJets.cc
@@ -982,7 +982,7 @@ void HLTJets::analyze(edm::Event const& iEvent,
             pfJetchargedEMFraction[ipfJet] = i->chargedEmEnergyFraction ();
 	    //std::cout << "jet pT = " << i->pt() << " ; neutralHadronEnergyFraction = " << i->neutralHadronEnergyFraction() << std::endl;
 
-	    if (i->pt() > 40. && abs(i->eta())<3.0)
+	    if (i->pt() > 40. && std::abs(i->eta())<3.0)
 	      pfHT  += i -> pt();
 	    if (i->pt() > 30.){
 	      pfMHTx = pfMHTx + i->px();

--- a/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
@@ -92,11 +92,11 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
     if((simTracks.isValid())&&(simVertices.isValid())){
       for (unsigned int j=0; j<simTracks->size(); j++) {
 	int pdgid = simTracks->at(j).type();
-	if (abs(pdgid)!=13) continue;
+	if (std::abs(pdgid)!=13) continue;
 	double pt = simTracks->at(j).momentum().pt();
 	if (pt<2.5) continue;
 	double eta = simTracks->at(j).momentum().eta();
-	if (abs(eta)>2.5) continue;
+	if (std::abs(eta)>2.5) continue;
 	if (simTracks->at(j).noVertex()) continue;
 	int vertIndex = simTracks->at(j).vertIndex();
 	double x = simVertices->at(vertIndex).position().x();
@@ -104,7 +104,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
 	double r = sqrt(x*x+y*y);
 	if (r>150.) continue; // I think units are cm here
 	double z = simVertices->at(vertIndex).position().z();
-	if (abs(z)>300.) continue; // I think units are cm here
+	if (std::abs(z)>300.) continue; // I think units are cm here
 	mu3 += 1;
 	break;
       }
@@ -130,7 +130,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
 	    const reco::Candidate & d = *p.daughter(j);
 	    if ((d.pdgId()==11)||(d.pdgId()==-11)){wel += 1;}
 	    if ((d.pdgId()==13)||(d.pdgId()==-13)){wmu += 1;}
-// 	    if ( (abs(d.pdgId())!=24) && ((mcpid[nmc])*(d.pdgId())>0) ) 
+// 	    if ( (std::abs(d.pdgId())!=24) && ((mcpid[nmc])*(d.pdgId())>0) ) 
 // 	      {std::cout << "Wrong sign between mother-W and daughter !" << std::endl;}
 	  }
 	}


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/ktjet/1.06-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet-contrib/1.020/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTAlCa.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTAlCa.cc -o tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTAlCa.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTJets.cc:985:27: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
             if (i->pt() > 40. && abs(i->eta())<3.0)
                                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTJets.cc:985:27: note: use function 'std::abs' instead
            if (i->pt() > 40. && abs(i->eta())<3.0)
                                 ^~~
                                 std::abs
>> Compiling edm plugin /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/ktjet/1.06-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet-contrib/1.020/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTMCtruth.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc -o tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTMCtruth.o
>> Compiling edm plugin /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/EventHeader.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/ktjet/1.06-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet-contrib/1.020/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/EventHeader.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/EventHeader.cc -o tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/EventHeader.o
1 warning generated.
>> Compiling edm plugin /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTHeavyIon.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/classlib/3.1.3-ikhhed/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/ktjet/1.06-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/protobuf/2.6.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet-contrib/1.020/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTHeavyIon.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTHeavyIon.cc -o tmp/slc6_amd64_gcc530/src/HLTrigger/HLTanalyzers/src/HLTriggerHLTanalyzers/HLTHeavyIon.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc:99:6: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if (abs(eta)>2.5) continue;
            ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc:99:6: note: use function 'std::abs' instead
        if (abs(eta)>2.5) continue;
            ^~~
            std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc:107:6: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
         if (abs(z)>300.) continue; // I think units are cm here
            ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc:107:6: note: use function 'std::abs' instead
        if (abs(z)>300.) continue; // I think units are cm here
            ^~~
            std::abs