### PR TITLE
Fixed gcc620 warning in OscarProducer

### DIFF
--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -55,7 +55,6 @@ namespace {
         StaticRandomEngineSetUnset(edm::StreamID const&);
         explicit StaticRandomEngineSetUnset(CLHEP::HepRandomEngine * engine);
         ~StaticRandomEngineSetUnset();
-        CLHEP::HepRandomEngine* getEngine() const;
     private:
         CLHEP::HepRandomEngine* m_currentEngine;
         CLHEP::HepRandomEngine* m_previousEngine;
@@ -260,11 +259,6 @@ StaticRandomEngineSetUnset::StaticRandomEngineSetUnset(
 StaticRandomEngineSetUnset::~StaticRandomEngineSetUnset() 
 {
   G4Random::setTheEngine(m_previousEngine);
-}
-
-CLHEP::HepRandomEngine* StaticRandomEngineSetUnset::getEngine() const 
-{ 
-  return m_currentEngine; 
 }
 
 DEFINE_FWK_MODULE(OscarMTProducer);

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -53,7 +53,6 @@ namespace {
         StaticRandomEngineSetUnset(edm::StreamID const&);
         explicit StaticRandomEngineSetUnset(CLHEP::HepRandomEngine * engine);
         ~StaticRandomEngineSetUnset();
-        CLHEP::HepRandomEngine* getEngine() const;
     private:
         CLHEP::HepRandomEngine* m_currentEngine;
         CLHEP::HepRandomEngine* m_previousEngine;
@@ -255,11 +254,6 @@ StaticRandomEngineSetUnset::StaticRandomEngineSetUnset(
 StaticRandomEngineSetUnset::~StaticRandomEngineSetUnset() 
 {
   G4Random::setTheEngine(m_previousEngine);
-}
-
-CLHEP::HepRandomEngine* StaticRandomEngineSetUnset::getEngine() const 
-{ 
-  return m_currentEngine; 
 }
 
 DEFINE_FWK_MODULE(OscarProducer);


### PR DESCRIPTION
The same method is removed from both producers, because it is not used and will be not used.