### PR TITLE
RecoTracker/DebugTools: bug fix beginRun not called because of incorrect parameters

### DIFF
--- a/RecoTracker/DebugTools/interface/TestHits.h
+++ b/RecoTracker/DebugTools/interface/TestHits.h
@@ -53,9 +53,9 @@ public:
   ~TestHits();
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/interface/TestHits.h
+++ b/RecoTracker/DebugTools/interface/TestHits.h
@@ -53,7 +53,7 @@ public:
   ~TestHits();
 
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 

--- a/RecoTracker/DebugTools/interface/TestSmoothHits.h
+++ b/RecoTracker/DebugTools/interface/TestSmoothHits.h
@@ -54,9 +54,9 @@ public:
   ~TestSmoothHits();
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/interface/TestSmoothHits.h
+++ b/RecoTracker/DebugTools/interface/TestSmoothHits.h
@@ -54,7 +54,7 @@ public:
   ~TestSmoothHits();
 
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 

--- a/RecoTracker/DebugTools/interface/TestTrackHits.h
+++ b/RecoTracker/DebugTools/interface/TestTrackHits.h
@@ -58,7 +58,7 @@ public:
   ~TestTrackHits();
 
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 

--- a/RecoTracker/DebugTools/interface/TestTrackHits.h
+++ b/RecoTracker/DebugTools/interface/TestTrackHits.h
@@ -58,9 +58,9 @@ public:
   ~TestTrackHits();
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/plugins/TestHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestHits.cc
@@ -34,7 +34,7 @@ TestHits::TestHits(const edm::ParameterSet& iConfig):
 
 TestHits::~TestHits(){}
 
-void TestHits::beginRun(edm::Run & run, const edm::EventSetup& iSetup)
+void TestHits::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
  
   iSetup.get<TrackerDigiGeometryRecord>().get(theG);

--- a/RecoTracker/DebugTools/plugins/TestOutliers.cc
+++ b/RecoTracker/DebugTools/plugins/TestOutliers.cc
@@ -59,7 +59,7 @@ public:
 
 
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endJob() override ;
 
@@ -894,7 +894,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void 
-TestOutliers::beginRun(edm::Run & run, const edm::EventSetup& es)
+TestOutliers::beginRun(edm::Run const& run, const edm::EventSetup& es)
 {
   es.get<TrackerDigiGeometryRecord>().get(theG);
   const bool oldAddDir = TH1::AddDirectoryStatus();

--- a/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
@@ -34,7 +34,7 @@ TestSmoothHits::TestSmoothHits(const edm::ParameterSet& iConfig):
 
 TestSmoothHits::~TestSmoothHits(){}
 
-void TestSmoothHits::beginRun(edm::Run & run, const edm::EventSetup& iSetup)
+void TestSmoothHits::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
  
   iSetup.get<TrackerDigiGeometryRecord>().get(theG);

--- a/RecoTracker/DebugTools/plugins/TestTrackHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestTrackHits.cc
@@ -36,7 +36,7 @@ TestTrackHits::TestTrackHits(const edm::ParameterSet& iConfig):
 
 TestTrackHits::~TestTrackHits(){}
 
-void TestTrackHits::beginRun(edm::Run & run, const edm::EventSetup& iSetup)
+void TestTrackHits::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) 
 {
   iSetup.get<TrackerDigiGeometryRecord>().get(theG);
   iSetup.get<IdealMagneticFieldRecord>().get(theMF);  


### PR DESCRIPTION
This fixes clang warning  hides overloaded virtual function [-Woverloaded-virtual]by adding const to function declaration of beginRun. A potential bug fix because beginRun is now called where it was not before.