### PR TITLE
Cosmetic cleanup SIM interface to field

### DIFF
--- a/SimG4Core/MagneticField/interface/Field.h
+++ b/SimG4Core/MagneticField/interface/Field.h
@@ -13,7 +13,7 @@ namespace sim {
 	 Field(const MagneticField * f, double d);
 	 virtual ~Field();
 	 G4Mag_UsualEqRhs* fieldEquation();
-	 virtual void GetFieldValue(const G4double p[4], G4double* b) const;
+	 virtual void GetFieldValue(const G4double p[4], G4double b[3]) const;
 	 void fieldEquation(G4Mag_UsualEqRhs* e);
       private:
 	 const MagneticField* theCMSMagneticField;

--- a/SimG4Core/MagneticField/interface/Field.h
+++ b/SimG4Core/MagneticField/interface/Field.h
@@ -13,12 +13,15 @@ namespace sim {
 	 Field(const MagneticField * f, double d);
 	 virtual ~Field();
 	 G4Mag_UsualEqRhs* fieldEquation();
-	 virtual void GetFieldValue(const double p[3],double b[3]) const;
+	 virtual void GetFieldValue(const G4double p[4], G4double* b) const;
 	 void fieldEquation(G4Mag_UsualEqRhs* e);
       private:
 	 const MagneticField* theCMSMagneticField;
 	 G4Mag_UsualEqRhs* theFieldEquation;
-	 double theDelta;
+         double theDelta;
+
+         mutable double oldx[3];
+         mutable double oldb[3];
    };
 }
 #endif

--- a/SimG4Core/MagneticField/src/Field.cc
+++ b/SimG4Core/MagneticField/src/Field.cc
@@ -21,7 +21,7 @@ Field::Field(const MagneticField * f, double d)
 
 Field::~Field() {}
 
-void Field::GetFieldValue(const G4double xyz[4], double* bfield) const 
+void Field::GetFieldValue(const G4double xyz[4], G4double bfield[3]) const 
 { 
   if (std::abs(oldx[0]-xyz[0])>theDelta ||
       std::abs(oldx[1]-xyz[1])>theDelta ||

--- a/SimG4Core/MagneticField/src/Field.cc
+++ b/SimG4Core/MagneticField/src/Field.cc
@@ -1,74 +1,48 @@
 #include "SimG4Core/MagneticField/interface/Field.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-//#include "Geometry/Vector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
 #include "G4Mag_UsualEqRhs.hh"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
-
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
-#include "FWCore/Utilities/interface/isFinite.h"
 
 using namespace sim;
 
 G4Mag_UsualEqRhs * Field::fieldEquation() { return theFieldEquation; }
 
 Field::Field(const MagneticField * f, double d) 
-    : G4MagneticField(), theCMSMagneticField(f),theDelta(d)
+  : G4MagneticField(), theCMSMagneticField(f), theDelta(d)
 {
+  for(int i=0; i<3; ++i) {
+    oldx[i] = 1.0e12;
+    oldb[i] = 0.0;
+  }
 }
 
 Field::~Field() {}
 
-void Field::GetFieldValue(const double xyz[3],double bfield[3]) const 
+void Field::GetFieldValue(const G4double xyz[4], double* bfield) const 
 { 
-
-    //
-    // this is another trick to check on a NaN, maybe it's even CPU-faster...
-    // but ler's stick to system function edm::isNotFinite(...) for now
-    //
-    // if ( !(xyz[0]==xyz[0]) || !(xyz[1]==xyz[1]) || !(xyz[2]==xyz[2]) )
-    if ( edm::isNotFinite(xyz[0]+xyz[1]+xyz[2]) != 0 )
+  if (std::abs(oldx[0]-xyz[0])>theDelta ||
+      std::abs(oldx[1]-xyz[1])>theDelta ||
+      std::abs(oldx[2]-xyz[2])>theDelta) 
     {
-       throw SimG4Exception( "SimG4CoreMagneticField: Corrupted Event - NaN detected (position)" ) ;
-    }
-    
-    // Which is worse, thread_local static here, or mutable members?
-    // Mutable members + synchronization would be the most correct. In
-    // practice I know there is (by construction via
-    // RunManagerMT/RunManagerMTWorker) one Field object per thread,
-    // managed via pointers in TLS, so thread_local here is also
-    // "correct", and fastest to write.
-    static thread_local float oldx[3] = {1.0e12,1.0e12,1.0e12};
-    static thread_local double b[3];
-
-    if (theDelta>0. &&
-	fabs(oldx[0]-xyz[0])<theDelta &&
-	fabs(oldx[1]-xyz[1])<theDelta &&
-	fabs(oldx[2]-xyz[2])<theDelta) 
-    {
-	// old b good enough
-	bfield[0] = b[0]; 
-	bfield[1] = b[1]; 
-	bfield[2] = b[2];
-	return;
+      static const float lunit = (float)(1.0/CLHEP::cm);
+      GlobalPoint ggg((float)(xyz[0])*lunit,(float)(xyz[1])*lunit,(float)(xyz[2])*lunit);
+      GlobalVector v = theCMSMagneticField->inTesla(ggg);
+      
+      static const float btesla = (float)CLHEP::tesla;
+      oldb[0] = (G4double)(v.x()*btesla);
+      oldb[1] = (G4double)(v.y()*btesla);
+      oldb[2] = (G4double)(v.z()*btesla);
+      oldx[0] = xyz[0];
+      oldx[1] = xyz[1];
+      oldx[2] = xyz[2];
     }
 
-    const GlobalPoint g(xyz[0]/cm,xyz[1]/cm,xyz[2]/cm);
-    GlobalVector v = theCMSMagneticField->inTesla(g);
-    b[0] = v.x()*tesla;
-    b[1] = v.y()*tesla;
-    b[2] = v.z()*tesla;
-
-    oldx[0] = xyz[0]; 
-    oldx[1] = xyz[1]; 
-    oldx[2] = xyz[2];
-
-    bfield[0] = b[0]; 
-    bfield[1] = b[1]; 
-    bfield[2] = b[2];
+  bfield[0] = oldb[0]; 
+  bfield[1] = oldb[1]; 
+  bfield[2] = oldb[2];
 }
 
 void Field::fieldEquation(G4Mag_UsualEqRhs* e) { theFieldEquation = e; }

--- a/SimG4Core/MagneticField/src/FieldBuilder.cc
+++ b/SimG4Core/MagneticField/src/FieldBuilder.cc
@@ -122,8 +122,17 @@ void FieldBuilder::configureForVolume( const std::string& volName,
   if (fP!=nullptr) configurePropagatorInField(fP);	
 
   edm::LogInfo("SimG4CoreApplication") 
-    << " FieldBuilder: Selected stepper: <" << stepper 
-    << ">  const field delta(mm)= " << delta;
+    << " FieldBuilder: Selected stepper:     <" << stepper << ">\n" 
+    << "               Field type            <" << fieldType<< ">\n"
+    << "               Field const delta(mm)= " << delta << "\n"
+    << "               MinStep(mm)            " << minStep<< "\n"
+    << "               DeltaChord(mm)         " << dChord<< "\n"
+    << "               DeltaOneStep(mm)       " << dOneStep<< "\n"
+    << "               DeltaIntersection(mm)  " << dIntersection<< "\n"
+    << "               IntersectionAndOneStep " << dIntersectionAndOneStep<< "\n"
+    << "               MaximumLoopCounts      " << maxLoopCount<< "\n"
+    << "               MinimumEpsilonStep     " << minEpsilonStep<< "\n"
+    << "               MaximumEpsilonStep     " << maxEpsilonStep;
 }
 
 G4LogicalVolume * FieldBuilder::fieldTopVolume() { return theTopVolume; }


### PR DESCRIPTION
Modifications in Field: use local  mutable variable instead of tls, reduce number of operations and remove unnecessary checks. This method is called several times at a simulation step, so minor optimisation is useful.  

In FieldBuilder a LogInfo with the full list of simulation parameters is added.

Overall should bring a tiny speadup.