### PR TITLE
Use dynamic_cast instead of reinterpret_cast in HeavyFlavorAnalysis

### DIFF
--- a/HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonEtaSelect.h
+++ b/HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonEtaSelect.h
@@ -44,7 +44,7 @@ class BPHMuonEtaSelect: public BPHParticleEtaSelect {
    */
   /// select muon
   virtual bool accept( const reco::Candidate& cand ) const {
-    if ( reinterpret_cast<const pat::Muon*>( &cand ) == 0 ) return false;
+    if ( dynamic_cast<const pat::Muon*>( &cand ) == 0 ) return false;
     return BPHParticleEtaSelect::accept( cand );
   }
 

--- a/HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonPtSelect.h
+++ b/HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonPtSelect.h
@@ -44,7 +44,7 @@ class BPHMuonPtSelect: public BPHParticlePtSelect {
    */
   /// select muon
   virtual bool accept( const reco::Candidate& cand ) const {
-    if ( reinterpret_cast<const pat::Muon*>( &cand ) == 0 ) return false;
+    if ( dynamic_cast<const pat::Muon*>( &cand ) == 0 ) return false;
     return BPHParticlePtSelect::accept( cand );
   }
 


### PR DESCRIPTION
The original code assumed calling reinterpret_cast on a pointer
would return 0 if the pointer was of the wrong type. That is not
the case. The code was changed to use dynamic_cast instead which
does have that behavior.

This problem was found by gcc 6.3 (it was a warning).