### PR TITLE
Calibration/IsolatedPatricles: fix clang warning hides overloaded virtual function

### DIFF
--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
@@ -921,7 +921,7 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent,
   
 
 
-void IsolatedTracksCone::beginJob(const edm::EventSetup&) {
+void IsolatedTracksCone::beginJob() {
 
   //   hbScale = 120.0;
   //   heScale = 135.0;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.h
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.h
@@ -104,7 +104,7 @@ public:
   double genPartPBins[22], genPartEtaBins[5];
   
 private:
-  virtual void beginJob(const edm::EventSetup&) ;
+  virtual void beginJob() ;
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() ;
 


### PR DESCRIPTION
Class inherits from edm::EDAnalyzer so is probably no longer used.