### PR TITLE
More import * cleanup

### DIFF
--- a/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
@@ -1,13 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4CaloL2L3CorrectorChain, \
-                                                              ak4CaloL2RelativeCorrector, \
-                                                              ak4CaloL3AbsoluteCorrector, \
-                                                              ak4CaloL2L3Corrector, \
-                                                              ak4CaloL2L3ResidualCorrectorChain, \
-                                                              ak4CaloResidualCorrector, \
-                                                              ak4CaloL2L3ResidualCorrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 corrCaloMetType1 = cms.EDProducer(
     "CaloJetMETcorrInputProducer",

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
@@ -1,14 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3ResidualCorrectorChain, \
-                                                              ak4PFCHSL1FastjetCorrector, \
-                                                              ak4PFCHSL2RelativeCorrector, \
-                                                              ak4PFCHSL3AbsoluteCorrector, \
-                                                              ak4PFCHSResidualCorrector, \
-                                                              ak4PFCHSL1FastL2L3ResidualCorrector, \
-                                                              ak4PFCHSL1FastL2L3CorrectorChain, \
-                                                              ak4PFCHSL1FastL2L3Corrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 ##____________________________________________________________________________||
 # select PFCandidates ("unclustered energy") not within jets

--- a/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
+++ b/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
@@ -22,8 +22,8 @@ selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0 = cms.EDFilter("PATSingl
 from RecoParticleFlow.PFTracking.particleFlowDisplacedVertex_cfi import particleFlowDisplacedVertex
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 
-from CommonTools.RecoUtils.pfcand_assomap_cfi import PFCandAssoMap
-pfCandidateToVertexAssociation = PFCandAssoMap.clone(
+from CommonTools.RecoUtils.pfcand_assomap_cfi import PFCandAssoMap as _PFCandAssoMap
+pfCandidateToVertexAssociation = _PFCandAssoMap.clone(
     PFCandidateCollection = cms.InputTag('particleFlow'),
     UseBeamSpotCompatibility = cms.untracked.bool(True),
     ignoreMissingCollection = cms.bool(True)

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 # load modules for producing Type 1 / Type 1 + 2 corrections for reco::PFMET objects
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import *
-from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 #from PhysicsTools.PatAlgos.producerLayer1.jetProducer_cfi import patJets
 
@@ -59,39 +58,39 @@ patPFMetT2CorrSequence = cms.Sequence(patPFMetT2Corr)
 
 #--------------------------------------------------------------------------------
 # produce Type 0 MET corrections
-from JetMETCorrections.Type1MET.correctionTermsPfMetType0PFCandidate_cff import *
+from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
 patPFMetT0Corr = pfMETcorrType0.clone()
 patPFMetT0CorrSequence = cms.Sequence(type0PFMEtCorrectionPFCandToVertexAssociation*patPFMetT0Corr)
 #--------------------------------------------------------------------------------
 
 #--------------------------------------------------------------------------------
 # produce Type xy MET corrections
-from JetMETCorrections.Type1MET.pfMETmultShiftCorrections_cfi import *
+import JetMETCorrections.Type1MET.pfMETmultShiftCorrections_cfi as _shiftMod
 #dummy module
 
-patPFMetTxyCorr = pfMEtMultShiftCorr.clone()
+patPFMetTxyCorr = _shiftMod.pfMEtMultShiftCorr.clone()
 
-patMultPhiCorrParams_Txy_50ns         = cms.VPSet( [pset for pset in multPhiCorrParams_Txy_50ns])
-patMultPhiCorrParams_T0pcTxy_50ns     = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcTxy_50ns])
-patMultPhiCorrParams_T0pcT1Txy_50ns   = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1Txy_50ns])
-patMultPhiCorrParams_T0pcT1T2Txy_50ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1T2Txy_50ns])
-patMultPhiCorrParams_T1Txy_50ns       = cms.VPSet( [pset for pset in multPhiCorrParams_T1Txy_50ns])
-patMultPhiCorrParams_T1T2Txy_50ns     = cms.VPSet( [pset for pset in multPhiCorrParams_T1T2Txy_50ns])
-patMultPhiCorrParams_T1SmearTxy_50ns  = cms.VPSet( [pset for pset in multPhiCorrParams_T1Txy_50ns])
-patMultPhiCorrParams_T1T2SmearTxy_50ns = cms.VPSet( [pset for pset in multPhiCorrParams_T1T2Txy_50ns])
-patMultPhiCorrParams_T0pcT1SmearTxy_50ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1Txy_50ns])
-patMultPhiCorrParams_T0pcT1T2SmearTxy_50ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1T2Txy_50ns])
+patMultPhiCorrParams_Txy_50ns         = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_Txy_50ns])
+patMultPhiCorrParams_T0pcTxy_50ns     = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcTxy_50ns])
+patMultPhiCorrParams_T0pcT1Txy_50ns   = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1Txy_50ns])
+patMultPhiCorrParams_T0pcT1T2Txy_50ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1T2Txy_50ns])
+patMultPhiCorrParams_T1Txy_50ns       = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1Txy_50ns])
+patMultPhiCorrParams_T1T2Txy_50ns     = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1T2Txy_50ns])
+patMultPhiCorrParams_T1SmearTxy_50ns  = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1Txy_50ns])
+patMultPhiCorrParams_T1T2SmearTxy_50ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1T2Txy_50ns])
+patMultPhiCorrParams_T0pcT1SmearTxy_50ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1Txy_50ns])
+patMultPhiCorrParams_T0pcT1T2SmearTxy_50ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1T2Txy_50ns])
 
-patMultPhiCorrParams_Txy_25ns         = cms.VPSet( [pset for pset in multPhiCorrParams_Txy_25ns])
-patMultPhiCorrParams_T0pcTxy_25ns     = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcTxy_25ns])
-patMultPhiCorrParams_T0pcT1Txy_25ns   = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1Txy_25ns])
-patMultPhiCorrParams_T0pcT1T2Txy_25ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1T2Txy_25ns])
-patMultPhiCorrParams_T1Txy_25ns       = cms.VPSet( [pset for pset in multPhiCorrParams_T1Txy_25ns])
-patMultPhiCorrParams_T1T2Txy_25ns     = cms.VPSet( [pset for pset in multPhiCorrParams_T1T2Txy_25ns])
-patMultPhiCorrParams_T1SmearTxy_25ns  = cms.VPSet( [pset for pset in multPhiCorrParams_T1Txy_25ns])
-patMultPhiCorrParams_T1T2SmearTxy_25ns = cms.VPSet( [pset for pset in multPhiCorrParams_T1T2Txy_25ns])
-patMultPhiCorrParams_T0pcT1SmearTxy_25ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1Txy_25ns])
-patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns = cms.VPSet( [pset for pset in multPhiCorrParams_T0pcT1T2Txy_25ns])
+patMultPhiCorrParams_Txy_25ns         = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_Txy_25ns])
+patMultPhiCorrParams_T0pcTxy_25ns     = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcTxy_25ns])
+patMultPhiCorrParams_T0pcT1Txy_25ns   = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1Txy_25ns])
+patMultPhiCorrParams_T0pcT1T2Txy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1T2Txy_25ns])
+patMultPhiCorrParams_T1Txy_25ns       = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1Txy_25ns])
+patMultPhiCorrParams_T1T2Txy_25ns     = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1T2Txy_25ns])
+patMultPhiCorrParams_T1SmearTxy_25ns  = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1Txy_25ns])
+patMultPhiCorrParams_T1T2SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T1T2Txy_25ns])
+patMultPhiCorrParams_T0pcT1SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1Txy_25ns])
+patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1T2Txy_25ns])
 
 #from Configuration.StandardSequences.Eras import eras
 #eras.run2_50ns_specific.toModify(patPFMetTxyCorr, parameters=patMultPhiCorrParams_Txy_50ns )


### PR DESCRIPTION
Note part of this backs out some changes I made
yesterday. After more thinking and discussing this
with Chris I realized that we need the import *'s
in cases where sequences are imported. So I backed
out the part of the change related to JetCorrectors
since that involves importing sequences.