### PR TITLE
EventFilter/CastorRawToDigi: fix clang warning by moving

### DIFF
--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -1,4 +1,3 @@
-using namespace std;
 #include "EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
@@ -15,6 +14,7 @@ using namespace std;
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+using namespace std;
 
 
 CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):


### PR DESCRIPTION
using namespace std statement after any system headers