### PR TITLE
Validation/RecoEgamma: potential bug endRun can be called

### DIFF
--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -792,7 +792,7 @@ void  TkConvValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run con
 
 }
 
-void  TkConvValidator::endRun (edm::Run& r, edm::EventSetup const & theEventSetup) {
+void  TkConvValidator::endRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
 
   delete thePhotonMCTruthFinder_;
 

--- a/Validation/RecoEgamma/plugins/TkConvValidator.h
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.h
@@ -61,7 +61,7 @@ class TkConvValidator : public DQMEDAnalyzer
   virtual void analyze( const edm::Event&, const edm::EventSetup& ) override ;
   void  bookHistograms( DQMStore::IBooker&, edm::Run const &, edm::EventSetup const &) override; 
   virtual void dqmBeginRun( edm::Run const & r, edm::EventSetup const & theEventSetup) override ;
-  virtual void endRun (edm::Run& r, edm::EventSetup const & es);
+  virtual void endRun (edm::Run const& r, edm::EventSetup const & es) override;
   virtual void endJob() ;
 
  private:


### PR DESCRIPTION
after fixing parameters to match base class function
to remove clang warning
warning: 'TkConvValidator::endRun' hides overloaded virtual function [-Woverloaded-virtual]