### PR TITLE
[90X] update MC Global Tags including latest ingredients as in Moriond17 campaign for run2, add new labels for e/gamma regressions and make pA queue more realistic

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,25 +10,25 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '90X_mcRun1_pA_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '90X_mcRun2_design_v0',
+    'run2_design'       :   '90X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '90X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '90X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '90X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '90X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '90X_mcRun2cosmics_startup_peak_v0',
+    'run2_mc_cosmics'   :   '90X_mcRun2cosmics_startup_peak_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '90X_mcRun2_HeavyIon_v0',
+    'run2_mc_hi'        :   '90X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '90X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '90X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '90X_dataRun2_v0',
+    'run1_data'         :   '90X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '90X_dataRun2_v0',
+    'run2_data'         :   '90X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '90X_dataRun2_relval_v0',
+    'run2_data_relval'  :   '90X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '90X_dataRun2_PromptLike_v0',
+    'run2_data_promptlike' : '90X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '90X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -38,15 +38,15 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v0',
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v0',
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v0',
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '90X_upgrade2023_realistic_v1'
+    'phase2_realistic'     : '90X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII simulation 
 
   * **RunII Ideal scenario** : [90X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_design_v1) as [90X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_design_v1/90X_mcRun2_design_v0): 
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
 
   * **RunII Asymptotic scenario** : [90X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_asymptotic_v1) as [90X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_asymptotic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_asymptotic_v1/90X_mcRun2_asymptotic_v0): 
      * updated ECAL TPG tags as in 80X_mcRun2_asymptotic_2016_TrancheIV_v6 (Moriond17 MC) for consistency with ECAL conditions
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
      * updated realistic CSC Bad chambers for 2016 simulation 
 
   * **RunII Startup scenario** : [90X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_startup_v1) as [90X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_startup_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_startup_v1/90X_mcRun2_startup_v0): 
      * added new labels for e/gamma regressions
 
   * **RunII Proton-Lead scenario** : [90X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_pA_v2) as [90X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_pA_v2/90X_mcRun2_pA_v1): 
      * updated ECAL TPG tags as in 80X_mcRun2_asymptotic_2016_TrancheIV_v6 (Moriond17 MC) for consistency with ECAL conditions
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
      * updated realistic CSC Bad chambers for 2016 simulation      

   * **RunII CRAFT scenario** : [90X_mcRun2cosmics_startup_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2cosmics_startup_peak_v1) as [90X_mcRun2cosmics_startup_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2cosmics_startup_peak_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2cosmics_startup_peak_v1/90X_mcRun2cosmics_startup_peak_v0): 
      * added new labels for e/gamma regressions
 
   * **RunII Heavy Ions scenario** : [90X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_HeavyIon_v1) as [90X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun2_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun2_HeavyIon_v1/90X_mcRun2_HeavyIon_v0): 
      * added new labels for e/gamma regressions
    
## RunII data 
 
   * **RunII Offline processing** : [90X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_v1) as [90X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_v1/90X_dataRun2_v0): 
      * added new labels for e/gamma regressions
 
   * **RunII Prompt processing** : [90X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_PromptLike_v1) as [90X_dataRun2_PromptLike_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_PromptLike_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_PromptLike_v1/90X_dataRun2_PromptLike_v0): 
      * added new labels for e/gamma regressions
 
   * **RunII Offline relval processing** : [90X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_relval_v1) as [90X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_dataRun2_relval_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_dataRun2_relval_v1/90X_dataRun2_relval_v0): 
      * added new labels for e/gamma regressions
 
## Upgrade 
 
   * **PhaseI realistic scenario** : [90X_upgrade2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v1) as [90X_upgrade2017_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_realistic_v1/90X_upgrade2017_realistic_v0): 
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
      * updated SiPixel FED cabling map to v4
 
   * **PhaseI design scenario** : [90X_upgrade2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v1) as [90X_upgrade2017_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_design_IdealBS_v1/90X_upgrade2017_design_IdealBS_v0): 
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
      * updated SiPixel FED cabling map to v4
 
   * **PhaseI cosmics scenario** : [90X_upgrade2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v1) as [90X_upgrade2017cosmics_realistic_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v1/90X_upgrade2017cosmics_realistic_peak_v0): 
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
      * updated SiPixel FED cabling map to v4
     
   * **PhaseII realistic scenario** : [90X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v2) as [90X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2023_realistic_v2/90X_upgrade2023_realistic_v1): 
      * updated ECAL TPG tags as in 80X_mcRun2_asymptotic_2016_TrancheIV_v6 (Moriond17 MC) for consistency with ECAL conditions
      * added new labels for e/gamma regressions
      * updated JECs as in `80X_mcRun2_asymptotic_2016_TrancheIV_v6` (version `Summer16_25nsV5_MC`) (Moriond17 MC)
 
