### PR TITLE
add consumes syntax for MCMultiParticleFilter

### DIFF
--- a/GeneratorInterface/GenFilters/interface/MCMultiParticleFilter.h
+++ b/GeneratorInterface/GenFilters/interface/MCMultiParticleFilter.h
@@ -34,6 +34,9 @@
 //
 // class declaration
 //
+namespace edm {
+  class HepMCProduct;
+}
 
 class MCMultiParticleFilter : public edm::EDFilter {
  public:
@@ -46,7 +49,7 @@ class MCMultiParticleFilter : public edm::EDFilter {
   
   // ----------member data ---------------------------
   
-  edm::InputTag src_;              // input tag
+  edm::EDGetTokenT<edm::HepMCProduct> src_; // input token
   int numRequired_;                // number of particles required to pass filter
   bool acceptMore_;                // if true (default), accept numRequired or more.
                                    // if false, accept events with exactly equal to numRequired.

--- a/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCMultiParticleFilter.cc
@@ -2,7 +2,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag(std::string("generator"),"unsmeared"))),
+  src_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag(std::string("generator"),"unsmeared")))),
   numRequired_(iConfig.getParameter<int>("NumRequired")),
   acceptMore_(iConfig.getParameter<bool>("AcceptMore")),
   particleID_(iConfig.getParameter< std::vector<int> >("ParticleID")),
@@ -54,7 +54,7 @@ MCMultiParticleFilter::~MCMultiParticleFilter()
 bool MCMultiParticleFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   edm::Handle<edm::HepMCProduct> evt;
-  iEvent.getByLabel(src_, evt);
+  iEvent.getByToken(src_, evt);
   
   totalEvents_++;
   int nFound = 0;


### PR DESCRIPTION
This should be propagated to 8_1_0, if not done automatically, for the central MC production.