### PR TITLE
EventFilter-EcalRawToDigi: fix clang warning hides overloaded virtual function

### DIFF
--- a/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
@@ -34,7 +34,7 @@ class DCCFEBlock : public DCCDataBlockPrototype {
     virtual void updateCollectors();
     
     void display(std::ostream & o); 
-    
+    using DCCDataBlockPrototype::unpack; 
     int unpack(const uint64_t** data, unsigned int * dwToEnd, bool zs, unsigned int expectedTowerID);
 
     unsigned int getLength(){return blockLength_; }

--- a/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
@@ -42,7 +42,7 @@ class DCCMemBlock : public DCCDataBlockPrototype {
     void updateCollectors();
     
     void display(std::ostream & o); 
-    
+    using DCCDataBlockPrototype::unpack; 
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int expectedTowerID);   
     			
   protected :

--- a/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
@@ -37,7 +37,7 @@ class DCCSRPBlock : public DCCDataBlockPrototype {
     DCCSRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
 	 
     void display(std::ostream & o); 
-
+    using DCCDataBlockPrototype::unpack;
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int numbFlags = SRP_NUMBFLAGS);     	 
 
     unsigned short srFlag(unsigned int feChannel){ return srFlags_[feChannel-1]; }

--- a/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
@@ -44,6 +44,7 @@ class DCCTCCBlock : public DCCDataBlockPrototype {
     /**
       Unpacks TCC data 
      */
+    using DCCDataBlockPrototype::unpack;
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, short tccChId=0);
 	 
     void display(std::ostream & o); 

--- a/EventFilter/EcalRawToDigi/src/DCCEBEventBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEBEventBlock.cc
@@ -164,7 +164,7 @@ void DCCEBEventBlock::unpack(const uint64_t * buffer, size_t numbBytes, unsigned
   
     // Unpack SRP block
     if(srChStatus_ != CH_TIMEOUT &&  srChStatus_ != CH_DISABLED){
-      STATUS = srpBlock_->unpack(&data_,&dwToEnd_);
+      STATUS = srpBlock_->unpack(&data_,&dwToEnd_,SRP_NUMBFLAGS);
       if ( STATUS == BLOCK_UNPACKED ){ ignoreSR = false; }
     }
     
@@ -319,7 +319,7 @@ void DCCEBEventBlock::unpack(const uint64_t * buffer, size_t numbBytes, unsigned
 int DCCEBEventBlock::unpackTCCBlocks(){
 
     if(tccChStatus_[0] != CH_TIMEOUT && tccChStatus_[0] != CH_DISABLED)
-      return tccBlock_->unpack(&data_,&dwToEnd_);
+      return tccBlock_->unpack(&data_,&dwToEnd_,0);
     else return BLOCK_UNPACKED;
 
 }

--- a/EventFilter/EcalRawToDigi/src/DCCEEEventBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEEEventBlock.cc
@@ -169,7 +169,7 @@ void DCCEEEventBlock::unpack(const uint64_t * buffer, size_t numbBytes, unsigned
   
     // Unpack SRP block
     if(srChStatus_ != CH_TIMEOUT &&  srChStatus_ != CH_DISABLED){
-      STATUS = srpBlock_->unpack(&data_,&dwToEnd_);
+      STATUS = srpBlock_->unpack(&data_,&dwToEnd_,SRP_NUMBFLAGS);
       if ( STATUS == BLOCK_UNPACKED ){ ignoreSR = false; }
     }
   }


### PR DESCRIPTION
by adding using directive and adding parameters to function calls to disambiguate from base class function call. If the function is called without the defaulted parameter it could be interpreted as a call to the base class function.