### PR TITLE
Fixes for changes in location of apple clang's libc++ header locations

### DIFF
--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -16,7 +16,9 @@
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include <functional>
+#ifndef __APPLE__
 #include <ext/functional>
+#endif
 #include <algorithm>
 
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -16,9 +16,6 @@
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include <functional>
-#ifndef __APPLE__
-#include <ext/functional>
-#endif
 #include <algorithm>
 
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -82,7 +82,9 @@ namespace edm {
     /// to use only comparators provided with CMSSW release.
     template<typename CMP> 
     range get(ID id, CMP comparator) const {
+#ifndef __APPLE__
       using namespace __gnu_cxx;
+#endif
       std::pair<typename mapType::const_iterator,
 	typename mapType::const_iterator> r =
         std::equal_range(map_.begin(), map_.end(), id, comp<CMP>(comparator));

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -20,7 +20,12 @@
  */
 #include <map>
 #include <vector>
+#ifdef __APPLE__
+#include <functional>
+#else
 #include <ext/functional>
+#endif
+
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/Common/interface/traits.h"

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -20,11 +20,7 @@
  */
 #include <map>
 #include <vector>
-#ifdef __APPLE__
 #include <functional>
-#else
-#include <ext/functional>
-#endif
 
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -82,9 +78,6 @@ namespace edm {
     /// to use only comparators provided with CMSSW release.
     template<typename CMP> 
     range get(ID id, CMP comparator) const {
-#ifndef __APPLE__
-      using namespace __gnu_cxx;
-#endif
       std::pair<typename mapType::const_iterator,
 	typename mapType::const_iterator> r =
         std::equal_range(map_.begin(), map_.end(), id, comp<CMP>(comparator));

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -14,7 +14,8 @@ EDProducts into an Event.
 #include <functional>
 #include <unordered_map>
 #include <string>
-#include<vector>
+#include <vector>
+#include <array>
 
 namespace edm {
   class BranchDescription;


### PR DESCRIPTION
These are ifdef'ed with __APPLE__ so they should not interfere with linux compilations. I had to add /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 to ROOT_ICLUDE_PATH before /usr/include/c++/4.2.1 to ensure that the correct header were picked up by genreflex. I also ensure that the cxxflags had this correct as well.