### PR TITLE
Remove Overlaps in FPix

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -21,7 +21,7 @@
  <Constant name="ZCylinder"      value="[AnchorZ]"/>
 
  <Constant name="FlexCableDiskRmin" value="[pixfwdSupportRingParameters:InnerDiskOuterRingCFRMax]"/>
- <Constant name="FlexCableDiskRmax" value="167.9*mm"/>
+ <Constant name="FlexCableDiskRmax" value="165.*mm"/>
  <Constant name="FlexCableDiskHalfThickness" value="0.15*mm"/>
 
 </ConstantsSection>


### PR DESCRIPTION
* Reduce Rmax of FlexCableDisc from 167.9 mm to 165. mm to remove the following overlaps with PixelForwardOuterDiskOuterRing and PixelForwardOuterDiskCFOuterRing

<img width="801" alt="screen shot 2017-01-11 at 17 58 32" src="https://cloud.githubusercontent.com/assets/1390682/21858937/1f507214-d82b-11e6-925b-e1edfbf8c95c.png">
<img width="1305" alt="screen shot 2017-01-11 at 18 03 29" src="https://cloud.githubusercontent.com/assets/1390682/21858938/1f782c78-d82b-11e6-9af7-7d42f5b9ded8.png">


