### PR TITLE
Further performance improvement in BoostedTauSeeds

### DIFF
--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -77,6 +77,9 @@ BoostedTauSeedsProducer::BoostedTauSeedsProducer(const edm::ParameterSet& cfg)
 
 namespace
 {
+  typedef std::vector<std::unordered_set<uint32_t> > JetToConstitMap;
+  constexpr double dR2Match = 1.0e-8;
+
   reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents)
   {    
     // CV: code for filling pfJetSpecific objects taken from
@@ -159,7 +162,7 @@ namespace
     }
   }
 
-  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(const reco::Jet& jet, const edm::Handle<reco::PFCandidateCollection>& pfCandidates, const reco::Jet::Constituents& jetConstituents, double dRmatch, bool invert)
+  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(const reco::Jet& jet, const edm::Handle<reco::PFCandidateCollection>& pfCandidates, const JetToConstitMap::value_type& constitmap, const reco::Jet::Constituents& jetConstituents, double dRmatch, bool invert)
   { 
     const double dRmatch2 = dRmatch*dRmatch;
     auto const & collection_cand = (*pfCandidates);
@@ -167,15 +170,7 @@ namespace
     size_t numPFCandidates = pfCandidates->size();
     for ( size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx ) {
       if(!(deltaR2(collection_cand[pfCandidateIdx], jet)<1.0)) continue;
-      bool isJetConstituent = false;
-      for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
-	    jetConstituent != jetConstituents.end(); ++jetConstituent ) {
-	double dR2 = deltaR2(collection_cand[pfCandidateIdx], **jetConstituent);
-	if ( dR2 < dRmatch2 ) {
-	  isJetConstituent = true;
-	  break;
-	}
-      }
+      bool isJetConstituent = constitmap.count(pfCandidateIdx);      
       if ( !(isJetConstituent^invert) ) {
 	reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
 	pfCandidates_exclJetConstituents.push_back(pfCandidate);
@@ -221,6 +216,17 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
   auto selectedSubjetPFCandidateAssociationForIsolation = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
   //auto selectedSubjetPFCandidateAssociationForIsoDepositVetos = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
 
+  // cache for jet->pfcandidate
+  JetToConstitMap constitmap(subjets->size());
+
+  // fill constituents map
+  const auto& thesubjets = *subjets;
+  for( unsigned i = 0; i < thesubjets.size(); ++i ) {
+    for ( unsigned j = 0; j < thesubjets[i].numberOfDaughters(); ++j ) {
+      constitmap[i].emplace(thesubjets[i].daughterPtr(j).key());
+    }
+  }
+
   for ( size_t idx = 0; idx < (subjets->size() / 2); ++idx ) {
     const reco::Jet* subjet1 = &subjets->at(2*idx);
     const reco::Jet* subjet2 = &subjets->at(2*idx + 1);
@@ -252,8 +258,8 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     edm::Ref<reco::PFJetCollection> subjetRef2(selectedSubjetRefProd, selectedSubjets->size() - 1);
         
     // find all PFCandidates that are not constituents of the **other** subjet
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, subjetConstituents2, 1.e-4, false);
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, subjetConstituents1, 1.e-4, false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, constitmap[2*idx], subjetConstituents2, 1.e-4, false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, constitmap[2*idx+1], subjetConstituents1, 1.e-4, false);
     if ( verbosity_ >= 1 ) {
       std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
       std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;


### PR DESCRIPTION
As discussed at the end of: https://github.com/cms-sw/cmssw/pull/17040

This PR uses a cache to collapse a double loop.