### PR TITLE
HBHE: M3 scale fixes + online/offline M2 parameter adjustements

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
@@ -8,7 +8,7 @@ static const double cap = 6.0;
 static const double tspar0[2] = {15.5, 12.2999};
 static const double tspar1[2] = {-3.2,-2.19142};
 static const double tspar2[2] = {32, 0};
-static const double tspar0_siPM[2] = {0, 0};
+static const double tspar0_siPM[2] = {3., 3.}; // 3ns delay for MC and DATA, recheck later for data
 static const double tspar1_siPM[2] = {0, 0};
 static const double tspar2_siPM[2] = {0, 0};
 
@@ -27,7 +27,7 @@ double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, doubl
   }
   else if (source==Data || source==MC){
     if(isHPD) return std::fmin(cap,tspar0[source-1]+tspar1[source-1]*log(fC+tspar2[source-1]));
-    return std::fmin(cap,tspar0_siPM[source-1]+tspar1_siPM[source-1]*log(fC+tspar2_siPM[source-1]));
+    return cap+tspar0_siPM[source-1];
   }
   return 0;
 }

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -80,7 +80,7 @@ def customiseFor15499(process):
 def customiseFor16569(process):
     for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
         if hasattr(process,mod):
-            getattr(process,mod).ts4chi2 = cms.vdouble(15.,15.)
+            getattr(process,mod).ts4chi2 = cms.vdouble(15.,5000.)
 
     return process
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -90,7 +90,7 @@ def customiseFor17094(process):
             getattr(process,mod).timeSigmaSiPM = cms.double(2.5)
             getattr(process,mod).pedSigmaSiPM = cms.double(0.00065)
             getattr(process,mod).noiseSiPM = cms.double(1)
-            getattr(process,mod).ts4Max = cms.vdouble(20.,20.)
+            getattr(process,mod).ts4Max = cms.vdouble(100.,45000.)
             getattr(process,mod).ts4chi2 = cms.vdouble(15.,15.)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -84,7 +84,7 @@ def customiseFor16569(process):
 
     return process
 
-def customiseForThis(process):
+def customiseFor17094(process):
     for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
         if hasattr(process,mod):
             getattr(process,mod).ts4Max = cms.vdouble(20.,20.)
@@ -188,7 +188,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     if cmsswVersion >= "CMSSW_9_0":
         process = customiseFor16792(process)
-        process = customiseForThis(process)
+        process = customiseFor17094(process)
         pass
 
 #   stage-2 changes only if needed

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -80,8 +80,14 @@ def customiseFor15499(process):
 def customiseFor16569(process):
     for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
         if hasattr(process,mod):
-            getattr(process,mod).ts4chi2 = cms.vdouble(15.,5000.)
+            getattr(process,mod).ts4chi2 = cms.vdouble(15.,15.)
 
+    return process
+
+def customiseForThis(process):
+    for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
+        if hasattr(process,mod):
+            getattr(process,mod).ts4Max = cms.vdouble(20.,20.)
     return process
 
 # Move pixel track fitter, filter, and cleaner to ED/ESProducts (PR #16792)
@@ -182,6 +188,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     if cmsswVersion >= "CMSSW_9_0":
         process = customiseFor16792(process)
+        process = customiseForThis(process)
         pass
 
 #   stage-2 changes only if needed

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -87,7 +87,12 @@ def customiseFor16569(process):
 def customiseFor17094(process):
     for mod in ['hltHbhereco','hltHbherecoMethod2L1EGSeeded','hltHbherecoMethod2L1EGUnseeded','hltHfreco','hltHoreco']:
         if hasattr(process,mod):
+            getattr(process,mod).timeSigmaSiPM = cms.double(2.5)
+            getattr(process,mod).pedSigmaSiPM = cms.double(0.00065)
+            getattr(process,mod).noiseSiPM = cms.double(1)
             getattr(process,mod).ts4Max = cms.vdouble(20.,20.)
+            getattr(process,mod).ts4chi2 = cms.vdouble(15.,15.)
+
     return process
 
 # Move pixel track fitter, filter, and cleaner to ED/ESProducts (PR #16792)

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
@@ -43,6 +43,7 @@ class HcalDeterministicFit {
   static constexpr float negThresh[2] = {-3., 15.};
   static constexpr float invGpar[3] = {-13.11, 11.29, 5.133};
   static constexpr float rCorr[2] = {0.95, 0.95};
+  static constexpr float rCorrSiPM[2] = {1., 1.};
   static constexpr float landauFrac[] = {0, 7.6377e-05, 0.000418655, 0.00153692, 0.00436844, 0.0102076, 
   0.0204177, 0.0360559, 0.057596, 0.0848493, 0.117069, 0.153152, 0.191858, 0.23198, 0.272461, 0.312438, 
   0.351262, 0.388476, 0.423788, 0.457036, 0.488159, 0.517167, 0.54412, 0.569112, 0.592254, 0.613668, 

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -87,8 +87,8 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   }
 
   if (fTimeSlew==0)respCorr=1.0;
-  else if (fTimeSlew==1)respCorr=rCorr[0];
-  else if (fTimeSlew==2)respCorr=rCorr[1];
+  else if (fTimeSlew==1) channelData.hasTimeInfo()?respCorr=rCorrSiPM[0]:respCorr=rCorr[0];
+  else if (fTimeSlew==2) channelData.hasTimeInfo()?respCorr=rCorrSiPM[1]:respCorr=rCorr[1];
   else if (fTimeSlew==3)respCorr=frespCorr;
 
   float tsShift3=0;

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -60,8 +60,8 @@ hbheprereco = cms.EDProducer(
         # Use "Method 2"?
         useM2 = cms.bool(True),
 
-        # Use "Method 3"? Change this to True when implemented.
-        useM3 = cms.bool(False)
+        # Use "Method 3"?
+        useM3 = cms.bool(True)
     ),
 
     # Reconstruction algorithm configuration data to fetch from DB, if any


### PR DESCRIPTION
The M3 scale is adjusted with the initial timing and the removal 0.95 of fudge scaling factor used for the HPD.

The parameters for the siPM are resynched between the HLT customisation file and the offline https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py

Validation slide here
http://dalfonso.web.cern.ch/dalfonso/M3scale.pdf

For the record 
1.   the customization done so far in HLTrigger/Configuration/python/customizeHLTforCMSSW.py affects only the run2-2016 see HcalHitReconstructor and not the HBHEPhase1Reconstructor This has been already discussed early in the week with @fwyzard and gennai.

