### PR TITLE
Fixed warnings and printouts in SIM

### DIFF
--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -283,6 +283,7 @@ void RunManager::initG4(const edm::EventSetup & es)
 
   int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),
 		      m_p.getParameter<int>("SteppingVerbosity"));
+  m_kernel->SetVerboseLevel(verb);
 
   m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   m_physicsList->SetCutsWithDefault();

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -154,6 +154,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),
 		      m_p.getParameter<int>("SteppingVerbosity"));
+  m_kernel->SetVerboseLevel(verb);
 
   m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   m_physicsList->SetCutsWithDefault();

--- a/SimG4Core/Geometry/src/G4CheckOverlap.cc
+++ b/SimG4Core/Geometry/src/G4CheckOverlap.cc
@@ -35,7 +35,9 @@ G4CheckOverlap::G4CheckOverlap(const edm::ParameterSet &p) {
 
   G4LogicalVolume* lv;
   const G4PhysicalVolumeStore * pvs = G4PhysicalVolumeStore::GetInstance();
+  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
   unsigned int numPV = pvs->size();
+  unsigned int numLV = lvs->size();
   unsigned int nn = nodeNames.size();
 
   std::vector<G4String> savedgdml;
@@ -45,7 +47,8 @@ G4CheckOverlap::G4CheckOverlap(const edm::ParameterSet &p) {
 	 << "; tolerance= " << tolerance/mm << " mm; verbose: " 
 	 << verbose << "\n"
 	 << "               RegionFlag: " << regionFlag
-	 << "  PVname: " << PVname << "  LVname: " << LVname << G4endl;
+	 << "  PVname: " << PVname << "  LVname: " << LVname << "\n"
+	 << "               Nlv= " << numLV << "   Npv= " << numPV << G4endl;
 
   if(0 < nn) { 
     for (unsigned int ii=0; ii<nn; ++ii) {
@@ -128,8 +131,6 @@ G4CheckOverlap::G4CheckOverlap(const edm::ParameterSet &p) {
   }
   if("" != LVname) {
     G4cout << "---------- List of Logical Volumes by name ------------------" << G4endl;
-    const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-    unsigned int numLV = lvs->size();
     for (unsigned int i=0; i<numLV; ++i) {
       if(LVname == ((*lvs)[i])->GetName()) {
 	G4int np = ((*lvs)[i])->GetNoDaughters();

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -165,9 +165,9 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4double highEnergyLimit = 100*MeV;
 
   G4Region* aRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HcalRegion");
+    G4RegionStore::GetInstance()->GetRegion("HcalRegion",false);
   G4Region* bRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HGCalRegion");
+    G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
 
   aParticleIterator->reset();
   while( (*aParticleIterator)() ){


### PR DESCRIPTION
Added optional verbosity to G4 kernel allowing to see some details including memory used for geometry voxelisation. Extended printout when check overlaps in geometry.

Fixed annoying warning due to absence of HGCal in Phase-1 setup.

All this does not affect production.