### PR TITLE
Better detection of unrunnable scheduled

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -31,14 +31,14 @@ from Validation.RecoParticleFlow.miniAODValidation_cff import *
 from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
 from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 
-prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
+prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq * cms.SequencePlaceholder("mix") )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
 prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * egammaValidationMiniAOD)
 
 
-validation = cms.Sequence(cms.SequencePlaceholder("mix")
-                         +genvalid_all
+validation = cms.Sequence(
+                         genvalid_all
                          *globaldigisanalyze
                          *globalhitsanalyze
                          *globalrechitsanalyze

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -230,12 +230,22 @@ namespace {
           }
           if( itLastMatch==cycle.end()) {
             //need to use the full cycle
+            //NOTE: this should just retest the same cycle but starting
+            // from a different position. If everything is correct, then
+            // this should also pass so in principal we could return here.
+            //However, as long as this isn't a performance problem, having
+            // this additional check could catch problems in the algorithm.
             tempStack.insert(tempStack.end(),cycle.begin(),itStartMatch);
           } else {
             tempStack.insert(tempStack.end(),cycle.begin(),itLastMatch+1);
           }
         } else {
           //std::cout <<"found later in cycle"<<std::endl;
+          if( (itStartMatch == cycle.begin()) and (cycle.end() == (itLastMatch+1)) ) {
+            //This is just the entire cycle starting where we've already started
+            // before. Given the cycle was OK before, it would also be OK this time
+            return;
+          }
           tempStack.insert(tempStack.end(),itStartMatch,itLastMatch+1);
         }
         //CDJ DEBUG

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -89,6 +89,19 @@ namespace {
     bool compare(Edge const& iLHS, Edge const& iRHS)  const;
     
     void tree_edge(Edge const& iEdge, Graph const& iGraph) {
+      typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
+      IndexMap const& index = get(boost::vertex_index, iGraph);
+      
+      auto in = index[source(iEdge,iGraph)];
+      for( auto it = m_stack.begin(); it != m_stack.end(); ++it) {
+        if(in ==index[source(*it,iGraph)]) {
+          //this vertex is now being used to probe a new edge
+          // so we should drop the rest of the tree
+          m_stack.erase(it, m_stack.end());
+          break;
+        }
+      }
+      
       m_stack.push_back(iEdge);
     }
     

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -351,8 +351,6 @@ namespace {
       // we already know we originate from a path because all tests
       // require starting from the root node which connects to all paths
       bool hasDataDependency =false;
-      std::unordered_map<unsigned int, unsigned int> pathToCountOfNonDataDependencies;
-      unsigned int nNonDataDependencies = 0;
       //Since we are dealing with a circle, we initialize the 'last' info with the end of the graph
       typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
       IndexMap const& index = get(boost::vertex_index, iGraph);
@@ -472,12 +470,6 @@ namespace {
           lastOut = out;
           lastEdgeHasDataDepencency =edgeHasDataDependency;
         }
-        if(not edgeHasDataDependency) {
-          ++nNonDataDependencies;
-          for(auto pathIndex : pathsOnEdge) {
-            pathToCountOfNonDataDependencies[pathIndex] +=1;
-          }
-        }
       }
       if(moduleAppearedEarlierInPath and not pathToModulesWhichMustAppearLater.empty()) {
         return;
@@ -486,13 +478,6 @@ namespace {
         return;
       }
       throwOnError(iCycleEdges,index,iGraph);
-      for(auto const& pathToCount : pathToCountOfNonDataDependencies) {
-        //If all the non data dependencies are seen on on path
-        // then at least two modules are in the wrong order
-        if (pathToCount.second == nNonDataDependencies) {
-          throwOnError(iCycleEdges,index,iGraph);
-        }
-      }
 
     }
     

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -22,9 +22,6 @@
 #include "boost/graph/depth_first_search.hpp"
 #include "boost/graph/visitors.hpp"
 
-//CDJ DEBUG
-#include <iostream>
-
 namespace {
   //====================================
   // checkForCorrectness algorithm
@@ -167,7 +164,6 @@ namespace {
       if(m_verticiesInFundamentalCycles.end() == m_verticiesInFundamentalCycles.find(out)) {
         return;
       }
-      //std::cout <<"found "<<out<<std::endl;
       
       for(auto const& cycle: m_fundamentalCycles) {
         //Is the out vertex in this cycle?
@@ -184,12 +180,6 @@ namespace {
           //this cycle isn't the one which uses the vertex from the stack
           continue;
         }
-        //std::cout <<"matching cycle"<<std::endl;
-        /*for(auto it =cycle.begin(); it!= cycle.end(); ++it) {
-          unsigned int inCycle =index[source(*it,iGraph)];
-          unsigned int outCycle =index[target(*it,iGraph)];
-          //std::cout << inCycle<<"->"<<outCycle<<std::endl;
-        } */
 
         //tempStack will hold a stack that could have been found by depth first
         // search if module to index ordering had been different
@@ -218,7 +208,6 @@ namespace {
           }
         }
         if(itLastMatch==cycle.end()) {
-          //std::cout <<"search earlier in cycle"<<std::endl;
           //See if we can find the attachment to the stack earlier in the cycle
           tempStack.insert(tempStack.end(),itStartMatch,cycle.end());
           for(auto it=cycle.begin(); it != itStartMatch;++it) {
@@ -240,7 +229,6 @@ namespace {
             tempStack.insert(tempStack.end(),cycle.begin(),itLastMatch+1);
           }
         } else {
-          //std::cout <<"found later in cycle"<<std::endl;
           if( (itStartMatch == cycle.begin()) and (cycle.end() == (itLastMatch+1)) ) {
             //This is just the entire cycle starting where we've already started
             // before. Given the cycle was OK before, it would also be OK this time
@@ -248,13 +236,6 @@ namespace {
           }
           tempStack.insert(tempStack.end(),itStartMatch,itLastMatch+1);
         }
-        //CDJ DEBUG
-        //std::cout<<"NEW CYCLE"<<std::endl;
-        /*for(auto const& edge: tempStack) {
-          unsigned int outCycle =index[target(edge,iGraph)];
-          unsigned int inCycle =index[source(edge,iGraph)];
-          //std::cout <<inCycle <<"->"<<outCycle<<std::endl;
-        }*/
         
         tempStack= findMinimumCycle(tempStack,iGraph);
         checkCycleForProblem(tempStack,iGraph);


### PR DESCRIPTION
Improved the algorithm used to detect unrunnable schedule. All known cases where the old algorithm failed to find can now be found. The theoretical underpinning for the use of graph traversal is now better understood and utilized.

The new code did detect one previously unknown scheduling problem which was also fixed.