### PR TITLE
[90X] Add new style of e/gamma regressions labels in Run1 MC Global Tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '90X_mcRun1_design_v0',
+    'run1_design'       :   '90X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '90X_mcRun1_realistic_v0',
+    'run1_mc'           :   '90X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '90X_mcRun1_HeavyIon_v0',
+    'run1_mc_hi'        :   '90X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '90X_mcRun1_pA_v0',
+    'run1_mc_pa'        :   '90X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '90X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2


### PR DESCRIPTION
This PR completes the updates of the e/gamma regressions started in #17048, now also for Run1 simulation. This PR is necessary for integrations of  PR #17101
attn: @rafaellopesdesa

# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Ideal scenario** : [90X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_design_v1) as [90X_mcRun1_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_design_v1/90X_mcRun1_design_v0): 
      * added additional e/gamma labels for electron / photon regressions (PR #17101)

   * **RunI Heavy Ions scenario** : [90X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_HeavyIon_v1) as [90X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_HeavyIon_v1/90X_mcRun1_HeavyIon_v0): 
      * added additional e/gamma labels for electron / photon regressions (PR #17101)

   * **RunI Realistic scenario** : [90X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_realistic_v1) as [90X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_realistic_v1/90X_mcRun1_realistic_v0): 
      * added additional e/gamma labels for electron / photon regressions (PR #17101)

   * **RunI Proton-Lead scenario** : [90X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_pA_v1) as [90X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_mcRun1_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_mcRun1_pA_v1/90X_mcRun1_pA_v0): 
      * added additional e/gamma labels for electron / photon regressions (PR #17101)