### PR TITLE
add the missing dependency for plugin

### DIFF
--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/BuildFile.xml
@@ -1,4 +1,12 @@
-<use name="RecoLocalTracker/SiPhase2Clusterizer"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="DataFormats/Common"/>
+<use   name="CondFormats/SiPixelObjects"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="DataFormats/SiPixelDetId"/>
+<use   name="DataFormats/Phase2TrackerCluster"/>
+<use   name="DataFormats/Phase2TrackerDigi"/>
+<use   name="root"/>
 <library   file="*.cc" name="Phase2TrackerClusterizerPlugin">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
 RecoLocalTracker/SiPhase2Clusterizer/BuildFile.xml was dropped in #16815 which we did not noticed as the patch releases were getting its contents from full base release. This Pr adds the missing/removed dependencies