### PR TITLE
L1Trigger/DTBti: fix clang warning hides overloaded virtual

### DIFF
--- a/L1Trigger/DTBti/interface/DTBtiCard.h
+++ b/L1Trigger/DTBti/interface/DTBtiCard.h
@@ -97,6 +97,7 @@ class DTBtiCard : public BTICache, public DTGeomSupplier {
      */
     DTBtiTrig* storeTrigger(DTBtiTrigData);
 
+    using  BTICache::reconstruct;
     // run the trigger algorithm
     virtual void reconstruct(const DTDigiCollection dtDigis) { clearCache();loadBTI(dtDigis); runBTI(); }
  


### PR DESCRIPTION
by adding using directive. Fixes clang warnings: In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTBti/interface/DTBtiChip.h:35:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTBti/interface/DTBtiCard.h:101:18: warning: 'DTBtiCard::reconstruct' hides overloaded virtual function [-Woverloaded-virtual]
     virtual void reconstruct(const DTDigiCollection dtDigis) { clearCache();loadBTI(dtDigis); runBTI(); }
                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTUtilities/interface/DTCache.h:52:16: note: hidden overloaded virtual function 'DTCache<DTBtiTrigData, std::vector<DTBtiTrigData, std::allocator<DTBtiTrigData> > >::reconstruct' declared here: different number of parameters (0 vs 1)
  virtual void reconstruct() {}
               ^
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTBti/src/DTBtiTrig.cc:20:
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTBti/interface/DTBtiChip.h:35:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTBti/interface/DTBtiCard.h:101:18: warning: 'DTBtiCard::reconstruct' hides overloaded virtual function [-Woverloaded-virtual]
     virtual void reconstruct(const DTDigiCollection dtDigis) { clearCache();loadBTI(dtDigis); runBTI(); }
                 ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/L1Trigger/DTUtilities/interface/DTCache.h:52:16: note: hidden overloaded virtual function 'DTCache<DTBtiTrigData, std::vector<DTBtiTrigData, std::allocator<DTBtiTrigData> > >::reconstruct' declared here: different number of parameters (0 vs 1)
  virtual void reconstruct() {}
               ^