### PR TITLE
Sim* and Track*: fix clang warnings about abs

### DIFF
--- a/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
+++ b/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
@@ -71,7 +71,7 @@ void  EnergyResolutionVsLumi::calcmuTot(){
     if(iEta==0) continue;
 
       double eta=EBDetId::approxEta(EBDetId(iEta,1));
-      eta = fabs(eta);
+      eta = std::abs(eta);
       double r= calcmuTot(eta);
       
       mu_eta[iEta]=r;
@@ -85,7 +85,7 @@ void  EnergyResolutionVsLumi::calcmuTot(){
 	{
 	  EEDetId eedetidpos(iX,iY,1);
 	  double eta= -log(tan(0.5*atan(sqrt((iX-50.0)*(iX-50.0)+(iY-50.0)*(iY-50.0))*2.98/328.)));
-          eta = fabs(eta);
+          eta = std::abs(eta);
           double r=calcmuTot(eta);
           double v=calcampDropPhotoDetector(eta);
 
@@ -104,7 +104,7 @@ double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted(DetId id, d
   double muTot=0;
   if(id.subdetId()==EcalBarrel) {
     EBDetId ebId(id);
-    int ieta= fabs(ebId.ieta());
+    int ieta= std::abs(ebId.ieta());
     muTot= mu_eta[ieta];
     
   } else if(id.subdetId()==EcalEndcap){
@@ -188,7 +188,7 @@ double EnergyResolutionVsLumi::calcnoiseADC(double eta)
   double Nadc = 1.1;
   double result =1.0;
   EvolutionECAL model;
-  if(fabs(eta)<1.497){
+  if(std::abs(eta)<1.497){
     Nadc = 1.1;
     result = model.NoiseFactorFE(totLumi, eta)*Nadc;
   }else{

--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -59,7 +59,7 @@ CastorShowerLibraryMaker::CastorShowerLibraryMaker(const edm::ParameterSet &p) :
 //
   NPGParticle               = PGParticleIDs.size(); 
   for(unsigned int i=0;i<PGParticleIDs.size();i++) {
-     switch (int(fabs(PGParticleIDs.at(i)))) {
+     switch (int(std::abs(PGParticleIDs.at(i)))) {
         case 11:
         case 22:
                DoEmSL = true;
@@ -336,7 +336,7 @@ void CastorShowerLibraryMaker::update(const G4Step * aStep) {
 // move track to z of CASTOR
          G4ThreeVector pos;
          pos.setZ(-14390);
-         double t = abs((pos.z()-trk->GetPosition().z()))/trk->GetVelocity();
+         double t = std::abs((pos.z()-trk->GetPosition().z()))/trk->GetVelocity();
          double r = (pos.z()-trk->GetPosition().z())/trk->GetMomentum().cosTheta();
          pos.setX(r*sin(trk->GetMomentum().theta())*cos(trk->GetMomentum().phi())+trk->GetPosition().x());
          pos.setY(r*sin(trk->GetMomentum().theta())*sin(trk->GetMomentum().phi())+trk->GetPosition().y());

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -363,14 +363,14 @@ G4VSolid * DDG4SolidConverter::pseudotrap(const DDSolid & solid) {
   else {
     x = pt.x2(); // tubs radius
   }
-  double openingAngle = 2.*asin(x/abs(r));
+  double openingAngle = 2.*asin(x/std::abs(r));
   //trap = new G4Trd(solid.name().name(), 
   double displacement=0;
   double startPhi=0;
   /* calculate the displacement of the tubs w.r.t. to the trap,
      determine the opening angle of the tubs */
   double delta = sqrt(r*r-x*x);
-  if (r < 0 && abs(r) >= x) {
+  if (r < 0 && std::abs(r) >= x) {
     intersec = true; // intersection solid
     h = pt.y1() < pt.y2() ? pt.y2() : pt.y1(); // tubs half height
     h += h/20.; // enlarge a bit - for subtraction solid
@@ -383,7 +383,7 @@ G4VSolid * DDG4SolidConverter::pseudotrap(const DDSolid & solid) {
       startPhi = 90.*deg - openingAngle/2.;
     }
   }
-  else if ( r > 0 && abs(r) >= x )
+  else if ( r > 0 && std::abs(r) >= x )
     {
       if (atMinusZ) {
         displacement = - pt.halfZ() + delta;
@@ -408,7 +408,7 @@ G4VSolid * DDG4SolidConverter::pseudotrap(const DDSolid & solid) {
   trap = new G4Trd(name, pt.x1(), pt.x2(), pt.y1(), pt.y2(), pt.halfZ());
   tubs = new G4Tubs(name, 
 		    0., // rMin
-		    abs(r), // rMax
+		    std::abs(r), // rMax
 		    h, // half height
 		    startPhi, // start angle
 		    openingAngle);
@@ -429,7 +429,7 @@ G4VSolid * DDG4SolidConverter::pseudotrap(const DDSolid & solid) {
       delete tubs;
       tubs = new G4Tubs(name, 
       sqrt(r*r-x*x), // rMin-approximation!
-      abs(r), // rMax
+      std::abs(r), // rMax
       h, // half height
       startPhi, // start angle
       openingAngle);
@@ -503,9 +503,9 @@ G4VSolid * DDG4SolidConverter::trunctubs(const DDSolid & solid) {
   // center point of the box
   double xBox;
   if (!cutInside) {
-    xBox = r+boxY/sin(abs(alpha));
+    xBox = r+boxY/sin(std::abs(alpha));
   } else {
-    xBox = -(boxY/sin(abs(alpha))-r);
+    xBox = -(boxY/sin(std::abs(alpha))-r);
   }
 
   G4ThreeVector trans(xBox,0.,0.);

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -125,7 +125,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
         << "Check detId " << detId << " digi " << me0Digi << std::endl;
 
       // selection
-      if (reDigitizeOnlyMuons_ and fabs(me0Digi.pdgid()) != 13) continue;
+      if (reDigitizeOnlyMuons_ and std::abs(me0Digi.pdgid()) != 13) continue;
       if (!reDigitizeNeutronBkg_ and !me0Digi.prompt()) continue;
 
       // scale for luminosity

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1939,12 +1939,12 @@ void SiPixelDigitizerAlgorithm::module_killing_DB(uint32_t detID) {
       
       for(std::vector<GlobalPixel>::const_iterator it = badrocpositions.begin(); it != badrocpositions.end(); ++it){
 	if(it->row >= 80 && ip.first >= 80 ){
-	  if((fabs(ip.second - it->col) < 26) ) {i->second.set(0.);}
+	  if((std::abs(ip.second - it->col) < 26) ) {i->second.set(0.);}
           else if(it->row==120 && ip.second-it->col==26){i->second.set(0.);}
           else if(it->row==119 && it->col-ip.second==26){i->second.set(0.);}
 	}
 	else if(it->row < 80 && ip.first < 80 ){
-	  if((fabs(ip.second - it->col) < 26) ){i->second.set(0.);}
+	  if((std::abs(ip.second - it->col) < 26) ){i->second.set(0.);}
           else if(it->row==40 && ip.second-it->col==26){i->second.set(0.);}
           else if(it->row==39 && it->col-ip.second==26){i->second.set(0.);}
        }

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -292,7 +292,7 @@ induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_poin
       size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
       size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
       for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( affectedStrip - strip )) ;
+	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( (long)affectedStrip - (long)strip )) ;
       }
 
       if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -292,7 +292,7 @@ induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_poin
       size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
       size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
       for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( (long)affectedStrip - (long)strip )) ;
+	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( (int)affectedStrip - (int)strip )) ;
       }
 
       if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -292,7 +292,7 @@ induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_poin
       size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
       size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
       for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( (int)affectedStrip - (int)strip )) ;
+	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at((size_t)std::abs( (int)affectedStrip - (int)strip )) ;
       }
 
       if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -292,7 +292,7 @@ induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_poin
       size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
       size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
       for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(abs( affectedStrip - strip )) ;
+	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(std::abs( affectedStrip - strip )) ;
       }
 
       if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;

--- a/TrackPropagation/NavGeometry/test/stubs/HelixPropagationTestGenerator.cc
+++ b/TrackPropagation/NavGeometry/test/stubs/HelixPropagationTestGenerator.cc
@@ -159,8 +159,8 @@ HelixPropagationTestGenerator::bidirectionalStep (const ExtendedDouble stepSize)
   //
   // recalculate position and direction in double precision
   //
-  currentPosition = VectorTypeExtended(theCenter.x()+cos(phiHelix)/fabs(theCurvature),
-				       theCenter.y()+sin(phiHelix)/fabs(theCurvature),
+  currentPosition = VectorTypeExtended(theCenter.x()+cos(phiHelix)/std::abs(theCurvature),
+				       theCenter.y()+sin(phiHelix)/std::abs(theCurvature),
 				       theCenter.z()+dPhi/theCurvature*startDirection.z()/startDirection.perp());
   currentDirection = VectorTypeExtended(cos(startDirection.phi()+dPhi)*startDirection.perp(),
 					sin(startDirection.phi()+dPhi)*startDirection.perp(),

--- a/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
+++ b/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
@@ -22,7 +22,7 @@ public:
 
     RK4OneStepTempl<T,N> solver;
     Vector one(       solver(startPar, startState, deriv, step));
-    if (std::abs(one[0])>huge || std::abs(one(1)>huge)) return std::pair<Vector, Scalar>(one,hugediff);
+    if (std::abs(one[0])>huge || std::abs(one(1))>huge) return std::pair<Vector, Scalar>(one,hugediff);
 
     Vector firstHalf( solver(startPar, startState, deriv, step/2));
     Vector secondHalf(solver(startPar+step/2, firstHalf, deriv, step/2));


### PR DESCRIPTION
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-08-1100" -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/SimTracker/SiPixelDigitizer/plugins/SimTrackerSiPixelDigitizerPlugins/SealModule.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/SimTracker/SiPixelDigitizer/plugins/SealModule.cc -o tmp/slc6_amd64_gcc530/src/SimTracker/SiPixelDigitizer/plugins/SimTrackerSiPixelDigitizerPlugins/SealModule.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc:1942:8: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
           if((fabs(ip.second - it->col) < 26) ) {i->second.set(0.);}
              ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc:1942:8: note: use function 'std::abs' instead
          if((fabs(ip.second - it->col) < 26) ) {i->second.set(0.);}
              ^~~~
              std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc:1947:8: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
           if((fabs(ip.second - it->col) < 26) ){i->second.set(0.);}
              ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc:1947:8: note: use function 'std::abs' instead
          if((fabs(ip.second - it->col) < 26) ){i->second.set(0.);}
              ^~~~
              std::absIn file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/TrackPropagation/RungeKutta/src/RKPropagatorInR.cc:9:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h:25:34: warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
     if (std::abs(one[0])>huge || std::abs(one(1)>huge)) return std::pair<Vector, Scalar>(one,hugediff);
                                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/TrackPropagation/RungeKutta/src/RKAdaptiveSolver.icc:43:15: note: in instantiation of member function 'RKOne4OrderStep<double, 5>::operator()' requested here
    tryStep = stepWithAccuracy( currentPar, currentStart, deriv, dist, stepSize);
              ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/TrackPropagation/RungeKutta/src/RKPropagatorInR.cc:36:12: note: in instantiation of member function 'RKAdaptiveSolver<double, RKOne4OrderStep, 5>::operator()' requested here
    Solver solver;
           ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h:25:34: note: remove the call to 'std::abs' since unsigned values cannot be negative
    if (std::abs(one[0])>huge || std::abs(one(1)>huge)) return std::pair<Vector, Scalar>(one,hugediff);
                                 ^~~~~~~~