### PR TITLE
Fix PUPPI lowPUCorr config 90X

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -4,7 +4,7 @@ puppiCentral = cms.VPSet(
                  cms.PSet(
                   algoId           = cms.int32(5),  #0 is default Puppi
                   useCharged       = cms.bool(True),
-                  applyLowPUCorr   = cms.bool(False),
+                  applyLowPUCorr   = cms.bool(True),
                   combOpt          = cms.int32(0),
                   cone             = cms.double(0.4),
                   rmsPtMin         = cms.double(0.1),
@@ -16,7 +16,7 @@ puppiForward = cms.VPSet(
                 cms.PSet(
                  algoId         = cms.int32(5),  #0 is default Puppi
                  useCharged     = cms.bool(False),
-                 applyLowPUCorr = cms.bool(False),
+                 applyLowPUCorr = cms.bool(True),
                  combOpt        = cms.int32(0),
                  cone           = cms.double(0.4),
                  rmsPtMin       = cms.double(0.5),


### PR DESCRIPTION
Re-enable PUPPI lowPUCorr, which was unintentionally disabled in #15562.
With lowPUCorr disabled, we get a 1-5% worsening in jet response, though the impact on jet resolution is minor, as shown on slide 6:
https://indico.cern.ch/event/587258/contributions/2366495/attachments/1368938/2117761/satoshi_updatedAfterTheMeeting.pdf
What is labeled v10 is in the CMSSW_8_0_>=20 and CMSSW_8_1_X and CMSSW_9_0_X releases at the moment.
What is labeled v10 LowPUCorr is in CMSSW_8_0_<20 and in this PR.
For CMSSW_8_0_>=20, we have corrected for this response drop with the jet energy corrections, however, we would like to fix this for CMSSW>=8_1_X releases, even though the effect on resolution is minor.

The impact of this PR on jet and MET response and resolution has been validated.

This PR changes the MINIAOD PUPPI jet+MET collection, no changes to RECO/AOD event content.