### PR TITLE
Validation/Mixing: fix clang warning vexing parse

### DIFF
--- a/Validation/Mixing/src/GlobalTest.cc
+++ b/Validation/Mixing/src/GlobalTest.cc
@@ -46,7 +46,7 @@ GlobalTest::GlobalTest(const edm::ParameterSet& iConfig):
     cfVertexToken_(consumes<CrossingFrame<SimTrack> >(
         iConfig.getParameter<edm::InputTag>("cfVertexTag")))
 {
-  std::string ecalsubdetb();
+  std::string ecalsubdetb("");
   std::string ecalsubdete("g4SimHitsEcalHitsEE");
   g4SimHits_EB_Token_ = consumes<CrossingFrame<PCaloHit> > (
       edm::InputTag("mix", "g4SimHitsEcalHitsEB"));


### PR DESCRIPTION
/GlobalTest.cc:49:26: warning: empty parentheses
interpreted as a function declaration [-Wvexing-parse]
   std::string ecalsubdetb();