### PR TITLE
SimMuon packages: Fix clang warnings about absolute value use.

### DIFF
--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -125,7 +125,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
         << "Check detId " << detId << " digi " << me0Digi << std::endl;
 
       // selection
-      if (reDigitizeOnlyMuons_ and fabs(me0Digi.pdgid()) != 13) continue;
+      if (reDigitizeOnlyMuons_ and std::abs(me0Digi.pdgid()) != 13) continue;
       if (!reDigitizeNeutronBkg_ and !me0Digi.prompt()) continue;
 
       // scale for luminosity


### PR DESCRIPTION
Replace abs/fabs with std::abs which has a signature for ints, doubles and floats.
Fixed misplaced parens which result in absolute values of a bool.
The absolute value of unsigned vars is meaningless. Cast to signed vars
to prevent difference from wrapping to unsigned var max value.