### PR TITLE
Reco*: fix bug because of misplaced parens; fix clang warnings about abs

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
@@ -67,7 +67,7 @@ private:
     ~EtaPhiRegion(){}
   bool operator()(float eta,float phi)const{
     return reco::deltaR2(eta,phi,centreEta_,centrePhi_)<maxDeltaR2_ ||
-      (std::abs(eta-centreEta_)<maxDEta_ && std::abs(reco::deltaPhi(phi,centrePhi_)<maxDPhi_));}
+      (std::abs(eta-centreEta_)<maxDEta_ && std::abs(reco::deltaPhi(phi,centrePhi_))<maxDPhi_);}
 
 };
 

--- a/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
@@ -231,7 +231,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
 
             for (std::vector<int>::iterator sit = deadNeighbourStati.begin(); sit != deadNeighbourStati.end(); ++sit) {
                //std::cout << "Neighbouring dead channel with status: " << *sit << std::endl;
-               if (channelAllowed == *sit || (channelAllowed < 0 && abs(channelAllowed) <= *sit)) {
+               if (channelAllowed == *sit || (channelAllowed < 0 && std::abs(channelAllowed) <= *sit)) {
                   passChannelLimitation = true;
                   break;
                }
@@ -326,7 +326,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
 
             for (std::vector<int>::iterator sit = deadNeighbourStati.begin(); sit != deadNeighbourStati.end(); ++sit) {
                //std::cout << "Neighbouring dead channel with status: " << *sit << std::endl;
-               if (channelAllowed == *sit || (channelAllowed < 0 && abs(channelAllowed) <= *sit)) {
+               if (channelAllowed == *sit || (channelAllowed < 0 && std::abs(channelAllowed) <= *sit)) {
                   passChannelLimitation = true;
                   break;
                }
@@ -344,7 +344,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::Event& iEvent, const edm::Eve
          double eta = cellGeom->getPosition().eta();
 
          if (!detIdAlreadyChecked && deadNeighbourStati.size() == 0 && eeBoundaryCalc.checkRecHitHasInvalidNeighbour(
-               *hit, ecalStatus) && abs(eta) < 1.6) {
+               *hit, ecalStatus) && std::abs(eta) < 1.6) {
 
             if (debug_)
                eeBoundaryCalc.setDebugMode();

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -258,7 +258,7 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
     {
       if( iWedge->NumberOfConstituents() > T_EcalPhiWedgeConstituents )
         GlobalTightId = true;
-      if( std::abs(iWedge->ZDirectionConfidence() > T_EcalPhiWedgeConfidence) )
+      if( std::abs(iWedge->ZDirectionConfidence()) > T_EcalPhiWedgeConfidence )
 	GlobalTightId = true;
     }
 

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h
@@ -33,7 +33,7 @@ public:
       Vector ec = charge * dp.cross(Vector(0,0,1)).unit();
       long double dist_tmp = 1./theCurvature/theCurvature - dp.perp2();
       theValid = (dist_tmp > 0.);
-      theCenter = p1+dp + ec*sqrt( fabs(dist_tmp ) );
+      theCenter = p1+dp + ec*sqrt( std::abs(dist_tmp ) );
     }
     bool   isValid() const { return theValid; }
     const  Point & center() const { return theCenter; }

--- a/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
@@ -67,45 +67,62 @@ void PFPhotonClusters::PFCrystalCoor(){
     double EtaCry = (Theta-ThetaCentr)/ThetaWidth; 
     CrysEta_=EtaCry;
     CrysPhi_=PhiCry;
-    
+    switch(std::abs(CrysIEta_)) {
+    case 24:
+      CrysIEtaCrack_=4;
+      break;
+    case 25:
+      CrysIEtaCrack_=5;
+      break;
+    case 26:
+      CrysIEtaCrack_=6;
+      break;
+    case 27:
+      CrysIEtaCrack_=7;
+      break;
+    case 44:
+      CrysIEtaCrack_=9;
+      break;
+    case 45:
+      CrysIEtaCrack_=10;
+      break;
+    case 46:
+      CrysIEtaCrack_=11;
+      break;
+    case 47:
+      CrysIEtaCrack_=12;
+      break;
+    case 64:
+      CrysIEtaCrack_=14;
+      break;
+    case 65:
+      CrysIEtaCrack_=15;
+      break;
+    case 66:
+      CrysIEtaCrack_=16;
+      break;
+    case 67:
+      CrysIEtaCrack_=17;
+      break;
+    case 84:
+      CrysIEtaCrack_=19;
+      break;
+    case 85:
+      CrysIEtaCrack_=20;
+      break;
+    default: 
     if(std::abs(CrysIEta_)==1 || std::abs(CrysIEta_)==2 )
       CrysIEtaCrack_=std::abs(CrysIEta_);
-    if(std::abs(CrysIEta_)>2 && std::abs(CrysIEta_)<24)
+    else if(std::abs(CrysIEta_)>2 && std::abs(CrysIEta_)<24)
       CrysIEtaCrack_=3;
-    if(std::abs(CrysIEta_)==24)
-      CrysIEtaCrack_=4;
-    if(std::abs(CrysIEta_)==25)
-      CrysIEtaCrack_=5;
-    if(std::abs(CrysIEta_)==26)
-      CrysIEtaCrack_=6;
-    if(std::abs(CrysIEta_)==27)
-      CrysIEtaCrack_=7;
-    if(std::abs(CrysIEta_)>27 &&  std::abs(CrysIEta_)<44)
+    else if(std::abs(CrysIEta_)>27 &&  std::abs(CrysIEta_)<44)
       CrysIEtaCrack_=8;
-    if(std::abs(CrysIEta_)==44)
-      CrysIEtaCrack_=9;
-    if(std::abs(CrysIEta_)==45)
-      CrysIEtaCrack_=10;
-    if(std::abs(CrysIEta_)==46)
-      CrysIEtaCrack_=11;
-    if(std::abs(CrysIEta_)==47)
-      CrysIEtaCrack_=12;
-    if(std::abs(CrysIEta_)>47 &&  std::abs(CrysIEta_)<64)
+    else if(std::abs(CrysIEta_)>47 &&  std::abs(CrysIEta_)<64)
       CrysIEtaCrack_=13;
-    if(std::abs(CrysIEta_)==64)
-      CrysIEtaCrack_=14;
-    if(std::abs(CrysIEta_)==65)
-	CrysIEtaCrack_=15;
-    if(std::abs(CrysIEta_)==66)
-      CrysIEtaCrack_=16;
-    if(std::abs(CrysIEta_)==67)
-      CrysIEtaCrack_=17;
-    if(std::abs(CrysIEta_)>67 &&  std::abs(CrysIEta_)<84)
+    else if(std::abs(CrysIEta_)>67 &&  std::abs(CrysIEta_)<84)
       CrysIEtaCrack_=18;
-    if(std::abs(CrysIEta_)==84)
-      CrysIEtaCrack_=19;
-    if(std::abs(CrysIEta_)==85)
-      CrysIEtaCrack_=20;
+    break;
+    }
   }
   else{
     isEB_=false;

--- a/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
@@ -69,7 +69,7 @@ void PFPhotonClusters::PFCrystalCoor(){
     CrysPhi_=PhiCry;
     
     if(std::abs(CrysIEta_)==1 || std::abs(CrysIEta_)==2 )
-      CrysIEtaCrack_=abs(CrysIEta_);
+      CrysIEtaCrack_=std::abs(CrysIEta_);
     if(std::abs(CrysIEta_)>2 && std::abs(CrysIEta_)<24)
       CrysIEtaCrack_=3;
     if(std::abs(CrysIEta_)==24)

--- a/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
@@ -68,43 +68,43 @@ void PFPhotonClusters::PFCrystalCoor(){
     CrysEta_=EtaCry;
     CrysPhi_=PhiCry;
     
-    if(abs(CrysIEta_)==1 || abs(CrysIEta_)==2 )
+    if(std::abs(CrysIEta_)==1 || abs(CrysIEta_)==2 )
       CrysIEtaCrack_=abs(CrysIEta_);
-    if(abs(CrysIEta_)>2 && abs(CrysIEta_)<24)
+    if(std::abs(CrysIEta_)>2 && abs(CrysIEta_)<24)
       CrysIEtaCrack_=3;
-    if(abs(CrysIEta_)==24)
+    if(std::abs(CrysIEta_)==24)
       CrysIEtaCrack_=4;
-    if(abs(CrysIEta_)==25)
+    if(std::abs(CrysIEta_)==25)
       CrysIEtaCrack_=5;
-    if(abs(CrysIEta_)==26)
+    if(std::abs(CrysIEta_)==26)
       CrysIEtaCrack_=6;
-    if(abs(CrysIEta_)==27)
+    if(std::abs(CrysIEta_)==27)
       CrysIEtaCrack_=7;
-    if(abs(CrysIEta_)>27 &&  abs(CrysIEta_)<44)
+    if(std::abs(CrysIEta_)>27 &&  abs(CrysIEta_)<44)
       CrysIEtaCrack_=8;
-    if(abs(CrysIEta_)==44)
+    if(std::abs(CrysIEta_)==44)
       CrysIEtaCrack_=9;
-    if(abs(CrysIEta_)==45)
+    if(std::abs(CrysIEta_)==45)
       CrysIEtaCrack_=10;
-    if(abs(CrysIEta_)==46)
+    if(std::abs(CrysIEta_)==46)
       CrysIEtaCrack_=11;
-    if(abs(CrysIEta_)==47)
+    if(std::abs(CrysIEta_)==47)
       CrysIEtaCrack_=12;
-    if(abs(CrysIEta_)>47 &&  abs(CrysIEta_)<64)
+    if(std::abs(CrysIEta_)>47 &&  abs(CrysIEta_)<64)
       CrysIEtaCrack_=13;
-    if(abs(CrysIEta_)==64)
+    if(std::abs(CrysIEta_)==64)
       CrysIEtaCrack_=14;
-    if(abs(CrysIEta_)==65)
+    if(std::abs(CrysIEta_)==65)
 	CrysIEtaCrack_=15;
-    if(abs(CrysIEta_)==66)
+    if(std::abs(CrysIEta_)==66)
       CrysIEtaCrack_=16;
-    if(abs(CrysIEta_)==67)
+    if(std::abs(CrysIEta_)==67)
       CrysIEtaCrack_=17;
-    if(abs(CrysIEta_)>67 &&  abs(CrysIEta_)<84)
+    if(std::abs(CrysIEta_)>67 &&  abs(CrysIEta_)<84)
       CrysIEtaCrack_=18;
-    if(abs(CrysIEta_)==84)
+    if(std::abs(CrysIEta_)==84)
       CrysIEtaCrack_=19;
-    if(abs(CrysIEta_)==85)
+    if(std::abs(CrysIEta_)==85)
       CrysIEtaCrack_=20;
   }
   else{
@@ -137,9 +137,9 @@ void PFPhotonClusters::FillClusterShape(){
       int deta=EBDetId::distanceEta(id,idseed_);
       int dphi=EBDetId::distancePhi(id,idseed_);
 
-      if(abs(deta)>2 ||abs(dphi)>2)continue;
+      if(std::abs(deta)>2 ||abs(dphi)>2)continue;
       
-      //f(abs(dphi)<=2 && abs(deta)<=2){
+      //f(std::abs(dphi)<=2 && abs(deta)<=2){
       EBDetId EBidSeed=EBDetId(idseed_.rawId());
       EBDetId EBid=EBDetId(id.rawId());
       int ind1=EBidSeed.ieta()-EBid.ieta();
@@ -179,7 +179,7 @@ void PFPhotonClusters::FillClusterShape(){
     else{
       int dx=EEDetId::distanceX(id,idseed_);
       int dy=EEDetId::distanceY(id,idseed_);
-      if(abs(dx)>2 ||abs(dy>2))continue;
+      if(std::abs(dx)>2 ||std::abs(dyi)>2) continue;
       EEDetId EEidSeed=EEDetId(idseed_.rawId());
       EEDetId EEid=EEDetId(id.rawId());
       int ind1=EEid.ix()-EEidSeed.ix();

--- a/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
@@ -179,7 +179,7 @@ void PFPhotonClusters::FillClusterShape(){
     else{
       int dx=EEDetId::distanceX(id,idseed_);
       int dy=EEDetId::distanceY(id,idseed_);
-      if(std::abs(dx)>2 ||std::abs(dyi)>2) continue;
+      if(std::abs(dx)>2 ||std::abs(dy)>2) continue;
       EEDetId EEidSeed=EEDetId(idseed_.rawId());
       EEDetId EEid=EEDetId(id.rawId());
       int ind1=EEid.ix()-EEidSeed.ix();

--- a/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFPhotonClusters.cc
@@ -68,9 +68,9 @@ void PFPhotonClusters::PFCrystalCoor(){
     CrysEta_=EtaCry;
     CrysPhi_=PhiCry;
     
-    if(std::abs(CrysIEta_)==1 || abs(CrysIEta_)==2 )
+    if(std::abs(CrysIEta_)==1 || std::abs(CrysIEta_)==2 )
       CrysIEtaCrack_=abs(CrysIEta_);
-    if(std::abs(CrysIEta_)>2 && abs(CrysIEta_)<24)
+    if(std::abs(CrysIEta_)>2 && std::abs(CrysIEta_)<24)
       CrysIEtaCrack_=3;
     if(std::abs(CrysIEta_)==24)
       CrysIEtaCrack_=4;
@@ -80,7 +80,7 @@ void PFPhotonClusters::PFCrystalCoor(){
       CrysIEtaCrack_=6;
     if(std::abs(CrysIEta_)==27)
       CrysIEtaCrack_=7;
-    if(std::abs(CrysIEta_)>27 &&  abs(CrysIEta_)<44)
+    if(std::abs(CrysIEta_)>27 &&  std::abs(CrysIEta_)<44)
       CrysIEtaCrack_=8;
     if(std::abs(CrysIEta_)==44)
       CrysIEtaCrack_=9;
@@ -90,7 +90,7 @@ void PFPhotonClusters::PFCrystalCoor(){
       CrysIEtaCrack_=11;
     if(std::abs(CrysIEta_)==47)
       CrysIEtaCrack_=12;
-    if(std::abs(CrysIEta_)>47 &&  abs(CrysIEta_)<64)
+    if(std::abs(CrysIEta_)>47 &&  std::abs(CrysIEta_)<64)
       CrysIEtaCrack_=13;
     if(std::abs(CrysIEta_)==64)
       CrysIEtaCrack_=14;
@@ -100,7 +100,7 @@ void PFPhotonClusters::PFCrystalCoor(){
       CrysIEtaCrack_=16;
     if(std::abs(CrysIEta_)==67)
       CrysIEtaCrack_=17;
-    if(std::abs(CrysIEta_)>67 &&  abs(CrysIEta_)<84)
+    if(std::abs(CrysIEta_)>67 &&  std::abs(CrysIEta_)<84)
       CrysIEtaCrack_=18;
     if(std::abs(CrysIEta_)==84)
       CrysIEtaCrack_=19;
@@ -113,7 +113,7 @@ void PFPhotonClusters::PFCrystalCoor(){
     CrysIX_=EEidSeed.ix();
     CrysIY_=EEidSeed.iy();
     float X0 = 0.89; float T0 = 1.2;
-    if(fabs(PFClusterRef_->eta())>1.653)T0=3.1;
+    if(std::abs(PFClusterRef_->eta())>1.653)T0=3.1;
     double depth = X0 * (T0 + log(PFClusterRef_->energy()));
     math::XYZVector center_pos=(seedPosition_)+depth*seedAxis_;
     double XCentr = center_pos.x();
@@ -137,9 +137,9 @@ void PFPhotonClusters::FillClusterShape(){
       int deta=EBDetId::distanceEta(id,idseed_);
       int dphi=EBDetId::distancePhi(id,idseed_);
 
-      if(std::abs(deta)>2 ||abs(dphi)>2)continue;
+      if(std::abs(deta)>2 ||std::abs(dphi)>2)continue;
       
-      //f(std::abs(dphi)<=2 && abs(deta)<=2){
+      //if(std::abs(dphi)<=2 && std::abs(deta)<=2){
       EBDetId EBidSeed=EBDetId(idseed_.rawId());
       EBDetId EBid=EBDetId(id.rawId());
       int ind1=EBidSeed.ieta()-EBid.ieta();
@@ -212,7 +212,7 @@ void PFPhotonClusters::FillClusterWidth(){
     if (dPhi < - TMath::Pi()) { dPhi = TMath::TwoPi() + dPhi; }
     numeratorEtaWidth += E * dEta * dEta;
     numeratorPhiWidth += E * dPhi * dPhi;
-    numeratorEtaPhiWidth += E * fabs(dPhi) * fabs(dEta);
+    numeratorEtaPhiWidth += E * std::abs(dPhi) * std::abs(dEta);
   }
   double denominator=PFClusterRef_->energy();
   sigetaeta_ = sqrt(numeratorEtaWidth / denominator);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -184,7 +184,7 @@ PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronF
     }
     
     PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo = PFRecoTauChargedHadron::kUndefined;
-    if ( fabs((*cand)->charge()) > 0.5 ) algo = PFRecoTauChargedHadron::kChargedPFCandidate;
+    if ( std::abs((*cand)->charge()) > 0.5 ) algo = PFRecoTauChargedHadron::kChargedPFCandidate;
     else algo = PFRecoTauChargedHadron::kPFNeutralHadron;
     std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
     if ( (*cand)->trackRef().isNonnull() ) chargedHadron->track_ = edm::refToPtr((*cand)->trackRef());

--- a/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
@@ -116,7 +116,7 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
 
           double deltaR   = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos,candPos);
           double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,candPos);
-          double deltaEta = abs(myElecTrkEcalPos.eta()-candPos.eta());
+          double deltaEta = std::abs(myElecTrkEcalPos.eta()-candPos.eta());
           double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
 
           if (myPFCands[i]->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
@@ -173,7 +173,7 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
                 ecalPosV.push_back(clusPos);
                 myECALenergy += en;
                 double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,clusPos);
-                double deltaEta = abs(myElecTrkEcalPos.eta()-clusPos.eta());
+                double deltaEta = std::abs(myElecTrkEcalPos.eta()-clusPos.eta());
                 double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
                 if (en >= EcalStripSumE_minClusEnergy_ && deltaEta<EcalStripSumE_deltaEta_ && deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_ && deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
                   myStripClusterE += en;

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
@@ -299,7 +299,7 @@ rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSe
 		mvaValue_Tight->Fill(tau->tauID("byTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoTight)[tau]);
 		mvaValue_vTight->Fill(tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoVTight)[tau]);
 		mvaValue_vvTight->Fill(tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoVVTight)[tau]);
-		mvaValueDiff->Fill(fabs(valueAOD - valueMiniAOD));
+		mvaValueDiff->Fill(std::abs(valueAOD - valueMiniAOD));
                 mvaValue_antiEMVA6->Fill((*mvaEleRaw)[tau] , taus->at(iTau).tauID("againstElectronMVA6Raw"));
 
 		if(valueAOD != valueMiniAOD)
@@ -344,7 +344,7 @@ rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSe
 
 			if((*dmfNew)[pfTau] < 0.5) continue;
 
-			if((float)pfTau->pt() < 18 || fabs((float)pfTau->eta()) > 2.3) continue;
+			if((float)pfTau->pt() < 18 || std::abs((float)pfTau->eta()) > 2.3) continue;
 
 			for(unsigned iTau = 0; iTau < unmatchedTaus.size(); iTau++)
 			{
@@ -391,131 +391,131 @@ rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSe
 				if(pfTau->pt() != unmatchedTaus.at(iTau)->pt()){
 					if(verbosity_) std::cout << "pt: PF = " << pfTau->pt() << ", pat = " << unmatchedTaus.at(iTau)->pt() << std::endl;
 					differences->Fill(0);
-					differencesWeighted->Fill(0.,fabs(pfTau->pt()-unmatchedTaus.at(iTau)->pt()));
+					differencesWeighted->Fill(0.,std::abs(pfTau->pt()-unmatchedTaus.at(iTau)->pt()));
 				}
 				if(pfTau->eta() != unmatchedTaus.at(iTau)->eta()){
 					if(verbosity_) std::cout << "eta: PF = " << pfTau->eta() << ", pat = " << unmatchedTaus.at(iTau)->eta() << std::endl;
 					differences->Fill(1);
-					differencesWeighted->Fill(1,fabs(pfTau->eta()-unmatchedTaus.at(iTau)->eta()));
+					differencesWeighted->Fill(1,std::abs(pfTau->eta()-unmatchedTaus.at(iTau)->eta()));
 				}
 				if(pfTau->phi() != unmatchedTaus.at(iTau)->phi()){
 					if(verbosity_) std::cout << "phi: PF = " << pfTau->phi() << ", pat = " << unmatchedTaus.at(iTau)->phi() << std::endl;
 					differences->Fill(2);
-					differencesWeighted->Fill(2,fabs(pfTau->phi()-unmatchedTaus.at(iTau)->phi()));
+					differencesWeighted->Fill(2,std::abs(pfTau->phi()-unmatchedTaus.at(iTau)->phi()));
 				}
 				if(pfTau->energy() != unmatchedTaus.at(iTau)->energy()){
 					if(verbosity_) std::cout << "energy PF = " << pfTau->energy() << ", pat = " << unmatchedTaus.at(iTau)->energy() << std::endl;
 					differences->Fill(3);
-					differencesWeighted->Fill(3,fabs(pfTau->energy()-unmatchedTaus.at(iTau)->energy()));
+					differencesWeighted->Fill(3,std::abs(pfTau->energy()-unmatchedTaus.at(iTau)->energy()));
 				}
 				if(pfTau->decayMode() != unmatchedTaus.at(iTau)->decayMode()){
 					if(verbosity_) std::cout << "decayMode: PF = " << pfTau->decayMode() << ", pat = " << unmatchedTaus.at(iTau)->decayMode() << std::endl;
 					differences->Fill(4);
-					differencesWeighted->Fill(4,fabs(pfTau->decayMode()-unmatchedTaus.at(iTau)->decayMode()));
+					differencesWeighted->Fill(4,std::abs(pfTau->decayMode()-unmatchedTaus.at(iTau)->decayMode()));
 				}
 				if((*chargedIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")){
 					if(verbosity_) std::cout << "chargedIso: PF = " << (*chargedIso)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum") << std::endl;
 					differences->Fill(5);
-					differencesWeighted->Fill(5,fabs((*chargedIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")));
+					differencesWeighted->Fill(5,std::abs((*chargedIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")));
 				}
 				if((*neutralIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")){
 					if(verbosity_) std::cout << "neutralIso: PF = " << (*neutralIso)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum") << std::endl;
 					differences->Fill(6);
-					differencesWeighted->Fill(6,fabs((*neutralIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")));
+					differencesWeighted->Fill(6,std::abs((*neutralIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")));
 				}
 				if((*puCorr)[pfTau] != unmatchedTaus.at(iTau)->tauID("puCorrPtSum")){
 					if(verbosity_) std::cout << "puCorr: PF = " << (*puCorr)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("puCorrPtSum") << std::endl;
 					differences->Fill(7);
-					differencesWeighted->Fill(7,fabs((*puCorr)[pfTau]-unmatchedTaus.at(iTau)->tauID("puCorrPtSum")));
+					differencesWeighted->Fill(7,std::abs((*puCorr)[pfTau]-unmatchedTaus.at(iTau)->tauID("puCorrPtSum")));
 				}
 				if((*photonSumOutsideSignalCone)[pfTau] != unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")){
 					if(verbosity_) std::cout << "photonSumOutsideSignalCone: PF = " << (*photonSumOutsideSignalCone)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone") << std::endl;
 					differences->Fill(8);
-					differencesWeighted->Fill(8,fabs((*photonSumOutsideSignalCone)[pfTau]-unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")));
+					differencesWeighted->Fill(8,std::abs((*photonSumOutsideSignalCone)[pfTau]-unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")));
 				}
 				if((*footPrint)[pfTau] != unmatchedTaus.at(iTau)->tauID("footprintCorrection")){
 					if(verbosity_) std::cout << "footPrint: PF = " << (*footPrint)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("footprintCorrection") << std::endl;
 					differences->Fill(9);
-					differencesWeighted->Fill(9,fabs((*footPrint)[pfTau]-unmatchedTaus.at(iTau)->tauID("footprintCorrection")));
+					differencesWeighted->Fill(9,std::abs((*footPrint)[pfTau]-unmatchedTaus.at(iTau)->tauID("footprintCorrection")));
 				}
 				if(decayDistMagAOD != decayDistMagMiniAOD){
 					if(verbosity_) std::cout << "decayDistMag: PF = " << decayDistMagAOD << ", pat = " << decayDistMagMiniAOD << std::endl;
 					differences->Fill(10);
-					differencesWeighted->Fill(10,fabs(decayDistMagAOD-decayDistMagMiniAOD));
+					differencesWeighted->Fill(10,std::abs(decayDistMagAOD-decayDistMagMiniAOD));
 				}
 				if(tauLifetimeInfo.dxy() != unmatchedTaus.at(iTau)->dxy()){
 					if(verbosity_) std::cout << "dxy: PF = " << tauLifetimeInfo.dxy() << ", pat = " << unmatchedTaus.at(iTau)->dxy() << std::endl;
 					differences->Fill(11);
-					differencesWeighted->Fill(11,fabs((float)tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
-					difference_dxy->Fill(fabs(tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
+					differencesWeighted->Fill(11,std::abs((float)tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
+					difference_dxy->Fill(std::abs(tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
 				}
 				if(tauLifetimeInfo.dxy_Sig() != unmatchedTaus.at(iTau)->dxy_Sig()){
 					if(verbosity_) std::cout << "dxy_Sig: PF = " << tauLifetimeInfo.dxy_Sig() << ", pat = " << unmatchedTaus.at(iTau)->dxy_Sig() << std::endl;
 					differences->Fill(12);
-					differencesWeighted->Fill(12,fabs((float)tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
-					difference_dxySig->Fill(fabs(tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
+					differencesWeighted->Fill(12,std::abs((float)tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
+					difference_dxySig->Fill(std::abs(tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
 				}
 				if(tauLifetimeInfo.ip3d() != unmatchedTaus.at(iTau)->ip3d()){
 					if(verbosity_) std::cout << "ip3d PF: = " << tauLifetimeInfo.ip3d() << ", pat = " << unmatchedTaus.at(iTau)->ip3d() << std::endl;
 					differences->Fill(13);
-					differencesWeighted->Fill(13,fabs((float)tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
-					difference_ip3d->Fill(fabs(tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
+					differencesWeighted->Fill(13,std::abs((float)tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
+					difference_ip3d->Fill(std::abs(tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
 				}
 				if(tauLifetimeInfo.ip3d_Sig() != unmatchedTaus.at(iTau)->ip3d_Sig()){
 					if(verbosity_) std::cout << "ip3d_Sig: PF = " << tauLifetimeInfo.ip3d_Sig() << ", pat = " << unmatchedTaus.at(iTau)->ip3d_Sig() << std::endl;
 					differences->Fill(14);
-					differencesWeighted->Fill(14,fabs((float)tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
-					difference_ip3dSig->Fill(fabs(tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
+					differencesWeighted->Fill(14,std::abs((float)tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
+					difference_ip3dSig->Fill(std::abs(tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
 				}
 				if(tauLifetimeInfo.hasSecondaryVertex() != unmatchedTaus.at(iTau)->hasSecondaryVertex()){
 					if(verbosity_) std::cout << "hasSV: PF = " << tauLifetimeInfo.hasSecondaryVertex() << ", pat = " << unmatchedTaus.at(iTau)->hasSecondaryVertex() << std::endl;
 					differences->Fill(15);
-					differencesWeighted->Fill(15,fabs((float)tauLifetimeInfo.hasSecondaryVertex()-unmatchedTaus.at(iTau)->hasSecondaryVertex()));
+					differencesWeighted->Fill(15,std::abs((float)tauLifetimeInfo.hasSecondaryVertex()-unmatchedTaus.at(iTau)->hasSecondaryVertex()));
 				}
 				if(tauLifetimeInfo.flightLengthSig() != unmatchedTaus.at(iTau)->flightLengthSig()){
 					if(verbosity_) std::cout << "flightlengthSig: PF = " << tauLifetimeInfo.flightLengthSig() << ", pat = " << unmatchedTaus.at(iTau)->flightLengthSig() << std::endl;
 					differences->Fill(16);
-					differencesWeighted->Fill(16,fabs((float)tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
-					difference_flightlengthSig->Fill(fabs(tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
+					differencesWeighted->Fill(16,std::abs((float)tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
+					difference_flightlengthSig->Fill(std::abs(tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
 				}
 				if((float)clusterVariables_.tau_n_photons_total(*pfTau) != (float)clusterVariables_.tau_n_photons_total(*unmatchedTaus.at(iTau))){
 					if(verbosity_) std::cout << "nPhoton PF: = " << (float)clusterVariables_.tau_n_photons_total(*pfTau) << ", pat = " << (float)clusterVariables_.tau_n_photons_total(*unmatchedTaus.at(iTau)) << std::endl;
 					differences->Fill(17);
-					differencesWeighted->Fill(17,fabs((float)clusterVariables_.tau_n_photons_total(*pfTau)-(float)clusterVariables_.tau_n_photons_total(*unmatchedTaus.at(iTau))));
+					differencesWeighted->Fill(17,std::abs((float)clusterVariables_.tau_n_photons_total(*pfTau)-(float)clusterVariables_.tau_n_photons_total(*unmatchedTaus.at(iTau))));
 				}
 				if(clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) != clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
 					if(verbosity_) std::cout << "ptWeightedDetaStrip: PF = " << clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) << ", pat = " << clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
 					differences->Fill(18);
-					differencesWeighted->Fill(18,fabs(clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDetaStrip->Fill(fabs(clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					differencesWeighted->Fill(18,std::abs(clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					difference_ptWeightedDetaStrip->Fill(std::abs(clusterVariables_.tau_pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
 				}
 				if(clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) != clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
 					if(verbosity_) std::cout << "ptWeightedDphiStrip: PF = " << clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) << ", pat = " << clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
 					differences->Fill(19);
-					differencesWeighted->Fill(19,fabs(clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDphiStrip->Fill(fabs(clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					differencesWeighted->Fill(19,std::abs(clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					difference_ptWeightedDphiStrip->Fill(std::abs(clusterVariables_.tau_pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
 				}
 				if(clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) != clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
 					if(verbosity_) std::cout << "ptWeightedDrSignal: PF = " << clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) << ", pat = " << clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
 					differences->Fill(20);
-					differencesWeighted->Fill(20,fabs(clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDrSignal->Fill(fabs(clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					differencesWeighted->Fill(20,std::abs(clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					difference_ptWeightedDrSignal->Fill(std::abs(clusterVariables_.tau_pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
 				}
 				if(clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) != clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
 					if(verbosity_) std::cout << "ptWeightedDrIso: PF = " << clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) << ", pat = " << clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
 					differences->Fill(21);
-					differencesWeighted->Fill(21,fabs(clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDrIso->Fill(fabs(clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					differencesWeighted->Fill(21,std::abs(clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
+					difference_ptWeightedDrIso->Fill(std::abs(clusterVariables_.tau_pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-clusterVariables_.tau_pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
 				}
 				if(clusterVariables_.tau_leadTrackChi2(*pfTau) != unmatchedTaus.at(iTau)->leadingTrackNormChi2()){
 					if(verbosity_) std::cout << "leadTrackChi2: PF = " << clusterVariables_.tau_leadTrackChi2(*pfTau) << ", pat = " << unmatchedTaus.at(iTau)->leadingTrackNormChi2() << std::endl;
 					differences->Fill(22);
-					differencesWeighted->Fill(22,fabs(clusterVariables_.tau_leadTrackChi2(*pfTau)-unmatchedTaus.at(iTau)->leadingTrackNormChi2()));
+					differencesWeighted->Fill(22,std::abs(clusterVariables_.tau_leadTrackChi2(*pfTau)-unmatchedTaus.at(iTau)->leadingTrackNormChi2()));
 				}
 				if(clusterVariables_.tau_Eratio(*pfTau) != clusterVariables_.tau_Eratio(*unmatchedTaus.at(iTau))){
 					if(verbosity_) std::cout << "eRatio: PF = " << clusterVariables_.tau_Eratio(*pfTau) << ", pat = " << clusterVariables_.tau_Eratio(*unmatchedTaus.at(iTau)) << std::endl;
 					differences->Fill(23);
-					differencesWeighted->Fill(23,fabs(clusterVariables_.tau_Eratio(*pfTau)-clusterVariables_.tau_Eratio(*unmatchedTaus.at(iTau))));
+					differencesWeighted->Fill(23,std::abs(clusterVariables_.tau_Eratio(*pfTau)-clusterVariables_.tau_Eratio(*unmatchedTaus.at(iTau))));
 				}
 				if(verbosity_) std::cout << "=============================================================" << std::endl;
 			}


### PR DESCRIPTION
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/src/L1MuonRegionProducer.cc:7:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h:36:36: warning: absolute value function 'fabs' given an argument of type 'long double' but has parameter of type 'double' which may cause truncation of value [-Wabsolute-value]
       theCenter = p1+dp + ec*sqrt( fabs(dist_tmp ) );
                                   ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h:36:36: note: use function 'std::abs' instead
      theCenter = p1+dp + ec*sqrt( fabs(dist_tmp ) );
                                   ^~~~
                                   std::abs
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/src/L1MuonPixelTrackFitter.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h:36:36: warning: absolute value function 'fabs' given an argument of type 'long double' but has parameter of type 'double' which may cause truncation of value [-Wabsolute-value]
       theCenter = p1+dp + ec*sqrt( fabs(dist_tmp ) );
                                   ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h:36:36: note: use function 'std::abs' instead
      theCenter = p1+dp + ec*sqrt( fabs(dist_tmp ) );
                                   ^~~~
                                   std::abs
1 warning generated.