### PR TITLE
Add missing HcalDeterministicFit::rCorrSiPM

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -7,6 +7,7 @@ constexpr float HcalDeterministicFit::invGpar[3];
 constexpr float HcalDeterministicFit::negThresh[2];
 constexpr int HcalDeterministicFit::HcalRegion[2];
 constexpr float HcalDeterministicFit::rCorr[2];
+constexpr float HcalDeterministicFit::rCorrSiPM[2];
 
 using namespace std;
 


### PR DESCRIPTION
The following error in blocking Clang builds:

    RecoLocalCaloHcalRecAlgos/HcalDeterministicFit.o: In function calDeterministicFit::phase1Apply(HBHEChannelInfo const&, float&, float&) const':
    RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc:(.text+0x583): undefined reference to calDeterministicFit::rCorrSiPM'
    RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc:(.text+0x5a9): undefined reference to calDeterministicFit::rCorrSiPM'

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>