### PR TITLE
implement Eras for HLT (90x)

### DIFF
--- a/HLTrigger/Configuration/python/Eras.py
+++ b/HLTrigger/Configuration/python/Eras.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+def modifyHLTforEras(fragment):
+    """load all Eras-based customisations for the HLT configuration"""
+
+    # modify the HLT configuration for the Phase I pixel geometry
+    from HLTrigger.Configuration.customizeHLTTrackingForPhaseI2017 import modifyHLTforPhaseIPixelGeom
+    modifyHLTforPhaseIPixelGeom(fragment)
+
+    # modify the HLT configuration to run the Phase I tracking in the particle flow sequence
+    from HLTrigger.Configuration.customizeHLTTrackingForPhaseI2017 import modifyHLTforPhaseIPFTracking
+    modifyHLTforPhaseIPFTracking(fragment)

--- a/HLTrigger/Configuration/python/Eras.py
+++ b/HLTrigger/Configuration/python/Eras.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
+
+# import the relevant eras from Configuration.Eras.*
 
 def modifyHLTforEras(fragment):
     """load all Eras-based customisations for the HLT configuration"""

--- a/HLTrigger/Configuration/python/HLT_25ns10e33_v2_cff.py
+++ b/HLTrigger/Configuration/python/HLT_25ns10e33_v2_cff.py
@@ -62944,3 +62944,7 @@ fragment = customizeHLTforAll(fragment,"25ns10e33_v2")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"25ns10e33_v2")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_25ns15e33_v4_cff.py
+++ b/HLTrigger/Configuration/python/HLT_25ns15e33_v4_cff.py
@@ -71359,3 +71359,7 @@ fragment = customizeHLTforAll(fragment,"25ns15e33_v4")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"25ns15e33_v4")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_Fake1_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake1_cff.py
@@ -210,3 +210,7 @@ fragment = customizeHLTforAll(fragment,"Fake1")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"Fake1")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_Fake_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake_cff.py
@@ -195,3 +195,7 @@ fragment = customizeHLTforAll(fragment,"Fake")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"Fake")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -65344,3 +65344,7 @@ fragment = customizeHLTforAll(fragment,"GRun")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"GRun")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -12554,3 +12554,7 @@ fragment = customizeHLTforAll(fragment,"HIon")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"HIon")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -18168,3 +18168,7 @@ fragment = customizeHLTforAll(fragment,"PIon")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"PIon")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/HLT_PRef_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PRef_cff.py
@@ -12773,3 +12773,7 @@ fragment = customizeHLTforAll(fragment,"PRef")
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 fragment = customizeHLTforCMSSW(fragment,"PRef")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(fragment)
+

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -193,6 +193,13 @@ from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 %%(process)s = customizeHLTforCMSSW(%%(process)s,"%s")
 """ % (self.config.type)
 
+    # Eras-based customisations
+    self.data += """
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(%%(process)s)
+"""
+
   # customize the configuration according to the options
   def customize(self):
 

--- a/HLTrigger/Configuration/python/common.py
+++ b/HLTrigger/Configuration/python/common.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+def producers_by_type(process, *types):
+    "Find all EDProducers in the Process that are instances of the given C++ type."
+    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
+
+def filters_by_type(process, *types):
+    "Find all EDFilters in the Process that are instances of the given C++ type."
+    return (filter for filter in process._Process__filters.values() if filter._TypedParameterizable__type in types)
+
+def analyzers_by_type(process, *types):
+    "Find all EDAnalyzers in the Process that are instances of the given C++ type."
+    return (analyzer for analyzer in process._Process__analyzers.values() if analyzer._TypedParameterizable__type in types)
+
+def esproducers_by_type(process, *types):
+    "Find all ESProducers in the Process that are instances of the given C++ type."
+    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
+

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,274 +1,350 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 from HLTrigger.Configuration.common import *
 
-def customizeHLTPhaseIPixelGeom(process):
+def modifyHLTforPhaseIPixelGeom(fragment):
+    """Modify the HLT configuration for the Phase I pixel geometry"""
 
-    for esproducer in esproducers_by_type(process,"ClusterShapeHitFilterESProducer"):
-         esproducer.PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par'
-    for producer in producers_by_type(process,"SiPixelRawToDigi"):
-        if "hlt" in producer.label():
-            producer.UsePhase1 = cms.bool( True )
-    return process
+    # modify all ClusterShapeHitFilterESProducer ESProducers
+    for esproducer in esproducers_by_type(fragment, "ClusterShapeHitFilterESProducer"):
+        eras.trackingPhase1.toModify(esproducer, PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par')
+
+    # modify all SiPixelRawToDigi EDProducers
+    for producer in producers_by_type(fragment, "SiPixelRawToDigi"):
+        eras.trackingPhase1.toModify(producer, UsePhase1 = cms.bool( True ))
 
 
-def customizeHLTForPFTrackingPhaseI2017(process):
+def modifyHLTforPhaseIPFTracking(fragment):
+    """Modify the HLT configuration to run the Phase I tracking in the particle flow sequence"""
 
-    process.hltPixelLayerTriplets.layerList = cms.vstring(
-        'BPix1+BPix2+BPix3',
-        'BPix2+BPix3+BPix4',
-        'BPix1+BPix3+BPix4',
-        'BPix1+BPix2+BPix4',
-        'BPix2+BPix3+FPix1_pos',
-        'BPix2+BPix3+FPix1_neg',
-        'BPix1+BPix2+FPix1_pos',
-        'BPix1+BPix2+FPix1_neg',
-        'BPix2+FPix1_pos+FPix2_pos',
-        'BPix2+FPix1_neg+FPix2_neg',
-        'BPix1+FPix1_pos+FPix2_pos',
-        'BPix1+FPix1_neg+FPix2_neg',
-        'FPix1_pos+FPix2_pos+FPix3_pos',
-        'FPix1_neg+FPix2_neg+FPix3_neg' 
-    )
-
-    process.hltPixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
-         BPix = cms.PSet(
-            useErrorsFromParam = cms.bool( True ),
-            hitErrorRPhi = cms.double( 0.0027 ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.006 )
-        ),
-        FPix = cms.PSet(
-            useErrorsFromParam = cms.bool( True ),
-            hitErrorRPhi = cms.double( 0.0051 ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.0036 )
-        ),
-        MTEC = cms.PSet( ),
-        MTIB = cms.PSet( ),
-        MTID = cms.PSet( ),
-        MTOB = cms.PSet( ),
-        TEC = cms.PSet( ),
-        TIB = cms.PSet( ),
-        TID = cms.PSet( ),
-        TOB = cms.PSet( ),
-        layerList = cms.vstring(
-            'BPix1+BPix2+BPix3+BPix4', 
-            'BPix1+BPix2+BPix3+FPix1_pos', 
-            'BPix1+BPix2+BPix3+FPix1_neg', 
-            'BPix1+BPix2+FPix1_pos+FPix2_pos', 
-            'BPix1+BPix2+FPix1_neg+FPix2_neg', 
-            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
-            'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
+    # hltPixelLayerTriplets
+    if hasattr(fragment, "hltPixelLayerTriplets"):
+        eras.trackingPhase1.toModify( fragment.hltPixelLayerTriplets,
+            layerList = cms.vstring(
+                'BPix1+BPix2+BPix3',
+                'BPix2+BPix3+BPix4',
+                'BPix1+BPix3+BPix4',
+                'BPix1+BPix2+BPix4',
+                'BPix2+BPix3+FPix1_pos',
+                'BPix2+BPix3+FPix1_neg',
+                'BPix1+BPix2+FPix1_pos',
+                'BPix1+BPix2+FPix1_neg',
+                'BPix2+FPix1_pos+FPix2_pos',
+                'BPix2+FPix1_neg+FPix2_neg',
+                'BPix1+FPix1_pos+FPix2_pos',
+                'BPix1+FPix1_neg+FPix2_neg',
+                'FPix1_pos+FPix2_pos+FPix3_pos',
+                'FPix1_neg+FPix2_neg+FPix3_neg'
+            )
         )
+
+    # hltPixelLayerQuadruplets
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "hltPixelLayerQuadruplets", cms.EDProducer("SeedingLayersEDProducer",
+             BPix = cms.PSet(
+                useErrorsFromParam = cms.bool( True ),
+                hitErrorRPhi = cms.double( 0.0027 ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.006 )
+            ),
+            FPix = cms.PSet(
+                useErrorsFromParam = cms.bool( True ),
+                hitErrorRPhi = cms.double( 0.0051 ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.0036 )
+            ),
+            MTEC = cms.PSet( ),
+            MTIB = cms.PSet( ),
+            MTID = cms.PSet( ),
+            MTOB = cms.PSet( ),
+            TEC = cms.PSet( ),
+            TIB = cms.PSet( ),
+            TID = cms.PSet( ),
+            TOB = cms.PSet( ),
+            layerList = cms.vstring(
+                'BPix1+BPix2+BPix3+BPix4',
+                'BPix1+BPix2+BPix3+FPix1_pos',
+                'BPix1+BPix2+BPix3+FPix1_neg',
+                'BPix1+BPix2+FPix1_pos+FPix2_pos',
+                'BPix1+BPix2+FPix1_neg+FPix2_neg',
+                'BPix1+FPix1_pos+FPix2_pos+FPix3_pos',
+                'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
+            )
+        ) )
     )
 
-    # Configure seed generator / pixel track producer
-    from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
+    # hltPixelTracks
+    if hasattr(fragment, "hltPixelTracks"):
+        from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
+        eras.trackingPhase1.toModify( fragment.hltPixelTracks, OrderedHitsFactoryPSet = _CAHitQuadrupletGenerator.clone(
+            ComponentName = cms.string("CAHitQuadrupletGenerator"),
+            extraHitRPhitolerance = cms.double(0.032),
+            maxChi2 = dict(
+                pt1     =   0.7,
+                pt2     =   2,
+                value1  = 200,
+                value2  =  50,
+                enabled = True,
+            ),
+            useBendingCorrection = True,
+            fitFastCircle = True,
+            fitFastCircleChi2Cut = True,
+            SeedingLayers = cms.InputTag("hltPixelLayerQuadruplets"),
+            CAThetaCut = cms.double(0.0012),
+            CAPhiCut = cms.double(0.2),
+            CAHardPtCut = cms.double(0),
+            SeedComparitorPSet = cms.PSet(
+                ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
+                clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
+            )
+        ) )
+        eras.trackingPhase1.toModify( fragment.hltPixelTracks.RegionFactoryPSet, RegionPSet = cms.PSet(
+            precise = cms.bool( True ),
+            beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
+            originRadius = cms.double(0.02),
+            ptMin = cms.double(0.9),
+            nSigmaZ = cms.double(4.0),
+        ) )
 
-    process.hltPixelTracks.OrderedHitsFactoryPSet  = _CAHitQuadrupletGenerator.clone(
-        ComponentName = cms.string("CAHitQuadrupletGenerator"),
-        extraHitRPhitolerance = cms.double(0.032),
-        maxChi2 = dict(
-            pt1    = 0.7,
-            pt2    = 2,
-            value1 = 200,
-            value2 = 50,
-            enabled = True,
-        ),
-        useBendingCorrection = True,
-        fitFastCircle = True,
-        fitFastCircleChi2Cut = True,
-        SeedingLayers = cms.InputTag("hltPixelLayerQuadruplets"),
-        CAThetaCut = cms.double(0.0012),
-        CAPhiCut = cms.double(0.2),
-        CAHardPtCut = cms.double(0),
-        SeedComparitorPSet = cms.PSet( 
-            ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
-            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
+        # HLTDoRecoPixelTracksSequence
+        eras.trackingPhase1.toModify( fragment, lambda fragment:
+            setattr(fragment, "HLTDoRecoPixelTracksSequence", cms.Sequence(
+                fragment.hltPixelLayerQuadruplets +
+                fragment.hltPixelTracks
+            ) )
         )
+
+    # HLTIter0PSetTrajectoryFilterIT
+    if hasattr(fragment, "HLTIter0PSetTrajectoryFilterIT"):
+        eras.trackingPhase1.toModify( fragment.HLTIter0PSetTrajectoryFilterIT,
+            minimumNumberOfHits = cms.int32( 4 ),
+            minHitsMinPt        = cms.int32( 4 )
+        )
+
+    # hltIter0PFlowTrackCutClassifier
+    if hasattr(fragment, "hltIter0PFlowTrackCutClassifier"):
+        eras.trackingPhase1.toModify( fragment.hltIter0PFlowTrackCutClassifier.mva,
+            minLayers    = cms.vint32( 3, 3, 4 ),
+            min3DLayers  = cms.vint32( 0, 3, 4 ),
+            minPixelHits = cms.vint32( 0, 3, 4 )
+        )
+
+    # hltIter1PixelLayerTriplets
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "hltIter1PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
+            layerList = cms.vstring(
+                'BPix1+BPix2+BPix3',
+                'BPix1+BPix2+FPix1_pos',
+                'BPix1+BPix2+FPix1_neg',
+                'BPix1+FPix1_pos+FPix2_pos',
+                'BPix1+FPix1_neg+FPix2_neg'
+            ),
+            MTOB = cms.PSet( ),
+            TEC = cms.PSet( ),
+            MTID = cms.PSet( ),
+            FPix = cms.PSet(
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.0036 ),
+                useErrorsFromParam = cms.bool( True ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
+                hitErrorRPhi = cms.double( 0.0051 )
+            ),
+            MTEC = cms.PSet( ),
+            MTIB = cms.PSet( ),
+            TID = cms.PSet( ),
+            TOB = cms.PSet( ),
+            BPix = cms.PSet(
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.006 ),
+                useErrorsFromParam = cms.bool( True ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
+                hitErrorRPhi = cms.double( 0.0027 )
+            ),
+            TIB = cms.PSet( )
+        ) )
     )
 
-    process.hltPixelTracks.RegionFactoryPSet.RegionPSet = cms.PSet(
-        precise = cms.bool( True ),
-        beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
-        originRadius = cms.double(0.02),
-        ptMin = cms.double(0.9),
-        nSigmaZ = cms.double(4.0),
+    # HLTIter1PSetTrajectoryFilterIT
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "HLTIter1PSetTrajectoryFilterIT", cms.PSet(
+            ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+            chargeSignificance = cms.double(-1.0),
+            constantValueForLostHitsFractionFilter = cms.double(2.0),
+            extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+            maxCCCLostHits = cms.int32(0), # offline (2),
+            maxConsecLostHits = cms.int32(1),
+            maxLostHits = cms.int32(1),  # offline (999),
+            maxLostHitsFraction = cms.double(0.1),
+            maxNumberOfHits = cms.int32(100),
+            minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+            minHitsMinPt = cms.int32(3),
+            minNumberOfHitsForLoopers = cms.int32(13),
+            minNumberOfHitsPerLoop = cms.int32(4),
+            minPt = cms.double(0.2),
+            minimumNumberOfHits = cms.int32(4), # 3 online
+            nSigmaMinPt = cms.double(5.0),
+            pixelSeedExtension = cms.bool(True),
+            seedExtension = cms.int32(1),
+            seedPairPenalty = cms.int32(0),
+            strictSeedExtension = cms.bool(True)
+        ) )
     )
 
-    process.HLTDoRecoPixelTracksSequence = cms.Sequence( process.hltPixelLayerQuadruplets + process.hltPixelTracks )
-    
-    process.HLTIter0PSetTrajectoryFilterIT.minimumNumberOfHits = cms.int32( 4 )
-    process.HLTIter0PSetTrajectoryFilterIT.minHitsMinPt        = cms.int32( 4 )
-    process.hltIter0PFlowTrackCutClassifier.mva.minLayers    = cms.vint32( 3, 3, 4 )
-    process.hltIter0PFlowTrackCutClassifier.mva.min3DLayers  = cms.vint32( 0, 3, 4 )
-    process.hltIter0PFlowTrackCutClassifier.mva.minPixelHits = cms.vint32( 0, 3, 4 )
-
-    process.hltIter1PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
-        layerList = cms.vstring( 
-            'BPix1+BPix2+BPix3', 
-            'BPix1+BPix2+FPix1_pos', 
-            'BPix1+BPix2+FPix1_neg', 
-            'BPix1+FPix1_pos+FPix2_pos', 
-            'BPix1+FPix1_neg+FPix2_neg'
-        ),
-        MTOB = cms.PSet( ),
-        TEC = cms.PSet( ),
-        MTID = cms.PSet( ),
-        FPix = cms.PSet( 
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.0036 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0051 )
-        ),
-        MTEC = cms.PSet( ),
-        MTIB = cms.PSet( ),
-        TID = cms.PSet( ),
-        TOB = cms.PSet( ),
-        BPix = cms.PSet( 
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.006 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0027 )
-        ),
-        TIB = cms.PSet( )
-    )
-    
-    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
-        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-        chargeSignificance = cms.double(-1.0),
-        constantValueForLostHitsFractionFilter = cms.double(2.0),
-        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-        maxCCCLostHits = cms.int32(0), # offline (2),
-        maxConsecLostHits = cms.int32(1),
-        maxLostHits = cms.int32(1),  # offline (999),
-        maxLostHitsFraction = cms.double(0.1),
-        maxNumberOfHits = cms.int32(100),
-        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-        minHitsMinPt = cms.int32(3),
-        minNumberOfHitsForLoopers = cms.int32(13),
-        minNumberOfHitsPerLoop = cms.int32(4),
-        minPt = cms.double(0.2),
-        minimumNumberOfHits = cms.int32(4), # 3 online
-        nSigmaMinPt = cms.double(5.0),
-        pixelSeedExtension = cms.bool(True),
-        seedExtension = cms.int32(1),
-        seedPairPenalty = cms.int32(0),
-        strictSeedExtension = cms.bool(True)
+    # HLTIter1PSetTrajectoryFilterInOutIT
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "HLTIter1PSetTrajectoryFilterInOutIT", cms.PSet(
+            ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+            chargeSignificance = cms.double(-1.0),
+            constantValueForLostHitsFractionFilter = cms.double(2.0),
+            extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+            maxCCCLostHits = cms.int32(0), # offline (2),
+            maxConsecLostHits = cms.int32(1),
+            maxLostHits = cms.int32(1),  # offline (999),
+            maxLostHitsFraction = cms.double(0.1),
+            maxNumberOfHits = cms.int32(100),
+            minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+            minHitsMinPt = cms.int32(3),
+            minNumberOfHitsForLoopers = cms.int32(13),
+            minNumberOfHitsPerLoop = cms.int32(4),
+            minPt = cms.double(0.2),
+            minimumNumberOfHits = cms.int32(4), # 3 online
+            nSigmaMinPt = cms.double(5.0),
+            pixelSeedExtension = cms.bool(True),
+            seedExtension = cms.int32(1),
+            seedPairPenalty = cms.int32(0),
+            strictSeedExtension = cms.bool(True)
+        ) )
     )
 
-    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
-        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-        chargeSignificance = cms.double(-1.0),
-        constantValueForLostHitsFractionFilter = cms.double(2.0),
-        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-        maxCCCLostHits = cms.int32(0), # offline (2),
-        maxConsecLostHits = cms.int32(1),
-        maxLostHits = cms.int32(1),  # offline (999),
-        maxLostHitsFraction = cms.double(0.1),
-        maxNumberOfHits = cms.int32(100),
-        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-        minHitsMinPt = cms.int32(3),
-        minNumberOfHitsForLoopers = cms.int32(13),
-        minNumberOfHitsPerLoop = cms.int32(4),
-        minPt = cms.double(0.2),
-        minimumNumberOfHits = cms.int32(4), # 3 online
-        nSigmaMinPt = cms.double(5.0),
-        pixelSeedExtension = cms.bool(True),
-        seedExtension = cms.int32(1),
-        seedPairPenalty = cms.int32(0),
-        strictSeedExtension = cms.bool(True)
+    # HLTIter1PSetTrajectoryBuilderIT
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "HLTIter1PSetTrajectoryBuilderIT", cms.PSet(
+            inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
+            propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
+            trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
+            maxCand = cms.int32( 2 ),
+            ComponentType = cms.string( "CkfTrajectoryBuilder" ),
+            propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
+            MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
+            estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
+            TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
+            updator = cms.string( "hltESPKFUpdator" ),
+            alwaysUseInvalidHits = cms.bool( False ),
+            intermediateCleaning = cms.bool( True ),
+            lostHitPenalty = cms.double( 30.0 ),
+            useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
+        ) )
     )
 
-    process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
-        inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
-        propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
-        trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
-        maxCand = cms.int32( 2 ),
-        ComponentType = cms.string( "CkfTrajectoryBuilder" ),
-        propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
-        MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
-        estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
-        TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
-        updator = cms.string( "hltESPKFUpdator" ),
-        alwaysUseInvalidHits = cms.bool( False ),
-        intermediateCleaning = cms.bool( True ),
-        lostHitPenalty = cms.double( 30.0 ),
-        useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
+    # HLTIterativeTrackingIteration1
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "HLTIterativeTrackingIteration1", cms.Sequence(
+            fragment.hltIter1ClustersRefRemoval +
+            fragment.hltIter1MaskedMeasurementTrackerEvent +
+            fragment.hltIter1PixelLayerTriplets +
+            fragment.hltIter1PFlowPixelSeeds +
+            fragment.hltIter1PFlowCkfTrackCandidates +
+            fragment.hltIter1PFlowCtfWithMaterialTracks +
+            fragment.hltIter1PFlowTrackCutClassifierPrompt +
+            fragment.hltIter1PFlowTrackCutClassifierDetached +
+            fragment.hltIter1PFlowTrackCutClassifierMerged +
+            fragment.hltIter1PFlowTrackSelectionHighPurity
+        ) )
     )
 
-    process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
-
-    process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
-        layerList = cms.vstring( 
-            'BPix1+BPix2+BPix3',
-            'BPix1+BPix2+FPix1_pos',
-            'BPix1+BPix2+FPix1_neg',
-            'BPix1+FPix1_pos+FPix2_pos',
-            'BPix1+FPix1_neg+FPix2_neg' 
-        ),
-        MTOB = cms.PSet( ),
-        TEC = cms.PSet( ),
-        MTID = cms.PSet( ),
-        FPix = cms.PSet( 
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.0036 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0051 )
-        ),
-        MTEC = cms.PSet( ),
-        MTIB = cms.PSet( ),
-        TID = cms.PSet( ),
-        TOB = cms.PSet( ),
-        BPix = cms.PSet( 
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.006 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0027 )
-        ),
-        TIB = cms.PSet( )
+    # hltIter2PixelLayerTriplets
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "hltIter2PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
+            layerList = cms.vstring(
+                'BPix1+BPix2+BPix3',
+                'BPix1+BPix2+FPix1_pos',
+                'BPix1+BPix2+FPix1_neg',
+                'BPix1+FPix1_pos+FPix2_pos',
+                'BPix1+FPix1_neg+FPix2_neg'
+            ),
+            MTOB = cms.PSet( ),
+            TEC = cms.PSet( ),
+            MTID = cms.PSet( ),
+            FPix = cms.PSet(
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.0036 ),
+                useErrorsFromParam = cms.bool( True ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
+                hitErrorRPhi = cms.double( 0.0051 )
+            ),
+            MTEC = cms.PSet( ),
+            MTIB = cms.PSet( ),
+            TID = cms.PSet( ),
+            TOB = cms.PSet( ),
+            BPix = cms.PSet(
+                HitProducer = cms.string( "hltSiPixelRecHits" ),
+                hitErrorRZ = cms.double( 0.006 ),
+                useErrorsFromParam = cms.bool( True ),
+                TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+                skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
+                hitErrorRPhi = cms.double( 0.0027 )
+            ),
+            TIB = cms.PSet( )
+        ) )
     )
 
-    process.hltIter2PFlowPixelSeeds.OrderedHitsFactoryPSet = cms.PSet( 
-        maxElement = cms.uint32( 0 ),
-        ComponentName = cms.string( "StandardHitTripletGenerator" ),
-        GeneratorPSet = cms.PSet( 
-            useBending = cms.bool( True ),
-            useFixedPreFiltering = cms.bool( False ),
-            maxElement = cms.uint32( 100000 ),
-            phiPreFiltering = cms.double( 0.3 ),
-            extraHitRPhitolerance = cms.double( 0.032 ),
-            useMultScattering = cms.bool( True ),
-            ComponentName = cms.string( "PixelTripletHLTGenerator" ),
-            extraHitRZtolerance = cms.double( 0.037 ),
-            SeedComparitorPSet = cms.PSet(  ComponentName = cms.string( "none" ) )
-        ),
-        SeedingLayers = cms.InputTag( "hltIter2PixelLayerTriplets" )
+    # hltIter2PFlowPixelSeeds
+    if hasattr(fragment, "hltIter2PFlowPixelSeeds"):
+        eras.trackingPhase1.toModify( fragment.hltIter2PFlowPixelSeeds,
+            OrderedHitsFactoryPSet = cms.PSet(
+                maxElement = cms.uint32( 0 ),
+                ComponentName = cms.string( "StandardHitTripletGenerator" ),
+                GeneratorPSet = cms.PSet(
+                    useBending = cms.bool( True ),
+                    useFixedPreFiltering = cms.bool( False ),
+                    maxElement = cms.uint32( 100000 ),
+                    phiPreFiltering = cms.double( 0.3 ),
+                    extraHitRPhitolerance = cms.double( 0.032 ),
+                    useMultScattering = cms.bool( True ),
+                    ComponentName = cms.string( "PixelTripletHLTGenerator" ),
+                    extraHitRZtolerance = cms.double( 0.037 ),
+                    SeedComparitorPSet = cms.PSet(  ComponentName = cms.string( "none" ) )
+                ),
+                SeedingLayers = cms.InputTag( "hltIter2PixelLayerTriplets" )
+            ),
+            SeedCreatorPSet = cms.PSet(
+                refToPSet_ = cms.string( "HLTSeedFromConsecutiveHitsTripletOnlyCreator" )
+            )
+        )
+
+    # HLTIterativeTrackingIteration2
+    eras.trackingPhase1.toModify( fragment, lambda fragment:
+        setattr(fragment, "HLTIterativeTrackingIteration2", cms.Sequence(
+            fragment.hltIter2ClustersRefRemoval +
+            fragment.hltIter2MaskedMeasurementTrackerEvent +
+            fragment.hltIter2PixelLayerTriplets +
+            fragment.hltIter2PFlowPixelSeeds +
+            fragment.hltIter2PFlowCkfTrackCandidates +
+            fragment.hltIter2PFlowCtfWithMaterialTracks +
+            fragment.hltIter2PFlowTrackCutClassifier +
+            fragment.hltIter2PFlowTrackSelectionHighPurity
+        ) )
     )
 
-    process.hltIter2PFlowPixelSeeds.SeedCreatorPSet = cms.PSet(  refToPSet_ = cms.string( "HLTSeedFromConsecutiveHitsTripletOnlyCreator" ) )
-    
-    process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
-
-    for seqName in process.sequences:
-        seq = getattr(process,seqName)
+    def add_hltPixelLayerQuadruplets_to_sequences(fragment):
         from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
-        l = list()
-        v = ModuleNodeVisitor(l)
-        seq.visit(v)
-        if process.hltPixelTracks in l and not process.hltPixelLayerQuadruplets in l:
-            seq.remove(process.hltPixelLayerTriplets)
-            index = seq.index(process.hltPixelTracks)
-            seq.insert(index,process.hltPixelLayerQuadruplets)
+        for seq_name in fragment.sequences:
+            seq = getattr(fragment, seq_name)
 
-    return process
+            # find the list of modules in the sequence
+            modules = list()
+            seq.visit( ModuleNodeVisitor(modules) )
+
+            if fragment.hltPixelTracks in modules and not fragment.hltPixelLayerQuadruplets in modules:
+                mod = seq.copy()
+                mod.remove(fragment.hltPixelLayerTriplets)
+                index = mod.index(fragment.hltPixelTracks)
+                mod.insert(index, fragment.hltPixelLayerQuadruplets)
+                eras.trackingPhase1.toReplaceWith(seq, mod)
+
+    eras.trackingPhase1.toModify( fragment, lambda fragment: add_hltPixelLayerQuadruplets_to_sequences(fragment) )

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,286 +1,274 @@
 import FWCore.ParameterSet.Config as cms
-
-
-def producers_by_type(process, *types):
-    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
-def esproducers_by_type(process, *types):
-	return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
-
+from HLTrigger.Configuration.common import *
 
 def customizeHLTPhaseIPixelGeom(process):
 
-	for esproducer in esproducers_by_type(process,"ClusterShapeHitFilterESProducer"):
-		 esproducer.PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par'
-	for producer in producers_by_type(process,"SiPixelRawToDigi"):
-		if "hlt" in producer.label():
-			producer.UsePhase1 = cms.bool( True )
-	return process
-    
+    for esproducer in esproducers_by_type(process,"ClusterShapeHitFilterESProducer"):
+         esproducer.PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par'
+    for producer in producers_by_type(process,"SiPixelRawToDigi"):
+        if "hlt" in producer.label():
+            producer.UsePhase1 = cms.bool( True )
+    return process
+
+
 def customizeHLTForPFTrackingPhaseI2017(process):
 
-	process = customizeHLTPhaseIPixelGeom(process)
+    process.hltPixelLayerTriplets.layerList = cms.vstring(
+        'BPix1+BPix2+BPix3',
+        'BPix2+BPix3+BPix4',
+        'BPix1+BPix3+BPix4',
+        'BPix1+BPix2+BPix4',
+        'BPix2+BPix3+FPix1_pos',
+        'BPix2+BPix3+FPix1_neg',
+        'BPix1+BPix2+FPix1_pos',
+        'BPix1+BPix2+FPix1_neg',
+        'BPix2+FPix1_pos+FPix2_pos',
+        'BPix2+FPix1_neg+FPix2_neg',
+        'BPix1+FPix1_pos+FPix2_pos',
+        'BPix1+FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix2_pos+FPix3_pos',
+        'FPix1_neg+FPix2_neg+FPix3_neg' 
+    )
 
-	process.hltPixelLayerTriplets.layerList = cms.vstring(
-	    'BPix1+BPix2+BPix3',
-	    'BPix2+BPix3+BPix4',
-	    'BPix1+BPix3+BPix4',
-	    'BPix1+BPix2+BPix4',
-	    'BPix2+BPix3+FPix1_pos',
-	    'BPix2+BPix3+FPix1_neg',
-	    'BPix1+BPix2+FPix1_pos',
-	    'BPix1+BPix2+FPix1_neg',
-	    'BPix2+FPix1_pos+FPix2_pos',
-	    'BPix2+FPix1_neg+FPix2_neg',
-	    'BPix1+FPix1_pos+FPix2_pos',
-	    'BPix1+FPix1_neg+FPix2_neg',
-	    'FPix1_pos+FPix2_pos+FPix3_pos',
-	    'FPix1_neg+FPix2_neg+FPix3_neg' 
-	)
-
-	process.hltPixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
-		 BPix = cms.PSet(
-		 	useErrorsFromParam = cms.bool( True ),
-		        hitErrorRPhi = cms.double( 0.0027 ),
-		        TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-	                HitProducer = cms.string( "hltSiPixelRecHits" ),
-		        hitErrorRZ = cms.double( 0.006 )
-		    ),
-		FPix = cms.PSet(
-		      useErrorsFromParam = cms.bool( True ),
-		      hitErrorRPhi = cms.double( 0.0051 ),
-		      TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-		      HitProducer = cms.string( "hltSiPixelRecHits" ),
-		      hitErrorRZ = cms.double( 0.0036 )
-		    ),
-	    MTEC = cms.PSet( ),
-	    MTIB = cms.PSet( ),
-	    MTID = cms.PSet( ),
-	    MTOB = cms.PSet( ),
-	    TEC = cms.PSet( ),
-	    TIB = cms.PSet( ),
-	    TID = cms.PSet( ),
-	    TOB = cms.PSet( ),
-	    layerList = cms.vstring(
-	        'BPix1+BPix2+BPix3+BPix4', 
-	        'BPix1+BPix2+BPix3+FPix1_pos', 
-	        'BPix1+BPix2+BPix3+FPix1_neg', 
-	        'BPix1+BPix2+FPix1_pos+FPix2_pos', 
-	        'BPix1+BPix2+FPix1_neg+FPix2_neg', 
-	        'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
-	        'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
-	    )
-	)
-
-
-   
-
-
-        # Configure seed generator / pixel track producer
-        from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
-
-        process.hltPixelTracks.OrderedHitsFactoryPSet  = _CAHitQuadrupletGenerator.clone(
-            ComponentName = cms.string("CAHitQuadrupletGenerator"),
-            extraHitRPhitolerance = cms.double(0.032),
-            maxChi2 = dict(
-                pt1    = 0.7, pt2    = 2,
-                value1 = 200, value2 = 50,
-                enabled = True,
-            ),
-            useBendingCorrection = True,
-            fitFastCircle = True,
-            fitFastCircleChi2Cut = True,
-            SeedingLayers = cms.InputTag("hltPixelLayerQuadruplets"),
-            CAThetaCut = cms.double(0.0012),
-            CAPhiCut = cms.double(0.2),
-            CAHardPtCut = cms.double(0),
- 	    SeedComparitorPSet = cms.PSet( 
-	          ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
-	          clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
-	    ),
-           
+    process.hltPixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
+         BPix = cms.PSet(
+            useErrorsFromParam = cms.bool( True ),
+            hitErrorRPhi = cms.double( 0.0027 ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.006 )
+        ),
+        FPix = cms.PSet(
+            useErrorsFromParam = cms.bool( True ),
+            hitErrorRPhi = cms.double( 0.0051 ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.0036 )
+        ),
+        MTEC = cms.PSet( ),
+        MTIB = cms.PSet( ),
+        MTID = cms.PSet( ),
+        MTOB = cms.PSet( ),
+        TEC = cms.PSet( ),
+        TIB = cms.PSet( ),
+        TID = cms.PSet( ),
+        TOB = cms.PSet( ),
+        layerList = cms.vstring(
+            'BPix1+BPix2+BPix3+BPix4', 
+            'BPix1+BPix2+BPix3+FPix1_pos', 
+            'BPix1+BPix2+BPix3+FPix1_neg', 
+            'BPix1+BPix2+FPix1_pos+FPix2_pos', 
+            'BPix1+BPix2+FPix1_neg+FPix2_neg', 
+            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
+            'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
         )
+    )
 
-	process.hltPixelTracks.RegionFactoryPSet.RegionPSet = cms.PSet(
-	    precise = cms.bool( True ),
-	    beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
-	    originRadius = cms.double(0.02),
-	    ptMin = cms.double(0.9),
-	    nSigmaZ = cms.double(4.0),
-	)
+    # Configure seed generator / pixel track producer
+    from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
 
+    process.hltPixelTracks.OrderedHitsFactoryPSet  = _CAHitQuadrupletGenerator.clone(
+        ComponentName = cms.string("CAHitQuadrupletGenerator"),
+        extraHitRPhitolerance = cms.double(0.032),
+        maxChi2 = dict(
+            pt1    = 0.7,
+            pt2    = 2,
+            value1 = 200,
+            value2 = 50,
+            enabled = True,
+        ),
+        useBendingCorrection = True,
+        fitFastCircle = True,
+        fitFastCircleChi2Cut = True,
+        SeedingLayers = cms.InputTag("hltPixelLayerQuadruplets"),
+        CAThetaCut = cms.double(0.0012),
+        CAPhiCut = cms.double(0.2),
+        CAHardPtCut = cms.double(0),
+        SeedComparitorPSet = cms.PSet( 
+            ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
+            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
+        )
+    )
 
-	process.HLTDoRecoPixelTracksSequence = cms.Sequence( process.hltPixelLayerQuadruplets + process.hltPixelTracks )
-	
-	process.HLTIter0PSetTrajectoryFilterIT.minimumNumberOfHits = cms.int32( 4 )
-	process.HLTIter0PSetTrajectoryFilterIT.minHitsMinPt        = cms.int32( 4 )
-	process.hltIter0PFlowTrackCutClassifier.mva.minLayers    = cms.vint32( 3, 3, 4 )
-	process.hltIter0PFlowTrackCutClassifier.mva.min3DLayers  = cms.vint32( 0, 3, 4 )
-	process.hltIter0PFlowTrackCutClassifier.mva.minPixelHits = cms.vint32( 0, 3, 4 )
-	
-	
+    process.hltPixelTracks.RegionFactoryPSet.RegionPSet = cms.PSet(
+        precise = cms.bool( True ),
+        beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
+        originRadius = cms.double(0.02),
+        ptMin = cms.double(0.9),
+        nSigmaZ = cms.double(4.0),
+    )
 
+    process.HLTDoRecoPixelTracksSequence = cms.Sequence( process.hltPixelLayerQuadruplets + process.hltPixelTracks )
+    
+    process.HLTIter0PSetTrajectoryFilterIT.minimumNumberOfHits = cms.int32( 4 )
+    process.HLTIter0PSetTrajectoryFilterIT.minHitsMinPt        = cms.int32( 4 )
+    process.hltIter0PFlowTrackCutClassifier.mva.minLayers    = cms.vint32( 3, 3, 4 )
+    process.hltIter0PFlowTrackCutClassifier.mva.min3DLayers  = cms.vint32( 0, 3, 4 )
+    process.hltIter0PFlowTrackCutClassifier.mva.minPixelHits = cms.vint32( 0, 3, 4 )
 
-	process.hltIter1PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
-	    layerList = cms.vstring( 
-	        'BPix1+BPix2+BPix3', 
-	        'BPix1+BPix2+FPix1_pos', 
-	        'BPix1+BPix2+FPix1_neg', 
-	        'BPix1+FPix1_pos+FPix2_pos', 
-	        'BPix1+FPix1_neg+FPix2_neg'
-	    ),
-	    MTOB = cms.PSet(  ),
-	    TEC = cms.PSet(  ),
-	    MTID = cms.PSet(  ),
-	    FPix = cms.PSet( 
-	      HitProducer = cms.string( "hltSiPixelRecHits" ),
-	      hitErrorRZ = cms.double( 0.0036 ),
-	      useErrorsFromParam = cms.bool( True ),
-	      TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-	      skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-	      hitErrorRPhi = cms.double( 0.0051 )
-	    ),
-	    MTEC = cms.PSet(  ),
-	    MTIB = cms.PSet(  ),
-	    TID = cms.PSet(  ),
-	    TOB = cms.PSet(  ),
-	    BPix = cms.PSet( 
-	      HitProducer = cms.string( "hltSiPixelRecHits" ),
-	      hitErrorRZ = cms.double( 0.006 ),
-	      useErrorsFromParam = cms.bool( True ),
-	      TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-	      skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-	      hitErrorRPhi = cms.double( 0.0027 )
-	    ),
-	    TIB = cms.PSet(  )
-	)
-	
-	process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
-	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-	    chargeSignificance = cms.double(-1.0),
-	    constantValueForLostHitsFractionFilter = cms.double(2.0),
-	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-	    maxCCCLostHits = cms.int32(0), # offline (2),
-	    maxConsecLostHits = cms.int32(1),
-	    maxLostHits = cms.int32(1),  # offline (999),
-	    maxLostHitsFraction = cms.double(0.1),
-	    maxNumberOfHits = cms.int32(100),
-	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-	    minHitsMinPt = cms.int32(3),
-	     minNumberOfHitsForLoopers = cms.int32(13),
-	    minNumberOfHitsPerLoop = cms.int32(4),
-	    minPt = cms.double(0.2),
-	    minimumNumberOfHits = cms.int32(4), # 3 online
-	    nSigmaMinPt = cms.double(5.0),
-	    pixelSeedExtension = cms.bool(True),
-	    seedExtension = cms.int32(1),
-	    seedPairPenalty = cms.int32(0),
-	    strictSeedExtension = cms.bool(True)
-	)
+    process.hltIter1PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
+        layerList = cms.vstring( 
+            'BPix1+BPix2+BPix3', 
+            'BPix1+BPix2+FPix1_pos', 
+            'BPix1+BPix2+FPix1_neg', 
+            'BPix1+FPix1_pos+FPix2_pos', 
+            'BPix1+FPix1_neg+FPix2_neg'
+        ),
+        MTOB = cms.PSet( ),
+        TEC = cms.PSet( ),
+        MTID = cms.PSet( ),
+        FPix = cms.PSet( 
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.0036 ),
+            useErrorsFromParam = cms.bool( True ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
+            hitErrorRPhi = cms.double( 0.0051 )
+        ),
+        MTEC = cms.PSet( ),
+        MTIB = cms.PSet( ),
+        TID = cms.PSet( ),
+        TOB = cms.PSet( ),
+        BPix = cms.PSet( 
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.006 ),
+            useErrorsFromParam = cms.bool( True ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
+            hitErrorRPhi = cms.double( 0.0027 )
+        ),
+        TIB = cms.PSet( )
+    )
+    
+    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
+        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+        chargeSignificance = cms.double(-1.0),
+        constantValueForLostHitsFractionFilter = cms.double(2.0),
+        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+        maxCCCLostHits = cms.int32(0), # offline (2),
+        maxConsecLostHits = cms.int32(1),
+        maxLostHits = cms.int32(1),  # offline (999),
+        maxLostHitsFraction = cms.double(0.1),
+        maxNumberOfHits = cms.int32(100),
+        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+        minHitsMinPt = cms.int32(3),
+        minNumberOfHitsForLoopers = cms.int32(13),
+        minNumberOfHitsPerLoop = cms.int32(4),
+        minPt = cms.double(0.2),
+        minimumNumberOfHits = cms.int32(4), # 3 online
+        nSigmaMinPt = cms.double(5.0),
+        pixelSeedExtension = cms.bool(True),
+        seedExtension = cms.int32(1),
+        seedPairPenalty = cms.int32(0),
+        strictSeedExtension = cms.bool(True)
+    )
 
-	process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
-	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-	    chargeSignificance = cms.double(-1.0),
-	    constantValueForLostHitsFractionFilter = cms.double(2.0),
-	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-	    maxCCCLostHits = cms.int32(0), # offline (2),
-	    maxConsecLostHits = cms.int32(1),
-	    maxLostHits = cms.int32(1),  # offline (999),
-	    maxLostHitsFraction = cms.double(0.1),
-	    maxNumberOfHits = cms.int32(100),
-	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-	    minHitsMinPt = cms.int32(3),
-	    minNumberOfHitsForLoopers = cms.int32(13),
-	    minNumberOfHitsPerLoop = cms.int32(4),
-	    minPt = cms.double(0.2),
-	    minimumNumberOfHits = cms.int32(4), # 3 online
-	    nSigmaMinPt = cms.double(5.0),
-	    pixelSeedExtension = cms.bool(True),
-	    seedExtension = cms.int32(1),
-	    seedPairPenalty = cms.int32(0),
-	    strictSeedExtension = cms.bool(True)
-	)
+    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
+        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+        chargeSignificance = cms.double(-1.0),
+        constantValueForLostHitsFractionFilter = cms.double(2.0),
+        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+        maxCCCLostHits = cms.int32(0), # offline (2),
+        maxConsecLostHits = cms.int32(1),
+        maxLostHits = cms.int32(1),  # offline (999),
+        maxLostHitsFraction = cms.double(0.1),
+        maxNumberOfHits = cms.int32(100),
+        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+        minHitsMinPt = cms.int32(3),
+        minNumberOfHitsForLoopers = cms.int32(13),
+        minNumberOfHitsPerLoop = cms.int32(4),
+        minPt = cms.double(0.2),
+        minimumNumberOfHits = cms.int32(4), # 3 online
+        nSigmaMinPt = cms.double(5.0),
+        pixelSeedExtension = cms.bool(True),
+        seedExtension = cms.int32(1),
+        seedPairPenalty = cms.int32(0),
+        strictSeedExtension = cms.bool(True)
+    )
 
-	process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
-	  inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
-	  propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
-	  trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
-	  maxCand = cms.int32( 2 ),
-	  ComponentType = cms.string( "CkfTrajectoryBuilder" ),
-	  propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
-	  MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
-	  estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
-	  TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
-	  updator = cms.string( "hltESPKFUpdator" ),
-	  alwaysUseInvalidHits = cms.bool( False ),
-	  intermediateCleaning = cms.bool( True ),
-	  lostHitPenalty = cms.double( 30.0 ),
-	  useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
-	)
+    process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
+        inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
+        propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
+        trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
+        maxCand = cms.int32( 2 ),
+        ComponentType = cms.string( "CkfTrajectoryBuilder" ),
+        propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
+        MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
+        estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
+        TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
+        updator = cms.string( "hltESPKFUpdator" ),
+        alwaysUseInvalidHits = cms.bool( False ),
+        intermediateCleaning = cms.bool( True ),
+        lostHitPenalty = cms.double( 30.0 ),
+        useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
+    )
 
-	process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
+    process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
 
+    process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
+        layerList = cms.vstring( 
+            'BPix1+BPix2+BPix3',
+            'BPix1+BPix2+FPix1_pos',
+            'BPix1+BPix2+FPix1_neg',
+            'BPix1+FPix1_pos+FPix2_pos',
+            'BPix1+FPix1_neg+FPix2_neg' 
+        ),
+        MTOB = cms.PSet( ),
+        TEC = cms.PSet( ),
+        MTID = cms.PSet( ),
+        FPix = cms.PSet( 
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.0036 ),
+            useErrorsFromParam = cms.bool( True ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
+            hitErrorRPhi = cms.double( 0.0051 )
+        ),
+        MTEC = cms.PSet( ),
+        MTIB = cms.PSet( ),
+        TID = cms.PSet( ),
+        TOB = cms.PSet( ),
+        BPix = cms.PSet( 
+            HitProducer = cms.string( "hltSiPixelRecHits" ),
+            hitErrorRZ = cms.double( 0.006 ),
+            useErrorsFromParam = cms.bool( True ),
+            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+            skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
+            hitErrorRPhi = cms.double( 0.0027 )
+        ),
+        TIB = cms.PSet( )
+    )
 
-	process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
-	    layerList = cms.vstring( 
-	        'BPix1+BPix2+BPix3',
-	        'BPix1+BPix2+FPix1_pos',
-	        'BPix1+BPix2+FPix1_neg',
-	        'BPix1+FPix1_pos+FPix2_pos',
-	        'BPix1+FPix1_neg+FPix2_neg' 
-	    ),
-	    MTOB = cms.PSet(  ),
-	    TEC = cms.PSet(  ),
-	    MTID = cms.PSet(  ),
-	    FPix = cms.PSet( 
-	      HitProducer = cms.string( "hltSiPixelRecHits" ),
-	      hitErrorRZ = cms.double( 0.0036 ),
-	      useErrorsFromParam = cms.bool( True ),
-	      TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-	      skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
-	      hitErrorRPhi = cms.double( 0.0051 )
-	    ),
-	    MTEC = cms.PSet(  ),
-	    MTIB = cms.PSet(  ),
-	    TID = cms.PSet(  ),
-	    TOB = cms.PSet(  ),
-	    BPix = cms.PSet( 
-	      HitProducer = cms.string( "hltSiPixelRecHits" ),
-	      hitErrorRZ = cms.double( 0.006 ),
-	      useErrorsFromParam = cms.bool( True ),
-	      TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-	      skipClusters = cms.InputTag( "hltIter2ClustersRefRemoval" ),
-	      hitErrorRPhi = cms.double( 0.0027 )
-	    ),
-	    TIB = cms.PSet(  )
-	)
-	process.hltIter2PFlowPixelSeeds.OrderedHitsFactoryPSet = cms.PSet( 
-	  maxElement = cms.uint32( 0 ),
-	  ComponentName = cms.string( "StandardHitTripletGenerator" ),
-	  GeneratorPSet = cms.PSet( 
-	    useBending = cms.bool( True ),
-	    useFixedPreFiltering = cms.bool( False ),
-	    maxElement = cms.uint32( 100000 ),
-	    phiPreFiltering = cms.double( 0.3 ),
-	    extraHitRPhitolerance = cms.double( 0.032 ),
-	    useMultScattering = cms.bool( True ),
-	    ComponentName = cms.string( "PixelTripletHLTGenerator" ),
-	    extraHitRZtolerance = cms.double( 0.037 ),
-	    SeedComparitorPSet = cms.PSet(  ComponentName = cms.string( "none" ) )
-	  ),
-	  SeedingLayers = cms.InputTag( "hltIter2PixelLayerTriplets" )
-	)
-	process.hltIter2PFlowPixelSeeds.SeedCreatorPSet = cms.PSet(  refToPSet_ = cms.string( "HLTSeedFromConsecutiveHitsTripletOnlyCreator" ) )
-	
-	process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
+    process.hltIter2PFlowPixelSeeds.OrderedHitsFactoryPSet = cms.PSet( 
+        maxElement = cms.uint32( 0 ),
+        ComponentName = cms.string( "StandardHitTripletGenerator" ),
+        GeneratorPSet = cms.PSet( 
+            useBending = cms.bool( True ),
+            useFixedPreFiltering = cms.bool( False ),
+            maxElement = cms.uint32( 100000 ),
+            phiPreFiltering = cms.double( 0.3 ),
+            extraHitRPhitolerance = cms.double( 0.032 ),
+            useMultScattering = cms.bool( True ),
+            ComponentName = cms.string( "PixelTripletHLTGenerator" ),
+            extraHitRZtolerance = cms.double( 0.037 ),
+            SeedComparitorPSet = cms.PSet(  ComponentName = cms.string( "none" ) )
+        ),
+        SeedingLayers = cms.InputTag( "hltIter2PixelLayerTriplets" )
+    )
 
-	for seqName in process.sequences:
-		seq = getattr(process,seqName)
-		from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
-		l = list()
-         	v = ModuleNodeVisitor(l)
-          	seq.visit(v)		
-		if process.hltPixelTracks in l and not process.hltPixelLayerQuadruplets in l:
-			seq.remove(process.hltPixelLayerTriplets)
-			index = seq.index(process.hltPixelTracks)
-			seq.insert(index,process.hltPixelLayerQuadruplets)
-	return process
+    process.hltIter2PFlowPixelSeeds.SeedCreatorPSet = cms.PSet(  refToPSet_ = cms.string( "HLTSeedFromConsecutiveHitsTripletOnlyCreator" ) )
+    
+    process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
+
+    for seqName in process.sequences:
+        seq = getattr(process,seqName)
+        from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
+        l = list()
+        v = ModuleNodeVisitor(l)
+        seq.visit(v)
+        if process.hltPixelTracks in l and not process.hltPixelLayerQuadruplets in l:
+            seq.remove(process.hltPixelLayerTriplets)
+            index = seq.index(process.hltPixelTracks)
+            seq.insert(index,process.hltPixelLayerQuadruplets)
+
+    return process

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from HLTrigger.Configuration.common import *
 
 def modifyHLTforPhaseIPixelGeom(fragment):
@@ -7,11 +7,11 @@ def modifyHLTforPhaseIPixelGeom(fragment):
 
     # modify all ClusterShapeHitFilterESProducer ESProducers
     for esproducer in esproducers_by_type(fragment, "ClusterShapeHitFilterESProducer"):
-        trackingPhase1.toModify(esproducer, PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par')
+        phase1Pixel.toModify(esproducer, PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par')
 
     # modify all SiPixelRawToDigi EDProducers
     for producer in producers_by_type(fragment, "SiPixelRawToDigi"):
-        trackingPhase1.toModify(producer, UsePhase1 = cms.bool( True ))
+        phase1Pixel.toModify(producer, UsePhase1 = cms.bool( True ))
 
 
 def modifyHLTforPhaseIPFTracking(fragment):
@@ -19,7 +19,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # hltPixelLayerTriplets
     if hasattr(fragment, "hltPixelLayerTriplets"):
-        trackingPhase1.toModify( fragment.hltPixelLayerTriplets,
+        phase1Pixel.toModify( fragment.hltPixelLayerTriplets,
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
                 'BPix2+BPix3+BPix4',
@@ -39,7 +39,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         )
 
     # hltPixelLayerQuadruplets
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "hltPixelLayerQuadruplets", cms.EDProducer("SeedingLayersEDProducer",
              BPix = cms.PSet(
                 useErrorsFromParam = cms.bool( True ),
@@ -78,7 +78,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     # hltPixelTracks
     if hasattr(fragment, "hltPixelTracks"):
         from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
-        trackingPhase1.toModify( fragment.hltPixelTracks, OrderedHitsFactoryPSet = _CAHitQuadrupletGenerator.clone(
+        phase1Pixel.toModify( fragment.hltPixelTracks, OrderedHitsFactoryPSet = _CAHitQuadrupletGenerator.clone(
             ComponentName = cms.string("CAHitQuadrupletGenerator"),
             extraHitRPhitolerance = cms.double(0.032),
             maxChi2 = dict(
@@ -100,7 +100,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
                 clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
             )
         ) )
-        trackingPhase1.toModify( fragment.hltPixelTracks.RegionFactoryPSet, RegionPSet = cms.PSet(
+        phase1Pixel.toModify( fragment.hltPixelTracks.RegionFactoryPSet, RegionPSet = cms.PSet(
             precise = cms.bool( True ),
             beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
             originRadius = cms.double(0.02),
@@ -109,7 +109,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         ) )
 
         # HLTDoRecoPixelTracksSequence
-        trackingPhase1.toModify( fragment, lambda fragment:
+        phase1Pixel.toModify( fragment, lambda fragment:
             setattr(fragment, "HLTDoRecoPixelTracksSequence", cms.Sequence(
                 fragment.hltPixelLayerQuadruplets +
                 fragment.hltPixelTracks
@@ -118,21 +118,21 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # HLTIter0PSetTrajectoryFilterIT
     if hasattr(fragment, "HLTIter0PSetTrajectoryFilterIT"):
-        trackingPhase1.toModify( fragment.HLTIter0PSetTrajectoryFilterIT,
+        phase1Pixel.toModify( fragment.HLTIter0PSetTrajectoryFilterIT,
             minimumNumberOfHits = cms.int32( 4 ),
             minHitsMinPt        = cms.int32( 4 )
         )
 
     # hltIter0PFlowTrackCutClassifier
     if hasattr(fragment, "hltIter0PFlowTrackCutClassifier"):
-        trackingPhase1.toModify( fragment.hltIter0PFlowTrackCutClassifier.mva,
+        phase1Pixel.toModify( fragment.hltIter0PFlowTrackCutClassifier.mva,
             minLayers    = cms.vint32( 3, 3, 4 ),
             min3DLayers  = cms.vint32( 0, 3, 4 ),
             minPixelHits = cms.vint32( 0, 3, 4 )
         )
 
     # hltIter1PixelLayerTriplets
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "hltIter1PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
@@ -169,7 +169,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryFilterIT
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryFilterIT", cms.PSet(
             ComponentType = cms.string('CkfBaseTrajectoryFilter'),
             chargeSignificance = cms.double(-1.0),
@@ -195,7 +195,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryFilterInOutIT
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryFilterInOutIT", cms.PSet(
             ComponentType = cms.string('CkfBaseTrajectoryFilter'),
             chargeSignificance = cms.double(-1.0),
@@ -221,7 +221,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryBuilderIT
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryBuilderIT", cms.PSet(
             inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
             propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
@@ -241,7 +241,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIterativeTrackingIteration1
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIterativeTrackingIteration1", cms.Sequence(
             fragment.hltIter1ClustersRefRemoval +
             fragment.hltIter1MaskedMeasurementTrackerEvent +
@@ -257,7 +257,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # hltIter2PixelLayerTriplets
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "hltIter2PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
@@ -295,7 +295,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # hltIter2PFlowPixelSeeds
     if hasattr(fragment, "hltIter2PFlowPixelSeeds"):
-        trackingPhase1.toModify( fragment.hltIter2PFlowPixelSeeds,
+        phase1Pixel.toModify( fragment.hltIter2PFlowPixelSeeds,
             OrderedHitsFactoryPSet = cms.PSet(
                 maxElement = cms.uint32( 0 ),
                 ComponentName = cms.string( "StandardHitTripletGenerator" ),
@@ -318,7 +318,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         )
 
     # HLTIterativeTrackingIteration2
-    trackingPhase1.toModify( fragment, lambda fragment:
+    phase1Pixel.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIterativeTrackingIteration2", cms.Sequence(
             fragment.hltIter2ClustersRefRemoval +
             fragment.hltIter2MaskedMeasurementTrackerEvent +
@@ -345,6 +345,6 @@ def modifyHLTforPhaseIPFTracking(fragment):
                 mod.remove(fragment.hltPixelLayerTriplets)
                 index = mod.index(fragment.hltPixelTracks)
                 mod.insert(index, fragment.hltPixelLayerQuadruplets)
-                trackingPhase1.toReplaceWith(seq, mod)
+                phase1Pixel.toReplaceWith(seq, mod)
 
-    trackingPhase1.toModify( fragment, lambda fragment: add_hltPixelLayerQuadruplets_to_sequences(fragment) )
+    phase1Pixel.toModify( fragment, lambda fragment: add_hltPixelLayerQuadruplets_to_sequences(fragment) )

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from HLTrigger.Configuration.common import *
 
 def modifyHLTforPhaseIPixelGeom(fragment):
@@ -7,11 +7,11 @@ def modifyHLTforPhaseIPixelGeom(fragment):
 
     # modify all ClusterShapeHitFilterESProducer ESProducers
     for esproducer in esproducers_by_type(fragment, "ClusterShapeHitFilterESProducer"):
-        eras.trackingPhase1.toModify(esproducer, PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par')
+        trackingPhase1.toModify(esproducer, PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1TkNewFPix.par')
 
     # modify all SiPixelRawToDigi EDProducers
     for producer in producers_by_type(fragment, "SiPixelRawToDigi"):
-        eras.trackingPhase1.toModify(producer, UsePhase1 = cms.bool( True ))
+        trackingPhase1.toModify(producer, UsePhase1 = cms.bool( True ))
 
 
 def modifyHLTforPhaseIPFTracking(fragment):
@@ -19,7 +19,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # hltPixelLayerTriplets
     if hasattr(fragment, "hltPixelLayerTriplets"):
-        eras.trackingPhase1.toModify( fragment.hltPixelLayerTriplets,
+        trackingPhase1.toModify( fragment.hltPixelLayerTriplets,
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
                 'BPix2+BPix3+BPix4',
@@ -39,7 +39,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         )
 
     # hltPixelLayerQuadruplets
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "hltPixelLayerQuadruplets", cms.EDProducer("SeedingLayersEDProducer",
              BPix = cms.PSet(
                 useErrorsFromParam = cms.bool( True ),
@@ -78,7 +78,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     # hltPixelTracks
     if hasattr(fragment, "hltPixelTracks"):
         from RecoPixelVertexing.PixelTriplets.CAHitQuadrupletGenerator_cfi import CAHitQuadrupletGenerator as _CAHitQuadrupletGenerator
-        eras.trackingPhase1.toModify( fragment.hltPixelTracks, OrderedHitsFactoryPSet = _CAHitQuadrupletGenerator.clone(
+        trackingPhase1.toModify( fragment.hltPixelTracks, OrderedHitsFactoryPSet = _CAHitQuadrupletGenerator.clone(
             ComponentName = cms.string("CAHitQuadrupletGenerator"),
             extraHitRPhitolerance = cms.double(0.032),
             maxChi2 = dict(
@@ -100,7 +100,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
                 clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
             )
         ) )
-        eras.trackingPhase1.toModify( fragment.hltPixelTracks.RegionFactoryPSet, RegionPSet = cms.PSet(
+        trackingPhase1.toModify( fragment.hltPixelTracks.RegionFactoryPSet, RegionPSet = cms.PSet(
             precise = cms.bool( True ),
             beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
             originRadius = cms.double(0.02),
@@ -109,7 +109,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         ) )
 
         # HLTDoRecoPixelTracksSequence
-        eras.trackingPhase1.toModify( fragment, lambda fragment:
+        trackingPhase1.toModify( fragment, lambda fragment:
             setattr(fragment, "HLTDoRecoPixelTracksSequence", cms.Sequence(
                 fragment.hltPixelLayerQuadruplets +
                 fragment.hltPixelTracks
@@ -118,21 +118,21 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # HLTIter0PSetTrajectoryFilterIT
     if hasattr(fragment, "HLTIter0PSetTrajectoryFilterIT"):
-        eras.trackingPhase1.toModify( fragment.HLTIter0PSetTrajectoryFilterIT,
+        trackingPhase1.toModify( fragment.HLTIter0PSetTrajectoryFilterIT,
             minimumNumberOfHits = cms.int32( 4 ),
             minHitsMinPt        = cms.int32( 4 )
         )
 
     # hltIter0PFlowTrackCutClassifier
     if hasattr(fragment, "hltIter0PFlowTrackCutClassifier"):
-        eras.trackingPhase1.toModify( fragment.hltIter0PFlowTrackCutClassifier.mva,
+        trackingPhase1.toModify( fragment.hltIter0PFlowTrackCutClassifier.mva,
             minLayers    = cms.vint32( 3, 3, 4 ),
             min3DLayers  = cms.vint32( 0, 3, 4 ),
             minPixelHits = cms.vint32( 0, 3, 4 )
         )
 
     # hltIter1PixelLayerTriplets
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "hltIter1PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
@@ -169,7 +169,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryFilterIT
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryFilterIT", cms.PSet(
             ComponentType = cms.string('CkfBaseTrajectoryFilter'),
             chargeSignificance = cms.double(-1.0),
@@ -195,7 +195,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryFilterInOutIT
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryFilterInOutIT", cms.PSet(
             ComponentType = cms.string('CkfBaseTrajectoryFilter'),
             chargeSignificance = cms.double(-1.0),
@@ -221,7 +221,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIter1PSetTrajectoryBuilderIT
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIter1PSetTrajectoryBuilderIT", cms.PSet(
             inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
             propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
@@ -241,7 +241,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # HLTIterativeTrackingIteration1
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIterativeTrackingIteration1", cms.Sequence(
             fragment.hltIter1ClustersRefRemoval +
             fragment.hltIter1MaskedMeasurementTrackerEvent +
@@ -257,7 +257,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
     )
 
     # hltIter2PixelLayerTriplets
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "hltIter2PixelLayerTriplets", cms.EDProducer( "SeedingLayersEDProducer",
             layerList = cms.vstring(
                 'BPix1+BPix2+BPix3',
@@ -295,7 +295,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
 
     # hltIter2PFlowPixelSeeds
     if hasattr(fragment, "hltIter2PFlowPixelSeeds"):
-        eras.trackingPhase1.toModify( fragment.hltIter2PFlowPixelSeeds,
+        trackingPhase1.toModify( fragment.hltIter2PFlowPixelSeeds,
             OrderedHitsFactoryPSet = cms.PSet(
                 maxElement = cms.uint32( 0 ),
                 ComponentName = cms.string( "StandardHitTripletGenerator" ),
@@ -318,7 +318,7 @@ def modifyHLTforPhaseIPFTracking(fragment):
         )
 
     # HLTIterativeTrackingIteration2
-    eras.trackingPhase1.toModify( fragment, lambda fragment:
+    trackingPhase1.toModify( fragment, lambda fragment:
         setattr(fragment, "HLTIterativeTrackingIteration2", cms.Sequence(
             fragment.hltIter2ClustersRefRemoval +
             fragment.hltIter2MaskedMeasurementTrackerEvent +
@@ -345,6 +345,6 @@ def modifyHLTforPhaseIPFTracking(fragment):
                 mod.remove(fragment.hltPixelLayerTriplets)
                 index = mod.index(fragment.hltPixelTracks)
                 mod.insert(index, fragment.hltPixelLayerQuadruplets)
-                eras.trackingPhase1.toReplaceWith(seq, mod)
+                trackingPhase1.toReplaceWith(seq, mod)
 
-    eras.trackingPhase1.toModify( fragment, lambda fragment: add_hltPixelLayerQuadruplets_to_sequences(fragment) )
+    trackingPhase1.toModify( fragment, lambda fragment: add_hltPixelLayerQuadruplets_to_sequences(fragment) )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,18 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from HLTrigger.Configuration.common import *
 
-#
-# reusable functions
-def producers_by_type(process, *types):
-    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
-def filters_by_type(process, *types):
-    return (filter for filter in process._Process__filters.values() if filter._TypedParameterizable__type in types)
-def analyzers_by_type(process, *types):
-    return (analyzer for analyzer in process._Process__analyzers.values() if analyzer._TypedParameterizable__type in types)
-
-def esproducers_by_type(process, *types):
-    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
-
-#
 # one action function per PR - put the PR number into the name of the function
 
 # example:

--- a/HLTrigger/Configuration/python/customizeHLTforHighPU.py
+++ b/HLTrigger/Configuration/python/customizeHLTforHighPU.py
@@ -1,18 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from HLTrigger.Configuration.common import *
 
-#
-# reusable functions
-def producers_by_type(process, *types):
-    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
-def filters_by_type(process, *types):
-    return (filter for filter in process._Process__filters.values() if filter._TypedParameterizable__type in types)
-def analyzers_by_type(process, *types):
-    return (analyzer for analyzer in process._Process__analyzers.values() if analyzer._TypedParameterizable__type in types)
-
-def esproducers_by_type(process, *types):
-    return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
-
-#
 # CMSSW version specific customizations
 def customizeHLTforHighPU(process):
     for module in producers_by_type(process,"SiPixelClusterProducer"):

--- a/HLTrigger/Configuration/test/OnLine_HLT_25ns10e33_v2.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_25ns10e33_v2.py
@@ -65679,3 +65679,7 @@ process = customizeHLTforAll(process,"25ns10e33_v2",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"25ns10e33_v2")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_25ns15e33_v4.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_25ns15e33_v4.py
@@ -74381,3 +74381,7 @@ process = customizeHLTforAll(process,"25ns15e33_v4",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"25ns15e33_v4")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
@@ -465,3 +465,7 @@ process = customizeHLTforAll(process,"Fake",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"Fake")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
@@ -480,3 +480,7 @@ process = customizeHLTforAll(process,"Fake1",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"Fake1")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
@@ -68143,3 +68143,7 @@ process = customizeHLTforAll(process,"GRun",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"GRun")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -13903,3 +13903,7 @@ process = customizeHLTforAll(process,"HIon",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"HIon")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -19621,3 +19621,7 @@ process = customizeHLTforAll(process,"PIon",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"PIon")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+

--- a/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
@@ -13764,3 +13764,7 @@ process = customizeHLTforAll(process,"PRef",_customInfo)
 from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
 process = customizeHLTforCMSSW(process,"PRef")
 
+# Eras-based customisations
+from HLTrigger.Configuration.Eras import modifyHLTforEras
+modifyHLTforEras(process)
+


### PR DESCRIPTION
These commits adapt the customisations for the Phase I pixel geometry and particle flow tracking to the `phase`Pixel` era.

The modifications are grouped in two functions, but each change goes through the Eras mechanism independently - sometimes requiring extra checks, because the individual customisations cannot assume the previous ones have been applied.