### PR TITLE
drop validation and Harvesting HLT sequences in FastSim

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1548,6 +1548,7 @@ steps['HARVESTCOS_UP17']={'-s'          :'HARVESTING:dqmHarvesting',
 steps['HARVESTFS']={'-s':'HARVESTING:validationHarvesting',
                    '--conditions':'auto:run1_mc',
                    '--mc':'',
+                    '--fast':'',
                     '--filetype':'DQM',
                    '--scenario':'pp'}
 steps['HARVESTHI']=merge([hiDefaults,{'-s':'HARVESTING:validationHarvesting+dqmHarvesting',
@@ -1588,6 +1589,7 @@ steps['HARVESTUP15_PPb']=merge([{'--conditions':'auto:run2_mc_pa','--era':'Run2_
 
 steps['HARVESTUP15FS']={'-s':'HARVESTING:validationHarvesting',
                         '--conditions':'auto:run2_mc',
+                        '--fast':'',
                         '--mc':'',
                         '--era':'Run2_2016',
                         '--filetype':'DQM',

--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -13,26 +13,56 @@ from Validation.RecoMET.METPostProcessor_cff import *
 
 dqmHarvesting = cms.Path(DQMOffline_SecondStep*DQMOffline_Certification)
 dqmHarvestingFakeHLT = cms.Path(DQMOffline_SecondStep_FakeHLT*DQMOffline_Certification)
+#dqmHarvesting = cms.Sequence(DQMOffline_SecondStep*DQMOffline_Certification)
+#dqmHarvestingFakeHLT = cms.Sequence(DQMOffline_SecondStep_FakeHLT*DQMOffline_Certification)
 
-dqmHarvestingPOG = cms.Path(DQMOffline_SecondStep_PrePOG)
+#dqmHarvestingPOG = cms.Path(DQMOffline_SecondStep_PrePOG)
+dqmHarvestingPOG = cms.Sequence(DQMOffline_SecondStep_PrePOG)
 
 dqmHarvestingPOGMC = cms.Path( DQMOffline_SecondStep_PrePOGMC )
+#dqmHarvestingPOGMC = cms.Sequence( DQMOffline_SecondStep_PrePOGMC )
 
+validationHarvestingNoHLT = cms.Path(postValidation*postValidation_gen)
 validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
+#validationHarvestingNoHLT = cms.Sequence(postValidation*postValidation_gen)
+#validationHarvesting = cms.Sequence(postValidation*hltpostvalidation*postValidation_gen)
 
+_validationHarvesting_fastsim = validationHarvesting.copy()
+for _entry in [hltpostvalidation]:
+    print 'dropping hltpostvalidation'
+    _validationHarvesting_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validationHarvesting,_validationHarvesting_fastsim)
+
+validationpreprodHarvestingNoHLT = cms.Path(postValidation_preprod*postValidation_gen)
 validationpreprodHarvesting = cms.Path(postValidation_preprod*hltpostvalidation_preprod*postValidation_gen)
+#validationpreprodHarvestingNoHLT = cms.Sequence(postValidation_preprod*postValidation_gen)
+#validationpreprodHarvesting = cms.Sequence(postValidation_preprod*hltpostvalidation_preprod*postValidation_gen)
+
+_validationpreprodHarvesting_fastsim = validationpreprodHarvesting.copy()
+for _entry in [hltpostvalidation_preprod]:
+    print 'dropping hltpostvalidation_preprod'
+    _validationpreprodHarvesting_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validationpreprodHarvesting,_validationpreprodHarvesting_fastsim)
+
 
 # empty (non-hlt) postvalidation sequence here yet
 validationprodHarvesting = cms.Path(hltpostvalidation_prod*postValidation_gen)
+#validationprodHarvesting = cms.Sequence(hltpostvalidation_prod*postValidation_gen)
 
 # to be removed in subsequent request
 # kept to avoid too many extra github signatures
 validationHarvestingFS = validationHarvesting.copy()
 
 validationHarvestingHI = cms.Path(postValidationHI)
+#validationHarvestingHI = cms.Sequence(postValidationHI)
 
 genHarvesting = cms.Path(postValidation_gen)
+#genHarvesting = cms.Sequence(postValidation_gen)
 
 alcaHarvesting = cms.Path()
+#alcaHarvesting = cms.Sequence()
 
 validationHarvestingMiniAOD = cms.Path(JetPostProcessor*METPostProcessorHarvesting*postValidationMiniAOD)
+#validationHarvestingMiniAOD = cms.Sequence(JetPostProcessor*METPostProcessorHarvesting*postValidationMiniAOD)

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -31,22 +31,30 @@ from Validation.RecoParticleFlow.miniAODValidation_cff import *
 from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
 from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 
+prevalidationNoHLT = cms.Sequence( globalPrevalidation * metPreValidSeq * jetPreValidSeq * cms.SequencePlaceholder("mix") )
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq * cms.SequencePlaceholder("mix") )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
 prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * egammaValidationMiniAOD)
 
+_prevalidation_fastsim = prevalidation.copy()
+for _entry in [hltassociation]:
+    _prevalidation_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(prevalidation,_prevalidation_fastsim)
 
-validation = cms.Sequence(
-                         genvalid_all
-                         *globaldigisanalyze
-                         *globalhitsanalyze
-                         *globalrechitsanalyze
-                         *globalValidation
+validationNoHLT = cms.Sequence(
+                               genvalid_all
+                               *globaldigisanalyze
+                               *globalhitsanalyze
+                               *globalrechitsanalyze
+                               *globalValidation)
+
+validation = cms.Sequence(validationNoHLT
                          *hltvalidation)
 
 _validation_fastsim = validation.copy()
-for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze]:
+for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze,hltvalidation]:
     _validation_fastsim.remove(_entry)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation,_validation_fastsim)
@@ -59,20 +67,40 @@ validationMiniAOD = cms.Sequence(type0PFMEtCorrectionPFCandToVertexAssociationFo
 
 prevalidation_preprod = cms.Sequence( preprodPrevalidation )
 
+validation_preprodNoHLT = cms.Sequence(
+                            genvalid_all
+                            +trackingTruthValid
+                            +tracksValidation
+                            +METRelValSequence
+                            +recoMuonValidation
+                            +muIsoVal_seq
+                            +muonIdValDQMSeq
+                          )
+
 validation_preprod = cms.Sequence(
-                          genvalid_all
-                          +trackingTruthValid
-                          +tracksValidation
-                          +METRelValSequence
-                          +recoMuonValidation
-                          +muIsoVal_seq
-                          +muonIdValDQMSeq
+                          validation_preprodNoHLT
                           +hltvalidation_preprod
                           )
 
+_validation_preprod_fastsim = validation_preprod.copy()
+for _entry in [hltvalidation_preprod]:
+    _validation_preprod_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validation_preprod,_validation_preprod_fastsim)
+
 validation.remove(condDataValidation)
-validation_prod = cms.Sequence(
+validation_prodNoHLT = cms.Sequence(
              genvalid_all
+            )
+
+validation_prod = cms.Sequence(
+             validation_prodNoHLT
             +hltvalidation_prod
             )
+
+_validation_prod_fastsim = validation_prodNoHLT.copy()
+for _entry in [hltvalidation_prod]:
+    _validation_prod_fastsim.remove(_entry)
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 


### PR DESCRIPTION
as agreed w/ PdmV, this PR is meant to drop the validation and Harvesting sequences related to the HLT from the standard workflow in FastSim

HLT step is still run in FastSim, because the step3 (miniAOD step) pretends to access to trigger info (patTrigger)

