### PR TITLE
TrackPropagation packages: Fix clang warnings about absolute value use.

### DIFF
--- a/TrackPropagation/NavGeometry/test/stubs/HelixPropagationTestGenerator.cc
+++ b/TrackPropagation/NavGeometry/test/stubs/HelixPropagationTestGenerator.cc
@@ -159,8 +159,8 @@ HelixPropagationTestGenerator::bidirectionalStep (const ExtendedDouble stepSize)
   //
   // recalculate position and direction in double precision
   //
-  currentPosition = VectorTypeExtended(theCenter.x()+cos(phiHelix)/fabs(theCurvature),
-				       theCenter.y()+sin(phiHelix)/fabs(theCurvature),
+  currentPosition = VectorTypeExtended(theCenter.x()+cos(phiHelix)/std::abs(theCurvature),
+				       theCenter.y()+sin(phiHelix)/std::abs(theCurvature),
 				       theCenter.z()+dPhi/theCurvature*startDirection.z()/startDirection.perp());
   currentDirection = VectorTypeExtended(cos(startDirection.phi()+dPhi)*startDirection.perp(),
 					sin(startDirection.phi()+dPhi)*startDirection.perp(),

--- a/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
+++ b/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
@@ -22,7 +22,7 @@ public:
 
     RK4OneStepTempl<T,N> solver;
     Vector one(       solver(startPar, startState, deriv, step));
-    if (std::abs(one[0])>huge || std::abs(one(1)>huge)) return std::pair<Vector, Scalar>(one,hugediff);
+    if (std::abs(one[0])>huge || std::abs(one(1))>huge) return std::pair<Vector, Scalar>(one,hugediff);
 
     Vector firstHalf( solver(startPar, startState, deriv, step/2));
     Vector secondHalf(solver(startPar+step/2, firstHalf, deriv, step/2));


### PR DESCRIPTION
Replace abs/fabs with std::abs which has a signature for ints, doubles and floats.
Fixed misplaced parens which result in absolute values of a bool.
The absolute value of unsigned vars is meaningless. Cast to signed vars
to prevent difference from wrapping to unsigned var max value.