### PR TITLE
RecoParticleFlow/Benchmark: fix clang warning about hides overloaded virtual

### DIFF
--- a/RecoParticleFlow/Benchmark/interface/BenchmarkTree.h
+++ b/RecoParticleFlow/Benchmark/interface/BenchmarkTree.h
@@ -35,6 +35,7 @@ class BenchmarkTree : public TTree {
  public:
   BenchmarkTree( const char* name,
 			const char* title);
+  using TTree::Fill;
   void Fill( const BenchmarkTreeEntry& entry );
   
  private:


### PR DESCRIPTION
by adding using directive. Fixes clang warning:

In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/RecoParticleFlow/Benchmark/src/BenchmarkTree.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/RecoParticleFlow/Benchmark/interface/BenchmarkTree.h:38:8: warning: 'BenchmarkTree::Fill' hides overloaded virtual function [-Woverloaded-virtual]
   void Fill( const BenchmarkTreeEntry& entry );
       ^