### PR TITLE
updating pA autoconditions for 80X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v12',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '80X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '80X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v19',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
Update to latest GT with updated reco BS. Needed for self-consistency of relval wf 281 after #16787 
Unfortunately, this GT crashes wf 281, seemingly due to an update to the L1 menu.  @mmusich can you please advise?  The error is as follows. 

%MSG-e GlobalObjectMapRecord:  HLTL1TSeed:hltL1sCastorMediumJetBptxAND  10-Dec-2016 10:29:47 CET Run: 1 Event: 1


  ERROR: The requested algorithm name = L1_CastorMediumJet_BptxAND
  does not exists in the trigger menu.
  Returning zero pointer for getObjectMap


%MSG
----- Begin Fatal Exception 10-Dec-2016 10:29:47 CET-----------------------
An exception of category 'FailModule' occurred while
   [0] Processing run: 1 lumi: 1 event: 1
   [1] Running path 'HLT_PAL1CastorMediumJet_BptxAND_v1'
   [2] Calling event method for module HLTL1TSeed/'hltL1sCastorMediumJetBptxAND'
Exception Message:

Algorithm L1_CastorMediumJet_BptxAND, requested as seed by a HLT path, cannot be matched to a L1 algo name in any GlobalObjectMap
Please check if algorithm L1_CastorMediumJet_BptxAND is present in the L1 menu