### PR TITLE
[90X] update 2023 upgrade simulation Global Tag with SIM and RECO geometries tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '90X_upgrade2023_realistic_v2'
+    'phase2_realistic'     : '90X_upgrade2023_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## Upgrade 
 
   * **PhaseII realistic scenario** : [90X_upgrade2023_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v3) as [90X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2023_realistic_v3/90X_upgrade2023_realistic_v2): 
      * added conditions for`GEMRecoGeometryRcd`,`ME0RecoGeometryRcd` 
      * updated RECO geometries for `HcalParametersRcd`, `IdealGeometryRecord`, `PGeometricDetExtraRcd`, `PHcalRcd`, `PTrackerParametersRcd`, `RPCRecoGeometryRcd` to version `81YV023` 
      * added 6 flavours of SIM geometry `GeometryFileRcd` with labels Extended2023D*, *=1,..,6
      * removed several unused labels of SIM geometry `GeometryFileRcd`:
```
   Record           Label                        Tag                                                      
   ---------------  ---------------------------  -------------------------------------------------------  
-  GeometryFileRcd  Extended2015CastorMeasured   XMLFILE_Geometry_80YV1_Extended2015CastorMeasured_mc     
-  GeometryFileRcd  Extended2015CastorSystMinus  XMLFILE_Geometry_80YV1_Extended2015CastorSystMinus_mc    
-  GeometryFileRcd  Extended2015CastorSystPlus   XMLFILE_Geometry_80YV1_Extended2015CastorSystPlus_mc     
-  GeometryFileRcd  Ideal                        XMLFILE_Geometry_Run2_76YV2_Ideal2015_mc                 
-  GeometryFileRcd  Extended2015ZeroMaterial     XMLFILE_Geometry_Run2_76YV2_Extended2015ZeroMaterial_mc  
-  GeometryFileRcd  Extended2015dev              XMLFILE_Geometry_Run2_76YV2_Extended2015dev_mc           
-  GeometryFileRcd  Ideal2015dev                 XMLFILE_Geometry_Run2_76YV2_Ideal2015dev_mc 
```
      

attn: @ianna this addresses [this](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2779.html) and this [request](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2780.html)