### PR TITLE
A correct description of the HL-LHC beamspot

### DIFF
--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -99,14 +99,11 @@ private:
     // crossing angle * crab frequency
     const double phiCR;
     
-    //width for x/y plane
+    //width for y plane
     double sigma(double z, double epsilon, double beta, double betagamma) const;
 
-    //width for x/y plane
-    double rhozt(double z, double t) const;
-        
     //density with crabbing
-    double integrandCC(double z, double t) const;
+    double integrandCC(double x, double z, double t) const;
 
     // 4D intensity
     double intensity(double x, double y,double z,double t) const;

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -78,14 +78,14 @@ private:
     //bunch length
     const double sigs;
 
-    // fraction of crab cavity voltage
-    const double oncc;
-
     //crabbing angle crossing
     const double alphax;
 
     //crabbing angle separation
     const double alphay;
+
+    // ratio of crabbing angle to crossing angle
+    const double oncc;
 
     //normalized crossing emittance
     const double epsx;

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -46,70 +46,70 @@ private:
     HLLHCEvtVtxGenerator&  operator = (const HLLHCEvtVtxGenerator & rhs );
     
     //spatial and time offset for mean collision
-    double fMeanX, fMeanY, fMeanZ, fTimeOffset;
+    const double fMeanX, fMeanY, fMeanZ, fTimeOffset;
 
     //proton beam energy
-    double fEproton;
-
-    //half crossing angle 
-    double fTheta;
-
-    //crab rotation in crossing plane
-    double fAlphax;
-
-    //crab frequence in crossing plane
-    double fOmegax;
-
-    //normalized emmittance in crossing plane
-    double fEpsilonx;
-
-    //beta function in crossing plane
-    double fBetax;
-  
-    //crab rotation in parallel plane
-    double fAlphay;
-
-    //crab frequence in parallel plane
-    double fOmegay;
-
-    //normalized emmittance parallel plane
-    double fEpsilony;
-
-    //beta function in parallel plane
-    double fBetay;
-  
-    //longitudinal bunch size
-    double fZsize;
-
-    //longitudinal beam profile
-    std::string fProfile;
-    // fProfile is one of:
-    // "Gaussian" and then fZsize is the width of the gaussian
-    // "Flat" and then fZsize is the half length of the bunch.
+    const double momeV;
+    const double gamma;
+    const double beta;
+    const double betagamma;
     
-    struct lhcbeamparams {
+    //crossing angle 
+    const double phi;
+    
+    //crab cavity frequency
+    const double wcc;
 
-        double betagamma; 
-        double theta;
-        double alphax;
-        double omegax;
-        double epsilonx;
-        double betax;
-        double alphay;
-        double omegay;
-        double epsilony;
-        double betay;
-        double zsize;  
-        std::string beamprofile;
-    };
+    // 800 MHz RF?
+    const bool RF800;
 
-    double p1(double x, double y, double z, double t, const lhcbeamparams& par);
+    //beta crossing plane (m)
+    const double betx;
 
-    double p2(double x, double y, double z, double t, const lhcbeamparams& par);
+    //beta separation plane (m)
+    const double bets;
 
-    double sigma(double z, double epsilon, double beta, double betagamma);
+    //horizontal emittance 
+    const double epsxn;
 
-    double rhoz(double z, const lhcbeamparams& par);
+    //vertical emittance
+    const double epssn;
+
+    //bunch length
+    const double sigs;
+
+    // fraction of crab cavity voltage
+    const double oncc;
+
+    //crabbing angle crossing
+    const double alphax;
+
+    //crabbing angle separation
+    const double alphay;
+
+    //normalized crossing emittance
+    const double epsx;
+
+    //normlaized separation emittance
+    const double epss;
+
+    //size in x
+    const double sigx;
+
+    // crossing angle * crab frequency
+    const double phiCR;
+    
+    //width for x/y plane
+    double sigma(double z, double epsilon, double beta, double betagamma) const;
+
+    //width for x/y plane
+    double rhozt(double z, double t) const;
+        
+    //density with crabbing
+    double integrandCC(double z, double t) const;
+
+    // 4D intensity
+    double intensity(double x, double y,double z,double t) const;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -631,17 +631,17 @@ HLLHCVtxSmearingParameters = cms.PSet(
     MeanZIncm = cms.double(0.),
     TimeOffsetInns = cms.double(0.0),
     EprotonInGeV = cms.double(6500.0),
-    HalfCrossingAngleInurad = cms.double(295.0),
-    CrabAngleCrossingPlaneInurad = cms.double(295.0),
-    CrabFrequencyCrossingPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceCrossingPlaneInum = cms.double(2.5),
-    BetaStarCrossingPlaneInm = cms.double(0.15),
-    CrabAngleParallelPlaneInurad = cms.double(0.0),
-    CrabFrequencyParallelPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceParallelPlaneInum = cms.double(2.5),
-    BetaStarParallelPlaneInm = cms.double(0.15),
-    ZsizeInm = cms.double(0.075),
-    BeamProfile=cms.string("Gauss")
+    CrossingAngleInurad = cms.double(510.0),
+    CrabFrequencyInMHz = cms.double(400.0),
+    RF800 = cms.bool(False),
+    BetaCrossingPlaneInm = cms.double(0.20),
+    BetaSeparationPlaneInm = cms.double(0.20),
+    HorizontalEmittance = cms.double(2.54924131e-06),
+    VerticalEmittance = cms.double(2.19302467e-06),
+    BunchLengthInm = cms.double(0.081),
+    CrabCavityVoltage = cms.double(1.0),
+    CrabbingAngleCrossingInurad = cms.double(380.0),
+    CrabbingAngleSeparationInurad = cms.double(0.0)    
 )
 
 # Parameters for HL-LHC Crab-kissing operation 13 TeV

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -638,7 +638,7 @@ HLLHCVtxSmearingParameters = cms.PSet(
     BetaSeparationPlaneInm = cms.double(0.20),
     HorizontalEmittance = cms.double(2.5e-06),
     VerticalEmittance = cms.double(2.05e-06),
-    BunchLengthInm = cms.double(0.09),
+    BunchLengthInm = cms.double(0.090),
     CrabbingAngleCrossingInurad = cms.double(380.0),
     CrabbingAngleSeparationInurad = cms.double(0.0)    
 )

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -636,10 +636,9 @@ HLLHCVtxSmearingParameters = cms.PSet(
     RF800 = cms.bool(False),
     BetaCrossingPlaneInm = cms.double(0.20),
     BetaSeparationPlaneInm = cms.double(0.20),
-    HorizontalEmittance = cms.double(2.54924131e-06),
-    VerticalEmittance = cms.double(2.19302467e-06),
-    BunchLengthInm = cms.double(0.081),
-    CrabCavityVoltage = cms.double(1.0),
+    HorizontalEmittance = cms.double(2.5e-06),
+    VerticalEmittance = cms.double(2.05e-06),
+    BunchLengthInm = cms.double(0.09),
     CrabbingAngleCrossingInurad = cms.double(380.0),
     CrabbingAngleSeparationInurad = cms.double(0.0)    
 )

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -22,6 +22,8 @@ namespace {
   constexpr double gamma34 = 1.22541670246517764513;    // Gamma(3/4)
   constexpr double gamma14 = 3.62560990822190831193;    // Gamma(1/4)
   constexpr double gamma54 = 0.90640247705547798267;    // Gamma(5/4)
+  constexpr double sqrt2 = 1.41421356237;
+  constexpr double sqrt2to5 = 5.65685424949;
   constexpr double two_pi=2.0*M_PI;
 }
 
@@ -200,8 +202,8 @@ double HLLHCEvtVtxGenerator::integrandCC(double z,
     
   const double sigs2 = sigs*sigs;
   
-  constexpr double factorRMSgauss4  = 1./std::sqrt(2.)/gamma34 * gamma14; // # Factor to take rms sigma as input of the supergaussian
-  constexpr double NormFactorGauss4 = std::pow(2.0,(5./2.)) * gamma54 * gamma54;
+  constexpr double factorRMSgauss4  = 1./sqrt2/gamma34 * gamma14; // # Factor to take rms sigma as input of the supergaussian
+  constexpr double NormFactorGauss4 = sqrt2to5 * gamma54 * gamma54;
   
   const double sinCR  = std::sin(phiCR/2.0);
   const double sinCR2 = sinCR*sinCR;

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -22,7 +22,7 @@ namespace {
   constexpr double gamma34 = 1.22541670246517764513;    // Gamma(3/4)
   constexpr double gamma14 = 3.62560990822190831193;    // Gamma(1/4)
   constexpr double gamma54 = 0.90640247705547798267;    // Gamma(5/4)
-  constexpr double two_pi=8.0*std::atan(1.0);
+  constexpr double two_pi=2.0*M_PI;
 }
 
 void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions &descriptions)

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -16,30 +16,67 @@
 
 using namespace std;
 
+namespace {
+  
+  constexpr double pmass = 0.9382720813e9; // eV
+  constexpr double gamma34 = 1.22541670246517764513;    // Gamma(3/4)
+  constexpr double gamma14 = 3.62560990822190831193;    // Gamma(1/4)
+  constexpr double gamma54 = 0.90640247705547798267;    // Gamma(5/4)
+  constexpr double two_pi=8.0*std::atan(1.0);
+}
+
+void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions &descriptions)
+{
+    edm::ParameterSetDescription desc;
+    desc.add<double>("MeanXIncm",0.0);
+    desc.add<double>("MeanYIncm",0.0);
+    desc.add<double>("MeanZIncm",0.0);
+    desc.add<double>("TimeOffsetInns",0.0);
+    desc.add<double>("EprotonInGeV", 7000.0);
+    desc.add<double>("CrossingAngleInurad", 510.0);
+    desc.add<double>("CrabbingAngleCrossingInurad", 380.0);
+    desc.add<double>("CrabbingAngleSeparationInurad", 0.0);
+    desc.add<double>("CrabFrequencyInMHz", 400.0);
+    desc.add<bool>("RF800", false);
+    desc.add<double>("BetaCrossingPlaneInm", 0.20);
+    desc.add<double>("BetaSeparationPlaneInm", 0.20);
+    desc.add<double>("HorizontalEmittance", 2.54924131e-06);
+    desc.add<double>("VerticalEmittance", 2.19302467e-06);
+    desc.add<double>("BunchLengthInm", 0.081);
+    desc.add<double>("CrabCavityVoltage", 1.0);    
+    desc.add<edm::InputTag>("src");
+    desc.add<bool>("readDB");
+    descriptions.add("HLLHCEvtVtxGenerator",desc);
+}
+
 HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet & p )
-    : BaseEvtVtxGenerator(p)
+  : BaseEvtVtxGenerator(p),
+    fMeanX(p.getParameter<double>("MeanXIncm")*cm),
+    fMeanY(p.getParameter<double>("MeanYIncm")*cm),
+    fMeanZ(p.getParameter<double>("MeanZIncm")*cm),
+    fTimeOffset(p.getParameter<double>("TimeOffsetInns")*ns*c_light),
+    momeV(p.getParameter<double>("EprotonInGeV")*1e9),
+    gamma(momeV/pmass + 1.0),
+    beta(std::sqrt((1.0 - 1.0/(gamma*gamma))*((1.0 + 1.0/(gamma*gamma))))),
+    betagamma(beta*gamma),
+    phi(p.getParameter<double>("CrossingAngleInurad")*1e-6),    
+    wcc(p.getParameter<double>("CrabFrequencyInMHz")*1e6),
+    RF800(p.getParameter<bool>("RF800")),
+    betx(p.getParameter<double>("BetaCrossingPlaneInm")),
+    bets(p.getParameter<double>("BetaSeparationPlaneInm")),
+    epsxn(p.getParameter<double>("HorizontalEmittance")),
+    epssn(p.getParameter<double>("VerticalEmittance")),
+    sigs(p.getParameter<double>("BunchLengthInm")),
+    oncc(p.getParameter<double>("CrabCavityVoltage")),
+    alphax(oncc*p.getParameter<double>("CrabbingAngleCrossingInurad")*1e-6),
+    alphay(oncc*p.getParameter<double>("CrabbingAngleSeparationInurad")*1e-6),
+    epsx(epsxn/(betagamma)),
+    epss(epsx),
+    sigx(std::sqrt(epsx*betx)),
+    phiCR(oncc*phi)
+    
 {   
-    fMeanX =  p.getParameter<double>("MeanXIncm")*cm;
-    fMeanY =  p.getParameter<double>("MeanYIncm")*cm;
-    fMeanZ =  p.getParameter<double>("MeanZIncm")*cm;
-    fTimeOffset = p.getParameter<double>("TimeOffsetInns")*ns*c_light;
-
-    fEproton = p.getParameter<double>("EprotonInGeV");
-    fTheta = p.getParameter<double>("HalfCrossingAngleInurad");
-
-    fAlphax = p.getParameter<double>("CrabAngleCrossingPlaneInurad");
-    fOmegax = p.getParameter<double>("CrabFrequencyCrossingPlaneInMHz");
-    fEpsilonx = p.getParameter<double>("NormalizedEmittanceCrossingPlaneInum");
-    fBetax = p.getParameter<double>("BetaStarCrossingPlaneInm");
-
-    fAlphay = p.getParameter<double>("CrabAngleParallelPlaneInurad");
-    fOmegay = p.getParameter<double>("CrabFrequencyParallelPlaneInMHz");
-    fEpsilony = p.getParameter<double>("NormalizedEmittanceParallelPlaneInum");
-    fBetay = p.getParameter<double>("BetaStarParallelPlaneInm");
-
-    fZsize = p.getParameter<double>("ZsizeInm");
-    fProfile = p.getParameter<string>("BeamProfile");
-
+ 
 }
 
 HLLHCEvtVtxGenerator::~HLLHCEvtVtxGenerator() 
@@ -49,187 +86,167 @@ HLLHCEvtVtxGenerator::~HLLHCEvtVtxGenerator()
 
 HepMC::FourVector* HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
 
-    lhcbeamparams params;
+  double imax=intensity(0.,0.,0.,0.);
 
-    params.betagamma=fEproton/0.94;  //FIXME 
-    params.theta=fTheta*1e-6;
-    params.alphax=fAlphax*1e-6;
-    params.omegax=fOmegax*1e6;
-    params.epsilonx=fEpsilonx*1e-6;
-    params.betax=fBetax;
-    params.alphay=fAlphay*1e-6;
-    params.omegay=fOmegay*1e6;
-    params.epsilony=fEpsilony*1e-6;
-    params.betay=fBetay;
-    params.zsize=fZsize;  
-    params.beamprofile=fProfile;
-
-
-    double imax=p1(0.0,0.0,0.0,0.0,params)*p2(0.0,0.0,0.0,0.0,params);
-
-    double x,y,z,t,i;
-
-    int count=0;
-    
-    auto shoot = [&](){ return CLHEP::RandFlat::shoot(engine); };
-
-    do
-    {
-        z=(shoot()-0.5)*6.0*fZsize;
-        t=(shoot()-0.5)*6.0*fZsize;
-        x=(shoot()-0.5)*12.0*sigma(0.0,params.epsilonx,params.betax,
-                                           params.betagamma);
-        y=(shoot()-0.5)*8.0*sigma(0.0,params.epsilony,params.betay,
-                                          params.betagamma);
-
-        i=p1(x,y,z,t,params)*p2(x,y,z,t,params);
-
-        if (i>imax)  edm::LogError("Too large intensity") 
-                         << "i>imax : "<<i<<" > "<<imax<<endl;
-        ++count;
-    }
-    while ((i<imax*shoot())&&count<10000);
+  double x(0.),y(0.),z(0.),t(0.),i(0.);
   
-    if (count>9999) edm::LogError("Too many tries ") 
-                        << " count : "<<count<<endl;
-		      
-    if(fVertex == 0)
-        fVertex = new HepMC::FourVector();
-
-    //---convert to mm
-    x*=1000.0;
-    y*=1000.0;
-    z*=1000.0;
-    t*=1000.0;
-
-    x+=fMeanX;
-    y+=fMeanY;
-    z+=fMeanZ;
-    t+=fTimeOffset;
-
-    fVertex->set( x, y, z, t );
-
-    return fVertex;
+  int count=0;
+  
+  auto shoot = [&](){ return CLHEP::RandFlat::shoot(engine); };
+  
+  do {
+    z=(shoot()-0.5)*6.0*sigs;
+    t=(shoot()-0.5)*6.0*sigs;
+    x=(shoot()-0.5)*12.0*sigma(0.0,epsxn,betx,betagamma);
+    y=(shoot()-0.5)*8.0*sigma(0.0,epssn,bets,betagamma);
+    
+    i=intensity(x,y,z,t);
+    
+    if (i>imax)  edm::LogError("Too large intensity") 
+                   << "i>imax : "<<i<<" > "<<imax<<endl;
+    ++count;
+  } while ((i<imax*shoot())&&count<10000);
+  
+  if (count>9999) edm::LogError("Too many tries ") 
+                    << " count : "<<count<<endl;
+  
+  if(fVertex == 0)
+    fVertex = new HepMC::FourVector();
+  
+  //---convert to mm
+  x*=1000.0;
+  y*=1000.0;
+  z*=1000.0;
+  t*=1000.0;
+  
+  x+=fMeanX;
+  y+=fMeanY;
+  z+=fMeanZ;
+  t+=fTimeOffset;
+  
+  fVertex->set( x, y, z, t );
+  
+  return fVertex;
 }
 
-void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions &descriptions)
-{
-    edm::ParameterSetDescription desc;
-    desc.add<double>("MeanXIncm");
-    desc.add<double>("MeanYIncm");
-    desc.add<double>("MeanZIncm");
-    desc.add<double>("TimeOffsetInns");
-    desc.add<double>("EprotonInGeV");
-    desc.add<double>("HalfCrossingAngleInurad");
-    desc.add<double>("CrabAngleCrossingPlaneInurad");
-    desc.add<double>("CrabFrequencyCrossingPlaneInMHz");
-    desc.add<double>("NormalizedEmittanceCrossingPlaneInum");
-    desc.add<double>("BetaStarCrossingPlaneInm");
-    desc.add<double>("CrabAngleParallelPlaneInurad");
-    desc.add<double>("CrabFrequencyParallelPlaneInMHz");
-    desc.add<double>("NormalizedEmittanceParallelPlaneInum");
-    desc.add<double>("BetaStarParallelPlaneInm");
-    desc.add<double>("ZsizeInm");
-    desc.add<string>("BeamProfile");  
-    desc.add<edm::InputTag>("src");
-    desc.add<bool>("readDB");
-    descriptions.add("HLLHCEvtVtxGenerator",desc);
-}
 
-double HLLHCEvtVtxGenerator::sigma(double z, double epsilon, double beta, double betagamma)
-{
-    double sigma=sqrt(epsilon*(beta+z*z/beta)/betagamma);
 
-    return sigma;
+double HLLHCEvtVtxGenerator::sigma(double z, double epsilon, double beta, double betagamma) const
+{
+  double sigma=std::sqrt(epsilon*(beta+z*z/beta)/betagamma);
+  
+  return sigma;
 } 
 
-double HLLHCEvtVtxGenerator::rhoz(double z, const lhcbeamparams& params)
-{
-    static double two_pi=8.0*atan(1.0);
-
-    if (params.beamprofile=="Flat")
-    {
-        if (fabs(z)<params.zsize)
-            return 1.0;
-        return 0.0;
-    }
-    else if (params.beamprofile=="Gauss")
-        return exp(-0.5*z*z/(params.zsize*params.zsize))/(sqrt(two_pi)*params.zsize);
-    else
-    {
-        edm::LogError("Wrong BeamProfile") << "BeamProfile: " << params.beamprofile
-                                           << " expect either 'Flat' or 'Gauss' " 
-                                           << endl;
-    }  
-    return 0.0; 
+double HLLHCEvtVtxGenerator::rhozt(double z, double ct) const 
+{  
+  return integrandCC(z,ct); 
 }
 
 
-double HLLHCEvtVtxGenerator::p1(double x, 
-				double y, 
-				double z, 
-				double t, 
-				const lhcbeamparams& params)
-{
-    double sigmax=sigma(z,params.epsilonx,params.betax,params.betagamma);
-    double sigmay=sigma(z,params.epsilony,params.betay,params.betagamma);
-
-    //---c in m/s --- remember t is already in meters
-    double c=c_light/m*s;
-    static double two_pi=8.0*atan(1.0);
+double HLLHCEvtVtxGenerator::intensity(double x, 
+                                       double y, 
+                                       double z, 
+                                       double t) const {
+  //---c in m/s --- remember t is already in meters
+  constexpr double c= 2.99792458e+8; // m/s
   
-    double omegax=two_pi*params.omegax;
-    double omegay=two_pi*params.omegay;
-    double alphax=params.alphax*cos(omegax*(z-t)/c);
-    double alphay=params.alphay*cos(omegay*(z-t)/c);
-
-    double cax=cos(alphax);
-    double sax=sin(alphax);
-
-    double cay=cos(alphay);
-    double say=sin(alphay);
-
-    double ct=cos(params.theta);
-    double st=sin(params.theta);
-
-    double dx=(z-t*ct)*(cax*st-sax*ct)-(x-t*st)*(sax*st+cax*ct);
-
-    double dy=-(z-t)*say-y*cay;
-
-    double zrho=rhoz((z-t*ct)*(cax*ct+sax*st)-(x-t*st)*(sax*ct-cax*st),
-                     params);
-
-    return exp(-0.5*dx*dx/(sigmax*sigmax))*exp(-0.5*dy*dy/(sigmay*sigmay))*zrho/(two_pi*sigmax*sigmay);
-}
-
-double HLLHCEvtVtxGenerator::p2(double x, 
-				double y, 
-				double z, 
-				double t, 
-				const lhcbeamparams& params)
-{
-    double sigmax=sigma(z,params.epsilonx,params.betax,params.betagamma);
-    double sigmay=sigma(z,params.epsilony,params.betay,params.betagamma);
-
-    static double two_pi=8.0*atan(1.0);
-
-    double cax=cos(-params.alphax);
-    double sax=sin(-params.alphax);
-
-    double cay=cos(params.alphay);
-    double say=sin(params.alphay);
-
-    double ct=cos(-params.theta);
-    double st=sin(-params.theta);
-
-    double dx=(z+t*ct)*(cax*st-sax*ct)-(x+t*st)*(sax*st+cax*ct);
-
-    double dy=-(z+t)*say-y*cay;
-
-    double zrho=rhoz((z+t*ct)*(cax*ct+sax*st)-(x+t*st)*(sax*ct-cax*st),
-                     params);
-
-    return exp(-0.5*dx*dx/(sigmax*sigmax))*exp(-0.5*dy*dy/(sigmay*sigmay))*zrho/(two_pi*sigmax*sigmay); 
-}
-
+  const double sigmax=sigma(z,epsxn,betx,betagamma);
+  const double sigmay=sigma(z,epssn,bets,betagamma);
+    
+  const double alphax_mod=alphax*std::cos(wcc*(z-t)/c);
+  const double alphay_mod=alphay*std::cos(wcc*(z-t)/c);
   
+  const double cax       = std::cos(alphax_mod);
+  const double sax_minus = std::sin(-alphax_mod);
+  const double sax_plus  = -sax_minus;
+
+  const double cay=std::cos(alphay_mod);
+  const double say=std::sin(alphay_mod);
+
+  const double ct       = std::cos(0.5*phi);
+  const double st_minus = std::sin(-0.5*phi);
+  const double st_plus  = -st_minus;
+
+  const double dx_plus  = (z-t*ct)*(cax*st_plus-sax_plus*ct)   - (x-t*st_plus)*(sax_plus*st_plus+cax*ct);
+  const double dx_minus = (z+t*ct)*(cax*st_minus-sax_minus*ct) - (x+t*st_minus)*(sax_minus*st_minus+cax*ct);
+
+  //const double dx=-(z-t)*sax_plus -x*cax; 
+
+  const double dy=-(z-t)*say-y*cay;
+
+  const double zrho=rhozt(z,t);
+
+  const double norm = (two_pi*sigmax*sigmay);
+  
+  return ( std::exp(-0.5*dx_plus*dx_plus/(sigmax*sigmax))*
+           std::exp(-0.5*dx_minus*dx_minus/(sigmax*sigmax))*
+           std::exp(-dy*dy/(sigmay*sigmay))*
+           zrho/(norm*norm) );
+}
+
+double HLLHCEvtVtxGenerator::integrandCC(double z, 
+                                         double ct) const {  
+  constexpr double local_c_light = 2.99792458e8;
+
+  const double k = wcc/local_c_light*two_pi;
+  const double k2 = k*k;
+  const double cos = std::cos(phi/2);
+  const double sin = std::sin(phi/2);
+  const double cos2 = cos*cos;
+  const double sin2 = sin*sin;
+    
+  const double sigx2 = sigx*sigx;
+  const double sigmax2=sigx2*(1+z*z/(betx*betx));
+    
+  const double sigs2 = sigs*sigs;
+  
+  constexpr double factorRMSgauss4  = 1./std::sqrt(2.)/gamma34 * gamma14; // # Factor to take rms sigma as input of the supergaussian
+  constexpr double NormFactorGauss4 = std::pow(2.0,(5./2.)) * gamma54 * gamma54;
+  
+  const double sinCR  = std::sin(phiCR/2);
+  const double sinCR2 = sinCR*sinCR;
+      
+  double result = -1.0;
+    
+  if( !RF800 ) {
+    const double norm =2.0/(two_pi*sigs2);
+    const double cosks = std::cos(k*z);
+    const double sinkct = std::sin(k*ct);
+    result = norm*std::exp(-ct*ct/sigs2
+                           -z*z*cos2/sigs2
+                           -1.0/(4*k2*sigmax2)*(
+                                                -4*cosks*cosks * sinkct*sinkct * sinCR2
+                                                -8*z*k*std::sin(k*z)*std::cos(k*ct) * sin * sinCR
+                                                +2 * sinCR2
+                                                -std::cos(2*k*(z-ct)) * sinCR2
+                                                -std::cos(2*k*(z+ct)) * sinCR2
+                                                +4*k2*z*z *sin2
+                                                )
+                           //+(2*ct/k)*np.cos(k*s)*np.sin(k*ct) *(sin*sinCR)/(sigs2*cos)  # small term
+                           //+ct**2*(sin2/sigs4)/(cos2/sigmax2)				              # small term
+                           )/std::sqrt(1.0+(z*z)/(betx*betx))/std::sqrt(1.0+(z*z)/(bets*bets));
+      
+  } else {
+    
+    const double norm = 2.0/(NormFactorGauss4*sigs2*factorRMSgauss4);
+    const double sigs4=sigs2*sigs2*factorRMSgauss4*factorRMSgauss4;
+    const double cosks = std::cos(k*z);
+    const double sinct = std::sin(k*ct);
+    result = norm*std::exp(
+                           -ct*ct*ct*ct/sigs4
+                           -z*z*z*z*cos2*cos2/sigs4
+                           -6*ct*ct*z*z*cos2/sigs4
+                           -sin2/(4*k2*sigmax2)*(
+                                                 2
+                                                 +4*k2*s*s
+                                                 -std::cos(2*k*(z-ct))
+                                                 -std::cos(2*k*(z+ct))
+                                                 -8*k*s*std::cos(k*ct)*std::sin(k*z) 
+                                                 -4 * cosks*cosks * sinct*sinct)
+                           )/std::sqrt(1+z*z/(betx*betx))/std::sqrt(1+z*z/(bets*bets));
+  }
+  
+  return result;
+}
+

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -40,10 +40,9 @@ void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions &desc
     desc.add<bool>("RF800", false);
     desc.add<double>("BetaCrossingPlaneInm", 0.20);
     desc.add<double>("BetaSeparationPlaneInm", 0.20);
-    desc.add<double>("HorizontalEmittance", 2.54924131e-06);
-    desc.add<double>("VerticalEmittance", 2.19302467e-06);
-    desc.add<double>("BunchLengthInm", 0.081);
-    desc.add<double>("CrabCavityVoltage", 1.0);    
+    desc.add<double>("HorizontalEmittance", 2.5e-06);
+    desc.add<double>("VerticalEmittance", 2.05e-06);
+    desc.add<double>("BunchLengthInm", 0.09);
     desc.add<edm::InputTag>("src");
     desc.add<bool>("readDB");
     descriptions.add("HLLHCEvtVtxGenerator",desc);
@@ -66,10 +65,10 @@ HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet & p )
     bets(p.getParameter<double>("BetaSeparationPlaneInm")),
     epsxn(p.getParameter<double>("HorizontalEmittance")),
     epssn(p.getParameter<double>("VerticalEmittance")),
-    sigs(p.getParameter<double>("BunchLengthInm")),
-    oncc(p.getParameter<double>("CrabCavityVoltage")),
-    alphax(oncc*p.getParameter<double>("CrabbingAngleCrossingInurad")*1e-6),
-    alphay(oncc*p.getParameter<double>("CrabbingAngleSeparationInurad")*1e-6),
+    sigs(p.getParameter<double>("BunchLengthInm")),    
+    alphax(p.getParameter<double>("CrabbingAngleCrossingInurad")*1e-6),
+    alphay(p.getParameter<double>("CrabbingAngleSeparationInurad")*1e-6),
+    oncc(alphax/phi),
     epsx(epsxn/(betagamma)),
     epss(epsx),
     sigx(std::sqrt(epsx*betx)),
@@ -171,9 +170,9 @@ double HLLHCEvtVtxGenerator::intensity(double x,
   const double dx_plus  = (z-t*ct)*(cax*st_plus-sax_plus*ct)   - (x-t*st_plus)*(sax_plus*st_plus+cax*ct);
   const double dx_minus = (z+t*ct)*(cax*st_minus-sax_minus*ct) - (x+t*st_minus)*(sax_minus*st_minus+cax*ct);
 
-  const double dx=-(z-t)*sax_plus -x*cax; 
+  const double dx=/*-(z-t)*sax_plus*/ -x*cax; 
 
-  const double dy=-(z-t)*say-y*cay;
+  const double dy=/*-(z-t)*say*/-y*cay;
 
   const double zrho=rhozt(z,t);
 

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -57,7 +57,7 @@ HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet & p )
     fTimeOffset(p.getParameter<double>("TimeOffsetInns")*ns*c_light),
     momeV(p.getParameter<double>("EprotonInGeV")*1e9),
     gamma(momeV/pmass + 1.0),
-    beta(std::sqrt((1.0 - 1.0/(gamma*gamma))*((1.0 + 1.0/(gamma*gamma))))),
+    beta(std::sqrt((1.0 - 1.0/gamma)*((1.0 + 1.0/gamma)))),
     betagamma(beta*gamma),
     phi(p.getParameter<double>("CrossingAngleInurad")*1e-6),    
     wcc(p.getParameter<double>("CrabFrequencyInMHz")*1e6),
@@ -154,8 +154,8 @@ double HLLHCEvtVtxGenerator::intensity(double x,
   const double sigmax=sigma(z,epsxn,betx,betagamma);
   const double sigmay=sigma(z,epssn,bets,betagamma);
     
-  const double alphax_mod=alphax*std::cos(wcc*(z-t)/c);
-  const double alphay_mod=alphay*std::cos(wcc*(z-t)/c);
+  const double alphax_mod=alphax;//*std::cos(wcc*(z-t)/c);
+  const double alphay_mod=alphay;//*std::cos(wcc*(z-t)/c);
   
   const double cax       = std::cos(alphax_mod);
   const double sax_minus = std::sin(-alphax_mod);
@@ -171,7 +171,7 @@ double HLLHCEvtVtxGenerator::intensity(double x,
   const double dx_plus  = (z-t*ct)*(cax*st_plus-sax_plus*ct)   - (x-t*st_plus)*(sax_plus*st_plus+cax*ct);
   const double dx_minus = (z+t*ct)*(cax*st_minus-sax_minus*ct) - (x+t*st_minus)*(sax_minus*st_minus+cax*ct);
 
-  //const double dx=-(z-t)*sax_plus -x*cax; 
+  const double dx=-(z-t)*sax_plus -x*cax; 
 
   const double dy=-(z-t)*say-y*cay;
 
@@ -179,8 +179,8 @@ double HLLHCEvtVtxGenerator::intensity(double x,
 
   const double norm = (two_pi*sigmax*sigmay);
   
-  return ( std::exp(-0.5*dx_plus*dx_plus/(sigmax*sigmax))*
-           std::exp(-0.5*dx_minus*dx_minus/(sigmax*sigmax))*
+  return ( std::exp(-0.5*dx*dx/(sigmax*sigmax))*
+           std::exp(-0.5*dx*dx/(sigmax*sigmax))*
            std::exp(-dy*dy/(sigmay*sigmay))*
            zrho/(norm*norm) );
 }
@@ -191,8 +191,8 @@ double HLLHCEvtVtxGenerator::integrandCC(double z,
 
   const double k = wcc/local_c_light*two_pi;
   const double k2 = k*k;
-  const double cos = std::cos(phi/2);
-  const double sin = std::sin(phi/2);
+  const double cos = std::cos(phi/2.0);
+  const double sin = std::sin(phi/2.0);
   const double cos2 = cos*cos;
   const double sin2 = sin*sin;
     
@@ -204,7 +204,7 @@ double HLLHCEvtVtxGenerator::integrandCC(double z,
   constexpr double factorRMSgauss4  = 1./std::sqrt(2.)/gamma34 * gamma14; // # Factor to take rms sigma as input of the supergaussian
   constexpr double NormFactorGauss4 = std::pow(2.0,(5./2.)) * gamma54 * gamma54;
   
-  const double sinCR  = std::sin(phiCR/2);
+  const double sinCR  = std::sin(phiCR/2.0);
   const double sinCR2 = sinCR*sinCR;
       
   double result = -1.0;
@@ -239,7 +239,7 @@ double HLLHCEvtVtxGenerator::integrandCC(double z,
                            -6*ct*ct*z*z*cos2/sigs4
                            -sin2/(4*k2*sigmax2)*(
                                                  2
-                                                 +4*k2*s*s
+                                                 +4*k2*z*z
                                                  -std::cos(2*k*(z-ct))
                                                  -std::cos(2*k*(z+ct))
                                                  -8*k*s*std::cos(k*ct)*std::sin(k*z) 


### PR DESCRIPTION
This PR changes the HL-LHC beamspot simulation we are using to be exactly the HL-LHC beamspot simulation from the HL-LHC machine group.

This PR is waiting for one more item: a correct description of the x and y distribution of vertices in the beamspot.  

The online beamspot doesn't need to be updated as the major change here is for the width of the beamspot in time, and the online beamspot only has spatial coordinates. There is a slight change in the beamspot z width but it does not invalidate the beamspot in the database.

Vertex profile in time (axis is ns, arb units):
<img width="699" alt="vertex_t_profile" src="https://cloud.githubusercontent.com/assets/1068089/21045326/37de8d10-be00-11e6-8dba-edf952fbee9c.png">

Vertex profile in z (axis in cm, normalized to ev/mm in 140 PU):
<img width="699" alt="vertex_z_profile" src="https://cloud.githubusercontent.com/assets/1068089/21045328/37e06d4c-be00-11e6-91d4-714c1633b13e.png">

Vertex shape in z and time (arb units):
<img width="696" alt="vertex_zt_profile" src="https://cloud.githubusercontent.com/assets/1068089/21045327/37df9868-be00-11e6-9ed4-814c29553703.png">

@davidlange6 It would be good to get this in for the tracker TDR production, I also found a weird bug in the old HL-LHC beamspot such that x and z were correlated (which should not be the case!).
