### PR TITLE
Remove use of tmpnam in generators

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -45,6 +45,10 @@
 #include "TString.h"
 #include <string>
 #include <stdlib.h> 
+#include <cstdio>
+
+#include "boost/filesystem.hpp"
+#include "boost/filesystem/path.hpp"
 
 using namespace gen;
 using namespace edm;
@@ -358,7 +362,10 @@ void EvtGenInterface::init(){
 
   if (fPSet->exists("user_decay_embedded")){
     std::vector<std::string> user_decay_lines = fPSet->getParameter<std::vector<std::string> >("user_decay_embedded");
-    std::string user_decay_tmp = std::tmpnam(nullptr);
+    auto tmp_dir = boost::filesystem::temp_directory_path();
+    tmp_dir += "%%%%-%%%%-%%%%-%%%%";
+    auto tmp_path = boost::filesystem::unique_path(tmp_dir);
+    std::string user_decay_tmp = std::string(tmp_path.c_str());
     FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
     if (!tmpf) {
         edm::LogError("EvtGenInterface::~EvtGenInterface") << "EvtGenInterface::init() fails when trying to open a temporary file for embedded user.dec. Terminating program ";


### PR DESCRIPTION
Removes a compiler warning in gcc620/530 since tmpnam is not threadsafe.