### PR TITLE
drop validation and Harvesting HLT sequences in FastSim

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -21,7 +21,7 @@ dqmHarvestingPOGMC = cms.Path( DQMOffline_SecondStep_PrePOGMC )
 validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
 validationHarvestingNoHLT = cms.Path(postValidation*postValidation_gen)
 
-_validationHarvesting_fastsim = validation.copy()
+_validationHarvesting_fastsim = validationHarvesting.copy()
 for _entry in [hltpostvalidation]:
     _validationHarvesting_fastsim.remove(_entry)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -19,8 +19,16 @@ dqmHarvestingPOG = cms.Path(DQMOffline_SecondStep_PrePOG)
 dqmHarvestingPOGMC = cms.Path( DQMOffline_SecondStep_PrePOGMC )
 
 validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
+validationHarvestingNoHLT = cms.Path(postValidation*postValidation_gen)
+
+_validationHarvesting_fastsim = validation.copy()
+for _entry in [hltpostvalidation]:
+    _validationHarvesting_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validationHarvesting,_validationHarvesting_fastsim)
 
 validationpreprodHarvesting = cms.Path(postValidation_preprod*hltpostvalidation_preprod*postValidation_gen)
+validationpreprodHarvestingNoHLT = cms.Path(postValidation_preprod*postValidation_gen)
 
 # empty (non-hlt) postvalidation sequence here yet
 validationprodHarvesting = cms.Path(hltpostvalidation_prod*postValidation_gen)

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -31,22 +31,25 @@ from Validation.RecoParticleFlow.miniAODValidation_cff import *
 from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
 from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 
+prevalidationNoHLT = cms.Sequence( globalPrevalidation * metPreValidSeq * jetPreValidSeq )
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
 prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * egammaValidationMiniAOD)
 
 
-validation = cms.Sequence(cms.SequencePlaceholder("mix")
-                         +genvalid_all
-                         *globaldigisanalyze
-                         *globalhitsanalyze
-                         *globalrechitsanalyze
-                         *globalValidation
+validationNoHLT = cms.Sequence(cms.SequencePlaceholder("mix")
+                               +genvalid_all
+                               *globaldigisanalyze
+                               *globalhitsanalyze
+                               *globalrechitsanalyze
+                               *globalValidation)
+
+validation = cms.Sequence(validationNoHLT
                          *hltvalidation)
 
 _validation_fastsim = validation.copy()
-for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze]:
+for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze,hltvalidation]:
     _validation_fastsim.remove(_entry)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation,_validation_fastsim)
@@ -59,20 +62,40 @@ validationMiniAOD = cms.Sequence(type0PFMEtCorrectionPFCandToVertexAssociationFo
 
 prevalidation_preprod = cms.Sequence( preprodPrevalidation )
 
+validation_preprodNoHLT = cms.Sequence(
+                            genvalid_all
+                            +trackingTruthValid
+                            +tracksValidation
+                            +METRelValSequence
+                            +recoMuonValidation
+                            +muIsoVal_seq
+                            +muonIdValDQMSeq
+                          )
+
 validation_preprod = cms.Sequence(
-                          genvalid_all
-                          +trackingTruthValid
-                          +tracksValidation
-                          +METRelValSequence
-                          +recoMuonValidation
-                          +muIsoVal_seq
-                          +muonIdValDQMSeq
+                          validation_preprodNoHLT
                           +hltvalidation_preprod
                           )
 
+_validation_preprod_fastsim = validation_preprod.copy()
+for _entry in [hltvalidation_preprod]:
+    _validation_preprod_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validation_preprod,_validation_preprod_fastsim)
+
 validation.remove(condDataValidation)
-validation_prod = cms.Sequence(
+validation_prodNoHLT = cms.Sequence(
              genvalid_all
+            )
+
+validation_prod = cms.Sequence(
+             validation_prodNoHLT
             +hltvalidation_prod
             )
+
+_validation_prod_fastsim = validation_prodNoHLT.copy()
+for _entry in [hltvalidation_prod]:
+    _validation_prod_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 


### PR DESCRIPTION
as agreed w/ PdmV, this PR is meant to drop the validation and Harvesting sequences related to the HLT from the standard workflow in FastSim

I still have to modify the FastSim workflows, though
this is needed in order to have the Harvesting step properly working
in particular, the command "--fast" should be added