### PR TITLE
HLTriggerOffline/Exotica: fix clang warnings

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
@@ -39,7 +39,7 @@
 
 //const unsigned int kNull = (unsigned int) - 1;
 
-class EVTColContainer;
+struct EVTColContainer;
 
 class HLTExoticaPlotter {
 public:

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -58,7 +58,7 @@
 #include<cstring>
 
 /// Class to manage all object collections from a centralized place.
-class EVTColContainer;
+struct EVTColContainer;
 
 /// This class is the main workhorse of the package.
 /// It makes the histograms for one given analysis, taking care

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
@@ -27,7 +27,7 @@
 #include <cstring>
 
 
-class EVTColContainer;
+struct EVTColContainer;
 
 /// The HLTExoticaValidator module is the main module of the
 /// package. It books a vector of auxiliary classes


### PR DESCRIPTION
by changing class to struct in forward declarations
to match original tags.