### PR TITLE
Calibration/EcalCalibAlgos: potential bug endRun could be called

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
@@ -45,7 +45,7 @@ class PhiSymmetryCalibration :  public edm::EDAnalyzer
 
   /// Called at beginning of job
   virtual void beginJob();
-  virtual void endRun(edm::Run&, const edm::EventSetup&);
+  virtual void endRun(edm::Run const&, const edm::EventSetup&);
   void endLuminosityBlock(edm::LuminosityBlock const& ,edm::EventSetup const&);
 
 

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
@@ -435,7 +435,7 @@ void PhiSymmetryCalibration::analyze( const edm::Event& event, const edm::EventS
   }
 }
 
-void PhiSymmetryCalibration::endRun(edm::Run& run, const edm::EventSetup&){
+void PhiSymmetryCalibration::endRun(edm::Run const& run, const edm::EventSetup&){
  
   
   std::cout  << "PHIREPRT : run "<< run.run() 


### PR DESCRIPTION
after correcting parameters to match base class functions
to fix clang warning hides overloaded virtual function [-Woverloaded-virtual]
   virtual void endRun(edm::Run&, const edm::EventSetup&);