### PR TITLE
RecoTauTag/ImpactParameter/test fix clang warning

### DIFF
--- a/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc
+++ b/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc
@@ -151,7 +151,7 @@ void TauImpactParameterTest::analyze(const edm::Event& iEvent, const edm::EventS
 
 	      if(tauTracks.size() == 1 || tauTracks.size() == 3){
 		const reco::TauImpactParameterTrackData* trackData = iJet->getTrackData(leadingTrack);
-		if(!(trackData == 0)){
+		if( trackData != nullptr) {
 		    Measurement1D tip = trackData->transverseIp;
 		    Measurement1D tzip = trackData->ip3D;
 

--- a/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc
+++ b/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc
@@ -151,7 +151,7 @@ void TauImpactParameterTest::analyze(const edm::Event& iEvent, const edm::EventS
 
 	      if(tauTracks.size() == 1 || tauTracks.size() == 3){
 		const reco::TauImpactParameterTrackData* trackData = iJet->getTrackData(leadingTrack);
-		if(! trackData == 0){
+		if(!(trackData == 0)){
 		    Measurement1D tip = trackData->transverseIp;
 		    Measurement1D tzip = trackData->ip3D;
 


### PR DESCRIPTION
add parens to clarify where ! is applied
Fixes warning

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc:154:6: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
                 if(! trackData == 0){
                   ^           ~~
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc:154:6: note: add parentheses after the '!' to evaluate the comparison first
                if(! trackData == 0){
                   ^
                     (             )
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/RecoTauTag/ImpactParameter/test/TauImpactParameterTest.cc:154:6: note: add parentheses around left hand side expression to silence this warning
                if(! trackData == 0){
                   ^
                   (          )