### PR TITLE
EventFilter/EcalTBRawToDigi: fix clang warnings about hides overloaded virtual function

### DIFF
--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
@@ -36,6 +36,7 @@ class DCCTBEventBlock : public DCCTBBlockPrototype {
 		DCCTBSRPBlock               * srpBlock();
 		DCCTBTrailerBlock           * trailerBlock();
 		std::vector< DCCTBTowerBlock * >   towerBlocksById(uint32_t towerId);
+		using DCCTBBlockPrototype::compare;
 		std::pair<bool,std::string> compare(DCCTBEventBlock * );
 
 		bool eventHasErrors();

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
@@ -36,7 +36,7 @@ class DCCTBSRPBlock : public DCCTBBlockPrototype {
 	protected :
 		
 		void dataCheck();
-		
+		using DCCTBBlockPrototype::increment;
 		void  increment(uint32_t numb);
 		
 		enum srpFields{ 

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
@@ -50,6 +50,7 @@ protected :
   /**
      Adds a new TCC block
   */
+  using DCCTBBlockPrototype::increment;
   void  increment(uint32_t numb);
   
   /**

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
@@ -27,7 +27,7 @@ class DCCTBXtalBlock : public DCCTBBlockPrototype {
 		std::vector<int> xtalDataSamples();
 
 	protected :
-		
+		using DCCTBBlockPrototype::increment;
 		void increment(uint32_t numb);
 		
 		enum xtalBlockFields{ BPOSITION_BLOCKID = 30, BLOCKID = 3};


### PR DESCRIPTION
by adding using directive.This fixes these clang warnings:

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h:39:31: warning: 'DCCTBEventBlock::compare' hides overloaded virtual function [-Woverloaded-virtual]
                 std::pair<bool,std::string> compare(DCCTBEventBlock * );
                                            ^

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h:40:9: warning: 'DCCTBSRPBlock::increment' hides overloaded virtual function [-Woverloaded-virtual]
                 void  increment(uint32_t numb);
                      ^
