### PR TITLE
remove nonsense error along trajectory

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
@@ -73,25 +73,14 @@ std::pair<uint8_t,Measurement1DFloat> ConversionHitChecker::nHitsBeforeVtx(const
   //if not then we need to subtract it from the count of hits before the vertex, since it has been implicitly included
 
   GlobalVector momDir = closest->updatedState().globalMomentum().unit();
-  double decayLengthHitToVtx = (vtxPos - closest->updatedState().globalPosition()).dot(momDir);
+  float decayLengthHitToVtx = (vtxPos - closest->updatedState().globalPosition()).dot(momDir);
 
   AlgebraicVector3 j;
   j[0] = momDir.x();
   j[1] = momDir.y();
   j[2] = momDir.z();
-  AlgebraicVector6 jj;
-  jj[0] = momDir.x();
-  jj[1] = momDir.y();
-  jj[2] = momDir.z();
-  jj[3] =0.;
-  jj[4] =0.;
-  jj[5] =0.;
-  
-  //TODO: In principle the hit measurement position is correlated with the vertex fit
-  //at worst though we inflate the uncertainty by a factor of two
-  double trackError2 = ROOT::Math::Similarity(jj,closest->updatedState().cartesianError().matrix());
-  double vertexError2 = ROOT::Math::Similarity(j,vtx.covariance());
-  double decayLenError = sqrt(trackError2+vertexError2);
+  float vertexError2 = ROOT::Math::Similarity(j,vtx.covariance());
+  auto decayLenError = std::sqrt(vertexError2);
 
   Measurement1DFloat decayLength(decayLengthHitToVtx,decayLenError);
 


### PR DESCRIPTION
Pretty obvious
in case you really wonder:

it seems to me that the author is trying to compute the trajectory error along the track direction.
At best of my understanding the trajectory is evaluated at fixed "path length" (or on the surface) and given such a constrain the error along the track direction shall be zero

If I add
```
+  std::cout << "Conv decayLenErrors " << std::sqrt(trackError2) << ' ' << std::sqrt(vertexError2) << std::endl;
```
I get [1] that seems to confirm my argument...

This PR goes in the direction of getting rid of Trajectory clients outside Pattern-Recognition and track fitting

v.



[1]
```
Conv decayLenErrors 8.08985e-09 0.303271
Conv decayLenErrors 1.0178e-08 0.308193
Conv decayLenErrors 3.5792e-11 0.18766
Conv decayLenErrors 6.88417e-11 0.18766
Conv decayLenErrors 4.80717e-10 0.127311
Conv decayLenErrors 2.18407e-10 0.13478
Conv decayLenErrors 6.20932e-10 0.0773271
Conv decayLenErrors 6.61983e-10 0.07734
Conv decayLenErrors 2.09942e-11 0.0376943
Conv decayLenErrors 1.00645e-11 0.037656
Conv decayLenErrors 4.66109e-10 0.90796
Conv decayLenErrors -nan 0.910426
Conv decayLenErrors 1.41406e-09 0.481755
Conv decayLenErrors 9.55233e-11 0.48931
Conv decayLenErrors 1.09899e-10 1.36467
Conv decayLenErrors 7.66701e-09 1.36451
Conv decayLenErrors 1.71128e-08 0.648829
Conv decayLenErrors 5.35681e-10 0.649918
Conv decayLenErrors 6.62235e-11 0.325768
Conv decayLenErrors 1.29224e-09 0.293336
Conv decayLenErrors 4.17621e-10 0.549151
Conv decayLenErrors 1.57907e-11 0.584518
Conv decayLenErrors 1.24353e-09 0.922273
Conv decayLenErrors 1.41729e-11 0.922496
Conv decayLenErrors 8.10341e-12 0.667636
Conv decayLenErrors 1.92729e-11 0.667601
Conv decayLenErrors 6.80979e-10 0.910948
Conv decayLenErrors 3.4351e-11 0.914169
Conv decayLenErrors 5.96534e-12 0.0216508
Conv decayLenErrors 3.13757e-11 0.0217808
Conv decayLenErrors 2.11458e-11 0.0399453
Conv decayLenErrors 7.23228e-12 0.0399368
Conv decayLenErrors 6.52953e-10 0.319295
Conv decayLenErrors 2.04955e-09 0.33336
Conv decayLenErrors 6.71637e-12 0.795876
Conv decayLenErrors 9.35454e-12 0.795864
Conv decayLenErrors 9.35454e-12 0.392259
Conv decayLenErrors 1.34314e-11 0.392277
Conv decayLenErrors 1.34314e-11 0.700822
Conv decayLenErrors 5.35559e-11 0.708999
Conv decayLenErrors 1.03494e-11 0.94411
Conv decayLenErrors 4.50016e-12 0.944118
Conv decayLenErrors 4.73188e-12 0.492338
```