### PR TITLE
Re-raise signals received after InitRootHandlers has been unloaded

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -566,6 +566,14 @@ namespace {
     }
     
     void sig_abort(int sig, siginfo_t*, void*) {
+      full_cerr_write("\n\nFatal system signal has occurred during exit\n");
+
+      // re-raise the signal to get the correct exit code
+      signal(sig, SIG_DFL);
+      raise(sig);
+
+      // shouldn't get here
+      ::sleep(10);
       ::abort();
     }
   }


### PR DESCRIPTION
When InitRootHandlers is unloaded, it sets the signal handlers for SIGILL, SIGSEGV, SIGBUS and SIGTERM to a handler that simply calls abort().  This is inconsistent with the behavior of the sig_dostack_then_abort() handler which re-raises those signals so that the exit code correctly reflects the signal received.  This PR updates sig_abort() to write a short message and re-raise the signal received so the exit code is set correctly.

This is in response to difficulties diagnosing CRAB job crashes at exit(), likely caused by memory corruption found during the destruction of ROOT globals, see:

https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/2350/2/1/1/1/1.html