### PR TITLE
SimDataFormats/CaloHit: fix clang warning hides overloaded virtual

### DIFF
--- a/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
@@ -22,7 +22,7 @@
     CastorShowerEvent();
     ~CastorShowerEvent();
     
-    void Clear();
+    void ClearB();
     
 //  private:
   

--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -14,8 +14,7 @@ class SLBin: public TObject {
              SLBin() {};
              ~SLBin() {};
 // Setters
-             using TObject::Clear;
-             void Clear()                       {NEvts=NBins=NEvtPerBin=0;Bins.clear();};
+             void ClearB()                       {NEvts=NBins=NEvtPerBin=0;Bins.clear();};
              void setNEvts(unsigned int n)      {NEvts = n;};
              void setNBins(unsigned int n)      {NBins = n;};
              void setNEvtPerBin(unsigned int n) {NEvtPerBin=n;};
@@ -42,7 +41,7 @@ class CastorShowerLibraryInfo : public TObject {
     CastorShowerLibraryInfo();
     ~CastorShowerLibraryInfo();
     
-    void Clear();
+    void ClearB();
     
     // Data members
     SLBin Energy;

--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -14,7 +14,7 @@ class SLBin: public TObject {
              SLBin() {};
              ~SLBin() {};
 // Setters
-             using TObject:Clear;
+             using TObject::Clear;
              void Clear()                       {NEvts=NBins=NEvtPerBin=0;Bins.clear();};
              void setNEvts(unsigned int n)      {NEvts = n;};
              void setNBins(unsigned int n)      {NBins = n;};

--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -14,6 +14,7 @@ class SLBin: public TObject {
              SLBin() {};
              ~SLBin() {};
 // Setters
+             using TObject:Clear;
              void Clear()                       {NEvts=NBins=NEvtPerBin=0;Bins.clear();};
              void setNEvts(unsigned int n)      {NEvts = n;};
              void setNBins(unsigned int n)      {NBins = n;};

--- a/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
@@ -9,7 +9,7 @@ CastorShowerEvent::CastorShowerEvent() {
 CastorShowerEvent::~CastorShowerEvent() {}
 
     
-void CastorShowerEvent::Clear() {
+void CastorShowerEvent::ClearB() {
    nhit = 0;
    detID.clear();
    hitPosition.clear();

--- a/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
@@ -9,8 +9,8 @@ CastorShowerLibraryInfo::CastorShowerLibraryInfo() {
 CastorShowerLibraryInfo::~CastorShowerLibraryInfo() {}
 
     
-void CastorShowerLibraryInfo::Clear() {
-   Energy.Clear();
-   Eta.Clear();
-   Phi.Clear();
+void CastorShowerLibraryInfo::ClearB() {
+   Energy.ClearB();
+   Eta.ClearB();
+   Phi.ClearB();
 }

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -224,7 +224,7 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) 
   int           parCode  = track->GetDefinition()->GetPDGEncoding();
 
   CastorShowerEvent hit;
-  hit.Clear();
+  hit.ClearB();
   
   ok = false;
   if (parCode == pi0PDG   || parCode == etaPDG    || parCode == nuePDG  ||

--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -531,7 +531,7 @@ void CastorShowerLibraryMaker::update(const EndOfEvent * evt) {
         NHitInEvent+=shower->getNhit();
         NEvtAccepted++;
       }
-      else {shower->Clear();}
+      else {shower->ClearB();}
   }
 // Check for unassociated energy
      
@@ -588,8 +588,8 @@ void CastorShowerLibraryMaker::update(const EndOfRun * run)
   hadInfo= &hadSLHolder.SLInfo;
 
   while(nEvtInTree<maxEvtInTree) {
-    if (emShower) emShower->Clear();
-    if (hadShower) hadShower->Clear();
+    if (emShower) emShower->ClearB();
+    if (hadShower) hadShower->ClearB();
     while(ibine<emSLHolder.SLEnergyBins.size()&&nEMevt>0){
       emShower = &(emSLHolder.SLCollection.at(ibine).at(ibineta).at(ibinphi).at(ievt));
       ievt++;


### PR DESCRIPTION
by adding using baseclass::function; statement