### PR TITLE
CA - Last hit quadruplet chi2 filter

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -264,8 +264,12 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
   std::array<GlobalPoint, 4> gps;
   std::array<GlobalError, 4> ges;
   std::array<bool, 4> barrels;
-  int fourthLayerId = -1;
-  int previousfourthLayerId = -2;
+  unsigned int fourthLayerId = 0;
+  unsigned int previousfourthLayerId = 0;
+  int subDetId = 0; 
+  int previousSubDetId = 0;
+  unsigned int sideId = 0; 
+  unsigned int previousSideId = 0; 
   std::array<unsigned int, 2> previousCellIds ={{0,0}};
   bool isTheSameTriplet = false;
   bool isTheSameFourthLayer = false;
@@ -299,8 +303,10 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     if(caOnlyOneLastHitPerLayerFilter)
     {
             fourthLayerId = tTopo->layer(ahit->geographicalId());
+            sideId = tTopo->side(ahit->geographicalId());
+            subDetId = ahit->geographicalId().subdetId();
 	    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-	    isTheSameFourthLayer = (fourthLayerId == previousfourthLayerId);
+            isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
 	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
 	    previousfourthLayerId = fourthLayerId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -289,19 +289,19 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
     if(caOnlyOneLastHitPerLayerFilter)
     {
-    layerSubDetId = ahit->geographicalId().subdetId();
-    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-    isTheSameFourthLayer = (layerSubDetId == previousLayerSubDetId);
+	    layerSubDetId = ahit->geographicalId().subdetId();
+	    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+	    isTheSameFourthLayer = (layerSubDetId == previousLayerSubDetId);
 
-    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
-    previousLayerSubDetId = layerSubDetId;
+	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
+	    previousLayerSubDetId = layerSubDetId;
 
 
-    if(!(isTheSameTriplet && isTheSameFourthLayer ))
-    {
-    	selectedChi2 = std::numeric_limits<float>::max();
-    	hasAlreadyPushedACandidate = false;
-    }
+	    if(!(isTheSameTriplet && isTheSameFourthLayer ))
+	    {
+		selectedChi2 = std::numeric_limits<float>::max();
+		hasAlreadyPushedACandidate = false;
+	    }
 
     }
 
@@ -370,20 +370,20 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
     if(caOnlyOneLastHitPerLayerFilter)
     {
-    if (chi2 < selectedChi2)
-    {
-    	selectedChi2 = chi2;
+	    if (chi2 < selectedChi2)
+	    {
+		selectedChi2 = chi2;
 
-    	if(hasAlreadyPushedACandidate)
-    	{
-    		result.pop_back();
+		if(hasAlreadyPushedACandidate)
+		{
+			result.pop_back();
 
-    	}
-	    result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),
-	    		foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
-	    hasAlreadyPushedACandidate = true;
+		}
+		result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),
+				foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+		hasAlreadyPushedACandidate = true;
 
-    }
+	    }
     }
     else
     {
@@ -393,7 +393,6 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
      
   }
 
-  std::cout << "result size: " << result.size() << " with filter " << caOnlyOneLastHitPerLayerFilter << std::endl;
 }
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -300,7 +300,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     {
             fourthLayerId = tTopo->layer(ahit->geographicalId());
 	    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-	    isTheSameFourthLayer = (layerSubDetId == previousLayerSubDetId);
+	    isTheSameFourthLayer = (fourthLayerId == previousfourthLayerId);
 
 	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
 	    previousfourthLayerId = fourthLayerId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -47,7 +47,8 @@ fitFastCircleChi2Cut(cfg.getParameter<bool>("fitFastCircleChi2Cut")),
 useBendingCorrection(cfg.getParameter<bool>("useBendingCorrection")),
 caThetaCut(cfg.getParameter<double>("CAThetaCut")),
 caPhiCut(cfg.getParameter<double>("CAPhiCut")),
-caHardPtCut(cfg.getParameter<double>("CAHardPtCut"))
+caHardPtCut(cfg.getParameter<double>("CAHardPtCut")),
+caOnlyOneLastHitPerLayerFilter(cfg.getParameter<bool>("CAOnlyOneLastHitPerLayerFilter"))
 {
   if(needSeedingLayerSetsHits)
     theSeedingLayerToken = iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"));
@@ -76,7 +77,7 @@ void CAHitQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& de
   desc.add<double>("CAThetaCut", 0.00125);
   desc.add<double>("CAPhiCut", 10);
   desc.add<double>("CAHardPtCut", 0);
-
+  desc.add<bool>("CAOnlyOneLastHitPerLayerFilter",false);
   edm::ParameterSetDescription descMaxChi2;
   descMaxChi2.add<double>("pt1", 0.2);
   descMaxChi2.add<double>("pt2", 1.5);
@@ -254,6 +255,14 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
   std::array<GlobalPoint, 4> gps;
   std::array<GlobalError, 4> ges;
   std::array<bool, 4> barrels;
+  int layerSubDetId = -1;
+  int previousLayerSubDetId = -2;
+  std::array<unsigned int, 2> previousCellIds ={{0,0}};
+  bool isTheSameTriplet = false;
+  bool isTheSameFourthLayer = false;
+  bool hasAlreadyPushedACandidate = false;
+  float selectedChi2 = std::numeric_limits<float>::max();
+
 
   unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
 
@@ -277,6 +286,25 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     gps[3] = ahit->globalPosition();
     ges[3] = ahit->globalPositionError();
     barrels[3] = isBarrel(ahit->geographicalId().subdetId());
+
+    if(caOnlyOneLastHitPerLayerFilter)
+    {
+    layerSubDetId = ahit->geographicalId().subdetId();
+    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+    isTheSameFourthLayer = (layerSubDetId == previousLayerSubDetId);
+
+    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
+    previousLayerSubDetId = layerSubDetId;
+
+
+    if(!(isTheSameTriplet && isTheSameFourthLayer ))
+    {
+    	selectedChi2 = std::numeric_limits<float>::max();
+    	hasAlreadyPushedACandidate = false;
+    }
+
+    }
+
 
     // TODO:
     // - 'line' is not used for anything
@@ -340,8 +368,32 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
         continue;
     }
 
-    result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+    if(caOnlyOneLastHitPerLayerFilter)
+    {
+    if (chi2 < selectedChi2)
+    {
+    	selectedChi2 = chi2;
+
+    	if(hasAlreadyPushedACandidate)
+    	{
+    		result.pop_back();
+
+    	}
+	    result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),
+	    		foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+	    hasAlreadyPushedACandidate = true;
+
+    }
+    }
+    else
+    {
+
+       result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+    }
+     
   }
+
+  std::cout << "result size: " << result.size() << " with filter " << caOnlyOneLastHitPerLayerFilter << std::endl;
 }
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -146,6 +146,6 @@ private:
     const float caThetaCut = 0.00125f;
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
-    const bool caOnlyOneLastHitPerLayerFilter = true;
+    const bool caOnlyOneLastHitPerLayerFilter = false;
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -146,6 +146,6 @@ private:
     const float caThetaCut = 0.00125f;
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
-
+    const bool caOnlyOneLastHitPerLayerFilter = true;
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/CAHitQuadrupletGenerator_cfi.py
@@ -15,4 +15,5 @@ CAHitQuadrupletGenerator = cms.PSet(
     CAThetaCut = cms.double(0.00125),
     CAPhiCut = cms.double(10),
     CAHardPtCut = cms.double(0),
+    CAOnlyOneLastHitPerLayerFilter= cms.bool(False)
 )


### PR DESCRIPTION
Adding the possibility to have a filter on the last hit of a quadruplet, like in quadruplets by propagation.
If two quadruplets have the first three hits in common and the fourth hits are on the same layer, pick the one with the lower chi2. 

This has the effect of reducing the fake and duplicate rate within the same iteration: e.g. https://fpantale.web.cern.ch/fpantale/offline_tuning/lastLayerChi2FilterPR/plots_initialStepPreSplitting.html

blue Quadruplets by propagation
red CA in the release
black CA with filter turned on (this PR) 

@VinInn @rovere @makortel 
