### PR TITLE
Avoid Oracle OCCI APIs which work with std::string in C++11 ABI mode

### DIFF
--- a/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
+++ b/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
@@ -110,7 +110,9 @@
    {
     std::cout<<"Exception thrown for insertBind"<<std::endl;
     std::cout<<"Error number: "<<  ex.getErrorCode() << std::endl;
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     std::cout<<ex.getMessage() << std::endl;
+#endif
    }
   }
 

--- a/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
@@ -1,5 +1,8 @@
 #include "OnlineDB/EcalCondDB/interface/LMFLmrSubIOV.h"
 
+#include <ctime>
+#include <string>
+
 void LMFLmrSubIOV::init() {
   m_className = "LMFLmrSubIOV";
 
@@ -109,11 +112,35 @@ std::string LMFLmrSubIOV::writeDBSql(Statement *stmt) {
   return sql;
 }
 
-void LMFLmrSubIOV::getParameters(ResultSet *rset) {
+void LMFLmrSubIOV::getParameters(ResultSet *rset) noexcept(false) {
   m_lmfIOV = rset->getInt(1);
   for (int i = 0; i < 3; i++) {
     oracle::occi::Date t = rset->getDate(i + 2);
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     m_t[i].setToString(t.toText("YYYY-MM-DD HH24:MI:SS"));
+#else
+    int year = 0;
+    unsigned int month = 0;
+    unsigned int day = 0;
+    unsigned int hour = 0;
+    unsigned int min = 0;
+    unsigned int seconds = 0;
+    t.getDate(year, month, day, hour, min, seconds);
+    const std::tm tt = {
+      .tm_sec = static_cast<int>(seconds),
+      .tm_min = static_cast<int>(min),
+      .tm_hour = static_cast<int>(hour),
+      .tm_mday = static_cast<int>(day),
+      .tm_mon = static_cast<int>(month),
+      .tm_year = year - 1900
+    };
+    char tt_str[30] = { 0 };
+    if (std::strftime(tt_str, sizeof(tt_str), "%F %T", &tt)) {
+      m_t[i].setToString(std::string(tt_str));
+    } else {
+      throw std::runtime_error("LMFLmrSubIOV::writeDBSql: failed to generate the date string");
+    }
+#endif
   }
 }
 
@@ -188,8 +215,13 @@ std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax,
       m_conn->terminateStatement(stmt);
     }
     catch (oracle::occi::SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
       throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: " +
 			       e.getMessage()));
+#else
+      throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: error code " +
+			       std::to_string(e.getErrorCode())));
+#endif
     }
   } else {
     throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: " +

--- a/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
@@ -2,6 +2,8 @@
 #include "OnlineDB/EcalCondDB/interface/LMFDefFabric.h"
 #include "OnlineDB/EcalCondDB/interface/DateHandler.h"
 
+#include <ctime>
+
 using namespace std;
 using namespace oracle::occi;
 
@@ -175,6 +177,7 @@ Tm LMFRunIOV::getSubRunEnd() const {
   return t;
 }
 
+// XXX: This method is not used within CMSSW
 Tm LMFRunIOV::getDBInsertionTime() const {
   Tm t;
   t.setToString(getString("db_timestamp"));
@@ -245,7 +248,7 @@ std::string LMFRunIOV::setByIDSql(Statement *stmt, int id)
    return sql;  
 }
 
-void LMFRunIOV::getParameters(ResultSet *rset) {
+void LMFRunIOV::getParameters(ResultSet *rset) noexcept(false) {
   DateHandler dh(m_env, m_conn);
   setLMFRunTag(rset->getInt(1));
   LMFSeqDat *seq;
@@ -267,7 +270,34 @@ void LMFRunIOV::getParameters(ResultSet *rset) {
   Date stop = rset->getDate(7);
   setString("subrun_end", dh.dateToTm(stop).str());
   setString("subrun_type", rset->getString(8));
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
   setString("db_timestamp", rset->getTimestamp(9).toText("YYYY-MM-DD HH24:MI:SS", 0));
+#else
+  int year = 0;
+  unsigned int month = 0;
+  unsigned int day = 0;
+  unsigned int hour = 0;
+  unsigned int minute = 0;
+  unsigned int second = 0;
+  unsigned int fs = 0;
+  rset->getTimestamp(9).getDate(year, month, day);
+  rset->getTimestamp(9).getTime(hour, minute, second, fs);
+  const std::tm tt = {
+// Different max(second) is defined by C99 and Oracle Timestamp.
+    .tm_sec = static_cast<int>(second),
+    .tm_min = static_cast<int>(minute),
+    .tm_hour = static_cast<int>(hour),
+    .tm_mday = static_cast<int>(day),
+    .tm_mon = static_cast<int>(month),
+    .tm_year = year - 1900
+  };
+  char tt_str[30] = { 0 };
+  if (std::strftime(tt_str, sizeof(tt_str), "%F %T", &tt)) {
+    setString("db_timestamp", std::string(tt_str));
+  } else {
+    throw std::runtime_error("LMFRunIOV::getParameters: failed to generate the date string for 'db_timestamp' parameter");
+  }
+#endif
 }
 
 bool LMFRunIOV::isValid() {

--- a/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
@@ -4,6 +4,7 @@
 #include <list>
 #include <string>
 #include <map>
+#include <ctime>
 
 #include "OnlineDB/EcalCondDB/interface/RunDCSHVDat.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
@@ -77,7 +78,11 @@ ResultSet *RunDCSHVDat::getBarrelRset(const Tm& timeStart) {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -101,7 +106,11 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset(const Tm& timeStart) {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -125,7 +134,11 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset(const Tm& timeStart) {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -162,7 +175,11 @@ ResultSet *RunDCSHVDat::getBarrelRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -179,7 +196,11 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getEndcapAnodeRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getEndcapAnodeRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -196,7 +217,11 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset() {
     rset = m_readStmt->executeQuery();
   } 
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::getEndcapDynodeRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSHVDat::getEndcapDynodeRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -234,7 +259,11 @@ void RunDCSHVDat::fillTheMap(ResultSet *rset,
     } 
   }
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSHVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 
@@ -242,7 +271,7 @@ void RunDCSHVDat::fillTheMap(ResultSet *rset,
 
 
 void RunDCSHVDat::fillTheMapByTime(ResultSet *rset,
-				   std::list<  DataReducer<RunDCSHVDat>::MyData<RunDCSHVDat>  >* my_data_list ) {
+				   std::list<  DataReducer<RunDCSHVDat>::MyData<RunDCSHVDat>  >* my_data_list ) noexcept(false) {
  
   //			       std::list< std::pair< Tm, std::map< EcalLogicID, RunDCSHVDat > > >* fillMap) {
 
@@ -270,7 +299,33 @@ void RunDCSHVDat::fillTheMapByTime(ResultSet *rset,
       // Date sinceDate = rset->getDate(9);
       Timestamp  ora_timestamp = rset->getTimestamp(9);
       Tm sinceTm; // YYYY-MM-DD HH:MM:SS
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
       sinceTm.setToString(ora_timestamp.toText("yyyy-mm-dd hh24:mi:ss",0));
+#else
+      int year = 0;
+      unsigned int month = 0;
+      unsigned int day = 0;
+      unsigned int hour = 0;
+      unsigned int minute = 0;
+      unsigned int second = 0;
+      unsigned int fs = 0;
+      ora_timestamp.getDate(year, month, day);
+      ora_timestamp.getTime(hour, minute, second, fs);
+      const std::tm tt = {
+        .tm_sec = static_cast<int>(second),
+        .tm_min = static_cast<int>(minute),
+        .tm_hour = static_cast<int>(hour),
+        .tm_mday = static_cast<int>(day),
+        .tm_mon = static_cast<int>(month),
+        .tm_year = year - 1900
+      };
+      char tt_str[30] = { 0 };
+      if (std::strftime(tt_str, sizeof(tt_str), "%F %T", &tt)) {
+        sinceTm.setToString(std::string(tt_str));
+      } else {
+        throw std::runtime_error("RunDCSHVDat::fillTheMapByTime: failed to generate the date string");
+      }
+#endif
 
       dat.setStatus(0);
       if (ec.getName() == "EB_HV_channel") {
@@ -298,7 +353,11 @@ void RunDCSHVDat::fillTheMapByTime(ResultSet *rset,
 
   }
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSHVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 
@@ -374,7 +433,11 @@ void RunDCSHVDat::fetchLastData(map< EcalLogicID, RunDCSHVDat >* fillMap )
     fillTheMap(rset, fillMap);
   } 
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSHVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 
@@ -410,6 +473,10 @@ void RunDCSHVDat::fetchHistoricalData(std::list< std::pair<Tm, std::map< EcalLog
 
   } 
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSHVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSHVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
@@ -64,7 +64,11 @@ ResultSet *RunDCSLVDat::getBarrelRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSLVDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSLVDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -81,7 +85,11 @@ ResultSet *RunDCSLVDat::getEndcapRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSLVDat::getEndcapRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSLVDat::getEndcapRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -116,7 +124,11 @@ void RunDCSLVDat::fillTheMap(ResultSet *rset,
     } 
   }
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSLVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSLVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 
@@ -188,6 +200,10 @@ void RunDCSLVDat::fetchLastData(map< EcalLogicID, RunDCSLVDat >* fillMap )
     fillTheMap(rset, fillMap);
   } 
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSLVDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSLVDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
@@ -85,7 +85,11 @@ ResultSet *RunDCSMagnetDat::getMagnetRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSMagnetDat::getBarrelRset():  " + e.getMessage() + " " + query));
+#else
+    throw(std::runtime_error("RunDCSMagnetDat::getBarrelRset():  error code " + std::to_string(e.getErrorCode()) + " " + query));
+#endif
   }
   return rset;
 }
@@ -125,7 +129,11 @@ void RunDCSMagnetDat::fillTheMap(ResultSet *rset,
     } 
   }
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSMagnetDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSMagnetDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 
@@ -169,7 +177,11 @@ void RunDCSMagnetDat::fetchLastData(map< EcalLogicID, RunDCSMagnetDat >* fillMap
 
   } 
   catch (SQLException &e) {
+#if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error("RunDCSMagnetDat::fetchData():  "+e.getMessage()));
+#else
+    throw(std::runtime_error("RunDCSMagnetDat::fetchData():  error code " + std::to_string(e.getErrorCode())));
+#endif
   }
 }
 


### PR DESCRIPTION
We have enabled C++11 ABI in GCC 6.3.0 architecture. This means that
things like std::string are not binary compatible between old "GCC 4"
ABI and new one (C++11, default since GCC 5). The changes to GNU C++
Standard Library were needed to meet C++ Standard Library requirements
for C++11. Note that GNU libstdc++ is dual-ABI.

Oracle Instant Client is not compiled with latest GCC and C++11 ABI. One
could avoid issues by using methods which do not use, e.g., std::string,
or use C-level API.

This lacks proper testings. All the tests within CMSSW are disabled for
unknown reason. Also these are probably not used within IB RelVals.

This does compile with GCC 6.3.0 + C++11 ABI.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>