### PR TITLE
SLHCUpgradeSimulations/Geometry: fix clang warnings in test class

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.cc
@@ -74,7 +74,7 @@ void FastsimHitNtuplizer::endJob()
 
 
 
-void FastsimHitNtuplizer::beginJob(const edm::EventSetup& es)
+void FastsimHitNtuplizer::beginJob()
 {
   std::cout << " FastsimHitNtuplizer::beginJob" << std::endl;
   std::string outputFile = conf_.getParameter<std::string>("OutputFile");

--- a/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.h
+++ b/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.h
@@ -34,7 +34,7 @@ class FastsimHitNtuplizer : public edm::EDAnalyzer
   
   explicit FastsimHitNtuplizer(const edm::ParameterSet& conf);
   virtual ~FastsimHitNtuplizer();
-  virtual void beginJob(const edm::EventSetup& es);
+  virtual void beginJob();
   virtual void endJob();
   virtual void analyze(const edm::Event& e, const edm::EventSetup& es);
 


### PR DESCRIPTION
Fix parameters in beginRun of test class to remove these warnings.

In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.cc:7:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.h:37:16: warning: 'FastsimHitNtuplizer::beginJob' hides overloaded virtual function [-Woverloaded-virtual]
   virtual void beginJob(const edm::EventSetup& es);
               ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/FWCore/Framework/interface/EDAnalyzer.h:75:18: note: hidden overloaded virtual function 'edm::EDAnalyzer::beginJob' declared here: different number of parameters (0 vs 1)
    virtual void beginJob(){}
                 ^
1 warning generated.