### PR TITLE
Implement handling of edm::shutdown_flag in online DQM sources

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -4,6 +4,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 // #include "FWCore/Sources/interface/ProducerSourceBase.h"
 
 using namespace dqmservices;
@@ -32,6 +33,11 @@ edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
   for (;;) {
     fiterator_.update_state();
 
+    if (edm::shutdown_flag.load()) {
+      fiterator_.logFileAction("Shutdown flag was set, shutting down.");
+      return InputSource::IsStop;
+    }
+
     // check for end of run file and force quit
     if (flagEndOfRunKills_ && (fiterator_.state() != State::OPEN)) {
       return InputSource::IsStop;
@@ -51,8 +57,8 @@ edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
     fiterator_.delay();
     // BUG: for an unknown reason it fails after a certain time if we use
     // IsSynchronize state
+    //
     // comment out in order to block at this level
-    // the only downside is that we cannot Ctrl+C :)
     // return InputSource::IsSynchronize;
   }
 

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
@@ -207,6 +208,13 @@ bool DQMStreamerReader::prepareNextFile() {
 
   for (;;) {
     fiterator_.update_state();
+
+    if (edm::shutdown_flag.load()) {
+      fiterator_.logFileAction("Shutdown flag was set, shutting down.");
+
+      closeFile_("shutdown flag is set");
+      return false;
+    }
 
     // check for end of run file and force quit
     if (flagEndOfRunKills_ && (fiterator_.state() != State::OPEN)) {


### PR DESCRIPTION
The process now exits gracefully, the moment ctrl+c is pressed or on SIGUSR2.
Discussion: https://hypernews.cern.ch/HyperNews/CMS/get/dqmDevel/2359.html