### PR TITLE
Fix gcc 6.2 compiler warnings for SiPixelObjects

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelChannel.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelChannel.h
@@ -34,8 +34,6 @@ namespace pos{
 
     std::string channelname() const;
 
-    friend std::ostream& operator<<(std::ostream& s, const PixelChannel& channel);
-
     // allows for use of find() function in a map of PixelChannels
     const bool operator<(const PixelChannel& aChannel) const{
       return (module_<aChannel.module_ || (module_==aChannel.module_ && TBMChannel_ < aChannel.TBMChannel_) );
@@ -49,6 +47,8 @@ namespace pos{
     PixelModuleName module_    ;
     PixelTBMChannel TBMChannel_;
   };
+
+  std::ostream& operator<<(std::ostream& s, const PixelChannel& channel);
 }
 
 #endif

--- a/CalibFormats/SiPixelObjects/interface/PixelROCDACSettings.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelROCDACSettings.h
@@ -19,6 +19,9 @@ namespace pos{
   typedef unsigned char bits8;
   typedef unsigned char bits4;
 
+  class PixelROCDACSettings;
+  std::ostream& operator<<(std::ostream& s, const PixelROCDACSettings& dacs);
+
 /*! \class PixelROCDACSettings PixelROCDACSettings.h "interface/PixelROCDACSettings.h"
 *   \brief This class implements..
 *

--- a/CalibFormats/SiPixelObjects/interface/PixelROCMaskBits.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelROCMaskBits.h
@@ -12,6 +12,10 @@
 #include "CalibFormats/SiPixelObjects/interface/PixelROCName.h"
 
 namespace pos{
+
+  class PixelROCMaskBits;
+  std::ostream& operator<<(std::ostream& s, const PixelROCMaskBits& maskbits);
+
 /*! \class PixelROCMaskBits PixelROCMaskBits.h "interface/PixelROCMaskBits.h"
 *   \brief This class implements..
 *

--- a/CalibFormats/SiPixelObjects/interface/PixelROCTrimBits.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelROCTrimBits.h
@@ -17,6 +17,10 @@ namespace pos{
 *
 *   A longer explanation will be placed here later
 */
+  class PixelROCTrimBits;
+  std::ostream& operator<<(std::ostream& s, const PixelROCTrimBits& trimbits);
+
+
   class PixelROCTrimBits {
 
   public:

--- a/CalibFormats/SiPixelObjects/interface/PixelTBMSettings.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTBMSettings.h
@@ -59,20 +59,19 @@ namespace pos{
 				  std::ofstream *out2 = NULL
 				  ) const ;
 
-    friend std::ostream& operator<<(std::ostream& s, const PixelTBMSettings& mask);
-
-    unsigned char getAnalogInputBias() {return analogInputBias_;}
+    unsigned char getAnalogInputBias() const {return analogInputBias_;}
     void setAnalogInputBias(unsigned char analogInputBias) {analogInputBias_=analogInputBias;}
     
-    unsigned char getAnalogOutputBias() {return analogOutputBias_;}
+    unsigned char getAnalogOutputBias() const {return analogOutputBias_;}
     void setAnalogOutputBias(unsigned char analogOutputBias) {analogOutputBias_=analogOutputBias;}
     
-    unsigned char getAnalogOutputGain() {return analogOutputGain_;}
+    unsigned char getAnalogOutputGain() const {return analogOutputGain_;}
     void setAnalogOutputGain(unsigned char analogOutputGain) {analogOutputGain_=analogOutputGain;}
     
     // Added by Dario (Apr 2008)
-    bool getMode(void)      {return singlemode_;}
+    bool getMode(void)      const {return singlemode_;}
     void setMode(bool mode) {singlemode_ = mode;}
+    PixelROCName const& getROCName() const { return rocid_;}
     void setROCName(std::string rocname){
       	PixelROCName tmp(rocname);
 	rocid_=tmp;
@@ -90,6 +89,8 @@ namespace pos{
     bool singlemode_;
 
   };
+
+  std::ostream& operator<<(std::ostream& s, const PixelTBMSettings& mask);
 }
 /* @} */
 #endif

--- a/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
@@ -318,11 +318,11 @@ void PixelTBMSettings::generateConfiguration(PixelFECConfigInterface* pixelFEC,
 
 std::ostream& pos::operator<<(std::ostream& s, const PixelTBMSettings& tbm){
 
-    s << "Module          :"<<tbm.rocid_.rocname() <<std::endl; 
-    s << "analogInputBias :"<<tbm.analogInputBias_<<std::endl;
-    s << "analogOutputBias:"<<tbm.analogOutputBias_<<std::endl;
-    s << "analogOutputGain:"<<tbm.analogOutputGain_<<std::endl;
-    if (tbm.singlemode_){
+    s << "Module          :"<<tbm.getROCName().rocname() <<std::endl; 
+    s << "analogInputBias :"<<tbm.getAnalogInputBias()<<std::endl;
+    s << "analogOutputBias:"<<tbm.getAnalogOutputBias()<<std::endl;
+    s << "analogOutputGain:"<<tbm.getAnalogOutputGain()<<std::endl;
+    if (tbm.getMode()){
       s << "mode            :Singlemode"<<std::endl;
     }
     else{


### PR DESCRIPTION
The operator<< needs to be in the same namespace as the class.