### PR TITLE
Added the differential fC/ADC gain calculation to HCAL QIE8 and QIE11

### DIFF
--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -20,10 +20,11 @@
    <class name="HFPreRecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="224636588"/>
    </class>
-   <class name="HBHEChannelInfo" ClassVersion="5">
+   <class name="HBHEChannelInfo" ClassVersion="6">
     <version ClassVersion="3" checksum="184305963"/>
     <version ClassVersion="4" checksum="1052948187"/>
     <version ClassVersion="5" checksum="2422402317"/>
+    <version ClassVersion="6" checksum="1871847034"/>
    </class>
    <class name="HFRecHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3957655113"/>

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -164,7 +164,7 @@ namespace {
             const float upGain = qup - q;
             const float downGain = q - qdown;
             const float averageGain = (qup - qdown)/2.f;
-            if (std::abs(upGain - downGain)/averageGain < 0.01f)
+            if (std::abs(upGain - downGain) < 0.01f*averageGain)
                 return averageGain;
             else
             {

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <cmath>
 #include <utility>
 #include <algorithm>
 
@@ -133,6 +134,56 @@ namespace {
     float getTDCTimeFromSample(const HcalQIESample&)
     {
         return HcalSpecialTimes::UNKNOWN_T_NOTDC;
+    }
+
+    float getDifferentialChargeGain(const HcalQIECoder& coder,
+                                    const HcalQIEShape& shape,
+                                    const unsigned adc,
+                                    const unsigned capid,
+                                    const bool isQIE11)
+    {
+        // We have 5-bit ADC mantissa in QIE8 and 6-bit in QIE11
+        static const unsigned mantissaMaskQIE8 = 0x1f;
+        static const unsigned mantissaMaskQIE11 = 0x3f;
+
+        const float q = coder.charge(shape, adc, capid);
+        const unsigned mantissaMask = isQIE11 ? mantissaMaskQIE11 : mantissaMaskQIE8;
+        const unsigned mantissa = adc & mantissaMask;
+
+        // First, check if we are in the two lowest or two highest ADC
+        // values for this range. Assume that they have the lowest and
+        // the highest gain in the range, respectively.
+        if (mantissa == 0U || mantissa == mantissaMask - 1U)
+            return coder.charge(shape, adc+1U, capid) - q;
+        else if (mantissa == 1U || mantissa == mantissaMask)
+            return q - coder.charge(shape, adc-1U, capid);
+        else
+        {
+            const float qup = coder.charge(shape, adc+1U, capid);
+            const float qdown = coder.charge(shape, adc-1U, capid);
+            const float upGain = qup - q;
+            const float downGain = q - qdown;
+            const float averageGain = (qup - qdown)/2.f;
+            if (std::abs(upGain - downGain)/averageGain < 0.01f)
+                return averageGain;
+            else
+            {
+                // We are in the gain transition region.
+                // Need to determine if we are in the lower
+                // gain ADC count or in the higher one.
+                // This can be done by figuring out if the
+                // "up" gain is more consistent then the
+                // "down" gain.
+                const float q2up = coder.charge(shape, adc+2U, capid);
+                const float q2down = coder.charge(shape, adc-2U, capid);
+                const float upGain2 = q2up - qup;
+                const float downGain2 = qdown - q2down;
+                if (std::abs(upGain2 - upGain) < std::abs(downGain2 - downGain))
+                    return upGain;
+                else
+                    return downGain;
+            }
+        }
     }
 
     // The first element of the pair indicates presence of optical
@@ -399,11 +450,11 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         const HcalCoderDb coder(*channelCoder, *shape);
         const RawChargeFromSample<DFrame> rcfs(cond, cell);
 
-	// needed for the dark current in the M2
-	const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
-	const double darkCurrent = siPMParameter.getDarkCurrent();
-	const double fcByPE = siPMParameter.getFCByPE();
-	const double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
+        // needed for the dark current in the M2
+        const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
+        const double darkCurrent = siPMParameter.getDarkCurrent();
+        const double fcByPE = siPMParameter.getFCByPE();
+        const double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
 
         // ADC to fC conversion
         CaloSamples cs;
@@ -419,24 +470,28 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         for (int ts = 0; ts < maxTS; ++ts)
         {
             auto s(frame[ts]);
+            const uint8_t adc = s.adc();
             const int capid = s.capid();
             const double pedestal = calib.pedestal(capid);
             const double pedestalWidth = calibWidth.pedestal(capid);
             const double gain = calib.respcorrgain(capid);
-	    const double gainWidth = calibWidth.gain(capid);
+            const double gainWidth = calibWidth.gain(capid);
             const double rawCharge = rcfs.getRawCharge(cs[ts], pedestal);
             const float t = getTDCTimeFromSample(s);
-            channelInfo->setSample(ts, s.adc(), rawCharge, pedestal, pedestalWidth, gain, gainWidth, t);
+            const float dfc = getDifferentialChargeGain(*channelCoder, *shape, adc,
+                                                        capid, channelInfo->hasTimeInfo());
+            channelInfo->setSample(ts, adc, dfc, rawCharge,
+                                   pedestal, pedestalWidth,
+                                   gain, gainWidth, t);
             if (ts == soi)
                 soiCapid = capid;
         }
 
-
         // Fill the overall channel info items
-	const int pulseShapeID = param_ts->pulseShapeID();
+        const int pulseShapeID = param_ts->pulseShapeID();
         const std::pair<bool,bool> hwerr = findHWErrors(frame, maxTS);
         channelInfo->setChannelInfo(cell, pulseShapeID, maxTS, soi, soiCapid,
-				    darkCurrent, fcByPE, lambda,
+                                    darkCurrent, fcByPE, lambda,
                                     hwerr.first, hwerr.second,
                                     taggedBadByDb || dropByZS);
 


### PR DESCRIPTION
The differential fC/ADC gain has been added to the HBHEChannelInfo object in order to use correct QIE quantization error in Method 2.

Some of the tabs in the code have been replaced with spaces for better formatting in LXR, etc.
