### PR TITLE
Fix FORTRAN warnings in ME2pythia.f

### DIFF
--- a/GeneratorInterface/PartonShowerVeto/src/ME2pythia.f
+++ b/GeneratorInterface/PartonShowerVeto/src/ME2pythia.f
@@ -909,7 +909,7 @@ C        write(*,*)'mektsc 357, 358: ',mektsc,' ',VINT(357),' ',VINT(358)
      $       THEN
 C            write(*,*)'rejection'  
           if(idbg.eq.1)
-     $       WRITE(LNHOUT,*),
+     $       WRITE(LNHOUT,*)
      $       'Failed due to ',max(VINT(357),VINT(358)),' > ',SQRT(YCUT)
           GOTO 999
         ENDIF
@@ -924,7 +924,7 @@ c     Highest multiplicity case
      $       THEN
 c     $     VINT(390).GT.PTCLUS(1)**2)THEN
           if(idbg.eq.1)
-     $       WRITE(LNHOUT,*),
+     $       WRITE(LNHOUT,*)
      $       'Failed due to ',max(VINT(357),VINT(358)),' > ',PTCLUS(1)
           GOTO 999
         ENDIF
@@ -1581,7 +1581,7 @@ c     if (found) write (*,*) name,var
         write (*,*) "         setting it to default value ",def_value
         var=def_value
       else
-        write(*,*),'Found parameter ',name,var
+        write(*,*) 'Found parameter ',name,var
       endif
       return
 


### PR DESCRIPTION
This seems to be written in FORTRAN 77 (decades old standard). These
warnings:

    Warning: Legacy Extension: Comma before i/o item list at (1)

to GNU FORTRAN extension "6.1.7 I/O item lists":

    To support legacy codes, GNU Fortran allows the input item list of
    the READ statement, and the output item lists of the WRITE and PRINT
    statements, to start with a comma.

The patch removes the commas.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>