### PR TITLE
SUSYBSMAnalysis/HSCP: potential bug beginJob can be called; addition of parens

### DIFF
--- a/SUSYBSMAnalysis/HSCP/plugins/SimHitShifter.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/SimHitShifter.cc
@@ -116,7 +116,7 @@ class SimHitShifter : public edm::EDProducer {
 
    private:
       std::string ShiftFileName;
-      virtual void beginJob(const edm::Run&, const edm::EventSetup&) ;
+      virtual void beginJob() override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() override ;
     
@@ -277,7 +277,7 @@ SimHitShifter::beginRun(const edm::Run& run, const edm::EventSetup& iSetup)
 
 // ------------ method called once each job just before starting event loop  ------------
 void 
-SimHitShifter::beginJob(const edm::Run& run, const edm::EventSetup& iSetup)
+SimHitShifter::beginJob()
 {
 
 }

--- a/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc
+++ b/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc
@@ -24,8 +24,8 @@ void BetaCalculatorRPC::algo(const std::vector<susybsm::RPCHit4D>& uHSCPRPCRecHi
   for(std::vector<susybsm::RPCHit4D>::iterator point = HSCPRPCRecHits.begin(); point < HSCPRPCRecHits.end(); ++point) {
     outOfTime |= (point->bx!=0); //condition 1: at least one measurement must have BX!=0
     increasing &= (point->bx>=lastbx); //condition 2: BX must be increase when going inside-out.
-    anydifferentzero &= (!point->bx==0); //to check one knee withoutzeros
-    anydifferentone &= (!point->bx==1); //to check one knee withoutones
+    anydifferentzero &= (!(point->bx==0)); //to check one knee withoutzeros
+    anydifferentone &= (!(point->bx==1)); //to check one knee withoutones
     lastbx = point->bx;
     //float r=point->gp.mag();
     //std::cout<<"Inside BetaCalculatorRPC \t \t  r="<<r<<" phi="<<point->gp.phi()<<" eta="<<point->gp.eta()<<" bx="<<point->bx<<" outOfTime"<<outOfTime<<" increasing"<<increasing<<" anydifferentzero"<<anydifferentzero<<std::endl;


### PR DESCRIPTION
after correcting parameters to match base class function
to fix clang warning. Also add parens to clarify where the !
is applied in if statement.

Fixes these warnings:

>> Compiling  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorTK.cc 
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-09-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-09-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj2/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/SUSYBSMAnalysis/HSCP/src/SUSYBSMAnalysisHSCP/BetaCalculatorTK.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorTK.cc -o tmp/slc6_amd64_gcc530/src/SUSYBSMAnalysis/HSCP/src/SUSYBSMAnalysisHSCP/BetaCalculatorTK.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:27:26: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
     anydifferentzero &= (!point->bx==0); //to check one knee withoutzeros
                         ^         ~~
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:27:26: note: add parentheses after the '!' to evaluate the comparison first
    anydifferentzero &= (!point->bx==0); //to check one knee withoutzeros
                         ^
                          (           )
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:27:26: note: add parentheses around left hand side expression to silence this warning
    anydifferentzero &= (!point->bx==0); //to check one knee withoutzeros
                         ^
                         (         )
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:28:25: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
     anydifferentone &= (!point->bx==1); //to check one knee withoutones
                        ^         ~~
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:28:25: note: add parentheses after the '!' to evaluate the comparison first
    anydifferentone &= (!point->bx==1); //to check one knee withoutones
                        ^
                         (           )
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc:28:25: note: add parentheses around left hand side expression to silence this warning
    anydifferentone &= (!point->bx==1); //to check one knee withoutones
                        ^
                        (         )

/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/llvm/4.0.0/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DCMSSW_GIT_HASH="CMSSW_9_0_CLANG_X_2016-12-09-1100" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_9_0_CLANG_X_2016-12-09-1100" -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=50300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/coral/CORAL_2_3_21-ghmdbj2/include/LCG -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/lcg/root/6.06.08-ogepgl/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/boost/1.57.0-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/pcre/8.37/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/clhep/2.3.4.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/gsl/2.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/hepmc/2.06.07/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/heppdt/3.03.00-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/python/2.7.11-oenich/include/python2.7 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/sigcpp/2.6.2/include/sigc++-2.0 -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tbb/2017_20161004oss/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/cms/vdt/v0.3.2-oenich/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/xz/5.2.1/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/zlib/1.2.8/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/eigen/3.3.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/md5/1.0.0/include -I/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc530/external/tinyxml/2.5.3-oenich/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++14 -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Wa,--compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -DBOOST_DISABLE_ASSERTS -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -fPIC -MMD -MF tmp/slc6_amd64_gcc530/src/SUSYBSMAnalysis/HSCP/plugins/SUSYBSMAnalysisHSCPPlugins/Skim_UpdatedMuonInnerTrackRef.d /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/plugins/Skim_UpdatedMuonInnerTrackRef.cc -o tmp/slc6_amd64_gcc530/src/SUSYBSMAnalysis/HSCP/plugins/SUSYBSMAnalysisHSCPPlugins/Skim_UpdatedMuonInnerTrackRef.o
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SUSYBSMAnalysis/HSCP/plugins/SimHitShifter.cc:119:20: warning: 'SimHitShifter::beginJob' hides overloaded virtual function [-Woverloaded-virtual]
       virtual void beginJob(const edm::Run&, const edm::EventSetup&) ;
                   ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/FWCore/Framework/interface/EDProducer.h:82:18: note: hidden overloaded virtual function 'edm::EDProducer::beginJob' declared here: different number of parameters (0 vs 2)
    virtual void beginJob() {}
                 ^