### PR TITLE
Add timing detectors to GeomDetEnumerators

### DIFF
--- a/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
@@ -8,13 +8,13 @@
  */
 namespace GeomDetEnumerators {
   enum Location {barrel, endcap, invalidLoc};
-  enum SubDetector {PixelBarrel, PixelEndcap, TIB, TOB, TID, TEC, CSC, DT, RPCBarrel, RPCEndcap, GEM, ME0, P2OTB, P2OTEC, P1PXB, P1PXEC, P2PXEC, invalidDet};
+  enum SubDetector {PixelBarrel, PixelEndcap, TIB, TOB, TID, TEC, CSC, DT, RPCBarrel, RPCEndcap, GEM, ME0, P2OTB, P2OTEC, P1PXB, P1PXEC, P2PXEC, TimingBarrel, TimingEndcap, invalidDet};
   // gives subdetId in DetId conrrepsonding to the above
-  constexpr unsigned int subDetId[18]={1,2,3,5,4,6, 0, 0,0,0,0,0,5,4,1,2,2, 0}; // don't ask, don't ask, simply do not ask!
+  constexpr unsigned int subDetId[20]={1,2,3,5,4,6, 0, 0,0,0,0,0,5,4,1,2,2, 2,2, 0}; // don't ask, don't ask, simply do not ask!
   //inverse (only for tracker)
   constexpr SubDetector tkDetEnum[8]={invalidDet, PixelBarrel, PixelEndcap, TIB, TID, TOB, TEC, invalidDet}; // don't ask, don't ask, simply do not ask!
   //to convert a physical subdetector (it could be larger than 5) into a geometry subdetector (between 0 and 5). ONLY for tracker
-  constexpr SubDetector subDetGeom[18]={PixelBarrel, PixelEndcap, TIB, TOB, TID, TEC, invalidDet, invalidDet, invalidDet, invalidDet, invalidDet, invalidDet, TOB, TID, PixelBarrel, PixelEndcap, PixelEndcap, invalidDet};
+  constexpr SubDetector subDetGeom[20]={PixelBarrel, PixelEndcap, TIB, TOB, TID, TEC, invalidDet, invalidDet, invalidDet, invalidDet, invalidDet, invalidDet, TOB, TID, PixelBarrel, PixelEndcap, PixelEndcap, invalidDet, invalidDet, invalidDet};
 
 bool isBarrel(GeomDetEnumerators::SubDetector m);
 bool isEndcap(GeomDetEnumerators::SubDetector m);
@@ -28,6 +28,7 @@ bool isRPC(const GeomDetEnumerators::SubDetector m);
 bool isGEM(const GeomDetEnumerators::SubDetector m);
 bool isME0(const GeomDetEnumerators::SubDetector m);
 bool isMuon(const GeomDetEnumerators::SubDetector m);
+bool isTiming(const GeomDetEnumerators::SubDetector m);
  
 }
 

--- a/Geometry/CommonDetUnit/src/GeomDetEnumerators.cc
+++ b/Geometry/CommonDetUnit/src/GeomDetEnumerators.cc
@@ -25,13 +25,15 @@ std::ostream& operator<<( std::ostream& s, SubDetector m){
   else if ( m == P1PXB ) return s << "Phase1PixelBarrel";
   else if ( m == P1PXEC ) return s << "Phase1PixelEndcap";
   else if ( m == P2PXEC ) return s << "Phase2PixelEndcap";
+  else if ( m == TimingBarrel ) return s << "Phase2TimingBarrel";
+  else if ( m == TimingEndcap ) return s << "Phase2TimingEndcap";
   else return s << "?";
 }
 
 
 bool GeomDetEnumerators::isBarrel(const GeomDetEnumerators::SubDetector subdet)
 {
-  return (subdet == PixelBarrel || subdet == TIB || subdet == TOB || subdet == P1PXB || subdet == P2OTB || isDT(subdet) || subdet == RPCBarrel);
+  return (subdet == PixelBarrel || subdet == TIB || subdet == TOB || subdet == P1PXB || subdet == P2OTB || isDT(subdet) || subdet == RPCBarrel || subdet == TimingBarrel );
 }
 
 bool GeomDetEnumerators::isEndcap(const GeomDetEnumerators::SubDetector subdet)
@@ -89,4 +91,9 @@ bool GeomDetEnumerators::isME0(const GeomDetEnumerators::SubDetector subdet)
 bool GeomDetEnumerators::isMuon(const GeomDetEnumerators::SubDetector subdet)
 {
   return (subdet == DT || subdet == CSC || isRPC(subdet) || subdet == GEM || subdet == ME0) ;
+}
+
+bool GeomDetEnumerators::isTiming(const GeomDetEnumerators::SubDetector subdet)
+{
+  return ( subdet == TimingBarrel || subdet == TimingEndcap ) ;
 }


### PR DESCRIPTION
This PR adds the timing detector layers such that they can be easily used in tracking geometries.
Pushing this now since it pulls down 464 packages.

This the first necessary step in developing tracking tools for the timing layer studies for the phase 2 upgrade. It allows for straightforward integration of the new detectors into the tracking geometries so that we can use tracks to pick timing hits. The next phase, after we establish the efficiency and purity that we can pick hits, is to extend the propagation and kalman fitting code to include an estimate of the particle's t0 so that we can take the time at detector back to the vertex using only reconstructed information.

