### PR TITLE
Fix crash in tracking MC validation plot scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -625,6 +625,11 @@ class Subtract:
         ret = histoA.Clone(self._name)
         ret.SetTitle(self._title)
 
+        # Disable canExtend if it is set, otherwise setting the
+        # overflow bin will extend instead, possibly causing weird
+        # effects downstream
+        ret.SetCanExtend(False)
+
         for i in xrange(0, histoA.GetNbinsX()+2): # include under- and overflow too
             val = histoA.GetBinContent(i)-histoB.GetBinContent(i)
             ret.SetBinContent(i, val)
@@ -659,6 +664,11 @@ class Transform:
 
         ret = histo.Clone(self._name)
         ret.SetTitle(self._title)
+
+        # Disable canExtend if it is set, otherwise setting the
+        # overflow bin will extend instead, possibly causing weird
+        # effects downstream
+        ret.SetCanExtend(False)
 
         for i in xrange(0, histo.GetNbinsX()+2):
             ret.SetBinContent(i, self._func(histo.GetBinContent(i)))


### PR DESCRIPTION
This PR fixes an assert-style exception in tracking MC validation plot scripts. The scripts worked with the same input in 810, so maybe there was some change in ROOT that allows these histogram to extend their x axis (leading to additional surprise-bins later). The fix is to explicitly disable the axis extension.

Thanks to @rovere for reporting the issue.

Tested in 9_0_0_pre2, no changes expected in standard workflows.

@rovere @VinInn 