### PR TITLE
Clean up import statements to only import what is necessary.

### DIFF
--- a/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
@@ -1,7 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Configuration.JetCorrectors_cff import *
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4CaloL2L3CorrectorChain, \
+                                                              ak4CaloL2RelativeCorrector, \
+                                                              ak4CaloL3AbsoluteCorrector, \
+                                                              ak4CaloL2L3Corrector, \
+                                                              ak4CaloL2L3ResidualCorrectorChain, \
+                                                              ak4CaloResidualCorrector, \
+                                                              ak4CaloL2L3ResidualCorrector
 
 corrCaloMetType1 = cms.EDProducer(
     "CaloJetMETcorrInputProducer",

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
@@ -1,12 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Configuration.JetCorrectors_cff import *
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain, \
+                                                              ak4PFCHSL1FastjetCorrector, \
+                                                              ak4PFCHSL2RelativeCorrector, \
+                                                              ak4PFCHSL3AbsoluteCorrector, \
+                                                              ak4PFCHSResidualCorrector, \
+                                                              ak4PFCHSL1FastL2L3ResidualCorrector, \
+                                                              ak4PFCHSL1FastL2L3CorrectorChain, \
+                                                              ak4PFCHSL1FastL2L3Corrector
 
 ##____________________________________________________________________________||
 # select PFCandidates ("unclustered energy") not within jets
 # for Type 2 MET correction
-from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import pfNoJet
+from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import pfNoJet as _pfNoJet
 # the new TopProjectors now work with Ptrs
 # a conversion is needed if objects are not available
 # add them upfront of the sequence
@@ -22,7 +29,7 @@ from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 # FIXME: THIS IS A WASTE, BUT NOT CLEAR HOW TO FIX IT CLEANLY: the module
 # downstream operates with View<reco::Candidate>, I wish one could read
 # it from std::vector<PFCandidateFwdPtr> directly
-pfCandsNotInJetsPtrForMetCorr = pfNoJet.clone(
+pfCandsNotInJetsPtrForMetCorr = _pfNoJet.clone(
     topCollection = cms.InputTag('pfJetsPtrForMetCorr'),
     bottomCollection = cms.InputTag('particleFlowPtrs')
 )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import *
 from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import *
-from JetMETCorrections.Type1MET.correctedMet_cff import *
+from JetMETCorrections.Type1MET.correctedMet_cff import caloMetT1, caloMetT1T2, pfMetT1, pfMetT1T2
 #from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
 
 #from JetMETCorrections.Type1MET.pfMETCorrections_cff import *

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # load modules for producing Type 1 / Type 1 + 2 corrections for reco::PFMET objects
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import *
+from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 #from PhysicsTools.PatAlgos.producerLayer1.jetProducer_cfi import patJets
 


### PR DESCRIPTION
Note that the change in patPFMETCorrections_cff moves the
import * in the right direction and allows fixing the other
files, but leaves more work to be done elsewhere in another PR.