### PR TITLE
Drop the customisation of the GT connection string for online DQM.

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,4 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
 GlobalTag.globaltag = "80X_dataRun2_HLT_v12"


### PR DESCRIPTION
The online filter farm is going to be equipped with:
* a site local config handling the connection to the local squid caches for retrieving conditions: the squid cache hierarchy is in fact configured using the network topology. This implies that the frontier connection string does not contain anymore the proxy and server URLs, as well as any further connection configuration parameters;
* a new frontier production servlet, pointing to the online production Database, namely `FrontierProd`. As a consequence, the online connection string will be exactly the same as the one used at any other computing tiers. The production string, as defined in `CondCore/ESSources/python/CondDBESSource_cfi.py`, becomes then the unique entry point for any condition retrieval in the framework: the site where the CMSSW jobs runs is responsible for configuring the frontier condition access in the site local config.

@fwyzard this is something you might want to watch as well.