### PR TITLE
Fix error from apple-clang-8.0 because of missing #include <functional>

### DIFF
--- a/DataFormats/Provenance/interface/Hash.h
+++ b/DataFormats/Provenance/interface/Hash.h
@@ -2,6 +2,7 @@
 #define DataFormats_Provenance_Hash_h
 
 #include <string>
+#include <functional>
 
 /*----------------------------------------------------------------------
   


### PR DESCRIPTION
While compiling with apple-clang-8.0 many error were the result of a missing include
in DataFormats/Provenenace/interface/Hash.h. The gcc header <string> includes
<functional> but the apple clang's version does not.

This is the error.

/private/var/folders/hm/7pxrf4vx4_g4f_nkfrcwqq8m0000gp/T/gartung/spack-stage/spack-stage-_shPan/spack-build/CMSSW_9_0_0_pre2/src/DataFormats/Provenance/interface/Hash.h:165:43: error: no m
ember named 'greater' in namespace 'std'
    return this->compareUsing(other, std::greater<std::string>());
                                     ~~~~~^
/private/var/folders/hm/7pxrf4vx4_g4f_nkfrcwqq8m0000gp/T/gartung/spack-stage/spack-stage-_shPan/spack-build/CMSSW_9_0_0_pre2/src/DataFormats/Provenance/interface/Hash.h:165:62: error: expe
cted '(' for function-style cast or type construction
    return this->compareUsing(other, std::greater<std::string>());
                                                  ~~~~~~~~~~~^
/private/var/folders/hm/7pxrf4vx4_g4f_nkfrcwqq8m0000gp/T/gartung/spack-stage/spack-stage-_shPan/spack-build/CMSSW_9_0_0_pre2/src/DataFormats/Provenance/interface/Hash.h:165:64: error: expe
cted expression
    return this->compareUsing(other, std::greater<std::string>());
                                                               ^
/private/var/folders/hm/7pxrf4vx4_g4f_nkfrcwqq8m0000gp/T/gartung/spack-stage/spack-stage-_shPan/spack-build/CMSSW_9_0_0_pre2/src/DataFormats/Provenance/interface/Hash.h:172:43: error: no t
emplate named 'equal_to' in namespace 'std'; did you mean '__equal_to'?
    return this->compareUsing(other, std::equal_to<std::string>());
                                     ~~~~~^~~~~~~~
                                          __equal_to
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:653:8: note: '__equal_to' declared here
struct __equal_to
       ^