### PR TITLE
Fix ME0 neutron background normalization

### DIFF
--- a/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PreRecoGaussianModel.h
@@ -49,6 +49,7 @@ private:
   int maxBunch_;
 
   double instLumi_;
+  double rateFact_;
 
   // params for the simple pol6 model of neutral bkg for ME0:
   std::vector<double> neuBkg, eleBkg;

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -58,6 +58,8 @@ private:
   bool verbose_;
   bool reDigitizeOnlyMuons_;
   bool reDigitizeNeutronBkg_;
+  double instLumiDefault_;
+  double rateFact_;
   double instLumi_;
   std::vector<double> centralTOF_;
   int nPartitions_;

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -21,6 +21,6 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     simulateNeutralBkg  = cms.bool(True),       # True - will simulate neutral (n+g)  background
     minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
     maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
-    instLumi = cms.double(5.0),       # in units of 1E34 cm^-2 s^-1
+    instLumi = cms.double(15.0),                # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200 and a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step.
     mixLabel = cms.string('mix'),
 )

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# Module to create simulated ME0 Pre Reco digis.
-simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
+me0PreRecoDigiCommonParameters = cms.PSet(
     inputCollection = cms.string('g4SimHitsMuonME0Hits'),
     digiPreRecoModelString = cms.string('PreRecoGaussian'),
     timeResolution = cms.double(0.0), # in ns
@@ -21,6 +20,12 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     simulateNeutralBkg  = cms.bool(True),       # True - will simulate neutral (n+g)  background
     minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
     maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
-    instLumi = cms.double(15.0),                # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200 and a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step.
+    instLumi = cms.double(7.5),                 # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
+    rateFact = cms.double(2.0),                 # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step.
     mixLabel = cms.string('mix'),
+)
+
+# Module to create simulated ME0 Pre Reco digis.
+simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
+    me0PreRecoDigiCommonParameters
 )

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -21,7 +21,7 @@ simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     verbose = cms.bool(False),
     reDigitizeOnlyMuons = cms.bool(False),
     reDigitizeNeutronBkg = cms.bool(True),
-    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This should be synchronized with the default digitizer
-    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This should be synchronized with the default digitizer
+    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default digitizer
+    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default digitizer
     instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
 )

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -19,5 +19,5 @@ simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     verbose = cms.bool(False),
     reDigitizeOnlyMuons = cms.bool(False),
     reDigitizeNeutronBkg = cms.bool(True),
-    instLumi = cms.double(5.0), # in units of 1E34 cm^-2 s^-1
+    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
 )

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from SimMuon.GEMDigitizer.muonME0DigisPreReco_cfi import me0PreRecoDigiCommonParameters
+
 # Module to create simulated ME0 Pre Reco digis.
 simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection = cms.string('simMuonME0Digis'),
@@ -19,5 +21,7 @@ simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     verbose = cms.bool(False),
     reDigitizeOnlyMuons = cms.bool(False),
     reDigitizeNeutronBkg = cms.bool(True),
+    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This should be synchronized with the default digitizer
+    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This should be synchronized with the default digitizer
     instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
 )

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -36,7 +36,8 @@ ME0PreRecoGaussianModel::ME0PreRecoGaussianModel(const edm::ParameterSet& config
   simulateNeutralBkg_(config.getParameter<bool>("simulateNeutralBkg")), 
   minBunch_(config.getParameter<int>("minBunch")), 
   maxBunch_(config.getParameter<int>("maxBunch")),
-  instLumi_(config.getParameter<double>("instLumi"))
+  instLumi_(config.getParameter<double>("instLumi")),
+  rateFact_(config.getParameter<double>("rateFact"))
 {
   // polynomial parametrisation of neutral (n+g) and electron background
   // This is the background for an Instantaneous Luminosity of L = 5E34 cm^-2 s^-1
@@ -178,7 +179,7 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll, CLHEP::
       for(int j=0; j<7; ++j) { averageElectronRatePerRoll += eleBkg[j]*yy_helper; yy_helper *= yy_glob; }
 
       // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)      
-      averageElectronRatePerRoll *= instLumi_*1.0/5;
+      averageElectronRatePerRoll *= instLumi_*rateFact_*1.0/5;
 
       // Rate [Hz/cm^2] * Nbx * 25*10^-9 [s] * Area [cm] = # hits in this roll in this bx
       const double averageElecRate(averageElectronRatePerRoll * (maxBunch_-minBunch_+1)*(bxwidth*1.0e-9) * areaIt); 
@@ -231,7 +232,7 @@ void ME0PreRecoGaussianModel::simulateNoise(const ME0EtaPartition* roll, CLHEP::
       for(int j=0; j<7; ++j) { averageNeutralRatePerRoll += neuBkg[j]*yy_helper; yy_helper *= yy_glob; }
 
       // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)      
-      averageNeutralRatePerRoll *= instLumi_*1.0/5;
+      averageNeutralRatePerRoll *= instLumi_*rateFact_*1.0/5;
       
       // Rate [Hz/cm^2] * Nbx * 25*10^-9 [s] * Area [cm] = # hits in this roll
       const double averageNeutrRate(averageNeutralRatePerRoll * (maxBunch_-minBunch_+1)*(bxwidth*1.0e-9) * areaIt);

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -85,13 +85,7 @@ for (const auto & hit: simHits)
   if (ex == 0) ex = error_u;//errors cannot be zero
   if (ey == 0) ey = error_v;
     
-  int evtId = hit.eventId().event();
-  int bx = hit.eventId().bunchCrossing();
-  int procType = hit.processType();
-  int res = 1;
-  if(!(evtId == 0 && bx == 0 && procType == 0)) res = 2;
-    
-  ME0DigiPreReco digi(x,y,ex,ey,corr,tof,pdgid,res);
+  ME0DigiPreReco digi(x,y,ex,ey,corr,tof,pdgid,1);
   digi_.insert(digi);
 
   edm::LogVerbatim("ME0PreRecoGaussianModel") << "[ME0PreRecoDigi :: simulateSignal] :: simhit in "<<roll->id()<<" at loc x = "<<std::setw(8)<<entry.x()<<" [cm]"

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -83,7 +83,14 @@ for (const auto & hit: simHits)
   int pdgid = hit.particleType();
   if (ex == 0) ex = error_u;//errors cannot be zero
   if (ey == 0) ey = error_v;
-  ME0DigiPreReco digi(x,y,ex,ey,corr,tof,pdgid,1);
+    
+  int evtId = hit.eventId().event();
+  int bx = hit.eventId().bunchCrossing();
+  int procType = hit.processType();
+  int res = 1;
+  if(!(evtId == 0 && bx == 0 && procType == 0)) res = 2;
+    
+  ME0DigiPreReco digi(x,y,ex,ey,corr,tof,pdgid,res);
   digi_.insert(digi);
 
   edm::LogVerbatim("ME0PreRecoGaussianModel") << "[ME0PreRecoDigi :: simulateSignal] :: simhit in "<<roll->id()<<" at loc x = "<<std::setw(8)<<entry.x()<<" [cm]"

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -133,7 +133,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
 
       // scale background hits for luminosity
       if (!me0Digi.prompt())
-	if (CLHEP::RandFlat::shoot(engine) > instLumi_*1.0/5) continue;
+	  if (CLHEP::RandFlat::shoot(engine) > instLumi_*1.0/15) continue;
       
       edm::LogVerbatim("ME0ReDigiProducer")
         << "\tPassed selection" << std::endl;

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -47,6 +47,8 @@ ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps)
   discretizeY_ = ps.getParameter<bool>("discretizeY");
   reDigitizeOnlyMuons_ = ps.getParameter<bool>("reDigitizeOnlyMuons");
   reDigitizeNeutronBkg_ = ps.getParameter<bool>("reDigitizeNeutronBkg");
+  rateFact_ = ps.getParameter<double>("rateFact");
+  instLumiDefault_ = ps.getParameter<double>("instLumiDefault");
   instLumi_ = ps.getParameter<double>("instLumi");
 }
 
@@ -133,7 +135,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
 
       // scale background hits for luminosity
       if (!me0Digi.prompt())
-	  if (CLHEP::RandFlat::shoot(engine) > instLumi_*1.0/15) continue;
+	  if (CLHEP::RandFlat::shoot(engine) > instLumi_*1.0/(instLumiDefault_*rateFact_)) continue;
       
       edm::LogVerbatim("ME0ReDigiProducer")
         << "\tPassed selection" << std::endl;


### PR DESCRIPTION
In this PR:
- Default digitizer: new parameter to rescale the neutron background also for the new beam pipe effect
- Default digitizer: new neutron background normalization to 7.5x10^35 Hz/cms^2 (PU200) + safety factor of 2 (new beam pipe)
- Re-digitizer: the same parameters (instLumi of the default digitizer and the rate safety factor) are introduced here. They depend from the value of the default digitizer in order to throw away the correct fraction of background hits and reproduce the desired rate
@jshlee @pietverwilligen @kpedro88 @dildick 