### PR TITLE
Smart G4 magnetic field manager

### DIFF
--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -30,7 +30,6 @@ namespace CLHEP {
 }
 
 namespace sim {
-  class FieldBuilder;
   class ChordFinderSetter;
 }
 
@@ -160,7 +159,6 @@ private:
   std::vector<std::shared_ptr<SimProducer> > m_producers;
     
   std::unique_ptr<SimTrackManager> m_trackManager;
-  sim::FieldBuilder             *m_fieldBuilder;
   sim::ChordFinderSetter        *m_chordFinderSetter;
     
   edm::ESWatcher<IdealGeometryRecord> idealGeomRcdWatcher_;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -18,7 +18,6 @@ namespace CLHEP {
 }
 
 namespace sim {
-  class FieldBuilder;
   class ChordFinderSetter;
 }
 
@@ -96,14 +95,6 @@ public:
     return m_physicsList.get();
   }
 
-  // In order to share the ChordFinderSetter (for
-  // G4MonopoleTransportation) with the worker threads, we need a
-  // non-const pointer. Thread-safety is handled inside
-  // ChordFinderStter with TLS. 
-  inline sim::ChordFinderSetter *chordFinderSetterForWorker() const {
-    return m_chordFinderSetter.get();
-  }
-
 private:
   void terminateRun();
   void DumpMagneticField( const G4Field*) const;
@@ -135,7 +126,6 @@ private:
   SimActivityRegistry m_registry;
   SensitiveDetectorCatalog m_catalog;
     
-  sim::FieldBuilder  *m_fieldBuilder;
   std::unique_ptr<sim::ChordFinderSetter> m_chordFinderSetter;
     
   std::string m_FieldFile;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -62,7 +62,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         NodeNames = cms.vstring('World')
     ),
     G4Commands = cms.vstring(),
-    SteppingVerbosity = cms.int32(1),
+    SteppingVerbosity = cms.int32(0),
     StepVerboseThreshold = cms.double(0.1), # in GeV
     VerboseEvents = cms.vint32(),
     VertexNumber  = cms.vint32(),

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -62,7 +62,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         NodeNames = cms.vstring('World')
     ),
     G4Commands = cms.vstring(),
-    SteppingVerbosity = cms.int32(0),
+    SteppingVerbosity = cms.int32(1),
     StepVerboseThreshold = cms.double(0.1), # in GeV
     VerboseEvents = cms.vint32(),
     VertexNumber  = cms.vint32(),
@@ -87,14 +87,18 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
                 Stepper = cms.string('G4ClassicalRK4'),
                 Type = cms.string('CMSIMField'),
                 StepperParam = cms.PSet(
-                    MaximumEpsilonStep = cms.untracked.double(0.01), ## in mm
-                    DeltaOneStep = cms.double(0.001), ## in mm
+                    MaximumEpsilonStep = cms.untracked.double(0.01),   ## in mm
+                    DeltaOneStep = cms.double(0.001),      ## in mm
                     MaximumLoopCounts = cms.untracked.double(1000.0),
                     DeltaChord = cms.double(0.001), ## in mm
-                    MinStep = cms.double(0.1), ## in mm
+                    MinStep = cms.double(0.1),      ## in mm
                     DeltaIntersectionAndOneStep = cms.untracked.double(-1.0),
-                    DeltaIntersection = cms.double(0.0001), ## in mm
-                    MinimumEpsilonStep = cms.untracked.double(1e-05) ## in mm
+                    DeltaIntersection = cms.double(0.0001),## in mm
+                    MinimumEpsilonStep = cms.untracked.double(1e-05), ## in mm
+                    EnergyThSimple = cms.double(0.0),                ## in GeV
+                    DeltaChordSimple = cms.double(0.1),    ## in mm
+                    DeltaOneStepSimple = cms.double(0.1),  ## in mm
+                    DeltaIntersectionSimple = cms.double(0.01),       ## in mm
                 )
             )
         ),

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -24,6 +24,7 @@
 #include "SimG4Core/MagneticField/interface/FieldBuilder.h"
 #include "SimG4Core/MagneticField/interface/ChordFinderSetter.h"
 #include "SimG4Core/MagneticField/interface/Field.h"
+#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -136,7 +137,7 @@ RunManager::RunManager(edm::ParameterSet const & p, edm::ConsumesCollector&& iC)
       m_pSteppingAction(p.getParameter<edm::ParameterSet>("SteppingAction")),
       m_g4overlap(p.getParameter<edm::ParameterSet>("G4CheckOverlap")),
       m_G4Commands(p.getParameter<std::vector<std::string> >("G4Commands")),
-      m_p(p), m_fieldBuilder(nullptr), m_chordFinderSetter(nullptr)
+      m_p(p), m_chordFinderSetter(nullptr)
 {    
   m_UIsession.reset(new CustomUIsession());
   m_kernel = new G4RunManagerKernel();
@@ -213,13 +214,13 @@ void RunManager::initG4(const edm::EventSetup & es)
       es.get<IdealMagneticFieldRecord>().get(pMF);
       const GlobalPoint g(0.,0.,0.);
 
-      m_chordFinderSetter = new sim::ChordFinderSetter();
-      m_fieldBuilder = new sim::FieldBuilder(&(*pMF), m_pField);
-      G4TransportationManager * tM = 
+      sim::FieldBuilder fieldBuilder(pMF.product(), m_pField);
+      CMSFieldManager* fieldManager = new CMSFieldManager();
+      G4TransportationManager * tM =
 	G4TransportationManager::GetTransportationManager();
-      m_fieldBuilder->build( tM->GetFieldManager(),
-			     tM->GetPropagatorInField(),
-                             m_chordFinderSetter);
+      tM->SetFieldManager(fieldManager);
+      fieldBuilder.build( fieldManager, tM->GetPropagatorInField());
+
       if("" != m_FieldFile) { 
 	DumpMagneticField(tM->GetFieldManager()->GetDetectorField()); 
       }

--- a/SimG4Core/MagneticField/interface/CMSFieldManager.h
+++ b/SimG4Core/MagneticField/interface/CMSFieldManager.h
@@ -1,0 +1,52 @@
+#ifndef SimG4Core_MagneticField_CMSFieldManager_H
+#define SimG4Core_MagneticField_CMSFieldManager_H
+
+/*
+   Created:  13 January 2017, V. Ivanchenko 
+   This class implements smart magnetic field manager 
+*/
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "G4FieldManager.hh"
+
+class G4Track;
+class G4ChordFinder;
+namespace sim { class Field; }
+
+class CMSFieldManager : public G4FieldManager
+{
+public:
+
+  explicit CMSFieldManager();
+
+  virtual ~CMSFieldManager();
+
+  virtual void ConfigureForTrack(const G4Track*); 
+
+  void InitialiseForVolume(const edm::ParameterSet&, sim::Field*, G4ChordFinder*, G4ChordFinder*, 
+                           const std::string& vol, const std::string& type, 
+                           const std::string& stepper, double delta, double minstep);
+
+  void SetMonopoleTracking(G4bool);
+
+private:
+
+  CMSFieldManager(const CMSFieldManager&);
+  CMSFieldManager& operator=(const CMSFieldManager&);
+
+  std::unique_ptr<sim::Field> theField;
+
+  G4ChordFinder* currChordFinder;
+  G4ChordFinder* chordFinder;
+  G4ChordFinder* chordFinderMonopole;
+
+  double dChord;
+  double dOneStep;
+  double dIntersection;
+  double energyThreshold;
+  double dChordSimple;
+  double dOneStepSimple;
+  double dIntersectionSimple;
+};
+#endif

--- a/SimG4Core/MagneticField/interface/ChordFinderSetter.h
+++ b/SimG4Core/MagneticField/interface/ChordFinderSetter.h
@@ -1,22 +1,11 @@
 #ifndef SimG4Core_ChordFinderSetter_H
 #define SimG4Core_ChordFinderSetter_H
 
-class G4ChordFinder;
-class G4FieldManager;
-
 namespace sim {
   class ChordFinderSetter {
   public:
     ChordFinderSetter();
     ~ChordFinderSetter();
-
-    bool isMonopoleSet() const { return fChordFinderMonopole; }
-    void setMonopole(G4ChordFinder *cfm) { fChordFinderMonopole = cfm; }
-
-    void setStepperAndChordFinder(G4FieldManager * fM, int val);
-
-  private:
-    static thread_local G4ChordFinder *fChordFinder, *fChordFinderMonopole;
   };
 };
 

--- a/SimG4Core/MagneticField/interface/Field.h
+++ b/SimG4Core/MagneticField/interface/Field.h
@@ -4,7 +4,6 @@
 #include "G4MagneticField.hh"
 
 class MagneticField;
-class G4Mag_UsualEqRhs;
 
 namespace sim {
    class Field : public G4MagneticField
@@ -12,16 +11,14 @@ namespace sim {
       public:
 	 Field(const MagneticField * f, double d);
 	 virtual ~Field();
-	 G4Mag_UsualEqRhs* fieldEquation();
 	 virtual void GetFieldValue(const G4double p[4], G4double b[3]) const;
-	 void fieldEquation(G4Mag_UsualEqRhs* e);
+
       private:
 	 const MagneticField* theCMSMagneticField;
-	 G4Mag_UsualEqRhs* theFieldEquation;
          double theDelta;
 
          mutable double oldx[3];
          mutable double oldb[3];
    };
-}
+};
 #endif

--- a/SimG4Core/MagneticField/interface/FieldBuilder.h
+++ b/SimG4Core/MagneticField/interface/FieldBuilder.h
@@ -2,68 +2,39 @@
 #define SimG4Core_FieldBuilder_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-// #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 #include <memory>
 
-// class DDLogicalPart;
 class MagneticField;
-
-class G4FieldManager;
+class CMSFieldManager;
 class G4Mag_UsualEqRhs;
 class G4PropagatorInField;
 class G4LogicalVolume;
 
 namespace sim {
   class Field;
-  class ChordFinderSetter;
   class FieldBuilder {
+
   public:
+
     FieldBuilder(const MagneticField*, const edm::ParameterSet&);
-    //~FieldBuilder();
 
-    /*
-      void readFieldParameters(DDLogicalPart theLogicalPart,
-                               const std::string& keywordField);
-    */
-    void build(G4FieldManager* fM = nullptr,
-	       G4PropagatorInField* fP = nullptr,
-               ChordFinderSetter *setter = nullptr);
+    ~FieldBuilder();
 
-    /*
-      void configure(const std::string& keywordField,
-	   	     G4FieldManager * fM = 0,
-		     G4PropagatorInField * fP = 0);
-    */
+    void build(CMSFieldManager* fM, G4PropagatorInField* fP);
+
     void configureForVolume( const std::string& volName, 
 			     edm::ParameterSet& volPSet,
-			     G4FieldManager * fM = nullptr,
-			     G4PropagatorInField * fP = nullptr,
-                             ChordFinderSetter *setter = nullptr);
-    G4LogicalVolume * fieldTopVolume();
+			     CMSFieldManager * fM,
+			     G4PropagatorInField * fP);
 
   private:
-    void configureFieldManager(G4FieldManager * fM, ChordFinderSetter *setter);
-    void configurePropagatorInField(G4PropagatorInField * fP);  
-  private:
-    std::auto_ptr<Field> theField;
+
+    Field* theField;
     G4Mag_UsualEqRhs *theFieldEquation;
-    G4LogicalVolume  *theTopVolume;
-	 
-    std::string keywordField;
-    std::string fieldType;
-    double fieldValue;
-    std::string stepper;
-    double minStep;
-    double dChord;
-    double dOneStep;
-    double dIntersection;
-    double dIntersectionAndOneStep;
-    double maxLoopCount;
-    double minEpsilonStep;
-    double maxEpsilonStep;
+    G4LogicalVolume  *theTopVolume;	 
+    edm::ParameterSet thePSet;
     double delta;
-    edm::ParameterSet thePSet ;
   };
-}
+};
 
 #endif

--- a/SimG4Core/MagneticField/src/CMSFieldManager.cc
+++ b/SimG4Core/MagneticField/src/CMSFieldManager.cc
@@ -1,0 +1,95 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
+#include "SimG4Core/MagneticField/interface/Field.h"
+
+#include "G4ChordFinder.hh"
+#include "G4Track.hh"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+CMSFieldManager::CMSFieldManager() 
+  : G4FieldManager(), currChordFinder(nullptr), chordFinder(nullptr),
+    chordFinderMonopole(nullptr), dChord(0.001), dOneStep(0.001),
+    dIntersection(0.0001), energyThreshold(0.0), dChordSimple(0.1),
+    dOneStepSimple(0.1), dIntersectionSimple(0.01)
+{}
+
+CMSFieldManager::~CMSFieldManager()
+{}
+
+void CMSFieldManager::InitialiseForVolume(const edm::ParameterSet& p, sim::Field* field,
+					  G4ChordFinder* cf, G4ChordFinder* cfmon, 
+                                          const std::string& vol, const std::string& type, 
+                                          const std::string& stepper,
+                                          double delta, double minstep)
+{
+  dChord = p.getParameter<double>("DeltaChord")*CLHEP::mm;
+  dOneStep = p.getParameter<double>("DeltaOneStep")*CLHEP::mm;
+  dIntersection = p.getParameter<double>("DeltaIntersection")*CLHEP::mm;
+  energyThreshold = p.getParameter<double>("EnergyThSimple")*CLHEP::GeV;
+  dChordSimple = p.getParameter<double>("DeltaChordSimple")*CLHEP::mm;
+  dOneStepSimple = p.getParameter<double>("DeltaOneStepSimple")*CLHEP::mm;
+  dIntersectionSimple = p.getParameter<double>("DeltaIntersectionSimple")*CLHEP::mm;
+  int maxLC = (int)p.getUntrackedParameter<double>("MaximumLoopCounts",1000);
+  double minEpsStep = 
+    p.getUntrackedParameter<double>("MinimumEpsilonStep",0.00001)*CLHEP::mm;
+  double maxEpsStep = 
+    p.getUntrackedParameter<double>("MaximumEpsilonStep",0.01)*CLHEP::mm;
+  edm::LogInfo("SimG4CoreApplication") 
+    << " New CMSFieldManager: LogicalVolume:      <" << vol << ">\n"
+    << "               Stepper:                   <" << stepper << ">\n" 
+    << "               Field type                 <" << type<< ">\n"
+    << "               Field const delta(mm)       " << delta << "\n"
+    << "               MinStep(mm)                 " << minstep<< "\n"
+    << "               DeltaChord(mm)              " << dChord<< "\n"
+    << "               DeltaOneStep(mm)            " << dOneStep<< "\n"
+    << "               DeltaIntersection(mm)       " << dIntersection<< "\n"
+    << "               EnergyThreshold(GeV)        " << energyThreshold<< "\n"
+    << "               DeltaChordSimple(mm)        " << dChord<< "\n"
+    << "               DeltaOneStepSimple(mm)      " << dOneStep<< "\n"
+    << "               DeltaIntersectionSimple(mm) " << dIntersection<< "\n"
+    << "               MaximumLoopCounts           " << maxLC<< "\n"
+    << "               MinimumEpsilonStep          " << minEpsStep<< "\n"
+    << "               MaximumEpsilonStep          " << maxEpsStep;
+
+  // initialisation of chord finders
+  chordFinder = cf;
+  chordFinderMonopole = cfmon;
+  chordFinder->SetDeltaChord(dChord);
+  chordFinderMonopole->SetDeltaChord(dChord);
+
+  // initialisation of field manager
+  theField.reset(field);
+  SetDetectorField(field);
+  SetDeltaOneStep(dOneStep);
+  SetDeltaIntersection(dIntersection);
+  SetMinimumEpsilonStep(minEpsStep);
+  SetMaximumEpsilonStep(maxEpsStep);
+
+  SetMonopoleTracking(false);
+}
+
+void CMSFieldManager::ConfigureForTrack(const G4Track* track)
+{
+  // run time parameters per track
+  if(track->GetKineticEnergy() <= energyThreshold && track->GetParentID() > 0) {
+    chordFinder->SetDeltaChord(dChordSimple);
+    SetDeltaOneStep(dOneStepSimple);
+    SetDeltaIntersection(dIntersectionSimple);
+  } else {
+    chordFinder->SetDeltaChord(dChord);
+    SetDeltaOneStep(dOneStep);
+    SetDeltaIntersection(dIntersection);
+  }
+} 
+
+void CMSFieldManager::SetMonopoleTracking(G4bool flag)
+{
+  if(flag) {
+    currChordFinder = chordFinderMonopole;
+    SetFieldChangesEnergy(true);
+  } else { 
+    currChordFinder = chordFinder;
+    SetFieldChangesEnergy(false);
+  }
+  SetChordFinder(currChordFinder);
+}

--- a/SimG4Core/MagneticField/src/ChordFinderSetter.cc
+++ b/SimG4Core/MagneticField/src/ChordFinderSetter.cc
@@ -1,22 +1,8 @@
 #include "SimG4Core/MagneticField/interface/ChordFinderSetter.h"
 
-#include "G4FieldManager.hh"
-
 namespace sim {
-  thread_local G4ChordFinder *ChordFinderSetter::fChordFinder = nullptr;
-  thread_local G4ChordFinder *ChordFinderSetter::fChordFinderMonopole = nullptr;
 
   ChordFinderSetter::ChordFinderSetter() {}
   ChordFinderSetter::~ChordFinderSetter() {}
 
-  void ChordFinderSetter::setStepperAndChordFinder(G4FieldManager * fM, int val) {
-    if (fM != 0) {
-      if (val == 0) {
-        if (fChordFinder != 0) fM->SetChordFinder(fChordFinder);
-      } else {
-        fChordFinder = fM->GetChordFinder();
-        if (fChordFinderMonopole != 0) fM->SetChordFinder(fChordFinderMonopole);
-      }
-    }
-  }
 }

--- a/SimG4Core/MagneticField/src/Field.cc
+++ b/SimG4Core/MagneticField/src/Field.cc
@@ -8,8 +8,6 @@
 
 using namespace sim;
 
-G4Mag_UsualEqRhs * Field::fieldEquation() { return theFieldEquation; }
-
 Field::Field(const MagneticField * f, double d) 
   : G4MagneticField(), theCMSMagneticField(f), theDelta(d)
 {
@@ -44,6 +42,4 @@ void Field::GetFieldValue(const G4double xyz[4], G4double bfield[3]) const
   bfield[1] = oldb[1]; 
   bfield[2] = oldb[2];
 }
-
-void Field::fieldEquation(G4Mag_UsualEqRhs* e) { theFieldEquation = e; }
 

--- a/SimG4Core/MagneticField/src/FieldBuilder.cc
+++ b/SimG4Core/MagneticField/src/FieldBuilder.cc
@@ -5,10 +5,10 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimG4Core/MagneticField/interface/FieldBuilder.h"
+#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 #include "SimG4Core/MagneticField/interface/Field.h"
 #include "SimG4Core/MagneticField/interface/FieldStepper.h"
 #include "SimG4Core/MagneticField/interface/G4MonopoleEquation.hh"
-#include "SimG4Core/MagneticField/interface/ChordFinderSetter.h"
 
 #include "G4Mag_UsualEqRhs.hh"
 #include "G4ClassicalRK4.hh"
@@ -17,28 +17,23 @@
 #include "G4TransportationManager.hh"
 #include "G4ChordFinder.hh"
 #include "G4UniformMagField.hh"
-
-#include "SimG4Core/MagneticField/interface/LocalFieldManager.h"
-
 #include "G4LogicalVolumeStore.hh"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 using namespace sim;
 
-FieldBuilder::FieldBuilder(const MagneticField * f, 
-			   const edm::ParameterSet & p) 
-  : theField(new Field(f, p.getParameter<double>("delta"))),
-    theFieldEquation(new G4Mag_UsualEqRhs(theField.get())),
-    theTopVolume(nullptr),
-    fieldValue(0.), minStep(0.), dChord(0.), dOneStep(0.),
-    dIntersection(0.), dIntersectionAndOneStep(0.), 
-    maxLoopCount(0), minEpsilonStep(0.), maxEpsilonStep(0.), 
-    thePSet(p) 
+FieldBuilder::FieldBuilder(const MagneticField * f, const edm::ParameterSet & p) 
+  : theTopVolume(nullptr),thePSet(p) 
 {
-  delta = p.getParameter<double>("delta");
-  theField->fieldEquation(theFieldEquation);
+  delta = p.getParameter<double>("delta")*CLHEP::mm;
+  theField = new Field(f, delta);
+  theFieldEquation = new G4Mag_UsualEqRhs(theField);
 }
 
-void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP, ChordFinderSetter *setter) 
+FieldBuilder::~FieldBuilder()
+{} 
+
+void FieldBuilder::build( CMSFieldManager* fM, G4PropagatorInField* fP) 
 {    
   edm::ParameterSet thePSetForGMFM =
     thePSet.getParameter<edm::ParameterSet>("ConfGlobalMFM");
@@ -48,50 +43,16 @@ void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP, ChordFind
   edm::ParameterSet volPSet =
     thePSetForGMFM.getParameter< edm::ParameterSet >( volName );
     
-  configureForVolume( volName, volPSet, fM, fP, setter );
-    
-  if ( thePSet.getParameter<bool>("UseLocalMagFieldManager") )  {
+  configureForVolume( volName, volPSet, fM, fP);
 
-    edm::LogInfo("SimG4CoreApplication") 
-      << " FieldBuilder: Local magnetic field is used";
-
-    edm::ParameterSet defpset ;
-    edm::ParameterSet thePSetForLMFM = 
-      thePSet.getUntrackedParameter<edm::ParameterSet>("ConfLocalMFM", defpset);
-    //
-    // Patology !!! LocalFM requested but configuration not given ! 
-    // In principal, need to throw an exception
-    //
-    if ( thePSetForLMFM == defpset )  {
-      edm::LogError("SimG4CoreApplication") 
-	<< " FieldBuilder::build: Patology! Local Mag.Field Manager requested but config not given!";
-      return ;
-    }
-       
-    std::vector<std::string> ListOfVolumes = 
-      thePSetForLMFM.getParameter< std::vector<std::string> >("ListOfVolumes");
-	  
-    // creating Local Mag.Field Manager
-    for (unsigned int i = 0; i < ListOfVolumes.size(); ++ i )   {
-      volPSet = thePSetForLMFM.getParameter< edm::ParameterSet >(ListOfVolumes[i]);
-      G4FieldManager* fAltM = new G4FieldManager() ;
-      configureForVolume( ListOfVolumes[i], volPSet, fAltM, nullptr, setter ) ;
-
-      LocalFieldManager* fLM = new LocalFieldManager( theField.get(), fM, fAltM ) ;
-      fLM->SetVerbosity(thePSet.getUntrackedParameter<bool>("Verbosity",false));
-      theTopVolume->SetFieldManager( fLM, true ) ;
-    }
-  } else {
-    edm::LogInfo("SimG4CoreApplication") 
-      << " FieldBuilder::build: Global magnetic field is used";
-  }
+  edm::LogInfo("SimG4CoreApplication") 
+    << " FieldBuilder::build: Global magnetic field is used";
 }
 
 void FieldBuilder::configureForVolume( const std::string& volName,
                                        edm::ParameterSet& volPSet,
-				       G4FieldManager * fM,
-				       G4PropagatorInField * fP,
-                                       ChordFinderSetter *setter) 
+				       CMSFieldManager * fM,
+				       G4PropagatorInField * fP) 
 {
   G4LogicalVolumeStore* theStore = G4LogicalVolumeStore::GetInstance();
   for (unsigned int i=0; i<(*theStore).size(); ++i ) {
@@ -101,75 +62,33 @@ void FieldBuilder::configureForVolume( const std::string& volName,
     }
   }
 
-  fieldType     = volPSet.getParameter<std::string>("Type") ;
-  stepper       = volPSet.getParameter<std::string>("Stepper") ;
-  edm::ParameterSet stpPSet = 
-    volPSet.getParameter<edm::ParameterSet>("StepperParam") ;
-  minStep       = stpPSet.getParameter<double>("MinStep") ;
-  dChord        = stpPSet.getParameter<double>("DeltaChord") ;
-  dOneStep      = stpPSet.getParameter<double>("DeltaOneStep") ;
-  dIntersection = stpPSet.getParameter<double>("DeltaIntersection") ;
-  dIntersectionAndOneStep = 
-    stpPSet.getUntrackedParameter<double>("DeltaIntersectionAndOneStep",-1.);
-  maxLoopCount = 
-    stpPSet.getUntrackedParameter<double>("MaximumLoopCounts",1000);
-  minEpsilonStep = 
+  std::string fieldType = volPSet.getParameter<std::string>("Type");
+  std::string stepper   = volPSet.getParameter<std::string>("Stepper");
+
+  edm::ParameterSet stpPSet = volPSet.getParameter<edm::ParameterSet>("StepperParam");
+  double minStep        = stpPSet.getParameter<double>("MinStep") ;
+  int maxLoopCount = 
+    (int)stpPSet.getUntrackedParameter<double>("MaximumLoopCounts",1000);
+  double minEpsilonStep = 
     stpPSet.getUntrackedParameter<double>("MinimumEpsilonStep",0.00001);
-  maxEpsilonStep = 
+  double maxEpsilonStep = 
     stpPSet.getUntrackedParameter<double>("MaximumEpsilonStep",0.01);
-   
-  if (fM!=nullptr) configureFieldManager(fM, setter);
-  if (fP!=nullptr) configurePropagatorInField(fP);	
 
-  edm::LogInfo("SimG4CoreApplication") 
-    << " FieldBuilder: Selected stepper:     <" << stepper << ">\n" 
-    << "               Field type            <" << fieldType<< ">\n"
-    << "               Field const delta(mm)= " << delta << "\n"
-    << "               MinStep(mm)            " << minStep<< "\n"
-    << "               DeltaChord(mm)         " << dChord<< "\n"
-    << "               DeltaOneStep(mm)       " << dOneStep<< "\n"
-    << "               DeltaIntersection(mm)  " << dIntersection<< "\n"
-    << "               IntersectionAndOneStep " << dIntersectionAndOneStep<< "\n"
-    << "               MaximumLoopCounts      " << maxLoopCount<< "\n"
-    << "               MinimumEpsilonStep     " << minEpsilonStep<< "\n"
-    << "               MaximumEpsilonStep     " << maxEpsilonStep;
-}
+  FieldStepper * theStepper = new FieldStepper(theFieldEquation, delta);
+  theStepper->select(stepper);
+  G4ChordFinder * cf = new G4ChordFinder(theField,minStep,theStepper);
 
-G4LogicalVolume * FieldBuilder::fieldTopVolume() { return theTopVolume; }
+  G4MonopoleEquation* monopoleEquation = new G4MonopoleEquation(theField);
+  G4MagIntegratorStepper* theStepperMon = new G4ClassicalRK4(monopoleEquation,8);
+  G4ChordFinder * cfmon = new G4ChordFinder(theField,minStep,theStepperMon);
 
-void FieldBuilder::configureFieldManager(G4FieldManager * fM, ChordFinderSetter *setter) {
+  fM->InitialiseForVolume(stpPSet, theField, cf, cfmon, volName, 
+			  fieldType, stepper, delta, minStep); 
 
-  if (fM!=nullptr) {
-    fM->SetDetectorField(theField.get());
-    FieldStepper * theStepper = 
-      new FieldStepper(theField->fieldEquation(), delta);
-    theStepper->select(stepper);
-    G4ChordFinder * CF = new G4ChordFinder(theField.get(),minStep,theStepper);
-    CF->SetDeltaChord(dChord);
-    fM->SetChordFinder(CF);
-    fM->SetDeltaOneStep(dOneStep);
-    fM->SetDeltaIntersection(dIntersection);
-    if (dIntersectionAndOneStep != -1.) 
-      fM->SetAccuraciesWithDeltaOneStep(dIntersectionAndOneStep);
-  }
-  if(setter && !setter->isMonopoleSet()) {
-    G4MonopoleEquation* fMonopoleEquation = 
-      new G4MonopoleEquation(theField.get());
-    G4MagIntegratorStepper* theStepper = 
-      new G4ClassicalRK4(fMonopoleEquation,8);
-    G4ChordFinder *chordFinderMonopole = 
-      new G4ChordFinder(theField.get(),minStep,theStepper);
-    chordFinderMonopole->SetDeltaChord(dChord);
-    setter->setMonopole(chordFinderMonopole);
-  }
-}
-
-void FieldBuilder::configurePropagatorInField(G4PropagatorInField * fP) {
-  if(fP!=0) {
-    fP->SetMaxLoopCount(int(maxLoopCount));
+  if(fP) {
+    fP->SetMaxLoopCount(maxLoopCount);
     fP->SetMinimumEpsilonStep(minEpsilonStep);
     fP->SetMaximumEpsilonStep(maxEpsilonStep);
-    fP->SetVerboseLevel(0);
+    //fP->SetVerboseLevel(0);
   }
 }
-

--- a/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.cc
+++ b/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.cc
@@ -48,6 +48,7 @@
 #include "G4FieldManagerStore.hh"
 #include "SimG4Core/Physics/interface/G4Monopole.hh"
 #include "SimG4Core/MagneticField/interface/ChordFinderSetter.h"
+#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 
 class G4VSensitiveDetector;
 
@@ -129,11 +130,10 @@ AlongStepGetPhysicalInteractionLength( const G4Track&  track,
                                              G4double& currentSafety,
                                              G4GPILSelection* selection )
 {
-  
-  //magSetup->SetStepperAndChordFinder(1); 
   // change to monopole equation
-  G4FieldManager* fieldMgrX=fFieldPropagator->FindAndSetFieldManager(track.GetVolume()); 
-  fChordFinderSetter->setStepperAndChordFinder (fieldMgrX, 1);
+  G4FieldManager* fieldMgr = fFieldPropagator->FindAndSetFieldManager(track.GetVolume()); 
+  CMSFieldManager* fieldMgrCMS = static_cast<CMSFieldManager*>(fieldMgr);
+  if(fieldMgrCMS) { fieldMgrCMS->SetMonopoleTracking(true); }
   
   G4double geometryStepLength, newSafety ; 
   fParticleIsLooping = false ;
@@ -186,21 +186,19 @@ AlongStepGetPhysicalInteractionLength( const G4Track&  track,
 
   // Check whether the particle have an (EM) field force exerting upon it
   //
-  G4FieldManager* fieldMgr=0;
   G4bool          fieldExertsForce = false ;
     
   if( (particleMagneticCharge != 0.0) )
   {      
-     fieldMgr= fFieldPropagator->FindAndSetFieldManager( track.GetVolume() ); 
-     if (fieldMgr != 0) {
-  // Message the field Manager, to configure it for this track
-  fieldMgr->ConfigureForTrack( &track );
-  // Moved here, in order to allow a transition
-  //   from a zero-field  status (with fieldMgr->(field)0
-  //   to a finite field  status
+     if (fieldMgr) {
+       // Message the field Manager, to configure it for this track
+       fieldMgr->ConfigureForTrack( &track );
+       // Moved here, in order to allow a transition
+       //   from a zero-field  status (with fieldMgr->(field)0
+       //   to a finite field  status
 
-        // If the field manager has no field, there is no field !
-        fieldExertsForce = (fieldMgr->GetDetectorField() != 0);
+       // If the field manager has no field, there is no field !
+       fieldExertsForce = (fieldMgr->GetDetectorField() != 0);
      }      
   }
 
@@ -613,10 +611,10 @@ PostStepGetPhysicalInteractionLength( const G4Track& track,
                                             G4double, // previousStepSize
                                             G4ForceCondition* pForceCond )
 {  
-  //magSetup->SetStepperAndChordFinder(0);
   // change back to usual equation
   G4FieldManager* fieldMgr=fFieldPropagator->FindAndSetFieldManager( track.GetVolume() ); 
-  fChordFinderSetter->setStepperAndChordFinder (fieldMgr, 0);
+  CMSFieldManager* fieldMgrCMS = static_cast<CMSFieldManager*>(fieldMgr);
+  if(fieldMgrCMS) { fieldMgrCMS->SetMonopoleTracking(true); }
   
   *pForceCond = Forced ; 
   return DBL_MAX ;  // was kInfinity ; but convention now is DBL_MAX

--- a/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.hh
+++ b/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.hh
@@ -55,11 +55,15 @@
 #include "G4Track.hh"
 #include "G4Step.hh"
 #include "G4ParticleChangeForTransport.hh"
-//#include "G4MonopoleFieldSetup.hh"
+
 #include "SimG4Core/MagneticField/interface/FieldBuilder.h"
 
 class G4SafetyHelper; 
 class G4Monopole;
+
+namespace sim {
+  class ChordFinderSetter;
+}
 
 #include <memory>
 


### PR DESCRIPTION
A new Geant4 field manager is added allowing to switch a set magnetic field parameters depending on track type and energy. This is needed because high precision tracking in field for low-energy particles is not needed in all CMS sub-detectors.

In the current variant of code this mechanism introduced but parameters are set to zero, so the simulation should produce unchanged results. New parameters of the method are configured by pythin and should be established after optimisation.

Additionally some clean-up is introduced:
  - improved Info printouts;
  - do not create field in master thread for ordinary runs - only in worker threads;
  - reduced number of objects registered in tls;
  - reduced number of mutable class members.
 