### PR TITLE
Validation/CaloTowers: fix clang warning hides overloaded virtual

### DIFF
--- a/Validation/CaloTowers/interface/CaloTowersValidation.h
+++ b/Validation/CaloTowers/interface/CaloTowersValidation.h
@@ -35,8 +35,6 @@ class CaloTowersValidation : public DQMEDAnalyzer {
    CaloTowersValidation(edm::ParameterSet const& conf);
   ~CaloTowersValidation();
   virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
-  virtual void beginRun();
-  virtual void endRun();
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:

--- a/Validation/CaloTowers/src/CaloTowersValidation.cc
+++ b/Validation/CaloTowers/src/CaloTowersValidation.cc
@@ -44,10 +44,6 @@ CaloTowersValidation::CaloTowersValidation(edm::ParameterSet const& conf)
 }
 
 
-void CaloTowersValidation::beginRun() {}
-
-void CaloTowersValidation::endRun() {}
-
 CaloTowersValidation::~CaloTowersValidation() {
 
 }


### PR DESCRIPTION
by removing function declarations that do not override behavior
of base class functions.