### PR TITLE
Validation: fix clang warnings about abs

### DIFF
--- a/Validation/EventGenerator/plugins/DrellYanValidation.cc
+++ b/Validation/EventGenerator/plugins/DrellYanValidation.cc
@@ -87,16 +87,16 @@ void DrellYanValidation::analyze(const edm::Event& iEvent,const edm::EventSetup&
   std::vector<const HepMC::GenParticle*> allproducts; 
 
   //requires status 1 for leptons and neutrinos (except tau)
-  int requiredstatus = (abs(_flavor) == 11 || abs(_flavor) == 12 || abs(_flavor) ==13 || abs(_flavor) ==14 || abs(_flavor) ==16) ? 1 : 3;
+  int requiredstatus = (std::abs(_flavor) == 11 || std::abs(_flavor) == 12 || std::abs(_flavor) ==13 || std::abs(_flavor) ==14 || std::abs(_flavor) ==16) ? 1 : 3;
 
-  bool vetotau = true; //(abs(_flavor) == 11 || abs(_flavor) == 12 || abs(_flavor) ==13 || abs(_flavor) ==14 || abs(_flavor) ==16) ? true : false;  
+  bool vetotau = true; //(std::abs(_flavor) == 11 || std::abs(_flavor) == 12 || std::abs(_flavor) ==13 || std::abs(_flavor) ==14 || std::abs(_flavor) ==16) ? true : false;  
 
   for(HepMC::GenEvent::particle_const_iterator iter = myGenEvent->particles_begin(); iter != myGenEvent->particles_end(); ++iter) {
     if (vetotau) {
-      if ((*iter)->status()==3 && abs((*iter)->pdg_id() == 15) ) return; 
+      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id() == 15) ) return; 
     }
     if((*iter)->status()==requiredstatus) {
-      if(abs((*iter)->pdg_id())==_flavor)
+      if(std::abs((*iter)->pdg_id())==_flavor)
 	allproducts.push_back(*iter);
     }
   }

--- a/Validation/EventGenerator/plugins/DrellYanValidation.cc
+++ b/Validation/EventGenerator/plugins/DrellYanValidation.cc
@@ -93,7 +93,7 @@ void DrellYanValidation::analyze(const edm::Event& iEvent,const edm::EventSetup&
 
   for(HepMC::GenEvent::particle_const_iterator iter = myGenEvent->particles_begin(); iter != myGenEvent->particles_end(); ++iter) {
     if (vetotau) {
-      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id() == 15) ) return; 
+      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id()) == 15)  return; 
     }
     if((*iter)->status()==requiredstatus) {
       if(std::abs((*iter)->pdg_id())==_flavor)

--- a/Validation/EventGenerator/plugins/HiggsValidation.cc
+++ b/Validation/EventGenerator/plugins/HiggsValidation.cc
@@ -85,7 +85,7 @@ void HiggsValidation::analyze(const edm::Event& iEvent,const edm::EventSetup& iS
   bool filled = false;
   for(HepMC::GenEvent::particle_const_iterator iter = myGenEvent->particles_begin(); 
       iter!= myGenEvent->particles_end() && !filled; ++iter) {
-    if(particle_id == fabs((*iter)->pdg_id())){
+    if(particle_id == std::abs((*iter)->pdg_id())){
       std::vector<HepMC::GenParticle*> decayprod;
       int channel = findHiggsDecayChannel(*iter,decayprod);
       HiggsDecayChannels->Fill(channel,weight);

--- a/Validation/EventGenerator/plugins/WValidation.cc
+++ b/Validation/EventGenerator/plugins/WValidation.cc
@@ -83,19 +83,19 @@ void WValidation::analyze(const edm::Event& iEvent,const edm::EventSetup& iSetup
   std::vector<const HepMC::GenParticle*> allneutrinos; 
 
   //requires status 1 for leptons and neutrinos (except tau)
-  int requiredstatus = (abs(_flavor) == 11 || abs(_flavor) ==13 ) ? 1 : 3;
+  int requiredstatus = (std::abs(_flavor) == 11 || std::abs(_flavor) ==13 ) ? 1 : 3;
 
-  bool vetotau = true; //(abs(_flavor) == 11 || abs(_flavor) == 12 || abs(_flavor) ==13 || abs(_flavor) ==14 || abs(_flavor) ==16) ? true : false;  
+  bool vetotau = true; //(std::abs(_flavor) == 11 || std::abs(_flavor) == 12 || std::abs(_flavor) ==13 || std::abs(_flavor) ==14 || std::abs(_flavor) ==16) ? true : false;  
 
   for(HepMC::GenEvent::particle_const_iterator iter = myGenEvent->particles_begin(); iter != myGenEvent->particles_end(); ++iter) {
     if (vetotau) {
-      if ((*iter)->status()==3 && abs((*iter)->pdg_id() == 15) ) return;
+      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id() == 15) ) return;
     }
     if((*iter)->status()==requiredstatus) {
       //@todo: improve this selection	
       if((*iter)->pdg_id()==_flavor)
 	allleptons.push_back(*iter);
-      else if (abs((*iter)->pdg_id()) == abs(_flavor)+1)
+      else if (std::abs((*iter)->pdg_id()) == std::abs(_flavor)+1)
 	allneutrinos.push_back(*iter);	
     }
   }

--- a/Validation/EventGenerator/plugins/WValidation.cc
+++ b/Validation/EventGenerator/plugins/WValidation.cc
@@ -89,7 +89,7 @@ void WValidation::analyze(const edm::Event& iEvent,const edm::EventSetup& iSetup
 
   for(HepMC::GenEvent::particle_const_iterator iter = myGenEvent->particles_begin(); iter != myGenEvent->particles_end(); ++iter) {
     if (vetotau) {
-      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id() == 15) ) return;
+      if ((*iter)->status()==3 && std::abs((*iter)->pdg_id()) == 15)  return;
     }
     if((*iter)->status()==requiredstatus) {
       //@todo: improve this selection	

--- a/Validation/HcalHits/src/HcalSimHitsValidation.cc
+++ b/Validation/HcalHits/src/HcalSimHitsValidation.cc
@@ -220,8 +220,8 @@ void HcalSimHitsValidation::endJob() {
 
     float phi_factor;
 
-    if      (fabs(ieta) <= 20) phi_factor = 72.;
-    else if (fabs(ieta) <  40) phi_factor = 36.;
+    if      (std::abs(ieta) <= 20) phi_factor = 72.;
+    else if (std::abs(ieta) <  40) phi_factor = 36.;
     else                       phi_factor = 18.;
     
     float cnorm;
@@ -332,7 +332,7 @@ void HcalSimHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
     double r  = dR(eta_MC, phi_MC, etaS, phiS);
     
     if (r < partR){      
-      eta_diff = fabs(eta_MC - etaS);
+      eta_diff = std::abs(eta_MC - etaS);
       if(eta_diff < etaMax) {
 	etaMax  = eta_diff; 
 	ietaMax = cell.ieta(); 

--- a/Validation/RecoParticleFlow/bin/plotCompare.cpp
+++ b/Validation/RecoParticleFlow/bin/plotCompare.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
     branchRefPrefix= argv[3];
     branchNewPrefix= argv[4];
   }
- if (argc == 3);
+ if (argc == 3) {};
  if ((argc != 3) && (argc != 5))
      // initialize plot comparison tool with 4 arguments
     {


### PR DESCRIPTION
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Validation/HcalHits/src/HcalSimHitsValidation.cc:223:14: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
     if      (fabs(ieta) <= 20) phi_factor = 72.;
             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Validation/HcalHits/src/HcalSimHitsValidation.cc:223:14: note: use function 'std::abs' instead
    if      (fabs(ieta) <= 20) phi_factor = 72.;
             ^~~~
             std::abs
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Validation/HcalHits/src/HcalSimHitsValidation.cc:224:14: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
     else if (fabs(ieta) <  40) phi_factor = 36.;
             ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7a46df93c511389b47098a1f5c9e31bc/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-08-1100/src/Validation/HcalHits/src/HcalSimHitsValidation.cc:224:14: note: use function 'std::abs' instead
    else if (fabs(ieta) <  40) phi_factor = 36.;
             ^~~~
             std::abs