### PR TITLE
HcalTBObjectUnpacker fix clang warning

### DIFF
--- a/RecoTBCalo/HcalTBObjectUnpacker/plugins/HcalTBObjectUnpacker.cc
+++ b/RecoTBCalo/HcalTBObjectUnpacker/plugins/HcalTBObjectUnpacker.cc
@@ -1,4 +1,3 @@
-using namespace std;
 
 #include "TBDataFormats/HcalTBObjects/interface/HcalTBTriggerData.h"
 #include "TBDataFormats/HcalTBObjects/interface/HcalTBRunData.h"
@@ -10,6 +9,7 @@ using namespace std;
 #include "DataFormats/Common/interface/Handle.h"
 #include <iostream>
 #include <fstream>
+using namespace std;
 
 
   HcalTBObjectUnpacker::HcalTBObjectUnpacker(edm::ParameterSet const& conf):


### PR DESCRIPTION
by moving using namespace std statement after any system headers.


  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/c6e477c85c30ed990e75acc26cea5f32/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-09-1100/src/RecoTBCalo/HcalTBObjectUnpacker/plugins/HcalTBObjectUnpacker.cc:1:17: warning: using directive refers to implicitly-defined namespace 'std'
 using namespace std;
                ^
1 warning generated.