### PR TITLE
DQMOffline/Hcal: fix clang warning hides overloaded virtual

### DIFF
--- a/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
+++ b/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
@@ -37,9 +37,7 @@ class CaloTowersAnalyzer : public DQMEDAnalyzer {
   virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
   virtual void beginJob() ;
   virtual void endJob() ;
-  virtual void beginRun() ;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  virtual void endRun() ;
 
  private:
   double dR(double eta1, double phi1, double eta2, double phi2);

--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -390,10 +390,6 @@ CaloTowersAnalyzer::CaloTowersAnalyzer(edm::ParameterSet const& conf){
 }
 
 
-void CaloTowersAnalyzer::beginRun() {}
-
-void CaloTowersAnalyzer::endRun() {}
-
 CaloTowersAnalyzer::~CaloTowersAnalyzer() {
   
 }


### PR DESCRIPTION
by removing function declarations that do not override behavior
of base class functions.