### PR TITLE
Fixed consumes in EcalDetailedTimeRecHitProducer

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalDetailedTimeRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalDetailedTimeRecHitProducer.cc
@@ -56,9 +56,14 @@ EcalDetailedTimeRecHitProducer::EcalDetailedTimeRecHitProducer(const edm::Parame
    
   correctForVertexZPosition_ = ps.getParameter<bool>("correctForVertexZPosition");
   useMCTruthVertex_ = ps.getParameter<bool>("useMCTruthVertex");
-  recoVertex_       = consumes<reco::VertexCollection>( ps.getParameter<edm::InputTag>("recoVertex") );
-  simVertex_       = consumes<edm::SimVertexContainer>( ps.getParameter<edm::InputTag>("simVertex") );
-  
+  if(correctForVertexZPosition_) {
+    if(not useMCTruthVertex_) {
+      recoVertex_       = consumes<reco::VertexCollection>( ps.getParameter<edm::InputTag>("recoVertex") );
+    } else {
+      simVertex_       = consumes<edm::SimVertexContainer>( ps.getParameter<edm::InputTag>("simVertex") );
+    }
+  }
+
   ebTimeLayer_ = ps.getParameter<int>("EBTimeLayer");
   eeTimeLayer_ = ps.getParameter<int>("EETimeLayer");
 


### PR DESCRIPTION
EcalDetailedTimeRecHitProducer was calling consumes for data products
unconditionally even though there were parameters which caused the
data products to not be gotten. Now the parameters also conditionally
protect the consumes calls to make the code internally consistent.

This is meant to fix a problem seen in MC production.