### PR TITLE
Add 2023 Geometry Scenario Version

### DIFF
--- a/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpSimGeometry_cfg.py
@@ -1,23 +1,35 @@
 import FWCore.ParameterSet.Config as cms
-import sys
+import sys, os, operator
 import FWCore.ParameterSet.VarParsing as VarParsing
 from FWCore.Utilities.Enumerate import Enumerate
+from pprint import pprint
+from dict2023Geometry import detectorVersionDict
 
-varType = Enumerate ("Run1 Ideal2015 Ideal2015dev 2015 2015dev GEMDev RPC4RE11 2017 2017dev 2017new 2017NewFPix 2019 2023D7 2023D10 2023D4 2023D8 MaPSA CRack DB")
+varType = Enumerate ("Run1 2015 2015dev 2017 2017Muon 2019 2023")
+defaultVersion=str();
 
 def help():
-   print "Usage: cmsRun dumpSimGeometry_cfg.py  tag=TAG "
+   print "Usage: cmsRun dumpSimGeometry_cfg.py  tag=TAG version=VERSION "
    print "   tag=tagname"
-   print "       indentify geometry condition database tag"
+   print "       indentify geometry scenario "
    print "      ", varType.keys()
    print ""
+   print "   version=versionNumber"
+   print "       scenario version from 2023 dictionary:"
+   print ""
    print "   out=outputFileName"
-   print "       default is cmsSimGeom<tag>.root"
+   print "       default is cmsSimGeom<tag><version>.root"
    print 
-   exit(1);
+   os._exit(1);
+
+def versionCheck(ver):
+   if ver == "":
+      print "Please, specify 2023 scenario version\n"
+      pprint(sorted(detectorVersionDict.items(),key=operator.itemgetter(1)))
+      help()
 
 def simGeoLoad(score):
-    print "Loading configuration for tag ", options.tag ,"...\n"
+    print "Loading configuration for scenario", options.tag , options.version ,"...\n"
     if score == "Run1":
        process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
@@ -27,73 +39,38 @@ def simGeoLoad(score):
     elif score == "2015dev":
        process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015devXML_cfi")
 
-    elif score == "GEMDev":
-       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015MuonGEMDevXML_cfi")
-       
-    elif score == "Ideal2015":
-       process.load("Geometry.CMSCommonData.cmsIdealGeometry2015XML_cfi")
-
-    elif score == "Ideal2015dev":
-       process.load("Geometry.CMSCommonData.cmsIdealGeometry2015devXML_cfi")
-
-    elif score == "RPC4RE11":
-       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2015XML_RPC4RE11_cfi")
-
     elif score == "2017":
-       process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
+       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
        
-    elif score == "2017dev":
-       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017devXML_cfi")
-
-    elif score == "2017new":
-       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017newXML_cfi")
-
-    elif score == "2017NewFPix":
-       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_NewFPix_cfi")
+    elif score == "2017Muon":
+       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017MuonXML_cfi")
 
     elif score == "2019":
-       process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
-  
-    elif score == "2023D7":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D7XML_cfi')
+       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2019XML_cfi")
 
-    elif score == "2023D10":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D10XML_cfi')
+    elif score == "2023":
+       versionCheck(options.version)
+       process.load("Geometry.CMSCommonData.cmsExtendedGeometry2023" + options.version + "XML_cfi")
  
-    elif score == "2023D4":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D4XML_cfi')
-    
-    elif score == "2023D8":
-       process.load('Geometry.CMSCommonData.cmsExtendedGeometry2023D8XML_cfi')
-
-    elif score == "MaPSA":
-       process.load('Geometry.TrackerCommonData.mapsaGeometryXML_cfi')
-
-    elif score == "CRack":
-       process.load('Geometry.TrackerCommonData.crackGeometryXML_cfi')
-
-    elif score == "DB":
-        process.load("Configuration.StandardSequences.GeometryDB_cff")
-        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-        from Configuration.AlCa.autoCond import autoCond
-        process.GlobalTag.globaltag = autoCond['run2_mc']
-
     else:
       help()
 
-
-
 options = VarParsing.VarParsing ()
 
-defaultTag=str(2015);
+defaultTag=str(2017);
 defaultLevel=14;
-defaultOutputFileName="cmsSimGeom.root"
+defaultOutputFileName="cmsSimGeom-"+ defaultTag +".root"
 
 options.register ('tag',
                   defaultTag, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "info about geometry database conditions")
+                  "info about geometry scenario")
+options.register ('version',
+                  defaultVersion, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "info about 2023 geometry scenario version")
 options.register ('out',
                   defaultOutputFileName, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
@@ -105,7 +82,7 @@ options.parseArguments()
 
 
 if (options.out == defaultOutputFileName ):
-   options.out = "cmsSimGeom-" + str(options.tag) + ".root"
+   options.out = "cmsSimGeom-" + str(options.tag) + str(options.version) + ".root"
 
 process = cms.Process("SIMDUMP")
 simGeoLoad(options.tag)
@@ -115,12 +92,12 @@ process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
 process.add_(cms.ESProducer("TGeoMgrFromDdd",
-        verbose = cms.untracked.bool(False),
-        level = cms.untracked.int32(defaultLevel)
-))
+                            verbose = cms.untracked.bool(False),
+                            level = cms.untracked.int32(defaultLevel)
+                            ))
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry", 
-               tag = cms.untracked.string(options.tag),
-               outputFileName = cms.untracked.string(options.out))
+                              tag = cms.untracked.string(options.tag),
+                              outputFileName = cms.untracked.string(options.out))
 
 process.p = cms.Path(process.dump)


### PR DESCRIPTION
* Try to avoid constant modification of the script with evolving 2023 geometry scenarios by adding a version (Dxxx) defined in dict2023Geometry.py

For example:
```
cmsRun Fireworks/Geometry/python/dumpSimGeometry_cfg.py tag=2023 version=D10
```

@kpedro88 - BTW, dict2023Geometry.py is out-of-date with available scenarios