### PR TITLE
EgammaAnalysis/ElectronTools: potential bug fix, add parens to set implied order of + and ?

### DIFF
--- a/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc
+++ b/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc
@@ -4,7 +4,7 @@ SimpleElectron::SimpleElectron(const reco::GsfElectron &in, unsigned int runNumb
         run_(runNumber),
         eClass_(int(in.classification())), 
         r9_(in.full5x5_r9()),
-        scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
+        scEnergy_(in.superCluster()->rawEnergy() + (in.isEB() ? 0 : in.superCluster()->preshowerEnergy())), 
         scEnergyError_(-999.),  // FIXME???
         trackMomentum_(in.trackMomentumAtVtx().R()), 
         trackMomentumError_(in.trackMomentumError()), 

--- a/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc
+++ b/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc
@@ -5,7 +5,7 @@ SimplePhoton::SimplePhoton(const reco::Photon &in, unsigned int runNumber, bool 
   run_(runNumber),
   eClass_(-1), 
   r9_(in.full5x5_r9()),
-  scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
+  scEnergy_(in.superCluster()->rawEnergy() + (in.isEB() ? 0 : in.superCluster()->preshowerEnergy())), 
   scEnergyError_(-999.),  // FIXME???
   regEnergy_(in.getCorrectedEnergy(reco::Photon::P4type::regression2)), 
   regEnergyError_(in.getCorrectedEnergyError(reco::Photon::P4type::regression2)), 

--- a/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
+++ b/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
@@ -26,9 +26,7 @@ public:
   ~CorrectECALIsolation();
 
 private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   edm::ParameterSet conf_;
 
@@ -83,12 +81,6 @@ void CorrectECALIsolation::analyze(const edm::Event& iEvent, const edm::EventSet
     }
   }
 }
-
-void CorrectECALIsolation::beginJob()
-{}
-
-void CorrectECALIsolation::endJob()
-{}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CorrectECALIsolation);

--- a/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
+++ b/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
@@ -26,7 +26,7 @@ public:
   ~CorrectECALIsolation();
 
 private:
-  virtual void beginJob(const edm::EventSetup&) ;
+  virtual void beginJob() ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 
@@ -84,7 +84,7 @@ void CorrectECALIsolation::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 }
 
-void CorrectECALIsolation::beginJob(const edm::EventSetup&)
+void CorrectECALIsolation::beginJob()
 {}
 
 void CorrectECALIsolation::endJob()

--- a/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
@@ -52,7 +52,7 @@ class ElectronIsoAnalyzer : public edm::EDAnalyzer {
   //
 
    private:
-      virtual void beginJob(const edm::EventSetup&) ;
+      virtual void beginJob() ;
       virtual void analyze(const edm::Event&, const edm::EventSetup&);
       virtual void endJob() ;
 
@@ -243,7 +243,7 @@ ElectronIsoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 }
 // ------------ method called once each job just before starting event loop  ------------
 void
-ElectronIsoAnalyzer::beginJob(const edm::EventSetup&)
+ElectronIsoAnalyzer::beginJob()
 {
 
   ev = 0;

--- a/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
@@ -52,9 +52,9 @@ class ElectronIsoAnalyzer : public edm::EDAnalyzer {
   //
 
    private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
 
 
   edm::ParameterSet conf_;

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -71,9 +71,9 @@ public:
   
   
 private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
   virtual void myBindVariables();
   virtual void myVar(const reco::GsfElectron& ele,
 		     const reco::Vertex& vertex,

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -71,7 +71,7 @@ public:
   
   
 private:
-  virtual void beginJob(const edm::EventSetup&) ;
+  virtual void beginJob() ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
   virtual void myBindVariables();
@@ -680,7 +680,7 @@ bool ElectronTestAnalyzer::trainTrigPresel(const reco::GsfElectron& ele) {
   return myTrigPresel;
 }
 void
-ElectronTestAnalyzer::beginJob(const edm::EventSetup&)
+ElectronTestAnalyzer::beginJob()
 {
 
   ev = 0;


### PR DESCRIPTION
These clang warnings imply a possible bug because + is evaluated before ?. Also clean up of test class functions.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc:8:56: warning: operator '?:' has lower precedence than '+'; '+' will be evaluated first [-Wparentheses]
   scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc:8:56: note: place parentheses around the '+' expression to silence this warning
  scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
                                                       ^
            (                                         )
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc:8:56: note: place parentheses around the '?:' expression to evaluate it first
  scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
                                                       ^
                                             (                                                   )
1 warning generated.
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc:7:62: warning: operator '?:' has lower precedence than '+'; '+' will be evaluated first [-Wparentheses]
         scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc:7:62: note: place parentheses around the '+' expression to silence this warning
        scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
                                                             ^
                  (                                         )
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/ba81249bb4729771235b98cb83b6e8d8/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_0_CLANG_X_2016-12-13-1100/src/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc:7:62: note: place parentheses around the '?:' expression to evaluate it first
        scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
                                                             ^
                                                   (                                                   )