### PR TITLE
[80X] update ECAL TPG tags and CSC bad chambers description as per request of HIN PAG

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v12',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '80X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '80X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_v19',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII simulation 
 
   * **RunII Proton-Lead scenario** : [80X_mcRun2_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v4) as [80X_mcRun2_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_pA_v4/80X_mcRun2_pA_v3): 
      * update ECAL TPG tag to be in synch with Moriond MC production
      * more realistic CSC bad chamber list (w.r.t 2016 data)

attn: @mandrenguyen this is as per your [request](https://hypernews.cern.ch/HyperNews/CMS/get/hi-general/3662/1/1/1.html)