### PR TITLE
Stop gcc 6.2 warnings in PFClusterTools

### DIFF
--- a/RecoParticleFlow/PFClusterTools/interface/Deposition.h
+++ b/RecoParticleFlow/PFClusterTools/interface/Deposition.h
@@ -59,11 +59,6 @@ public:
 
 	virtual ~Deposition();
 
-	/*
-	 * Streams a description of this deposition into the supplied stream.
-	 * */
-	friend std::ostream& operator<<(std::ostream& s, const Deposition& d);
-
 private:
 	//DetectorElement* myElement;
 	DetectorElementPtr myElementPtr;
@@ -76,6 +71,11 @@ private:
 
 typedef boost::shared_ptr<Deposition> DepositionPtr;
 
+/*
+ * Streams a description of this deposition into the supplied stream.
+ * */
+std::ostream& operator<<(std::ostream& s, const Deposition& d);
+ 
 }
 
 #endif /*DEPOSITION_HH_*/

--- a/RecoParticleFlow/PFClusterTools/interface/ParticleDeposit.h
+++ b/RecoParticleFlow/PFClusterTools/interface/ParticleDeposit.h
@@ -79,8 +79,6 @@ public:
 
 	double getTargetFunctionContrib() const;
 
-	friend std::ostream& operator<<(std::ostream& s, const ParticleDeposit& p);
-
 private:
 	static unsigned count;
 	//ParticleDeposit(const ParticleDeposit& pd);
@@ -101,6 +99,7 @@ private:
 
 
 typedef boost::shared_ptr<ParticleDeposit> ParticleDepositPtr;
+std::ostream& operator<<(std::ostream& s, const ParticleDeposit& p);
 
 }
 


### PR DESCRIPTION
Made operator<< no longer a friend and declared it in the same
namespace as the class.