### PR TITLE
PhysicsTools: fix clang warnings about abs

### DIFF
--- a/PhysicsTools/Heppy/src/BTagSF.cc
+++ b/PhysicsTools/Heppy/src/BTagSF.cc
@@ -37,12 +37,12 @@ Bool_t BTagSF::isbtagged(Float_t pt, Float_t eta, Float_t csv, Int_t jetflavor, 
   Double_t demoteProb_btag=0; // ~probability to demote from tagged
 
   if(SFb < 1) {
-    demoteProb_btag = fabs(1.0 - SFb);
+    demoteProb_btag = std::abs(1.0 - SFb);
   } else {
-    promoteProb_btag = fabs(SFb - 1.0)/((SFb/eff_b) - 1.0);
+    promoteProb_btag = std::abs(SFb - 1.0)/((SFb/eff_b) - 1.0);
   }
 
-  if(fabs(jetflavor) == 5) {                // real b-jet
+  if(std::abs(jetflavor) == 5) {                // real b-jet
     if(csv > 0.679) {                       // if tagged
       btagged = kTRUE;
       if(demoteProb_btag > 0 && randm->Uniform() > demoteProb_btag) btagged = kTRUE;  // leave it tagged
@@ -60,7 +60,7 @@ Bool_t BTagSF::isbtagged(Float_t pt, Float_t eta, Float_t csv, Int_t jetflavor, 
   Double_t SFl = 0, eff_l = 0;
 
   // c or light
-  if(fabs(jetflavor) == 4) {
+  if(std::abs(jetflavor) == 4) {
     // SFc = SFb with twice the quoted uncertainty
     SFl = getSFc(pt, btagsys, is2012);
     eff_l = 0.192*SFl; // eff_c in MC for CSVM = (-1.5734604211*x*x*x*x +  1.52798999269*x*x*x +  0.866697059943*x*x +  -1.66657942274*x +  0.780639301724), x = 0.679
@@ -73,7 +73,7 @@ Bool_t BTagSF::isbtagged(Float_t pt, Float_t eta, Float_t csv, Int_t jetflavor, 
   Double_t demoteProb_mistag=0; // ~probability to demote from tagged
 
   if(SFl > 1) {
-    promoteProb_mistag = fabs(SFl - 1.0)/((SFl/eff_l) - 1.0);
+    promoteProb_mistag = std::abs(SFl - 1.0)/((SFl/eff_l) - 1.0);
   }
   else {
     demoteProb_mistag = SFl;
@@ -216,29 +216,29 @@ Double_t BTagSF::getSFl(Float_t pt, Float_t eta, UInt_t mistagsys, Bool_t is2012
   Double_t SFl = 0;
 
   if(!is2012) {
-    if(fabs(eta) >= 0.0 && fabs(eta) < 0.8) {
+    if(std::abs(eta) >= 0.0 && std::abs(eta) < 0.8) {
       if(mistagsys == kNo)        SFl = ((1.06182+(0.000617034*x))+(-1.5732e-06*(x*x)))+(3.02909e-10*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((0.972455+(7.51396e-06*x))+(4.91857e-07*(x*x)))+(-1.47661e-09*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.15116+(0.00122657*x))+(-3.63826e-06*(x*x)))+(2.08242e-09*(x*(x*x)));
-    } else if(fabs(eta) >= 0.8 && fabs(eta) < 1.6) {
+    } else if(std::abs(eta) >= 0.8 && std::abs(eta) < 1.6) {
       if(mistagsys == kNo)        SFl = ((1.111+(-9.64191e-06*x))+(1.80811e-07*(x*x)))+(-5.44868e-10*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((1.02055+(-0.000378856*x))+(1.49029e-06*(x*x)))+(-1.74966e-09*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.20146+(0.000359543*x))+(-1.12866e-06*(x*x)))+(6.59918e-10*(x*(x*x)));
-    } else if(fabs(eta) >= 1.6 && fabs(eta) < 2.4) {
+    } else if(std::abs(eta) >= 1.6 && std::abs(eta) < 2.4) {
       if(mistagsys == kNo)        SFl = ((1.08498+(-0.000701422*x))+(3.43612e-06*(x*x)))+(-4.11794e-09*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((0.983476+(-0.000607242*x))+(3.17997e-06*(x*x)))+(-4.01242e-09*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.18654+(-0.000795808*x))+(3.69226e-06*(x*x)))+(-4.22347e-09*(x*(x*x)));
     }
   } else {
-    if(fabs(eta) >= 0.0 && fabs(eta) < 0.8) {
+    if(std::abs(eta) >= 0.0 && std::abs(eta) < 0.8) {
       if(mistagsys == kNo)        SFl = ((1.07541+(0.00231827*x))+(-4.74249e-06*(x*x)))+(2.70862e-09*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((0.964527+(0.00149055*x))+(-2.78338e-06*(x*x)))+(1.51771e-09*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.18638+(0.00314148*x))+(-6.68993e-06*(x*x)))+(3.89288e-09*(x*(x*x)));
-    } else if(fabs(eta) >= 0.8 && fabs(eta) < 1.6) {
+    } else if(std::abs(eta) >= 0.8 && std::abs(eta) < 1.6) {
       if(mistagsys == kNo)        SFl = ((1.05613+(0.00114031*x))+(-2.56066e-06*(x*x)))+(1.67792e-09*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((0.946051+(0.000759584*x))+(-1.52491e-06*(x*x)))+(9.65822e-10*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.16624+(0.00151884*x))+(-3.59041e-06*(x*x)))+(2.38681e-09*(x*(x*x)));
-    } else if(fabs(eta) >= 1.6 && fabs(eta) < 2.4) {
+    } else if(std::abs(eta) >= 1.6 && std::abs(eta) < 2.4) {
       if(mistagsys == kNo)        SFl = ((1.05625+(0.000487231*x))+(-2.22792e-06*(x*x)))+(1.70262e-09*(x*(x*x)));
       else if(mistagsys == kDown) SFl = ((0.956736+(0.000280197*x))+(-1.42739e-06*(x*x)))+(1.0085e-09*(x*(x*x)));
       else if(mistagsys == kUp)   SFl = ((1.15575+(0.000693344*x))+(-3.02661e-06*(x*x)))+(2.39752e-09*(x*(x*x)));
@@ -256,11 +256,11 @@ Double_t BTagSF::getMistag(Float_t pt, Float_t eta)
 
   Double_t eff_l = 0.0;
 
-  if(fabs(eta) >= 0.0 && fabs(eta) < 0.8) {
+  if(std::abs(eta) >= 0.0 && std::abs(eta) < 0.8) {
     eff_l = ((0.00967751+(2.54564e-05*x))+(-6.92256e-10*(x*x)));
-  } else if(fabs(eta) >= 0.8 && fabs(eta) < 1.6) {
+  } else if(std::abs(eta) >= 0.8 && std::abs(eta) < 1.6) {
     eff_l = ((0.00974141+(5.09503e-05*x))+(2.0641e-08*(x*x)));
-  } else if(fabs(eta) >= 1.6 && fabs(eta) < 2.4) {
+  } else if(std::abs(eta) >= 1.6 && std::abs(eta) < 2.4) {
     eff_l = ((0.013595+(0.000104538*x))+(-1.36087e-08*(x*x)));
   }
 

--- a/PhysicsTools/Utilities/test/testFunctions.cc
+++ b/PhysicsTools/Utilities/test/testFunctions.cc
@@ -53,15 +53,15 @@ void testFunctions::checkAll() {
     Minus<Gaussian>::type gm1 = - g1;
     Composition<Identity, Gaussian>::type gg1 = compose(i, g1);
     double x = 0.5;
-    CPPUNIT_ASSERT(fabs(g1plus2(x) - (g1(x) + g2(x))) < epsilon);
-    CPPUNIT_ASSERT(fabs(g1times2(x) - (g1(x) * g2(x))) < epsilon);
-    CPPUNIT_ASSERT(fabs(g1minus2(x) - (g1(x) - g2(x))) < epsilon);
-    CPPUNIT_ASSERT(fabs(g1over2(x) - (g1(x) / g2(x))) < epsilon);
-    CPPUNIT_ASSERT(fabs(gm1(x) - (-g1(x)) < epsilon));
+    CPPUNIT_ASSERT(std::abs(g1plus2(x) - (g1(x) + g2(x))) < epsilon);
+    CPPUNIT_ASSERT(std::abs(g1times2(x) - (g1(x) * g2(x))) < epsilon);
+    CPPUNIT_ASSERT(std::abs(g1minus2(x) - (g1(x) - g2(x))) < epsilon);
+    CPPUNIT_ASSERT(std::abs(g1over2(x) - (g1(x) / g2(x))) < epsilon);
+    CPPUNIT_ASSERT(std::abs(gm1(x) - (-g1(x)) < epsilon));
     Convolution<Gaussian, Gaussian, TrapezoidIntegrator>::type ggt(g1, g1, -5, 5, TrapezoidIntegrator(1000));
-    CPPUNIT_ASSERT(fabs(ggt(0) - g1(0)/sqrt(2.0))<epsilon);
+    CPPUNIT_ASSERT(std::abs(ggt(0) - g1(0)/sqrt(2.0))<epsilon);
     Convolution<Gaussian, Gaussian, GaussLegendreIntegrator>::type gggl(g1, g1, -5, 5, GaussLegendreIntegrator(1000, epsilon));
-    CPPUNIT_ASSERT(fabs(gggl(0) - g1(0)/sqrt(2.0))<epsilon);
+    CPPUNIT_ASSERT(std::abs(gggl(0) - g1(0)/sqrt(2.0))<epsilon);
     CPPUNIT_ASSERT(gg1(0) == g1(0));
   }
   {
@@ -71,13 +71,13 @@ void testFunctions::checkAll() {
     x = value;
 
     Exp<X>::type f_exp = exp(x);
-    CPPUNIT_ASSERT(fabs(f_exp() - exp(value)) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f_exp() - exp(value)) < epsilon);
     Sin<X>::type f_sin = sin(x);
-    CPPUNIT_ASSERT(fabs(f_sin() - sin(value)) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f_sin() - sin(value)) < epsilon);
     Cos<X>::type f_cos = cos(x);
-    CPPUNIT_ASSERT(fabs(f_cos() - cos(value)) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f_cos() - cos(value)) < epsilon);
     Log<X>::type f_log = log(x);
-    CPPUNIT_ASSERT(fabs(f_log() - log(value)) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f_log() - log(value)) < epsilon);
   }
   {
     Numerical<1> _1;
@@ -98,7 +98,7 @@ void testFunctions::checkAll() {
     X x = 3.141516;
     Expression f = sin(x) * cos(x);
     const double epsilon = 1.e-4;
-    CPPUNIT_ASSERT(fabs(f() - (sin(x) * cos(x))()) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f() - (sin(x) * cos(x))()) < epsilon);
   }
   {
     TestFun f;
@@ -110,17 +110,17 @@ void testFunctions::checkAll() {
     x = 0.5; y = g(x), y1 = g1(x), y2 = g2(x);
     CPPUNIT_ASSERT(y == y1 && y1 == y2);
     CPPUNIT_ASSERT(f.counter_ == 1);
-    CPPUNIT_ASSERT(fabs(f(x) - y) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f(x) - y) < epsilon);
     f.reset();
     x = 1.5; y1 = g1(x), y = g(x), y2 = g2(x);
     CPPUNIT_ASSERT(y == y1 && y1 == y2);
     CPPUNIT_ASSERT(f.counter_ == 1);
-    CPPUNIT_ASSERT(fabs(f(x) - y) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f(x) - y) < epsilon);
     f.reset();
     x = 0.765; y2 = g2(x), y1 = g1(x), y = g(x);
     CPPUNIT_ASSERT(y == y1 && y1 == y2);
     CPPUNIT_ASSERT(f.counter_ == 1); 
-    CPPUNIT_ASSERT(fabs(f(x) - y) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f(x) - y) < epsilon);
     f.reset();
     g(0.5); 
     CPPUNIT_ASSERT(f.counter_ == 1);
@@ -138,6 +138,6 @@ void testFunctions::checkAll() {
     CPPUNIT_ASSERT(y == y1 && y1 == y2);
     CPPUNIT_ASSERT(f.counter_ == 1);
     f.reset();
-    CPPUNIT_ASSERT(fabs(f(x) - y) < epsilon);
+    CPPUNIT_ASSERT(std::abs(f(x) - y) < epsilon);
   }
 }


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/lhapdf/6.1.6-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/yaml-cpp/0.5.1-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/fastjet/3.1.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/ktjet/1.06-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/PhysicsTools/Heppy/src/PhysicsToolsHeppy/FSRWeightAlgo.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/PhysicsTools/Heppy/src/FSRWeightAlgo.cc -o tmp/slc6_amd64_gcc530/src/PhysicsTools/Heppy/src/PhysicsToolsHeppy/FSRWeightAlgo.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/PhysicsTools/Heppy/src/BTagSF.cc:45:6: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
   if(fabs(jetflavor) == 5) {                // real b-jet
     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/PhysicsTools/Heppy/src/BTagSF.cc:45:6: note: use function 'std::abs' instead
  if(fabs(jetflavor) == 5) {                // real b-jet
     ^~~~
     std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/PhysicsTools/Heppy/src/BTagSF.cc:63:6: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
   if(fabs(jetflavor) == 4) {
     ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/PhysicsTools/Heppy/src/BTagSF.cc:63:6: note: use function 'std::abs' instead
  if(fabs(jetflavor) == 4) {
     ^~~~
     std::abs