### PR TITLE
SimG4CMS packages: Fix clang warnings about absolute value use.

### DIFF
--- a/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
+++ b/SimG4CMS/Calo/src/EnergyResolutionVsLumi.cc
@@ -71,7 +71,7 @@ void  EnergyResolutionVsLumi::calcmuTot(){
     if(iEta==0) continue;
 
       double eta=EBDetId::approxEta(EBDetId(iEta,1));
-      eta = fabs(eta);
+      eta = std::abs(eta);
       double r= calcmuTot(eta);
       
       mu_eta[iEta]=r;
@@ -85,7 +85,7 @@ void  EnergyResolutionVsLumi::calcmuTot(){
 	{
 	  EEDetId eedetidpos(iX,iY,1);
 	  double eta= -log(tan(0.5*atan(sqrt((iX-50.0)*(iX-50.0)+(iY-50.0)*(iY-50.0))*2.98/328.)));
-          eta = fabs(eta);
+          eta = std::abs(eta);
           double r=calcmuTot(eta);
           double v=calcampDropPhotoDetector(eta);
 
@@ -104,7 +104,7 @@ double EnergyResolutionVsLumi::calcLightCollectionEfficiencyWeighted(DetId id, d
   double muTot=0;
   if(id.subdetId()==EcalBarrel) {
     EBDetId ebId(id);
-    int ieta= fabs(ebId.ieta());
+    int ieta= std::abs(ebId.ieta());
     muTot= mu_eta[ieta];
     
   } else if(id.subdetId()==EcalEndcap){
@@ -188,7 +188,7 @@ double EnergyResolutionVsLumi::calcnoiseADC(double eta)
   double Nadc = 1.1;
   double result =1.0;
   EvolutionECAL model;
-  if(fabs(eta)<1.497){
+  if(std::abs(eta)<1.497){
     Nadc = 1.1;
     result = model.NoiseFactorFE(totLumi, eta)*Nadc;
   }else{

--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -59,7 +59,7 @@ CastorShowerLibraryMaker::CastorShowerLibraryMaker(const edm::ParameterSet &p) :
 //
   NPGParticle               = PGParticleIDs.size(); 
   for(unsigned int i=0;i<PGParticleIDs.size();i++) {
-     switch (int(fabs(PGParticleIDs.at(i)))) {
+     switch (int(std::abs(PGParticleIDs.at(i)))) {
         case 11:
         case 22:
                DoEmSL = true;
@@ -336,7 +336,7 @@ void CastorShowerLibraryMaker::update(const G4Step * aStep) {
 // move track to z of CASTOR
          G4ThreeVector pos;
          pos.setZ(-14390);
-         double t = abs((pos.z()-trk->GetPosition().z()))/trk->GetVelocity();
+         double t = std::abs((pos.z()-trk->GetPosition().z()))/trk->GetVelocity();
          double r = (pos.z()-trk->GetPosition().z())/trk->GetMomentum().cosTheta();
          pos.setX(r*sin(trk->GetMomentum().theta())*cos(trk->GetMomentum().phi())+trk->GetPosition().x());
          pos.setY(r*sin(trk->GetMomentum().theta())*sin(trk->GetMomentum().phi())+trk->GetPosition().y());

--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -59,7 +59,7 @@ CastorShowerLibraryMaker::CastorShowerLibraryMaker(const edm::ParameterSet &p) :
 //
   NPGParticle               = PGParticleIDs.size(); 
   for(unsigned int i=0;i<PGParticleIDs.size();i++) {
-     switch (int(std::abs(PGParticleIDs.at(i)))) {
+     switch (std::abs(PGParticleIDs.at(i))) {
         case 11:
         case 22:
                DoEmSL = true;


### PR DESCRIPTION
Replace abs/fabs with std::abs which has a signature for ints and floats.
Fixed misplaced parens which result in absolute values of a bool.
The absolute value of unsigned vars is meaningless. Cast to signed vars
to prevent difference from wrapping to unsigned var max value.