### PR TITLE
DAQ test module updates (80X)

### DIFF
--- a/EventFilter/Utilities/plugins/ExceptionGenerator.h
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.h
@@ -19,7 +19,6 @@ namespace evf{
 						   
       explicit ExceptionGenerator( const edm::ParameterSet&);
       ~ExceptionGenerator(){};
-      void beginStream();
       void beginRun(edm::Run& r, const edm::EventSetup& iSetup);
       void analyze(const edm::Event & e, const edm::EventSetup& c);
       void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
@@ -27,6 +26,7 @@ namespace evf{
     private:
       int actionId_;
       unsigned int intqualifier_;
+      double qualifier2_;
       std::string qualifier_;
       bool actionRequired_;
       std::string original_referrer_;

--- a/EventFilter/Utilities/python/ExceptionGenerator_cfi.py
+++ b/EventFilter/Utilities/python/ExceptionGenerator_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 ExceptionGenerator = cms.EDAnalyzer( "ExceptionGenerator",
              defaultAction       = cms.untracked.int32(-1),
-             defaultQualifier    = cms.untracked.int32(0)
+             defaultQualifier    = cms.untracked.int32(0),
+             secondQualifier    = cms.untracked.double(1.0)
 )
 
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -293,7 +293,7 @@ bool FedRawDataInputSource::checkNextEvent()
           maybeOpenNewLumiSection( event_->lumi() );
 	}
       }
-      if (fileListLoopMode_)
+      if (fileListMode_ || fileListLoopMode_)
         eventRunNumber_=runNumber_;
       else 
         eventRunNumber_=event_->run();


### PR DESCRIPTION
* new test cases allowing randomized event processing time emulation with sleep as well as CPU burn
* fileListMode in FedRawDataInputSource (mode only used for tests) now always overrides even run number with one initialized at the beginning of the run