### PR TITLE
SimTracker packages: Fix clang warnings about absolute value use.

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1939,12 +1939,12 @@ void SiPixelDigitizerAlgorithm::module_killing_DB(uint32_t detID) {
       
       for(std::vector<GlobalPixel>::const_iterator it = badrocpositions.begin(); it != badrocpositions.end(); ++it){
 	if(it->row >= 80 && ip.first >= 80 ){
-	  if((fabs(ip.second - it->col) < 26) ) {i->second.set(0.);}
+	  if((std::abs(ip.second - it->col) < 26) ) {i->second.set(0.);}
           else if(it->row==120 && ip.second-it->col==26){i->second.set(0.);}
           else if(it->row==119 && it->col-ip.second==26){i->second.set(0.);}
 	}
 	else if(it->row < 80 && ip.first < 80 ){
-	  if((fabs(ip.second - it->col) < 26) ){i->second.set(0.);}
+	  if((std::abs(ip.second - it->col) < 26) ){i->second.set(0.);}
           else if(it->row==40 && ip.second-it->col==26){i->second.set(0.);}
           else if(it->row==39 && it->col-ip.second==26){i->second.set(0.);}
        }

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -292,7 +292,7 @@ induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_poin
       size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
       size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
       for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at(abs( affectedStrip - strip )) ;
+	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at((size_t)std::abs( (int)affectedStrip - (int)strip )) ;
       }
 
       if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;


### PR DESCRIPTION
Replace abs/fabs with std::abs which has a signature for ints and floats.
Fixed misplaced parens which result in absolute values of a bool.
The absolute value of unsigned vars is meaningless. Cast to signed vars
to prevent difference from wrapping to unsigned var max value.