### PR TITLE
Make TimeReport work properly with SubProcesses

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -522,7 +522,8 @@ namespace edm {
       summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(
                                                     prealloc.numberOfStreams(),
                                                     modDesc,
-                                                    tns);
+                                                    tns,
+                                                    processContext);
       auto timeKeeperPtr = summaryTimeKeeper_.get();
 
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
@@ -616,6 +617,9 @@ namespace edm {
       // The trigger report (pass/fail etc.):
 
       LogVerbatim("FwkSummary") << "";
+      if(streamSchedules_[0]->context().processContext()->isSubProcess()) {
+        LogVerbatim("FwkSummary") << "TrigReport Process: "<<streamSchedules_[0]->context().processContext()->processName();
+      }
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Event  Summary ------------";
       if(!tr.trigPathSummaries.empty()) {
         LogVerbatim("FwkSummary") << "TrigReport"

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -258,6 +258,7 @@ namespace edm {
       return number_of_unscheduled_modules_;
     }
     
+    StreamContext const& context() const { return streamContext_;}
   private:
     //Sentry class to only send a signal if an
     // exception occurs. An exception is identified

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -37,6 +37,7 @@ namespace edm {
   class PathContext;
   class HLTPathStatus;
   class ModuleCallingContext;
+  class ProcessContext;
   struct TriggerTimingReport;
   namespace service {
     class TriggersNameService;
@@ -48,7 +49,8 @@ namespace edm {
   public:
     SystemTimeKeeper(unsigned int iNumStreams,
                      std::vector<const ModuleDescription*> const& iModules,
-                     service::TriggerNamesService const& iNameService);
+                     service::TriggerNamesService const& iNameService,
+                     ProcessContext const* iProcessContext);
     
     // ---------- const member functions ---------------------
     
@@ -103,6 +105,7 @@ namespace edm {
     std::vector<std::vector<std::string>> m_modulesOnPaths;
 
     CPUTimer m_processingLoopTimer;
+    ProcessContext const* m_processContext;
     
     unsigned int m_minModuleID;
     unsigned int m_endPathOffset;


### PR DESCRIPTION
Asking for a TimeReport while a SubProcesses is in the job caused a crashed.