### PR TITLE
Fix randomly failing framework unit test

### DIFF
--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -12,10 +12,7 @@ F3=${LOCAL_TEST_DIR}/test_one_modules_cfg.py
 
 #the last few lines of the output are the printout from the
 # ConcurrentModuleTimer service detailing how much time was
-# spent in 2,3 or 4 modules running simultaneously. Given the
-# only module that can run concurrently is the internal
-# TriggerResults producer, we will ignore times less then 0.01s
-# except for 2 at a time where we allow less than 0.02.
+# spent in 2,3 or 4 modules running simultaneously.
 touch empty_file
 
-(cmsRun ${LOCAL_TEST_DIR}/test_no_concurrent_module_cfg.py 2>&1) | tail -n 3 | grep -v ' 0.00' | grep -v ' 0 ' | grep -v 'e-' | grep -v '2 0.01' | diff - empty_file || die "Failure using test_no_concurrent_module_cfg.py" $?
+(cmsRun ${LOCAL_TEST_DIR}/test_no_concurrent_module_cfg.py 2>&1) | tail -n 3 | grep -v ' 0 ' | grep -v 'e-' | diff - empty_file || die "Failure using test_no_concurrent_module_cfg.py" $?

--- a/FWCore/Framework/test/test_no_concurrent_module_cfg.py
+++ b/FWCore/Framework/test/test_no_concurrent_module_cfg.py
@@ -28,4 +28,6 @@ process.c2 = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer",
 
 process.p = cms.Path(process.c1+process.c2)
 
-process.add_(cms.Service("ConcurrentModuleTimer"))
+process.add_(cms.Service("ConcurrentModuleTimer",
+                         modulesToExclude = cms.untracked.vstring("TriggerResults"),
+                         excludeSource = cms.untracked.bool(True)))


### PR DESCRIPTION
The test run_global_stream_one.sh includes a test to check that
when using modules which share a resource that only one module
runs at a time. Previously, the measurement mechanism also included
TriggerResults and the source in the timing which could create
false positives and fail the test. Now the test excludes those
two from the measurement so the test should never see more than one
module running at a time.