### PR TITLE
Fix lostmidfrac in track MVA selection

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
@@ -46,7 +46,7 @@ struct mva {
     int lostIn = trk.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS);
     int lostOut = trk.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_OUTER_HITS);
     auto tmva_minlost_ = std::min(lostIn,lostOut);
-    auto tmva_lostmidfrac_ = trk.numberOfLostHits() / (trk.numberOfValidHits() + trk.numberOfLostHits());
+    auto tmva_lostmidfrac_ = static_cast<float>(trk.numberOfLostHits()) / static_cast<float>(trk.numberOfValidHits() + trk.numberOfLostHits());
    
     float gbrVals_[PROMPT ? 16 : 12];
     gbrVals_[0] = tmva_pt_;


### PR DESCRIPTION
This PR fixes a small bug in the track MVA selection: in the MVA training, the so-called `lostmidfrac` (=nlost/(nvalid+nlost)) is correctly calculated in floating point, but in the MVA application side the fraction is calculated in integers (effectively leading the fraction to be always 0).

Below are MTV plots for 1000 events of ttbar+35PU in 810pre16 for
* phase0 https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase0_fixMVA/
* phase1 https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_8_1_0_pre16_phase1_fixMVA/

The main effect is a small (~2 % in phase0, ~1 % in phase1) decrease in the fake rates.

Tested in 8_1_0_pre16, expecting changes described above in phase0 and phase1 workflows, no change expected in phase2 (as MVA selection is not used there yet).

@rovere @VinInn 