### PR TITLE
Extended Multifit functionality

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -29,9 +29,9 @@ class EcalUncalibRecHitMultiFitAlgo
   void disableErrorCalculation() { _computeErrors = false; }
   void setDoPrefit(bool b) { _doPrefit = b; }
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
-  void setDynamicPedestals(bool b=true) { _dynamicPedestals = b; }
-  void setMitigateBadSamples(bool b=true) { _mitigateBadSamples = b; }
-  void setSelectiveBadSampleCriteria(bool b=true) { _selectiveBadSampleCriteria = b; }
+  void setDynamicPedestals(bool b) { _dynamicPedestals = b; }
+  void setMitigateBadSamples(bool b) { _mitigateBadSamples = b; }
+  void setSelectiveBadSampleCriteria(bool b) { _selectiveBadSampleCriteria = b; }
   void setAddPedestalUncertainty(double x) { _addPedestalUncertainty = x; }
   void setSimplifiedNoiseModelForGainSwitch(bool b) { _simplifiedNoiseModelForGainSwitch = b; }
   

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -30,6 +30,7 @@ class EcalUncalibRecHitMultiFitAlgo
   void setDoPrefit(bool b) { _doPrefit = b; }
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
   void setDynamicPedestals(bool b=true) { _dynamicPedestals = b; }
+  void setMitigateBadSamples(bool b=true) { _mitigateBadSamples = b; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -31,7 +31,9 @@ class EcalUncalibRecHitMultiFitAlgo
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
   void setDynamicPedestals(bool b=true) { _dynamicPedestals = b; }
   void setMitigateBadSamples(bool b=true) { _mitigateBadSamples = b; }
+  void setSelectiveBadSampleCriteria(bool b=true) { _selectiveBadSampleCriteria = b; }
   void setAddPedestalUncertainty(double x) { _addPedestalUncertainty = x; }
+  void setSimplifiedNoiseModelForGainSwitch(bool b) { _simplifiedNoiseModelForGainSwitch = b; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;
@@ -41,7 +43,9 @@ class EcalUncalibRecHitMultiFitAlgo
    double _prefitMaxChiSq;
    bool _dynamicPedestals;
    bool _mitigateBadSamples;
+   bool _selectiveBadSampleCriteria;
    double _addPedestalUncertainty;
+   bool _simplifiedNoiseModelForGainSwitch;
    BXVector _singlebx;
 
 };

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -25,10 +25,11 @@ class EcalUncalibRecHitMultiFitAlgo
   
   EcalUncalibRecHitMultiFitAlgo();
   ~EcalUncalibRecHitMultiFitAlgo() { };
-  EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrix &noisecor, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
+  EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrixGainArray &noisecors, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
   void disableErrorCalculation() { _computeErrors = false; }
   void setDoPrefit(bool b) { _doPrefit = b; }
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
+  void setDynamicPedestals(bool b=true) { _dynamicPedestals = b; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;
@@ -36,6 +37,8 @@ class EcalUncalibRecHitMultiFitAlgo
    bool _computeErrors;
    bool _doPrefit;
    double _prefitMaxChiSq;
+   bool _dynamicPedestals;
+   bool _mitigateBadSamples;
    BXVector _singlebx;
 
 };

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -31,6 +31,7 @@ class EcalUncalibRecHitMultiFitAlgo
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
   void setDynamicPedestals(bool b=true) { _dynamicPedestals = b; }
   void setMitigateBadSamples(bool b=true) { _mitigateBadSamples = b; }
+  void setAddPedestalUncertainty(double x) { _addPedestalUncertainty = x; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;
@@ -40,6 +41,7 @@ class EcalUncalibRecHitMultiFitAlgo
    double _prefitMaxChiSq;
    bool _dynamicPedestals;
    bool _mitigateBadSamples;
+   double _addPedestalUncertainty;
    BXVector _singlebx;
 
 };

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -6,7 +6,7 @@
 
 constexpr int SampleVectorSize = 10;
 constexpr int FullSampleVectorSize = 19;
-constexpr int PulseVectorSize = 20;
+constexpr int PulseVectorSize = 24;
 constexpr int NGains = 3;
 
 typedef Eigen::Matrix<double,SampleVectorSize,1> SampleVector;

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -1,16 +1,30 @@
-#include <Eigen/Dense>
+#ifndef EigenMatrixTypes_h
+#define EigenMatrixTypes_h
 
-typedef Eigen::Matrix<double,10,1> SampleVector;
-typedef Eigen::Matrix<double,19,1> FullSampleVector;
-typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,10,1> PulseVector;
-typedef Eigen::Matrix<char,Eigen::Dynamic,1,0,10,1> BXVector;
-typedef Eigen::Matrix<double,10,10> SampleMatrix;
-typedef Eigen::Matrix<double,19,19> FullSampleMatrix;
-typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,10,10> PulseMatrix;
-typedef Eigen::Matrix<double,10,Eigen::Dynamic,0,10,10> SamplePulseMatrix;
+#include <Eigen/Dense>
+#include <array>
+
+constexpr int SampleVectorSize = 10;
+constexpr int FullSampleVectorSize = 19;
+constexpr int PulseVectorSize = 20;
+constexpr int NGains = 3;
+
+typedef Eigen::Matrix<double,SampleVectorSize,1> SampleVector;
+typedef Eigen::Matrix<double,FullSampleVectorSize,1> FullSampleVector;
+typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,PulseVectorSize,1> PulseVector;
+typedef Eigen::Matrix<char,Eigen::Dynamic,1,0,PulseVectorSize,1> BXVector;
+typedef Eigen::Matrix<char,SampleVectorSize,1> SampleGainVector;
+typedef Eigen::Matrix<double,SampleVectorSize,SampleVectorSize> SampleMatrix;
+typedef Eigen::Matrix<double,FullSampleVectorSize,FullSampleVectorSize> FullSampleMatrix;
+typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,PulseVectorSize,PulseVectorSize> PulseMatrix;
+typedef Eigen::Matrix<double,SampleVectorSize,Eigen::Dynamic,0,SampleVectorSize,PulseVectorSize> SamplePulseMatrix;
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
 typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
 
 typedef Eigen::Matrix<double,1,1> SingleMatrix;
 typedef Eigen::Matrix<double,1,1> SingleVector;
+
+typedef std::array<SampleMatrix,NGains> SampleMatrixGainArray;
+
+#endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -1,5 +1,5 @@
-#ifndef EigenMatrixTypes_h
-#define EigenMatrixTypes_h
+#ifndef RecoLocalCalo_EcalRecAlgos_EigenMatrixTypes_h
+#define RecoLocalCalo_EcalRecAlgos_EigenMatrixTypes_h
 
 #include <Eigen/Dense>
 #include <array>

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -6,7 +6,7 @@
 
 constexpr int SampleVectorSize = 10;
 constexpr int FullSampleVectorSize = 19;
-constexpr int PulseVectorSize = 24;
+constexpr int PulseVectorSize = 12;
 constexpr int NGains = 3;
 
 typedef Eigen::Matrix<double,SampleVectorSize,1> SampleVector;

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -16,7 +16,7 @@ class PulseChiSqSNNLS {
     ~PulseChiSqSNNLS();
     
     
-    bool DoFit(const SampleVector &samples, const SampleMatrix &samplecov, const SampleGainVector &gains, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov);
+    bool DoFit(const SampleVector &samples, const SampleMatrix &samplecov, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const SampleGainVector &gains = -1*SampleGainVector::Ones(), const SampleGainVector &badSamples = SampleGainVector::Zero());
     
     const SamplePulseMatrix &pulsemat() const { return _pulsemat; }
     const SampleMatrix &invcov() const { return _invcov; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -16,7 +16,7 @@ class PulseChiSqSNNLS {
     ~PulseChiSqSNNLS();
     
     
-    bool DoFit(const SampleVector &samples, const SampleMatrix &samplecor, double pederr, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov);
+    bool DoFit(const SampleVector &samples, const SampleMatrix &samplecov, const SampleGainVector &gains, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov);
     
     const SamplePulseMatrix &pulsemat() const { return _pulsemat; }
     const SampleMatrix &invcov() const { return _invcov; }
@@ -32,10 +32,10 @@ class PulseChiSqSNNLS {
 
   protected:
     
-    bool Minimize(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
+    bool Minimize(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
     bool NNLS();
     bool OnePulseMinimize();
-    bool updateCov(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
+    bool updateCov(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
     double ComputeChiSq();
     double ComputeApproxUncertainty(unsigned int ipulse);
     

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -34,6 +34,8 @@ class PulseChiSqSNNLS {
     
     bool Minimize(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
     bool NNLS();
+    void NNLSUnconstrainParameter(Index idxp);
+    void NNLSConstrainParameter(Index minratioidx);
     bool OnePulseMinimize();
     bool updateCov(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
     double ComputeChiSq();
@@ -60,7 +62,6 @@ class PulseChiSqSNNLS {
     SamplePulseMatrix invcovp;
     PulseMatrix aTamat;
     PulseVector aTbvec;
-    PulseVector wvec;
     PulseVector updatework;
     
     PulseVector ampvecpermtest;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
@@ -8,7 +8,9 @@
 EcalUncalibRecHitMultiFitAlgo::EcalUncalibRecHitMultiFitAlgo() : 
   _computeErrors(true),
   _doPrefit(false),
-  _prefitMaxChiSq(1.0) { 
+  _prefitMaxChiSq(1.0),
+  _dynamicPedestals(false),
+  _mitigateBadSamples(false) { 
     
   _singlebx.resize(1);
   _singlebx << 0;
@@ -20,18 +22,21 @@ EcalUncalibRecHitMultiFitAlgo::EcalUncalibRecHitMultiFitAlgo() :
 }
 
 /// compute rechits
-EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrix &noisecor, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX) {
+EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrixGainArray &noisecors, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX) {
 
   uint32_t flags = 0;
   
   const unsigned int nsample = EcalDataFrame::MAXSAMPLES;
   
   double maxamplitude = -std::numeric_limits<double>::max();
+  double maxgainratio = -std::numeric_limits<double>::max();
+  unsigned int iSampleMax = 0;
   
   double pedval = 0.;
-  double pedrms = 0.;
-  
+    
   SampleVector amplitudes;
+  SampleGainVector gainsNoise;
+  SampleGainVector gainsPedestal;
   for(unsigned int iSample = 0; iSample < nsample; iSample++) {
     
     const EcalMGPASample &sample = dataFrame.sample(iSample);
@@ -40,50 +45,107 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
     int gainId = sample.gainId();
     
     double pedestal = 0.;
-    double pederr = 0.;
     double gainratio = 1.;
         
     if (gainId==0 || gainId==3) {
       pedestal = aped->mean_x1;
-      pederr = aped->rms_x1;
       gainratio = aGain->gain6Over1()*aGain->gain12Over6();
+      gainsNoise[iSample] = 2;
+      gainsPedestal[iSample] = _dynamicPedestals ? 2 : -1;  //-1 for static pedestal
     }
     else if (gainId==1) {
       pedestal = aped->mean_x12;
-      pederr = aped->rms_x12;
       gainratio = 1.;
+      gainsNoise[iSample] = 0;
+      gainsPedestal[iSample] = _dynamicPedestals ? 0 : -1; //-1 for static pedestal
     }
     else if (gainId==2) {
       pedestal = aped->mean_x6;
-      pederr = aped->rms_x6;
       gainratio = aGain->gain12Over6();
+      gainsNoise[iSample] = 1;
+      gainsPedestal[iSample] = _dynamicPedestals ? 1 : -1; //-1 for static pedestals
     }
 
-    amplitude = ((double)(sample.adc()) - pedestal) * gainratio;
+    if (_dynamicPedestals) {
+      amplitude = (double)(sample.adc())*gainratio;
+    }
+    else {
+      amplitude = ((double)(sample.adc()) - pedestal) * gainratio;
+    }
     
     if (gainId == 0) {
       //saturation
-      amplitude = (4095. - pedestal) * gainratio;
+      if (_dynamicPedestals) {
+        amplitude = 4095.*gainratio;
+      }
+      else {
+        amplitude = (4095. - pedestal) * gainratio;
+      }
     }
         
     amplitudes[iSample] = amplitude;
     
-    if (amplitude>maxamplitude) {
+    if (gainratio > maxgainratio || gainId==0 || amplitude>maxamplitude) {
     //if (iSample==5) {
       maxamplitude = amplitude;
+      maxgainratio = gainratio;
+      iSampleMax = iSample;
       pedval = pedestal;
-      pedrms = pederr*gainratio;
-    }    
+    }
         
+  }
+  
+  bool hasGainSwitch = gainsNoise != SampleGainVector::Zero();
+  
+  //special handling for saturated samples, sample immediately before saturation or for
+  //case where maximum sample has gain switched but previous sample has not
+  //which is potentially affected by slew rate limitation (EB only)
+  //Amplitude is set to zero, and a floating negative single-sample offset is added to the fit
+  //to effectively remove the affected sample
+  if (_mitigateBadSamples && hasGainSwitch) {
+    bool isbarrel = dataFrame.id().subdetId()==EcalBarrel;
+    for(unsigned int iSample = 0; iSample < nsample; iSample++) {
+      int gainId = dataFrame.sample(iSample).gainId();
+      int gainIdNext = iSample<nsample ? dataFrame.sample(iSample+1).gainId() : gainId;
+      
+      bool isSaturated = gainId==0;
+      bool isNextSaturated = gainIdNext==0;
+      bool isSlewLimited = isbarrel && iSample==(iSampleMax-1) && gainsNoise.coeff(iSampleMax)>0 && gainsNoise.coeff(iSample)!=gainsNoise.coeff(iSampleMax);
+      
+      if (isSaturated || isNextSaturated || isSlewLimited) {
+        amplitudes[iSample] = 0.;
+        gainsPedestal[iSample]=3+iSample; //special gain index for per-sample dynamic pedestal
+      }
+    }
   }
   
   double amplitude, amperr, chisq;
   bool status = false;
   
+  //compute noise covariance matrix, which depends on the sample gains
+  SampleMatrix noisecov;
+  if (hasGainSwitch) {
+    std::array<double,3> pedrmss = {{aped->rms_x12, aped->rms_x6, aped->rms_x1}};
+    std::array<double,3> gainratios = {{ 1., aGain->gain12Over6(), aGain->gain6Over1()*aGain->gain12Over6()}};
+    noisecov = SampleMatrix::Zero();
+    for (unsigned int gainidx=0; gainidx<noisecors.size(); ++gainidx) {
+      SampleGainVector mask = gainidx*SampleGainVector::Ones();
+      SampleVector pedestal = (gainsNoise.array()==mask.array()).cast<SampleVector::value_type>();
+      if (pedestal.maxCoeff()>0.) {
+        //select out relevant components of each correlation matrix, and assume no correlation between samples with
+        //different gain
+        noisecov += gainratios[gainidx]*gainratios[gainidx]*pedrmss[gainidx]*pedrmss[gainidx]*pedestal.asDiagonal()*noisecors[gainidx]*pedestal.asDiagonal();
+      }
+    }
+  }
+  else {
+    noisecov = aped->rms_x12*aped->rms_x12*noisecors[0];
+  }
+  
   //optimized one-pulse fit for hlt
   bool usePrefit = false;
   if (_doPrefit) {
-    status = _pulsefuncSingle.DoFit(amplitudes,noisecor,pedrms,_singlebx,fullpulse,fullpulsecov);
+    status = _pulsefuncSingle.DoFit(amplitudes,noisecov,gainsPedestal,_singlebx,fullpulse,fullpulsecov);
     amplitude = status ? _pulsefuncSingle.X()[0] : 0.;
     amperr = status ? _pulsefuncSingle.Errors()[0] : 0.;
     chisq = _pulsefuncSingle.ChiSq();
@@ -96,7 +158,7 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   if (!usePrefit) {
   
     if(!_computeErrors) _pulsefunc.disableErrorCalculation();
-    status = _pulsefunc.DoFit(amplitudes,noisecor,pedrms,activeBX,fullpulse,fullpulsecov);
+    status = _pulsefunc.DoFit(amplitudes,noisecov,gainsPedestal,activeBX,fullpulse,fullpulsecov);
     chisq = _pulsefunc.ChiSq();
     
     if (!status) {
@@ -127,8 +189,11 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   if (!usePrefit) {
     for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
       int bx = _pulsefunc.BXs().coeff(ipulse);
-      if (bx!=0) {
+      if (bx!=0 && bx>-100) {
         rh.setOutOfTimeAmplitude(bx+5, status ? _pulsefunc.X().coeff(ipulse) : 0.);
+      }
+      else if (bx==(-100-gainsPedestal[iSampleMax])) {
+        rh.setPedestal(status ? _pulsefunc.X().coeff(ipulse) : 0.);
       }
     }
   }

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
@@ -187,25 +187,6 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   
   double jitter = 0.;
   
-//   if (hasGainSwitch) {
-//     for(unsigned int iSample = 0; iSample < nsample; iSample++) {
-//       const EcalMGPASample &sample = dataFrame.sample(iSample);
-//       
-//       int gainId = sample.gainId();
-//       int rawamplitude = sample.adc();
-//       
-//       printf("isample = %i, gainid = %i, rawamplitude = %i\n",int(iSample),gainId,rawamplitude);
-//       
-//     }
-//     for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
-//       printf("bx = %i, amplitude = %5f\n",_pulsefunc.BXs()[ipulse],_pulsefunc.X()[ipulse]);
-//     }
-//     printf("chisq = %5e\n",chisq);
-//   }
-  
-  //printf("status = %i\n",int(status));
-  //printf("amplitude = %5f +- %5f, chisq = %5f\n",amplitude,amperr,chisq);
-  
   EcalUncalibratedRecHit rh( dataFrame.id(), amplitude , pedval, jitter, chisq, flags );
   rh.setAmplitudeError(amperr);
   

--- a/RecoLocalCalo/EcalRecAlgos/src/EigenMatrixTypes.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EigenMatrixTypes.cc
@@ -1,0 +1,2 @@
+#include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
+

--- a/RecoLocalCalo/EcalRecAlgos/src/EigenMatrixTypes.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EigenMatrixTypes.cc
@@ -1,2 +1,0 @@
-#include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
-

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -52,6 +52,7 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   
   dynamicPedestals_ = ps.getParameter<bool>("dynamicPedestals");
   mitigateBadSamples_ = ps.getParameter<bool>("mitigateBadSamples");
+  addPedestalUncertainty_ = ps.getParameter<double>("addPedestalUncertainty");
 
   // algorithm to be used for timing
   auto const & timeAlgoName = ps.getParameter<std::string>("timealgo");
@@ -263,6 +264,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
 
         multiFitMethod_.setDynamicPedestals(dynamicPedestals_);
         multiFitMethod_.setMitigateBadSamples(mitigateBadSamples_);
+        multiFitMethod_.setAddPedestalUncertainty(addPedestalUncertainty_);
         
         if (detid.subdetId()==EcalEndcap) {
                 unsigned int hashedIndex = EEDetId(detid).hashedIndex();
@@ -582,6 +584,7 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<double>("prefitMaxChiSqEE", 10., true) and
 	      edm::ParameterDescription<bool>("dynamicPedestals", false, true) and
 	      edm::ParameterDescription<bool>("mitigateBadSamples", false, true) and
+	      edm::ParameterDescription<double>("addPedestalUncertainty", 0., true) and
 	      edm::ParameterDescription<std::string>("timealgo", "RatioMethod", true) and
 	      edm::ParameterDescription<std::vector<double>>("EBtimeFitParameters", {-2.015452e+00, 3.130702e+00, -1.234730e+01, 4.188921e+01, -8.283944e+01, 9.101147e+01, -5.035761e+01, 1.105621e+01}, true) and
 	      edm::ParameterDescription<std::vector<double>>("EEtimeFitParameters", {-2.390548e+00, 3.553628e+00, -1.762341e+01, 6.767538e+01, -1.332130e+02, 1.407432e+02, -7.541106e+01, 1.620277e+01}, true) and

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -23,10 +23,7 @@
 #include <FWCore/ParameterSet/interface/EmptyGroupDescription.h>
 
 EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet&ps,edm::ConsumesCollector& c) :
-  EcalUncalibRecHitWorkerBaseClass(ps,c),
-  noisecorEBg12(SampleMatrix::Zero()), noisecorEEg12(SampleMatrix::Zero()),
-  noisecorEBg6(SampleMatrix::Zero()), noisecorEEg6(SampleMatrix::Zero()),
-  noisecorEBg1(SampleMatrix::Zero()), noisecorEEg1(SampleMatrix::Zero())
+  EcalUncalibRecHitWorkerBaseClass(ps,c)
 {
 
   // get the BX for the pulses to be activated
@@ -52,6 +49,9 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
 
   prefitMaxChiSqEB_ = ps.getParameter<double>("prefitMaxChiSqEB");
   prefitMaxChiSqEE_ = ps.getParameter<double>("prefitMaxChiSqEE");
+  
+  dynamicPedestals_ = ps.getParameter<bool>("dynamicPedestals");
+  mitigateBadSamples_ = ps.getParameter<bool>("mitigateBadSamples");
 
   // algorithm to be used for timing
   auto const & timeAlgoName = ps.getParameter<std::string>("timealgo");
@@ -128,7 +128,14 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::EventSetup& es)
         // for the time correction methods
         es.get<EcalTimeBiasCorrectionsRcd>().get(timeCorrBias_);
 
-        int nnoise = noisecovariances->EBG12SamplesCorrelation.size();
+        int nnoise = SampleVector::RowsAtCompileTime;
+        SampleMatrix &noisecorEBg12 = noisecors_[1][0];
+        SampleMatrix &noisecorEBg6 = noisecors_[1][1];
+        SampleMatrix &noisecorEBg1 = noisecors_[1][2];
+        SampleMatrix &noisecorEEg12 = noisecors_[0][0];
+        SampleMatrix &noisecorEEg6 = noisecors_[0][1];
+        SampleMatrix &noisecorEEg1 = noisecors_[0][2];
+                
         for (int i=0; i<nnoise; ++i) {
           for (int j=0; j<nnoise; ++j) {
             int vidx = std::abs(j-i);
@@ -322,16 +329,9 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         } else {
                 // multifit
                 bool barrel = detid.subdetId()==EcalBarrel;
-                int gain = 2;
-                if (((EcalDataFrame)(*itdg)).hasSwitchToGain6()) {
-                  gain = 1;
-                }
-                if (((EcalDataFrame)(*itdg)).hasSwitchToGain1()) {
-                  gain = 0;
-                }
-                const SampleMatrix &noisecormat = noisecor(barrel,gain);
+                const SampleMatrixGainArray &noisecors = noisecor(barrel);
                                 
-                uncalibRecHit = multiFitMethod_.makeRecHit(*itdg, aped, aGain, noisecormat,fullpulse,fullpulsecov,activeBX);
+                uncalibRecHit = multiFitMethod_.makeRecHit(*itdg, aped, aGain, noisecors,fullpulse,fullpulsecov,activeBX);
                 
                 // === time computation ===
                 if(timealgo_==ratioMethod) {
@@ -577,6 +577,8 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<bool>("doPrefitEE", false, true) and
 	      edm::ParameterDescription<double>("prefitMaxChiSqEB", 25., true) and
 	      edm::ParameterDescription<double>("prefitMaxChiSqEE", 10., true) and
+	      edm::ParameterDescription<bool>("dynamicPedestals", false, true) and
+	      edm::ParameterDescription<bool>("mitigateBadSamples", false, true) and
 	      edm::ParameterDescription<std::string>("timealgo", "RatioMethod", true) and
 	      edm::ParameterDescription<std::vector<double>>("EBtimeFitParameters", {-2.015452e+00, 3.130702e+00, -1.234730e+01, 4.188921e+01, -8.283944e+01, 9.101147e+01, -5.035761e+01, 1.105621e+01}, true) and
 	      edm::ParameterDescription<std::vector<double>>("EEtimeFitParameters", {-2.390548e+00, 3.553628e+00, -1.762341e+01, 6.767538e+01, -1.332130e+02, 1.407432e+02, -7.541106e+01, 1.620277e+01}, true) and

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -261,6 +261,9 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         const EcalPulseShapes::Item * aPulse = 0;
         const EcalPulseCovariances::Item * aPulseCov = 0;
 
+        multiFitMethod_.setDynamicPedestals(dynamicPedestals_);
+        multiFitMethod_.setMitigateBadSamples(mitigateBadSamples_);
+        
         if (detid.subdetId()==EcalEndcap) {
                 unsigned int hashedIndex = EEDetId(detid).hashedIndex();
                 aped      = &peds->endcap(hashedIndex);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -60,18 +60,11 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 double timeCorrection(float ampli,
                     const std::vector<float>& amplitudeBins, const std::vector<float>& shiftBins);
 
-                const SampleMatrix & noisecor(bool barrel, int gain) const { return *noisecors[barrel?1:0][gain];} 
+                const SampleMatrix & noisecor(bool barrel, int gain) const { return noisecors_[barrel?1:0][gain];}
+                const SampleMatrixGainArray &noisecor(bool barrel) const { return noisecors_[barrel?1:0]; }
                 
                 // multifit method
-                SampleMatrix noisecorEBg12;
-                SampleMatrix noisecorEEg12;
-                SampleMatrix noisecorEBg6;
-                SampleMatrix noisecorEEg6;
-                SampleMatrix noisecorEBg1;
-                SampleMatrix noisecorEEg1;
-                SampleMatrix const * const noisecors[2][3] = 
-                       { {&noisecorEEg1, &noisecorEEg6, &noisecorEEg12}, 
-                         {&noisecorEBg1, &noisecorEBg6, &noisecorEBg12}};
+                std::array<SampleMatrixGainArray, 2> noisecors_;
                 BXVector activeBX;
                 bool ampErrorCalculation_;
                 bool useLumiInfoRunHeader_;
@@ -97,6 +90,8 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 bool doPrefitEE_;
 		double prefitMaxChiSqEB_;
 		double prefitMaxChiSqEE_;
+                bool dynamicPedestals_;
+                bool mitigateBadSamples_;
 
                 // ratio method
                 std::vector<double> EBtimeFitParameters_; 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -90,9 +90,15 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 bool doPrefitEE_;
 		double prefitMaxChiSqEB_;
 		double prefitMaxChiSqEE_;
-                bool dynamicPedestals_;
-                bool mitigateBadSamples_;
-                double addPedestalUncertainty_;
+                bool dynamicPedestalsEB_;
+                bool dynamicPedestalsEE_;
+                bool mitigateBadSamplesEB_;
+                bool mitigateBadSamplesEE_;
+                bool selectiveBadSampleCriteriaEB_;
+                bool selectiveBadSampleCriteriaEE_;
+                double addPedestalUncertaintyEB_;
+                double addPedestalUncertaintyEE_;
+                bool simplifiedNoiseModelForGainSwitch_;
 
                 // ratio method
                 std::vector<double> EBtimeFitParameters_; 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -92,6 +92,7 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
 		double prefitMaxChiSqEE_;
                 bool dynamicPedestals_;
                 bool mitigateBadSamples_;
+                double addPedestalUncertainty_;
 
                 // ratio method
                 std::vector<double> EBtimeFitParameters_; 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -19,6 +19,9 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       doPrefitEE = cms.bool(False),
       prefitMaxChiSqEB = cms.double(25.),
       prefitMaxChiSqEE = cms.double(10.),
+      
+      dynamicPedestals = cms.bool(True),
+      mitigateBadSamples = cms.bool(True),
   
       # decide which algorithm to be use to calculate the jitter
       timealgo = cms.string("RatioMethod"),

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -20,9 +20,15 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       prefitMaxChiSqEB = cms.double(25.),
       prefitMaxChiSqEE = cms.double(10.),
       
-      dynamicPedestals = cms.bool(False),
-      mitigateBadSamples = cms.bool(True),
-      addPedestalUncertainty = cms.double(0.),
+      dynamicPedestalsEB = cms.bool(False),
+      dynamicPedestalsEE = cms.bool(False),
+      mitigateBadSamplesEB = cms.bool(False),
+      mitigateBadSamplesEE = cms.bool(False),
+      selectiveBadSampleCriteriaEB = cms.bool(False),
+      selectiveBadSampleCriteriaEE = cms.bool(False),
+      simplifiedNoiseModelForGainSwitch = cms.bool(True),
+      addPedestalUncertaintyEB = cms.double(0.),
+      addPedestalUncertaintyEE = cms.double(0.),
   
       # decide which algorithm to be use to calculate the jitter
       timealgo = cms.string("RatioMethod"),

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -20,7 +20,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       prefitMaxChiSqEB = cms.double(25.),
       prefitMaxChiSqEE = cms.double(10.),
       
-      dynamicPedestals = cms.bool(True),
+      dynamicPedestals = cms.bool(False),
       mitigateBadSamples = cms.bool(True),
       addPedestalUncertainty = cms.double(0.),
   

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -22,6 +22,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       
       dynamicPedestals = cms.bool(True),
       mitigateBadSamples = cms.bool(True),
+      addPedestalUncertainty = cms.double(0.),
   
       # decide which algorithm to be use to calculate the jitter
       timealgo = cms.string("RatioMethod"),


### PR DESCRIPTION
Extends ecal multifit functionality with possibility for

1) Dynamic pedestals
2) Inflated pedestal uncertainty at level of python configuration
3) Better handling of noise covariance matrix for gain switch rechits
4) Ability to remove single sample from the fit to mitigate slew rate limitation

More information and background in
https://indico.cern.ch/event/600314/contributions/2441465/attachments/1398120/2132187/multifit-Jan18-2017.pdf

All of the new options are disabled by default, and therefore this pull request is expected to give 1:1 identical results for all standard workflows (including HLT).  There may be a small cpu and/or memory increase as the size on the stack of some of the matrix types have been increased to accommodate the new functionality.

This should not necessarily be merged yet, pending further tests and understanding of plans for 2017 data/mc, but want to at least run through the automated tests and verify 1:1 identity with present settings.

@emanueledimarco @amassiro @lgray @VinInn 