### PR TITLE
Technical optimizations of PuppiContainer

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -8,11 +8,14 @@
 
 //FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
+#include "CommonTools/UtilAlgos/interface/KDTreeLinkerAlgoT.h"
 
 //......................
 class PuppiContainer{
 public:
   
+  typedef KDTreeLinkerAlgo<unsigned,2> KDTree;
+  typedef KDTreeNodeInfoT<unsigned,2> KDNode;
 
   // Helper class designed to store Puppi information inside of fastjet pseudojets.
   // In CMSSW we use the user_index to refer to the index of the input collection, 
@@ -42,34 +45,48 @@ public:
     std::vector<fastjet::PseudoJet> const & pfParticles() const { return fPFParticles; }    
     std::vector<fastjet::PseudoJet> const & pvParticles() const { return fChargedPV; }        
     std::vector<double> const & puppiWeights();
-    const std::vector<double> & puppiRawAlphas() const { return fRawAlphas; }
-    const std::vector<double> & puppiAlphas() const { return fVals; }
-    // const std::vector<double>& puppiAlpha   () const {return fAlpha;}
-    const std::vector<double> & puppiAlphasMed() const {return fAlphaMed;}
-    const std::vector<double> & puppiAlphasRMS() const {return fAlphaRMS;}
+    const std::vector<double> & puppiRawAlphas(){ return fRawAlphas; }
+    const std::vector<double> & puppiAlphas(){ return fVals; }
+    // const std::vector<double> puppiAlpha   () {return fAlpha;}
+    const std::vector<double> & puppiAlphasMed() {return fAlphaMed;}
+    const std::vector<double> & puppiAlphasRMS() {return fAlphaRMS;}
 
     int puppiNAlgos(){ return fNAlgos; }
     std::vector<fastjet::PseudoJet> const & puppiParticles() const { return fPupParticles;}
 
 protected:
-    double  goodVar      (unsigned iPart, std::vector<fastjet::PseudoJet> const &iParts, std::vector<unsigned> const &idxParts, int iOpt,const double iRCone) const;
-    void    getRMSAvg    (int iOpt, 
+    
+
+    double  goodVar( fastjet::PseudoJet const &iPart,
+		     std::vector<fastjet::PseudoJet> const &iParts, 
+		     int iOpt,
+		     const double iRCone );
+    
+    void    getRMSAvg( int iOpt, 
+		       std::vector<fastjet::PseudoJet> const &iConstits, 
+		       std::vector<fastjet::PseudoJet> const &iParticles, 
+		       std::vector<fastjet::PseudoJet> const &iChargeParticles );
+    
+    void    getRawAlphas( int iOpt,
 			  std::vector<fastjet::PseudoJet> const &iConstits,
-			  std::vector<unsigned> const &iParticles,
-			  std::vector<unsigned> const &iChargeParticles);
-    void    getRawAlphas    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,
-			     std::vector<unsigned> const &iParticles,
-			     std::vector<unsigned> const &iChargeParticles);
-    double  getChi2FromdZ(double iDZ) const;
-    int     getPuppiId   ( float iPt, float iEta);
-    double  var_within_R (int iId, const std::vector<fastjet::PseudoJet> & particles, const std::vector<unsigned>& idxs, unsigned centre, const double R) const;  
+			  std::vector<fastjet::PseudoJet> const &iParticles,
+			  std::vector<fastjet::PseudoJet> const &iChargeParticles );
+    
+    double  getChi2FromdZ( double iDZ );
+    int     getPuppiId   ( float iPt, float iEta );
+    double  var_within_R ( int iId, 
+			   const std::vector<fastjet::PseudoJet> & particles, 
+			   const fastjet::PseudoJet& centre, 
+			   const double R );  
     
     bool      fPuppiDiagnostics;
     std::vector<RecoObj>   fRecoParticles;
     std::vector<fastjet::PseudoJet> fPFParticles;
-    std::vector<unsigned> fPFParticlesIdx;
-    std::vector<fastjet::PseudoJet> fChargedPV; 
-    std::vector<unsigned> fChargedPVIdx; 
+    std::vector<KDNode> fPFParticlesNodes;
+    KDTree fPFParticlesTree;
+    std::vector<fastjet::PseudoJet> fChargedPV;
+    std::vector<KDNode> fChargedPVNodes;
+    KDTree fChargedPVTree;
     std::vector<fastjet::PseudoJet> fPupParticles;
     std::vector<double>    fWeights;
     std::vector<double>    fVals;
@@ -87,10 +104,6 @@ protected:
     int    fNPV;
     double fPVFrac;
     std::vector<PuppiAlgo> fPuppiAlgo;
-
-    //caches for heavy calculations
-    std::vector<double> particlesEta;
-    std::vector<double> particlesPhi;
 };
 #endif
 

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -105,7 +105,7 @@ protected:
     double fPVFrac;
     std::vector<PuppiAlgo> fPuppiAlgo;
 
-    std::vector<double> fPFParticlesEta, fChargedPVEta;
+    std::vector<double> fPFParticlesRap, fChargedPVRap;
     std::vector<double> fPFParticlesPhi, fChargedPVPhi;
 };
 #endif

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -42,27 +42,34 @@ public:
     std::vector<fastjet::PseudoJet> const & pfParticles() const { return fPFParticles; }    
     std::vector<fastjet::PseudoJet> const & pvParticles() const { return fChargedPV; }        
     std::vector<double> const & puppiWeights();
-    const std::vector<double> & puppiRawAlphas(){ return fRawAlphas; }
-    const std::vector<double> & puppiAlphas(){ return fVals; }
-    // const std::vector<double> puppiAlpha   () {return fAlpha;}
-    const std::vector<double> & puppiAlphasMed() {return fAlphaMed;}
-    const std::vector<double> & puppiAlphasRMS() {return fAlphaRMS;}
+    const std::vector<double> & puppiRawAlphas() const { return fRawAlphas; }
+    const std::vector<double> & puppiAlphas() const { return fVals; }
+    // const std::vector<double>& puppiAlpha   () const {return fAlpha;}
+    const std::vector<double> & puppiAlphasMed() const {return fAlphaMed;}
+    const std::vector<double> & puppiAlphasRMS() const {return fAlphaRMS;}
 
     int puppiNAlgos(){ return fNAlgos; }
     std::vector<fastjet::PseudoJet> const & puppiParticles() const { return fPupParticles;}
 
 protected:
-    double  goodVar      (fastjet::PseudoJet const &iPart,std::vector<fastjet::PseudoJet> const &iParts, int iOpt,const double iRCone);
-    void    getRMSAvg    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargeParticles);
-    void    getRawAlphas    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargeParticles);
-    double  getChi2FromdZ(double iDZ);
+    double  goodVar      (unsigned iPart, std::vector<fastjet::PseudoJet> const &iParts, std::vector<unsigned> const &idxParts, int iOpt,const double iRCone) const;
+    void    getRMSAvg    (int iOpt, 
+			  std::vector<fastjet::PseudoJet> const &iConstits,
+			  std::vector<unsigned> const &iParticles,
+			  std::vector<unsigned> const &iChargeParticles);
+    void    getRawAlphas    (int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,
+			     std::vector<unsigned> const &iParticles,
+			     std::vector<unsigned> const &iChargeParticles);
+    double  getChi2FromdZ(double iDZ) const;
     int     getPuppiId   ( float iPt, float iEta);
-    double  var_within_R (int iId, const std::vector<fastjet::PseudoJet> & particles, const fastjet::PseudoJet& centre, const double R);  
+    double  var_within_R (int iId, const std::vector<fastjet::PseudoJet> & particles, const std::vector<unsigned>& idxs, unsigned centre, const double R) const;  
     
     bool      fPuppiDiagnostics;
     std::vector<RecoObj>   fRecoParticles;
     std::vector<fastjet::PseudoJet> fPFParticles;
-    std::vector<fastjet::PseudoJet> fChargedPV;
+    std::vector<unsigned> fPFParticlesIdx;
+    std::vector<fastjet::PseudoJet> fChargedPV; 
+    std::vector<unsigned> fChargedPVIdx; 
     std::vector<fastjet::PseudoJet> fPupParticles;
     std::vector<double>    fWeights;
     std::vector<double>    fVals;
@@ -80,6 +87,10 @@ protected:
     int    fNPV;
     double fPVFrac;
     std::vector<PuppiAlgo> fPuppiAlgo;
+
+    //caches for heavy calculations
+    std::vector<double> particlesEta;
+    std::vector<double> particlesPhi;
 };
 #endif
 

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -104,6 +104,9 @@ protected:
     int    fNPV;
     double fPVFrac;
     std::vector<PuppiAlgo> fPuppiAlgo;
+
+    std::vector<double> fPFParticlesEta, fChargedPVEta;
+    std::vector<double> fPFParticlesPhi, fChargedPVPhi;
 };
 #endif
 

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -103,28 +103,33 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     int    pVtxId = -9999; 
     bool lFirst = true;
     const pat::PackedCandidate *lPack = dynamic_cast<const pat::PackedCandidate*>(&(*itPF));
-    if(lPack == 0 ) {
-
+    if(lPack == 0 ) {      
       const reco::PFCandidate *pPF = dynamic_cast<const reco::PFCandidate*>(&(*itPF));
+      const auto& trackRef = pPF->trackRef();
+      const auto& gsfTrackRef = pPF->gsfTrackRef();
+      const bool tkRefIsNonNull = trackRef.isNonnull();
+      const bool gsfRefIsNonNull = gsfTrackRef.isNonnull();
       double curdz = 9999;
       int closestVtxForUnassociateds = -9999;
-      for(reco::VertexCollection::const_iterator iV = pvCol->begin(); iV!=pvCol->end(); ++iV) {
+      for(reco::VertexCollection::const_iterator iV = pvCol->begin(); iV!=pvCol->end(); ++iV) {	
         if(lFirst) {
-          if      ( pPF->trackRef().isNonnull()    ) pDZ = pPF->trackRef()   ->dz(iV->position());
-          else if ( pPF->gsfTrackRef().isNonnull() ) pDZ = pPF->gsfTrackRef()->dz(iV->position());
-          if      ( pPF->trackRef().isNonnull()    ) pD0 = pPF->trackRef()   ->d0();
-          else if ( pPF->gsfTrackRef().isNonnull() ) pD0 = pPF->gsfTrackRef()->d0();
-          lFirst = false;
+          if        ( tkRefIsNonNull ) {
+	    pDZ = trackRef   ->dz(iV->position());
+	    pD0 = trackRef   ->d0();
+	  } else if ( gsfRefIsNonNull ) {
+	    pDZ = gsfTrackRef->dz(iV->position());
+	    pD0 = gsfTrackRef->d0();
+	  }
           if(pDZ > -9999) pVtxId = 0;
         }
-        if(iV->trackWeight(pPF->trackRef())>0) {
+        if(iV->trackWeight(trackRef)>0) {
             closestVtx  = &(*iV);
             break;
           }        
         // in case it's unassocciated, keep more info
         double tmpdz = 99999;
-        if      ( pPF->trackRef().isNonnull()    ) tmpdz = pPF->trackRef()   ->dz(iV->position());
-        else if ( pPF->gsfTrackRef().isNonnull() ) tmpdz = pPF->gsfTrackRef()->dz(iV->position());
+        if      ( tkRefIsNonNull    ) tmpdz = trackRef   ->dz(iV->position());
+        else if ( gsfRefIsNonNull   ) tmpdz = gsfTrackRef->dz(iV->position());
         if (std::abs(tmpdz) < curdz){
           curdz = std::abs(tmpdz);
           closestVtxForUnassociateds = pVtxId;
@@ -205,9 +210,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         curpupweight = lPack->puppiWeight();
       }
       lWeights.push_back(curpupweight);
-      fastjet::PseudoJet curjet( curpupweight*lPack->px(), curpupweight*lPack->py(), curpupweight*lPack->pz(), curpupweight*lPack->energy());
-      curjet.set_user_index(lPackCtr);
-      lCandidates.push_back(curjet);
+      lCandidates.emplace_back(curpupweight*lPack->px(), curpupweight*lPack->py(), curpupweight*lPack->pz(), curpupweight*lPack->energy());
+      lCandidates.back().set_user_index(lPackCtr);
       lPackCtr++;
     }
   }
@@ -233,6 +237,12 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LorentzVectorCollection puppiP4s;
   std::vector<reco::CandidatePtr> values(hPFProduct->size());
 
+  
+  std::unordered_map<int,unsigned> userIdx2lCand; 
+  for( unsigned i = 0 ; i < lCandidates.size(); ++i ) {
+    userIdx2lCand[lCandidates[i].user_index()] = i;
+  }
+
   for ( auto i0 = hPFProduct->begin(),
 	  i0begin = hPFProduct->begin(),
 	  i0end = hPFProduct->end(); i0 != i0end; ++i0 ) {
@@ -252,9 +262,10 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     int val = i0 - i0begin;
 
     // Find the Puppi particle matched to the input collection using the "user_index" of the object. 
-    auto puppiMatched = find_if( lCandidates.begin(), lCandidates.end(), [&val]( fastjet::PseudoJet const & i ){ return i.user_index() == val; } );
-    if ( puppiMatched != lCandidates.end() ) {
-      pVec.SetPxPyPzE(puppiMatched->px(),puppiMatched->py(),puppiMatched->pz(),puppiMatched->E());
+    auto puppiMatched = userIdx2lCand.find(val);
+    if ( puppiMatched != userIdx2lCand.end() ) {
+      const auto& temp = lCandidates[puppiMatched->second];
+      pVec.SetPxPyPzE(temp.px(),temp.py(),temp.pz(),temp.E());
     } else {
       pVec.SetPxPyPzE( 0, 0, 0, 0);
     }

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -29,12 +29,12 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     //Clear everything
     fRecoParticles.resize(0);
     fPFParticlesNodes.resize(0);
-    fPFParticlesEta.resize(0);
+    fPFParticlesRap.resize(0);
     fPFParticlesPhi.resize(0);
     fPFParticles  .resize(0);
     fPFParticlesTree.clear();
     fChargedPVNodes.resize(0);
-    fChargedPVEta.resize(0);
+    fChargedPVRap.resize(0);
     fChargedPVPhi.resize(0);
     fChargedPV    .resize(0);
     fChargedPVTree.clear();
@@ -71,42 +71,42 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
         if(fRecoParticle.id == 2 and fRecoParticle.charge != 0) puppi_register = fRecoParticle.charge+5; // from NPV use the charge as key +5 as key
         curPseudoJet.set_user_info( new PuppiUserInfo( puppi_register ) );
         // fill vector of pseudojets for internal references
-	const double eta = curPseudoJet.eta();
+	const double rap = curPseudoJet.rapidity();
 	double phi = curPseudoJet.phi();
 	if( phi > M_PI ) phi -= 2*M_PI; // convert to atan2 notation [-pi,pi]
-        fPFParticlesNodes.emplace_back(i,(float)eta,(float)phi);
-	fPFParticlesNodes.emplace_back(i,(float)eta,(float)(phi+2*M_PI));
-	fPFParticlesNodes.emplace_back(i,(float)eta,(float)(phi-2*M_PI));
+        fPFParticlesNodes.emplace_back(i,(float)rap,(float)phi);
+	fPFParticlesNodes.emplace_back(i,(float)rap,(float)(phi+2*M_PI));
+	fPFParticlesNodes.emplace_back(i,(float)rap,(float)(phi-2*M_PI));
 	fPFParticles.push_back(curPseudoJet);
-	fPFParticlesEta.push_back(eta);
+	fPFParticlesRap.push_back(rap);
 	fPFParticlesPhi.push_back(phi);
 	
 	if( i == 0 ) {
-	  minpos[0] = eta; minpos[1] = phi-2*M_PI;
-	  maxpos[0] = eta; maxpos[1] = phi+2*M_PI;
+	  minpos[0] = rap; minpos[1] = phi-2*M_PI;
+	  maxpos[0] = rap; maxpos[1] = phi+2*M_PI;
 	} else {
-	  minpos[0] = std::min((float)eta,minpos[0]);
+	  minpos[0] = std::min((float)rap,minpos[0]);
 	  minpos[1] = std::min((float)(phi-2*M_PI),minpos[1]);
-	  maxpos[0] = std::max((float)eta,maxpos[0]);
+	  maxpos[0] = std::max((float)rap,maxpos[0]);
 	  maxpos[1] = std::max((float)(phi+2*M_PI),maxpos[1]);	  
 	}
 	
         //Take Charged particles associated to PV
         if(std::abs(fRecoParticle.id) == 1) { 
 	  if( fChargedPV.size() == 0 ) {
-	    chminpos[0] = eta; chminpos[1] = phi-2*M_PI;
-	    chmaxpos[0] = eta; chmaxpos[1] = phi+2*M_PI;
+	    chminpos[0] = rap; chminpos[1] = phi-2*M_PI;
+	    chmaxpos[0] = rap; chmaxpos[1] = phi+2*M_PI;
 	  } else {
-	    chminpos[0] = std::min((float)eta,chminpos[0]);
+	    chminpos[0] = std::min((float)rap,chminpos[0]);
 	    chminpos[1] = std::min((float)(phi-2*M_PI),chminpos[1]);
-	    chmaxpos[0] = std::max((float)eta,chmaxpos[0]);
+	    chmaxpos[0] = std::max((float)rap,chmaxpos[0]);
 	    chmaxpos[1] = std::max((float)(phi+2*M_PI),chmaxpos[1]);	  
 	  }
-	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)phi);
-	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)(phi+2*M_PI));
-	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)(phi-2*M_PI));
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)rap,(float)phi);
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)rap,(float)(phi+2*M_PI));
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)rap,(float)(phi-2*M_PI));
 	  fChargedPV.push_back(curPseudoJet);
-	  fChargedPVEta.push_back(eta);
+	  fChargedPVRap.push_back(rap);
 	  fChargedPVPhi.push_back(phi);
 	}
         if(std::abs(fRecoParticle.id) >= 1 ) fPVFrac+=1.;
@@ -148,10 +148,10 @@ double PuppiContainer::var_within_R(int iId, const vector<PseudoJet> & particles
     const double R2 = R*R;
 
     std::vector<KDNode> found;
-    const double centreEta = centre.eta();
+    const double centreRap = centre.rapidity();
     double centrePhi = centre.phi();
     if( centrePhi > M_PI ) centrePhi -= 2*M_PI; // convert to atan2 notation [-pi,pi]
-    KDTreeBox bounds((float)(centreEta - Rprime), (float)(centreEta + Rprime),
+    KDTreeBox bounds((float)(centreRap - Rprime), (float)(centreRap + Rprime),
 		     (float)(centrePhi - Rprime), (float)(centrePhi + Rprime));
 
     if( &particles == &fPFParticles ) {
@@ -167,9 +167,9 @@ double PuppiContainer::var_within_R(int iId, const vector<PseudoJet> & particles
     for( auto const& node : found ) {
       double pt(std::numeric_limits<double>::max()), dr2(std::numeric_limits<double>::max());
       if( &particles == &fPFParticles ) {
-	dr2 = reco::deltaR2(centreEta,centrePhi,fPFParticlesEta[node.data],fPFParticlesPhi[node.data]); 
+	dr2 = reco::deltaR2(centreRap,centrePhi,fPFParticlesRap[node.data],fPFParticlesPhi[node.data]); 
       } else if( &particles == &fChargedPV ) {
-	dr2 = reco::deltaR2(centreEta,centrePhi,fChargedPVEta[node.data],fChargedPVPhi[node.data]); 
+	dr2 = reco::deltaR2(centreRap,centrePhi,fChargedPVRap[node.data],fChargedPVPhi[node.data]); 
       }
       
       if( dr2 >= R2 || dr2  <  0.0001 ) continue;

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -28,13 +28,15 @@ PuppiContainer::PuppiContainer(const edm::ParameterSet &iConfig) {
 
 void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     //Clear everything
-    fRecoParticles .resize(0);
-    fPFParticles   .resize(0);
-    fPFParticlesIdx.resize(0);
-    fChargedPV     .resize(0);
-    fChargedPVIdx  .resize(0);
-    fPupParticles  .resize(0);
-    fWeights       .resize(0);
+    fRecoParticles.resize(0);
+    fPFParticlesNodes.resize(0);
+    fPFParticles  .resize(0);
+    fPFParticlesTree.clear();
+    fChargedPVNodes.resize(0);
+    fChargedPV    .resize(0);
+    fChargedPVTree.clear();
+    fPupParticles .resize(0);
+    fWeights      .resize(0);
     fVals.resize(0);
     fRawAlphas.resize(0);
     fAlphaMed     .resize(0);
@@ -44,10 +46,13 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     fPVFrac = 0.;
     fNPV    = 1.;
     fRecoParticles = iRecoObjects;
+
+    std::array<float,2> minpos({ {0.0f,0.0f} }), maxpos({ {0.0f,0.0f} });
+    std::array<float,2> chminpos({ {0.0f,0.0f} }), chmaxpos({ {0.0f,0.0f} });
+
     for (unsigned int i = 0; i < fRecoParticles.size(); i++){
         fastjet::PseudoJet curPseudoJet;
-        const auto& fRecoParticle = fRecoParticles[i];
-	fPFParticlesIdx.push_back(i);
+        auto fRecoParticle = fRecoParticles[i];
         // float nom = sqrt((fRecoParticle.m)*(fRecoParticle.m) + (fRecoParticle.pt)*(fRecoParticle.pt)*(cosh(fRecoParticle.eta))*(cosh(fRecoParticle.eta))) + (fRecoParticle.pt)*sinh(fRecoParticle.eta);//hacked
         // float denom = sqrt((fRecoParticle.m)*(fRecoParticle.m) + (fRecoParticle.pt)*(fRecoParticle.pt));//hacked
         // float rapidity = log(nom/denom);//hacked
@@ -55,7 +60,7 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
             curPseudoJet.reset_PtYPhiM(fRecoParticle.pt,fRecoParticle.rapidity,fRecoParticle.phi,fRecoParticle.m);//hacked
         } else {        
             curPseudoJet.reset_PtYPhiM(0, 99., 0, 0);//skipping may have been a better choice     
-        }
+        }                   
         //curPseudoJet.reset_PtYPhiM(fRecoParticle.pt,fRecoParticle.eta,fRecoParticle.phi,fRecoParticle.m);
         int puppi_register = 0;
         if(fRecoParticle.id == 0 or fRecoParticle.charge == 0)  puppi_register = 0; // zero is neutral hadron
@@ -63,13 +68,38 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
         if(fRecoParticle.id == 2 and fRecoParticle.charge != 0) puppi_register = fRecoParticle.charge+5; // from NPV use the charge as key +5 as key
         curPseudoJet.set_user_info( new PuppiUserInfo( puppi_register ) );
         // fill vector of pseudojets for internal references
-        fPFParticles.push_back(curPseudoJet);
-	particlesEta.push_back(fPFParticles.back().eta());
-	particlesPhi.push_back(fPFParticles.back().phi());
+	const double eta = curPseudoJet.eta();
+	const double phi = curPseudoJet.phi();
+        fPFParticlesNodes.emplace_back(i,(float)eta,(float)phi);
+	fPFParticlesNodes.emplace_back(i,(float)eta,(float)(phi+2*M_PI));
+	fPFParticlesNodes.emplace_back(i,(float)eta,(float)(phi-2*M_PI));
+	fPFParticles.push_back(curPseudoJet);
+	
+	if( i == 0 ) {
+	  minpos[0] = eta; minpos[1] = phi-2*M_PI;
+	  maxpos[0] = eta; maxpos[1] = phi+2*M_PI;
+	} else {
+	  minpos[0] = std::min((float)eta,minpos[0]);
+	  minpos[1] = std::min((float)(phi-2*M_PI),minpos[1]);
+	  maxpos[0] = std::max((float)eta,maxpos[0]);
+	  maxpos[1] = std::max((float)(phi+2*M_PI),maxpos[1]);	  
+	}
+	
         //Take Charged particles associated to PV
-        if(std::abs(fRecoParticle.id) == 1) {
-	  fChargedPV.push_back(curPseudoJet);
-	  fChargedPVIdx.push_back(i);
+        if(std::abs(fRecoParticle.id) == 1) { 
+	  if( fChargedPV.size() == 0 ) {
+	    chminpos[0] = eta; chminpos[1] = phi-2*M_PI;
+	    chmaxpos[0] = eta; chmaxpos[1] = phi+2*M_PI;
+	  } else {
+	    chminpos[0] = std::min((float)eta,chminpos[0]);
+	    chminpos[1] = std::min((float)(phi-2*M_PI),chminpos[1]);
+	    chmaxpos[0] = std::max((float)eta,chmaxpos[0]);
+	    chmaxpos[1] = std::max((float)(phi+2*M_PI),chmaxpos[1]);	  
+	  }
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)phi);
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)(phi+2*M_PI));
+	  fChargedPVNodes.emplace_back(fChargedPV.size(),(float)eta,(float)(phi-2*M_PI));
+	  fChargedPV.push_back(curPseudoJet);	  
 	}
         if(std::abs(fRecoParticle.id) >= 1 ) fPVFrac+=1.;
         //if((fRecoParticle.id == 0) && (inParticles[i].id == 2))  _genParticles.push_back( curPseudoJet);
@@ -77,30 +107,27 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
         //if(fRecoParticle.id == 3) _chargedNoPV.push_back(curPseudoJet);
         // if(fNPV < fRecoParticle.vtxId) fNPV = fRecoParticle.vtxId;
     }
-    if (fPVFrac != 0) fPVFrac = double(fChargedPVIdx.size())/fPVFrac;
+    if (fPVFrac != 0) fPVFrac = double(fChargedPV.size())/fPVFrac;
     else fPVFrac = 0;
+
+    KDTreeBox bounds(minpos[0],maxpos[0],
+                     minpos[1],maxpos[1]);
+    KDTreeBox chbounds(chminpos[0],chmaxpos[0],
+		       chminpos[1],chmaxpos[1]);
+
+    fPFParticlesTree.build(fPFParticlesNodes,bounds);
+    fChargedPVTree.build(fChargedPVNodes,chbounds);
+
 }
 PuppiContainer::~PuppiContainer(){}
 
-double PuppiContainer::goodVar(unsigned iPart,
-			       std::vector<PseudoJet> const &iParts, 
-			       std::vector<unsigned> const &idxParts, 
-			       int iOpt,
-			       const double iRCone) const {
+double PuppiContainer::goodVar(PseudoJet const &iPart,std::vector<PseudoJet> const &iParts, int iOpt,const double iRCone) {
     double lPup = 0;
-    lPup = var_within_R(iOpt,iParts,idxParts,iPart,iRCone);
+    lPup = var_within_R(iOpt,iParts,iPart,iRCone);
     return lPup;
 }
-double PuppiContainer::var_within_R(int iId, 
-				    const vector<PseudoJet> & particles,
-				    const std::vector<unsigned>& iparticles, 
-				    unsigned icentre, 
-				    const double R) const {
+double PuppiContainer::var_within_R(int iId, const vector<PseudoJet> & particles, const PseudoJet& centre, const double R){
     if(iId == -1) return 1;
-
-    const auto& centre = fPFParticles[icentre];
-    const double etaCentre = particlesEta[icentre];
-    const double phiCentre = particlesPhi[icentre];
 
     //this is a circle in rapidity-phi
     //it would make more sense to have var definition consistent
@@ -109,33 +136,45 @@ double PuppiContainer::var_within_R(int iId,
     //the original code used Selector infrastructure: it is too heavy here
     //logic of SelectorCircle is preserved below
 
-    const double R2 = R*R;
-    vector<double > near_dR2s;     near_dR2s.reserve(std::min(50UL, particles.size()));
-    vector<double > near_pts;      near_pts.reserve(std::min(50UL, particles.size()));
-    for (auto ipart : iparticles) {
-      const double eta = particlesEta[ipart];
-      const double phi = particlesPhi[ipart];
-      const auto& part = particles[ipart];      
-      const double dr2 = reco::deltaR2(etaCentre,phiCentre,eta,phi);
-      if ( dr2 < R2 ) {
+    std::vector<KDNode> found;
+    const double centreEta = centre.eta();
+    const double centrePhi = centre.phi();
+    KDTreeBox bounds((float)(centreEta - R), (float)(centreEta + R),
+		     (float)(centrePhi - R), (float)(centrePhi + R));
+
+    if( &particles == &fPFParticles ) {
+      fPFParticlesTree.search(bounds,found);
+    } else if( &particles == &fChargedPV ) {
+      fChargedPVTree.search(bounds,found);
+    }
+
+    vector<double > near_dR2s;     near_dR2s.reserve(found.size());
+    vector<double > near_pts;      near_pts.reserve(found.size());
+    for( auto const& node : found ) {
+      const double dr2 = reco::deltaR2(centreEta,node.dims[0],centrePhi,node.dims[1]);      
+      if( dr2 < R*R ){
 	near_dR2s.push_back(dr2);
-	near_pts.push_back(part.pt());
+	if( &particles == &fPFParticles ) {
+	  near_pts.push_back(fPFParticles[node.data].pt());
+	} else if( &particles == &fChargedPV ) {
+	  near_pts.push_back(fChargedPV[node.data].pt());
+	}
       }
     }
     double var = 0;
     //double lSumPt = 0;
     //if(iId == 1) for(auto  pt : near_pts) lSumPt += pt;
-    const auto nParts = near_dR2s.size();
+    auto nParts = near_dR2s.size();
     for(auto i = 0UL; i < nParts; ++i){
-        auto dr2_inv = 1.0/near_dR2s[i];
+        auto inv_dr2 = 1.0/near_dR2s[i];
         auto pt  = near_pts[i];
         if(near_dR2s[i]  <  0.0001) continue;
-        if(iId == 0) var += (pt*dr2_inv);
+        if(iId == 0) var += (pt * inv_dr2);
         else if(iId == 1) var += pt;
-        else if(iId == 2) var += (dr2_inv);
-        else if(iId == 3) var += (dr2_inv);
+        else if(iId == 2) var += (inv_dr2);
+        else if(iId == 3) var += (inv_dr2);
         else if(iId == 4) var += pt;
-        else if(iId == 5) var += (pt * pt*dr2_inv);
+        else if(iId == 5) var += (pt * pt * inv_dr2);
     }
     if(iId == 1) var += centre.pt(); //Sum in a cone
     else if(iId == 0 && var != 0) var = log(var);
@@ -144,14 +183,11 @@ double PuppiContainer::var_within_R(int iId,
     return var;
 }
 //In fact takes the median not the average
-void PuppiContainer::getRMSAvg(int iOpt,
-			       std::vector<fastjet::PseudoJet> const &iConstits,
-			       std::vector<unsigned> const &iParticles,
-			       std::vector<unsigned> const &iChargedParticles) {
+void PuppiContainer::getRMSAvg(int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargedParticles) {
     for(unsigned int i0 = 0; i0 < iConstits.size(); i0++ ) {
         double pVal = -1;
         //Calculate the Puppi Algo to use
-        int  pPupId   = getPuppiId(iConstits[i0].pt(),particlesEta[i0]);
+        int  pPupId   = getPuppiId(iConstits[i0].pt(),iConstits[i0].eta());
         if(pPupId == -1 || fPuppiAlgo[pPupId].numAlgos() <= iOpt){
             fVals.push_back(-1);
             continue;
@@ -161,8 +197,8 @@ void PuppiContainer::getRMSAvg(int iOpt,
         bool pCharged = fPuppiAlgo[pPupId].isCharged(iOpt);
         double pCone  = fPuppiAlgo[pPupId].coneSize (iOpt);
         //Compute the Puppi Metric
-        if(!pCharged) pVal = goodVar(i0,iConstits,iParticles       ,pAlgo,pCone);
-        else          pVal = goodVar(i0,iConstits,iChargedParticles,pAlgo,pCone);
+        if(!pCharged) pVal = goodVar(iConstits[i0],iParticles       ,pAlgo,pCone);
+        if( pCharged) pVal = goodVar(iConstits[i0],iChargedParticles,pAlgo,pCone);
         fVals.push_back(pVal);
         //if(std::isnan(pVal) || std::isinf(pVal)) cerr << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt() << " -- " << iConstits[i0].eta() << endl;
         if( ! edm::isFinite(pVal)) {
@@ -177,8 +213,8 @@ void PuppiContainer::getRMSAvg(int iOpt,
             pCharged = fPuppiAlgo[i1].isCharged(iOpt);
             pCone    = fPuppiAlgo[i1].coneSize (iOpt);
             double curVal = -1; 
-            if(!pCharged) curVal = goodVar(i0,iConstits,iParticles       ,pAlgo,pCone);
-            else          curVal = goodVar(i0,iConstits,iChargedParticles,pAlgo,pCone);
+            if(!pCharged) curVal = goodVar(iConstits[i0],iParticles       ,pAlgo,pCone);
+            if( pCharged) curVal = goodVar(iConstits[i0],iChargedParticles,pAlgo,pCone);
             //std::cout << "i1 = " << i1 << ", curVal = " << curVal << ", eta = " << iConstits[i0].eta() << ", pupID = " << pPupId << std::endl;
             fPuppiAlgo[i1].add(iConstits[i0],curVal,iOpt);
         }
@@ -187,9 +223,7 @@ void PuppiContainer::getRMSAvg(int iOpt,
     for(int i0 = 0; i0 < fNAlgos; i0++) fPuppiAlgo[i0].computeMedRMS(iOpt,fPVFrac);
 }
 //In fact takes the median not the average
-void PuppiContainer::getRawAlphas(int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,
-				  std::vector<unsigned> const &iParticles,
-				  std::vector<unsigned> const &iChargedParticles) {
+void PuppiContainer::getRawAlphas(int iOpt,std::vector<fastjet::PseudoJet> const &iConstits,std::vector<fastjet::PseudoJet> const &iParticles,std::vector<fastjet::PseudoJet> const &iChargedParticles) {
     for(int j0 = 0; j0 < fNAlgos; j0++){
         for(unsigned int i0 = 0; i0 < iConstits.size(); i0++ ) {
             double pVal = -1;
@@ -198,8 +232,8 @@ void PuppiContainer::getRawAlphas(int iOpt,std::vector<fastjet::PseudoJet> const
             bool pCharged = fPuppiAlgo[j0].isCharged(iOpt);
             double pCone  = fPuppiAlgo[j0].coneSize (iOpt);
             //Compute the Puppi Metric
-            if(!pCharged) pVal = goodVar(i0,iConstits,iParticles       ,pAlgo,pCone);
-            else          pVal = goodVar(i0,iConstits,iChargedParticles,pAlgo,pCone);
+            if(!pCharged) pVal = goodVar(iConstits[i0],iParticles       ,pAlgo,pCone);
+            if( pCharged) pVal = goodVar(iConstits[i0],iChargedParticles,pAlgo,pCone);
             fRawAlphas.push_back(pVal);
             if( ! edm::isFinite(pVal)) {
                 LogDebug( "NotFound" )  << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt() << " -- " << iConstits[i0].eta() << endl;
@@ -225,7 +259,7 @@ int    PuppiContainer::getPuppiId( float iPt, float iEta) {
     //if(lId == -1) std::cerr << "Error : Full fiducial range is not defined " << std::endl;
     return lId;
 }
-double PuppiContainer::getChi2FromdZ(double iDZ) const {
+double PuppiContainer::getChi2FromdZ(double iDZ) {
     //We need to obtain prob of PU + (1-Prob of LV)
     // Prob(LV) = Gaus(dZ,sigma) where sigma = 1.5mm  (its really more like 1mm)
     //double lProbLV = ROOT::Math::normal_cdf_c(std::abs(iDZ),0.2)*2.; //*2 is to do it double sided
@@ -249,9 +283,9 @@ std::vector<double> const & PuppiContainer::puppiWeights() {
     //Run through all compute mean and RMS
     int lNParticles    = fRecoParticles.size();
     for(int i0 = 0; i0 < lNMaxAlgo; i0++) {
-        getRMSAvg(i0,fPFParticles,fPFParticlesIdx,fChargedPVIdx);
+        getRMSAvg(i0,fPFParticles,fPFParticles,fChargedPV);
     }
-    if (fPuppiDiagnostics) getRawAlphas(0,fPFParticles,fPFParticlesIdx,fChargedPVIdx);
+    if (fPuppiDiagnostics) getRawAlphas(0,fPFParticles,fPFParticles,fChargedPV);
 
     std::vector<double> pVals;
     for(int i0 = 0; i0 < lNParticles; i0++) {

--- a/CommonTools/UtilAlgos/interface/KDTreeLinkerAlgoT.h
+++ b/CommonTools/UtilAlgos/interface/KDTreeLinkerAlgoT.h
@@ -1,7 +1,7 @@
-#ifndef KDTreeLinkerAlgoTemplated_h
-#define KDTreeLinkerAlgoTemplated_h
+#ifndef CommonTools_UtilAlgos_KDTreeLinkerAlgoTemplated_h
+#define CommonTools_UtilAlgos_KDTreeLinkerAlgoTemplated_h
 
-#include "KDTreeLinkerToolsT.h"
+#include "CommonTools/UtilAlgos/interface/KDTreeLinkerToolsT.h"
 
 #include <cassert>
 #include <vector>

--- a/CommonTools/UtilAlgos/interface/KDTreeLinkerToolsT.h
+++ b/CommonTools/UtilAlgos/interface/KDTreeLinkerToolsT.h
@@ -1,5 +1,5 @@
-#ifndef KDTreeLinkerToolsTemplated_h
-#define KDTreeLinkerToolsTemplated_h
+#ifndef CommonTools_UtilAlgos_KDTreeLinkerToolsTemplated_h
+#define CommonTools_UtilAlgos_KDTreeLinkerToolsTemplated_h
 
 #include <array>
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -22,7 +22,7 @@
 #include <set>
 
 
-#include "KDTreeLinkerAlgoT.h"
+#include "CommonTools/UtilAlgos/interface/KDTreeLinkerAlgoT.h"
 
 
 template <typename T>


### PR DESCRIPTION
Use a kd-tree to speed up the searches of nearest neighbors for pf candidates in puppi.

Overall a factor 5-6 improvement. 