### PR TITLE
Fix geometry ordering for Phase2 Pixel

### DIFF
--- a/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
+++ b/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
@@ -58,7 +58,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
       std::string DetIdPrint;
 
       if (subdet == PixelSubdetector::PixelBarrel) {
-        std::cout << "PixelSubdetector::PixelBarrel " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->pxbLayer(*id);
@@ -68,7 +67,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 	resultsOld[2] = tTopo->pxbLadder(*id);
       }
       else if (subdet == PixelSubdetector::PixelEndcap) {
-        std::cout << "PixelSubdetector::PixelEndcap " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->pxfDisk(*id);
@@ -84,7 +82,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 	resultsOld[6] = tTopo->pxfPanel(*id);
       }
       else if (subdet == StripSubdetector::TIB) {
-        std::cout << "StripSubdetector::TIB " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->tibLayer(*id);
@@ -114,7 +111,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 
       }
       else if (subdet == StripSubdetector::TID) {
-        std::cout << "StripSubdetector::TID " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->tidWheel(*id);
@@ -142,7 +138,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 	resultsOld[12] = tTopo->tidIsFrontRing(*id);
       }
       else if (subdet == StripSubdetector::TOB) {
-        std::cout << "StripSubdetector::TOB " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->tobLayer(*id);
@@ -165,7 +160,6 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 	resultsOld[10] = tTopo->tobIsZMinusSide(*id);
       }
       else if (subdet == StripSubdetector::TEC) {
-        std::cout << "StripSubdetector::TEC " << std::endl;
 	DetIdPrint = tTopo->print(*id);
 	std::cout << DetIdPrint << std::endl;
 	resultsOld[0] = tTopo->tecWheel(*id);
@@ -202,6 +196,13 @@ void TrackerTopologyAnalyzer::analyze( const edm::Event &iEvent, const edm::Even
 	for ( unsigned int i=0; i<nComp; i++)
 	  std::cout << "["<<resultsOld[i]<<","<<resultsNew[i]<< "] " <<std::endl;
       }
+
+      const GeomDet* geom = geo->idToDet(*id);
+      std::cout << "  (phi, z, r) : ("
+                << geom->surface().position().phi()  << " , "
+                << geom->surface().position().z()    << " , "
+                << geom->surface().position().perp() << ")" << std::endl;
+
     }
   }
   std::cout << "Good: " << nOk << std::endl;

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -14,6 +14,7 @@
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 
@@ -229,6 +230,7 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
   auto out_duplicateCandidates = std::make_unique<std::vector<TrackCandidate>>();
 
   auto out_candidateMap = std::make_unique<CandidateToDuplicate>();
+  LogDebug("DuplicateTrackMerger") << "Number of tracks to be checked for merging: " << tracks.size();
 
   for(int i = 0; i < (int)tracks.size(); i++){
     const reco::Track *rt1 = &tracks[i];

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapLayerBuilder.cc
@@ -10,7 +10,7 @@ Phase2EndcapLayer* Phase2EndcapLayerBuilder::build(const GeometricDet* aPhase2En
 {
   LogTrace("TkDetLayers") << "Phase2EndcapLayerBuilder::build";
   vector<const GeometricDet*>  theGeometricRings = aPhase2EndcapLayer->components();
-  edm::LogInfo("TkDetLayers") << "theGeometricRings.size(): " << theGeometricRings.size() ;
+  LogTrace("TkDetLayers") << "theGeometricRings.size(): " << theGeometricRings.size() ;
 
   Phase2EndcapRingBuilder myBuilder;
   vector<const Phase2EndcapRing*> thePhase2EndcapRings;

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
@@ -64,7 +64,8 @@ Phase2EndcapRing::Phase2EndcapRing(vector<const GeomDet*>& innerDets,
   LogDebug("TkDetLayers") << "DEBUG INFO for Phase2EndcapRing" ;
   for(vector<const GeomDet*>::const_iterator it=theFrontDets.begin(); 
       it!=theFrontDets.end(); it++){
-    LogDebug("TkDetLayers") << "frontDet phi,z,r: " 
+    LogDebug("TkDetLayers") << "frontDet detId,phi,z,r: "
+                            << (*it)->geographicalId().rawId()  << " , "
 			    << (*it)->surface().position().phi()  << " , "
 			    << (*it)->surface().position().z()    << " , "
 			    << (*it)->surface().position().perp() ;
@@ -73,7 +74,8 @@ Phase2EndcapRing::Phase2EndcapRing(vector<const GeomDet*>& innerDets,
   if(!theFrontDetBrothers.empty()){
     for(vector<const GeomDet*>::const_iterator it=theFrontDetBrothers.begin(); 
         it!=theFrontDetBrothers.end(); it++){
-      LogDebug("TkDetLayers") << "frontDet brothers phi,z,r: " 
+      LogDebug("TkDetLayers") << "frontDet brothers detId,phi,z,r: "
+                            << (*it)->geographicalId().rawId()  << " , "
   			    << (*it)->surface().position().phi()  << " , "
   			    << (*it)->surface().position().z()    << " , "
   			    << (*it)->surface().position().perp() ;
@@ -82,7 +84,8 @@ Phase2EndcapRing::Phase2EndcapRing(vector<const GeomDet*>& innerDets,
 
   for(vector<const GeomDet*>::const_iterator it=theBackDets.begin(); 
       it!=theBackDets.end(); it++){
-    LogDebug("TkDetLayers") << "backDet phi,z,r: " 
+    LogDebug("TkDetLayers") << "backDet detId,phi,z,r: "
+                            << (*it)->geographicalId().rawId()  << " , "
 			    << (*it)->surface().position().phi() << " , "
 			    << (*it)->surface().position().z()   << " , "
 			    << (*it)->surface().position().perp() ;
@@ -91,7 +94,8 @@ Phase2EndcapRing::Phase2EndcapRing(vector<const GeomDet*>& innerDets,
   if(!theBackDetBrothers.empty()){
     for(vector<const GeomDet*>::const_iterator it=theBackDetBrothers.begin(); 
         it!=theBackDetBrothers.end(); it++){
-      LogDebug("TkDetLayers") << "backDet brothers phi,z,r: " 
+      LogDebug("TkDetLayers") << "backDet brothers detId,phi,z,r: "
+                            << (*it)->geographicalId().rawId()  << " , "
   			    << (*it)->surface().position().phi() << " , "
   			    << (*it)->surface().position().z()   << " , "
   			    << (*it)->surface().position().perp() ;
@@ -160,9 +164,11 @@ Phase2EndcapRing::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 					  crossings.closestIndex(), crossingSide);
 
   //due to propagator problems, when we add single pt sub modules, we should order them in z (endcap)
-  sort(result.begin(),result.end(),DetGroupElementZLess());
+  if(!theFrontDetBrothers.empty() && !theBackDetBrothers.empty())
+    sort(result.begin(),result.end(),DetGroupElementZLess());
 
 #ifdef EDM_ML_DEBUG
+  LogTrace("TkDetLayers") <<"Number of groups : " << result.size() << std::endl;
   for (auto&  grp : result) {
     if ( grp.empty() )  continue;
       LogTrace("TkDetLayers") <<"New group in Phase2EndcapRing made by : " << std::endl;

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -161,6 +161,7 @@ LayerMeasurements::groupedMeasurements( const DetLayer& layer,
     }
     
     // sort the final result
+    LogDebug("LayerMeasurements")<<"Sorting " << tmpVec.size() << " measurements in this grp.";
     sort( tmpVec.begin(), tmpVec.end(), TrajMeasLessEstim());
     addInvalidMeas( tmpVec, grp,layer); 
     result.emplace_back(std::move(tmpVec), std::move(grp));


### PR DESCRIPTION
After this fix on the order in the Forward Pixel GeometrySearch, the number of duplicates is reduced of more than a factor 10. Fakerate and efficiency are almost unchanged.
Here the result using the release CMSSW_9_0_X_2017-01-08-2300 with a sample of 1000 events of TTbar (WF#21234.1):
![dupfix](https://cloud.githubusercontent.com/assets/5331004/21846575/0be68bd8-d7f8-11e6-8275-5cc09891875c.png)
This PR is considered to be quite important for future Phase2 developments and it would be great to have it in the next pre-release (from the [twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/ReleaseSchedule) is not possible yet to see the developments for 90X).

Informing @delaere @atricomi @boudoul 
