### PR TITLE
Stop gcc 6.2 warning in HFShowerLibrary

### DIFF
--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -126,7 +126,8 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
 
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
-  if (fibre)  delete   fibre;  fibre  = 0;
+  if (fibre)  delete   fibre;
+  fibre  = 0;
   if (photo)  delete photo;
 }
 


### PR DESCRIPTION
gcc complained that a statement after an 'if' was not protected
by the 'if'. Moving the statement to a line after stops the warning.