### PR TITLE
RecoTracker test classes: fix clang warnings

### DIFF
--- a/RecoTracker/MeasurementDet/test/MeasurementTrackerUpdator.cc
+++ b/RecoTracker/MeasurementDet/test/MeasurementTrackerUpdator.cc
@@ -46,9 +46,7 @@ public:
 
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string theMeasurementTrackerName;
 };
@@ -74,8 +72,6 @@ void MeasurementTrackerUpdator::analyze(const edm::Event& iEvent, const edm::Eve
 
 }
 
-void MeasurementTrackerUpdator::beginRun(edm::Run const& run, const edm::EventSetup&) {}
-void MeasurementTrackerUpdator::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(MeasurementTrackerUpdator);

--- a/RecoTracker/MeasurementDet/test/MeasurementTrackerUpdator.cc
+++ b/RecoTracker/MeasurementDet/test/MeasurementTrackerUpdator.cc
@@ -46,7 +46,7 @@ public:
 
 
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 
@@ -74,7 +74,7 @@ void MeasurementTrackerUpdator::analyze(const edm::Event& iEvent, const edm::Eve
 
 }
 
-void MeasurementTrackerUpdator::beginRun(edm::Run & run, const edm::EventSetup&) {}
+void MeasurementTrackerUpdator::beginRun(edm::Run const& run, const edm::EventSetup&) {}
 void MeasurementTrackerUpdator::endJob() {}
 
 //define this as a plug-in

--- a/RecoTracker/TkMSParametrization/test/TestMS.cc
+++ b/RecoTracker/TkMSParametrization/test/TestMS.cc
@@ -37,7 +37,7 @@ class TestMS : public edm::EDAnalyzer {
 public:
   explicit TestMS(const edm::ParameterSet& conf);
   ~TestMS();
-  virtual void beginRun(edm::Run & run, const edm::EventSetup& es);
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup& es);
   virtual void analyze(const edm::Event& ev, const edm::EventSetup& es);
   virtual void endJob();
 private:
@@ -77,7 +77,7 @@ void TestMS::analyze(
 }
 
 
-void TestMS::beginRun(edm::Run & run, const edm::EventSetup& es) 
+void TestMS::beginRun(edm::Run const& run, const edm::EventSetup& es) 
 {
 
   edm::ESHandle<GeometricSearchTracker> tracker;

--- a/RecoTracker/TkMSParametrization/test/TestMS.cc
+++ b/RecoTracker/TkMSParametrization/test/TestMS.cc
@@ -37,9 +37,9 @@ class TestMS : public edm::EDAnalyzer {
 public:
   explicit TestMS(const edm::ParameterSet& conf);
   ~TestMS();
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup& es);
-  virtual void analyze(const edm::Event& ev, const edm::EventSetup& es);
-  virtual void endJob();
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup& es) override;
+  virtual void analyze(const edm::Event& ev, const edm::EventSetup& es) override;
+
 private:
   TFile * rootFile;
   TH1F *hB1, *hB2, *hB3, *hF1, *hF2;
@@ -132,10 +132,6 @@ void TestMS::beginRun(edm::Run const& run, const edm::EventSetup& es)
 
 
 
-}
-
-void TestMS::endJob()
-{
 }
 
 

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -53,9 +53,8 @@ public:
   
   
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string theNavigationSchoolName;
   const TrackerTopology *tTopo;
@@ -276,8 +275,6 @@ void NavigationSchoolAnalyzer::beginRun(edm::Run const & run, const edm::EventSe
   edm::LogInfo("NavigationSchoolAnalyzer")<<"NavigationSchool display of: " <<theNavigationSchoolName<<"\n";
   print (std::cout,nav.product());
 }
-
-void NavigationSchoolAnalyzer::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(NavigationSchoolAnalyzer);

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -53,7 +53,7 @@ public:
   
   
 private:
-  virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
+  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 
@@ -264,7 +264,7 @@ void NavigationSchoolAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
 
 }
 
-void NavigationSchoolAnalyzer::beginRun(edm::Run & run, const edm::EventSetup& iSetup) {
+void NavigationSchoolAnalyzer::beginRun(edm::Run const & run, const edm::EventSetup& iSetup) {
 //  edm::ESHandle<TrackerTopology> tTopoHandle;
 //  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
 //  tTopo = tTopoHandle.product();

--- a/RecoTracker/TrackProducer/test/TrackValidator.cc
+++ b/RecoTracker/TrackProducer/test/TrackValidator.cc
@@ -51,7 +51,7 @@ class TrackValidator : public edm::EDAnalyzer {
     }
   }
 
-  void beginRun(edm::Run & run, const edm::EventSetup& setup) {
+  void beginRun(edm::Run const& run, const edm::EventSetup& setup) {
 
     for (unsigned int j=0;j<label.size();j++){
       

--- a/RecoTracker/TrackProducer/test/TrackValidator.cc
+++ b/RecoTracker/TrackProducer/test/TrackValidator.cc
@@ -51,7 +51,7 @@ class TrackValidator : public edm::EDAnalyzer {
     }
   }
 
-  void beginRun(edm::Run const& run, const edm::EventSetup& setup) {
+  void beginRun(edm::Run const& run, const edm::EventSetup& setup) override {
 
     for (unsigned int j=0;j<label.size();j++){
       
@@ -118,7 +118,7 @@ class TrackValidator : public edm::EDAnalyzer {
 
   }
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override{
 std::cout << "In TrackValidator\n";
     edm::ESHandle<TransientTrackBuilder> theB;
     setup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
@@ -289,7 +289,7 @@ std::cout << "In TrackValidator\n";
 
   }
 
-  void endJob() {
+  void endJob() override {
 
     for (unsigned int w=0;w<label.size();w++){
       TDirectory * p = hFile->mkdir(label[w].c_str());

--- a/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
+++ b/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
@@ -50,9 +50,7 @@ class TrajectoryAnalyzer : public edm::EDAnalyzer {
 
 
    private:
-      virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
 
       // ----------member data ---------------------------
   edm::ParameterSet param_;
@@ -120,16 +118,6 @@ TrajectoryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 }
 
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-TrajectoryAnalyzer::beginRun(edm::Run const& run, const edm::EventSetup&)
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-TrajectoryAnalyzer::endJob() {
-}
 
 //define this as a plug-in
 

--- a/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
+++ b/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
@@ -50,9 +50,9 @@ class TrajectoryAnalyzer : public edm::EDAnalyzer {
 
 
    private:
-      virtual void beginRun(edm::Run & run, const edm::EventSetup&) ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
 
       // ----------member data ---------------------------
   edm::ParameterSet param_;
@@ -122,7 +122,7 @@ TrajectoryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
 // ------------ method called once each job just before starting event loop  ------------
 void 
-TrajectoryAnalyzer::beginRun(edm::Run & run, const edm::EventSetup&)
+TrajectoryAnalyzer::beginRun(edm::Run const& run, const edm::EventSetup&)
 {
 }
 


### PR DESCRIPTION
by changing function parameters to match base class functions.
