### PR TITLE
Validation/MuonRPCGeometry: potential bug beginJob might be called

### DIFF
--- a/Validation/MuonRPCGeometry/plugins/RPCPhiEff.cc
+++ b/Validation/MuonRPCGeometry/plugins/RPCPhiEff.cc
@@ -325,7 +325,7 @@ std::string RPCPhiEff::fromRaw(const edm::Event & iEvent){
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void RPCPhiEff::beginJob(const edm::EventSetup &)
+void RPCPhiEff::beginJob()
 {
 }
 

--- a/Validation/MuonRPCGeometry/plugins/RPCPhiEff.h
+++ b/Validation/MuonRPCGeometry/plugins/RPCPhiEff.h
@@ -44,7 +44,7 @@ class RPCPhiEff:public edm::EDAnalyzer {
 
 
  private:
-  virtual void beginJob(const edm::EventSetup &);
+  virtual void beginJob();
   virtual void analyze(const edm::Event &, const edm::EventSetup &);
   std::string fromCones(const edm::Event & iEvent);
   std::string fromRaw(const edm::Event & iEvent);


### PR DESCRIPTION
after fixing parameters to match base class function
to fix clang warning
'RPCPhiEff::beginJob' hides overloaded virtual function [-Woverloaded-virtual]
   virtual void beginJob(const edm::EventSetup &);