### PR TITLE
Use raise as a threading debugging aid

### DIFF
--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -16,6 +16,7 @@
 // user include files
 #include "tbb/task.h"
 #include <cassert>
+#include <signal.h> /*CDJ DEBUG*/
 
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 #include "FWCore/Concurrency/interface/hardware_pause.h"
@@ -54,6 +55,11 @@ WaitingTaskList::reset()
   m_exceptionPtr = std::exception_ptr{};
   unsigned int nSeenTasks = m_lastAssignedCacheIndex;
   m_lastAssignedCacheIndex = 0;
+  //CDJ DEBUG
+  if(m_head != nullptr) {
+    //force traceback
+    raise(15);
+  }
   assert(m_head == nullptr);
   if (nSeenTasks > m_nodeCacheSize) {
     //need to expand so next time we don't have to do any

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -46,6 +46,8 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <signal.h> /*CDJ DEBUG*/
+#include <iostream> /*CDJ DEBUG*/
 
 namespace edm {
 
@@ -396,6 +398,13 @@ namespace edm {
     // first before writing anything to the file about this event
     // NOTE: pEventAux_, pBranchListIndexes_, pEventSelectionIDs_, and pEventEntryInfoVector_
     // must be set before calling fillBranches since they get written out in that routine.
+    //CDJ DEBUG
+    if(pEventAux_->processHistoryID() != e.processHistoryID()) {
+      //force traceback
+      std::cout<<" FAILURE "<<pEventAux_->processHistoryID()<<" "<<e.processHistoryID()<<std::endl;
+      raise(15);
+    }
+
     assert(pEventAux_->processHistoryID() == e.processHistoryID());
     pBranchListIndexes_ = &e.branchListIndexes();
 


### PR DESCRIPTION
The phase 2 framework change is causing two asserts to go off.
In order to track why, the asserts were changed to raise(15) in
order to halt all threads and get a traceback when the problem
occurs. (this development is already in 90xdevel branch)