### PR TITLE
DQM/EcalCommon: fix clang warnings about hides overloaded virtual

### DIFF
--- a/DQM/EcalCommon/interface/MESetDet2D.h
+++ b/DQM/EcalCommon/interface/MESetDet2D.h
@@ -24,30 +24,37 @@ namespace ecaldqm
     void fill(EcalElectronicsId const&, double = 1., double = 0., double = 0.) override;
     void fill(int, double = 1., double = 1., double = 1.) override;
 
+    using MESetEcal::setBinContent;
     void setBinContent(DetId const&, double) override;
     void setBinContent(EcalElectronicsId const&, double) override;
     void setBinContent(int, double) override;
 
+    using MESetEcal::setBinError;
     void setBinError(DetId const&, double) override;
     void setBinError(EcalElectronicsId const&, double) override;
     void setBinError(int, double) override;
 
+    using MESetEcal::setBinEntries;
     void setBinEntries(DetId const&, double) override;
     void setBinEntries(EcalElectronicsId const&, double) override;
     void setBinEntries(int, double) override;
 
+    using MESetEcal::getBinContent;
     double getBinContent(DetId const&, int = 0) const override;
     double getBinContent(EcalElectronicsId const&, int = 0) const override;
     double getBinContent(int, int = 0) const override;
 
+    using MESetEcal::getBinError;
     double getBinError(DetId const&, int = 0) const override;
     double getBinError(EcalElectronicsId const&, int = 0) const override;
     double getBinError(int, int = 0) const override;
 
+    using MESetEcal::getBinEntries;
     double getBinEntries(DetId const&, int = 0) const override;
     double getBinEntries(EcalElectronicsId const&, int = 0) const override;
     double getBinEntries(int, int) const override;
 
+    using MESetEcal::findBin;
     int findBin(DetId const&) const;
     int findBin(EcalElectronicsId const&) const;
 

--- a/DQM/EcalCommon/interface/MESetProjection.h
+++ b/DQM/EcalCommon/interface/MESetProjection.h
@@ -22,16 +22,22 @@ namespace ecaldqm
     void fill(int, double = 1., double = 1., double = 0.) override;
     void fill(double, double = 1., double = 0.) override;
 
+    using MESetEcal::setBinContent;
     void setBinContent(DetId const&, double) override;
 
+    using MESetEcal::setBinError;
     void setBinError(DetId const&, double) override;
 
+    using MESetEcal::setBinEntries;
     void setBinEntries(DetId const&, double) override;
 
+    using MESetEcal::getBinContent;
     double getBinContent(DetId const&, int = 0) const override;
 
+    using MESetEcal::getBinError;
     double getBinError(DetId const&, int = 0) const override;
 
+    using MESetEcal::getBinEntries;
     double getBinEntries(DetId const&, int = 0) const override;
   };
 }


### PR DESCRIPTION
by adding using directive.  Fixes warnings:

In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:27:10: warning: 'ecaldqm::MESetDet2D::setBinContent' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinContent(DetId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:34:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:35:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:36:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:28:10: warning: 'ecaldqm::MESetDet2D::setBinContent' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinContent(EcalElectronicsId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:34:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:35:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:36:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:29:10: warning: 'ecaldqm::MESetDet2D::setBinContent' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinContent(int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:34:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:35:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:36:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinContent' declared here: different number of parameters (3 vs 2)
    void setBinContent(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:31:10: warning: 'ecaldqm::MESetDet2D::setBinError' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinError(DetId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:38:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:39:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:40:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:32:10: warning: 'ecaldqm::MESetDet2D::setBinError' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinError(EcalElectronicsId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:38:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:39:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:40:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:33:10: warning: 'ecaldqm::MESetDet2D::setBinError' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinError(int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:38:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:39:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:40:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinError' declared here: different number of parameters (3 vs 2)
    void setBinError(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:35:10: warning: 'ecaldqm::MESetDet2D::setBinEntries' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinEntries(DetId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:42:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:43:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:44:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:36:10: warning: 'ecaldqm::MESetDet2D::setBinEntries' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinEntries(EcalElectronicsId const&, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:42:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:43:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:44:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:37:10: warning: 'ecaldqm::MESetDet2D::setBinEntries' hides overloaded virtual functions [-Woverloaded-virtual]
     void setBinEntries(int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:42:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(DetId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:43:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(EcalElectronicsId const&, int, double) override;
         ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:44:10: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::setBinEntries' declared here: different number of parameters (3 vs 2)
    void setBinEntries(int, int, double) override;
         ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:51:9: warning: 'ecaldqm::MESetDet2D::findBin' hides overloaded virtual functions [-Woverloaded-virtual]
     int findBin(DetId const&) const;
        ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:58:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(DetId const&, double, double = 0.) const;
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:59:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(EcalElectronicsId const&, double, double = 0.) const;
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:60:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(int, double, double = 0.) const;
                ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/src/MESetDet2D.cc:1:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetDet2D.h:52:9: warning: 'ecaldqm::MESetDet2D::findBin' hides overloaded virtual functions [-Woverloaded-virtual]
     int findBin(EcalElectronicsId const&) const;
        ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:58:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(DetId const&, double, double = 0.) const;
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:59:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(EcalElectronicsId const&, double, double = 0.) const;
                ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/DQM/EcalCommon/interface/MESetEcal.h:60:17: note: hidden overloaded virtual function 'ecaldqm::MESetEcal::findBin' declared here: different number of parameters (3 vs 1)
    virtual int findBin(int, double, double = 0.) const;
                ^
