### PR TITLE
Force untracked parameters for modules into Registry

### DIFF
--- a/FWCore/Framework/src/WorkerMaker.cc
+++ b/FWCore/Framework/src/WorkerMaker.cc
@@ -1,6 +1,7 @@
 
 #include "FWCore/Framework/src/WorkerMaker.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -76,6 +77,13 @@ namespace edm {
       throwValidationException(p, iException);
     }
     p.pset_->registerIt();
+    //Need to be certain top level untracked parameters are stored in
+    // the registry even if another PSet already exists in the
+    // registry from a previous process
+    //NOTE: a better implementation would be to change ParameterSet::registerIt
+    // but that would require rebuilding much more code so will be done at
+    // a later date.
+    edm::pset::Registry::instance()->insertMapped(*(p.pset_),true);
     
     ModuleDescription md = createModuleDescription(p);
     std::shared_ptr<maker::ModuleHolder> module;

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -49,7 +49,7 @@ namespace edm {
       /// same.  Return 'true' if we really added the new
       /// value_type object, and 'false' if the
       /// value_type object was already present.
-      bool insertMapped(value_type const& v);
+      bool insertMapped(value_type const& v, bool forceUpdate = false);
 
       ///Not thread safe
       void clear();

--- a/FWCore/ParameterSet/src/Registry.cc
+++ b/FWCore/ParameterSet/src/Registry.cc
@@ -32,8 +32,12 @@ namespace edm {
     }
   
     bool
-    Registry::insertMapped(value_type const& v) {
-      return m_map.insert(std::make_pair(v.id(),v)).second;
+    Registry::insertMapped(value_type const& v, bool forceUpdate) {
+      auto wasAdded = m_map.insert(std::make_pair(v.id(),v));
+      if(forceUpdate and not wasAdded.second) {
+        wasAdded.first->second = v;
+      }
+      return wasAdded.second;
     }
     
     void


### PR DESCRIPTION
If an input file contained the same PSet ID (because of identical
tracked parameters) as a module in a process, the untracked
parameters for the module are not available in the Registry. This
caused problems with the deleteEarly system which uses an untracked
parameter. We now force the PSet for a module to be injected into
the Registry.