### PR TITLE
reduce input tag memory churn by passing correct type constant to tokenize

### DIFF
--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -5,6 +5,7 @@
 namespace edm {
 
   const std::string InputTag::kSkipCurrentProcess("@skipCurrentProcess");
+  static std::string const separator(":");
 
   InputTag::InputTag()
   : label_(),
@@ -51,7 +52,7 @@ namespace edm {
     skipCurrentProcess_(false) {
 
     // string is delimited by colons
-    std::vector<std::string> tokens = tokenize(s, ":");
+    std::vector<std::string> tokens = tokenize(s, separator);
     size_t nwords = tokens.size();
     if(nwords > 3) {
       throw edm::Exception(errors::Configuration,"InputTag")
@@ -165,7 +166,6 @@ namespace edm {
     //NOTE: since the encoding gets used to form the configuration hash I did not want
     // to change it so that not specifying a process would cause two colons to appear in the
     // encoding and thus not being backwards compatible
-    static std::string const separator(":");
     std::string result = label_;
     if(!instance_.empty() || !process_.empty()) {
       result += separator + instance_;


### PR DESCRIPTION
In issue #14897 we found that 'InputTag::InputTag(std::string const& s)'  gets called quite a lot due to implicit conversions from string to InputTag.  In that constructor, 'tokenize(const std::string & input, const std::string &separator)'  is called with a second argument ":", in effect doing 'string(":").c_str()'.  This PR moves a 'static std::string const separator(":")' to file scope and reuses it for the call to tokenize, as discussed in the referenced issue.

This is completely trivial, but InputTag(string) really is called a lot, so reducing its memory churn seems worthwhile.