### PR TITLE
Fix operator!= for pat::strbitset

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/strbitset.h
+++ b/PhysicsTools/SelectorUtils/interface/strbitset.h
@@ -296,7 +296,7 @@ class strbitset {
 
   //! inequality operator to bool
   bool operator!=( bool b ) const {
-    return ! ( operator!=(b));
+    return ! ( operator==(b));
   }
 
   //! returns number of bits set


### PR DESCRIPTION
The operator!= was calling itself to form an infinite recursion.
It now calls ! operator== which was the original intent.

This was found by clang.