### PR TITLE
Replaced tab with space to avoid gcc 6.3 warning in L1Trigger/L1TCommon

### DIFF
--- a/L1Trigger/L1TCommon/src/Setting.cc
+++ b/L1Trigger/L1TCommon/src/Setting.cc
@@ -191,10 +191,10 @@ void TableRow::setRowColumns(const std::vector<std::string>& columns)
     if( colDict_.get() == 0 )
         colDict_ = std::shared_ptr< std::map<std::string,int> >(new std::map<std::string,int>());
 
-	colDict_->clear();
+    colDict_->clear();
 
-	for(unsigned int i=0; i<columns.size(); i++) 
-		(*colDict_)[ columns[i] ] = i;
+    for(unsigned int i=0; i<columns.size(); i++) 
+	(*colDict_)[ columns[i] ] = i;
 }
 
 void TableRow::setRowTypes(const std::vector<std::string>& types)


### PR DESCRIPTION
Because of the different possible spacing used for tabs, gcc 6.3
was warning of a line after an `if` that might appear to visually
be part of the `if` but is, in fact, not. Switching from tabs to
using spaces, which is consistent with the rest of the document,
removes the warning.