### PR TITLE
SLHCUpgradeSimulations/Geometry/test fix clang warning hides overloaded virtual

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.cc
@@ -65,7 +65,7 @@ FastsimHitNtuplizer::FastsimHitNtuplizer(edm::ParameterSet const& conf) :
 
 FastsimHitNtuplizer::~FastsimHitNtuplizer() { }  
 
-void FastsimHitNtuplizer::endJob() 
+void FastsimHitNtuplizer::endRun(const edm::Run&, const edm::EventSetup& es) 
 {
   std::cout << " FastsimHitNtuplizer::endJob" << std::endl;
   tfile_->Write();
@@ -74,7 +74,7 @@ void FastsimHitNtuplizer::endJob()
 
 
 
-void FastsimHitNtuplizer::beginJob(const edm::EventSetup& es)
+void FastsimHitNtuplizer::beginRun(const edm::Run&, const edm::EventSetup& es)
 {
   std::cout << " FastsimHitNtuplizer::beginJob" << std::endl;
   std::string outputFile = conf_.getParameter<std::string>("OutputFile");

--- a/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.h
+++ b/SLHCUpgradeSimulations/Geometry/test/FastsimHitNtuplizer.h
@@ -34,8 +34,8 @@ class FastsimHitNtuplizer : public edm::EDAnalyzer
   
   explicit FastsimHitNtuplizer(const edm::ParameterSet& conf);
   virtual ~FastsimHitNtuplizer();
-  virtual void beginJob(const edm::EventSetup& es);
-  virtual void endJob();
+  virtual void beginRun(const edm::Run&, const edm::EventSetup& es);
+  virtual void endRun(const edm::Run&, const edm::EventSetup& es);
   virtual void analyze(const edm::Event& e, const edm::EventSetup& es);
 
  protected:


### PR DESCRIPTION
Change beginJob to beginRun to have access to EventStore and set the correct base function signature.