### PR TITLE
FriendlyName: add "String" options for C++11 ABI

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -42,6 +42,8 @@ namespace edm {
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
     static boost::regex const reString("std::basic_string<char>");
     static boost::regex const reString2("std::string");
+    static boost::regex const reStringCXX11("std::__cxx11::basic_string<char>");
+    static boost::regex const reString2CXX11("std::__cxx11::basic_string<char,std::char_traits<char> >");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
@@ -77,6 +79,8 @@ namespace edm {
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reString2,"String");
+       name = regex_replace(name,reStringCXX11,"String");
+       name = regex_replace(name,reString2CXX11,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
        name = regex_replace(name,reULongLong,"ull");
        name = regex_replace(name,reLongLong,"ll");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -40,6 +40,10 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("std::vector<bar::Foo>","barFoos") );
   classToFriendly.insert( Values("std::shared_ptr<Foo>","FooSharedPtr"));
   classToFriendly.insert( Values("std::shared_ptr<bar::Foo>","barFooSharedPtr"));
+  classToFriendly.insert( Values("std::basic_string<char>","String"));
+  classToFriendly.insert( Values("std::string","String"));
+  classToFriendly.insert( Values("std::__cxx11::basic_string<char>","String"));
+  classToFriendly.insert( Values("std::__cxx11::basic_string<char,std::char_traits<char> >","String"));
   classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
   classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
   classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));


### PR DESCRIPTION
This is needed for C++11 (and above) ABI, which is available starting GCC 5.

Signed-off-by: David Abdurachmanov <davidlt@cern.ch>