### PR TITLE
MuonAnalysis: fix clang warnings about abs

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
@@ -63,8 +63,8 @@ bool MuScleFitMuonSelector::selGlobalMuon(const pat::Muon* aMuon)
     aMuon->muonID("TrackerMuonArbitrated") &&
     aMuon->muonID("TMLastStationAngTight") &&
     p.pixelLayersWithMeasurement() > 1 &&
-    fabs(iTrack->dxy()) < 3.0 &&  //should be done w.r.t. PV!
-    fabs(iTrack->dz()) < 15.0 //should be done w.r.t. PV!
+    std::abs(iTrack->dxy()) < 3.0 &&  //should be done w.r.t. PV!
+    std::abs(iTrack->dz()) < 15.0 //should be done w.r.t. PV!
   );
 }
 
@@ -79,8 +79,8 @@ bool MuScleFitMuonSelector::selTrackerMuon(const pat::Muon* aMuon)
     aMuon->muonID("TrackerMuonArbitrated") &&
     aMuon->muonID("TMLastStationAngTight") &&
     p.pixelLayersWithMeasurement() > 1 &&
-    fabs(iTrack->dxy()) < 3.0 && //should be done w.r.t. PV!
-    fabs(iTrack->dz()) < 15.0 //should be done w.r.t. PV!
+    std::abs(iTrack->dxy()) < 3.0 && //should be done w.r.t. PV!
+    std::abs(iTrack->dz()) < 15.0 //should be done w.r.t. PV!
   );
 }
 
@@ -379,7 +379,7 @@ GenMuonPair MuScleFitMuonSelector::findGenMuFromRes( const edm::HepMCProduct* ev
   //Loop on generated particles
   for (HepMC::GenEvent::particle_const_iterator part=Evt->particles_begin();
        part!=Evt->particles_end(); part++) {
-    if (fabs((*part)->pdg_id())==13 && (*part)->status()==1) {
+    if (std::abs((*part)->pdg_id())==13 && (*part)->status()==1) {
       bool fromRes = false;
       unsigned int motherPdgId = 0;
       for (HepMC::GenVertex::particle_iterator mother = (*part)->production_vertex()->particles_begin(HepMC::ancestors);
@@ -423,8 +423,8 @@ GenMuonPair MuScleFitMuonSelector::findGenMuFromRes( const reco::GenParticleColl
   //Loop on generated particles
   if( debug_>0 ) std::cout << "Starting loop on " << genParticles->size() << " genParticles" << std::endl;
   for( reco::GenParticleCollection::const_iterator part=genParticles->begin(); part!=genParticles->end(); ++part ) {
-    if (debug_>0) std::cout<<"genParticle has pdgId = "<<fabs(part->pdgId())<<" and status = "<<part->status()<<std::endl;
-    if (fabs(part->pdgId())==13){// && part->status()==3) {
+    if (debug_>0) std::cout<<"genParticle has pdgId = "<<std::abs(part->pdgId())<<" and status = "<<part->status()<<std::endl;
+    if (std::abs(part->pdgId())==13){// && part->status()==3) {
       bool fromRes = false;
       unsigned int motherPdgId = part->mother()->pdgId();
       if( debug_>0 ) {
@@ -472,7 +472,7 @@ std::pair<lorentzVector, lorentzVector> MuScleFitMuonSelector::findSimMuFromRes(
   std::pair<lorentzVector, lorentzVector> simMuFromRes;
   for( edm::SimTrackContainer::const_iterator simTrack=simTracks->begin(); simTrack!=simTracks->end(); ++simTrack ) {
     //Chose muons
-    if (fabs((*simTrack).type())==13) {
+    if (std::abs((*simTrack).type())==13) {
       //If tracks from IP than find mother
       if ((*simTrack).genpartIndex()>0) {
 	HepMC::GenParticle* gp = evtMC->GetEvent()->barcode_to_particle ((*simTrack).genpartIndex());

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc
@@ -132,7 +132,7 @@ void MuScleFitPlotter::fillGen(const edm::HepMCProduct* evtMC, bool sherpaFlag_)
     
     for (HepMC::GenEvent::particle_const_iterator part=Evt->particles_begin(); 
 	 part!=Evt->particles_end(); part++) {
-      if (fabs((*part)->pdg_id())==13 && (*part)->status()==1) {//looks for muon in the final state
+      if (std::abs((*part)->pdg_id())==13 && (*part)->status()==1) {//looks for muon in the final state
 	bool fromRes = false;
 	for (HepMC::GenVertex::particle_iterator mother = (*part)->production_vertex()->particles_begin(HepMC::ancestors);//loops on the mother of the final state muons
 	     mother != (*part)->production_vertex()->particles_end(HepMC::ancestors); ++mother) {
@@ -239,7 +239,7 @@ void MuScleFitPlotter::fillSim(edm::Handle<edm::SimTrackContainer> simTracks)
   //Loop on simulated tracks
   for( edm::SimTrackContainer::const_iterator simTrack=simTracks->begin(); simTrack!=simTracks->end(); ++simTrack ) {
     // Select the muons from all the simulated tracks
-    if (fabs((*simTrack).type())==13) {
+    if (std::abs((*simTrack).type())==13) {
       simMuons.push_back(*simTrack);	  
       mapHisto["hSimMu"]->Fill((*simTrack).momentum());
     }
@@ -264,7 +264,7 @@ void MuScleFitPlotter::fillSim(edm::Handle<edm::SimTrackContainer> simTracks)
     std::pair<SimTrack,SimTrack> simMuFromBestRes = MuScleFitUtils::findBestSimuRes(simMuons);
     reco::Particle::LorentzVector bestSimZ = (simMuFromBestRes.first).momentum()+(simMuFromBestRes.second).momentum();
     mapHisto["hSimBestRes"]->Fill(bestSimZ);
-    if (fabs(simMuFromBestRes.first.momentum().eta())<2.5 && fabs(simMuFromBestRes.second.momentum().eta())<2.5 &&
+    if (std::abs(simMuFromBestRes.first.momentum().eta())<2.5 && std::abs(simMuFromBestRes.second.momentum().eta())<2.5 &&
 	simMuFromBestRes.first.momentum().pt()>2.5 && simMuFromBestRes.second.momentum().pt()>2.5) {
       mapHisto["hSimBestResVSMu"]->Fill (simMuFromBestRes.first.momentum(), bestSimZ, int(simMuFromBestRes.first.charge()));
       mapHisto["hSimBestResVSMu"]->Fill (simMuFromBestRes.second.momentum(),bestSimZ, int(simMuFromBestRes.second.charge()));
@@ -281,7 +281,7 @@ void MuScleFitPlotter::fillGenSim(edm::Handle<edm::HepMCProduct> evtMC, edm::Han
   //Fill resonance info
   reco::Particle::LorentzVector rightSimRes = (simMuFromRes.first)+(simMuFromRes.second);
   mapHisto["hSimRightRes"]->Fill(rightSimRes);
-  /*if ((fabs(simMuFromRes.first.Eta())<2.5 && fabs(simMuFromRes.second.Eta())<2.5) 
+  /*if ((std::abs(simMuFromRes.first.Eta())<2.5 && std::abs(simMuFromRes.second.Eta())<2.5) 
     && simMuFromRes.first.Pt()>2.5 && simMuFromRes.second.Pt()>2.5) {
   }*/
 }

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -380,7 +380,7 @@ std::pair<MuScleFitMuon, MuScleFitMuon> MuScleFitUtils::findBestRecoRes(const st
             //   std::cout << "Error: ResMass["<<ires<<"] = " << ResMass[ires] << std::endl;
             //   exit(1);
             // }
-            double deltaMass = fabs(mcomb-ResMass[ires])/ResMass[ires];
+            double deltaMass = std::abs(mcomb-ResMass[ires])/ResMass[ires];
             if (deltaMass<minDeltaMass){
               bestMassMuons = std::make_pair((*Muon1), (*Muon2));
               minDeltaMass = deltaMass;
@@ -638,7 +638,7 @@ double MuScleFitUtils::massResolution( const lorentzVector& mu1,
   // ----------
   bool didit = false;
   for (int ires=0; ires<6; ires++) {
-    if (!didit && resfind[ires]>0 && fabs(mass-ResMass[ires])<ResHalfWidth[ires]) {
+    if (!didit && resfind[ires]>0 && std::abs(mass-ResMass[ires])<ResHalfWidth[ires]) {
       if (mass_res>ResMaxSigma[ires] && counter_resprob<100) {
 	counter_resprob++;
 	LogDebug("MuScleFitUtils") << "RESOLUTION PROBLEM: ires=" << ires << std::endl;
@@ -980,10 +980,10 @@ double MuScleFitUtils::massProb( const double & mass, const double & resEta, con
         //                     backgroundHandler->resMass( useBackgroundWindow, 0 ),
         //                     windowFactors.first, windowFactors.second )
         && checkMassWindow( mass, windowBorders.first, windowBorders.second )
-        // && fabs(rapidity)<2.4
+        // && std::abs(rapidity)<2.4
         ) {
 
-      int iY = (int)(fabs(rapidity)*10.);
+      int iY = (int)(std::abs(rapidity)*10.);
       if( iY > 23 ) iY = 23;
 
       if (MuScleFitUtils::debug>1) std::cout << "massProb:resFound = 0, rapidity bin =" << iY << std::endl;
@@ -1567,7 +1567,7 @@ void MuScleFitUtils::minimizeLikelihood()
       if (errp!=0) {
 	parerr[3*ipar] = errp;
       } else {
-	parerr[3*ipar] = (((errh)>(fabs(errl)))?(errh):(fabs(errl)));
+	parerr[3*ipar] = (((errh)>(std::abs(errl)))?(errh):(std::abs(errl)));
       }
       parerr[3*ipar+1] = errl;
       parerr[3*ipar+2] = errh;
@@ -2194,7 +2194,7 @@ std::pair<lorentzVector, lorentzVector> MuScleFitUtils::findSimMuFromRes( const 
   std::pair<lorentzVector, lorentzVector> simMuFromRes;
   for( edm::SimTrackContainer::const_iterator simTrack=simTracks->begin(); simTrack!=simTracks->end(); ++simTrack ) {
     //Chose muons
-    if (fabs((*simTrack).type())==13) {
+    if (std::abs((*simTrack).type())==13) {
       //If tracks from IP than find mother
       if ((*simTrack).genpartIndex()>0) {
 	HepMC::GenParticle* gp = evtMC->GetEvent()->barcode_to_particle ((*simTrack).genpartIndex());
@@ -2232,7 +2232,7 @@ std::pair<lorentzVector, lorentzVector> MuScleFitUtils::findGenMuFromRes( const 
   //Loop on generated particles
   for (HepMC::GenEvent::particle_const_iterator part=Evt->particles_begin();
        part!=Evt->particles_end(); part++) {
-    if (fabs((*part)->pdg_id())==13 && (*part)->status()==1) {
+    if (std::abs((*part)->pdg_id())==13 && (*part)->status()==1) {
       bool fromRes = false;
       for (HepMC::GenVertex::particle_iterator mother = (*part)->production_vertex()->particles_begin(HepMC::ancestors);
 	   mother != (*part)->production_vertex()->particles_end(HepMC::ancestors); ++mother) {
@@ -2270,7 +2270,7 @@ std::pair<lorentzVector, lorentzVector> MuScleFitUtils::findGenMuFromRes( const 
   //Loop on generated particles
   if( debug>0 ) std::cout << "Starting loop on " << genParticles->size() << " genParticles" << std::endl;
   for( reco::GenParticleCollection::const_iterator part=genParticles->begin(); part!=genParticles->end(); ++part ) {
-    if (fabs(part->pdgId())==13 && part->status()==1) {
+    if (std::abs(part->pdgId())==13 && part->status()==1) {
       bool fromRes = false;
       unsigned int motherPdgId = part->mother()->pdgId();
       if( debug>0 ) {

--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -22,7 +22,7 @@
  FLAVOUR:
   - for non-muons: 0
   - for primary muons: 13
-  - for non primary muons: flavour of the mother: abs(pdgId) of heaviest quark, or 15 for tau
+  - for non primary muons: flavour of the mother: std::abs(pdgId) of heaviest quark, or 15 for tau
 
 */
 //
@@ -318,7 +318,7 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     }
                     // in this case, we might want to know the heaviest mom flavour
                     for (reco::GenParticleRef nMom = genMom;
-                         nMom.isNonnull() && abs(nMom->pdgId()) >= 100; // stop when we're no longer looking at hadrons or mesons
+                         nMom.isNonnull() && std::abs(nMom->pdgId()) >= 100; // stop when we're no longer looking at hadrons or mesons
                          nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef() : reco::GenParticleRef()) {
                         int flav = flavour(nMom->pdgId());
                         if (hmomFlav[i] < flav) hmomFlav[i] = flav;
@@ -390,16 +390,16 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             else if (momFlav[i] == 5) ext[i] = 8; // b->mu
             else if (momFlav[i] == 4) ext[i] = (hmomFlav[i] == 5 ? 7 : 6); // b->c->mu and c->mu
             else if (momStatus[i] != -1) { // primary light particle
-                int id = abs(momPdgId[i]);
+                int id = std::abs(momPdgId[i]);
                 if (id != /*pi+*/211 && id != /*K+*/321 && id != 130 /*K0L*/)  ext[i] = 5; // other light particle, possibly short-lived
-                else if (prodRho[i] < decayRho_ && abs(prodZ[i]) < decayAbsZ_) ext[i] = 4; // decay a la ppMuX (primary pi/K within a cylinder)
+                else if (prodRho[i] < decayRho_ && std::abs(prodZ[i]) < decayAbsZ_) ext[i] = 4; // decay a la ppMuX (primary pi/K within a cylinder)
                 else                                                           ext[i] = 3; // late decay that wouldn't be in ppMuX
             } else ext[i] = 2; // decay of non-primary particle, would not be in ppMuX
             if (isGhost) ext[i] = -ext[i];
 
-            if (linkToGenParticles_ && abs(ext[i]) >= 2) {
+            if (linkToGenParticles_ && std::abs(ext[i]) >= 2) {
                 // Link to the genParticle if possible, but not decays in flight (in ppMuX they're in GEN block, but they have wrong parameters)
-                if (!tp->genParticles().empty() && abs(ext[i]) >= 5) {
+                if (!tp->genParticles().empty() && std::abs(ext[i]) >= 5) {
                     if (genParticles.id() != tp->genParticles().id()) {
                         throw cms::Exception("Configuration") << "Product ID mismatch between the genParticle collection (" << genParticles_ << ", id " << genParticles.id() << ") and the references in the TrackingParticles (id " << tp->genParticles().id() << ")\n";
                     }
@@ -465,7 +465,7 @@ MuonMCClassifier::writeValueMap(edm::Event &iEvent,
 
 int
 MuonMCClassifier::flavour(int pdgId) const {
-    int flav = abs(pdgId);
+    int flav = std::abs(pdgId);
     // for quarks, leptons and bosons except gluons, take their pdgId
     // muons and taus have themselves as flavour
     if (flav <= 37 && flav != 21) return flav;


### PR DESCRIPTION
>> Compiling edm plugin /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/ResolutionAnalyzer.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuonAnalysisMomentumScaleCalibrationPlugins/ResolutionAnalyzer.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/ResolutionAnalyzer.cc -o tmp/slc6_amd64_gcc530/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuonAnalysisMomentumScaleCalibrationPlugins/ResolutionAnalyzer.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc:135:11: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if (fabs((*part)->pdg_id())==13 && (*part)->status()==1) {//looks for muon in the final state
          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc:135:11: note: use function 'std::abs' instead
      if (fabs((*part)->pdg_id())==13 && (*part)->status()==1) {//looks for muon in the final state
          ^~~~
          std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc:242:9: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
     if (fabs((*simTrack).type())==13) {
        ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitPlotter.cc:242:9: note: use function 'std::abs' instead
    if (fabs((*simTrack).type())==13) {
        ^~~~
        std::abs