### PR TITLE
2015LowPUMixProfile

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -108,6 +108,7 @@ addMixingScenario("2015_25ns_HiLum_PoissonOOTPU",{'file': 'SimGeneral.MixingModu
 addMixingScenario("2015_25ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_Startup_PoissonOOTPU_cfi'})
 addMixingScenario("2015_50ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_50ns_Startup_PoissonOOTPU_cfi'})
 addMixingScenario("2015_25ns_FallMC_matchData_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_FallMC_matchData_PoissonOOTPU_cfi'})
+addMixingScenario("2015_25nsLowPU_matchData_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 

--- a/SimGeneral/MixingModule/python/mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12),
+          probValue = cms.vdouble(
+                   0.862811884308912,
+                   0.122649088500652,
+                   0.013156023430157,
+                   0.001271967352346,
+                   0.000100080253829,
+                   8.21711557752311E-06,
+                   1.47486689852979E-06,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
New PU mixing profile to produce MC with PU compatible with the CMS+TOTEM run taken on 2015. 
Number of events in function of the number of reconstructed primary vertexes using the CMS+TOTEM run dataset /FSQJets1/Run2015D-16Dec2015-v1/AOD are:
#Vertex   #Events
1  4.09507e+06
2  582116
3  62441
4  6037
5  475
6  39
7  7
8  0
9  1
10  1
11  1
12  0
13  0
14  1

The <PV>: 1.15 that corresponds to <PU> = <PV> - 1 = 0.15

File created:
SimGeneral/MixingModule/mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi.py
- based on "mix_2015_25ns_FallMC_matchData_PoissonOOTPU_cfi.py" and changing the probabilities

File edited to include the new mixing profile:
Configuration/StandardSequences/python/Mixing.py