### PR TITLE
Speed improvement to HGCDigitizer

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -93,7 +93,7 @@ private :
   std::unique_ptr<HGCEEDigitizer>      theHGCEEDigitizer_;
   std::unique_ptr<HGCHEbackDigitizer>  theHGCHEbackDigitizer_;
   std::unique_ptr<HGCHEfrontDigitizer> theHGCHEfrontDigitizer_;
-
+  
   //geometries
   std::unordered_set<DetId> validIds_;
   const HGCalGeometry* gHGCal_;
@@ -110,6 +110,10 @@ private :
 
   //delay to apply after evaluating time of arrival at the sensitive detector
   float tofDelay_;
+
+  //average occupancies
+  std::array<double,3> averageOccupancies_;
+  uint32_t nEvents_;
 };
 
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -133,6 +133,8 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps,
 //
 void HGCDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& es) 
 {
+  // reserve memory for a full detector
+  simHitAccumulator_->reserve( validIds_.size() );
 }
 
 //
@@ -142,7 +144,9 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   const CaloSubdetectorGeometry* theGeom = ( nullptr == gHGCal_ ? 
 					     static_cast<const CaloSubdetectorGeometry*>(gHcal_) : 
 					     static_cast<const CaloSubdetectorGeometry*>(gHGCal_)  );
-
+  // release memory for unfilled parts of hash table
+  simHitAccumulator_->reserve(simHitAccumulator_->size());
+	
   if( producesEEDigis() ) 
     {
       std::unique_ptr<HGCEEDigiCollection> digiResult(new HGCEEDigiCollection() );
@@ -269,7 +273,6 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
   
   //loop over sorted hits
   nchits = hitRefs.size();
-  simHitAccumulator_->reserve(simHitAccumulator_->size() + nchits);
   for(int i=0; i<nchits; ++i) {
     const int hitidx   = std::get<0>(hitRefs[i]);
     const uint32_t id  = std::get<1>(hitRefs[i]);
@@ -331,7 +334,6 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 	}
     }
   }
-  simHitAccumulator_->reserve(simHitAccumulator_->size());
   hitRefs.clear();
 }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -24,6 +24,8 @@
 using namespace hgc_digi;
 
 namespace {
+  
+  constexpr std::array<double,3> occupancyGuesses = { { 0.5,0.2,0.2 } };
 
   float getPositionDistance(const HGCalGeometry* geom, const DetId& id) {
     return geom->getPosition(id).mag();
@@ -99,7 +101,9 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps,
                            edm::ConsumesCollector& iC) :
   simHitAccumulator_( new HGCSimHitDataAccumulator() ),
   mySubDet_(ForwardSubdetector::ForwardEmpty),
-  refSpeed_(0.1*CLHEP::c_light) //[CLHEP::c_light]=mm/ns convert to cm/ns
+  refSpeed_(0.1*CLHEP::c_light), //[CLHEP::c_light]=mm/ns convert to cm/ns
+  averageOccupancies_(occupancyGuesses),
+  nEvents_(1)
 {
   //configure from cfg
   hitCollection_     = ps.getParameter< std::string >("hitCollection");
@@ -134,7 +138,21 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps,
 void HGCDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& es) 
 {
   // reserve memory for a full detector
-  simHitAccumulator_->reserve( validIds_.size() );
+  unsigned idx = std::numeric_limits<unsigned>::max();
+  switch(mySubDet_) {
+  case ForwardSubdetector::HGCEE:
+    idx = 0;
+    break;
+  case ForwardSubdetector::HGCHEF:
+    idx = 1;
+    break;
+  case ForwardSubdetector::HGCHEB:
+    idx = 2;
+    break;
+  default:
+    break;
+  }
+  simHitAccumulator_->reserve( averageOccupancies_[idx]*validIds_.size() );
 }
 
 //
@@ -144,9 +162,30 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   const CaloSubdetectorGeometry* theGeom = ( nullptr == gHGCal_ ? 
 					     static_cast<const CaloSubdetectorGeometry*>(gHcal_) : 
 					     static_cast<const CaloSubdetectorGeometry*>(gHGCal_)  );
+  
+  ++nEvents_;
+  unsigned idx = std::numeric_limits<unsigned>::max();
+  switch(mySubDet_) {
+  case ForwardSubdetector::HGCEE:
+    idx = 0;
+    break;
+  case ForwardSubdetector::HGCHEF:
+    idx = 1;
+    break;
+  case ForwardSubdetector::HGCHEB:
+    idx = 2;
+    break;
+  default:
+    break;
+  }
   // release memory for unfilled parts of hash table
-  simHitAccumulator_->reserve(simHitAccumulator_->size());
-	
+  if( validIds_.size()*averageOccupancies_[idx] > simHitAccumulator_->size() ) {
+    simHitAccumulator_->reserve(simHitAccumulator_->size());
+  }
+  //update occupancy guess
+  const double thisOcc = simHitAccumulator_->size()/((double)validIds_.size());
+  averageOccupancies_[idx] = (averageOccupancies_[idx]*(nEvents_-1) + thisOcc)/nEvents_;
+  
   if( producesEEDigis() ) 
     {
       std::unique_ptr<HGCEEDigiCollection> digiResult(new HGCEEDigiCollection() );


### PR DESCRIPTION
This PR implements smarter rehashing within the HGCDigitizer classes yielding a factor 7 improvement in speed of that module in high pileup. There is also a scheme to keep the hash table size under control using a running average of the occupancy, this allows us to maintain a slim memory profile and small total number of rehashes.

Results below are with 200PU in D4 using CMSSW_9_0_X_2016-12-11-110.

igprof output before patch:
```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
            0.0  .........       0.02 / 2'873.81     <spontaneous> [1]
           65.4  .........   1'880.77 / 2'121.26     edm::MixingModule::pileAllWorkers(edm::EventPrincipal const&, edm::ModuleCallingContext const*, int, int, int&, edm::EventSetup const&, edm::StreamID const&) [28]
[29]       65.4   1'880.79       0.13 / 1'880.66   edm::MixingModule::accumulateEvent(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&)
           42.2  .........   1'213.16 / 1'213.16     HGCDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, CLHEP::HepRandomEngine*) [30]
            9.7  .........     279.27 / 279.27       void cms::Phase2TrackerDigitizer::accumulate_local<PileUpEventPrincipal>(PileUpEventPrincipal const&, edm::EventSetup const&) [43]
            5.4  .........     154.53 / 154.53       EcalDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [96]
            4.7  .........     134.16 / 134.16       TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [105]
            1.8  .........      52.12 / 52.14        cms::PileupVertexAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [163]
            1.1  .........      30.56 / 30.56        HcalDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, CLHEP::HepRandomEngine*) [616]
            0.5  .........      14.09 / 14.09        CaloTruthAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [1008]
            0.1  .........       1.98 / 1.98         EcalTimeDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [1427]
            0.0  .........       0.68 / 0.68         SiStripDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [1940]
            0.0  .........       0.05 / 0.05         HGCDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [3987]
            0.0  .........       0.04 / 0.04         HcalDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [4145]
            0.0  .........       0.02 / 0.02         cms::Phase2TrackerDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [5949]

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
```

igprof output with patch:
```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
            0.0  .........       0.02 / 1'773.66     <spontaneous> [1]
           46.3  .........     821.99 / 1'062.78     edm::MixingModule::pileAllWorkers(edm::EventPrincipal const&, edm::ModuleCallingContext const*, int, int, int&, edm::EventSetup const&, edm::StreamID const&) [28]
[29]       46.3     822.01       0.11 / 821.90     edm::MixingModule::accumulateEvent(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&)
           15.5  .........     274.75 / 274.75       void cms::Phase2TrackerDigitizer::accumulate_local<PileUpEventPrincipal>(PileUpEventPrincipal const&, edm::EventSetup const&) [40]
            9.6  .........     170.05 / 170.05       HGCDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, CLHEP::HepRandomEngine*) [86]
            8.6  .........     152.25 / 152.25       EcalDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [95]
            7.3  .........     130.35 / 130.35       TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [105]
            2.8  .........      50.13 / 50.19        cms::PileupVertexAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [162]
            1.6  .........      28.95 / 28.95        HcalDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, CLHEP::HepRandomEngine*) [637]
            0.8  .........      13.32 / 13.32        CaloTruthAccumulator::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [1011]
            0.1  .........       1.45 / 1.45         EcalTimeDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [1519]
            0.0  .........       0.56 / 0.56         SiStripDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [2010]
            0.0  .........       0.03 / 0.03         HcalDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [5124]
            0.0  .........       0.02 / 0.02         HGCDigiProducer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [5406]
            0.0  .........       0.02 / 0.02         cms::Phase2TrackerDigitizer::accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) [5409]

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
```

virtual and rss before patch:
```
MemoryReport> Peak virtual size 5676.52 Mbytes
 Key events increasing vsize: 
[2] run: 1 lumi: 1 event: 5  vsize = 3972.17 deltaVsize = 160 rss = 2923.42 delta = 425.906
[6] run: 1 lumi: 1 event: 20  vsize = 4556.52 deltaVsize = 224 rss = 3304.84 delta = 381.422
[8] run: 1 lumi: 1 event: 1  vsize = 5324.52 deltaVsize = 672 rss = 3686.03 delta = 381.188
[9] run: 1 lumi: 1 event: 18  vsize = 5676.52 deltaVsize = 352 rss = 3875.34 delta = 189.309
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[8] run: 1 lumi: 1 event: 1  vsize = 5324.52 deltaVsize = 672 rss = 3686.03 delta = 276.277
[10] run: 1 lumi: 1 event: 37  vsize = 5676.52 deltaVsize = 0 rss = 3687.72 delta = -187.617
[9] run: 1 lumi: 1 event: 18  vsize = 5676.52 deltaVsize = 352 rss = 3875.34 delta = 189.309
```

virtual and rss after patch:
```
MemoryReport> Peak virtual size 5646.11 Mbytes
 Key events increasing vsize: 
[2] run: 1 lumi: 1 event: 5  vsize = 3973.76 deltaVsize = 160 rss = 2930.69 delta = 442.617
[5] run: 1 lumi: 1 event: 7  vsize = 4398.11 deltaVsize = 168 rss = 3194.73 delta = 264.039
[8] run: 1 lumi: 1 event: 1  vsize = 5262.11 deltaVsize = 672 rss = 3718.68 delta = 523.949
[9] run: 1 lumi: 1 event: 18  vsize = 5454.11 deltaVsize = 192 rss = 3851.01 delta = 132.328
[10] run: 1 lumi: 1 event: 37  vsize = 5646.11 deltaVsize = 192 rss = 3870.63 delta = 19.6211
[8] run: 1 lumi: 1 event: 1  vsize = 5262.11 deltaVsize = 672 rss = 3718.68 delta = 317.082
[9] run: 1 lumi: 1 event: 18  vsize = 5454.11 deltaVsize = 192 rss = 3851.01 delta = 132.328
[10] run: 1 lumi: 1 event: 37  vsize = 5646.11 deltaVsize = 192 rss = 3870.63 delta = 19.6211
```