### PR TITLE
Reduce CPU time in MuonAssociatorByHitsHelper

### DIFF
--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -1175,9 +1175,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
 int MuonAssociatorByHitsHelper::getShared(MapOfMatchedIds & matchedIds, TrackingParticleCollection::const_iterator trpart) const {
     
   int nshared = 0;
-  TrackingParticle::g4t_iterator simtrack;
-  TrackingParticle::g4t_iterator tbegin = trpart->g4Track_begin();
-  TrackingParticle::g4t_iterator tend = trpart->g4Track_end();
+  const std::vector<SimTrack>& g4Tracks = trpart->g4Tracks();
 
   // map is indexed over the rechits of the reco::Track (no double-countings allowed)
   for (MapOfMatchedIds::const_iterator iRecH=matchedIds.begin(); iRecH!=matchedIds.end(); ++iRecH) {
@@ -1193,9 +1191,9 @@ int MuonAssociatorByHitsHelper::getShared(MapOfMatchedIds & matchedIds, Tracking
       EncodedEventId evtId = iSimH->second;
       
       // look for shared hits with the given TrackingParticle (looping over component SimTracks)
-      for (simtrack = tbegin; simtrack != tend; ++simtrack) {
+      for (const auto& simtrack : g4Tracks) {
           
-          if (simtrack->trackId() == simtrackId  &&  simtrack->eventId() == evtId) {
+          if (simtrack.trackId() == simtrackId  &&  simtrack.eventId() == evtId) {
             found = true;
               break;
           }

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -1185,10 +1185,10 @@ int MuonAssociatorByHitsHelper::getShared(MapOfMatchedIds & matchedIds, Tracking
     
     bool found = false;
     
-    for (std::vector<SimHitIdpr>::const_iterator iSimH=SimTrackIds.begin(); iSimH!=SimTrackIds.end(); ++iSimH) {
+    for (const auto& iSimH : SimTrackIds) {
         
-      uint32_t simtrackId = iSimH->first;
-      EncodedEventId evtId = iSimH->second;
+      uint32_t simtrackId = iSimH.first;
+      EncodedEventId evtId = iSimH.second;
       
       // look for shared hits with the given TrackingParticle (looping over component SimTracks)
       for (const auto& simtrack : g4Tracks) {


### PR DESCRIPTION
There was some work done to improve efficiency in `MuonAssociatorByHitsHelper` previously in #16669, but it did not fully solve the problem. After a number of attempts, I determined that calls to `std::vector<>::begin()/end()` can actually become rather costly when repeated ad infinitum in 200PU workflows. Using range-based loops turned out to be the easiest solution. (Unfortunately, the outermost loop in `getShared()` can't be optimized this way because `boost::ptr_vector` doesn't appear to support it.)

igprof results for step3 using 5 events w/ 200PU in WF 21434.0 (ttbar 2023D4PU):

baseline:
```
[32]       11.7     889.68     301.64 / 588.03     MuonAssociatorByHitsHelper::getShared(boost::ptr_vector<std::pair<unsigned int, std::vector<std::pair<unsigned int, EncodedEventId>, std::allocator<std::pair<unsigned int, EncodedEventId> > > >, boost::heap_clone_allocator, std::allocator<void*> >&, __gnu_cxx::__normal_iterator<TrackingParticle const*, std::vector<TrackingParticle, std::allocator<TrackingParticle> > >) const
            6.4  .........     487.96 / 487.96       TrackingParticle::g4Track_begin() const [43]
            1.1  .........      80.48 / 80.52        TrackingParticle::g4Track_end() const [188]
            0.3  .........      19.59 / 155.88       _init [127]
```

PR:
```
[39]        6.8     495.26     495.26 / 0.00       MuonAssociatorByHitsHelper::getShared(boost::ptr_vector<std::pair<unsigned int, std::vector<std::pair<unsigned int, EncodedEventId>, std::allocator<std::pair<unsigned int, EncodedEventId> > > >, boost::heap_clone_allocator, std::allocator<void*> >&, __gnu_cxx::__normal_iterator<TrackingParticle const*, std::vector<TrackingParticle, std::allocator<TrackingParticle> > >) const
```

This module only runs in Validation, so this won't have an impact on CPU time, but will help with relvals. Further improvements should come from more dedicated reorganization of the code by muon experts.