### PR TITLE
RecoLocal*: fix clang warnings about abs

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h
@@ -118,7 +118,7 @@ void EcalUncalibRecHitRatioMethodAlgo<C>::init(const C &dataFrame,
   }
   if (num_ != 0 && dataFrame.sample(1).gainId() == 1 &&
       sampleMask_.useSample(1, theDetId_) &&
-      fabs(dataFrame.sample(1).adc() - dataFrame.sample(0).adc()) <
+      std::abs(dataFrame.sample(1).adc() - dataFrame.sample(0).adc()) <
           3 * pedestalRMSes[0]) {
     pedestal_ += double(dataFrame.sample(1).adc());
     num_++;
@@ -610,7 +610,7 @@ double EcalUncalibRecHitRatioMethodAlgo<C>::computeAmplitudeImpl(
   double amplitudeMax = 0;
   if (sum1 > 0) {
     double denom = sumFF * sum1 - sumF * sumF;
-    if (fabs(denom) > 1.0e-20) {
+    if (std::abs(denom) > 1.0e-20) {
       amplitudeMax = (sumAF * sum1 - sumA * sumF) / denom;
     }
   }

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -132,7 +132,7 @@ std::vector<CSCStripHit> CSCHitFromStripOnly::runStrip( const CSCDetId& id, cons
     if(imax>0 ){
       maximum_to_left =  theMaxima.at(imax-1) - theMaxima.at(imax);
     }
-    if(fabs(maximum_to_right) < fabs(maximum_to_left)){
+    if(std::abs(maximum_to_right) < std::abs(maximum_to_left)){
       theClosestMaximum.push_back(maximum_to_right);
     }
     else{

--- a/RecoLocalMuon/CSCRecHitD/src/CSCXonStrip_MatchGatti.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCXonStrip_MatchGatti.cc
@@ -346,7 +346,7 @@ void CSCXonStrip_MatchGatti::findXOnStrip( const CSCDetId& id, const CSCLayer* l
     }
     if(0==stripHit.deadStrip() &&
        stripHit.numberOfConsecutiveStrips()<maxConsecutiveStrips &&
-       fabs(stripHit.closestMaximum())>maxConsecutiveStrips/2 ){
+       std::abs(stripHit.closestMaximum())>maxConsecutiveStrips/2 ){
       sigma =  float(calculateXonStripError(stripWidth, ME1_1));
     }
     else{ //---- near dead strip or too close maxima or too wide strip cluster
@@ -546,16 +546,16 @@ double CSCXonStrip_MatchGatti::estimated2GattiCorrection(double x_estimated, flo
     delta_strip_width = stripWidth - int(stripWidth*10)/10.;
     delta_strip_widthUpDown = 0.1;
 
-    if(fabs(x_estimated)>0.5){
-      if(fabs(x_estimated)>1.){
+    if(std::abs(x_estimated)>0.5){
+      if(std::abs(x_estimated)>1.){
         corr_2_xestim = 1.;// for now; to be investigated
       }
       else{	 
-	//if(fabs(Xestimated)>0.55){
+	//if(std::abs(Xestimated)>0.55){
 	  //std::cout<<"X position from the estimated position above 0.55 (safty margin)?! "<<std::endl;
 	  //CorrToXc = 999.;
 	//}
-	xestim_bin = int((1.- fabs(x_estimated))/half_strip_width * n_bins);
+	xestim_bin = int((1.- std::abs(x_estimated))/half_strip_width * n_bins);
 	if(ME1_1){
 	  diff_2_strip_width = x_correction_ME1_1[stripUp][xestim_bin]-x_correction_ME1_1[stripDown][xestim_bin];
 	  corr_2_xestim =  x_correction_ME1_1[stripDown][xestim_bin] +
@@ -570,7 +570,7 @@ double CSCXonStrip_MatchGatti::estimated2GattiCorrection(double x_estimated, flo
       }
     }
     else{
-      xestim_bin = int((fabs(x_estimated)/half_strip_width) * n_bins);
+      xestim_bin = int((std::abs(x_estimated)/half_strip_width) * n_bins);
       if(ME1_1){
 	diff_2_strip_width = x_correction_ME1_1[stripUp][xestim_bin] - x_correction_ME1_1[stripDown][xestim_bin];
 	corr_2_xestim =  x_correction_ME1_1[stripDown][xestim_bin] +
@@ -659,7 +659,7 @@ double CSCXonStrip_MatchGatti::calculateXonStripError(float stripWidth, bool ME1
   //  double x_shift = sqrt( pow( xf_ErrorNoise, 2) + pow( xf_ErrorXTasym, 2)) * 
   //(1 + (estimated2GattiCorrection(xf+0.001, stripWidth, ME1_1) -
   //  estimated2GattiCorrection(xf, stripWidth, ME1_1))*1000.);
-  double x_error =   std::sqrt( std::pow( fabs(x_shift)*stripWidth, 2) + std::pow(const_syst, 2) );
+  double x_error =   std::sqrt( std::pow( std::abs(x_shift)*stripWidth, 2) + std::pow(const_syst, 2) );
   return  x_error; 
 }
 

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
@@ -540,7 +540,7 @@ void inline SiStripAPVRestorer::Cleaner_LocalMinimumAdder(const std::vector<int1
 	  	float m = (adc2 -adc1)/(strip2 -strip1);
     
 		//2,4
-        	if((strip2 - strip1) >slopeX_ && abs(adc1 -adc2) >slopeY_){
+        	if((strip2 - strip1) >slopeX_ && std::abs(adc1 -adc2) >slopeY_){
 		       	float itStrip = 1;
         		float strip = itStrip + strip1;
  			while(strip < strip2){

--- a/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc
@@ -41,7 +41,7 @@ subtract_(const uint32_t& detId,const uint16_t& firstAPV, std::vector<T>& digis)
     if ( !qualityHandle->IsStripBad(detQualityRange,istrip+firstAPV*128) ) {
       float stripNoise=noiseHandle->getNoiseFast(istrip+firstAPV*128,detNoiseRange);
 
-      if( fabs(digis[istrip]-FixedBias) < cut_to_avoid_signal_*stripNoise ) { 
+      if( std::abs(digis[istrip]-FixedBias) < cut_to_avoid_signal_*stripNoise ) { 
 	double nWeight = 1/(stripNoise*stripNoise);
 	sumVal += (digis[istrip]-FixedBias)*nWeight;
 	sumWt += nWeight;


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripPedestalsSubtractor.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/SiStripPedestalsSubtractor.cc -o tmp/slc6_amd64_gcc530/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripPedestalsSubtractor.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc:44:11: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
       if( fabs(digis[istrip]-FixedBias) < cut_to_avoid_signal_*stripNoise ) { 
          ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc:23:113: note: in instantiation of function template specialization 'TT6CMNSubtractor::subtract_<short>' requested here
void TT6CMNSubtractor::subtract(const uint32_t& detId, const uint16_t& firstAPV,  std::vector<int16_t>& digis){ subtract_(detId, firstAPV, digis);}
                                                                                                                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc:44:11: note: use function 'std::abs' instead
      if( fabs(digis[istrip]-FixedBias) < cut_to_avoid_signal_*stripNoise ) { 
          ^~~~
          std::abs
>> Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/MedianCMNSubtractor.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc -o tmp/slc6_amd64_gcc530/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/MedianCMNSubtractor.o
1 warning generated.
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc:543:43: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
                 if((strip2 - strip1) >slopeX_ && abs(adc1 -adc2) >slopeY_){
                                                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc:543:43: note: use function 'std::abs' instead
                if((strip2 - strip1) >slopeX_ && abs(adc1 -adc2) >slopeY_){
                                                 ^~~
                                                 std::abs