### PR TITLE
Bringing Phase2 ZS in sync with Phase1 one

### DIFF
--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -24,8 +24,5 @@ simHcalDigis = cms.EDProducer("HcalRealisticZS",
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify( simHcalDigis,
                              useConfigZSvalues = cms.int32(1),
-                             HBlevel = cms.int32(8),
-                             HElevel = cms.int32(3),
-                             HOlevel = cms.int32(24),
-                             HFlevel = cms.int32(-99)
+                             HElevel = cms.int32(3)
 )

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -24,8 +24,8 @@ simHcalDigis = cms.EDProducer("HcalRealisticZS",
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify( simHcalDigis,
                              useConfigZSvalues = cms.int32(1),
-                             HBlevel = cms.int32(16),
-                             HElevel = cms.int32(16),
-                             HOlevel = cms.int32(16),
-                             HFlevel = cms.int32(16)
+                             HBlevel = cms.int32(8),
+                             HElevel = cms.int32(3),
+                             HOlevel = cms.int32(24),
+                             HFlevel = cms.int32(-99)
 )


### PR DESCRIPTION
Update old ("SLHC" releases era) HCAL ZeroSuppression levels for Phase 2 to those used by Phase 1. 
Up to now comparison of Phase 2 RelVals to Phase 1 ones used to exhibit a difference in the soft part of spectra due to obsolete ZS settings in Phase 2 setup.       