### PR TITLE
CalibTracker-SiStripLorentzAngle: potential bug beginRun now called

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
@@ -35,7 +35,7 @@ class SiStripLAProfileBooker : public edm::EDAnalyzer
   
   ~SiStripLAProfileBooker();
   
-  void beginRun(const edm::EventSetup& c);
+  void beginRun(edm::Run const&,const edm::EventSetup& c);
   
   void endJob(); 
   

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -68,7 +68,7 @@ SiStripLAProfileBooker::SiStripLAProfileBooker(edm::ParameterSet const& conf) :
 
   //BeginRun
 
-void SiStripLAProfileBooker::beginRun(const edm::EventSetup& c){
+void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c){
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;


### PR DESCRIPTION
because beginRun parameters were corrected to match base class to
fix clang warning hides overloaded virtual function [-Woverloaded-virtual]