### PR TITLE
L1Trigger: fix clang warnings about abs

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/BXAnalyzer.h
+++ b/L1Trigger/L1TMuonEndCap/interface/BXAnalyzer.h
@@ -27,7 +27,7 @@ std::vector<std::vector<ConvertedHit>> GroupBX(std::vector<ConvertedHit> ConvHit
     if((diff < 3) && (diff > -1))
       output[2].push_back(*i);
     
-    if(fabs(diff) < 2)
+    if(std::abs(diff) < 2)
       output[1].push_back(*i);
   }
 

--- a/L1Trigger/L1TMuonEndCap/interface/Matching.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Matching.h
@@ -71,7 +71,7 @@ MatchingOutput PhiMatching(SortingOutput Sout){
 	  //	std::cout<<"Winners[z][w].Strip(): "<<Winners[z][w].Strip()<<" + 1 - Thits[i].Zhit():"<<Thits[i].Zhit()<<" = "<<(Winners[z][w].Strip() + 1) - Thits[i].Zhit()<<". Thits[i].Phi()>>5 = "<<(Thits[i].Phi() >> 5)<<"\n";
 	  //}
 	  
-	  if((fabs(Winners[z][w].Strip() - (Thits[i].Phi()>>5)) <= phdiff[setstation]) && inBXgroup && inzone){//is close to winner keystrip and in same zone?
+	  if((std::abs(Winners[z][w].Strip() - (Thits[i].Phi()>>5)) <= phdiff[setstation]) && inBXgroup && inzone){//is close to winner keystrip and in same zone?
 	    
 	    if(ph_output.x[z][w][setstation].Phi() == -999){//has this already been set? no
 	      
@@ -86,8 +86,8 @@ MatchingOutput PhiMatching(SortingOutput Sout){
 	      
 	      if(verbose) std::cout<<"has already been set"<<std::endl;
 	      
-	      int d1 = fabs((ph_output.x[z][w][setstation].Phi()>>5) - Winners[z][w].Strip());
-	      int d2 = fabs((Thits[i].Phi()>>5) - Winners[z][w].Strip());
+	      int d1 = std::abs((ph_output.x[z][w][setstation].Phi()>>5) - Winners[z][w].Strip());
+	      int d2 = std::abs((Thits[i].Phi()>>5) - Winners[z][w].Strip());
 	      
 	      if(verbose) std::cout<<"d1 = "<<d1<<" and d2 = "<<d2<<"\n";
 	      

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
@@ -44,8 +44,8 @@ template< >
 bool TTClusterAlgorithm_neighbor< Ref_Phase2TrackerDigi_ >::isANeighbor( const Ref_Phase2TrackerDigi_& center,
                                                                  const Ref_Phase2TrackerDigi_& mayNeigh ) const
 {
-  unsigned int rowdist = abs(center->row() - mayNeigh->row());
-  unsigned int coldist = abs(center->column() - mayNeigh->column());
+  unsigned int rowdist = std::abs(center->row() - mayNeigh->row());
+  unsigned int coldist = std::abs(center->column() - mayNeigh->column());
   return rowdist <= 1 && coldist <= 1;
 }
 

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
@@ -44,8 +44,8 @@ template< >
 bool TTClusterAlgorithm_neighbor< Ref_Phase2TrackerDigi_ >::isANeighbor( const Ref_Phase2TrackerDigi_& center,
                                                                  const Ref_Phase2TrackerDigi_& mayNeigh ) const
 {
-  unsigned int rowdist = std::abs(center->row() - mayNeigh->row());
-  unsigned int coldist = std::abs(center->column() - mayNeigh->column());
+  unsigned int rowdist = std::abs((int)(center->row()) - (int)(mayNeigh->row()));
+  unsigned int coldist = std::abs((int)(center->column()) - (int)(mayNeigh->column()));
   return rowdist <= 1 && coldist <= 1;
 }
 

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
@@ -115,7 +115,7 @@ void TTClusterAlgorithm_official< Ref_Phase2TrackerDigi_ >::Cluster( std::vector
         }
 
         /// Skip non-contiguous column
-        if ( std::abs( mapIter1DCbCR1->first.first - lastCol ) != 1 )
+        if ( std::abs( (int)(mapIter1DCbCR1->first.first) - (int)lastCol ) != 1 )
         {
           ++mapIter1DCbCR1;
           continue;

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
@@ -115,7 +115,7 @@ void TTClusterAlgorithm_official< Ref_Phase2TrackerDigi_ >::Cluster( std::vector
         }
 
         /// Skip non-contiguous column
-        if ( fabs( mapIter1DCbCR1->first.first - lastCol ) != 1 )
+        if ( std::abs( mapIter1DCbCR1->first.first - lastCol ) != 1 )
         {
           ++mapIter1DCbCR1;
           continue;

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -86,14 +86,14 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
   ///    in inner and outer stack member, in terms of outer member pitch
   ///    (in case they are the same, this is just a plain coordinate difference)
   double dispD = 2 * (mp1.x() - mp0.x()) * (pitch0.first / pitch1.first); /// In HALF-STRIP units!
-  int dispI = ((dispD>0)-(dispD<0))*floor(fabs(dispD)); /// In HALF-STRIP units!
+  int dispI = ((dispD>0)-(dispD<0))*floor(std::abs(dispD)); /// In HALF-STRIP units!
   /// 2) offset is the projection with a straight line of the innermost
   ///    hit towards the ourermost stack member, still in terms of outer member pitch
   ///    NOTE: in terms of coordinates, the center of the module is at NROWS/2-0.5 to
   ///    be consistent with the definition given above 
   
   double offsetD = 2 * delta * ( mp0.x() - (top0->nrows()/2 - 0.5) ) * (pitch0.first / pitch1.first); /// In HALF-STRIP units!
-  int offsetI = ((offsetD>0)-(offsetD<0))*floor(fabs(offsetD)); /// In HALF-STRIP units!
+  int offsetI = ((offsetD>0)-(offsetD<0))*floor(std::abs(offsetD)); /// In HALF-STRIP units!
 
   if (stDetId.subdetId()==StripSubdetector::TOB)
   {
@@ -120,7 +120,7 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
   }
 
   /// Accept the stub if the post-offset correction displacement is smaller than the half-window
-  if ( fabs(dispI - offsetI) <= window ) /// In HALF-STRIP units!
+  if ( std::abs(dispI - offsetI) <= window ) /// In HALF-STRIP units!
   {
     aConfirmation = true;
     aDisplacement = dispI; /// In HALF-STRIP units!


### PR DESCRIPTION
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DataFormats/L1TrackTrigger/interface/TTTypes.h:18:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DataFormats/L1TrackTrigger/interface/TTStub.h:159:16: warning: unused variable 'iClu' [-Wunused-variable]
   unsigned int iClu = 0;
               ^
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc:118:14: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
         if ( fabs( mapIter1DCbCR1->first.first - lastCol ) != 1 )
             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc:118:14: note: remove the call to 'fabs' since unsigned values cannot be negative
        if ( fabs( mapIter1DCbCR1->first.first - lastCol ) != 1 )
             ^~~~
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc:10:
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/interface/TTClusterAlgorithm_neighbor.h:27:
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/interface/TTClusterAlgorithm.h:23:
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DataFormats/L1TrackTrigger/interface/TTTypes.h:18:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/DataFormats/L1TrackTrigger/interface/TTStub.h:159:16: warning: unused variable 'iClu' [-Wunused-variable]
   unsigned int iClu = 0;
               ^
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc:47:26: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
   unsigned int rowdist = abs(center->row() - mayNeigh->row());
                         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc:47:26: note: remove the call to 'abs' since unsigned values cannot be negative
  unsigned int rowdist = abs(center->row() - mayNeigh->row());
                         ^~~
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc:48:26: warning: taking the absolute value of unsigned type 'unsigned int' has no effect [-Wabsolute-value]
   unsigned int coldist = abs(center->column() - mayNeigh->column());
                         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc:48:26: note: remove the call to 'abs' since unsigned values cannot be negative
  unsigned int coldist = abs(center->column() - mayNeigh->column());
                         ^~~