### PR TITLE
Calibration/EcalAlCaRecoProducers: fix clang warnings

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/src/ValueMapTraslator.cc
+++ b/Calibration/EcalAlCaRecoProducers/src/ValueMapTraslator.cc
@@ -50,14 +50,7 @@ class ValueMapTraslator : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() ;
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-      
-      virtual void beginRun(edm::Run&, edm::EventSetup const&);
-      virtual void endRun(edm::Run&, edm::EventSetup const&);
-      virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-      virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
 
       // ----------member data ---------------------------
   edm::InputTag referenceCollectionTAG,oldreferenceCollectionTAG;
@@ -175,41 +168,6 @@ ValueMapTraslator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    iEvent.put(std::move(valueVectorPtr));
    
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-ValueMapTraslator::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-ValueMapTraslator::endJob() {
-}
-
-// ------------ method called when starting to processes a run  ------------
-void 
-ValueMapTraslator::beginRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a run  ------------
-void 
-ValueMapTraslator::endRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void 
-ValueMapTraslator::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void 
-ValueMapTraslator::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
because beginRun parameters were corrected to match base class to
fix clang warning hides overloaded virtual function [-Woverloaded-virtual]