### PR TITLE
HBHE: use proper quantization noise in the M2

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -547,8 +547,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     energyArr[ip] = energy; pedenArr[ip] = peden;
 
     // quantization noise from the ADC (QIE8 or QIE10/11)
-    if(!channelData.hasTimeInfo()) noiseADCArr[ip] = psfPtr_->sigmaHPDQIE8(chargeArr[ip]);
-    if(channelData.hasTimeInfo()) noiseADCArr[ip] = psfPtr_->sigmaSiPMQIE10(chargeArr[ip]);
+    noiseADCArr[ip] = channelData.tsDFcPerADC(ip);
 
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -547,7 +547,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     energyArr[ip] = energy; pedenArr[ip] = peden;
 
     // quantization noise from the ADC (QIE8 or QIE10/11)
-    noiseADCArr[ip] = channelData.tsDFcPerADC(ip);
+    noiseADCArr[ip] = (1./sqrt(12))*channelData.tsDFcPerADC(ip);
 
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -547,7 +547,11 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     energyArr[ip] = energy; pedenArr[ip] = peden;
 
     // quantization noise from the ADC (QIE8 or QIE10/11)
-    noiseADCArr[ip] = (1./sqrt(12))*channelData.tsDFcPerADC(ip);
+    if(channelData.hasTimeInfo()) {
+      noiseADCArr[ip] = (1./sqrt(12))*channelData.tsDFcPerADC(ip);
+    } else {
+      noiseADCArr[ip] = psfPtr_->sigmaHPDQIE8(chargeArr[ip]); // Add Greg's channel discretization
+    }
 
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;


### PR DESCRIPTION
Hi.
Added proper quantization noise introduced in #16951 
Validation test in
http://dalfonso.web.cern.ch/dalfonso/dalfonso_M2adcFIX.pdf

Fix only the HE for the 2017 scenario. 
It affect both data and MC.
