### PR TITLE
Fix compiler warning in CalibCalorimetry/HcalAlgos

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
@@ -1713,7 +1713,7 @@ void HcalLogicalMapGenerator::buildCALIBMap(const HcalTopology* topo,
           
           (ieta==0) ? iphi=((iwedge*idphi)+71-idphi)%72 : iphi=(((iwedge/2)*idphi)+71-idphi)%72;
           //nothing on htr_fi=4 for the top
-          do {
+          //do {
             if (iside==0&&ifb==3) break;
             CALIBLogicalMapEntry caliblmapentry(
 						ifi_ch, ihtr_fi, ispigot, ifed, icrate, ihtr, fpga,
@@ -1727,7 +1727,7 @@ void HcalLogicalMapGenerator::buildCALIBMap(const HcalTopology* topo,
 	    const HcalGenericDetId hgdi(caliblmapentry.getDetId());	  
 	    const unsigned int hashedId=topo->detId2denseIdCALIB(hgdi);
 	    if (hgdi.genericSubdet()==HcalGenericDetId::HcalGenCalibration) HxCalibHash2Entry.at(hashedId)=CALIBEntries.size();
-	  } while (ifb!=ifb);
+	  //} while (ifb!=ifb);
         }
       }
     }

--- a/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
@@ -1714,7 +1714,7 @@ void HcalLogicalMapGenerator::buildCALIBMap(const HcalTopology* topo,
           (ieta==0) ? iphi=((iwedge*idphi)+71-idphi)%72 : iphi=(((iwedge/2)*idphi)+71-idphi)%72;
           //nothing on htr_fi=4 for the top
           //do {
-            if (iside==0&&ifb==3) break;
+	  if (iside==0&&ifb==3) continue; // adjust logic since no longer inside loop
             CALIBLogicalMapEntry caliblmapentry(
 						ifi_ch, ihtr_fi, ispigot, ifed, icrate, ihtr, fpga,
 						det, ieta, iphi, ich_type, 


### PR DESCRIPTION
Remove a do-while loop that only ever executed once.
Now we just execute the code.