### PR TITLE
Fix l1 fat event filters 90x bis - now use TCDS unpacked data for L1T

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -39,6 +39,8 @@ Implementation:
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
+#include "EventFilter/FEDInterface/interface/FED1024.h"
+
 
 //
 // class declaration
@@ -102,12 +104,13 @@ L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSet
     return false;
   }
 
-  const FEDRawData& l1tRcd = feds->FEDData(1024);
+  const FEDRawData& tcdsRcd = feds->FEDData(1024);
+  const unsigned char *data = tcdsRcd.data();
 
-  const unsigned char *data = l1tRcd.data();
   FEDHeader header(data);
+  evf::evtn::TCDSRecord record((unsigned char *) data);
 
-  bool fatEvent = (header.lvl1ID() % period_ == 0 );
+  bool fatEvent = (record.getHeader().getData().header.triggerCount % period_ == 0 );
 
   return fatEvent;
 

--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -55,7 +55,8 @@ private:
   virtual void endJob() override ;
   
   // ----------member data ---------------------------
-  edm::InputTag src_;
+  edm::EDGetTokenT<int> src_;
+
   int period_;       // validation event period
 
 };
@@ -65,8 +66,8 @@ private:
 // constructors and destructor
 //
 L1TValidationEventFilter::L1TValidationEventFilter(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  period_( iConfig.getUntrackedParameter<int>("period", 107) )
+  src_(consumes<int>(iConfig.getParameter<edm::InputTag>("src"))),
+  period_( iConfig.getParameter<int>("period") )
 {
   //now do what ever initialization is needed
 
@@ -93,7 +94,7 @@ L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSet
   using namespace edm;
 
   Handle<int> triggerCount;
-  iEvent.getByLabel(InputTag(src_.label(),"triggerCount"), triggerCount);
+  iEvent.getByToken(src_,triggerCount);
   if (!triggerCount.isValid()) {
     LogError("L1T") << "TCDS data not unpacked: triggerCount not availble in Event.";
     return false;

--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -39,8 +39,6 @@ Implementation:
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
-#include "EventFilter/FEDInterface/interface/FED1024.h"
-
 
 //
 // class declaration
@@ -57,8 +55,7 @@ private:
   virtual void endJob() override ;
   
   // ----------member data ---------------------------
-  edm::EDGetTokenT<FEDRawDataCollection> fedData_;
-
+  edm::InputTag src_;
   int period_;       // validation event period
 
 };
@@ -68,11 +65,10 @@ private:
 // constructors and destructor
 //
 L1TValidationEventFilter::L1TValidationEventFilter(const edm::ParameterSet& iConfig) :
+  src_(iConfig.getParameter<edm::InputTag>("src")),
   period_( iConfig.getUntrackedParameter<int>("period", 107) )
 {
   //now do what ever initialization is needed
-
-  fedData_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
 
 }
 
@@ -95,22 +91,15 @@ bool
 L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   using namespace edm;
-  
-  edm::Handle<FEDRawDataCollection> feds;
-  iEvent.getByToken(fedData_, feds);
 
-  if (!feds.isValid()) {
-    LogError("L1T") << "Cannot unpack: no FEDRawDataCollection found";
+  Handle<int> triggerCount;
+  iEvent.getByLabel(InputTag(src_.label(),"triggerCount"), triggerCount);
+  if (!triggerCount.isValid()) {
+    LogError("L1T") << "TCDS data not unpacked: triggerCount not availble in Event.";
     return false;
   }
 
-  const FEDRawData& tcdsRcd = feds->FEDData(1024);
-  const unsigned char *data = tcdsRcd.data();
-
-  FEDHeader header(data);
-  evf::evtn::TCDSRecord record((unsigned char *) data);
-
-  bool fatEvent = (record.getHeader().getData().header.triggerCount % period_ == 0 );
+  bool fatEvent = (*triggerCount % period_ == 0 );
 
   return fatEvent;
 

--- a/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TValidationEventFilter.cc
@@ -55,7 +55,7 @@ private:
   virtual void endJob() override ;
   
   // ----------member data ---------------------------
-  edm::EDGetTokenT<int> src_;
+  edm::EDGetTokenT<int64_t> src_;
 
   int period_;       // validation event period
 
@@ -66,7 +66,7 @@ private:
 // constructors and destructor
 //
 L1TValidationEventFilter::L1TValidationEventFilter(const edm::ParameterSet& iConfig) :
-  src_(consumes<int>(iConfig.getParameter<edm::InputTag>("src"))),
+  src_(consumes<int64_t>(iConfig.getParameter<edm::InputTag>("src"))),
   period_( iConfig.getParameter<int>("period") )
 {
   //now do what ever initialization is needed
@@ -93,7 +93,7 @@ L1TValidationEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSet
 {
   using namespace edm;
 
-  Handle<int> triggerCount;
+  Handle<int64_t> triggerCount;
   iEvent.getByToken(src_,triggerCount);
   if (!triggerCount.isValid()) {
     LogError("L1T") << "TCDS data not unpacked: triggerCount not availble in Event.";

--- a/EventFilter/L1TRawToDigi/python/validationEventFilter_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/validationEventFilter_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 
 validationEventFilter = cms.EDFilter(
     "L1TValidationEventFilter",
-    inputTag  = cms.InputTag("rawDataCollector"),
+    src       = cms.InputTag("tcdsDigis"),
     period    = cms.untracked.int32(107)
 )

--- a/EventFilter/L1TRawToDigi/python/validationEventFilter_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/validationEventFilter_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 
 validationEventFilter = cms.EDFilter(
     "L1TValidationEventFilter",
-    src       = cms.InputTag("tcdsDigis"),
-    period    = cms.untracked.int32(107)
+    src       = cms.InputTag("tcdsDigis","triggerCount"),
+    period    = cms.int32(107)
 )

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -66,7 +66,7 @@ TcdsRawToDigi::TcdsRawToDigi(const edm::ParameterSet& iConfig)
     edm::InputTag dataLabel = iConfig.getParameter<edm::InputTag>("InputLabel");
     dataToken_=consumes<FEDRawDataCollection>(dataLabel);
     produces<int>( "nibble" ).setBranchAlias( "nibble");
-    produces<int>( "triggerCount" ).setBranchAlias( "triggerCount");
+    produces<int64_t>( "triggerCount" ).setBranchAlias( "triggerCount");
 }
 
 
@@ -94,7 +94,7 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         if(tcdsData.size()>0){
             evf::evtn::TCDSRecord tcdsRecord(tcdsData.data());
             nibble = (int)tcdsRecord.getHeader().getData().header.nibble;
-            triggerCount = (int)tcdsRecord.getHeader().getData().header.triggerCount;
+            triggerCount = (int64_t)tcdsRecord.getHeader().getData().header.triggerCount;
         } else {
             nibble=-2;
             triggerCount=-2;
@@ -106,7 +106,7 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     //std::cout<<"nibble is "<<nibble<<std::endl;
 
     iEvent.put(std::make_unique<int>(nibble), "nibble");
-    iEvent.put(std::make_unique<int>(triggerCount), "triggerCount");
+    iEvent.put(std::make_unique<int64_t>(triggerCount), "triggerCount");
 }
 
  

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -66,6 +66,7 @@ TcdsRawToDigi::TcdsRawToDigi(const edm::ParameterSet& iConfig)
     edm::InputTag dataLabel = iConfig.getParameter<edm::InputTag>("InputLabel");
     dataToken_=consumes<FEDRawDataCollection>(dataLabel);
     produces<int>( "nibble" ).setBranchAlias( "nibble");
+    produces<int>( "triggerCount" ).setBranchAlias( "triggerCount");
 }
 
 
@@ -87,20 +88,25 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iEvent.getByToken(dataToken_,rawdata);
 
     int nibble=-99;
+    int triggerCount = -99;
     if( rawdata.isValid() ) {
         const FEDRawData& tcdsData = rawdata->FEDData(FEDNumbering::MINTCDSuTCAFEDID);
         if(tcdsData.size()>0){
             evf::evtn::TCDSRecord tcdsRecord(tcdsData.data());
             nibble = (int)tcdsRecord.getHeader().getData().header.nibble;
+            triggerCount = (int)tcdsRecord.getHeader().getData().header.triggerCount;
         } else {
             nibble=-2;
+            triggerCount=-2;
         }
     } else {
         nibble=-1;
+        triggerCount=-1;
     }
     //std::cout<<"nibble is "<<nibble<<std::endl;
 
     iEvent.put(std::make_unique<int>(nibble), "nibble");
+    iEvent.put(std::make_unique<int>(triggerCount), "triggerCount");
 }
 
  

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -55,6 +55,8 @@ private:
   const int fedId_;
   /// if invert_=true, invert that event accept decision
   const bool invert_;
+  /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11
+  const bool useTCDS_;
 };
 
 #endif

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -56,7 +56,7 @@ private:
   /// if invert_=true, invert that event accept decision
   const bool invert_;
   /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11
-  const bool useTCDS_;
+  bool useTCDS_;
 };
 
 #endif

--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -56,7 +56,7 @@ private:
   /// if invert_=true, invert that event accept decision
   const bool invert_;
   /// if useTCDS=true, use 64-bit Event Number from TCDS record (FED 1024) word 11
-  bool useTCDS_;
+  const bool useTCDS_;
 };
 
 #endif

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -42,6 +42,10 @@ HLTL1NumberFilter::HLTL1NumberFilter(const edm::ParameterSet& config) :
   invert_( config.getParameter<bool>("invert") ),
   useTCDS_( config.getParameter<bool>("useTCDSEventNumber") )
 {
+
+  // only try and use TCDS event number if the FED ID 1024 is selected
+  if (fedId_!=1024) useTCDS_ = false;
+
 }
 
 

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -40,12 +40,9 @@ HLTL1NumberFilter::HLTL1NumberFilter(const edm::ParameterSet& config) :
   period_( config.getParameter<unsigned int>("period") ),
   fedId_(  config.getParameter<int>("fedId") ),
   invert_( config.getParameter<bool>("invert") ),
-  useTCDS_( config.getParameter<bool>("useTCDSEventNumber") )
-{
-
   // only try and use TCDS event number if the FED ID 1024 is selected
-  if (fedId_!=1024) useTCDS_ = false;
-
+  useTCDS_( config.getParameter<bool>("useTCDSEventNumber") and fedId_ == 1024)
+{
 }
 
 
@@ -81,14 +78,17 @@ HLTL1NumberFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSet
     edm::Handle<FEDRawDataCollection> theRaw ;
     iEvent.getByToken(inputToken_,theRaw) ;
     const FEDRawData& data = theRaw->FEDData(fedId_) ;
-    if (data.data() && data.size() > 0){
-      FEDHeader header(data.data()) ;
-      if (period_!=0) accept = ( ( (header.lvl1ID())%period_ ) == 0 );
-      if (useTCDS_ && period_!=0) {
-	evf::evtn::TCDSRecord record((unsigned char *)data.data());
-	accept = ( (record.getHeader().getData().header.triggerCount % period_) == 0 );
+    if (data.data() and data.size() > 0) {
+      unsigned long counter;
+      if (useTCDS_) {
+        evf::evtn::TCDSRecord record(data.data());
+        counter = record.getHeader().getData().header.triggerCount;
+      } else {
+        FEDHeader header(data.data());
+        counter = header.lvl1ID();
       }
-      if (invert_) accept = !accept;
+      if (period_!=0) accept = (counter % period_ == 0);
+      if (invert_) accept = not accept;
       return accept;
     } else{
       LogWarning("HLTL1NumberFilter")<<"No valid data for FED "<<fedId_<<" used by HLTL1NumberFilter";


### PR DESCRIPTION
This is a 90x version of 81x PR #16782 (and also replacement for PR #16799)

The two commits 	70ae7c3 and 	b5b3430 are to address @davidlange6 comment https://github.com/cms-sw/cmssw/pull/16799#discussion_r90223960
Will cherry-pick them  to 81x PR once this merged. 

