### PR TITLE
Remove compiler warnings in E/gamma packages

### DIFF
--- a/RecoEgamma/EgammaTools/interface/ConversionTools.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionTools.h
@@ -30,7 +30,6 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Math/interface/Point3D.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 class ConversionTools

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAnalFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAnalFitAlgo.h
@@ -66,13 +66,13 @@ template<class C> class EcalUncalibRecHitRecAnalFitAlgo : public EcalUncalibRecH
     uint32_t flag = 0;
     for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
       int gainId = dataFrame.sample(iSample).gainId(); 
-      if ( dataFrame.isSaturated() != -1 ) 
+      if ( dataFrame.isSaturated() ) 
 	{
 	  gainId = 3;
 	  isSaturated = 1;
 	}
 
-      if (gainId != gainId0) iGainSwitch++ ;
+      if (gainId != gainId0) ++iGainSwitch ;
       if (!iGainSwitch)
 	frame[iSample] = double(dataFrame.sample(iSample).adc());
       else


### PR DESCRIPTION
Remove comparison of now-boolean variable to a signed quantity (always true).
Remove inclusion of magnetic field from ConversionTools (not being used and throws a strange warning).