### PR TITLE
Fix exception message context information

### DIFF
--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -115,28 +115,29 @@ namespace edm {
                          std::string const& id,
                          PathContext const& pathContext) {
     std::ostringstream ost;
-    if (isEvent) {
-      ost << "Calling event method";
+    if (not isEvent) {
+      //For the event case, the Worker has already
+      // added the necessary module context to the exception
+      if (begin && branchType == InRun) {
+        ost << "Calling beginRun";
+      }
+      else if (begin && branchType == InLumi) {
+        ost << "Calling beginLuminosityBlock";
+      }
+      else if (!begin && branchType == InLumi) {
+        ost << "Calling endLuminosityBlock";
+      }
+      else if (!begin && branchType == InRun) {
+        ost << "Calling endRun";
+      }
+      else {
+        // It should be impossible to get here ...
+        ost << "Calling unknown function";
+      }
+      ost << " for module " << desc.moduleName() << "/'" << desc.moduleLabel() << "'";
+      ex.addContext(ost.str());
+      ost.str("");
     }
-    else if (begin && branchType == InRun) {
-      ost << "Calling beginRun";
-    }
-    else if (begin && branchType == InLumi) {
-      ost << "Calling beginLuminosityBlock";
-    }
-    else if (!begin && branchType == InLumi) {
-      ost << "Calling endLuminosityBlock";
-    }
-    else if (!begin && branchType == InRun) {
-      ost << "Calling endRun";
-    }
-    else {
-      // It should be impossible to get here ...
-      ost << "Calling unknown function";
-    }
-    ost << " for module " << desc.moduleName() << "/'" << desc.moduleLabel() << "'";
-    ex.addContext(ost.str());
-    ost.str("");
     ost << "Running path '" << pathContext.pathName() << "'";
     ex.addContext(ost.str());
     ost.str("");

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -104,7 +104,7 @@ private:
     ModuleCallingContext const* imcc = mcc;
     while(imcc->type() == ParentContext::Type::kModule) {
       std::ostringstream iost;
-      iost << "Calling method for unscheduled module "
+      iost << "Calling method for module "
       << imcc->moduleDescription()->moduleName() << "/'"
       << imcc->moduleDescription()->moduleLabel() << "'";
       ex.addContext(iost.str());
@@ -112,7 +112,7 @@ private:
     }
     if(imcc->type() == ParentContext::Type::kInternal) {
       std::ostringstream iost;
-      iost << "Calling method for unscheduled module "
+      iost << "Calling method for module "
       << imcc->moduleDescription()->moduleName() << "/'"
       << imcc->moduleDescription()->moduleLabel() << "' (probably inside some kind of mixing module)";
       ex.addContext(iost.str());
@@ -120,7 +120,7 @@ private:
     }
     while(imcc->type() == ParentContext::Type::kModule) {
       std::ostringstream iost;
-      iost << "Calling method for unscheduled module "
+      iost << "Calling method for module "
       << imcc->moduleDescription()->moduleName() << "/'"
       << imcc->moduleDescription()->moduleLabel() << "'";
       ex.addContext(iost.str());

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -650,9 +650,9 @@ namespace edm {
         assert(not cached_exception_);
         std::ostringstream iost;
         if(iEPtr) {
-          iost<<"Prefetching for unscheduled module ";
+          iost<<"Prefetching for module ";
         } else {
-          iost<<"Calling method for unscheduled module ";
+          iost<<"Calling method for module ";
         }
         iost<<description().moduleName() << "/'"
         << description().moduleLabel() << "'";


### PR DESCRIPTION
If an exception occurred, the exception message context would contain
two lines referring to the module on the originating path. This was
from both the Worker and the Path printing module related information.
Now the module info only comes from the Worker.