### PR TITLE
bug fix for GsfEleEcalDrivenCut 

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
@@ -4,12 +4,7 @@
 
 class GsfEleEcalDrivenCut : public CutApplicatorBase {
 public:
-  GsfEleEcalDrivenCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    ecalDrivenEB_(c.getParameter<int>("ecalDrivenEB")),
-    ecalDrivenEE_(c.getParameter<int>("ecalDrivenEE")),
-    barrelCutOff_(c.getParameter<double>("barrelCutOff")){
-  }
+  GsfEleEcalDrivenCut(const edm::ParameterSet& c);
   
   result_type operator()(const reco::GsfElectronPtr&) const override final;
 
@@ -20,25 +15,61 @@ public:
   }
 
 private:
-  const int ecalDrivenEB_, ecalDrivenEE_;// -1 ignore, 0 = fail ecalDriven, 1 =pass ecalDriven
+  static bool isValidCutVal(int val);
+
+private:
+  enum EcalDrivenCode{IGNORE=-1,FAIL=0,PASS=1};
+  const int ecalDrivenEB_, ecalDrivenEE_;
   const double barrelCutOff_;
+  
 };
 
 DEFINE_EDM_PLUGIN(CutApplicatorFactory,
 		  GsfEleEcalDrivenCut,
 		  "GsfEleEcalDrivenCut");
 
+
+ 
+GsfEleEcalDrivenCut::GsfEleEcalDrivenCut(const edm::ParameterSet& c) :
+  CutApplicatorBase(c),
+  ecalDrivenEB_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEB"))),
+  ecalDrivenEE_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEE"))),
+  barrelCutOff_(c.getParameter<double>("barrelCutOff"))
+{
+  if(!isValidCutVal(ecalDrivenEB_) || !isValidCutVal(ecalDrivenEE_)){
+    std::ostringstream errMsg;
+    errMsg<<"error in constructing GsfEleEcalDrivenCut"<<std::endl;
+    errMsg<<"values of ecalDrivenEB: "<<ecalDrivenEB_<<" and/or ecalDrivenEE: "<<ecalDrivenEE_<<" are invalid "<<std::endl;
+    errMsg<<"allowed values are IGNORE:"<<IGNORE<<" FAIL:"<<FAIL<<" PASS:"<<PASS;
+    throw edm::Exception(edm::errors::Configuration,errMsg.str());
+  }
+}
+
 CutApplicatorBase::result_type 
 GsfEleEcalDrivenCut::
 operator()(const reco::GsfElectronPtr& cand) const{ 
-  const bool ecalDriven =  std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? 
+  const auto ecalDrivenRequirement =  std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? 
     ecalDrivenEB_ : ecalDrivenEE_;
-  if(ecalDriven<0) return true;
-  else if(ecalDriven==0) return !cand->ecalDriven();
-  else return cand->ecalDriven();
+  if(ecalDrivenRequirement==IGNORE) return true;
+  else if(ecalDrivenRequirement==FAIL) return !cand->ecalDriven();
+  else if(ecalDrivenRequirement==PASS) return cand->ecalDriven();
+  else{  
+    std::ostringstream errMsg;
+    errMsg<<"error in "<<__FILE__<<" line "<<__LINE__<<std::endl;
+    errMsg<<"default option should not be reached, code has been updated without changing the logic, this needs to be fixed";
+    throw edm::Exception(edm::errors::LogicError,errMsg.str());
+  }
 }
 
 double GsfEleEcalDrivenCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   return ele->ecalDriven();
+}
+
+bool GsfEleEcalDrivenCut::isValidCutVal(int val)
+{
+  if(val==IGNORE) return true;
+  if(val==FAIL) return true;
+  if(val==PASS) return true;
+  return false;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
@@ -37,11 +37,10 @@ GsfEleEcalDrivenCut::GsfEleEcalDrivenCut(const edm::ParameterSet& c) :
   barrelCutOff_(c.getParameter<double>("barrelCutOff"))
 {
   if(!isValidCutVal(ecalDrivenEB_) || !isValidCutVal(ecalDrivenEE_)){
-    std::ostringstream errMsg;
-    errMsg<<"error in constructing GsfEleEcalDrivenCut"<<std::endl;
-    errMsg<<"values of ecalDrivenEB: "<<ecalDrivenEB_<<" and/or ecalDrivenEE: "<<ecalDrivenEE_<<" are invalid "<<std::endl;
-    errMsg<<"allowed values are IGNORE:"<<IGNORE<<" FAIL:"<<FAIL<<" PASS:"<<PASS;
-    throw edm::Exception(edm::errors::Configuration,errMsg.str());
+    throw edm::Exception(edm::errors::Configuration)
+      <<"error in constructing GsfEleEcalDrivenCut"<<std::endl
+      <<"values of ecalDrivenEB: "<<ecalDrivenEB_<<" and/or ecalDrivenEE: "<<ecalDrivenEE_<<" are invalid "<<std::endl
+      <<"allowed values are IGNORE:"<<IGNORE<<" FAIL:"<<FAIL<<" PASS:"<<PASS;
   }
 }
 
@@ -54,10 +53,9 @@ operator()(const reco::GsfElectronPtr& cand) const{
   else if(ecalDrivenRequirement==FAIL) return !cand->ecalDriven();
   else if(ecalDrivenRequirement==PASS) return cand->ecalDriven();
   else{  
-    std::ostringstream errMsg;
-    errMsg<<"error in "<<__FILE__<<" line "<<__LINE__<<std::endl;
-    errMsg<<"default option should not be reached, code has been updated without changing the logic, this needs to be fixed";
-    throw edm::Exception(edm::errors::LogicError,errMsg.str());
+    throw edm::Exception(edm::errors::LogicError)
+      <<"error in "<<__FILE__<<" line "<<__LINE__<<std::endl
+      <<"default option should not be reached, code has been updated without changing the logic, this needs to be fixed";
   }
 }
 


### PR DESCRIPTION
Thanks to @lgray, a bug was found where the GsfEleEcalDrivenCut accidentally stores the cut value in a bool rather than an int. This meant that the "ignore" code (-1) would be configured to "require ecal driven" (1). 

This has no impact in any official E/g ID as its never set to ignore (only the case when you want it ignored in the barrel and not the endcap or vice versa would have this). Still it should be fixed. No need for any backports. 

At the same time, I made the whole thing more robust against user config errors, to the point it will now throw an exception and a clear message if the config file passes in something other -1,0,1 for the cut value.

Out of ~7000 DY events, no changes in the number of electrons passing the HEEP V60 ID (which uses this cut) is observed. 