### PR TITLE
Stop gcc 6.2 compiler warnings in PF data products

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h
@@ -34,16 +34,16 @@ namespace reco {
 
     double isolation() const { return isolation_; }
     
-
-    friend std::ostream& operator<<( std::ostream& out, 
-				     const IsolatedPFCandidate& c );
-  
   private:
 
 /*     PFCandidateRef parent_; */
 
     double isolation_;
   };
+
+  std::ostream& operator<<( std::ostream& out, 
+                            const IsolatedPFCandidate& c );
+  
 
 
 }

--- a/DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidate.h
@@ -33,14 +33,14 @@ namespace reco {
     /// return reference to the associated vertex
     const VertexRef&  vertexRef() const {return vertexRef_;}
     
-
-    friend std::ostream& operator<<( std::ostream& out, 
-				     const PileUpPFCandidate& c );
-  
   private:
     
     VertexRef     vertexRef_;
   };
+
+  std::ostream& operator<<( std::ostream& out, 
+                            const PileUpPFCandidate& c );
+  
 
 
 }

--- a/DataFormats/ParticleFlowReco/interface/CaloWindow.h
+++ b/DataFormats/ParticleFlowReco/interface/CaloWindow.h
@@ -68,7 +68,7 @@ public:
 	 * A copy of the vector of energies for each pane
 	 * @return a vector of energies
 	 */
-	std::vector<double> getEnergies() const {
+	std::vector<double> const & getEnergies() const {
 		return myPanes_;
 	}
 
@@ -86,10 +86,9 @@ public:
 private:
 	unsigned panes_;
 	std::vector<double> myPanes_;
-
-	friend std::ostream& operator<<(std::ostream& s, const CaloRing& caloRing);
-
 };
+ 
+std::ostream& operator<<(std::ostream& s, const CaloRing& caloRing);
 
 class CaloWindow {
 public:
@@ -119,7 +118,7 @@ public:
 	 * and the first entry of the bary centre itself
 	 *
 	 */
-	std::map<unsigned, CaloRing> getRingDepositions() const {
+	std::map<unsigned, CaloRing>const&  getRingDepositions() const {
 		return energies_;
 	}
 
@@ -138,6 +137,9 @@ public:
 	 * @return a vector of doubles
 	 */
 	std::vector<double> stream(double normalisation = 1.0) const;
+
+	double baryEta() const {return baryEta_;}
+	double baryPhi() const { return baryPhi_;}
 
 private:
 	//Where is the barycentre of this window?
@@ -163,10 +165,11 @@ private:
 	std::map<unsigned, CaloRing> energies_;
 
 
-	friend std::ostream& operator<<(std::ostream& s,
-			const CaloWindow& caloWindow);
 
 };
+
+std::ostream& operator<<(std::ostream& s,
+                         const CaloWindow& caloWindow);
 
 class TestCaloWindow {
 public:

--- a/DataFormats/ParticleFlowReco/interface/PFBlock.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlock.h
@@ -118,8 +118,6 @@ namespace reco {
       return linkData_;
     }
 
-    friend std::ostream& operator<<( std::ostream& out, const PFBlock& co );
-
   private:
     
     /// \return size of linkData_, calculated from the number of elements
@@ -132,6 +130,9 @@ namespace reco {
     edm::OwnVector< reco::PFBlockElement >          elements_;
         
   };
+
+  std::ostream& operator<<( std::ostream& out, const PFBlock& co );
+
 }
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -124,9 +124,6 @@ namespace reco {
     virtual bool isPrimary() const { return false; }
     virtual bool isLinkedToDisplacedVertex() const {return false;}
 
-    friend std::ostream& operator<<( std::ostream& out, 
-                                     const PFBlockElement& element );
-
     // Glowinski & Gouzevitch
     void setMultilinks(const PFMultiLinksTC& ml) {multilinks_ = ml;}
     void setIsValidMultilinks(bool isVal) {multilinks_.isValid = isVal;}
@@ -177,5 +174,9 @@ namespace reco {
     const static VertexCompositeCandidateRef nullVertex_;
   
   };
+
+    std::ostream& operator<<( std::ostream& out, 
+                              const PFBlockElement& element );
+
 }
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -116,9 +116,6 @@ namespace reco {
     
     PFCluster& operator=(const PFCluster&);
     
-    friend    std::ostream& operator<<(std::ostream& out, 
-				       const PFCluster& cluster);
-
     /// \todo move to PFClusterTools
     static void setDepthCorParameters(int mode, 
 				      double a, double b, 
@@ -227,6 +224,11 @@ namespace reco {
     /// color (transient)
     int                 color_;
   };
+
+  std::ostream& operator<<(std::ostream& out, 
+                           const PFCluster& cluster);
+
+
 }
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
@@ -33,9 +33,6 @@ namespace reco {
     /// \return energy fraction
     double fraction() const {return fraction_;}
     
-    friend    std::ostream& operator<<(std::ostream& out,
-                                       const PFRecHitFraction& hit);
-    
   private:
     
     /// corresponding rechit 
@@ -45,6 +42,10 @@ namespace reco {
     double    fraction_;
     
   };
+
+  std::ostream& operator<<(std::ostream& out,
+                           const PFRecHitFraction& hit);
+    
 }
 
 

--- a/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
@@ -59,10 +59,6 @@ namespace reco {
     /// \return the significance of the signed transverse impact parameter
     const float STIP() const{return STIP_;}
 
-  
-    friend  std::ostream& operator<<(std::ostream& out, 
-                                     const PFRecTrack& track);
-
   private:
 
     /// type of fitting algorithm used to reconstruct the track
@@ -77,6 +73,8 @@ namespace reco {
 
   };
 
+  std::ostream& operator<<(std::ostream& out, 
+                           const PFRecTrack& track);
 
 }
 

--- a/DataFormats/ParticleFlowReco/interface/PFSimParticle.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSimParticle.h
@@ -51,9 +51,6 @@ namespace reco {
     std::vector<double> recHitContribFrac() 
       const {return recHitContribFrac_;} 
 
-    friend  std::ostream& operator<<(std::ostream& out, 
-                                     const PFSimParticle& track);
-
   private:
     
     /// pdg code 
@@ -73,6 +70,10 @@ namespace reco {
     std::vector<double>   recHitContribFrac_;
 
   };
+
+  std::ostream& operator<<(std::ostream& out, 
+                           const PFSimParticle& track);
+
 
 }
 

--- a/DataFormats/ParticleFlowReco/interface/PFSuperCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSuperCluster.h
@@ -41,9 +41,6 @@ namespace reco {
     
     PFSuperCluster& operator=(const PFSuperCluster&);
     
-    friend    std::ostream& operator<<(std::ostream& out, 
-				       const PFSuperCluster& cluster);
-
   private:
     
     /// vector of clusters
@@ -51,6 +48,10 @@ namespace reco {
     
     friend class ::PFSuperClusterAlgo;
   };
+
+  std::ostream& operator<<(std::ostream& out, 
+                           const PFSuperCluster& cluster);
+
 }
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrack.h
@@ -121,9 +121,6 @@ namespace reco {
     
       int          color() const { return color_; }    
 
-      friend  std::ostream& operator<<(std::ostream& out, 
-                                       const PFTrack& track);
-
     protected:
 
       /// maximal number of tracking layers
@@ -145,6 +142,8 @@ namespace reco {
       int  color_;
 
     };
+    std::ostream& operator<<(std::ostream& out, 
+                             const PFTrack& track);
 
 }
 

--- a/DataFormats/ParticleFlowReco/src/CaloWindow.cc
+++ b/DataFormats/ParticleFlowReco/src/CaloWindow.cc
@@ -65,9 +65,8 @@ void CaloRing::printEnergies(std::ostream& s, double range) {
 
 std::ostream& pftools::operator<<(std::ostream& s,
 		const pftools::CaloRing& caloRing) {
-	for (std::vector<double>::const_iterator it = caloRing.myPanes_.begin(); it
-			!= caloRing.myPanes_.end(); ++it) {
-		s << *it << "\t";
+	for (auto const& e: caloRing.getEnergies()) {
+		s << e << "\t";
 	}
 	s << " => ring E = " << caloRing.totalE();
 	return s;
@@ -76,11 +75,11 @@ std::ostream& pftools::operator<<(std::ostream& s,
 std::ostream& pftools::operator<<(std::ostream& s,
 		const pftools::CaloWindow& caloWindow) {
 
-	s << "CaloWindow at (" << caloWindow.baryEta_ << ", "
-			<< caloWindow.baryPhi_ << "):\n";
+	s << "CaloWindow at (" << caloWindow.baryEta() << ", "
+	  << caloWindow.baryPhi() << "):\n";
 	double totalE(0.0);
 	for (std::map<unsigned, pftools::CaloRing>::const_iterator cit =
-			caloWindow.energies_.begin(); cit != caloWindow.energies_.end(); ++cit) {
+	      caloWindow.getRingDepositions().begin(); cit != caloWindow.getRingDepositions().end(); ++cit) {
 		unsigned ring = (*cit).first;
 		const CaloRing& cr = (*cit).second;
 		s << "Ring " << ring << ":\t" << cr << "\n";

--- a/DataFormats/ParticleFlowReco/src/PFBlock.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlock.cc
@@ -287,11 +287,11 @@ ostream& reco::operator<<(  ostream& out,
     out<<setiosflags(ios::fixed);
     out<<setprecision(1);      
   
-    for(unsigned i=0; i<block.elements_.size(); i++) {
+    for(unsigned i=0; i<block.elements().size(); i++) {
       if ( !toPrint[i] ) continue;
       out<<"\t";
       out <<setw(width) << elid[i];
-      for(unsigned j=0; j<block.elements_.size(); j++) {
+      for(unsigned j=0; j<block.elements().size(); j++) {
 	if ( !toPrint[j] ) continue;
         double Dist = block.dist(i,j, block.linkData());//,PFBlock::LINKTEST_ALL);
 
@@ -308,23 +308,23 @@ ostream& reco::operator<<(  ostream& out,
     out<<"\t" << setw(width) << " ";
     for(unsigned ie=0; ie<elid.size(); ie++) 
       if ( toPrint[ie] && 
-	   ( block.elements_[ie].type() == PFBlockElement::TRACK ||
-	     block.elements_[ie].type() == PFBlockElement::GSF )) 
+	   ( block.elements()[ie].type() == PFBlockElement::TRACK ||
+	     block.elements()[ie].type() == PFBlockElement::GSF )) 
 	out <<setw(width)<< elid[ie];
     out<<endl;  
     out<<setiosflags(ios::fixed);
     out<<setprecision(1);      
   
-    for(unsigned i=0; i<block.elements_.size(); i++) {
+    for(unsigned i=0; i<block.elements().size(); i++) {
       if ( !toPrint[i] || 
-	   (block.elements_[i].type() != PFBlockElement::TRACK &&
-	    block.elements_[i].type() != PFBlockElement::GSF )) continue;
+	   (block.elements()[i].type() != PFBlockElement::TRACK &&
+	    block.elements()[i].type() != PFBlockElement::GSF )) continue;
       out<<"\t";
       out <<setw(width) << elid[i];
-      for(unsigned j=0; j<block.elements_.size(); j++) {
+      for(unsigned j=0; j<block.elements().size(); j++) {
 	if ( !toPrint[j] || 
-	     (block.elements_[j].type() != PFBlockElement::TRACK &&
-	      block.elements_[j].type() != PFBlockElement::GSF )) continue;
+	     (block.elements()[j].type() != PFBlockElement::TRACK &&
+	      block.elements()[j].type() != PFBlockElement::GSF )) continue;
 	double Dist = block.dist(i,j, block.linkData());//,PFBlock::LINKTEST_ALL);
 
 	// out<<setw(width)<< Dist*1000.;

--- a/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
@@ -33,10 +33,10 @@ std::ostream& reco::operator<<( std::ostream& out,
   
   if(! out) return out;
   
-  out<<"element "<<element.index()<<"- type "<<element.type_<<" ";
+  out<<"element "<<element.index()<<"- type "<<element.type()<<" ";
   
   try {
-    switch(element.type_) {
+    switch(element.type()) {
     case PFBlockElement::TRACK:
       {
         const reco::PFBlockElementTrack& et =

--- a/DataFormats/ParticleFlowReco/src/PFRecTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecTrack.cc
@@ -52,10 +52,10 @@ std::ostream& reco::operator<<(std::ostream& out,
       << "\tnumber of tracker measurements = " 
       << track.nTrajectoryMeasurements() << std::endl
       <<"\tnumber of points total = "
-      << track.trajectoryPoints_.size()<< std::endl;
+      << track.trajectoryPoints().size()<< std::endl;
 
-  for(unsigned i=0; i<track.trajectoryPoints_.size(); i++) 
-    out<<track.trajectoryPoints_[i]<<std::endl;
+  for(unsigned i=0; i<track.trajectoryPoints().size(); i++) 
+    out<<track.trajectoryPoints()[i]<<std::endl;
 
 
   return out;

--- a/DataFormats/ParticleFlowReco/src/PFSimParticle.cc
+++ b/DataFormats/ParticleFlowReco/src/PFSimParticle.cc
@@ -177,8 +177,8 @@ ostream& reco::operator<<(ostream& out,
   out<<resetiosflags(ios::right|ios::fixed);
   
   out<<"\tdaughters : ";
-  for(unsigned i=0; i<particle.daughterIds_.size(); i++) 
-    out<<particle.daughterIds_[i]<<" ";
+  for(unsigned i=0; i<particle.daughterIds().size(); i++) 
+    out<<particle.daughterIds()[i]<<" ";
   
   //   out<<endl;
   //   for(unsigned i=0; i<particle.trajectoryPoints_.size(); i++) 

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -110,8 +110,8 @@ ostream& reco::operator<<(ostream& out,
      <<" Z0 = "<<closestApproach.position().Z()<<endl
      <<"\tnumber of tracker measurements = " 
      <<track.nTrajectoryMeasurements()<<endl;
-  for(unsigned i=0; i<track.trajectoryPoints_.size(); i++) 
-    out<<track.trajectoryPoints_[i]<<endl;
+  for(unsigned i=0; i<track.trajectoryPoints().size(); i++) 
+    out<<track.trajectoryPoints()[i]<<endl;
   
 
   return out;


### PR DESCRIPTION
The gcc 6.2 compiler was complaining about operator<< for various
ParticleFlow data products not being in the proper namespace. As
part of the cleanup of the warnings all the operator<< are no longer
friends of the classes (since they can all use public methods).