### PR TITLE
updating pA autoconditions for 90X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '90X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '90X_mcRun2_pA_v0',
+    'run2_mc_pa'        :   '90X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '90X_dataRun2_v0',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
Update to latest GT with updated reco BS.  Needed for self-consistency of relval wf 281 after #16786 