### PR TITLE
Value initialize MapType to avoid -Werror=maybe-uninitialized

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -272,7 +272,7 @@ addValueToObject(ObjType& obj,
 		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
 		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & val_map)
 {
-  MapType value;
+  MapType value{};
   assignValue(ptr,val_map.second,vmaps,value);
   if( !obj.hasUserData(val_map.first) ) {
     obj.addUserData(val_map.first,value);


### PR DESCRIPTION
When MapType = int it's default-initialized to indeterminate value.
Using such value would cause undefined behavior.

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc530/CMSSW_9_0_X_2017-01-15-1100/RecoEgamma/EgammaTools

Signed-off-by: David Abdurachmanov <davidlt@cern.ch>