### PR TITLE
[WIP] Replace throw specifier (deprecated) with noexcept (C++11)

### DIFF
--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -89,6 +89,7 @@ namespace edm {
       class RunCacheHolder : public virtual T {
       public:
         RunCacheHolder() = default;
+        ~RunCacheHolder() noexcept(false);
         RunCacheHolder( RunCacheHolder<T,C> const&) = delete;
         RunCacheHolder<T,C>& operator=(RunCacheHolder<T,C> const&) = delete;
       protected:

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -55,6 +55,7 @@ namespace edm {
       class RunCacheHolder {
       public:
         RunCacheHolder() = default;
+        ~RunCacheHolder() noexcept(false);
         RunCacheHolder( RunCacheHolder<C> const&) = delete;
         RunCacheHolder<C>& operator=(RunCacheHolder<C> const&) = delete;
         void setRunCache(C const* iCache) { cache_=iCache; }

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -48,6 +48,7 @@ struct UnsafeCache {
 };
 
 struct Dummy {
+  ~Dummy() noexcept(false) {};
 };
 
 } //end anonymous namespace

--- a/OnlineDB/CSCCondDB/interface/CSCCableRead.h
+++ b/OnlineDB/CSCCondDB/interface/CSCCableRead.h
@@ -16,11 +16,11 @@ class csccableread
   /**
    * Constructor for csccableread
    */
-  csccableread () throw (oracle::occi::SQLException);
+  csccableread () noexcept(false);
   /**
    * Destructor for cscmap
    */
-  ~csccableread () throw (oracle::occi::SQLException);
+  ~csccableread () noexcept(false);
 
 void cable_read (int chamber_index, std::string *chamber_label,
      float *cfeb_length, std::string *cfeb_rev, float *alct_length,

--- a/OnlineDB/CSCCondDB/interface/CSCMap.h
+++ b/OnlineDB/CSCCondDB/interface/CSCMap.h
@@ -16,11 +16,11 @@ class cscmap
   /**
    * Constructor for cscmap
    */
-  cscmap () throw (oracle::occi::SQLException);
+  cscmap () noexcept(false);
   /**
    * Destructor for cscmap
    */
-  ~cscmap () throw (oracle::occi::SQLException);
+  ~cscmap () noexcept(false);
 
 /*  Method 'crate0_chamber' returns for a given logical crate
 |   number 'crate0' (values 0-59) and DMB number 'dmb' 

--- a/OnlineDB/CSCCondDB/interface/CSCMap1.h
+++ b/OnlineDB/CSCCondDB/interface/CSCMap1.h
@@ -17,11 +17,11 @@ class cscmap1
   /**
    * Constructor for cscmap1
    */
-  cscmap1 () throw (oracle::occi::SQLException);
+  cscmap1 () noexcept(false);
   /**
    * Destructor for cscmap1
    */
-  ~cscmap1 () throw (oracle::occi::SQLException);
+  ~cscmap1 () noexcept(false);
 
   /* 'chamberid' is a decimal chamber identifier like 122090 */
   void chamber (int chamberid, CSCMapItem::MapItem *item);

--- a/OnlineDB/CSCCondDB/interface/CSCOnlineDB.h
+++ b/OnlineDB/CSCCondDB/interface/CSCOnlineDB.h
@@ -26,11 +26,11 @@ class condbon
   /**
    * Constructor for condbon
    */
-  condbon () throw (oracle::occi::SQLException);
+  condbon () noexcept(false);
   /**
    * Destructor for condbon
    */
-  ~condbon () throw (oracle::occi::SQLException);
+  ~condbon () noexcept(false);
 /* time should be given in format like "Fri May 26 16:55:51 2006" */
   void cdbon_write (CSCobject *obj, std::string obj_name, int record,
                     int global_run, std::string time);

--- a/OnlineDB/CSCCondDB/src/CSCCableRead.cc
+++ b/OnlineDB/CSCCondDB/src/CSCCableRead.cc
@@ -4,7 +4,7 @@
   /**
    * Constructor for csccableread
    */
-  csccableread::csccableread () throw (oracle::occi::SQLException)
+  csccableread::csccableread () noexcept(false)
   {
     std::string db_user;
     std::string db_pass;
@@ -19,7 +19,7 @@
   /**
    * Destructor for csccableread.
    */
-  csccableread::~csccableread () throw (oracle::occi::SQLException)
+  csccableread::~csccableread () noexcept(false)
   {
     env->terminateConnection (con);
     oracle::occi::Environment::terminateEnvironment (env);

--- a/OnlineDB/CSCCondDB/src/CSCMap.cc
+++ b/OnlineDB/CSCCondDB/src/CSCMap.cc
@@ -4,7 +4,7 @@
   /**
    * Constructor for cscmap
    */
-  cscmap::cscmap () throw (oracle::occi::SQLException)
+  cscmap::cscmap () noexcept(false)
   {
     std::string db_user;
     std::string db_pass;
@@ -19,7 +19,7 @@
   /**
    * Destructor for cscmap.
    */
-  cscmap::~cscmap () throw (oracle::occi::SQLException)
+  cscmap::~cscmap () noexcept(false)
   {
     env->terminateConnection (con);
     oracle::occi::Environment::terminateEnvironment (env);

--- a/OnlineDB/CSCCondDB/src/CSCMap1.cc
+++ b/OnlineDB/CSCCondDB/src/CSCMap1.cc
@@ -4,7 +4,7 @@
   /**
    * Constructor for cscmap1
    */
-  cscmap1::cscmap1 () throw (oracle::occi::SQLException)
+  cscmap1::cscmap1 () noexcept(false)
   {
     std::string db_user;
     std::string db_pass;
@@ -20,7 +20,7 @@
   /**
    * Destructor for cscmap1.
    */
-  cscmap1::~cscmap1 () throw (oracle::occi::SQLException)
+  cscmap1::~cscmap1 () noexcept(false)
   {
     env->terminateConnection (con);
     oracle::occi::Environment::terminateEnvironment (env);

--- a/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
+++ b/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
@@ -3,7 +3,7 @@
   /**
    * Constructor for condbon
    */
-  condbon::condbon () throw (oracle::occi::SQLException)
+  condbon::condbon () noexcept(false)
   {
     std::string db_user;
     std::string db_pass;
@@ -18,7 +18,7 @@
   /**
    * Destructor for condbon.
    */
-  condbon::~condbon () throw (oracle::occi::SQLException)
+  condbon::~condbon () noexcept(false)
   {
     env->terminateConnection (con);
     oracle::occi::Environment::terminateEnvironment (env);

--- a/OnlineDB/EcalCondDB/interface/CaliCrystalIntercalDat.h
+++ b/OnlineDB/EcalCondDB/interface/CaliCrystalIntercalDat.h
@@ -32,16 +32,16 @@ class CaliCrystalIntercalDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
   
   void writeDB(const EcalLogicID* ecid, const CaliCrystalIntercalDat* item, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   void fetchData(std::map< EcalLogicID, CaliCrystalIntercalDat >* fillVec, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, CaliCrystalIntercalDat >* data, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   

--- a/OnlineDB/EcalCondDB/interface/CaliGainRatioDat.h
+++ b/OnlineDB/EcalCondDB/interface/CaliGainRatioDat.h
@@ -29,16 +29,16 @@ class CaliGainRatioDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
   
   void writeDB(const EcalLogicID* ecid, const CaliGainRatioDat* item, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   void fetchData(std::map< EcalLogicID, CaliGainRatioDat >* fillVec, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, CaliGainRatioDat >* data, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   // User data
   float m_g1_g12;

--- a/OnlineDB/EcalCondDB/interface/CaliGeneralDat.h
+++ b/OnlineDB/EcalCondDB/interface/CaliGeneralDat.h
@@ -26,13 +26,13 @@ class CaliGeneralDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
   
   void writeDB(const EcalLogicID* ecid, const CaliGeneralDat* item, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   void fetchData(std::map< EcalLogicID, CaliGeneralDat >* fillVec, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   // User data
   int m_numEvents;

--- a/OnlineDB/EcalCondDB/interface/CaliHVScanRatioDat.h
+++ b/OnlineDB/EcalCondDB/interface/CaliHVScanRatioDat.h
@@ -29,13 +29,13 @@ class CaliHVScanRatioDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
   
   void writeDB(const EcalLogicID* ecid, const CaliHVScanRatioDat* item, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   void fetchData(std::map< EcalLogicID, CaliHVScanRatioDat >* fillVec, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   // User data
   float m_hvratio;

--- a/OnlineDB/EcalCondDB/interface/CaliIOV.h
+++ b/OnlineDB/EcalCondDB/interface/CaliIOV.h
@@ -29,8 +29,8 @@ class CaliIOV : public IIOV {
 
   // Methods from IUniqueDBObject
   int getID(){ return m_ID;} ;
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const CaliIOV &m) const
@@ -49,8 +49,8 @@ class CaliIOV : public IIOV {
   Tm m_till;
   CaliTag m_caliTag;
 
-  int writeDB() throw(std::runtime_error);
-  void setByTm(CaliTag* tag, const Tm& time) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void setByTm(CaliTag* tag, const Tm& time) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/CaliTag.h
+++ b/OnlineDB/EcalCondDB/interface/CaliTag.h
@@ -36,8 +36,8 @@ class CaliTag : public ITag {
 
 
   // Methods using ID
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const CaliTag &t) const 
@@ -57,11 +57,11 @@ class CaliTag : public ITag {
   std::string m_dataType;
 
   // Methods from ITag
-  int writeDB() throw(std::runtime_error);
-  void fetchParentIDs(int* locId) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void fetchParentIDs(int* locId) noexcept(false);
 
   // Public access methods
-  void fetchAllTags( std::vector<CaliTag>* fillVec) throw(std::runtime_error);
+  void fetchAllTags( std::vector<CaliTag>* fillVec) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/CaliTempDat.h
+++ b/OnlineDB/EcalCondDB/interface/CaliTempDat.h
@@ -32,16 +32,16 @@ class CaliTempDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
   
   void writeDB(const EcalLogicID* ecid, const CaliTempDat* item, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   
   void fetchData(std::map< EcalLogicID, CaliTempDat >* fillVec, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, CaliTempDat >* data, CaliIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   

--- a/OnlineDB/EcalCondDB/interface/DCSPTMTempList.h
+++ b/OnlineDB/EcalCondDB/interface/DCSPTMTempList.h
@@ -24,8 +24,8 @@ class DCSPTMTempList  : public IDBObject {
   std::vector<DCSPTMTemp> getList() ;
   
   // this fills the vector 
-  void fetchValuesForECIDAndTime(const EcalLogicID& ecid, const Tm& start, const Tm& end) throw(std::runtime_error);
-  void fetchValuesForECID(const EcalLogicID& ecid) throw(std::runtime_error);
+  void fetchValuesForECIDAndTime(const EcalLogicID& ecid, const Tm& start, const Tm& end) noexcept(false);
+  void fetchValuesForECID(const EcalLogicID& ecid) noexcept(false);
 
 
  private:

--- a/OnlineDB/EcalCondDB/interface/DCUCCSDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUCCSDat.h
@@ -83,16 +83,16 @@ class DCUCCSDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUCCSDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUCCSDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCUCCSDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_m1_vdd1;

--- a/OnlineDB/EcalCondDB/interface/DCUCapsuleTempDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUCapsuleTempDat.h
@@ -23,16 +23,16 @@ class DCUCapsuleTempDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUCapsuleTempDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTempDat>* data, DCUIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCUCapsuleTempDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_capsuleTemp;

--- a/OnlineDB/EcalCondDB/interface/DCUCapsuleTempRawDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUCapsuleTempRawDat.h
@@ -26,16 +26,16 @@ class DCUCapsuleTempRawDat : public IDataItem {
    
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUCapsuleTempRawDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTempRawDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCUCapsuleTempRawDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_capsuleTempADC;

--- a/OnlineDB/EcalCondDB/interface/DCUIDarkDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUIDarkDat.h
@@ -23,17 +23,17 @@ class DCUIDarkDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUIDarkDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUIDarkDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, DCUIDarkDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_apdIDark;

--- a/OnlineDB/EcalCondDB/interface/DCUIDarkPedDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUIDarkPedDat.h
@@ -23,16 +23,16 @@ class DCUIDarkPedDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUIDarkPedDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUIDarkPedDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCUIDarkPedDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_ped;

--- a/OnlineDB/EcalCondDB/interface/DCUIOV.h
+++ b/OnlineDB/EcalCondDB/interface/DCUIOV.h
@@ -27,8 +27,8 @@ class DCUIOV : public IIOV {
 
   // Methods from IUniqueDBObject
   int getID(){ return m_ID;} ;
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const DCUIOV &m) const
@@ -47,8 +47,8 @@ class DCUIOV : public IIOV {
   Tm m_till;
   DCUTag m_dcuTag;
 
-  int writeDB() throw(std::runtime_error);
-  void setByTm(DCUTag* tag, const Tm& time) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void setByTm(DCUTag* tag, const Tm& time) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/DCULVRBTempsDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCULVRBTempsDat.h
@@ -30,16 +30,16 @@ class DCULVRBTempsDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCULVRBTempsDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCULVRBTempsDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCULVRBTempsDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_t1;

--- a/OnlineDB/EcalCondDB/interface/DCULVRTempsDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCULVRTempsDat.h
@@ -30,16 +30,16 @@ class DCULVRTempsDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCULVRTempsDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCULVRTempsDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCULVRTempsDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_t1;

--- a/OnlineDB/EcalCondDB/interface/DCULVRVoltagesDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCULVRVoltagesDat.h
@@ -66,16 +66,16 @@ class DCULVRVoltagesDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCULVRVoltagesDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCULVRVoltagesDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCULVRVoltagesDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_vfe1_A;

--- a/OnlineDB/EcalCondDB/interface/DCUTag.h
+++ b/OnlineDB/EcalCondDB/interface/DCUTag.h
@@ -26,8 +26,8 @@ class DCUTag : public ITag {
   void setLocationDef(const LocationDef& locDef);
 
   // Methods using ID
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const DCUTag &t) const 
@@ -45,11 +45,11 @@ class DCUTag : public ITag {
 
 
   // Methods from ITag
-  int writeDB() throw(std::runtime_error);
-  void fetchParentIDs(int* locId) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void fetchParentIDs(int* locId) noexcept(false);
 
   // Public access methods
-  void fetchAllTags( std::vector<DCUTag>* fillVec) throw(std::runtime_error);
+  void fetchAllTags( std::vector<DCUTag>* fillVec) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/DCUVFETempDat.h
+++ b/OnlineDB/EcalCondDB/interface/DCUVFETempDat.h
@@ -23,16 +23,16 @@ class DCUVFETempDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const DCUVFETempDat* item, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, DCUVFETempDat>* data, DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, DCUVFETempDat >* fillVec, DCUIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_vfeTemp;

--- a/OnlineDB/EcalCondDB/interface/EcalCommon.h
+++ b/OnlineDB/EcalCondDB/interface/EcalCommon.h
@@ -18,7 +18,7 @@ class EcalCommon {
    *  Convert a supermodule crystal number to a trigger tower number
    */
   static int crystalToTriggerTower( int xtal )
-    throw(std::runtime_error);
+    noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h
+++ b/OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h
@@ -89,7 +89,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    * Destructor
    */
   virtual ~EcalCondDBInterface()
-    throw(std::runtime_error)
+    noexcept(false)
     {
       // call the parent destructor
       
@@ -120,7 +120,7 @@ class EcalCondDBInterface : public EcalDBConnection {
 			      int id2 = EcalLogicID::NULLID,
 			      int id3 = EcalLogicID::NULLID,
 			      std::string mapsTo = "" )
-    throw(std::runtime_error);
+    noexcept(false);
 
   /**
    *  Build various reverse maps
@@ -142,7 +142,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    *  logicID:  DB logic_id
    */
   EcalLogicID getEcalLogicID( int logicID )
-    throw(std::runtime_error);
+    noexcept(false);
 
   /**
    *  Get a set of EcalLogicID in one transaction
@@ -158,56 +158,56 @@ class EcalCondDBInterface : public EcalDBConnection {
 					      int fromId2 = EcalLogicID::NULLID, int toId2 = EcalLogicID::NULLID,
 					      int fromId3 = EcalLogicID::NULLID, int toId3 = EcalLogicID::NULLID,
 					      std::string mapsTo = "" )
-    throw(std::runtime_error);
+    noexcept(false);
 
   std::map<int, int> getEcalLogicID2LmrMap();
   std::vector<EcalLogicID> getEcalLogicIDSetOrdered( std::string name,
 						     int fromId1, int toId1,
 						     int fromId2 = EcalLogicID::NULLID, int toId2 = EcalLogicID::NULLID,
 						     int fromId3 = EcalLogicID::NULLID, int toId3 = EcalLogicID::NULLID,
-						     std::string mapsTo = "", int orderedBy= EcalLogicID::NULLID ) throw(std::runtime_error);
+						     std::string mapsTo = "", int orderedBy= EcalLogicID::NULLID ) noexcept(false);
 
 
   /**
    *  Insert a run IOV object.  Nothing is committed in the event of an exception
    */
   void insertRunIOV(RunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   // updates the end time of an iov
   void updateRunIOV(RunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void updateRunIOVStartTime(RunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void updateRunIOVEndTime(RunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
-  void updateRunConfig(ODRunConfigInfo* od) throw(std::runtime_error);
+  void updateRunConfig(ODRunConfigInfo* od) noexcept(false);
 
   void insertLmfIOV(LMFIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void insertLmfLmrSubIOV(LMFLmrSubIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void insertLmfSeq(LMFSeqDat* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void insertLmfRunIOV(LMFRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
   void insertLmfDat(LMFDat* dat)
-    throw(std::runtime_error);
+    noexcept(false);
   void insertLmfDat(std::list<LMFDat*> dat)
-    throw(std::runtime_error);
+    noexcept(false);
 
   /**
    *  Return run Fe Config Dat objects for a given run
    */
 
   std::list<ODDelaysDat> fetchFEDelaysForRun(RunIOV *iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   /**
    *  Return a run IOV object for a given tag
    */
   RunIOV fetchRunIOV(RunTag* tag, run_t run)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
 
@@ -217,10 +217,10 @@ class EcalCondDBInterface : public EcalDBConnection {
    *  so an exception is thrown if more than one result exists.
    */
   RunIOV fetchRunIOV(std::string location, run_t run)
-    throw(std::runtime_error);
+    noexcept(false);
 
   RunIOV fetchRunIOV(std::string location, const Tm &t)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
 
@@ -228,28 +228,28 @@ class EcalCondDBInterface : public EcalDBConnection {
    *  Insert a monitoring run object.  Nothing is committed in the event of an exception
    */
   void insertMonRunIOV(MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   /**
    *  Insert a DCU IOV object.  Nothing is committed in the event of an exception
    */
   void insertDCUIOV(DCUIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   /**
    *  Return a monitoring run object
    */
   MonRunIOV fetchMonRunIOV(RunTag* runtag, MonRunTag* montag, run_t run, subrun_t monrun)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   /**
    *   Return a DCU IOV object
    */
   DCUIOV fetchDCUIOV(DCUTag* tag, const Tm& evenTm)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
 
@@ -257,7 +257,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    *  Return a laser monitoring farm run object
    */
   LMFRunIOV fetchLMFRunIOV(RunTag* runtag, LMFRunTag* lmftag, run_t run, subrun_t lmfrun)
-    throw(std::runtime_error);
+    noexcept(false);
   bool fetchLMFRunIOV(const LMFSeqDat&, LMFRunIOV&, int lmr, int type, 
 		      int color) const;
   RunIOV fetchLMFLastRun() const; 
@@ -266,30 +266,30 @@ class EcalCondDBInterface : public EcalDBConnection {
    *   Return a Calibration IOV object
    */
   CaliIOV fetchCaliIOV(CaliTag* tag, const Tm& evenTm)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
  /**
    *   Return a Run List
    */
-  RunList fetchRunList(const RunTag& tag) throw(std::runtime_error);
-  RunList fetchRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error);
-  RunList fetchNonEmptyRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error);
-  RunList fetchNonEmptyGlobalRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error);
-  RunList fetchRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) throw(std::runtime_error);
-  RunList fetchGlobalRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) throw(std::runtime_error);
-  RunList fetchRunListLastNRuns(const RunTag& tag, int max_run, int n_runs) throw(std::runtime_error);
+  RunList fetchRunList(const RunTag& tag) noexcept(false);
+  RunList fetchRunList(const RunTag& tag, int min_run, int max_run) noexcept(false);
+  RunList fetchNonEmptyRunList(const RunTag& tag, int min_run, int max_run) noexcept(false);
+  RunList fetchNonEmptyGlobalRunList(const RunTag& tag, int min_run, int max_run) noexcept(false);
+  RunList fetchRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) noexcept(false);
+  RunList fetchGlobalRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) noexcept(false);
+  RunList fetchRunListLastNRuns(const RunTag& tag, int max_run, int n_runs) noexcept(false);
 
  /**
    *   Return a PTM Temp List
    */
 
-  DCSPTMTempList fetchDCSPTMTempList(const EcalLogicID& ecid)  throw(std::runtime_error);
-  DCSPTMTempList fetchDCSPTMTempList(const EcalLogicID& ecid, const Tm& start, const Tm& end) throw(std::runtime_error);
+  DCSPTMTempList fetchDCSPTMTempList(const EcalLogicID& ecid)  noexcept(false);
+  DCSPTMTempList fetchDCSPTMTempList(const EcalLogicID& ecid, const Tm& start, const Tm& end) noexcept(false);
 
-  MonRunList fetchMonRunList(const RunTag& tag, const MonRunTag& monruntag) throw(std::runtime_error);
-  MonRunList fetchMonRunList(const RunTag& tag, const MonRunTag& monruntag,int min_run, int max_run) throw(std::runtime_error);
-  MonRunList fetchMonRunListLastNRuns(const RunTag& tag, const MonRunTag& monruntag, int max_run, int n_runs) throw(std::runtime_error);
+  MonRunList fetchMonRunList(const RunTag& tag, const MonRunTag& monruntag) noexcept(false);
+  MonRunList fetchMonRunList(const RunTag& tag, const MonRunTag& monruntag,int min_run, int max_run) noexcept(false);
+  MonRunList fetchMonRunListLastNRuns(const RunTag& tag, const MonRunTag& monruntag, int max_run, int n_runs) noexcept(false);
 
 
 
@@ -305,7 +305,7 @@ class EcalCondDBInterface : public EcalDBConnection {
 
   template<class DATT, class IOVT>
   void insertDataSet(const std::map< EcalLogicID, DATT >* data, IOVT* iov)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     try {
       iov->setConnection(env, conn);
@@ -345,7 +345,7 @@ class EcalCondDBInterface : public EcalDBConnection {
   //test for DB Array insertion
   template<class DATT, class IOVT>
   void insertDataArraySet(const std::map< EcalLogicID, DATT >* data, IOVT* iov)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     try {
       iov->setConnection(env, conn);
@@ -380,7 +380,7 @@ class EcalCondDBInterface : public EcalDBConnection {
 
  template<class DATT, class IOVT>
   void insertDataSetVector( const std::vector<EcalLogicID>& ecid, const std::vector<IOVT>& run_iov, const std::vector<DATT>& data )
-    throw(std::runtime_error)
+    noexcept(false)
   {
    
     int nruns= run_iov.size();
@@ -422,7 +422,7 @@ class EcalCondDBInterface : public EcalDBConnection {
 
  template<class ICONF >
    void insertConfigSet( ICONF* iconf)
-   throw(std::runtime_error)
+   noexcept(false)
    {
      try {
        iconf->setConnection(env, conn);
@@ -446,7 +446,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class ICONF>
   void fetchConfigSet( ICONF* iconf)
-    throw(std::runtime_error)
+    noexcept(false)
   {
 
     iconf->clear();
@@ -462,7 +462,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class ICONF>
   void fetchLastConfigSet( ICONF* iconf)
-    throw(std::runtime_error)
+    noexcept(false)
   {
 
     iconf->clear();
@@ -480,7 +480,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT, class ICONF>
   void insertConfigDataSet(const std::vector< DATT > data, ICONF* iconf)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     try {
       iconf->setConnection(env, conn);
@@ -519,7 +519,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT, class ICONF>
   void insertConfigDataArraySet(const std::vector< DATT >& data, ICONF* iconf)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     try {
       iconf->setConnection(env, conn);
@@ -555,7 +555,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT, class ICONF>
   void fetchConfigDataSet(std::vector< DATT >* fillMap, ICONF* iconf)
-    throw(std::runtime_error)
+    noexcept(false)
   {
 
     DATT datiface;
@@ -578,7 +578,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT, class IOVT>
   void fetchDataSet(std::map< EcalLogicID, DATT >* fillMap, IOVT* iov)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     fillMap->clear();
 
@@ -599,7 +599,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT>
   void fetchDCSDataSet(std::list< std::pair< Tm, std::map<  EcalLogicID, DATT > > >* fillMap, const Tm& t)
-    throw(std::runtime_error)
+    noexcept(false)
   {
     fillMap->clear();
     
@@ -622,7 +622,7 @@ class EcalCondDBInterface : public EcalDBConnection {
    */
   template<class DATT, class IOVT>
   void fetchDataSetWithMap(std::map< EcalLogicID, DATT >* fillMap, IOVT* iov, std::string mapping_name )
-    throw(std::runtime_error)
+    noexcept(false)
   {
     fillMap->clear();
 
@@ -646,7 +646,7 @@ class EcalCondDBInterface : public EcalDBConnection {
   void fetchValidDataSet(std::map< EcalLogicID, DATT >* fillMap, 
 			 IOVT* fillIOV, 
 			 RunTag* tag, run_t run = (unsigned int)-1)
-  throw(std::runtime_error)
+  noexcept(false)
   {
     fillMap->clear();
     DATT datiface;
@@ -670,7 +670,7 @@ class EcalCondDBInterface : public EcalDBConnection {
   void fetchValidDataSet(std::map< EcalLogicID, DATT >* fillMap,
                          IOVT* fillIOV,
                          std::string location, run_t run = (unsigned int)-1)
-  throw(std::runtime_error)
+  noexcept(false)
   {
     fillMap->clear();
     DATT datiface;

--- a/OnlineDB/EcalCondDB/interface/EcalDBConnection.h
+++ b/OnlineDB/EcalCondDB/interface/EcalDBConnection.h
@@ -29,7 +29,7 @@ class EcalDBConnection {
 		    std::string user,
 		    std::string pass,
 		    int port = 1521 )
-    throw(std::runtime_error);
+    noexcept(false);
 
 
 
@@ -40,14 +40,14 @@ class EcalDBConnection {
   EcalDBConnection( std::string sid,
 		    std::string user,
 		    std::string pass )
-    throw(std::runtime_error);
+    noexcept(false);
   
 
 
   /**
    *  Destructor
    */
-  virtual ~EcalDBConnection() throw(std::runtime_error);
+  virtual ~EcalDBConnection() noexcept(false);
 
   /**
    *  Get a new Statement

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadStripDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadStripDat.h
@@ -37,17 +37,17 @@ class FEConfigBadStripDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const FEConfigBadStripDat* item, FEConfigBadStripInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< FEConfigBadStripDat >& data, FEConfigBadStripInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< FEConfigBadStripDat >* fillMap, FEConfigBadStripInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_tcc;

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadStripInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadStripInfo.h
@@ -22,19 +22,19 @@ class FEConfigBadStripInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(FEConfigBadStripInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigBadStripInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadTTDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadTTDat.h
@@ -34,17 +34,17 @@ class FEConfigBadTTDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const FEConfigBadTTDat* item, FEConfigBadTTInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< FEConfigBadTTDat >& data, FEConfigBadTTInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< FEConfigBadTTDat >* fillMap, FEConfigBadTTInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_tcc;

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadTTInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadTTInfo.h
@@ -22,19 +22,19 @@ class FEConfigBadTTInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(FEConfigBadTTInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigBadTTInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadXTDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadXTDat.h
@@ -37,17 +37,17 @@ class FEConfigBadXTDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const FEConfigBadXTDat* item, FEConfigBadXTInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< FEConfigBadXTDat >& data, FEConfigBadXTInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< FEConfigBadXTDat >* fillMap, FEConfigBadXTInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_tcc;

--- a/OnlineDB/EcalCondDB/interface/FEConfigBadXTInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigBadXTInfo.h
@@ -22,19 +22,19 @@ class FEConfigBadXTInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(FEConfigBadXTInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigBadXTInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrDat.h
@@ -21,19 +21,15 @@ class FEConfigFgrDat : public IDataItem {
   inline int getFgrGroupId() const { return m_group_id; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigFgrDat* item, FEConfigFgrInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigFgrDat* item, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrDat>* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrDat>* data, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigFgrDat >* fillMap, FEConfigFgrInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigFgrDat >* fillMap, FEConfigFgrInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrEEStripDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrEEStripDat.h
@@ -27,19 +27,15 @@ class FEConfigFgrEEStripDat : public IDataItem {
   inline unsigned int getLutFgr() const { return m_lut_fg; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigFgrEEStripDat* item, FEConfigFgrInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigFgrEEStripDat* item, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEEStripDat>* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEEStripDat>* data, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigFgrEEStripDat >* fillMap, FEConfigFgrInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigFgrEEStripDat >* fillMap, FEConfigFgrInfo* iconf) noexcept(false);
 
   // User data
   unsigned int m_thresh;

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrEETowerDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrEETowerDat.h
@@ -23,19 +23,15 @@ class FEConfigFgrEETowerDat : public IDataItem {
   inline int getLutValue() const { return m_lut; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigFgrEETowerDat* item, FEConfigFgrInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigFgrEETowerDat* item, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEETowerDat>* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEETowerDat>* data, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigFgrEETowerDat >* fillMap, FEConfigFgrInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigFgrEETowerDat >* fillMap, FEConfigFgrInfo* iconf) noexcept(false);
 
   // User data
 

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrGroupDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrGroupDat.h
@@ -32,19 +32,15 @@ class FEConfigFgrGroupDat : public IDataItem {
   inline int getLUTValue() const { return m_lut; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigFgrGroupDat* item, FEConfigFgrInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigFgrGroupDat* item, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrGroupDat>* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrGroupDat>* data, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigFgrGroupDat >* fillMap, FEConfigFgrInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigFgrGroupDat >* fillMap, FEConfigFgrInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrInfo.h
@@ -37,9 +37,9 @@ class FEConfigFgrInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigFgrInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigFgrInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigFgrInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigFgrInfo * result) noexcept(false);
+  void fetchLastData(FEConfigFgrInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigFgrParamDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigFgrParamDat.h
@@ -29,19 +29,15 @@ class FEConfigFgrParamDat : public IDataItem {
   inline float getFGhighratio() const { return m_highratio; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigFgrParamDat* item, FEConfigFgrInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigFgrParamDat* item, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrParamDat>* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigFgrParamDat>* data, FEConfigFgrInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigFgrParamDat >* fillMap, FEConfigFgrInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigFgrParamDat >* fillMap, FEConfigFgrInfo* iconf) noexcept(false);
 
   // User data
 float  m_fglowthresh ;

--- a/OnlineDB/EcalCondDB/interface/FEConfigLUTDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLUTDat.h
@@ -21,19 +21,15 @@ class FEConfigLUTDat : public IDataItem {
   inline int getLUTGroupId() const { return m_group_id; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigLUTDat* item, FEConfigLUTInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigLUTDat* item, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTDat>* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTDat>* data, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigLUTDat >* fillMap, FEConfigLUTInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigLUTDat >* fillMap, FEConfigLUTInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigLUTGroupDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLUTGroupDat.h
@@ -26,19 +26,15 @@ class FEConfigLUTGroupDat : public IDataItem {
 
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigLUTGroupDat* item, FEConfigLUTInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigLUTGroupDat* item, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTGroupDat>* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTGroupDat>* data, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigLUTGroupDat >* fillMap, FEConfigLUTInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigLUTGroupDat >* fillMap, FEConfigLUTInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigLUTInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLUTInfo.h
@@ -37,9 +37,9 @@ class FEConfigLUTInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigLUTInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigLUTInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigLUTInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigLUTInfo * result) noexcept(false);
+  void fetchLastData(FEConfigLUTInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigLUTParamDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLUTParamDat.h
@@ -29,19 +29,15 @@ class FEConfigLUTParamDat : public IDataItem {
   inline float getTTThreshhigh() const{ return m_tthreshhigh; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigLUTParamDat* item, FEConfigLUTInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigLUTParamDat* item, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTParamDat>* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigLUTParamDat>* data, FEConfigLUTInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigLUTParamDat >* fillMap, FEConfigLUTInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigLUTParamDat >* fillMap, FEConfigLUTInfo* iconf) noexcept(false);
 
   // User data
 float  m_etsat ;

--- a/OnlineDB/EcalCondDB/interface/FEConfigLinDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLinDat.h
@@ -33,19 +33,15 @@ class FEConfigLinDat : public IDataItem {
   inline int getShift1() const { return m_shift1; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigLinDat* item, FEConfigLinInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigLinDat* item, FEConfigLinInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigLinDat>* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigLinDat>* data, FEConfigLinInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigLinDat >* fillMap, FEConfigLinInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigLinDat >* fillMap, FEConfigLinInfo* iconf) noexcept(false);
 
   // User data
   int m_multx12;

--- a/OnlineDB/EcalCondDB/interface/FEConfigLinInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLinInfo.h
@@ -37,9 +37,9 @@ class FEConfigLinInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigLinInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigLinInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigLinInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigLinInfo * result) noexcept(false);
+  void fetchLastData(FEConfigLinInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigLinParamDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigLinParamDat.h
@@ -23,19 +23,15 @@ class FEConfigLinParamDat : public IDataItem {
   inline float getETSat() const       { return m_etsat; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigLinParamDat* item, FEConfigLinInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigLinParamDat* item, FEConfigLinInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigLinParamDat>* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigLinParamDat>* data, FEConfigLinInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigLinParamDat >* fillMap, FEConfigLinInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigLinParamDat >* fillMap, FEConfigLinInfo* iconf) noexcept(false);
 
   // User data
 float  m_etsat ;

--- a/OnlineDB/EcalCondDB/interface/FEConfigMainInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigMainInfo.h
@@ -96,18 +96,18 @@ int getBstId()const {return m_bst_id;  }
   Tm m_db_time;
   std::string m_description;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigMainInfo * result)     throw(std::runtime_error);
-  void insertConfig() throw(std::runtime_error);
+  void fetchData(FEConfigMainInfo * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error); // fetches 
-  int fetchNextId() throw(std::runtime_error); // fetches 
-  int fetchIDLast() throw(std::runtime_error); // fetches the last one
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false); // fetches 
+  int fetchNextId() noexcept(false); // fetches 
+  int fetchIDLast() noexcept(false); // fetches the last one
+  void setByID(int id) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/FEConfigParamDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigParamDat.h
@@ -36,18 +36,18 @@ class FEConfigParamDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const FEConfigParamDat* item, FEConfigLinInfo* iconf)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void writeArrayDB(const std::map< EcalLogicID, FEConfigParamDat>* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, FEConfigParamDat >* fillMap, FEConfigLinInfo* iconf)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
 float  m_etsat ;

--- a/OnlineDB/EcalCondDB/interface/FEConfigPedDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigPedDat.h
@@ -31,17 +31,13 @@ class FEConfigPedDat : public IDataItem {
 
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigPedDat* item, FEConfigPedInfo* iconf )
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigPedDat* item, FEConfigPedInfo* iconf ) noexcept(false);
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigPedDat >* data, FEConfigPedInfo* iconf)
-    throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigPedDat >* data, FEConfigPedInfo* iconf) noexcept(false);
 
-  void fetchData(std::map< EcalLogicID, FEConfigPedDat >* fillMap, FEConfigPedInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigPedDat >* fillMap, FEConfigPedInfo* iconf) noexcept(false);
 
   // User data
   float m_pedMeanG1;

--- a/OnlineDB/EcalCondDB/interface/FEConfigPedInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigPedInfo.h
@@ -37,9 +37,9 @@ class FEConfigPedInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigPedInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigPedInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigPedInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigPedInfo * result) noexcept(false);
+  void fetchLastData(FEConfigPedInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigSlidingDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigSlidingDat.h
@@ -21,19 +21,15 @@ class FEConfigSlidingDat : public IDataItem {
   inline float getSliding() const { return m_sliding; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigSlidingDat* item, FEConfigSlidingInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigSlidingDat* item, FEConfigSlidingInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigSlidingDat>* data, FEConfigSlidingInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigSlidingDat>* data, FEConfigSlidingInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigSlidingDat >* fillMap, FEConfigSlidingInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigSlidingDat >* fillMap, FEConfigSlidingInfo* iconf) noexcept(false);
 
   // User data
   float m_sliding;

--- a/OnlineDB/EcalCondDB/interface/FEConfigSlidingInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigSlidingInfo.h
@@ -37,9 +37,9 @@ class FEConfigSlidingInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigSlidingInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigSlidingInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigSlidingInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigSlidingInfo * result) noexcept(false);
+  void fetchLastData(FEConfigSlidingInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigSpikeDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigSpikeDat.h
@@ -21,19 +21,15 @@ class FEConfigSpikeDat : public IDataItem {
   inline int getSpikeThreshold() const { return m_thr; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigSpikeDat* item, FEConfigSpikeInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigSpikeDat* item, FEConfigSpikeInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigSpikeDat>* data, FEConfigSpikeInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigSpikeDat>* data, FEConfigSpikeInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigSpikeDat >* fillMap, FEConfigSpikeInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigSpikeDat >* fillMap, FEConfigSpikeInfo* iconf) noexcept(false);
 
   // User data
   int m_thr;

--- a/OnlineDB/EcalCondDB/interface/FEConfigSpikeInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigSpikeInfo.h
@@ -33,9 +33,9 @@ class FEConfigSpikeInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -49,11 +49,11 @@ class FEConfigSpikeInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigSpikeInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigSpikeInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigSpikeInfo * result) noexcept(false);
+  void fetchLastData(FEConfigSpikeInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigTimingDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigTimingDat.h
@@ -23,17 +23,13 @@ class FEConfigTimingDat : public IDataItem {
   inline int getTimingPar2() const { return m_par2; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigTimingDat* item, FEConfigTimingInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigTimingDat* item, FEConfigTimingInfo* iconf) noexcept(false);
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigTimingDat>* data, FEConfigTimingInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigTimingDat>* data, FEConfigTimingInfo* iconf) noexcept(false);
 
-  void fetchData(std::map< EcalLogicID, FEConfigTimingDat >* fillMap, FEConfigTimingInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigTimingDat >* fillMap, FEConfigTimingInfo* iconf) noexcept(false);
 
   // User data
   int m_par1;

--- a/OnlineDB/EcalCondDB/interface/FEConfigTimingInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigTimingInfo.h
@@ -34,9 +34,9 @@ class FEConfigTimingInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -49,11 +49,11 @@ class FEConfigTimingInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigTimingInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigTimingInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigTimingInfo * result) noexcept(false);
+  void fetchLastData(FEConfigTimingInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/FEConfigWeightDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigWeightDat.h
@@ -21,19 +21,15 @@ class FEConfigWeightDat : public IDataItem {
   inline int getWeightGroupId() const { return m_group_id; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigWeightDat* item, FEConfigWeightInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigWeightDat* item, FEConfigWeightInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigWeightDat>* data, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigWeightDat>* data, FEConfigWeightInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigWeightDat >* fillMap, FEConfigWeightInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigWeightDat >* fillMap, FEConfigWeightInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigWeightGroupDat.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigWeightGroupDat.h
@@ -32,19 +32,15 @@ class FEConfigWeightGroupDat : public IDataItem {
   inline float getWeight4() const { return m_w4; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const FEConfigWeightGroupDat* item, FEConfigWeightInfo* iconf)
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const FEConfigWeightGroupDat* item, FEConfigWeightInfo* iconf) noexcept(false);
 
 
-  void writeArrayDB(const std::map< EcalLogicID, FEConfigWeightGroupDat>* data, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error);
+  void writeArrayDB(const std::map< EcalLogicID, FEConfigWeightGroupDat>* data, FEConfigWeightInfo* iconf) noexcept(false);
 
 
-  void fetchData(std::map< EcalLogicID, FEConfigWeightGroupDat >* fillMap, FEConfigWeightInfo* iconf)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, FEConfigWeightGroupDat >* fillMap, FEConfigWeightInfo* iconf) noexcept(false);
 
   // User data
   int m_group_id;

--- a/OnlineDB/EcalCondDB/interface/FEConfigWeightInfo.h
+++ b/OnlineDB/EcalCondDB/interface/FEConfigWeightInfo.h
@@ -37,9 +37,9 @@ class FEConfigWeightInfo : public  IODConfig {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchNextId() noexcept(false);
+  void setByID(int id) noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
   // operators
@@ -53,11 +53,11 @@ class FEConfigWeightInfo : public  IODConfig {
   Tm m_db_time;
   int m_version;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB() throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(FEConfigWeightInfo * result)     throw(std::runtime_error);
-  void fetchLastData(FEConfigWeightInfo * result)     throw(std::runtime_error);
+  void fetchData(FEConfigWeightInfo * result) noexcept(false);
+  void fetchLastData(FEConfigWeightInfo * result) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/IDBObject.h
+++ b/OnlineDB/EcalCondDB/interface/IDBObject.h
@@ -38,8 +38,7 @@ class IDBObject {
   oracle::occi::Environment* m_env;
   oracle::occi::Connection* m_conn;
   
-  void checkConnection() const
-    throw(std::runtime_error)
+  void checkConnection() const noexcept(false)
     {
       if (m_conn == NULL) {
 	throw std::runtime_error("ERROR:  Connection was not set");

--- a/OnlineDB/EcalCondDB/interface/IDataItem.h
+++ b/OnlineDB/EcalCondDB/interface/IDataItem.h
@@ -28,16 +28,14 @@ class IDataItem : public IDBObject {
   oracle::occi::Statement* m_writeStmt;
   oracle::occi::Statement* m_readStmt;
 
-  inline void checkPrepare() 
-    throw(std::runtime_error) 
+  inline void checkPrepare() noexcept(false)
     {
       if (m_writeStmt == NULL) {
 	throw(std::runtime_error("Write statement not prepared"));
       }
     }
 
-  inline void terminateWriteStatement()
-    throw(std::runtime_error)
+  inline void terminateWriteStatement() noexcept(false)
   {
     if (m_writeStmt != NULL) {
       m_conn->terminateStatement(m_writeStmt);
@@ -47,20 +45,17 @@ class IDataItem : public IDBObject {
   }
 
 
-  inline void createReadStatement()
-    throw(std::runtime_error)
+  inline void createReadStatement() noexcept(false)
   {
       m_readStmt=m_conn->createStatement();
   }
 
-  inline void setPrefetchRowCount(int ncount)
-    throw(std::runtime_error)
+  inline void setPrefetchRowCount(int ncount) noexcept(false)
   {
     m_readStmt->setPrefetchRowCount(ncount);
   }
 
-  inline void terminateReadStatement()
-    throw(std::runtime_error)
+  inline void terminateReadStatement() noexcept(false)
   {
     if (m_readStmt != NULL) {
       m_conn->terminateStatement(m_readStmt);
@@ -72,8 +67,7 @@ class IDataItem : public IDBObject {
 
 
   // Prepare a statement for writing operations
-  virtual void prepareWrite() 
-    throw(std::runtime_error) =0;
+  virtual void prepareWrite() noexcept(false) = 0;
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/IODConfig.h
+++ b/OnlineDB/EcalCondDB/interface/IODConfig.h
@@ -36,16 +36,14 @@ class IODConfig : public IDBObject {
   Statement* m_writeStmt;
   Statement* m_readStmt;
 
-  inline void checkPrepare() 
-    throw(std::runtime_error) 
+  inline void checkPrepare() noexcept(false)
     {
       if (m_writeStmt == NULL) {
 	throw(std::runtime_error("Write statement not prepared"));
       }
     }
 
-  inline void terminateWriteStatement()
-    throw(std::runtime_error)
+  inline void terminateWriteStatement() noexcept(false)
   {
     if (m_writeStmt != NULL) {
       m_conn->terminateStatement(m_writeStmt);
@@ -55,20 +53,17 @@ class IODConfig : public IDBObject {
   }
 
 
-  inline void createReadStatement()
-    throw(std::runtime_error)
+  inline void createReadStatement() noexcept(false)
   {
       m_readStmt=m_conn->createStatement();
   }
 
-  inline void setPrefetchRowCount(int ncount)
-    throw(std::runtime_error)
+  inline void setPrefetchRowCount(int ncount) noexcept(false)
   {
     m_readStmt->setPrefetchRowCount(ncount);
   }
 
-  inline void terminateReadStatement()
-    throw(std::runtime_error)
+  inline void terminateReadStatement() noexcept(false)
   {
     if (m_readStmt != NULL) {
       m_conn->terminateStatement(m_readStmt);
@@ -80,13 +75,12 @@ class IODConfig : public IDBObject {
 
 
   // Prepare a statement for writing operations
-  virtual void prepareWrite() throw(std::runtime_error) =0;
+  virtual void prepareWrite() noexcept(false) = 0;
 
-  //  virtual void writeDB() throw(std::runtime_error) ;
+  //  virtual void writeDB() noexcept(false) ;
 
 
-void populateClob (Clob &clob, std::string fname, unsigned int bufsize)
- throw (std::runtime_error)
+void populateClob (Clob &clob, std::string fname, unsigned int bufsize) noexcept(false)
 {
 
   try{
@@ -157,8 +151,7 @@ void populateClob (Clob &clob, std::string fname, unsigned int bufsize)
 }
 
 
-unsigned char* readClob (Clob &clob, int size)
-  throw (std::runtime_error)
+unsigned char* readClob (Clob &clob, int size) noexcept(false)
 {
 
   try{

--- a/OnlineDB/EcalCondDB/interface/IRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/IRunIOV.h
@@ -10,9 +10,9 @@ typedef int run_t;
 
 class IRunIOV {
  public:
-  virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const throw(std::runtime_error) =0;
+  virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const noexcept(false) =0;
 
-  virtual void fetchWithin(std::vector<IIOV>* fillVec, const run_t beginRun, const run_t endRun, ITag* tag) const throw(std::runtime_error) =0;
+  virtual void fetchWithin(std::vector<IIOV>* fillVec, const run_t beginRun, const run_t endRun, ITag* tag) const noexcept(false) =0;
   
 };
 

--- a/OnlineDB/EcalCondDB/interface/ITimeIOV.h
+++ b/OnlineDB/EcalCondDB/interface/ITimeIOV.h
@@ -10,9 +10,9 @@
 
 class ITimeIOV {
  public:
-  virtual void fetchAt(IIOV* fillIOV, const Tm eventTm, ITag* tag) const throw(std::runtime_error) =0;
+  virtual void fetchAt(IIOV* fillIOV, const Tm eventTm, ITag* tag) const noexcept(false) =0;
 
-  virtual void fetchWithin(std::vector<IIOV*>* fillVec, const Tm beginTm, const Tm endTm, ITag* tag) const throw(std::runtime_error) =0;
+  virtual void fetchWithin(std::vector<IIOV*>* fillVec, const Tm beginTm, const Tm endTm, ITag* tag) const noexcept(false) =0;
   
 };
 

--- a/OnlineDB/EcalCondDB/interface/ITimingDat.h
+++ b/OnlineDB/EcalCondDB/interface/ITimingDat.h
@@ -53,8 +53,7 @@ ITimingDat()
   
 
  private:
-void prepareWrite()
-  throw(std::runtime_error)
+void prepareWrite() noexcept(false)
 {
   this->checkConnection();
 
@@ -71,8 +70,7 @@ void prepareWrite()
 
 
   template<class DATT, class IOVT>
-  void writeDB(const EcalLogicID* ecid, const DATT* item, IOVT* iov)
-    throw(std::runtime_error)
+  void writeDB(const EcalLogicID* ecid, const DATT* item, IOVT* iov) noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -99,9 +97,7 @@ void prepareWrite()
 }
 
   template<class DATT, class IOVT>
-    void writeArrayDB(const std::map< EcalLogicID, DATT >* data, IOVT* iov)
-    throw(std::runtime_error)
-
+    void writeArrayDB(const std::map< EcalLogicID, DATT >* data, IOVT* iov) noexcept(false)
 {
   using oracle::occi::OCCIINT;
   using oracle::occi::OCCIFLOAT;
@@ -194,8 +190,7 @@ void prepareWrite()
 
 
   template<class DATT, class IOVT>
-  void fetchData(std::map< EcalLogicID, DATT >* fillMap, IOVT* iov)
-  throw(std::runtime_error)
+  void fetchData(std::map< EcalLogicID, DATT >* fillMap, IOVT* iov) noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/interface/IUniqueDBObject.h
+++ b/OnlineDB/EcalCondDB/interface/IUniqueDBObject.h
@@ -10,8 +10,8 @@
  */
 class IUniqueDBObject : public IDBObject {
  public:
-  virtual int fetchID() throw(std::runtime_error) =0;
-  virtual void setByID(int id) throw(std::runtime_error) =0;
+  virtual int fetchID() noexcept(false) = 0;
+  virtual void setByID(int id) noexcept(false) = 0;
 
  protected:
   // ID from the database

--- a/OnlineDB/EcalCondDB/interface/LMFColoredTable.h
+++ b/OnlineDB/EcalCondDB/interface/LMFColoredTable.h
@@ -69,7 +69,7 @@ class LMFColoredTable : public LMFDat {
     return getData(id, "VMAX");
   }
 
-  int writeDB() throw(std::runtime_error);
+  int writeDB() noexcept(false);
 
 
  protected:

--- a/OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h
+++ b/OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h
@@ -52,7 +52,7 @@ class LMFCorrCoefDatComponent: public LMFDat {
   std::string foreignKeyName() const;
   std::string getTableName() const;
   std::string getIovIdFieldName() const;
-  int writeDB() throw(std::runtime_error);
+  int writeDB() noexcept(false);
 
  private:
   void init();

--- a/OnlineDB/EcalCondDB/interface/LMFDat.h
+++ b/OnlineDB/EcalCondDB/interface/LMFDat.h
@@ -43,8 +43,8 @@ class LMFDat : public LMFUnique {
     return getLMFRunIOV().getSubRunStart();
   }
 
-  void getPrevious(LMFDat *dat) throw(std::runtime_error);
-  void getNext(LMFDat *dat) throw(std::runtime_error);
+  void getPrevious(LMFDat *dat) noexcept(false);
+  void getNext(LMFDat *dat) noexcept(false);
 
   virtual std::string getTableName() const {
     return m_tableName;
@@ -124,27 +124,26 @@ class LMFDat : public LMFUnique {
   void dump() const ;
   void dump(int n) const ;
   virtual void dump(int n, int max) const ;
-  std::map<int, std::vector<float> > fetchData() throw(std::runtime_error);
-  void fetch() throw(std::runtime_error);
-  void fetch(int logic_id) throw(std::runtime_error);
-  void fetch(int logic_id, const Tm &tm) throw(std::runtime_error);
-  void fetch(int logic_id, const Tm *timestamp, int dir) throw(std::runtime_error);
-  void fetch(const EcalLogicID &id, const Tm &tm) throw(std::runtime_error);
-  void fetch(const EcalLogicID &id, const Tm &tm, int dir) throw(std::runtime_error);
-  void fetch(const EcalLogicID &id) 
-    throw(std::runtime_error);
+  std::map<int, std::vector<float> > fetchData() noexcept(false);
+  void fetch() noexcept(false);
+  void fetch(int logic_id) noexcept(false);
+  void fetch(int logic_id, const Tm &tm) noexcept(false);
+  void fetch(int logic_id, const Tm *timestamp, int dir) noexcept(false);
+  void fetch(const EcalLogicID &id, const Tm &tm) noexcept(false);
+  void fetch(const EcalLogicID &id, const Tm &tm, int dir) noexcept(false);
+  void fetch(const EcalLogicID &id) noexcept(false);
 
   virtual bool isValid();
   void setWhereClause(std::string w);
   void setWhereClause(std::string w, const std::vector<std::string>& p);
  protected:
-  void getNeighbour(LMFDat *dat, int which) throw(std::runtime_error);
-  int writeDB() throw(std::runtime_error);
+  void getNeighbour(LMFDat *dat, int which) noexcept(false);
+  int writeDB() noexcept(false);
   bool check();
   void adjustParameters(int n, std::string &sql, Statement *stmt);
   std::string buildInsertSql();
   std::string buildSelectSql(int logic_id = 0, int direction = 0);
-  void getKeyTypes() throw(std::runtime_error);
+  void getKeyTypes() noexcept(false);
 
   int m_max;
   std::vector<std::string> m_type;

--- a/OnlineDB/EcalCondDB/interface/LMFDefFabric.h
+++ b/OnlineDB/EcalCondDB/interface/LMFDefFabric.h
@@ -46,7 +46,7 @@ class LMFDefFabric: public IDBObject {
   std::list<LMFTrigType> getTriggerTypes() const;
   std::list<LMFRunTag>   getRunTags() const;
 
-  void initialize() throw(std::runtime_error);
+  void initialize() noexcept(false);
   void debug();
   void noDebug();
 

--- a/OnlineDB/EcalCondDB/interface/LMFLmrSubIOV.h
+++ b/OnlineDB/EcalCondDB/interface/LMFLmrSubIOV.h
@@ -68,15 +68,10 @@ class LMFLmrSubIOV : public LMFUnique {
     return m_t[2];
   }
 
-  std::list<int> getIOVIDsLaterThan(const Tm &t)
-    throw(std::runtime_error);
-  std::list<int> getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax)
-    throw(std::runtime_error);
-  std::list<int> getIOVIDsLaterThan(const Tm &t, int howMany)
-    throw(std::runtime_error);
-  std::list<int> getIOVIDsLaterThan(const Tm &t, const Tm &tmax,
-				    int howMany)
-    throw(std::runtime_error);
+  std::list<int> getIOVIDsLaterThan(const Tm &t) noexcept(false);
+  std::list<int> getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax) noexcept(false);
+  std::list<int> getIOVIDsLaterThan(const Tm &t, int howMany) noexcept(false);
+  std::list<int> getIOVIDsLaterThan(const Tm &t, const Tm &tmax, int howMany) noexcept(false);
 
   // Operators
   inline bool operator==(const LMFLmrSubIOV &m) const

--- a/OnlineDB/EcalCondDB/interface/LMFRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/LMFRunIOV.h
@@ -94,7 +94,7 @@ class LMFRunIOV : public LMFUnique {
   std::list<LMFRunIOV> fetchBySequence(const std::vector<int>& par,
 				       const std::string &sql,
 				       const std::string &method)
-    throw (std::runtime_error);
+    noexcept(false);
 
   LMFDefFabric *_fabric;
 };

--- a/OnlineDB/EcalCondDB/interface/LMFSeqDat.h
+++ b/OnlineDB/EcalCondDB/interface/LMFSeqDat.h
@@ -89,17 +89,17 @@ class LMFSeqDat : public LMFUnique {
   std::string writeDBSql(Statement *stmt);
   void getParameters(ResultSet *rset);
 
-  void fetchParentIDs() throw(std::runtime_error);
+  void fetchParentIDs() noexcept(false);
   std::map<int, LMFSeqDat> fetchByRunIOV(const std::vector<std::string>& par, 
 					 std::string sql,
 					 std::string method) 
-    throw(std::runtime_error);
+    noexcept(false);
   std::map<int, LMFSeqDat> fetchByRunIOV(int par, std::string sql,
 					 std::string method) 
-    throw(std::runtime_error);
+    noexcept(false);
   std::map<int, LMFSeqDat> fetchByRunIOV(std::string sql,
 					 std::string method) 
-    throw(std::runtime_error);
+    noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/LMFUnique.h
+++ b/OnlineDB/EcalCondDB/interface/LMFUnique.h
@@ -55,12 +55,12 @@ class LMFUnique: public IUniqueDBObject {
   std::string getClassName() const { return m_className; }
   std::string getString(std::string fieldname) const;
 
-  int fetchID() throw(std::runtime_error); 
+  int fetchID() noexcept(false); 
 
   LMFUnique& setString(std::string key, std::string value);
   LMFUnique& setInt(std::string key, int value);
   void attach(std::string name, LMFUnique *u);
-  void setByID(int id) throw(std::runtime_error);
+  void setByID(int id) noexcept(false);
 
   virtual void dump() const ;
   virtual void dump(int n) const ;
@@ -68,8 +68,7 @@ class LMFUnique: public IUniqueDBObject {
   inline void debug() { m_debug = 1; }
   inline void nodebug() { m_debug = 0; }
 
-  virtual boost::ptr_list<LMFUnique> fetchAll() const 
-    throw (std::runtime_error);
+  virtual boost::ptr_list<LMFUnique> fetchAll() const noexcept(false);
 
   virtual bool operator<(const LMFUnique &r) {
     return (m_ID < r.m_ID);
@@ -92,8 +91,8 @@ class LMFUnique: public IUniqueDBObject {
   virtual LMFUnique * createObject() const;
 
  protected:
-  virtual int writeDB() throw(std::runtime_error);
-  virtual int writeForeignKeys() throw(std::runtime_error);
+  virtual int writeDB() noexcept(false);
+  virtual int writeForeignKeys() noexcept(false);
   virtual void setClassName(std::string s) { m_className = s; }
 
   std::string m_className;

--- a/OnlineDB/EcalCondDB/interface/LocationDef.h
+++ b/OnlineDB/EcalCondDB/interface/LocationDef.h
@@ -21,8 +21,8 @@ class LocationDef : public IDef {
   void setLocation(std::string loc);
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   inline bool operator==(const LocationDef& l) const { return m_loc == l.m_loc; }
   inline bool operator!=(const LocationDef& l) const { return m_loc != l.m_loc; }
@@ -31,7 +31,7 @@ class LocationDef : public IDef {
   // User data for this def
   std::string m_loc;
 
-  void fetchAllDefs( std::vector<LocationDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<LocationDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/MODCCSFEDat.h
+++ b/OnlineDB/EcalCondDB/interface/MODCCSFEDat.h
@@ -22,18 +22,18 @@ class MODCCSFEDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MODCCSFEDat* item, MODRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MODCCSFEDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MODCCSFEDat >* fillMap, MODRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_word;

--- a/OnlineDB/EcalCondDB/interface/MODCCSHFDat.h
+++ b/OnlineDB/EcalCondDB/interface/MODCCSHFDat.h
@@ -40,16 +40,16 @@ class MODCCSHFDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MODCCSHFDat* item, MODRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MODCCSHFDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MODCCSHFDat >* fillMap, MODRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   unsigned char* m_clob;
@@ -57,9 +57,9 @@ class MODCCSHFDat : public IDataItem {
   std::string m_file;
   int testing;
   unsigned char* readClob (Clob &clob, int size)
-    throw (std::runtime_error);
+    noexcept(false);
   void populateClob (Clob &clob, std::string fname, unsigned int clob_size)
-    throw (std::runtime_error);
+    noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/MODCCSTRDat.h
+++ b/OnlineDB/EcalCondDB/interface/MODCCSTRDat.h
@@ -22,18 +22,18 @@ class MODCCSTRDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MODCCSTRDat* item, MODRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MODCCSTRDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MODCCSTRDat >* fillMap, MODRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_word;

--- a/OnlineDB/EcalCondDB/interface/MODDCCDetailsDat.h
+++ b/OnlineDB/EcalCondDB/interface/MODDCCDetailsDat.h
@@ -55,18 +55,18 @@ class MODDCCDetailsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MODDCCDetailsDat* item, MODRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MODDCCDetailsDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MODDCCDetailsDat >* fillMap, MODRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_qpll;

--- a/OnlineDB/EcalCondDB/interface/MODDCCOperationDat.h
+++ b/OnlineDB/EcalCondDB/interface/MODDCCOperationDat.h
@@ -22,18 +22,18 @@ class MODDCCOperationDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MODDCCOperationDat* item, MODRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MODDCCOperationDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MODDCCOperationDat >* fillMap, MODRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   std::string m_word;

--- a/OnlineDB/EcalCondDB/interface/MODRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/MODRunIOV.h
@@ -31,8 +31,8 @@ class MODRunIOV : public IIOV {
   Tm getSubRunEnd() const;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const MODRunIOV &m) const
@@ -52,10 +52,10 @@ class MODRunIOV : public IIOV {
   Tm m_subRunStart;
   Tm m_subRunEnd;
 
-  int writeDB() throw(std::runtime_error);
-  void fetchParentIDs(int* runIOVID) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void fetchParentIDs(int* runIOVID) noexcept(false);
 
-  void setByRun(RunIOV* runiov, subrun_t subrun) throw(std::runtime_error);
+  void setByRun(RunIOV* runiov, subrun_t subrun) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/MonCrystalConsistencyDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonCrystalConsistencyDat.h
@@ -38,16 +38,16 @@ class MonCrystalConsistencyDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonCrystalConsistencyDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonCrystalConsistencyDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonCrystalConsistencyDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/MonDelaysTTDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonDelaysTTDat.h
@@ -30,16 +30,16 @@ class MonDelaysTTDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonDelaysTTDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonDelaysTTDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonDelaysTTDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/MonH4TablePositionDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonH4TablePositionDat.h
@@ -25,16 +25,16 @@ class MonH4TablePositionDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonH4TablePositionDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonH4TablePositionDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonH4TablePositionDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   // User data
   float m_tableX;

--- a/OnlineDB/EcalCondDB/interface/MonLaserBlueDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserBlueDat.h
@@ -36,16 +36,16 @@ class MonLaserBlueDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserBlueDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 void writeArrayDB(const std::map< EcalLogicID,  MonLaserBlueDat>* data, MonRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLaserBlueDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_apdMean;

--- a/OnlineDB/EcalCondDB/interface/MonLaserGreenDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserGreenDat.h
@@ -36,17 +36,17 @@ class MonLaserGreenDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserGreenDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonLaserGreenDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonLaserGreenDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_apdMean;

--- a/OnlineDB/EcalCondDB/interface/MonLaserIRedDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserIRedDat.h
@@ -36,16 +36,16 @@ class MonLaserIRedDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserIRedDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonLaserIRedDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLaserIRedDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_apdMean;

--- a/OnlineDB/EcalCondDB/interface/MonLaserPulseDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserPulseDat.h
@@ -31,16 +31,16 @@ class MonLaserPulseDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserPulseDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonLaserPulseDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLaserPulseDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_pulseHeightMean;

--- a/OnlineDB/EcalCondDB/interface/MonLaserRedDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserRedDat.h
@@ -36,16 +36,16 @@ class MonLaserRedDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserRedDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonLaserRedDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLaserRedDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_apdMean;

--- a/OnlineDB/EcalCondDB/interface/MonLaserStatusDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLaserStatusDat.h
@@ -30,16 +30,16 @@ class MonLaserStatusDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLaserStatusDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonLaserStatusDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLaserStatusDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_laserPower;

--- a/OnlineDB/EcalCondDB/interface/MonLed1Dat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLed1Dat.h
@@ -36,16 +36,16 @@ class MonLed1Dat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLed1Dat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 void writeArrayDB(const std::map< EcalLogicID,  MonLed1Dat>* data, MonRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLed1Dat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_vptMean;

--- a/OnlineDB/EcalCondDB/interface/MonLed2Dat.h
+++ b/OnlineDB/EcalCondDB/interface/MonLed2Dat.h
@@ -36,16 +36,16 @@ class MonLed2Dat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonLed2Dat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 void writeArrayDB(const std::map< EcalLogicID,  MonLed2Dat>* data, MonRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonLed2Dat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_vptMean;

--- a/OnlineDB/EcalCondDB/interface/MonMemChConsistencyDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonMemChConsistencyDat.h
@@ -38,17 +38,17 @@ class MonMemChConsistencyDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonMemChConsistencyDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonMemChConsistencyDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonMemChConsistencyDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_processedEvents;

--- a/OnlineDB/EcalCondDB/interface/MonMemTTConsistencyDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonMemTTConsistencyDat.h
@@ -41,17 +41,17 @@ class MonMemTTConsistencyDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonMemTTConsistencyDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonMemTTConsistencyDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonMemTTConsistencyDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_processedEvents;

--- a/OnlineDB/EcalCondDB/interface/MonOccupancyDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonOccupancyDat.h
@@ -29,17 +29,17 @@ class MonOccupancyDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonOccupancyDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonOccupancyDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonOccupancyDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_eventsOverLowThreshold;

--- a/OnlineDB/EcalCondDB/interface/MonPNBlueDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNBlueDat.h
@@ -47,16 +47,16 @@ class MonPNBlueDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNBlueDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNBlueDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNBlueDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNGreenDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNGreenDat.h
@@ -47,17 +47,17 @@ class MonPNGreenDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNGreenDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNGreenDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonPNGreenDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNIRedDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNIRedDat.h
@@ -47,16 +47,16 @@ class MonPNIRedDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNIRedDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNIRedDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNIRedDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNLed1Dat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNLed1Dat.h
@@ -47,16 +47,16 @@ class MonPNLed1Dat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNLed1Dat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNLed1Dat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNLed1Dat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNLed2Dat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNLed2Dat.h
@@ -47,16 +47,16 @@ class MonPNLed2Dat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNLed2Dat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNLed2Dat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNLed2Dat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNMGPADat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNMGPADat.h
@@ -47,16 +47,16 @@ class MonPNMGPADat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNMGPADat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNMGPADat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNMGPADat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNPedDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNPedDat.h
@@ -35,18 +35,18 @@ class MonPNPedDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNPedDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNPedDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MonPNPedDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_pedMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPNRedDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPNRedDat.h
@@ -47,16 +47,16 @@ class MonPNRedDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPNRedDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPNRedDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPNRedDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPedestalOffsetsDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPedestalOffsetsDat.h
@@ -32,17 +32,17 @@ class MonPedestalOffsetsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPedestalOffsetsDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPedestalOffsetsDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonPedestalOffsetsDat >* fillMap, MonRunIOV* iov, std::string mappa=" cv.maps_to " )
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_dacG1;

--- a/OnlineDB/EcalCondDB/interface/MonPedestalsDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPedestalsDat.h
@@ -40,18 +40,18 @@ class MonPedestalsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPedestalsDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void writeArrayDB(const std::map< EcalLogicID, MonPedestalsDat>* data, MonRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonPedestalsDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_pedMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonPedestalsOnlineDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPedestalsOnlineDat.h
@@ -29,18 +29,18 @@ class MonPedestalsOnlineDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPedestalsOnlineDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonPedestalsOnlineDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error);
+  noexcept(false);
 
 
 
   void fetchData(std::map< EcalLogicID, MonPedestalsOnlineDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG12;

--- a/OnlineDB/EcalCondDB/interface/MonPulseShapeDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonPulseShapeDat.h
@@ -20,7 +20,7 @@ class MonPulseShapeDat : public IDataItem {
   inline std::string getTable() { return "MON_PULSE_SHAPE_DAT"; }
 
   inline void setSamples( std::vector<float> &samples, int gain )
-    throw(std::runtime_error)
+    noexcept(false)
     { 
       if (samples.size() != 10) {
 	throw(std::runtime_error("MonPulseShapeDat::setSamples:  There should be 10 samples."));
@@ -38,7 +38,7 @@ class MonPulseShapeDat : public IDataItem {
     }
 
   inline std::vector<float> getSamples(int gain) const
-    throw(std::runtime_error)
+    noexcept(false)
     { 
       if (gain == 1) {
 	return m_samplesG1;
@@ -53,13 +53,13 @@ class MonPulseShapeDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonPulseShapeDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonPulseShapeDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   std::vector<float> m_samplesG1;

--- a/OnlineDB/EcalCondDB/interface/MonRunDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonRunDat.h
@@ -35,13 +35,13 @@ class MonRunDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonRunDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonRunDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_numEvents;

--- a/OnlineDB/EcalCondDB/interface/MonRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/MonRunIOV.h
@@ -34,8 +34,8 @@ class MonRunIOV : public IIOV {
   Tm getSubRunEnd() const;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const MonRunIOV &m) const
@@ -57,10 +57,10 @@ class MonRunIOV : public IIOV {
   Tm m_subRunStart;
   Tm m_subRunEnd;
 
-  int writeDB() throw(std::runtime_error);
-  void fetchParentIDs(int* monRunTagID, int* runIOVID) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void fetchParentIDs(int* monRunTagID, int* runIOVID) noexcept(false);
 
-  void setByRun(MonRunTag* montag, RunIOV* runiov, subrun_t subrun) throw(std::runtime_error);
+  void setByRun(MonRunTag* montag, RunIOV* runiov, subrun_t subrun) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/MonRunList.h
+++ b/OnlineDB/EcalCondDB/interface/MonRunList.h
@@ -29,9 +29,9 @@ class MonRunList  : public IDBObject {
   std::vector<MonRunIOV> getRuns() ;
   
   // Methods from IUniqueDBObject
-  void fetchRuns() throw(std::runtime_error);
-  void fetchRuns(int min_run, int max_run) throw(std::runtime_error);
-  void fetchLastNRuns( int max_run, int n_runs  )throw(std::runtime_error);
+  void fetchRuns() noexcept(false);
+  void fetchRuns(int min_run, int max_run) noexcept(false);
+  void fetchLastNRuns( int max_run, int n_runs  )noexcept(false);
 
  private:
   // User data for this IOV

--- a/OnlineDB/EcalCondDB/interface/MonRunOutcomeDef.h
+++ b/OnlineDB/EcalCondDB/interface/MonRunOutcomeDef.h
@@ -23,8 +23,8 @@ class MonRunOutcomeDef : public IDef {
   std::string getLongDesc() const;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const MonRunOutcomeDef &d) const { return m_shortDesc == d.m_shortDesc; }
@@ -35,7 +35,7 @@ class MonRunOutcomeDef : public IDef {
   std::string m_shortDesc;
   std::string m_longDesc;
 
-  void fetchAllDefs( std::vector<MonRunOutcomeDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<MonRunOutcomeDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/MonRunTag.h
+++ b/OnlineDB/EcalCondDB/interface/MonRunTag.h
@@ -27,8 +27,8 @@ class MonRunTag : public ITag {
   void setMonVersionDef(const MonVersionDef& ver);
 
   // Methods using ID
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const MonRunTag &t) const
@@ -45,12 +45,12 @@ class MonRunTag : public ITag {
   MonVersionDef m_monVersionDef;
 
   // Methods from ITag
-  int writeDB() throw(std::runtime_error);
+  int writeDB() noexcept(false);
 
   // Access methods
-  void fetchAllTags( std::vector<MonRunTag>* fillVec) throw(std::runtime_error);
+  void fetchAllTags( std::vector<MonRunTag>* fillVec) noexcept(false);
 
-  void fetchParentIDs(int* verID) throw(std::runtime_error);
+  void fetchParentIDs(int* verID) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/MonShapeQualityDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonShapeQualityDat.h
@@ -23,16 +23,16 @@ class MonShapeQualityDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonShapeQualityDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonShapeQualityDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonShapeQualityDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_avgChi2;

--- a/OnlineDB/EcalCondDB/interface/MonTTConsistencyDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonTTConsistencyDat.h
@@ -41,16 +41,16 @@ class MonTTConsistencyDat : public IDataItem {
   
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonTTConsistencyDat* item, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonTTConsistencyDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, MonTTConsistencyDat >* fillVec, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_processedEvents;

--- a/OnlineDB/EcalCondDB/interface/MonTestPulseDat.h
+++ b/OnlineDB/EcalCondDB/interface/MonTestPulseDat.h
@@ -41,17 +41,17 @@ class MonTestPulseDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const MonTestPulseDat* item, MonRunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::map< EcalLogicID, MonTestPulseDat >* data, MonRunIOV* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::map< EcalLogicID, MonTestPulseDat >* fillMap, MonRunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_adcMeanG1;

--- a/OnlineDB/EcalCondDB/interface/MonVersionDef.h
+++ b/OnlineDB/EcalCondDB/interface/MonVersionDef.h
@@ -23,8 +23,8 @@ class MonVersionDef : public IDef {
   std::string getDescription() const;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators
   inline bool operator==(const MonVersionDef &d) const { return m_monVer == d.m_monVer; }
@@ -35,7 +35,7 @@ class MonVersionDef : public IDef {
   std::string m_monVer;
   std::string m_desc;
 
-  void fetchAllDefs( std::vector<MonVersionDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<MonVersionDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/ODBadTTDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODBadTTDat.h
@@ -37,17 +37,17 @@ class ODBadTTDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODBadTTDat* item, ODBadTTInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODBadTTDat >& data, ODBadTTInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODBadTTDat >* fillMap, ODBadTTInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_sm;

--- a/OnlineDB/EcalCondDB/interface/ODBadTTInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODBadTTInfo.h
@@ -22,19 +22,19 @@ class ODBadTTInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(ODBadTTInfo * result)     throw(std::runtime_error);
+  void fetchData(ODBadTTInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODBadXTDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODBadXTDat.h
@@ -37,17 +37,17 @@ class ODBadXTDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODBadXTDat* item, ODBadXTInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODBadXTDat >& data, ODBadXTInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODBadXTDat >* fillMap, ODBadXTInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_sm;

--- a/OnlineDB/EcalCondDB/interface/ODBadXTInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODBadXTInfo.h
@@ -22,19 +22,19 @@ class ODBadXTInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(ODBadXTInfo * result)     throw(std::runtime_error);
+  void fetchData(ODBadXTInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODCCSConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODCCSConfig.h
@@ -63,19 +63,19 @@ class ODCCSConfig : public IODConfig {
   inline void setTEDelay(int x) { m_te_delay = x; }
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODCCSConfig * result)     throw(std::runtime_error);
+  void fetchData(ODCCSConfig * result)     noexcept(false);
 
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODCCSCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODCCSCycle.h
@@ -35,16 +35,16 @@ class ODCCSCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_ccs_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODCCSCycle * result)     throw(std::runtime_error);
+  void fetchData(ODCCSCycle * result) noexcept(false);
 
- void insertConfig() throw(std::runtime_error);
+ void insertConfig() noexcept(false);
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODCond2ConfInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODCond2ConfInfo.h
@@ -41,21 +41,21 @@ class ODCond2ConfInfo : public IODConfig {
 
   // the tag is already in IODConfig 
 
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODCond2ConfInfo * result)     throw(std::runtime_error);
+  void fetchData(ODCond2ConfInfo * result)     noexcept(false);
 
-  void fetchParents()  throw(std::runtime_error) ;
+  void fetchParents()  noexcept(false) ;
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODDCCConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODDCCConfig.h
@@ -47,14 +47,14 @@ class ODDCCConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODDCCConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODDCCConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODDCCCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODDCCCycle.h
@@ -33,16 +33,16 @@ class ODDCCCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_dcc_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODDCCCycle * result)     throw(std::runtime_error);
-  void insertConfig() throw(std::runtime_error);
+  void fetchData(ODDCCCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODDCUConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODDCUConfig.h
@@ -27,14 +27,14 @@ class ODDCUConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODDCUConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODDCUConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODDCUCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODDCUCycle.h
@@ -33,16 +33,16 @@ class ODDCUCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_dcu_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODDCUCycle * result)     throw(std::runtime_error);
-  void insertConfig() throw(std::runtime_error);
+  void fetchData(ODDCUCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODDelaysDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODDelaysDat.h
@@ -33,20 +33,15 @@ class ODDelaysDat : public IODConfig {
   inline int getTimeOffset() const { return m_t1; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const ODDelaysDat* item, ODFEDelaysInfo* iov )
-    throw(std::runtime_error);
+  void writeDB(const ODDelaysDat* item, ODFEDelaysInfo* iov ) noexcept(false);
 
-  void writeArrayDB(const std::vector< ODDelaysDat >& data, ODFEDelaysInfo* iov)
-    throw(std::runtime_error);
+  void writeArrayDB(const std::vector< ODDelaysDat >& data, ODFEDelaysInfo* iov) noexcept(false);
 
 
-  void fetchData(std::vector< ODDelaysDat >* fillMap, int id)
-     throw(std::runtime_error);
-  void fetchData(std::vector< ODDelaysDat >* fillMap, ODFEDelaysInfo* iov)
-     throw(std::runtime_error);
+  void fetchData(std::vector< ODDelaysDat >* fillMap, int id) noexcept(false);
+  void fetchData(std::vector< ODDelaysDat >* fillMap, ODFEDelaysInfo* iov) noexcept(false);
 
   // User data
   int m_sm;

--- a/OnlineDB/EcalCondDB/interface/ODEcalCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODEcalCycle.h
@@ -66,12 +66,12 @@ class ODEcalCycle : public IODConfig {
   void printout();
 
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  int fetchID()        throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
-  void fetchData(ODEcalCycle * result)     throw(std::runtime_error);
+  int fetchID()        noexcept(false);
+  void setByID(int id) noexcept(false);
+  void fetchData(ODEcalCycle * result)     noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODFEDAQConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODFEDAQConfig.h
@@ -42,19 +42,19 @@ class ODFEDAQConfig : public IODConfig {
   inline void setComment(std::string x) { m_com = x; }
   inline std::string getComment() const { return m_com; }
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODFEDAQConfig * result)     throw(std::runtime_error);
+  void fetchData(ODFEDAQConfig * result)     noexcept(false);
 
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODFEDelaysInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODFEDelaysInfo.h
@@ -22,19 +22,19 @@ class ODFEDelaysInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(ODFEDelaysInfo * result)     throw(std::runtime_error);
+  void fetchData(ODFEDelaysInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODFEPedestalOffsetInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODFEPedestalOffsetInfo.h
@@ -23,19 +23,19 @@ class ODFEPedestalOffsetInfo : public IODConfig {
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(ODFEPedestalOffsetInfo * result)     throw(std::runtime_error);
-  void fetchLastData(ODFEPedestalOffsetInfo * result)     throw(std::runtime_error);
+  void fetchData(ODFEPedestalOffsetInfo * result) noexcept(false);
+  void fetchLastData(ODFEPedestalOffsetInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODFEWeightsInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODFEWeightsInfo.h
@@ -23,18 +23,18 @@ class ODFEWeightsInfo : public IODConfig {
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
-  int fetchID()  throw(std::runtime_error);
+  int fetchID() noexcept(false);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB() noexcept(false);
 
   void clear();
 
-  void fetchData(ODFEWeightsInfo * result)     throw(std::runtime_error);
+  void fetchData(ODFEWeightsInfo * result) noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODGolBiasCurrentDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODGolBiasCurrentDat.h
@@ -41,17 +41,17 @@ class ODGolBiasCurrentDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODGolBiasCurrentDat* item, ODGolBiasCurrentInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODGolBiasCurrentDat >& data, ODGolBiasCurrentInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODGolBiasCurrentDat >* fillMap, ODGolBiasCurrentInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_gol;

--- a/OnlineDB/EcalCondDB/interface/ODGolBiasCurrentInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODGolBiasCurrentInfo.h
@@ -22,19 +22,19 @@ class ODGolBiasCurrentInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODGolBiasCurrentInfo * result)     throw(std::runtime_error);
+  void fetchData(ODGolBiasCurrentInfo * result)     noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODJBH4Config.h
+++ b/OnlineDB/EcalCondDB/interface/ODJBH4Config.h
@@ -46,12 +46,12 @@ class ODJBH4Config : public IODConfig {
 
 
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODJBH4Config * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
+  void fetchData(ODJBH4Config * result)     noexcept(false);
+  int fetchID()  noexcept(false);
+  int fetchNextId() noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODJBH4Cycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODJBH4Cycle.h
@@ -33,16 +33,16 @@ class ODJBH4Cycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_jbh4_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODJBH4Cycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODJBH4Cycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODLTCConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODLTCConfig.h
@@ -36,14 +36,14 @@ class ODLTCConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODLTCConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODLTCConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODLTCCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODLTCCycle.h
@@ -34,16 +34,16 @@ class ODLTCCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_ltc_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODLTCCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODLTCCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODLTSConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODLTSConfig.h
@@ -32,12 +32,12 @@ class ODLTSConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
  private:
-  int fetchNextId() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODLTSConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODLTSConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODLTSCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODLTSCycle.h
@@ -33,16 +33,16 @@ class ODLTSCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_lts_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODLTSCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODLTSCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODLaserConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODLaserConfig.h
@@ -191,14 +191,14 @@ class ODLaserConfig : public IODConfig {
 
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODLaserConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODLaserConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODLaserCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODLaserCycle.h
@@ -33,16 +33,16 @@ class ODLaserCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_laser_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODLaserCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODLaserCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODPedestalOffsetsDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODPedestalOffsetsDat.h
@@ -44,17 +44,17 @@ class ODPedestalOffsetsDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODPedestalOffsetsDat* item, ODFEPedestalOffsetInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODPedestalOffsetsDat >& data, ODFEPedestalOffsetInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODPedestalOffsetsDat >* fillMap, ODFEPedestalOffsetInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_sm;

--- a/OnlineDB/EcalCondDB/interface/ODRunConfigCycleInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODRunConfigCycleInfo.h
@@ -54,17 +54,17 @@ int getCycleNumber()const {return m_cycle_num;  }
   std::string m_tag;
   std::string m_description;
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
+  void writeDB() noexcept(false);
   void clear();
-  void fetchData(ODRunConfigCycleInfo * result)     throw(std::runtime_error);
-  void insertConfig() throw(std::runtime_error);
+  void fetchData(ODRunConfigCycleInfo * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error); // fetches the Cycle by the seq_id and cycle_num
-  int fetchIDLast() throw(std::runtime_error); // fetches the Cycle by the seq_id and cycle_num
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false); // fetches the Cycle by the seq_id and cycle_num
+  int fetchIDLast() noexcept(false); // fetches the Cycle by the seq_id and cycle_num
+  void setByID(int id) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/ODRunConfigInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODRunConfigInfo.h
@@ -76,16 +76,16 @@ std::string getUsageStatus() const{  return m_usage_status;}
   std::string m_usage_status;
 
   // Methods from IUniqueDBObject
-  int fetchNextId()  throw(std::runtime_error);
-  int fetchID() throw(std::runtime_error);
-  int fetchIDFromTagAndVersion() throw(std::runtime_error);
-  int fetchIDLast() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchNextId()  noexcept(false);
+  int fetchID() noexcept(false);
+  int fetchIDFromTagAndVersion() noexcept(false);
+  int fetchIDLast() noexcept(false);
+  void setByID(int id) noexcept(false);
 
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
-  void fetchData(ODRunConfigInfo * result)     throw(std::runtime_error);
-  int updateDefaultCycle()   throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
+  void fetchData(ODRunConfigInfo * result)     noexcept(false);
+  int updateDefaultCycle()   noexcept(false);
   void clear();
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODRunConfigSeqInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODRunConfigSeqInfo.h
@@ -55,15 +55,15 @@ class ODRunConfigSeqInfo : public IODConfig {
   std::string m_description;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error); // fetches the sequence by the ecal_config_id and seq_num
-  int fetchIDLast() throw(std::runtime_error); // fetches the sequence by the ecal_config_id and seq_num
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false); // fetches the sequence by the ecal_config_id and seq_num
+  int fetchIDLast() noexcept(false); // fetches the sequence by the ecal_config_id and seq_num
+  void setByID(int id) noexcept(false);
 
-  void  writeDB()throw(std::runtime_error);
+  void  writeDB()noexcept(false);
 
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void fetchData(ODRunConfigSeqInfo * result)     throw(std::runtime_error);
+  void fetchData(ODRunConfigSeqInfo * result)     noexcept(false);
   void clear();
 
 

--- a/OnlineDB/EcalCondDB/interface/ODSRPConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODSRPConfig.h
@@ -54,14 +54,14 @@ class ODSRPConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODSRPConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODSRPConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODSRPCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODSRPCycle.h
@@ -33,16 +33,16 @@ class ODSRPCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_srp_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODSRPCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODSRPCycle * result) noexcept(false);
+   void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODScanConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODScanConfig.h
@@ -35,12 +35,12 @@ class ODScanConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
 
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODScanConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
-  int fetchNextId() throw(std::runtime_error);
+  void fetchData(ODScanConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
+  int fetchNextId() noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/ODScanCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODScanCycle.h
@@ -34,16 +34,16 @@ class ODScanCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_scan_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODScanCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODScanCycle * result) noexcept(false);
+   void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODTCCConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODTCCConfig.h
@@ -48,14 +48,14 @@ class ODTCCConfig : public IODConfig {
 
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODTCCConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODTCCConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODTCCCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODTCCCycle.h
@@ -33,16 +33,16 @@ class ODTCCCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_tcc_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODTCCCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODTCCCycle * result) noexcept(false);
+   void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODTCCEEConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODTCCEEConfig.h
@@ -53,14 +53,14 @@ class ODTCCEEConfig : public IODConfig {
 
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODTCCEEConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODTCCEEConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODTCCEECycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODTCCEECycle.h
@@ -33,16 +33,16 @@ class ODTCCEECycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_tcc_ee_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODTCCEECycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODTCCEECycle * result) noexcept(false);
+   void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODTTCFConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODTTCFConfig.h
@@ -40,19 +40,19 @@ class ODTTCFConfig : public IODConfig {
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODTTCFConfig * result)     throw(std::runtime_error);
+  void fetchData(ODTTCFConfig * result)     noexcept(false);
 
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODTTCFCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODTTCFCycle.h
@@ -33,16 +33,16 @@ class ODTTCFCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_ttcf_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODTTCFCycle * result)     throw(std::runtime_error);
-   void insertConfig() throw(std::runtime_error);
+  void fetchData(ODTTCFCycle * result) noexcept(false);
+   void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODTTCciConfig.h
+++ b/OnlineDB/EcalCondDB/interface/ODTTCciConfig.h
@@ -46,14 +46,14 @@ class ODTTCciConfig : public IODConfig {
 
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
-  void writeDB()       throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
+  void writeDB()       noexcept(false);
   void clear();
-  void fetchData(ODTTCciConfig * result)     throw(std::runtime_error);
-  int fetchID()  throw(std::runtime_error);
+  void fetchData(ODTTCciConfig * result)     noexcept(false);
+  int fetchID()  noexcept(false);
 
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
 
   // User data
   int m_ID;

--- a/OnlineDB/EcalCondDB/interface/ODTTCciCycle.h
+++ b/OnlineDB/EcalCondDB/interface/ODTTCciCycle.h
@@ -33,16 +33,16 @@ class ODTTCciCycle :  public IODConfig  {
   // User data 
   int m_ID;
   int  m_ttcci_config_id;
-  void writeDB() throw(std::runtime_error);
-  void prepareWrite()  throw(std::runtime_error);
+  void writeDB() noexcept(false);
+  void prepareWrite() noexcept(false);
   void clear();
-  void fetchData(ODTTCciCycle * result)     throw(std::runtime_error);
-  void insertConfig() throw(std::runtime_error);
+  void fetchData(ODTTCciCycle * result) noexcept(false);
+  void insertConfig() noexcept(false);
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
 
 };

--- a/OnlineDB/EcalCondDB/interface/ODTowersToByPassDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODTowersToByPassDat.h
@@ -38,17 +38,17 @@ class ODTowersToByPassDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODTowersToByPassDat* item, ODTowersToByPassInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODTowersToByPassDat >& data, ODTowersToByPassInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODTowersToByPassDat >* fillMap, ODTowersToByPassInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_tr;

--- a/OnlineDB/EcalCondDB/interface/ODTowersToByPassInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODTowersToByPassInfo.h
@@ -22,19 +22,19 @@ class ODTowersToByPassInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODTowersToByPassInfo * result)     throw(std::runtime_error);
+  void fetchData(ODTowersToByPassInfo * result)     noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODVfeToRejectDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODVfeToRejectDat.h
@@ -38,17 +38,17 @@ class ODVfeToRejectDat : public IODConfig {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODVfeToRejectDat* item, ODVfeToRejectInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODVfeToRejectDat >& data, ODVfeToRejectInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODVfeToRejectDat >* fillMap, ODVfeToRejectInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
 

--- a/OnlineDB/EcalCondDB/interface/ODVfeToRejectInfo.h
+++ b/OnlineDB/EcalCondDB/interface/ODVfeToRejectInfo.h
@@ -22,19 +22,19 @@ class ODVfeToRejectInfo : public IODConfig {
 
   inline void setVersion(int id) { m_version = id; }
   inline int getVersion() const { return m_version; }
-  int fetchID()  throw(std::runtime_error);
+  int fetchID()  noexcept(false);
 
-  int fetchNextId() throw(std::runtime_error);
+  int fetchNextId() noexcept(false);
   void setParameters(const std::map<std::string,std::string>& my_keys_map);
   
  private:
-  void prepareWrite()  throw(std::runtime_error);
+  void prepareWrite()  noexcept(false);
 
-  void writeDB()       throw(std::runtime_error);
+  void writeDB()       noexcept(false);
 
   void clear();
 
-  void fetchData(ODVfeToRejectInfo * result)     throw(std::runtime_error);
+  void fetchData(ODVfeToRejectInfo * result)     noexcept(false);
 
 
 

--- a/OnlineDB/EcalCondDB/interface/ODWeightsDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODWeightsDat.h
@@ -54,19 +54,19 @@ class ODWeightsDat : public IODConfig {
  private:
   void clear();
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODWeightsDat* item, ODFEWeightsInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODWeightsDat >& data, ODFEWeightsInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODWeightsDat >* fillMap, ODFEWeightsInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
-  void fetchData(ODWeightsDat * p)     throw(std::runtime_error);
+  void fetchData(ODWeightsDat * p)     noexcept(false);
 
   // User data
   int m_sm;

--- a/OnlineDB/EcalCondDB/interface/ODWeightsSamplesDat.h
+++ b/OnlineDB/EcalCondDB/interface/ODWeightsSamplesDat.h
@@ -35,19 +35,19 @@ class ODWeightsSamplesDat : public IODConfig {
  private:
   void clear();
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const ODWeightsSamplesDat* item, ODFEWeightsInfo* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeArrayDB(const std::vector< ODWeightsSamplesDat >& data, ODFEWeightsInfo* iov)
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   void fetchData(std::vector< ODWeightsSamplesDat >* fillMap, ODFEWeightsInfo* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
-  void fetchData(ODWeightsSamplesDat * p)     throw(std::runtime_error);
+  void fetchData(ODWeightsSamplesDat * p)     noexcept(false);
 
   // User data
 

--- a/OnlineDB/EcalCondDB/interface/RunCommentDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunCommentDat.h
@@ -26,13 +26,13 @@ class RunCommentDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunCommentDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunCommentDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
  std::string m_source ;

--- a/OnlineDB/EcalCondDB/interface/RunConfigDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunConfigDat.h
@@ -24,14 +24,11 @@ class RunConfigDat : public IDataItem {
   inline void setConfigVersion(int ver) { m_configVer = ver; }
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const RunConfigDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const RunConfigDat* item, RunIOV* iov ) noexcept(false);
 
-  void fetchData(std::map< EcalLogicID, RunConfigDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, RunConfigDat >* fillMap, RunIOV* iov) noexcept(false);
 
   // User data
   std::string m_configTag;

--- a/OnlineDB/EcalCondDB/interface/RunCrystalErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunCrystalErrorsDat.h
@@ -23,13 +23,13 @@ class RunCrystalErrorsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunCrystalErrorsDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunCrystalErrorsDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   uint64_t m_errorBits;

--- a/OnlineDB/EcalCondDB/interface/RunDCSHVDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunDCSHVDat.h
@@ -58,19 +58,19 @@ class RunDCSHVDat : public IDataItem {
 
 
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunDCSHVDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunDCSHVDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void fetchLastData(std::map< EcalLogicID, RunDCSHVDat >* fillMap)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void fetchHistoricalData(std::list< std::pair<Tm, std::map< EcalLogicID, RunDCSHVDat > > >* fillMap, const Tm& timeStart  )
-    throw(std::runtime_error);
+    noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/RunDCSLVDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunDCSLVDat.h
@@ -48,16 +48,16 @@ class RunDCSLVDat : public IDataItem {
   int nowMicroseconds();
   void fillTheMap(ResultSet *, std::map< EcalLogicID, RunDCSLVDat >* );
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunDCSLVDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunDCSLVDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void fetchLastData(std::map< EcalLogicID, RunDCSLVDat >* fillMap)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_lv;

--- a/OnlineDB/EcalCondDB/interface/RunDCSMagnetDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunDCSMagnetDat.h
@@ -37,16 +37,16 @@ class RunDCSMagnetDat : public IDataItem {
   void fillTheMap(ResultSet *, std::map< EcalLogicID, RunDCSMagnetDat >* );
 
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunDCSMagnetDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunDCSMagnetDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   void fetchLastData(std::map< EcalLogicID, RunDCSMagnetDat >* fillMap)
-     throw(std::runtime_error);
+     noexcept(false);
 
 
   // User data

--- a/OnlineDB/EcalCondDB/interface/RunDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunDat.h
@@ -22,13 +22,13 @@ class RunDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_numEvents;

--- a/OnlineDB/EcalCondDB/interface/RunFEConfigDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunFEConfigDat.h
@@ -24,14 +24,11 @@ class RunFEConfigDat : public IDataItem {
   std::list<ODDelaysDat> getDelays();
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const RunFEConfigDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const RunFEConfigDat* item, RunIOV* iov ) noexcept(false);
 
-  void fetchData(std::map< EcalLogicID, RunFEConfigDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, RunFEConfigDat >* fillMap, RunIOV* iov) noexcept(false);
 
   // User data
 

--- a/OnlineDB/EcalCondDB/interface/RunH4TablePositionDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunH4TablePositionDat.h
@@ -31,13 +31,13 @@ class RunH4TablePositionDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunH4TablePositionDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunH4TablePositionDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   int m_table_x ;

--- a/OnlineDB/EcalCondDB/interface/RunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/RunIOV.h
@@ -35,9 +35,9 @@ class RunIOV : public IIOV {
   // Methods from IUniqueDBObject
   int getID(){ return m_ID;} ;
 
-  int fetchID() throw(std::runtime_error);
-  int fetchIDByRunAndTag() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  int fetchIDByRunAndTag() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // operators
   inline bool operator==(const RunIOV &r) const
@@ -58,29 +58,29 @@ class RunIOV : public IIOV {
   RunTag m_runTag;
   Tm m_dbtime;
 
-  int writeDB() throw(std::runtime_error);
-  int updateEndTimeDB() throw(std::runtime_error);
-  int updateStartTimeDB() throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  int updateEndTimeDB() noexcept(false);
+  int updateStartTimeDB() noexcept(false);
 
-  void setByRun(RunTag* tag, run_t run) throw(std::runtime_error);
-  void setByRun(std::string location, run_t run) throw(std::runtime_error);
-  void setByTime(std::string location, const Tm &t) throw(std::runtime_error);
-  void setByRecentData(std::string dataTable, RunTag* tag, run_t run = (unsigned int)-1) throw(std::runtime_error);
-  void setByRecentData(std::string dataTable, std::string location, run_t run) throw(std::runtime_error);
+  void setByRun(RunTag* tag, run_t run) noexcept(false);
+  void setByRun(std::string location, run_t run) noexcept(false);
+  void setByTime(std::string location, const Tm &t) noexcept(false);
+  void setByRecentData(std::string dataTable, RunTag* tag, run_t run = (unsigned int)-1) noexcept(false);
+  void setByRecentData(std::string dataTable, std::string location, run_t run) noexcept(false);
 
 
-/*   void fetchEarliest(RunIOV* fillIOV, RunTag* tag) const throw(std::runtime_error); */
-/*   void fetchLatest(RunIOV* fillIOV, RunTag* tag) const throw(std::runtime_error); */
-/*   oracle::occi::Statement* prepareFetch(const std::string sql, RunTag* tag) const throw(std::runtime_error); */
-/*   void fill(RunIOV* target, oracle::occi::ResultSet* rset) const throw(std::runtime_error); */
+/*   void fetchEarliest(RunIOV* fillIOV, RunTag* tag) const noexcept(false); */
+/*   void fetchLatest(RunIOV* fillIOV, RunTag* tag) const noexcept(false); */
+/*   oracle::occi::Statement* prepareFetch(const std::string sql, RunTag* tag) const noexcept(false); */
+/*   void fill(RunIOV* target, oracle::occi::ResultSet* rset) const noexcept(false); */
 
 /*   // Methods for fetching by Tm */
-/*   void fetchAt(RunIOV* iov, const Tm eventTm, RunTag* tag) const throw(std::runtime_error); */
-/*   void fetchWithin(std::vector<RunIOV>* fillVec, const Tm beginTm, const Tm endTm, RunTag* tag) const throw(std::runtime_error); */
+/*   void fetchAt(RunIOV* iov, const Tm eventTm, RunTag* tag) const noexcept(false); */
+/*   void fetchWithin(std::vector<RunIOV>* fillVec, const Tm beginTm, const Tm endTm, RunTag* tag) const noexcept(false); */
 
 /*   // Methods for fetching by run_t */
-/*   void fetchAt(RunIOV* fillIOV, const run_t run, RunTag* tag) const throw(std::runtime_error); */
-/*   void fetchWithin(std::vector<RunIOV>* fillVec, const run_t beginRun, const run_t endRun, RunTag* tag) const throw(std::runtime_error); */
+/*   void fetchAt(RunIOV* fillIOV, const run_t run, RunTag* tag) const noexcept(false); */
+/*   void fetchWithin(std::vector<RunIOV>* fillVec, const run_t beginRun, const run_t endRun, RunTag* tag) const noexcept(false); */
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/RunLaserRunDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunLaserRunDat.h
@@ -25,13 +25,13 @@ class RunLaserRunDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunLaserRunDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunLaserRunDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   std::string m_laserSeqType;

--- a/OnlineDB/EcalCondDB/interface/RunList.h
+++ b/OnlineDB/EcalCondDB/interface/RunList.h
@@ -27,16 +27,16 @@ class RunList  : public IDBObject {
   std::vector<RunIOV> getRuns() ;
   
   // Methods from IUniqueDBObject
-  void fetchRuns() throw(std::runtime_error);
-  void fetchNonEmptyRuns() throw(std::runtime_error);
-  void fetchNonEmptyGlobalRuns() throw(std::runtime_error);
-  void fetchNonEmptyRuns(int min_run, int max_run) throw(std::runtime_error);
-  void fetchNonEmptyGlobalRuns(int min_run, int max_run) throw(std::runtime_error);
-  void fetchRuns(int min_run, int max_run) throw(std::runtime_error);
-  void fetchRuns(int min_run, int max_run, bool withTriggers, bool withGlobalTriggers) throw(std::runtime_error);
-  void fetchLastNRuns( int max_run, int n_runs  ) throw(std::runtime_error);
-  void fetchRunsByLocation (int min_run, int max_run, const LocationDef& locDef )  throw(std::runtime_error);
-  void fetchGlobalRunsByLocation(int min_run, int max_run, const LocationDef& locDef )  throw(std::runtime_error);
+  void fetchRuns() noexcept(false);
+  void fetchNonEmptyRuns() noexcept(false);
+  void fetchNonEmptyGlobalRuns() noexcept(false);
+  void fetchNonEmptyRuns(int min_run, int max_run) noexcept(false);
+  void fetchNonEmptyGlobalRuns(int min_run, int max_run) noexcept(false);
+  void fetchRuns(int min_run, int max_run) noexcept(false);
+  void fetchRuns(int min_run, int max_run, bool withTriggers, bool withGlobalTriggers) noexcept(false);
+  void fetchLastNRuns( int max_run, int n_runs  ) noexcept(false);
+  void fetchRunsByLocation (int min_run, int max_run, const LocationDef& locDef )  noexcept(false);
+  void fetchGlobalRunsByLocation(int min_run, int max_run, const LocationDef& locDef )  noexcept(false);
 
 
  private:

--- a/OnlineDB/EcalCondDB/interface/RunMemChErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunMemChErrorsDat.h
@@ -23,13 +23,13 @@ class RunMemChErrorsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunMemChErrorsDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunMemChErrorsDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   uint64_t m_errorBits;

--- a/OnlineDB/EcalCondDB/interface/RunMemTTErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunMemTTErrorsDat.h
@@ -23,13 +23,13 @@ class RunMemTTErrorsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunMemTTErrorsDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunMemTTErrorsDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   uint64_t m_errorBits;

--- a/OnlineDB/EcalCondDB/interface/RunModeDef.h
+++ b/OnlineDB/EcalCondDB/interface/RunModeDef.h
@@ -23,8 +23,8 @@ class RunModeDef : public IDef {
 
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators.  m_desc is not considered, it cannot be written to DB anyhow
   inline bool operator==(const RunModeDef &t) const { return m_runMode == t.m_runMode; }
@@ -35,7 +35,7 @@ class RunModeDef : public IDef {
   std::string m_runMode;
 
 
-  void fetchAllDefs( std::vector<RunModeDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<RunModeDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/RunPNErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunPNErrorsDat.h
@@ -23,13 +23,13 @@ class RunPNErrorsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunPNErrorsDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunPNErrorsDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   uint64_t m_errorBits;

--- a/OnlineDB/EcalCondDB/interface/RunPTMTempDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunPTMTempDat.h
@@ -21,13 +21,13 @@ class RunPTMTempDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunPTMTempDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunPTMTempDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   float m_temperature;

--- a/OnlineDB/EcalCondDB/interface/RunSeqDef.h
+++ b/OnlineDB/EcalCondDB/interface/RunSeqDef.h
@@ -30,8 +30,8 @@ class RunSeqDef : public IDef {
 
   
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators.  m_desc is not considered, it cannot be written to DB anyhow
   inline bool operator==(const RunSeqDef &t) const { return m_runSeq == t.m_runSeq; }
@@ -42,10 +42,10 @@ class RunSeqDef : public IDef {
   std::string m_runSeq;
   RunTypeDef m_runType;  
 
-  int writeDB()throw(std::runtime_error);
+  int writeDB() noexcept(false);
 
 
-  void fetchAllDefs( std::vector<RunSeqDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<RunSeqDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/RunTPGConfigDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunTPGConfigDat.h
@@ -24,14 +24,11 @@ class RunTPGConfigDat : public IDataItem {
 
 
  private:
-  void prepareWrite() 
-    throw(std::runtime_error);
+  void prepareWrite() noexcept(false);
 
-  void writeDB(const EcalLogicID* ecid, const RunTPGConfigDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+  void writeDB(const EcalLogicID* ecid, const RunTPGConfigDat* item, RunIOV* iov ) noexcept(false);
 
-  void fetchData(std::map< EcalLogicID, RunTPGConfigDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+  void fetchData(std::map< EcalLogicID, RunTPGConfigDat >* fillMap, RunIOV* iov) noexcept(false);
 
   // User data
   int m_version;

--- a/OnlineDB/EcalCondDB/interface/RunTTErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunTTErrorsDat.h
@@ -23,13 +23,13 @@ class RunTTErrorsDat : public IDataItem {
 
  private:
   void prepareWrite() 
-    throw(std::runtime_error);
+    noexcept(false);
 
   void writeDB(const EcalLogicID* ecid, const RunTTErrorsDat* item, RunIOV* iov )
-    throw(std::runtime_error);
+    noexcept(false);
 
   void fetchData(std::map< EcalLogicID, RunTTErrorsDat >* fillMap, RunIOV* iov)
-     throw(std::runtime_error);
+     noexcept(false);
 
   // User data
   uint64_t m_errorBits;

--- a/OnlineDB/EcalCondDB/interface/RunTag.h
+++ b/OnlineDB/EcalCondDB/interface/RunTag.h
@@ -29,8 +29,8 @@ class RunTag : public ITag {
   void setRunTypeDef(const RunTypeDef& runTypeDef);
 
   // Methods using ID
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // operators
   inline bool operator==(const RunTag& t) const
@@ -49,11 +49,11 @@ class RunTag : public ITag {
   RunTypeDef m_runTypeDef;
 
   // Methods from ITag
-  int writeDB() throw(std::runtime_error);
-  void fetchParentIDs(int* locId, int* runTypeID) throw(std::runtime_error);
+  int writeDB() noexcept(false);
+  void fetchParentIDs(int* locId, int* runTypeID) noexcept(false);
 
   // Public access methods
-  void fetchAllTags( std::vector<RunTag>* fillVec) throw(std::runtime_error);
+  void fetchAllTags( std::vector<RunTag>* fillVec) noexcept(false);
 
 };
 

--- a/OnlineDB/EcalCondDB/interface/RunTypeDef.h
+++ b/OnlineDB/EcalCondDB/interface/RunTypeDef.h
@@ -23,8 +23,8 @@ class RunTypeDef : public IDef {
   std::string getDescription() const;
 
   // Methods from IUniqueDBObject
-  int fetchID() throw(std::runtime_error);
-  void setByID(int id) throw(std::runtime_error);
+  int fetchID() noexcept(false);
+  void setByID(int id) noexcept(false);
 
   // Operators.  m_desc is not considered, it cannot be written to DB anyhow
   inline bool operator==(const RunTypeDef &t) const { return m_runType == t.m_runType; }
@@ -35,7 +35,7 @@ class RunTypeDef : public IDef {
   std::string m_runType;
   std::string m_desc;
 
-  void fetchAllDefs( std::vector<RunTypeDef>* fillVec) throw(std::runtime_error);
+  void fetchAllDefs( std::vector<RunTypeDef>* fillVec) noexcept(false);
 };
 
 #endif

--- a/OnlineDB/EcalCondDB/interface/Tm.h
+++ b/OnlineDB/EcalCondDB/interface/Tm.h
@@ -92,7 +92,7 @@ class Tm {
   /*
    *  Set to string of format YYYY-MM-DD HH:MM:SS
    */
-  void setToString(const std::string s) throw(std::runtime_error);
+  void setToString(const std::string s) noexcept(false);
 
   void dumpTm();
 

--- a/OnlineDB/EcalCondDB/src/CaliCrystalIntercalDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliCrystalIntercalDat.cc
@@ -30,7 +30,7 @@ CaliCrystalIntercalDat::~CaliCrystalIntercalDat()
 
 
 void CaliCrystalIntercalDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   
@@ -48,7 +48,7 @@ void CaliCrystalIntercalDat::prepareWrite()
 
 
 void CaliCrystalIntercalDat::writeDB(const EcalLogicID* ecid, const CaliCrystalIntercalDat* item, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -77,7 +77,7 @@ void CaliCrystalIntercalDat::writeDB(const EcalLogicID* ecid, const CaliCrystalI
 
 
 void CaliCrystalIntercalDat::fetchData(std::map< EcalLogicID, CaliCrystalIntercalDat >* fillMap, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -123,7 +123,7 @@ void CaliCrystalIntercalDat::fetchData(std::map< EcalLogicID, CaliCrystalInterca
 }
 
 void CaliCrystalIntercalDat::writeArrayDB(const std::map< EcalLogicID, CaliCrystalIntercalDat >* data, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/CaliGainRatioDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliGainRatioDat.cc
@@ -29,7 +29,7 @@ CaliGainRatioDat::~CaliGainRatioDat()
 
 
 void CaliGainRatioDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   
@@ -47,7 +47,7 @@ void CaliGainRatioDat::prepareWrite()
 
 
 void CaliGainRatioDat::writeDB(const EcalLogicID* ecid, const CaliGainRatioDat* item, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -75,7 +75,7 @@ void CaliGainRatioDat::writeDB(const EcalLogicID* ecid, const CaliGainRatioDat* 
 
 
 void CaliGainRatioDat::fetchData(std::map< EcalLogicID, CaliGainRatioDat >* fillMap, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -120,7 +120,7 @@ void CaliGainRatioDat::fetchData(std::map< EcalLogicID, CaliGainRatioDat >* fill
 }
 
 void CaliGainRatioDat::writeArrayDB(const std::map< EcalLogicID, CaliGainRatioDat >* data, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/CaliGeneralDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliGeneralDat.cc
@@ -28,7 +28,7 @@ CaliGeneralDat::~CaliGeneralDat()
 
 
 void CaliGeneralDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   
@@ -46,7 +46,7 @@ void CaliGeneralDat::prepareWrite()
 
 
 void CaliGeneralDat::writeDB(const EcalLogicID* ecid, const CaliGeneralDat* item, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -73,7 +73,7 @@ void CaliGeneralDat::writeDB(const EcalLogicID* ecid, const CaliGeneralDat* item
 
 
 void CaliGeneralDat::fetchData(std::map< EcalLogicID, CaliGeneralDat >* fillMap, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/CaliHVScanRatioDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliHVScanRatioDat.cc
@@ -29,7 +29,7 @@ CaliHVScanRatioDat::~CaliHVScanRatioDat()
 
 
 void CaliHVScanRatioDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   
@@ -47,7 +47,7 @@ void CaliHVScanRatioDat::prepareWrite()
 
 
 void CaliHVScanRatioDat::writeDB(const EcalLogicID* ecid, const CaliHVScanRatioDat* item, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -75,7 +75,7 @@ void CaliHVScanRatioDat::writeDB(const EcalLogicID* ecid, const CaliHVScanRatioD
 
 
 void CaliHVScanRatioDat::fetchData(std::map< EcalLogicID, CaliHVScanRatioDat >* fillMap, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/CaliIOV.cc
+++ b/OnlineDB/EcalCondDB/src/CaliIOV.cc
@@ -77,7 +77,7 @@ CaliTag CaliIOV::getCaliTag() const
 
 
 int CaliIOV::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -126,7 +126,7 @@ int CaliIOV::fetchID()
 
 
 void CaliIOV::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -163,7 +163,7 @@ void CaliIOV::setByID(int id)
 
 
 int CaliIOV::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -213,7 +213,7 @@ int CaliIOV::writeDB()
 
 
 void CaliIOV::setByTm(CaliTag* tag, const Tm& eventTm)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   

--- a/OnlineDB/EcalCondDB/src/CaliTag.cc
+++ b/OnlineDB/EcalCondDB/src/CaliTag.cc
@@ -112,7 +112,7 @@ void CaliTag::setDataType(string dataType)
 
 
 int CaliTag::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return tag from memory if available
   if (m_ID) {
@@ -158,7 +158,7 @@ int CaliTag::fetchID()
 
 
 void CaliTag::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -192,7 +192,7 @@ void CaliTag::setByID(int id)
 
 
 int CaliTag::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if this data is already in the DB
   if (this->fetchID()) { 
@@ -236,7 +236,7 @@ int CaliTag::writeDB()
 
 
 void CaliTag::fetchAllTags( std::vector<CaliTag>* fillVec)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {
@@ -259,7 +259,7 @@ void CaliTag::fetchAllTags( std::vector<CaliTag>* fillVec)
 
 
 void CaliTag::fetchParentIDs(int* locID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the location
   m_locDef.setConnection(m_env, m_conn);

--- a/OnlineDB/EcalCondDB/src/CaliTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliTempDat.cc
@@ -30,7 +30,7 @@ CaliTempDat::~CaliTempDat()
 
 
 void CaliTempDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   
@@ -48,7 +48,7 @@ void CaliTempDat::prepareWrite()
 
 
 void CaliTempDat::writeDB(const EcalLogicID* ecid, const CaliTempDat* item, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -77,7 +77,7 @@ void CaliTempDat::writeDB(const EcalLogicID* ecid, const CaliTempDat* item, Cali
 
 
 void CaliTempDat::fetchData(std::map< EcalLogicID, CaliTempDat >* fillMap, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -123,7 +123,7 @@ void CaliTempDat::fetchData(std::map< EcalLogicID, CaliTempDat >* fillMap, CaliI
 }
 
 void CaliTempDat::writeArrayDB(const std::map< EcalLogicID, CaliTempDat >* data, CaliIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCSPTMTempList.cc
+++ b/OnlineDB/EcalCondDB/src/DCSPTMTempList.cc
@@ -29,7 +29,7 @@ DCSPTMTempList::~DCSPTMTempList()
 
 
 void DCSPTMTempList::fetchValuesForECID(const EcalLogicID& ecid)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -94,7 +94,7 @@ void DCSPTMTempList::fetchValuesForECID(const EcalLogicID& ecid)
 }
 
 void DCSPTMTempList::fetchValuesForECIDAndTime(const EcalLogicID& ecid, const Tm& start, const Tm& end)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();

--- a/OnlineDB/EcalCondDB/src/DCUCCSDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCCSDat.cc
@@ -35,7 +35,7 @@ DCUCCSDat::~DCUCCSDat()
 }
 
 void DCUCCSDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -59,7 +59,7 @@ void DCUCCSDat::prepareWrite()
 
 void DCUCCSDat::writeDB(const EcalLogicID* ecid, const DCUCCSDat* item, 
 			DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -99,7 +99,7 @@ void DCUCCSDat::writeDB(const EcalLogicID* ecid, const DCUCCSDat* item,
 
 void DCUCCSDat::fetchData(std::map< EcalLogicID, DCUCCSDat >* fillMap, 
 			  DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -151,7 +151,7 @@ void DCUCCSDat::fetchData(std::map< EcalLogicID, DCUCCSDat >* fillMap,
 }
 
 void DCUCCSDat::writeArrayDB(const std::map< EcalLogicID, DCUCCSDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUCapsuleTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCapsuleTempDat.cc
@@ -28,7 +28,7 @@ DCUCapsuleTempDat::~DCUCapsuleTempDat()
 
 
 void DCUCapsuleTempDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void DCUCapsuleTempDat::prepareWrite()
 
 
 void DCUCapsuleTempDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTempDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void DCUCapsuleTempDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTempDat
 
 
 void DCUCapsuleTempDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -114,7 +114,7 @@ void DCUCapsuleTempDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempDat >* fi
   }
 }
 void DCUCapsuleTempDat::writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTempDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUCapsuleTempRawDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCapsuleTempRawDat.cc
@@ -29,7 +29,7 @@ DCUCapsuleTempRawDat::~DCUCapsuleTempRawDat()
 
 
 void DCUCapsuleTempRawDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void DCUCapsuleTempRawDat::prepareWrite()
 
 
 void DCUCapsuleTempRawDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTempRawDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -74,7 +74,7 @@ void DCUCapsuleTempRawDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTemp
 
 
 void DCUCapsuleTempRawDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempRawDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -118,7 +118,7 @@ void DCUCapsuleTempRawDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempRawDat
 }
 
 void DCUCapsuleTempRawDat::writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTempRawDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUIDarkDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIDarkDat.cc
@@ -28,7 +28,7 @@ DCUIDarkDat::~DCUIDarkDat()
 
 
 void DCUIDarkDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void DCUIDarkDat::prepareWrite()
 
 
 void DCUIDarkDat::writeDB(const EcalLogicID* ecid, const DCUIDarkDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void DCUIDarkDat::writeDB(const EcalLogicID* ecid, const DCUIDarkDat* item, DCUI
 
 
 void DCUIDarkDat::fetchData(std::map< EcalLogicID, DCUIDarkDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -114,7 +114,7 @@ void DCUIDarkDat::fetchData(std::map< EcalLogicID, DCUIDarkDat >* fillMap, DCUIO
   }
 }
 void DCUIDarkDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUIDarkPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIDarkPedDat.cc
@@ -28,7 +28,7 @@ DCUIDarkPedDat::~DCUIDarkPedDat()
 
 
 void DCUIDarkPedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void DCUIDarkPedDat::prepareWrite()
 
 
 void DCUIDarkPedDat::writeDB(const EcalLogicID* ecid, const DCUIDarkPedDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void DCUIDarkPedDat::writeDB(const EcalLogicID* ecid, const DCUIDarkPedDat* item
 
 
 void DCUIDarkPedDat::fetchData(std::map< EcalLogicID, DCUIDarkPedDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -114,7 +114,7 @@ void DCUIDarkPedDat::fetchData(std::map< EcalLogicID, DCUIDarkPedDat >* fillMap,
   }
 }
 void DCUIDarkPedDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkPedDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUIOV.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIOV.cc
@@ -77,7 +77,7 @@ DCUTag DCUIOV::getDCUTag() const
 
 
 int DCUIOV::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -125,7 +125,7 @@ int DCUIOV::fetchID()
 
 
 void DCUIOV::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -162,7 +162,7 @@ void DCUIOV::setByID(int id)
 
 
 int DCUIOV::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -212,7 +212,7 @@ int DCUIOV::writeDB()
 
 
 void DCUIOV::setByTm(DCUTag* tag, const Tm& eventTm)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   

--- a/OnlineDB/EcalCondDB/src/DCULVRBTempsDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRBTempsDat.cc
@@ -30,7 +30,7 @@ DCULVRBTempsDat::~DCULVRBTempsDat()
 
 
 void DCULVRBTempsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void DCULVRBTempsDat::prepareWrite()
 
 
 void DCULVRBTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRBTempsDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void DCULVRBTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRBTempsDat* it
 
 
 void DCULVRBTempsDat::fetchData(std::map< EcalLogicID, DCULVRBTempsDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -121,7 +121,7 @@ void DCULVRBTempsDat::fetchData(std::map< EcalLogicID, DCULVRBTempsDat >* fillMa
 }
 
 void DCULVRBTempsDat::writeArrayDB(const std::map< EcalLogicID, DCULVRBTempsDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCULVRTempsDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRTempsDat.cc
@@ -30,7 +30,7 @@ DCULVRTempsDat::~DCULVRTempsDat()
 
 
 void DCULVRTempsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void DCULVRTempsDat::prepareWrite()
 
 
 void DCULVRTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRTempsDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void DCULVRTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRTempsDat* item
 
 
 void DCULVRTempsDat::fetchData(std::map< EcalLogicID, DCULVRTempsDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/DCULVRVoltagesDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRVoltagesDat.cc
@@ -42,7 +42,7 @@ DCULVRVoltagesDat::~DCULVRVoltagesDat()
 
 
 void DCULVRVoltagesDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -60,7 +60,7 @@ void DCULVRVoltagesDat::prepareWrite()
 
 
 void DCULVRVoltagesDat::writeDB(const EcalLogicID* ecid, const DCULVRVoltagesDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -100,7 +100,7 @@ void DCULVRVoltagesDat::writeDB(const EcalLogicID* ecid, const DCULVRVoltagesDat
 
 
 void DCULVRVoltagesDat::fetchData(std::map< EcalLogicID, DCULVRVoltagesDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -156,7 +156,7 @@ void DCULVRVoltagesDat::fetchData(std::map< EcalLogicID, DCULVRVoltagesDat >* fi
   }
 }
 void DCULVRVoltagesDat::writeArrayDB(const std::map< EcalLogicID, DCULVRVoltagesDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/DCUTag.cc
+++ b/OnlineDB/EcalCondDB/src/DCUTag.cc
@@ -60,7 +60,7 @@ void DCUTag::setLocationDef(const LocationDef& locDef)
 
 
 int DCUTag::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return tag from memory if available
   if (m_ID) {
@@ -100,7 +100,7 @@ int DCUTag::fetchID()
 
 
 void DCUTag::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -131,7 +131,7 @@ void DCUTag::setByID(int id)
 
 
 int DCUTag::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if this data is already in the DB
   if (this->fetchID()) { 
@@ -172,7 +172,7 @@ int DCUTag::writeDB()
 
 
 void DCUTag::fetchAllTags( std::vector<DCUTag>* fillVec)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {
@@ -195,7 +195,7 @@ void DCUTag::fetchAllTags( std::vector<DCUTag>* fillVec)
 
 
 void DCUTag::fetchParentIDs(int* locID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the location
   m_locDef.setConnection(m_env, m_conn);

--- a/OnlineDB/EcalCondDB/src/DCUVFETempDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUVFETempDat.cc
@@ -28,7 +28,7 @@ DCUVFETempDat::~DCUVFETempDat()
 
 
 void DCUVFETempDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void DCUVFETempDat::prepareWrite()
 
 
 void DCUVFETempDat::writeDB(const EcalLogicID* ecid, const DCUVFETempDat* item, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void DCUVFETempDat::writeDB(const EcalLogicID* ecid, const DCUVFETempDat* item, 
 
 
 void DCUVFETempDat::fetchData(std::map< EcalLogicID, DCUVFETempDat >* fillMap, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -115,7 +115,7 @@ void DCUVFETempDat::fetchData(std::map< EcalLogicID, DCUVFETempDat >* fillMap, D
 }
 
 void DCUVFETempDat::writeArrayDB(const std::map< EcalLogicID, DCUVFETempDat >* data, DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/EcalCommon.cc
+++ b/OnlineDB/EcalCondDB/src/EcalCommon.cc
@@ -6,7 +6,7 @@
 using namespace std;
 
 int EcalCommon::crystalToTriggerTower(int xtal)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   if (xtal < 1 || xtal > 1700) {
     throw(std::runtime_error("ERROR:  crystalToTriggerTower:  crystal number out of bounds"));

--- a/OnlineDB/EcalCondDB/src/EcalCondDBInterface.cc
+++ b/OnlineDB/EcalCondDB/src/EcalCondDBInterface.cc
@@ -67,7 +67,7 @@ void EcalCondDBInterface::fillLogicId2DetIdMaps() {
 
 
 EcalLogicID EcalCondDBInterface::getEcalLogicID( int logicID )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   string sql = "SELECT name, logic_id, id1, id2, id3, maps_to FROM channelView WHERE logic_id = :logicID AND name=maps_to";
@@ -104,7 +104,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( int logicID )
 }
 
 std::list<ODDelaysDat> EcalCondDBInterface::fetchFEDelaysForRun(RunIOV *iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::list<ODDelaysDat> ret;
   RunFEConfigDat d;
@@ -142,7 +142,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( string name,
 						 int id2,
 						 int id3,
 						 string mapsTo )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   if (mapsTo == "") {
@@ -204,7 +204,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSet( string name,
 							    int fromId2, int toId2,
 							    int fromId3, int toId3,
 							    string mapsTo )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   if (mapsTo == "") {
     mapsTo = name;
@@ -404,7 +404,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSetOrdered( string n
 							    string mapsTo, int orderedBy )
   // the orderedBy can be 1, 2, 3, 4
   // corresponding to id1 id2 id3 or logic_id 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   if (mapsTo == "") {
     mapsTo = name;
@@ -516,7 +516,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSetOrdered( string n
 
 
 void EcalCondDBInterface::insertRunIOV(RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -529,7 +529,7 @@ void EcalCondDBInterface::insertRunIOV(RunIOV* iov)
 }
 
 void EcalCondDBInterface::insertLmfSeq(LMFSeqDat *iov) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     iov->setConnection(env, conn);
@@ -542,7 +542,7 @@ void EcalCondDBInterface::insertLmfSeq(LMFSeqDat *iov)
 }
 
 void EcalCondDBInterface::insertLmfLmrSubIOV(LMFLmrSubIOV *iov) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     iov->setConnection(env, conn);
@@ -555,7 +555,7 @@ void EcalCondDBInterface::insertLmfLmrSubIOV(LMFLmrSubIOV *iov)
 }
 
 void EcalCondDBInterface::insertLmfIOV(LMFIOV *iov) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     iov->setConnection(env, conn);
@@ -568,7 +568,7 @@ void EcalCondDBInterface::insertLmfIOV(LMFIOV *iov)
 }
 
 void EcalCondDBInterface::insertLmfDat(LMFDat *dat) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     dat->setConnection(env, conn);
@@ -581,7 +581,7 @@ void EcalCondDBInterface::insertLmfDat(LMFDat *dat)
 }
 
 void EcalCondDBInterface::insertLmfDat(std::list<LMFDat *> dat) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     std::list<LMFDat *>::iterator i = dat.begin();
@@ -599,7 +599,7 @@ void EcalCondDBInterface::insertLmfDat(std::list<LMFDat *> dat)
 }
 
 void EcalCondDBInterface::insertLmfRunIOV(LMFRunIOV *iov) 
-  throw(std::runtime_error) 
+  noexcept(false) 
 {
   try {
     iov->setConnection(env, conn);
@@ -612,7 +612,7 @@ void EcalCondDBInterface::insertLmfRunIOV(LMFRunIOV *iov)
 }
 
 void EcalCondDBInterface::updateRunIOV(RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -625,7 +625,7 @@ void EcalCondDBInterface::updateRunIOV(RunIOV* iov)
 }
 
 void EcalCondDBInterface::updateRunIOVEndTime(RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -638,7 +638,7 @@ void EcalCondDBInterface::updateRunIOVEndTime(RunIOV* iov)
 }
 
 void EcalCondDBInterface::updateRunIOVStartTime(RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -651,7 +651,7 @@ void EcalCondDBInterface::updateRunIOVStartTime(RunIOV* iov)
 }
 
 void EcalCondDBInterface::updateRunConfig(ODRunConfigInfo* od)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     od->setConnection(env, conn);
@@ -664,7 +664,7 @@ void EcalCondDBInterface::updateRunConfig(ODRunConfigInfo* od)
 }
 
 RunIOV EcalCondDBInterface::fetchRunIOV(RunTag* tag, run_t run)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   RunIOV iov;
   iov.setConnection(env, conn);
@@ -675,7 +675,7 @@ RunIOV EcalCondDBInterface::fetchRunIOV(RunTag* tag, run_t run)
 
 
 RunIOV EcalCondDBInterface::fetchRunIOV(std::string location, run_t run)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   RunIOV iov;
   iov.setConnection(env, conn);
@@ -684,7 +684,7 @@ RunIOV EcalCondDBInterface::fetchRunIOV(std::string location, run_t run)
 }
 
 RunIOV EcalCondDBInterface::fetchRunIOV(std::string location, const Tm &t) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   RunIOV iov;
   iov.setConnection(env, conn);
@@ -693,7 +693,7 @@ RunIOV EcalCondDBInterface::fetchRunIOV(std::string location, const Tm &t)
 }
 
 void EcalCondDBInterface::insertMonRunIOV(MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -706,7 +706,7 @@ void EcalCondDBInterface::insertMonRunIOV(MonRunIOV* iov)
 }
 
 void EcalCondDBInterface::insertDCUIOV(DCUIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
     iov->setConnection(env, conn);
@@ -722,7 +722,7 @@ void EcalCondDBInterface::insertDCUIOV(DCUIOV* iov)
 
 
 MonRunIOV EcalCondDBInterface::fetchMonRunIOV(RunTag* runtag, MonRunTag* montag, run_t run, subrun_t subrun)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   RunIOV runiov = fetchRunIOV(runtag, run);
   MonRunIOV moniov;
@@ -734,7 +734,7 @@ MonRunIOV EcalCondDBInterface::fetchMonRunIOV(RunTag* runtag, MonRunTag* montag,
 
 
 DCUIOV EcalCondDBInterface::fetchDCUIOV(DCUTag* tag, const Tm& eventTm)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   DCUIOV dcuiov;
   dcuiov.setConnection(env, conn);
@@ -748,7 +748,7 @@ RunIOV EcalCondDBInterface::fetchLMFLastRun() const {
 }
 
 LMFRunIOV EcalCondDBInterface::fetchLMFRunIOV(RunTag* runtag, LMFRunTag* lmftag, run_t run, subrun_t subrun)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   RunIOV runiov = fetchRunIOV(runtag, run);
   LMFRunIOV lmfiov;
@@ -789,7 +789,7 @@ bool EcalCondDBInterface::fetchLMFRunIOV(const LMFSeqDat &seq, LMFRunIOV& iov,
 }
 
 CaliIOV EcalCondDBInterface::fetchCaliIOV(CaliTag* tag, const Tm& eventTm)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   CaliIOV caliiov;
   caliiov.setConnection(env, conn);
@@ -798,7 +798,7 @@ CaliIOV EcalCondDBInterface::fetchCaliIOV(CaliTag* tag, const Tm& eventTm)
 }
 
 DCSPTMTempList EcalCondDBInterface::fetchDCSPTMTempList(const EcalLogicID& ecid)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   DCSPTMTempList r;
   r.setConnection(env, conn);
@@ -807,7 +807,7 @@ DCSPTMTempList EcalCondDBInterface::fetchDCSPTMTempList(const EcalLogicID& ecid)
 }
 
 DCSPTMTempList EcalCondDBInterface::fetchDCSPTMTempList(const EcalLogicID& ecid, const Tm& start, const Tm& end)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   DCSPTMTempList r;
   r.setConnection(env, conn);
@@ -816,7 +816,7 @@ DCSPTMTempList EcalCondDBInterface::fetchDCSPTMTempList(const EcalLogicID& ecid,
 }
 
 RunList EcalCondDBInterface::fetchRunList(const RunTag& tag)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   RunList r;
   r.setConnection(env, conn);
@@ -825,7 +825,7 @@ RunList EcalCondDBInterface::fetchRunList(const RunTag& tag)
   return r;
 }
 
-RunList EcalCondDBInterface::fetchRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error){
+RunList EcalCondDBInterface::fetchRunList(const RunTag& tag, int min_run, int max_run) noexcept(false){
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -833,7 +833,7 @@ RunList EcalCondDBInterface::fetchRunList(const RunTag& tag, int min_run, int ma
   return r;
 }
 
-RunList EcalCondDBInterface::fetchNonEmptyRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error){
+RunList EcalCondDBInterface::fetchNonEmptyRunList(const RunTag& tag, int min_run, int max_run) noexcept(false){
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -841,7 +841,7 @@ RunList EcalCondDBInterface::fetchNonEmptyRunList(const RunTag& tag, int min_run
   return r;
 }
 
-RunList EcalCondDBInterface::fetchNonEmptyGlobalRunList(const RunTag& tag, int min_run, int max_run) throw(std::runtime_error){
+RunList EcalCondDBInterface::fetchNonEmptyGlobalRunList(const RunTag& tag, int min_run, int max_run) noexcept(false){
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -850,7 +850,7 @@ RunList EcalCondDBInterface::fetchNonEmptyGlobalRunList(const RunTag& tag, int m
 }
 
 RunList EcalCondDBInterface::fetchRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -859,7 +859,7 @@ RunList EcalCondDBInterface::fetchRunListByLocation(const RunTag& tag, int min_r
 }
 
 RunList EcalCondDBInterface::fetchGlobalRunListByLocation(const RunTag& tag, int min_run, int max_run , const LocationDef& locDef) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -868,7 +868,7 @@ RunList EcalCondDBInterface::fetchGlobalRunListByLocation(const RunTag& tag, int
 }
 
 RunList EcalCondDBInterface::fetchRunListLastNRuns(const RunTag& tag, int max_run, int n_runs) 
-  throw(std::runtime_error){
+  noexcept(false){
   RunList r;
   r.setConnection(env, conn);
   r.setRunTag(tag);
@@ -882,7 +882,7 @@ RunList EcalCondDBInterface::fetchRunListLastNRuns(const RunTag& tag, int max_ru
 // from here it is for the MonRunList 
 
 MonRunList EcalCondDBInterface::fetchMonRunList(const RunTag& tag, const MonRunTag& monrunTag)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   MonRunList r;
   r.setConnection(env, conn);
@@ -893,7 +893,7 @@ MonRunList EcalCondDBInterface::fetchMonRunList(const RunTag& tag, const MonRunT
 }
 
 MonRunList EcalCondDBInterface::fetchMonRunList(const RunTag& tag, const MonRunTag& monrunTag,int min_run, int max_run)
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   MonRunList r;
   r.setConnection(env, conn);
@@ -904,7 +904,7 @@ MonRunList EcalCondDBInterface::fetchMonRunList(const RunTag& tag, const MonRunT
 }
 
 MonRunList EcalCondDBInterface::fetchMonRunListLastNRuns(const RunTag& tag, const MonRunTag& monrunTag,int max_run, int n_runs )
-  throw(std::runtime_error)
+  noexcept(false)
 {  
   MonRunList r;
   r.setConnection(env, conn);

--- a/OnlineDB/EcalCondDB/src/EcalDBConnection.cc
+++ b/OnlineDB/EcalCondDB/src/EcalDBConnection.cc
@@ -17,7 +17,7 @@ EcalDBConnection::EcalDBConnection( string host,
 				    string user,
 				    string pass,
 				    int port )
-  throw(std::runtime_error)
+  noexcept(false)
 {
     stringstream ss;
   try {    
@@ -41,7 +41,7 @@ EcalDBConnection::EcalDBConnection( string host,
 EcalDBConnection::EcalDBConnection( string sid,
 				    string user,
 				    string pass )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {    
     env = Environment::createEnvironment(Environment::OBJECT);
@@ -58,7 +58,7 @@ EcalDBConnection::EcalDBConnection( string sid,
   this->port = port;
 }
 
-EcalDBConnection::~EcalDBConnection()  throw(std::runtime_error) {
+EcalDBConnection::~EcalDBConnection()  noexcept(false) {
   //Close database conection and terminate environment
   try {
     conn->terminateStatement(stmt);

--- a/OnlineDB/EcalCondDB/src/FEConfigBadStripDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadStripDat.cc
@@ -31,7 +31,7 @@ FEConfigBadStripDat::~FEConfigBadStripDat()
 
 
 void FEConfigBadStripDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void FEConfigBadStripDat::prepareWrite()
 
 
 void FEConfigBadStripDat::writeDB(const FEConfigBadStripDat* item, FEConfigBadStripInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -68,7 +68,7 @@ void FEConfigBadStripDat::writeDB(const FEConfigBadStripDat* item, FEConfigBadSt
 
 
 void FEConfigBadStripDat::fetchData(std::vector< FEConfigBadStripDat >* p, FEConfigBadStripInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -105,7 +105,7 @@ void FEConfigBadStripDat::fetchData(std::vector< FEConfigBadStripDat >* p, FECon
 //  ************************************************************************   // 
 
 void FEConfigBadStripDat::writeArrayDB(const std::vector< FEConfigBadStripDat >& data, FEConfigBadStripInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigBadStripInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadStripInfo.cc
@@ -33,7 +33,7 @@ FEConfigBadStripInfo::~FEConfigBadStripInfo()
 
 
 
-int FEConfigBadStripInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigBadStripInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int FEConfigBadStripInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigBadStripInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void FEConfigBadStripInfo::setParameters(const std::map<string,string>& my_keys_
 }
 
 void FEConfigBadStripInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void FEConfigBadStripInfo::writeDB()
 
 
 void FEConfigBadStripInfo::fetchData(FEConfigBadStripInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -169,7 +169,7 @@ void FEConfigBadStripInfo::fetchData(FEConfigBadStripInfo * result)
   }
 }
 
-int FEConfigBadStripInfo::fetchID()    throw(std::runtime_error)
+int FEConfigBadStripInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/FEConfigBadTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadTTDat.cc
@@ -30,7 +30,7 @@ FEConfigBadTTDat::~FEConfigBadTTDat()
 
 
 void FEConfigBadTTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void FEConfigBadTTDat::prepareWrite()
 
 
 void FEConfigBadTTDat::writeDB(const FEConfigBadTTDat* item, FEConfigBadTTInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -66,7 +66,7 @@ void FEConfigBadTTDat::writeDB(const FEConfigBadTTDat* item, FEConfigBadTTInfo* 
 
 
 void FEConfigBadTTDat::fetchData(std::vector< FEConfigBadTTDat >* p, FEConfigBadTTInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -102,7 +102,7 @@ void FEConfigBadTTDat::fetchData(std::vector< FEConfigBadTTDat >* p, FEConfigBad
 //  ************************************************************************   // 
 
 void FEConfigBadTTDat::writeArrayDB(const std::vector< FEConfigBadTTDat >& data, FEConfigBadTTInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigBadTTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadTTInfo.cc
@@ -33,7 +33,7 @@ FEConfigBadTTInfo::~FEConfigBadTTInfo()
 
 
 
-int FEConfigBadTTInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigBadTTInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int FEConfigBadTTInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigBadTTInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void FEConfigBadTTInfo::setParameters(const std::map<string,string>& my_keys_map
 }
 
 void FEConfigBadTTInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void FEConfigBadTTInfo::writeDB()
 
 
 void FEConfigBadTTInfo::fetchData(FEConfigBadTTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -169,7 +169,7 @@ void FEConfigBadTTInfo::fetchData(FEConfigBadTTInfo * result)
   }
 }
 
-int FEConfigBadTTInfo::fetchID()    throw(std::runtime_error)
+int FEConfigBadTTInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/FEConfigBadXTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadXTDat.cc
@@ -31,7 +31,7 @@ FEConfigBadXTDat::~FEConfigBadXTDat()
 
 
 void FEConfigBadXTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void FEConfigBadXTDat::prepareWrite()
 
 
 void FEConfigBadXTDat::writeDB(const FEConfigBadXTDat* item, FEConfigBadXTInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -68,7 +68,7 @@ void FEConfigBadXTDat::writeDB(const FEConfigBadXTDat* item, FEConfigBadXTInfo* 
 
 
 void FEConfigBadXTDat::fetchData(std::vector< FEConfigBadXTDat >* p, FEConfigBadXTInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -105,7 +105,7 @@ void FEConfigBadXTDat::fetchData(std::vector< FEConfigBadXTDat >* p, FEConfigBad
 //  ************************************************************************   // 
 
 void FEConfigBadXTDat::writeArrayDB(const std::vector< FEConfigBadXTDat >& data, FEConfigBadXTInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigBadXTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadXTInfo.cc
@@ -33,7 +33,7 @@ FEConfigBadXTInfo::~FEConfigBadXTInfo()
 
 
 
-int FEConfigBadXTInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigBadXTInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int FEConfigBadXTInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigBadXTInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void FEConfigBadXTInfo::setParameters(const std::map<string,string>& my_keys_map
 }
 
 void FEConfigBadXTInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void FEConfigBadXTInfo::writeDB()
 
 
 void FEConfigBadXTInfo::fetchData(FEConfigBadXTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -169,7 +169,7 @@ void FEConfigBadXTInfo::fetchData(FEConfigBadXTInfo * result)
   }
 }
 
-int FEConfigBadXTInfo::fetchID()    throw(std::runtime_error)
+int FEConfigBadXTInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrDat.cc
@@ -28,7 +28,7 @@ FEConfigFgrDat::~FEConfigFgrDat()
 
 
 void FEConfigFgrDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void FEConfigFgrDat::prepareWrite()
 
 
 void FEConfigFgrDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrDat* item, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigFgrDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrDat* item
 
 
 void FEConfigFgrDat::fetchData(map< EcalLogicID, FEConfigFgrDat >* fillMap, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void FEConfigFgrDat::fetchData(map< EcalLogicID, FEConfigFgrDat >* fillMap, FECo
 }
 
 void FEConfigFgrDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrDat >* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrEEStripDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrEEStripDat.cc
@@ -29,7 +29,7 @@ FEConfigFgrEEStripDat::~FEConfigFgrEEStripDat()
 
 
 void FEConfigFgrEEStripDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void FEConfigFgrEEStripDat::prepareWrite()
 
 
 void FEConfigFgrEEStripDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEEStripDat* item, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -73,7 +73,7 @@ void FEConfigFgrEEStripDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEE
 
 
 void FEConfigFgrEEStripDat::fetchData(map< EcalLogicID, FEConfigFgrEEStripDat >* fillMap, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -117,7 +117,7 @@ void FEConfigFgrEEStripDat::fetchData(map< EcalLogicID, FEConfigFgrEEStripDat >*
 }
 
 void FEConfigFgrEEStripDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEEStripDat >* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrEETowerDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrEETowerDat.cc
@@ -28,7 +28,7 @@ FEConfigFgrEETowerDat::~FEConfigFgrEETowerDat()
 
 
 void FEConfigFgrEETowerDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void FEConfigFgrEETowerDat::prepareWrite()
 
 
 void FEConfigFgrEETowerDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEETowerDat* item, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -71,7 +71,7 @@ void FEConfigFgrEETowerDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEE
 
 
 void FEConfigFgrEETowerDat::fetchData(map< EcalLogicID, FEConfigFgrEETowerDat >* fillMap, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -114,7 +114,7 @@ void FEConfigFgrEETowerDat::fetchData(map< EcalLogicID, FEConfigFgrEETowerDat >*
 }
 
 void FEConfigFgrEETowerDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrEETowerDat >* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrGroupDat.cc
@@ -33,7 +33,7 @@ FEConfigFgrGroupDat::~FEConfigFgrGroupDat()
 
 
 void FEConfigFgrGroupDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -51,7 +51,7 @@ void FEConfigFgrGroupDat::prepareWrite()
 
 
 void FEConfigFgrGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrGroupDat* item, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -82,7 +82,7 @@ void FEConfigFgrGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrGrou
 
 
 void FEConfigFgrGroupDat::fetchData(map< EcalLogicID, FEConfigFgrGroupDat >* fillMap, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -126,7 +126,7 @@ void FEConfigFgrGroupDat::fetchData(map< EcalLogicID, FEConfigFgrGroupDat >* fil
 }
 
 void FEConfigFgrGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrGroupDat >* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrInfo.cc
@@ -35,7 +35,7 @@ FEConfigFgrInfo::~FEConfigFgrInfo()
 
 
 
-int FEConfigFgrInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigFgrInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigFgrInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigFgrInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigFgrInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void FEConfigFgrInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigFgrInfo::writeDB()
 
 
 void FEConfigFgrInfo::fetchData(FEConfigFgrInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigFgrInfo::fetchData(FEConfigFgrInfo * result)
 }
 
 void FEConfigFgrInfo::fetchLastData(FEConfigFgrInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigFgrInfo::fetchLastData(FEConfigFgrInfo * result)
   }
 }
 
-int FEConfigFgrInfo::fetchID()    throw(std::runtime_error)
+int FEConfigFgrInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigFgrInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigFgrInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrParamDat.cc
@@ -31,7 +31,7 @@ FEConfigFgrParamDat::~FEConfigFgrParamDat()
 
 
 void FEConfigFgrParamDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void FEConfigFgrParamDat::prepareWrite()
 
 
 void FEConfigFgrParamDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrParamDat* item, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -77,7 +77,7 @@ void FEConfigFgrParamDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrPara
 
 
 void FEConfigFgrParamDat::fetchData(map< EcalLogicID, FEConfigFgrParamDat >* fillMap, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -123,7 +123,7 @@ void FEConfigFgrParamDat::fetchData(map< EcalLogicID, FEConfigFgrParamDat >* fil
 }
 
 void FEConfigFgrParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrParamDat >* data, FEConfigFgrInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTDat.cc
@@ -28,7 +28,7 @@ FEConfigLUTDat::~FEConfigLUTDat()
 
 
 void FEConfigLUTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void FEConfigLUTDat::prepareWrite()
 
 
 void FEConfigLUTDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTDat* item, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigLUTDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTDat* item
 
 
 void FEConfigLUTDat::fetchData(map< EcalLogicID, FEConfigLUTDat >* fillMap, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void FEConfigLUTDat::fetchData(map< EcalLogicID, FEConfigLUTDat >* fillMap, FECo
 }
 
 void FEConfigLUTDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTDat >* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
@@ -31,7 +31,7 @@ FEConfigLUTGroupDat::~FEConfigLUTGroupDat()
 
 
 void FEConfigLUTGroupDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void FEConfigLUTGroupDat::prepareWrite()
 }
 
 void FEConfigLUTGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTGroupDat* item, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -122,7 +122,7 @@ void FEConfigLUTGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTGrou
 
 
 void FEConfigLUTGroupDat::fetchData(map< EcalLogicID, FEConfigLUTGroupDat >* fillMap, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -178,7 +178,7 @@ void FEConfigLUTGroupDat::fetchData(map< EcalLogicID, FEConfigLUTGroupDat >* fil
 }
 
 void FEConfigLUTGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTGroupDat >* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTInfo.cc
@@ -35,7 +35,7 @@ FEConfigLUTInfo::~FEConfigLUTInfo()
 
 
 
-int FEConfigLUTInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigLUTInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigLUTInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigLUTInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigLUTInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void FEConfigLUTInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigLUTInfo::writeDB()
 
 
 void FEConfigLUTInfo::fetchData(FEConfigLUTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigLUTInfo::fetchData(FEConfigLUTInfo * result)
 }
 
 void FEConfigLUTInfo::fetchLastData(FEConfigLUTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigLUTInfo::fetchLastData(FEConfigLUTInfo * result)
   }
 }
 
-int FEConfigLUTInfo::fetchID()    throw(std::runtime_error)
+int FEConfigLUTInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigLUTInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigLUTInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTParamDat.cc
@@ -30,7 +30,7 @@ FEConfigLUTParamDat::~FEConfigLUTParamDat()
 
 
 void FEConfigLUTParamDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void FEConfigLUTParamDat::prepareWrite()
 
 
 void FEConfigLUTParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTParamDat* item, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -75,7 +75,7 @@ void FEConfigLUTParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTPara
 
 
 void FEConfigLUTParamDat::fetchData(map< EcalLogicID, FEConfigLUTParamDat >* fillMap, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -122,7 +122,7 @@ void FEConfigLUTParamDat::fetchData(map< EcalLogicID, FEConfigLUTParamDat >* fil
 }
 
 void FEConfigLUTParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTParamDat >* data, FEConfigLUTInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigLinDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinDat.cc
@@ -34,7 +34,7 @@ FEConfigLinDat::~FEConfigLinDat()
 
 
 void FEConfigLinDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -52,7 +52,7 @@ void FEConfigLinDat::prepareWrite()
 
 
 void FEConfigLinDat::writeDB(const EcalLogicID* ecid, const FEConfigLinDat* item, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -82,7 +82,7 @@ void FEConfigLinDat::writeDB(const EcalLogicID* ecid, const FEConfigLinDat* item
 
 
 void FEConfigLinDat::fetchData(map< EcalLogicID, FEConfigLinDat >* fillMap, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -130,7 +130,7 @@ void FEConfigLinDat::fetchData(map< EcalLogicID, FEConfigLinDat >* fillMap, FECo
 }
 
 void FEConfigLinDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLinDat >* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigLinInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinInfo.cc
@@ -35,7 +35,7 @@ FEConfigLinInfo::~FEConfigLinInfo()
 
 
 
-int FEConfigLinInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigLinInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigLinInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigLinInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigLinInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void FEConfigLinInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigLinInfo::writeDB()
 
 
 void FEConfigLinInfo::fetchData(FEConfigLinInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigLinInfo::fetchData(FEConfigLinInfo * result)
 }
 
 void FEConfigLinInfo::fetchLastData(FEConfigLinInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigLinInfo::fetchLastData(FEConfigLinInfo * result)
   }
 }
 
-int FEConfigLinInfo::fetchID()    throw(std::runtime_error)
+int FEConfigLinInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigLinInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigLinInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigLinParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinParamDat.cc
@@ -27,7 +27,7 @@ FEConfigLinParamDat::~FEConfigLinParamDat()
 
 
 void FEConfigLinParamDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void FEConfigLinParamDat::prepareWrite()
 
 
 void FEConfigLinParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLinParamDat* item, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigLinParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLinPara
 
 
 void FEConfigLinParamDat::fetchData(map< EcalLogicID, FEConfigLinParamDat >* fillMap, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -115,7 +115,7 @@ void FEConfigLinParamDat::fetchData(map< EcalLogicID, FEConfigLinParamDat >* fil
 }
 
 void FEConfigLinParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLinParamDat >* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigMainInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigMainInfo.cc
@@ -46,7 +46,7 @@ void FEConfigMainInfo::clear() {
 
 
 }
-int FEConfigMainInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigMainInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -68,7 +68,7 @@ int FEConfigMainInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 int FEConfigMainInfo::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID>0) {
@@ -120,7 +120,7 @@ int FEConfigMainInfo::fetchID()
 
 
 void FEConfigMainInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -143,7 +143,7 @@ void FEConfigMainInfo::prepareWrite()
 
 
 void FEConfigMainInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -188,7 +188,7 @@ void FEConfigMainInfo::writeDB()
 
 
 int FEConfigMainInfo::fetchIDLast()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -216,7 +216,7 @@ int FEConfigMainInfo::fetchIDLast()
 
 
 void FEConfigMainInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -261,7 +261,7 @@ void FEConfigMainInfo::setByID(int id)
 
 
 void FEConfigMainInfo::fetchData(FEConfigMainInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 { std::cout << " ### 1 getId from FEConfigMainInfo = " << result->getId() << std::endl;
  std::cout << " tag/version " << result->getConfigTag() <<"/"<<result->getVersion() << std::endl;
   
@@ -314,7 +314,7 @@ void FEConfigMainInfo::fetchData(FEConfigMainInfo * result)
 }
 
  void FEConfigMainInfo::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/FEConfigParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigParamDat.cc
@@ -34,7 +34,7 @@ FEConfigParamDat::~FEConfigParamDat()
 
 
 void FEConfigParamDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -52,7 +52,7 @@ void FEConfigParamDat::prepareWrite()
 
 
 void FEConfigParamDat::writeDB(const EcalLogicID* ecid, const FEConfigParamDat* item, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -83,7 +83,7 @@ void FEConfigParamDat::writeDB(const EcalLogicID* ecid, const FEConfigParamDat* 
 
 
 void FEConfigParamDat::fetchData(map< EcalLogicID, FEConfigParamDat >* fillMap, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -134,7 +134,7 @@ void FEConfigParamDat::fetchData(map< EcalLogicID, FEConfigParamDat >* fillMap, 
 }
 
 void FEConfigParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigParamDat >* data, FEConfigLinInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigPedDat.cc
@@ -29,7 +29,7 @@ FEConfigPedDat::~FEConfigPedDat()
 
 
 void FEConfigPedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void FEConfigPedDat::prepareWrite()
 
 
 void FEConfigPedDat::writeDB(const EcalLogicID* ecid, const FEConfigPedDat* item, FEConfigPedInfo* iconf )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -73,7 +73,7 @@ void FEConfigPedDat::writeDB(const EcalLogicID* ecid, const FEConfigPedDat* item
 
 
 void FEConfigPedDat::fetchData(map< EcalLogicID, FEConfigPedDat >* fillMap, FEConfigPedInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -118,7 +118,7 @@ void FEConfigPedDat::fetchData(map< EcalLogicID, FEConfigPedDat >* fillMap, FECo
 }
 
 void FEConfigPedDat::writeArrayDB(const std::map< EcalLogicID, FEConfigPedDat >* data, FEConfigPedInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigPedInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigPedInfo.cc
@@ -35,7 +35,7 @@ FEConfigPedInfo::~FEConfigPedInfo()
 
 
 
-int FEConfigPedInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigPedInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigPedInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigPedInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigPedInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void FEConfigPedInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigPedInfo::writeDB()
 
 
 void FEConfigPedInfo::fetchData(FEConfigPedInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigPedInfo::fetchData(FEConfigPedInfo * result)
 }
 
 void FEConfigPedInfo::fetchLastData(FEConfigPedInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigPedInfo::fetchLastData(FEConfigPedInfo * result)
   }
 }
 
-int FEConfigPedInfo::fetchID()    throw(std::runtime_error)
+int FEConfigPedInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigPedInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigPedInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigSlidingDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSlidingDat.cc
@@ -28,7 +28,7 @@ FEConfigSlidingDat::~FEConfigSlidingDat()
 
 
 void FEConfigSlidingDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void FEConfigSlidingDat::prepareWrite()
 
 
 void FEConfigSlidingDat::writeDB(const EcalLogicID* ecid, const FEConfigSlidingDat* item, FEConfigSlidingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -71,7 +71,7 @@ void FEConfigSlidingDat::writeDB(const EcalLogicID* ecid, const FEConfigSlidingD
 
 
 void FEConfigSlidingDat::fetchData(map< EcalLogicID, FEConfigSlidingDat >* fillMap, FEConfigSlidingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -114,7 +114,7 @@ void FEConfigSlidingDat::fetchData(map< EcalLogicID, FEConfigSlidingDat >* fillM
 }
 
 void FEConfigSlidingDat::writeArrayDB(const std::map< EcalLogicID, FEConfigSlidingDat >* data, FEConfigSlidingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigSlidingInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSlidingInfo.cc
@@ -35,7 +35,7 @@ FEConfigSlidingInfo::~FEConfigSlidingInfo()
 
 
 
-int FEConfigSlidingInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigSlidingInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigSlidingInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigSlidingInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigSlidingInfo::setParameters(const std::map<string,string>& my_keys_m
 }
 
 void FEConfigSlidingInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigSlidingInfo::writeDB()
 
 
 void FEConfigSlidingInfo::fetchData(FEConfigSlidingInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigSlidingInfo::fetchData(FEConfigSlidingInfo * result)
 }
 
 void FEConfigSlidingInfo::fetchLastData(FEConfigSlidingInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigSlidingInfo::fetchLastData(FEConfigSlidingInfo * result)
   }
 }
 
-int FEConfigSlidingInfo::fetchID()    throw(std::runtime_error)
+int FEConfigSlidingInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigSlidingInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigSlidingInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigSpikeDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSpikeDat.cc
@@ -28,7 +28,7 @@ FEConfigSpikeDat::~FEConfigSpikeDat()
 
 
 void FEConfigSpikeDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void FEConfigSpikeDat::prepareWrite()
 
 
 void FEConfigSpikeDat::writeDB(const EcalLogicID* ecid, const FEConfigSpikeDat* item, FEConfigSpikeInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigSpikeDat::writeDB(const EcalLogicID* ecid, const FEConfigSpikeDat* 
 
 
 void FEConfigSpikeDat::fetchData(map< EcalLogicID, FEConfigSpikeDat >* fillMap, FEConfigSpikeInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -111,7 +111,7 @@ void FEConfigSpikeDat::fetchData(map< EcalLogicID, FEConfigSpikeDat >* fillMap, 
 }
 
 void FEConfigSpikeDat::writeArrayDB(const std::map< EcalLogicID, FEConfigSpikeDat >* data, FEConfigSpikeInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigSpikeInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSpikeInfo.cc
@@ -34,7 +34,7 @@ FEConfigSpikeInfo::~FEConfigSpikeInfo()
 
 
 
-int FEConfigSpikeInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigSpikeInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -57,7 +57,7 @@ int FEConfigSpikeInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigSpikeInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -96,7 +96,7 @@ void FEConfigSpikeInfo::setParameters(const std::map<string,string>& my_keys_map
 }
 
 void FEConfigSpikeInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -123,7 +123,7 @@ void FEConfigSpikeInfo::writeDB()
 
 
 void FEConfigSpikeInfo::fetchData(FEConfigSpikeInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -157,7 +157,7 @@ void FEConfigSpikeInfo::fetchData(FEConfigSpikeInfo * result)
 }
 
 void FEConfigSpikeInfo::fetchLastData(FEConfigSpikeInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -181,7 +181,7 @@ void FEConfigSpikeInfo::fetchLastData(FEConfigSpikeInfo * result)
   }
 }
 
-int FEConfigSpikeInfo::fetchID()    throw(std::runtime_error)
+int FEConfigSpikeInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -216,7 +216,7 @@ int FEConfigSpikeInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigSpikeInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigTimingDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigTimingDat.cc
@@ -29,7 +29,7 @@ FEConfigTimingDat::~FEConfigTimingDat()
 
 
 void FEConfigTimingDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -44,7 +44,7 @@ void FEConfigTimingDat::prepareWrite()
 
 
 void FEConfigTimingDat::writeDB(const EcalLogicID* ecid, const FEConfigTimingDat* item, FEConfigTimingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigTimingDat::writeDB(const EcalLogicID* ecid, const FEConfigTimingDat
 
 
 void FEConfigTimingDat::fetchData(map< EcalLogicID, FEConfigTimingDat >* fillMap, FEConfigTimingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -112,7 +112,7 @@ void FEConfigTimingDat::fetchData(map< EcalLogicID, FEConfigTimingDat >* fillMap
 }
 
 void FEConfigTimingDat::writeArrayDB(const std::map< EcalLogicID, FEConfigTimingDat >* data, FEConfigTimingInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigTimingInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigTimingInfo.cc
@@ -34,7 +34,7 @@ FEConfigTimingInfo::~FEConfigTimingInfo()
 
 
 
-int FEConfigTimingInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigTimingInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -57,7 +57,7 @@ int FEConfigTimingInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigTimingInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -96,7 +96,7 @@ void FEConfigTimingInfo::setParameters(const std::map<string,string>& my_keys_ma
 }
 
 void FEConfigTimingInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -123,7 +123,7 @@ void FEConfigTimingInfo::writeDB()
 
 
 void FEConfigTimingInfo::fetchData(FEConfigTimingInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -157,7 +157,7 @@ void FEConfigTimingInfo::fetchData(FEConfigTimingInfo * result)
 }
 
 void FEConfigTimingInfo::fetchLastData(FEConfigTimingInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -181,7 +181,7 @@ void FEConfigTimingInfo::fetchLastData(FEConfigTimingInfo * result)
   }
 }
 
-int FEConfigTimingInfo::fetchID()    throw(std::runtime_error)
+int FEConfigTimingInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -216,7 +216,7 @@ int FEConfigTimingInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigTimingInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightDat.cc
@@ -28,7 +28,7 @@ FEConfigWeightDat::~FEConfigWeightDat()
 
 
 void FEConfigWeightDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void FEConfigWeightDat::prepareWrite()
 
 
 void FEConfigWeightDat::writeDB(const EcalLogicID* ecid, const FEConfigWeightDat* item, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void FEConfigWeightDat::writeDB(const EcalLogicID* ecid, const FEConfigWeightDat
 
 
 void FEConfigWeightDat::fetchData(map< EcalLogicID, FEConfigWeightDat >* fillMap, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void FEConfigWeightDat::fetchData(map< EcalLogicID, FEConfigWeightDat >* fillMap
 }
 
 void FEConfigWeightDat::writeArrayDB(const std::map< EcalLogicID, FEConfigWeightDat >* data, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightGroupDat.cc
@@ -33,7 +33,7 @@ FEConfigWeightGroupDat::~FEConfigWeightGroupDat()
 
 
 void FEConfigWeightGroupDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -51,7 +51,7 @@ void FEConfigWeightGroupDat::prepareWrite()
 
 
 void FEConfigWeightGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigWeightGroupDat* item, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -82,7 +82,7 @@ void FEConfigWeightGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigWeig
 
 
 void FEConfigWeightGroupDat::fetchData(map< EcalLogicID, FEConfigWeightGroupDat >* fillMap, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -126,7 +126,7 @@ void FEConfigWeightGroupDat::fetchData(map< EcalLogicID, FEConfigWeightGroupDat 
 }
 
 void FEConfigWeightGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigWeightGroupDat >* data, FEConfigWeightInfo* iconf)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightInfo.cc
@@ -35,7 +35,7 @@ FEConfigWeightInfo::~FEConfigWeightInfo()
 
 
 
-int FEConfigWeightInfo::fetchNextId()  throw(std::runtime_error) {
+int FEConfigWeightInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int FEConfigWeightInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void FEConfigWeightInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -98,7 +98,7 @@ void FEConfigWeightInfo::setParameters(const std::map<string,string>& my_keys_ma
 }
 
 void FEConfigWeightInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -126,7 +126,7 @@ void FEConfigWeightInfo::writeDB()
 
 
 void FEConfigWeightInfo::fetchData(FEConfigWeightInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -161,7 +161,7 @@ void FEConfigWeightInfo::fetchData(FEConfigWeightInfo * result)
 }
 
 void FEConfigWeightInfo::fetchLastData(FEConfigWeightInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -186,7 +186,7 @@ void FEConfigWeightInfo::fetchLastData(FEConfigWeightInfo * result)
   }
 }
 
-int FEConfigWeightInfo::fetchID()    throw(std::runtime_error)
+int FEConfigWeightInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {
@@ -221,7 +221,7 @@ int FEConfigWeightInfo::fetchID()    throw(std::runtime_error)
 
 
 void FEConfigWeightInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/LMFColoredTable.cc
+++ b/OnlineDB/EcalCondDB/src/LMFColoredTable.cc
@@ -87,7 +87,7 @@ LMFColoredTable& LMFColoredTable::setSystem(std::string system) {
 }
 
 int LMFColoredTable::writeDB() 
-  throw(std::runtime_error) {
+  noexcept(false) {
   // check if the VMIN version has been properly set, otherwise 
   // change it to the default value
   std::map<int, std::vector<float> >::iterator i = m_data.begin();

--- a/OnlineDB/EcalCondDB/src/LMFCorrCoefDatComponent.cc
+++ b/OnlineDB/EcalCondDB/src/LMFCorrCoefDatComponent.cc
@@ -151,7 +151,7 @@ LMFSeqDat LMFCorrCoefDatComponent::getSequence(const EcalLogicID &id) {
 }
 
 int LMFCorrCoefDatComponent::writeDB() 
-  throw(std::runtime_error) {
+  noexcept(false) {
   int ret = 0;
   try {
     ret = LMFDat::writeDB();

--- a/OnlineDB/EcalCondDB/src/LMFDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDat.cc
@@ -186,19 +186,19 @@ std::string LMFDat::buildSelectSql(int logic_id, int direction) {
 }
 
 void LMFDat::getPrevious(LMFDat *dat)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   getNeighbour(dat, -1);
 }
 
 void LMFDat::getNext(LMFDat *dat)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   getNeighbour(dat, +1);
 }
 
 void LMFDat::getNeighbour(LMFDat *dat, int which)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // there should be just one record in this case
   if (m_data.size() == 1) {
@@ -216,38 +216,38 @@ void LMFDat::getNeighbour(LMFDat *dat, int which)
 }
 
 void LMFDat::fetch(const EcalLogicID &id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetch(id.getLogicID());
 }
 
 void LMFDat::fetch(const EcalLogicID &id, const Tm &tm) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetch(id.getLogicID(), &tm, 1);
 }
 
 void LMFDat::fetch(const EcalLogicID &id, const Tm &tm, int direction) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   setInt(foreignKeyName(), 0); /* set the LMF_IOV_ID to undefined */
   fetch(id.getLogicID(), &tm, direction);
 }
 
 void LMFDat::fetch() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetch(0);
 }
 
 void LMFDat::fetch(int logic_id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetch(logic_id, NULL, 0);
 }
 
 void LMFDat::fetch(int logic_id, const Tm &tm) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetch(logic_id, &tm, 1);
 }
@@ -279,7 +279,7 @@ void LMFDat::adjustParameters(int count, std::string &sql,
 }
 
 void LMFDat::fetch(int logic_id, const Tm *timestamp, int direction) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   bool ok = check();
   if ((timestamp == NULL) && (getLMFRunIOVID() == 0)) {
@@ -350,7 +350,7 @@ bool LMFDat::isValid() {
 }
 
 std::map<int, std::vector<float> > LMFDat::fetchData() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if any of the data is already in the database
   std::map<int, std::vector<float> > s = m_data;
@@ -396,7 +396,7 @@ std::map<int, std::vector<float> > LMFDat::fetchData()
 }
 
 int LMFDat::writeDB() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // first of all check if data already present
   if (m_debug) {
@@ -540,7 +540,7 @@ int LMFDat::writeDB()
 }
 
 void LMFDat::getKeyTypes() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   m_type.reserve(m_keys.size());
   for (unsigned int i = 0; i < m_keys.size(); i++) {

--- a/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
@@ -167,7 +167,7 @@ int LMFDefFabric::getRunTagID(std::string tag, int version) const {
 }
 
 void LMFDefFabric::initialize() 
-  throw (std::runtime_error) {
+  noexcept(false) {
   _lmfColors.clear();
   _lmfTrigTypes.clear();
   _lmfRunTags.clear();

--- a/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
@@ -118,14 +118,14 @@ void LMFLmrSubIOV::getParameters(ResultSet *rset) {
 }
 
 std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &t) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   Tm tinf;
   tinf.setToString("9999-12-31 23:59:59");
   return getIOVIDsLaterThan(t, tinf, 0);
 }
 
 std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &t, int howmany) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   Tm tinf;
   tinf.setToString("9999-12-31 23:59:59");
   return getIOVIDsLaterThan(t, tinf, howmany);
@@ -133,13 +133,13 @@ std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &t, int howmany)
 
 std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &tmin,
 						const Tm &tmax) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   return getIOVIDsLaterThan(tmin, tmax, 0);
 }
 
 std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax,
 						int howMany) 
-  throw(std::runtime_error) {
+  noexcept(false) {
   Tm tinf;
   tinf.setToString("9999-12-31 23:59:59");
   std::string sql = "SELECT * FROM (SELECT LMR_SUB_IOV_ID "  

--- a/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
@@ -318,7 +318,7 @@ std::string LMFRunIOV::writeDBSql(Statement *stmt)
 std::list<LMFRunIOV> LMFRunIOV::fetchBySequence(const vector<int>& par, 
 						const std::string &sql,
 						const std::string &method) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::list<LMFRunIOV> l;
   this->checkConnection();

--- a/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
@@ -179,7 +179,7 @@ std::string LMFSeqDat::writeDBSql(Statement *stmt)
 }
 
 void LMFSeqDat::fetchParentIDs()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the RunIOV
   m_runIOV.setConnection(m_env, m_conn);
@@ -194,7 +194,7 @@ void LMFSeqDat::fetchParentIDs()
 
 std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(std::string sql,
 						  std::string method)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::vector<std::string> pars;
   return fetchByRunIOV(pars, sql, method);
@@ -203,7 +203,7 @@ std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(std::string sql,
 std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(int par, 
 						  std::string sql,
 						  std::string method)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::vector<std::string> pars;
   std::stringstream ss;
@@ -215,7 +215,7 @@ std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(int par,
 std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(const std::vector<std::string>& pars, 
 						  std::string sql,
 						  std::string method)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::map<int, LMFSeqDat> l;
   this->checkConnection();

--- a/OnlineDB/EcalCondDB/src/LMFUnique.cc
+++ b/OnlineDB/EcalCondDB/src/LMFUnique.cc
@@ -62,7 +62,7 @@ void LMFUnique::attach(std::string name, LMFUnique *u) {
 }
 
 boost::ptr_list<LMFUnique> LMFUnique::fetchAll() const  
-  throw(std::runtime_error)
+  noexcept(false)
 {
   /*
     Returns a list of pointers to DB objects
@@ -211,7 +211,7 @@ int LMFUnique::getInt(std::string s) const {
 }
 
 int LMFUnique::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   /*
     This method fetch the ID of the object from the database according
@@ -284,7 +284,7 @@ int LMFUnique::fetchID()
 }
 
 void LMFUnique::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   /*
     Given the ID of an object setup it
@@ -321,7 +321,7 @@ void LMFUnique::setByID(int id)
 }
 
 int LMFUnique::writeForeignKeys() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   std::map<std::string, LMFUnique*>::const_iterator i = m_foreignKeys.begin();
   std::map<std::string, LMFUnique*>::const_iterator e = m_foreignKeys.end();
@@ -337,7 +337,7 @@ int LMFUnique::writeForeignKeys()
 }
 
 int LMFUnique::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   clock_t start = 0;
   clock_t end = 0;

--- a/OnlineDB/EcalCondDB/src/LocationDef.cc
+++ b/OnlineDB/EcalCondDB/src/LocationDef.cc
@@ -41,7 +41,7 @@ void LocationDef::setLocation(string loc)
 
   
 int LocationDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -74,7 +74,7 @@ int LocationDef::fetchID()
 
 
 void LocationDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -101,7 +101,7 @@ void LocationDef::setByID(int id)
 
 
 void LocationDef::fetchAllDefs( std::vector<LocationDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {

--- a/OnlineDB/EcalCondDB/src/MODCCSFEDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSFEDat.cc
@@ -27,7 +27,7 @@ MODCCSFEDat::~MODCCSFEDat()
 
 
 void MODCCSFEDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void MODCCSFEDat::prepareWrite()
 
 
 void MODCCSFEDat::writeDB(const EcalLogicID* ecid, const MODCCSFEDat* item, MODRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void MODCCSFEDat::writeDB(const EcalLogicID* ecid, const MODCCSFEDat* item, MODR
 
 
 void MODCCSFEDat::fetchData(std::map< EcalLogicID, MODCCSFEDat >* fillMap, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void MODCCSFEDat::fetchData(std::map< EcalLogicID, MODCCSFEDat >* fillMap, MODRu
 }
 
 void MODCCSFEDat::writeArrayDB(const std::map< EcalLogicID, MODCCSFEDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
@@ -59,7 +59,7 @@ void MODCCSHFDat::setFile(std::string x) {
 }
 
 void MODCCSHFDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -79,7 +79,7 @@ void MODCCSHFDat::prepareWrite()
 
 
 void MODCCSHFDat::writeDB(const EcalLogicID* ecid, const MODCCSHFDat* item, MODRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -140,7 +140,7 @@ void MODCCSHFDat::writeDB(const EcalLogicID* ecid, const MODCCSHFDat* item, MODR
 
 
 void MODCCSHFDat::fetchData(std::map< EcalLogicID, MODCCSHFDat >* fillMap, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -183,7 +183,7 @@ void MODCCSHFDat::fetchData(std::map< EcalLogicID, MODCCSHFDat >* fillMap, MODRu
 }
 
 void MODCCSHFDat::writeArrayDB(const std::map< EcalLogicID, MODCCSHFDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -256,7 +256,7 @@ void MODCCSHFDat::writeArrayDB(const std::map< EcalLogicID, MODCCSHFDat >* data,
 
 
 void MODCCSHFDat::populateClob (Clob &clob, std::string fname, unsigned int clob_size )
- throw (std::runtime_error)
+ noexcept(false)
 {
 
   try{
@@ -328,7 +328,7 @@ void MODCCSHFDat::populateClob (Clob &clob, std::string fname, unsigned int clob
 
 
 unsigned char* MODCCSHFDat::readClob (oracle::occi::Clob &clob, int size)
-  throw (std::runtime_error)
+  noexcept(false)
 {
 
   try{

--- a/OnlineDB/EcalCondDB/src/MODCCSTRDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSTRDat.cc
@@ -27,7 +27,7 @@ MODCCSTRDat::~MODCCSTRDat()
 
 
 void MODCCSTRDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void MODCCSTRDat::prepareWrite()
 
 
 void MODCCSTRDat::writeDB(const EcalLogicID* ecid, const MODCCSTRDat* item, MODRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void MODCCSTRDat::writeDB(const EcalLogicID* ecid, const MODCCSTRDat* item, MODR
 
 
 void MODCCSTRDat::fetchData(std::map< EcalLogicID, MODCCSTRDat >* fillMap, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void MODCCSTRDat::fetchData(std::map< EcalLogicID, MODCCSTRDat >* fillMap, MODRu
 }
 
 void MODCCSTRDat::writeArrayDB(const std::map< EcalLogicID, MODCCSTRDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MODDCCDetailsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODDCCDetailsDat.cc
@@ -39,7 +39,7 @@ MODDCCDetailsDat::~MODDCCDetailsDat()
 
 
 void MODDCCDetailsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -59,7 +59,7 @@ void MODDCCDetailsDat::prepareWrite()
 
 
 void MODDCCDetailsDat::writeDB(const EcalLogicID* ecid, const MODDCCDetailsDat* item, MODRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -95,7 +95,7 @@ void MODDCCDetailsDat::writeDB(const EcalLogicID* ecid, const MODDCCDetailsDat* 
 
 
 void MODDCCDetailsDat::fetchData(std::map< EcalLogicID, MODDCCDetailsDat >* fillMap, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -149,7 +149,7 @@ void MODDCCDetailsDat::fetchData(std::map< EcalLogicID, MODDCCDetailsDat >* fill
 }
 
 void MODDCCDetailsDat::writeArrayDB(const std::map< EcalLogicID, MODDCCDetailsDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MODDCCOperationDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODDCCOperationDat.cc
@@ -27,7 +27,7 @@ MODDCCOperationDat::~MODDCCOperationDat()
 
 
 void MODDCCOperationDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void MODDCCOperationDat::prepareWrite()
 
 
 void MODDCCOperationDat::writeDB(const EcalLogicID* ecid, const MODDCCOperationDat* item, MODRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void MODDCCOperationDat::writeDB(const EcalLogicID* ecid, const MODDCCOperationD
 
 
 void MODDCCOperationDat::fetchData(std::map< EcalLogicID, MODDCCOperationDat >* fillMap, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -113,7 +113,7 @@ void MODDCCOperationDat::fetchData(std::map< EcalLogicID, MODDCCOperationDat >* 
 }
 
 void MODDCCOperationDat::writeArrayDB(const std::map< EcalLogicID, MODDCCOperationDat >* data, MODRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MODRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/MODRunIOV.cc
@@ -99,7 +99,7 @@ Tm MODRunIOV::getSubRunEnd() const
 
 
 int MODRunIOV::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -154,7 +154,7 @@ int MODRunIOV::fetchID()
 
 
 void MODRunIOV::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -193,7 +193,7 @@ void MODRunIOV::setByID(int id)
 
 
 int MODRunIOV::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -245,7 +245,7 @@ int MODRunIOV::writeDB()
 
 
 void MODRunIOV::fetchParentIDs( int* runIOVID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the RunIOV
   m_runIOV.setConnection(m_env, m_conn);
@@ -260,7 +260,7 @@ void MODRunIOV::fetchParentIDs( int* runIOVID)
 
 
 void MODRunIOV::setByRun( RunIOV* runiov, subrun_t subrun)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   

--- a/OnlineDB/EcalCondDB/src/MonCrystalConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonCrystalConsistencyDat.cc
@@ -31,7 +31,7 @@ MonCrystalConsistencyDat::~MonCrystalConsistencyDat()
 
 
 void MonCrystalConsistencyDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonCrystalConsistencyDat::prepareWrite()
 
 
 void MonCrystalConsistencyDat::writeDB(const EcalLogicID* ecid, const MonCrystalConsistencyDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -77,7 +77,7 @@ void MonCrystalConsistencyDat::writeDB(const EcalLogicID* ecid, const MonCrystal
 }
 
 void MonCrystalConsistencyDat::fetchData(std::map< EcalLogicID, MonCrystalConsistencyDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -126,7 +126,7 @@ void MonCrystalConsistencyDat::fetchData(std::map< EcalLogicID, MonCrystalConsis
 }
 
 void MonCrystalConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonCrystalConsistencyDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonDelaysTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonDelaysTTDat.cc
@@ -30,7 +30,7 @@ MonDelaysTTDat::~MonDelaysTTDat()
 
 
 void MonDelaysTTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void MonDelaysTTDat::prepareWrite()
 
 
 void MonDelaysTTDat::writeDB(const EcalLogicID* ecid, const MonDelaysTTDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void MonDelaysTTDat::writeDB(const EcalLogicID* ecid, const MonDelaysTTDat* item
 
 
 void MonDelaysTTDat::fetchData(std::map< EcalLogicID, MonDelaysTTDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -122,7 +122,7 @@ void MonDelaysTTDat::fetchData(std::map< EcalLogicID, MonDelaysTTDat >* fillMap,
 }
 
 void MonDelaysTTDat::writeArrayDB(const std::map< EcalLogicID, MonDelaysTTDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonH4TablePositionDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonH4TablePositionDat.cc
@@ -27,7 +27,7 @@ MonH4TablePositionDat::~MonH4TablePositionDat()
 
 
 void MonH4TablePositionDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void MonH4TablePositionDat::prepareWrite()
 
 
 void MonH4TablePositionDat::writeDB(const EcalLogicID* ecid, const MonH4TablePositionDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void MonH4TablePositionDat::writeDB(const EcalLogicID* ecid, const MonH4TablePos
 
 
 void MonH4TablePositionDat::fetchData(std::map< EcalLogicID, MonH4TablePositionDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -116,7 +116,7 @@ void MonH4TablePositionDat::fetchData(std::map< EcalLogicID, MonH4TablePositionD
 }
 
 void MonH4TablePositionDat::writeArrayDB(const std::map< EcalLogicID, MonH4TablePositionDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserBlueDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserBlueDat.cc
@@ -31,7 +31,7 @@ MonLaserBlueDat::~MonLaserBlueDat()
 
 
 void MonLaserBlueDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLaserBlueDat::prepareWrite()
 
 
 void MonLaserBlueDat::writeDB(const EcalLogicID* ecid, const MonLaserBlueDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLaserBlueDat::writeDB(const EcalLogicID* ecid, const MonLaserBlueDat* it
 
 
 void MonLaserBlueDat::fetchData(std::map< EcalLogicID, MonLaserBlueDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLaserBlueDat::fetchData(std::map< EcalLogicID, MonLaserBlueDat >* fillMa
 }
 
 void MonLaserBlueDat::writeArrayDB(const std::map< EcalLogicID, MonLaserBlueDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserGreenDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserGreenDat.cc
@@ -31,7 +31,7 @@ MonLaserGreenDat::~MonLaserGreenDat()
 
 
 void MonLaserGreenDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLaserGreenDat::prepareWrite()
 
 
 void MonLaserGreenDat::writeDB(const EcalLogicID* ecid, const MonLaserGreenDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLaserGreenDat::writeDB(const EcalLogicID* ecid, const MonLaserGreenDat* 
 
 
 void MonLaserGreenDat::fetchData(std::map< EcalLogicID, MonLaserGreenDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLaserGreenDat::fetchData(std::map< EcalLogicID, MonLaserGreenDat >* fill
 }
 
 void MonLaserGreenDat::writeArrayDB(const std::map< EcalLogicID, MonLaserGreenDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserIRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserIRedDat.cc
@@ -31,7 +31,7 @@ MonLaserIRedDat::~MonLaserIRedDat()
 
 
 void MonLaserIRedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLaserIRedDat::prepareWrite()
 
 
 void MonLaserIRedDat::writeDB(const EcalLogicID* ecid, const MonLaserIRedDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLaserIRedDat::writeDB(const EcalLogicID* ecid, const MonLaserIRedDat* it
 
 
 void MonLaserIRedDat::fetchData(std::map< EcalLogicID, MonLaserIRedDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLaserIRedDat::fetchData(std::map< EcalLogicID, MonLaserIRedDat >* fillMa
 }
 
 void MonLaserIRedDat::writeArrayDB(const std::map< EcalLogicID, MonLaserIRedDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserPulseDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserPulseDat.cc
@@ -29,7 +29,7 @@ MonLaserPulseDat::~MonLaserPulseDat()
 
 
 void MonLaserPulseDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void MonLaserPulseDat::prepareWrite()
 
 
 void MonLaserPulseDat::writeDB(const EcalLogicID* ecid, const MonLaserPulseDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void MonLaserPulseDat::writeDB(const EcalLogicID* ecid, const MonLaserPulseDat* 
 
 
 void MonLaserPulseDat::fetchData(std::map< EcalLogicID, MonLaserPulseDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -122,7 +122,7 @@ void MonLaserPulseDat::fetchData(std::map< EcalLogicID, MonLaserPulseDat >* fill
 }
 
 void MonLaserPulseDat::writeArrayDB(const std::map< EcalLogicID, MonLaserPulseDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserRedDat.cc
@@ -31,7 +31,7 @@ MonLaserRedDat::~MonLaserRedDat()
 
 
 void MonLaserRedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLaserRedDat::prepareWrite()
 
 
 void MonLaserRedDat::writeDB(const EcalLogicID* ecid, const MonLaserRedDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLaserRedDat::writeDB(const EcalLogicID* ecid, const MonLaserRedDat* item
 
 
 void MonLaserRedDat::fetchData(std::map< EcalLogicID, MonLaserRedDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLaserRedDat::fetchData(std::map< EcalLogicID, MonLaserRedDat >* fillMap,
 }
 
 void MonLaserRedDat::writeArrayDB(const std::map< EcalLogicID, MonLaserRedDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLaserStatusDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserStatusDat.cc
@@ -29,7 +29,7 @@ MonLaserStatusDat::~MonLaserStatusDat()
 
 
 void MonLaserStatusDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void MonLaserStatusDat::prepareWrite()
 
 
 void MonLaserStatusDat::writeDB(const EcalLogicID* ecid, const MonLaserStatusDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void MonLaserStatusDat::writeDB(const EcalLogicID* ecid, const MonLaserStatusDat
 
 
 void MonLaserStatusDat::fetchData(std::map< EcalLogicID, MonLaserStatusDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/MonLed1Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLed1Dat.cc
@@ -31,7 +31,7 @@ MonLed1Dat::~MonLed1Dat()
 
 
 void MonLed1Dat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLed1Dat::prepareWrite()
 
 
 void MonLed1Dat::writeDB(const EcalLogicID* ecid, const MonLed1Dat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLed1Dat::writeDB(const EcalLogicID* ecid, const MonLed1Dat* item, MonRun
 
 
 void MonLed1Dat::fetchData(std::map< EcalLogicID, MonLed1Dat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLed1Dat::fetchData(std::map< EcalLogicID, MonLed1Dat >* fillMap, MonRunI
 }
 
 void MonLed1Dat::writeArrayDB(const std::map< EcalLogicID, MonLed1Dat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonLed2Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLed2Dat.cc
@@ -31,7 +31,7 @@ MonLed2Dat::~MonLed2Dat()
 
 
 void MonLed2Dat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonLed2Dat::prepareWrite()
 
 
 void MonLed2Dat::writeDB(const EcalLogicID* ecid, const MonLed2Dat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonLed2Dat::writeDB(const EcalLogicID* ecid, const MonLed2Dat* item, MonRun
 
 
 void MonLed2Dat::fetchData(std::map< EcalLogicID, MonLed2Dat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -128,7 +128,7 @@ void MonLed2Dat::fetchData(std::map< EcalLogicID, MonLed2Dat >* fillMap, MonRunI
 }
 
 void MonLed2Dat::writeArrayDB(const std::map< EcalLogicID, MonLed2Dat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonMemChConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonMemChConsistencyDat.cc
@@ -31,7 +31,7 @@ MonMemChConsistencyDat::~MonMemChConsistencyDat()
 
 
 void MonMemChConsistencyDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonMemChConsistencyDat::prepareWrite()
 
 
 void MonMemChConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemChConsistencyDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -79,7 +79,7 @@ void MonMemChConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemChCons
 
 
 void MonMemChConsistencyDat::fetchData(std::map< EcalLogicID, MonMemChConsistencyDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -127,7 +127,7 @@ void MonMemChConsistencyDat::fetchData(std::map< EcalLogicID, MonMemChConsistenc
 }
 
 void MonMemChConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonMemChConsistencyDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonMemTTConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonMemTTConsistencyDat.cc
@@ -32,7 +32,7 @@ MonMemTTConsistencyDat::~MonMemTTConsistencyDat()
 
 
 void MonMemTTConsistencyDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -50,7 +50,7 @@ void MonMemTTConsistencyDat::prepareWrite()
 
 
 void MonMemTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemTTConsistencyDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -81,7 +81,7 @@ void MonMemTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemTTCons
 
 
 void MonMemTTConsistencyDat::fetchData(std::map< EcalLogicID, MonMemTTConsistencyDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -130,7 +130,7 @@ void MonMemTTConsistencyDat::fetchData(std::map< EcalLogicID, MonMemTTConsistenc
 }
 
 void MonMemTTConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonMemTTConsistencyDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonOccupancyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonOccupancyDat.cc
@@ -28,7 +28,7 @@ MonOccupancyDat::~MonOccupancyDat()
 
 
 void MonOccupancyDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void MonOccupancyDat::prepareWrite()
 
 
 void MonOccupancyDat::writeDB(const EcalLogicID* ecid, const MonOccupancyDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -74,7 +74,7 @@ void MonOccupancyDat::writeDB(const EcalLogicID* ecid, const MonOccupancyDat* it
 
 
 void MonOccupancyDat::fetchData(std::map< EcalLogicID, MonOccupancyDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -119,7 +119,7 @@ void MonOccupancyDat::fetchData(std::map< EcalLogicID, MonOccupancyDat >* fillMa
 }
 
 void MonOccupancyDat::writeArrayDB(const std::map< EcalLogicID, MonOccupancyDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNBlueDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNBlueDat.cc
@@ -36,7 +36,7 @@ MonPNBlueDat::~MonPNBlueDat()
 
 
 void MonPNBlueDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNBlueDat::prepareWrite()
 
 
 void MonPNBlueDat::writeDB(const EcalLogicID* ecid, const MonPNBlueDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNBlueDat::writeDB(const EcalLogicID* ecid, const MonPNBlueDat* item, Mo
 
 
 void MonPNBlueDat::fetchData(std::map< EcalLogicID, MonPNBlueDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -138,7 +138,7 @@ void MonPNBlueDat::fetchData(std::map< EcalLogicID, MonPNBlueDat >* fillMap, Mon
 }
 
 void MonPNBlueDat::writeArrayDB(const std::map< EcalLogicID, MonPNBlueDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNGreenDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNGreenDat.cc
@@ -36,7 +36,7 @@ MonPNGreenDat::~MonPNGreenDat()
 
 
 void MonPNGreenDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNGreenDat::prepareWrite()
 
 
 void MonPNGreenDat::writeDB(const EcalLogicID* ecid, const MonPNGreenDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNGreenDat::writeDB(const EcalLogicID* ecid, const MonPNGreenDat* item, 
 
 
 void MonPNGreenDat::fetchData(std::map< EcalLogicID, MonPNGreenDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -137,7 +137,7 @@ void MonPNGreenDat::fetchData(std::map< EcalLogicID, MonPNGreenDat >* fillMap, M
   }
 }
 void MonPNGreenDat::writeArrayDB(const std::map< EcalLogicID, MonPNGreenDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNIRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNIRedDat.cc
@@ -36,7 +36,7 @@ MonPNIRedDat::~MonPNIRedDat()
 
 
 void MonPNIRedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNIRedDat::prepareWrite()
 
 
 void MonPNIRedDat::writeDB(const EcalLogicID* ecid, const MonPNIRedDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNIRedDat::writeDB(const EcalLogicID* ecid, const MonPNIRedDat* item, Mo
 
 
 void MonPNIRedDat::fetchData(std::map< EcalLogicID, MonPNIRedDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -137,7 +137,7 @@ void MonPNIRedDat::fetchData(std::map< EcalLogicID, MonPNIRedDat >* fillMap, Mon
   }
 }
 void MonPNIRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNIRedDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNLed1Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNLed1Dat.cc
@@ -36,7 +36,7 @@ MonPNLed1Dat::~MonPNLed1Dat()
 
 
 void MonPNLed1Dat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNLed1Dat::prepareWrite()
 
 
 void MonPNLed1Dat::writeDB(const EcalLogicID* ecid, const MonPNLed1Dat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNLed1Dat::writeDB(const EcalLogicID* ecid, const MonPNLed1Dat* item, Mo
 
 
 void MonPNLed1Dat::fetchData(std::map< EcalLogicID, MonPNLed1Dat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -138,7 +138,7 @@ void MonPNLed1Dat::fetchData(std::map< EcalLogicID, MonPNLed1Dat >* fillMap, Mon
 }
 
 void MonPNLed1Dat::writeArrayDB(const std::map< EcalLogicID, MonPNLed1Dat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNLed2Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNLed2Dat.cc
@@ -36,7 +36,7 @@ MonPNLed2Dat::~MonPNLed2Dat()
 
 
 void MonPNLed2Dat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNLed2Dat::prepareWrite()
 
 
 void MonPNLed2Dat::writeDB(const EcalLogicID* ecid, const MonPNLed2Dat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNLed2Dat::writeDB(const EcalLogicID* ecid, const MonPNLed2Dat* item, Mo
 
 
 void MonPNLed2Dat::fetchData(std::map< EcalLogicID, MonPNLed2Dat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -138,7 +138,7 @@ void MonPNLed2Dat::fetchData(std::map< EcalLogicID, MonPNLed2Dat >* fillMap, Mon
 }
 
 void MonPNLed2Dat::writeArrayDB(const std::map< EcalLogicID, MonPNLed2Dat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNMGPADat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNMGPADat.cc
@@ -36,7 +36,7 @@ MonPNMGPADat::~MonPNMGPADat()
 
 
 void MonPNMGPADat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNMGPADat::prepareWrite()
 
 
 void MonPNMGPADat::writeDB(const EcalLogicID* ecid, const MonPNMGPADat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNMGPADat::writeDB(const EcalLogicID* ecid, const MonPNMGPADat* item, Mo
 
 
 void MonPNMGPADat::fetchData(std::map< EcalLogicID, MonPNMGPADat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -138,7 +138,7 @@ void MonPNMGPADat::fetchData(std::map< EcalLogicID, MonPNMGPADat >* fillMap, Mon
 }
 
 void MonPNMGPADat::writeArrayDB(const std::map< EcalLogicID, MonPNMGPADat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNPedDat.cc
@@ -32,7 +32,7 @@ MonPNPedDat::~MonPNPedDat()
 
 
 void MonPNPedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -50,7 +50,7 @@ void MonPNPedDat::prepareWrite()
 
 
 void MonPNPedDat::writeDB(const EcalLogicID* ecid, const MonPNPedDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -80,7 +80,7 @@ void MonPNPedDat::writeDB(const EcalLogicID* ecid, const MonPNPedDat* item, MonR
 
 
 void MonPNPedDat::fetchData(std::map< EcalLogicID, MonPNPedDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -126,7 +126,7 @@ void MonPNPedDat::fetchData(std::map< EcalLogicID, MonPNPedDat >* fillMap, MonRu
 }
 
 void MonPNPedDat::writeArrayDB(const std::map< EcalLogicID, MonPNPedDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPNRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNRedDat.cc
@@ -36,7 +36,7 @@ MonPNRedDat::~MonPNRedDat()
 
 
 void MonPNRedDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void MonPNRedDat::prepareWrite()
 
 
 void MonPNRedDat::writeDB(const EcalLogicID* ecid, const MonPNRedDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -88,7 +88,7 @@ void MonPNRedDat::writeDB(const EcalLogicID* ecid, const MonPNRedDat* item, MonR
 
 
 void MonPNRedDat::fetchData(std::map< EcalLogicID, MonPNRedDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -137,7 +137,7 @@ void MonPNRedDat::fetchData(std::map< EcalLogicID, MonPNRedDat >* fillMap, MonRu
   }
 }
 void MonPNRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNRedDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPedestalOffsetsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalOffsetsDat.cc
@@ -31,7 +31,7 @@ MonPedestalOffsetsDat::~MonPedestalOffsetsDat()
 
 
 void MonPedestalOffsetsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -49,7 +49,7 @@ void MonPedestalOffsetsDat::prepareWrite()
 
 
 void MonPedestalOffsetsDat::writeDB(const EcalLogicID* ecid, const MonPedestalOffsetsDat* item, MonRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void MonPedestalOffsetsDat::writeDB(const EcalLogicID* ecid, const MonPedestalOf
 
 
 void MonPedestalOffsetsDat::fetchData(std::map< EcalLogicID, MonPedestalOffsetsDat >* fillMap, MonRunIOV* iov,  std::string mappa )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -122,7 +122,7 @@ void MonPedestalOffsetsDat::fetchData(std::map< EcalLogicID, MonPedestalOffsetsD
 }
 
 void MonPedestalOffsetsDat::writeArrayDB(const std::map< EcalLogicID, MonPedestalOffsetsDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPedestalsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalsDat.cc
@@ -33,7 +33,7 @@ MonPedestalsDat::~MonPedestalsDat()
 
 
 void MonPedestalsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -53,7 +53,7 @@ void MonPedestalsDat::prepareWrite()
 
 
 void MonPedestalsDat::writeDB(const EcalLogicID* ecid, const MonPedestalsDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -84,7 +84,7 @@ void MonPedestalsDat::writeDB(const EcalLogicID* ecid, const MonPedestalsDat* it
 
 
 void MonPedestalsDat::fetchData(map< EcalLogicID, MonPedestalsDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -134,7 +134,7 @@ void MonPedestalsDat::fetchData(map< EcalLogicID, MonPedestalsDat >* fillMap, Mo
 }
 
 void MonPedestalsDat::writeArrayDB(const std::map< EcalLogicID, MonPedestalsDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPedestalsOnlineDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalsOnlineDat.cc
@@ -30,7 +30,7 @@ MonPedestalsOnlineDat::~MonPedestalsOnlineDat()
 
 
 void MonPedestalsOnlineDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void MonPedestalsOnlineDat::prepareWrite()
 
 
 void MonPedestalsOnlineDat::writeDB(const EcalLogicID* ecid, const MonPedestalsOnlineDat* item, MonRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -75,7 +75,7 @@ void MonPedestalsOnlineDat::writeDB(const EcalLogicID* ecid, const MonPedestalsO
 
 
 void MonPedestalsOnlineDat::fetchData(std::map< EcalLogicID, MonPedestalsOnlineDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -120,7 +120,7 @@ void MonPedestalsOnlineDat::fetchData(std::map< EcalLogicID, MonPedestalsOnlineD
 }
 
 void MonPedestalsOnlineDat::writeArrayDB(const std::map< EcalLogicID, MonPedestalsOnlineDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonPulseShapeDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPulseShapeDat.cc
@@ -31,7 +31,7 @@ MonPulseShapeDat::~MonPulseShapeDat()
 
 
 void MonPulseShapeDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -55,7 +55,7 @@ void MonPulseShapeDat::prepareWrite()
 
 
 void MonPulseShapeDat::writeDB(const EcalLogicID* ecid, const MonPulseShapeDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -90,7 +90,7 @@ void MonPulseShapeDat::writeDB(const EcalLogicID* ecid, const MonPulseShapeDat* 
 
 
 void MonPulseShapeDat::fetchData(std::map< EcalLogicID, MonPulseShapeDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/MonRunDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunDat.cc
@@ -32,7 +32,7 @@ MonRunDat::~MonRunDat()
 
 
 void MonRunDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -50,7 +50,7 @@ void MonRunDat::prepareWrite()
 
 
 void MonRunDat::writeDB(const EcalLogicID* ecid, const MonRunDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -84,7 +84,7 @@ void MonRunDat::writeDB(const EcalLogicID* ecid, const MonRunDat* item, MonRunIO
 
 
 void MonRunDat::fetchData(map< EcalLogicID, MonRunDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/MonRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunIOV.cc
@@ -116,7 +116,7 @@ Tm MonRunIOV::getSubRunEnd() const
 
 
 int MonRunIOV::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -171,7 +171,7 @@ int MonRunIOV::fetchID()
 
 
 void MonRunIOV::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -214,7 +214,7 @@ void MonRunIOV::setByID(int id)
 
 
 int MonRunIOV::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -271,7 +271,7 @@ int MonRunIOV::writeDB()
 
 
 void MonRunIOV::fetchParentIDs(int* monRunTagID, int* runIOVID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the MonRunTag
   m_monRunTag.setConnection(m_env, m_conn);
@@ -290,7 +290,7 @@ void MonRunIOV::fetchParentIDs(int* monRunTagID, int* runIOVID)
 
 
 void MonRunIOV::setByRun(MonRunTag* montag, RunIOV* runiov, subrun_t subrun)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   

--- a/OnlineDB/EcalCondDB/src/MonRunList.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunList.cc
@@ -50,7 +50,7 @@ std::vector<MonRunIOV> MonRunList::getRuns()
 
 
 void MonRunList::fetchRuns()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -147,7 +147,7 @@ void MonRunList::fetchRuns()
 }
 
 void MonRunList::fetchRuns(int min_run, int max_run)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -257,7 +257,7 @@ void MonRunList::fetchRuns(int min_run, int max_run)
 }
 
 void MonRunList::fetchLastNRuns( int max_run, int n_runs  )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   // fetch the last n_runs that come just before max_run (including max_run)

--- a/OnlineDB/EcalCondDB/src/MonRunOutcomeDef.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunOutcomeDef.cc
@@ -50,7 +50,7 @@ string MonRunOutcomeDef::getLongDesc() const
 
   
 int MonRunOutcomeDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -83,7 +83,7 @@ int MonRunOutcomeDef::fetchID()
 
 
 void MonRunOutcomeDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -111,7 +111,7 @@ void MonRunOutcomeDef::setByID(int id)
 
 
 void MonRunOutcomeDef::fetchAllDefs( std::vector<MonRunOutcomeDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {

--- a/OnlineDB/EcalCondDB/src/MonRunTag.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunTag.cc
@@ -57,7 +57,7 @@ void MonRunTag::setMonVersionDef(const MonVersionDef& ver)
 
 
 int MonRunTag::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return tag from memory if available
   if (m_ID) {
@@ -98,7 +98,7 @@ int MonRunTag::fetchID()
 
 
 void MonRunTag::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -126,7 +126,7 @@ void MonRunTag::setByID(int id)
 
 
 int MonRunTag::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if this data is already in the DB
   if (this->fetchID()) { 
@@ -167,7 +167,7 @@ int MonRunTag::writeDB()
 
 
 void MonRunTag::fetchAllTags( std::vector<MonRunTag>* fillVec)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {
@@ -190,7 +190,7 @@ void MonRunTag::fetchAllTags( std::vector<MonRunTag>* fillVec)
 
 
 void MonRunTag::fetchParentIDs(int* verID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the monitoring version
   m_monVersionDef.setConnection(m_env, m_conn);

--- a/OnlineDB/EcalCondDB/src/MonShapeQualityDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonShapeQualityDat.cc
@@ -28,7 +28,7 @@ MonShapeQualityDat::~MonShapeQualityDat()
 
 
 void MonShapeQualityDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void MonShapeQualityDat::prepareWrite()
 
 
 void MonShapeQualityDat::writeDB(const EcalLogicID* ecid, const MonShapeQualityDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void MonShapeQualityDat::writeDB(const EcalLogicID* ecid, const MonShapeQualityD
 
 
 void MonShapeQualityDat::fetchData(std::map< EcalLogicID, MonShapeQualityDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -115,7 +115,7 @@ void MonShapeQualityDat::fetchData(std::map< EcalLogicID, MonShapeQualityDat >* 
 }
 
 void MonShapeQualityDat::writeArrayDB(const std::map< EcalLogicID, MonShapeQualityDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonTTConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonTTConsistencyDat.cc
@@ -32,7 +32,7 @@ MonTTConsistencyDat::~MonTTConsistencyDat()
 
 
 void MonTTConsistencyDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -50,7 +50,7 @@ void MonTTConsistencyDat::prepareWrite()
 
 
 void MonTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonTTConsistencyDat* item, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -81,7 +81,7 @@ void MonTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonTTConsistenc
 
 
 void MonTTConsistencyDat::fetchData(std::map< EcalLogicID, MonTTConsistencyDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -130,7 +130,7 @@ void MonTTConsistencyDat::fetchData(std::map< EcalLogicID, MonTTConsistencyDat >
 }
 
 void MonTTConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonTTConsistencyDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonTestPulseDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonTestPulseDat.cc
@@ -34,7 +34,7 @@ MonTestPulseDat::~MonTestPulseDat()
 
 
 void MonTestPulseDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -52,7 +52,7 @@ void MonTestPulseDat::prepareWrite()
 
 
 void MonTestPulseDat::writeDB(const EcalLogicID* ecid, const MonTestPulseDat* item, MonRunIOV* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -83,7 +83,7 @@ void MonTestPulseDat::writeDB(const EcalLogicID* ecid, const MonTestPulseDat* it
 
 
 void MonTestPulseDat::fetchData(std::map< EcalLogicID, MonTestPulseDat >* fillMap, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();
@@ -132,7 +132,7 @@ void MonTestPulseDat::fetchData(std::map< EcalLogicID, MonTestPulseDat >* fillMa
 }
 
 void MonTestPulseDat::writeArrayDB(const std::map< EcalLogicID, MonTestPulseDat >* data, MonRunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();

--- a/OnlineDB/EcalCondDB/src/MonVersionDef.cc
+++ b/OnlineDB/EcalCondDB/src/MonVersionDef.cc
@@ -47,7 +47,7 @@ string MonVersionDef::getDescription() const
 
   
 int MonVersionDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -81,7 +81,7 @@ int MonVersionDef::fetchID()
 
 
 void MonVersionDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -108,7 +108,7 @@ void MonVersionDef::setByID(int id)
 
 
 void MonVersionDef::fetchAllDefs( std::vector<MonVersionDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {

--- a/OnlineDB/EcalCondDB/src/ODBadTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadTTDat.cc
@@ -30,7 +30,7 @@ ODBadTTDat::~ODBadTTDat()
 
 
 void ODBadTTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void ODBadTTDat::prepareWrite()
 
 
 void ODBadTTDat::writeDB(const ODBadTTDat* item, ODBadTTInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -66,7 +66,7 @@ void ODBadTTDat::writeDB(const ODBadTTDat* item, ODBadTTInfo* iov )
 
 
 void ODBadTTDat::fetchData(std::vector< ODBadTTDat >* p, ODBadTTInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -102,7 +102,7 @@ void ODBadTTDat::fetchData(std::vector< ODBadTTDat >* p, ODBadTTInfo* iov)
 //  ************************************************************************   // 
 
 void ODBadTTDat::writeArrayDB(const std::vector< ODBadTTDat >& data, ODBadTTInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODBadTTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadTTInfo.cc
@@ -33,7 +33,7 @@ ODBadTTInfo::~ODBadTTInfo()
 
 
 
-int ODBadTTInfo::fetchNextId()  throw(std::runtime_error) {
+int ODBadTTInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODBadTTInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODBadTTInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void ODBadTTInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODBadTTInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void ODBadTTInfo::writeDB()
 
 
 void ODBadTTInfo::fetchData(ODBadTTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -169,7 +169,7 @@ void ODBadTTInfo::fetchData(ODBadTTInfo * result)
   }
 }
 
-int ODBadTTInfo::fetchID()    throw(std::runtime_error)
+int ODBadTTInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODBadXTDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadXTDat.cc
@@ -31,7 +31,7 @@ ODBadXTDat::~ODBadXTDat()
 
 
 void ODBadXTDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void ODBadXTDat::prepareWrite()
 
 
 void ODBadXTDat::writeDB(const ODBadXTDat* item, ODBadXTInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -68,7 +68,7 @@ void ODBadXTDat::writeDB(const ODBadXTDat* item, ODBadXTInfo* iov )
 
 
 void ODBadXTDat::fetchData(std::vector< ODBadXTDat >* p, ODBadXTInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -105,7 +105,7 @@ void ODBadXTDat::fetchData(std::vector< ODBadXTDat >* p, ODBadXTInfo* iov)
 //  ************************************************************************   // 
 
 void ODBadXTDat::writeArrayDB(const std::vector< ODBadXTDat >& data, ODBadXTInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODBadXTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadXTInfo.cc
@@ -33,7 +33,7 @@ ODBadXTInfo::~ODBadXTInfo()
 
 
 
-int ODBadXTInfo::fetchNextId()  throw(std::runtime_error) {
+int ODBadXTInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODBadXTInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODBadXTInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void ODBadXTInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODBadXTInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void ODBadXTInfo::writeDB()
 
 
 void ODBadXTInfo::fetchData(ODBadXTInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -169,7 +169,7 @@ void ODBadXTInfo::fetchData(ODBadXTInfo * result)
   }
 }
 
-int ODBadXTInfo::fetchID()    throw(std::runtime_error)
+int ODBadXTInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODCCSConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODCCSConfig.cc
@@ -55,7 +55,7 @@ ODCCSConfig::~ODCCSConfig()
 
 
 
-int ODCCSConfig::fetchNextId()  throw(std::runtime_error) {
+int ODCCSConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -77,7 +77,7 @@ int ODCCSConfig::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODCCSConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -133,7 +133,7 @@ void ODCCSConfig::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODCCSConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -193,7 +193,7 @@ void ODCCSConfig::writeDB()
 
 
 void ODCCSConfig::fetchData(ODCCSConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -239,7 +239,7 @@ void ODCCSConfig::fetchData(ODCCSConfig * result)
   }
 }
 
-int ODCCSConfig::fetchID()    throw(std::runtime_error)
+int ODCCSConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODCCSCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODCCSCycle.cc
@@ -24,7 +24,7 @@ ODCCSCycle::~ODCCSCycle()
 
 
 void ODCCSCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODCCSCycle::prepareWrite()
 }
 
 
-void ODCCSCycle::writeDB()  throw(std::runtime_error)
+void ODCCSCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODCCSCycle::clear(){
 
 
 int ODCCSCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODCCSCycle::fetchID()
 
 
 void ODCCSCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODCCSCycle::setByID(int id)
 
 
 void ODCCSCycle::fetchData(ODCCSCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODCCSCycle::fetchData(ODCCSCycle * result)
 }
 
 void ODCCSCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODCond2ConfInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODCond2ConfInfo.cc
@@ -42,7 +42,7 @@ ODCond2ConfInfo::~ODCond2ConfInfo()
 
 
 
-int ODCond2ConfInfo::fetchNextId()  throw(std::runtime_error) {
+int ODCond2ConfInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -64,7 +64,7 @@ int ODCond2ConfInfo::fetchNextId()  throw(std::runtime_error) {
 
 }
 
-void ODCond2ConfInfo::fetchParents()  throw(std::runtime_error) {
+void ODCond2ConfInfo::fetchParents()  noexcept(false) {
 
 
 
@@ -107,7 +107,7 @@ void ODCond2ConfInfo::fetchParents()  throw(std::runtime_error) {
 }
 
 void ODCond2ConfInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -152,7 +152,7 @@ void ODCond2ConfInfo::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODCond2ConfInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -185,7 +185,7 @@ void ODCond2ConfInfo::writeDB()
 
 
 void ODCond2ConfInfo::fetchData(ODCond2ConfInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -231,7 +231,7 @@ void ODCond2ConfInfo::fetchData(ODCond2ConfInfo * result)
   }
 }
 
-int ODCond2ConfInfo::fetchID()    throw(std::runtime_error)
+int ODCond2ConfInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODDCCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCCConfig.cc
@@ -32,7 +32,7 @@ ODDCCConfig::~ODDCCConfig()
 {
 }
 
-int ODDCCConfig::fetchNextId()  throw(std::runtime_error) {
+int ODDCCConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -57,7 +57,7 @@ int ODDCCConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODDCCConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -151,7 +151,7 @@ void ODDCCConfig::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODDCCConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -205,7 +205,7 @@ void ODDCCConfig::clear(){
 
 
 void ODDCCConfig::fetchData(ODDCCConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   //  result->clear();
@@ -266,7 +266,7 @@ void ODDCCConfig::fetchData(ODDCCConfig * result)
 
 
 
-int ODDCCConfig::fetchID()    throw(std::runtime_error)
+int ODDCCConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODDCCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCCCycle.cc
@@ -24,7 +24,7 @@ ODDCCCycle::~ODDCCCycle()
 
 
 void ODDCCCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODDCCCycle::prepareWrite()
 }
 
 
-void ODDCCCycle::writeDB()  throw(std::runtime_error)
+void ODDCCCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODDCCCycle::clear(){
 
 
 int ODDCCCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODDCCCycle::fetchID()
 
 
 void ODDCCCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODDCCCycle::setByID(int id)
 
 
 void ODDCCCycle::fetchData(ODDCCCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODDCCCycle::fetchData(ODDCCCycle * result)
 }
 
 void ODDCCCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODDCUConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCUConfig.cc
@@ -41,7 +41,7 @@ void ODDCUConfig::setParameters(const std::map<string,string>& my_keys_map){
   
 }
 
-int ODDCUConfig::fetchNextId()  throw(std::runtime_error) {
+int ODDCUConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -64,7 +64,7 @@ int ODDCUConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODDCUConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -85,7 +85,7 @@ void ODDCUConfig::prepareWrite()
 
 
 void ODDCUConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -111,7 +111,7 @@ void ODDCUConfig::writeDB()
 
 
 void ODDCUConfig::fetchData(ODDCUConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -139,7 +139,7 @@ void ODDCUConfig::fetchData(ODDCUConfig * result)
   }
 }
 
-int ODDCUConfig::fetchID()    throw(std::runtime_error)
+int ODDCUConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODDCUCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCUCycle.cc
@@ -24,7 +24,7 @@ ODDCUCycle::~ODDCUCycle()
 
 
 void ODDCUCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODDCUCycle::prepareWrite()
 }
 
 
-void ODDCUCycle::writeDB()  throw(std::runtime_error)
+void ODDCUCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODDCUCycle::clear(){
 
 
 int ODDCUCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODDCUCycle::fetchID()
 
 
 void ODDCUCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODDCUCycle::setByID(int id)
 
 
 void ODDCUCycle::fetchData(ODDCUCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODDCUCycle::fetchData(ODDCUCycle * result)
 }
 
 void ODDCUCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODDelaysDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODDelaysDat.cc
@@ -30,7 +30,7 @@ ODDelaysDat::~ODDelaysDat()
 
 
 void ODDelaysDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void ODDelaysDat::prepareWrite()
 
 
 void ODDelaysDat::writeDB(const ODDelaysDat* item, ODFEDelaysInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -64,14 +64,14 @@ void ODDelaysDat::writeDB(const ODDelaysDat* item, ODFEDelaysInfo* iov )
 }
 
 void ODDelaysDat::fetchData(std::vector< ODDelaysDat >* p, ODFEDelaysInfo* iov)
-  throw(std::runtime_error) {
+  noexcept(false) {
   iov->setConnection(m_env, m_conn);
   int iovID = iov->fetchID();
   fetchData(p, iovID);
 }
 
 void ODDelaysDat::fetchData(std::vector< ODDelaysDat >* p, int iovID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -106,7 +106,7 @@ void ODDelaysDat::fetchData(std::vector< ODDelaysDat >* p, int iovID)
 //  ************************************************************************   // 
 
 void ODDelaysDat::writeArrayDB(const std::vector< ODDelaysDat >& data, ODFEDelaysInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODEcalCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODEcalCycle.cc
@@ -42,7 +42,7 @@ ODEcalCycle::~ODEcalCycle()
 
 
 void ODEcalCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<< "ODEcalCycle::prepareWrite(): this is a view writing specific tables  "<< endl;
@@ -52,7 +52,7 @@ void ODEcalCycle::prepareWrite()
 
 
 void ODEcalCycle::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   ODRunConfigCycleInfo cyc;
@@ -200,7 +200,7 @@ void ODEcalCycle::clear(){
 }
 
 int ODEcalCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID>0) {
@@ -234,7 +234,7 @@ int ODEcalCycle::fetchID()
 }
 
 void ODEcalCycle::setByID(int id)
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -306,7 +306,7 @@ void ODEcalCycle::printout(){
 
 
 void ODEcalCycle::fetchData(ODEcalCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   //  result->clear();

--- a/OnlineDB/EcalCondDB/src/ODFEDAQConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEDAQConfig.cc
@@ -52,7 +52,7 @@ ODFEDAQConfig::~ODFEDAQConfig()
 
 
 
-int ODFEDAQConfig::fetchNextId()  throw(std::runtime_error) {
+int ODFEDAQConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -74,7 +74,7 @@ int ODFEDAQConfig::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODFEDAQConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -119,7 +119,7 @@ void ODFEDAQConfig::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODFEDAQConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -155,7 +155,7 @@ void ODFEDAQConfig::writeDB()
 
 
 void ODFEDAQConfig::fetchData(ODFEDAQConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -222,7 +222,7 @@ void ODFEDAQConfig::fetchData(ODFEDAQConfig * result)
   }
 }
 
-int ODFEDAQConfig::fetchID()    throw(std::runtime_error)
+int ODFEDAQConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODFEDelaysInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEDelaysInfo.cc
@@ -34,7 +34,7 @@ ODFEDelaysInfo::~ODFEDelaysInfo()
 
 
 
-int ODFEDelaysInfo::fetchNextId()  throw(std::runtime_error) {
+int ODFEDelaysInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int ODFEDelaysInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODFEDelaysInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -97,7 +97,7 @@ void ODFEDelaysInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODFEDelaysInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -129,7 +129,7 @@ void ODFEDelaysInfo::writeDB()
 
 
 void ODFEDelaysInfo::fetchData(ODFEDelaysInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -168,7 +168,7 @@ void ODFEDelaysInfo::fetchData(ODFEDelaysInfo * result)
   }
 }
 
-int ODFEDelaysInfo::fetchID()    throw(std::runtime_error)
+int ODFEDelaysInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODFEPedestalOffsetInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEPedestalOffsetInfo.cc
@@ -34,7 +34,7 @@ ODFEPedestalOffsetInfo::~ODFEPedestalOffsetInfo()
 
 
 
-int ODFEPedestalOffsetInfo::fetchNextId()  throw(std::runtime_error) {
+int ODFEPedestalOffsetInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -57,7 +57,7 @@ int ODFEPedestalOffsetInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODFEPedestalOffsetInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -96,7 +96,7 @@ void ODFEPedestalOffsetInfo::setParameters(const std::map<string,string>& my_key
 }
 
 void ODFEPedestalOffsetInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -132,7 +132,7 @@ void ODFEPedestalOffsetInfo::writeDB()
 
 
 void ODFEPedestalOffsetInfo::fetchData(ODFEPedestalOffsetInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -171,7 +171,7 @@ void ODFEPedestalOffsetInfo::fetchData(ODFEPedestalOffsetInfo * result)
 }
 
 void ODFEPedestalOffsetInfo::fetchLastData(ODFEPedestalOffsetInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -192,7 +192,7 @@ void ODFEPedestalOffsetInfo::fetchLastData(ODFEPedestalOffsetInfo * result)
   }
 }
 
-int ODFEPedestalOffsetInfo::fetchID()    throw(std::runtime_error)
+int ODFEPedestalOffsetInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODFEWeightsInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEWeightsInfo.cc
@@ -34,7 +34,7 @@ ODFEWeightsInfo::~ODFEWeightsInfo()
 
 
 
-int ODFEWeightsInfo::fetchNextId()  throw(std::runtime_error) {
+int ODFEWeightsInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -57,7 +57,7 @@ int ODFEWeightsInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODFEWeightsInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -96,7 +96,7 @@ void ODFEWeightsInfo::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODFEWeightsInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -129,7 +129,7 @@ void ODFEWeightsInfo::writeDB()
 
 
 void ODFEWeightsInfo::fetchData(ODFEWeightsInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -168,7 +168,7 @@ void ODFEWeightsInfo::fetchData(ODFEWeightsInfo * result)
   }
 }
 
-int ODFEWeightsInfo::fetchID()    throw(std::runtime_error)
+int ODFEWeightsInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODGolBiasCurrentDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODGolBiasCurrentDat.cc
@@ -32,7 +32,7 @@ ODGolBiasCurrentDat::~ODGolBiasCurrentDat()
 
 
 void ODGolBiasCurrentDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void ODGolBiasCurrentDat::prepareWrite()
 
 
 void ODGolBiasCurrentDat::writeDB(const ODGolBiasCurrentDat* item, ODGolBiasCurrentInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -71,7 +71,7 @@ void ODGolBiasCurrentDat::writeDB(const ODGolBiasCurrentDat* item, ODGolBiasCurr
 
 
 void ODGolBiasCurrentDat::fetchData(std::vector< ODGolBiasCurrentDat >* p, ODGolBiasCurrentInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -111,7 +111,7 @@ void ODGolBiasCurrentDat::fetchData(std::vector< ODGolBiasCurrentDat >* p, ODGol
 //  ************************************************************************   // 
 
 void ODGolBiasCurrentDat::writeArrayDB(const std::vector< ODGolBiasCurrentDat >& data, ODGolBiasCurrentInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODGolBiasCurrentInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODGolBiasCurrentInfo.cc
@@ -33,7 +33,7 @@ ODGolBiasCurrentInfo::~ODGolBiasCurrentInfo()
 
 
 
-int ODGolBiasCurrentInfo::fetchNextId()  throw(std::runtime_error) {
+int ODGolBiasCurrentInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODGolBiasCurrentInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODGolBiasCurrentInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void ODGolBiasCurrentInfo::setParameters(const std::map<string,string>& my_keys_
 }
 
 void ODGolBiasCurrentInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void ODGolBiasCurrentInfo::writeDB()
 
 
 void ODGolBiasCurrentInfo::fetchData(ODGolBiasCurrentInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -180,7 +180,7 @@ void ODGolBiasCurrentInfo::fetchData(ODGolBiasCurrentInfo * result)
   }
 }
 
-int ODGolBiasCurrentInfo::fetchID()    throw(std::runtime_error)
+int ODGolBiasCurrentInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODJBH4Config.cc
+++ b/OnlineDB/EcalCondDB/src/ODJBH4Config.cc
@@ -38,7 +38,7 @@ void ODJBH4Config::clear(){
 }
 
 
-int ODJBH4Config::fetchNextId()  throw(std::runtime_error) {
+int ODJBH4Config::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -60,7 +60,7 @@ int ODJBH4Config::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODJBH4Config::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -82,7 +82,7 @@ void ODJBH4Config::prepareWrite()
 
 
 void ODJBH4Config::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -116,7 +116,7 @@ void ODJBH4Config::writeDB()
 
 
 void ODJBH4Config::fetchData(ODJBH4Config * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -151,7 +151,7 @@ void ODJBH4Config::fetchData(ODJBH4Config * result)
   }
 }
 
-int ODJBH4Config::fetchID()    throw(std::runtime_error)
+int ODJBH4Config::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODJBH4Cycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODJBH4Cycle.cc
@@ -24,7 +24,7 @@ ODJBH4Cycle::~ODJBH4Cycle()
 
 
 void ODJBH4Cycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODJBH4Cycle::prepareWrite()
 }
 
 
-void ODJBH4Cycle::writeDB()  throw(std::runtime_error)
+void ODJBH4Cycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODJBH4Cycle::clear(){
 
 
 int ODJBH4Cycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODJBH4Cycle::fetchID()
 
 
 void ODJBH4Cycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODJBH4Cycle::setByID(int id)
 
 
 void ODJBH4Cycle::fetchData(ODJBH4Cycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODJBH4Cycle::fetchData(ODJBH4Cycle * result)
 }
 
  void ODJBH4Cycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODLTCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTCConfig.cc
@@ -31,7 +31,7 @@ ODLTCConfig::~ODLTCConfig()
   //  delete [] m_ltc_clob;
 }
 
-int ODLTCConfig::fetchNextId()  throw(std::runtime_error) {
+int ODLTCConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODLTCConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODLTCConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -146,7 +146,7 @@ void ODLTCConfig::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODLTCConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"updating the clob "<<std::endl;
@@ -197,7 +197,7 @@ void ODLTCConfig::clear(){
 
 
 void ODLTCConfig::fetchData(ODLTCConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -245,7 +245,7 @@ void ODLTCConfig::fetchData(ODLTCConfig * result)
 
 
 
-int ODLTCConfig::fetchID()    throw(std::runtime_error)
+int ODLTCConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODLTCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTCCycle.cc
@@ -24,7 +24,7 @@ ODLTCCycle::~ODLTCCycle()
 
 
 void ODLTCCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODLTCCycle::prepareWrite()
 }
 
 
-void ODLTCCycle::writeDB()  throw(std::runtime_error)
+void ODLTCCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODLTCCycle::clear(){
 
 
 int ODLTCCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODLTCCycle::fetchID()
 
 
 void ODLTCCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODLTCCycle::setByID(int id)
 
 
 void ODLTCCycle::fetchData(ODLTCCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODLTCCycle::fetchData(ODLTCCycle * result)
 }
 
 void ODLTCCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODLTSConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTSConfig.cc
@@ -50,7 +50,7 @@ void ODLTSConfig::setParameters(const std::map<string,string>& my_keys_map){
   
 }
 
-int ODLTSConfig::fetchNextId()  throw(std::runtime_error) {
+int ODLTSConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -73,7 +73,7 @@ int ODLTSConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODLTSConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -95,7 +95,7 @@ void ODLTSConfig::prepareWrite()
 
 
 void ODLTSConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -125,7 +125,7 @@ void ODLTSConfig::writeDB()
 
 
 void ODLTSConfig::fetchData(ODLTSConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -158,7 +158,7 @@ void ODLTSConfig::fetchData(ODLTSConfig * result)
   }
 }
 
-int ODLTSConfig::fetchID()    throw(std::runtime_error)
+int ODLTSConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODLTSCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTSCycle.cc
@@ -24,7 +24,7 @@ ODLTSCycle::~ODLTSCycle()
 
 
 void ODLTSCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODLTSCycle::prepareWrite()
 }
 
 
-void ODLTSCycle::writeDB()  throw(std::runtime_error)
+void ODLTSCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODLTSCycle::clear(){
 
 
 int ODLTSCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODLTSCycle::fetchID()
 
 
 void ODLTSCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODLTSCycle::setByID(int id)
 
 
 void ODLTSCycle::fetchData(ODLTSCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODLTSCycle::fetchData(ODLTSCycle * result)
 }
 
  void ODLTSCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODLaserConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLaserConfig.cc
@@ -192,7 +192,7 @@ void ODLaserConfig::setParameters(const std::map<string,string>& my_keys_map){
   
 }
 
-int ODLaserConfig::fetchNextId()  throw(std::runtime_error) {
+int ODLaserConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -215,7 +215,7 @@ int ODLaserConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODLaserConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -295,7 +295,7 @@ void ODLaserConfig::prepareWrite()
 
 
 void ODLaserConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -406,7 +406,7 @@ void ODLaserConfig::writeDB()
 
 
 void ODLaserConfig::fetchData(ODLaserConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -511,7 +511,7 @@ void ODLaserConfig::fetchData(ODLaserConfig * result)
   }
 }
 
-int ODLaserConfig::fetchID()    throw(std::runtime_error)
+int ODLaserConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODLaserCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLaserCycle.cc
@@ -24,7 +24,7 @@ ODLaserCycle::~ODLaserCycle()
 
 
 void ODLaserCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODLaserCycle::prepareWrite()
 }
 
 
-void ODLaserCycle::writeDB()  throw(std::runtime_error)
+void ODLaserCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODLaserCycle::clear(){
 
 
 int ODLaserCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODLaserCycle::fetchID()
 
 
 void ODLaserCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODLaserCycle::setByID(int id)
 
 
 void ODLaserCycle::fetchData(ODLaserCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODLaserCycle::fetchData(ODLaserCycle * result)
 }
 
  void ODLaserCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODPedestalOffsetsDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODPedestalOffsetsDat.cc
@@ -32,7 +32,7 @@ ODPedestalOffsetsDat::~ODPedestalOffsetsDat()
 
 
 void ODPedestalOffsetsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void ODPedestalOffsetsDat::prepareWrite()
 
 
 void ODPedestalOffsetsDat::writeDB(const ODPedestalOffsetsDat* item, ODFEPedestalOffsetInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -71,7 +71,7 @@ void ODPedestalOffsetsDat::writeDB(const ODPedestalOffsetsDat* item, ODFEPedesta
 
 
 void ODPedestalOffsetsDat::fetchData(std::vector< ODPedestalOffsetsDat >* p, ODFEPedestalOffsetInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -112,7 +112,7 @@ void ODPedestalOffsetsDat::fetchData(std::vector< ODPedestalOffsetsDat >* p, ODF
 //  ************************************************************************   // 
 
 void ODPedestalOffsetsDat::writeArrayDB(const std::vector< ODPedestalOffsetsDat >& data, ODFEPedestalOffsetInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODRunConfigCycleInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigCycleInfo.cc
@@ -38,7 +38,7 @@ void ODRunConfigCycleInfo::clear() {
 }
 
 void ODRunConfigCycleInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -54,7 +54,7 @@ void ODRunConfigCycleInfo::prepareWrite()
 
 
 void ODRunConfigCycleInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -90,7 +90,7 @@ void ODRunConfigCycleInfo::writeDB()
 
 
 int ODRunConfigCycleInfo::fetchID() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID>0) {
@@ -129,7 +129,7 @@ int ODRunConfigCycleInfo::fetchID()
 
 
 int ODRunConfigCycleInfo::fetchIDLast()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -157,7 +157,7 @@ int ODRunConfigCycleInfo::fetchIDLast()
 
 
 void ODRunConfigCycleInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -189,7 +189,7 @@ void ODRunConfigCycleInfo::setByID(int id)
 
 
 void ODRunConfigCycleInfo::fetchData(ODRunConfigCycleInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -216,7 +216,7 @@ void ODRunConfigCycleInfo::fetchData(ODRunConfigCycleInfo * result)
 }
 
  void ODRunConfigCycleInfo::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODRunConfigInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigInfo.cc
@@ -51,7 +51,7 @@ void ODRunConfigInfo::setRunModeDef(const RunModeDef& runModeDef)
 }
 //
 
-int ODRunConfigInfo::fetchNextId()  throw(std::runtime_error) {
+int ODRunConfigInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -73,7 +73,7 @@ int ODRunConfigInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 int ODRunConfigInfo::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID>0) {
@@ -110,7 +110,7 @@ int ODRunConfigInfo::fetchID()
 
 
 int ODRunConfigInfo::fetchIDLast()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -138,7 +138,7 @@ int ODRunConfigInfo::fetchIDLast()
 
 //
 int ODRunConfigInfo::fetchIDFromTagAndVersion()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchID();
   return m_ID;
@@ -147,7 +147,7 @@ int ODRunConfigInfo::fetchIDFromTagAndVersion()
 
 
 void ODRunConfigInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -190,7 +190,7 @@ void ODRunConfigInfo::setByID(int id)
 }
 
 void ODRunConfigInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -215,7 +215,7 @@ void ODRunConfigInfo::prepareWrite()
 
 
 void ODRunConfigInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -263,7 +263,7 @@ void ODRunConfigInfo::writeDB()
 
 
 int ODRunConfigInfo::updateDefaultCycle()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -301,7 +301,7 @@ void ODRunConfigInfo::clear(){
 }
 
 void ODRunConfigInfo::fetchData(ODRunConfigInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   DateHandler dh(m_env, m_conn);

--- a/OnlineDB/EcalCondDB/src/ODRunConfigSeqInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigSeqInfo.cc
@@ -41,7 +41,7 @@ void ODRunConfigSeqInfo::setRunSeqDef(const RunSeqDef& run_seq)
 
 
 int ODRunConfigSeqInfo::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID>0) {
@@ -79,7 +79,7 @@ int ODRunConfigSeqInfo::fetchID()
 
 
 int ODRunConfigSeqInfo::fetchIDLast()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -107,7 +107,7 @@ int ODRunConfigSeqInfo::fetchIDLast()
 
 
 void ODRunConfigSeqInfo::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -141,7 +141,7 @@ void ODRunConfigSeqInfo::setByID(int id)
 }
 
 void ODRunConfigSeqInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -155,7 +155,7 @@ void ODRunConfigSeqInfo::prepareWrite()
   }
 }
 void ODRunConfigSeqInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -205,7 +205,7 @@ void ODRunConfigSeqInfo::clear(){
 
 
 void ODRunConfigSeqInfo::fetchData(ODRunConfigSeqInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   //  result->clear();

--- a/OnlineDB/EcalCondDB/src/ODSRPConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODSRPConfig.cc
@@ -38,7 +38,7 @@ ODSRPConfig::~ODSRPConfig()
 {
 }
 
-int ODSRPConfig::fetchNextId()  throw(std::runtime_error) {
+int ODSRPConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -114,7 +114,7 @@ void ODSRPConfig::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODSRPConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -164,7 +164,7 @@ void ODSRPConfig::prepareWrite()
 
 
 void ODSRPConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"updating the clob 2"<<std::endl;
@@ -201,7 +201,7 @@ void ODSRPConfig::writeDB()
 
 
 void ODSRPConfig::fetchData(ODSRPConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   //  result->clear();
@@ -262,7 +262,7 @@ void ODSRPConfig::fetchData(ODSRPConfig * result)
 
 
 
-int ODSRPConfig::fetchID()    throw(std::runtime_error)
+int ODSRPConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODSRPCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODSRPCycle.cc
@@ -24,7 +24,7 @@ ODSRPCycle::~ODSRPCycle()
 
 
 void ODSRPCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODSRPCycle::prepareWrite()
 }
 
 
-void ODSRPCycle::writeDB()  throw(std::runtime_error)
+void ODSRPCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODSRPCycle::clear(){
 
 
 int ODSRPCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODSRPCycle::fetchID()
 
 
 void ODSRPCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODSRPCycle::setByID(int id)
 
 
 void ODSRPCycle::fetchData(ODSRPCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODSRPCycle::fetchData(ODSRPCycle * result)
 }
 
 void ODSRPCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODScanConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODScanConfig.cc
@@ -35,7 +35,7 @@ void ODScanConfig::clear(){
 
 }
 
-int ODScanConfig::fetchNextId()  throw(std::runtime_error) {
+int ODScanConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -77,7 +77,7 @@ void ODScanConfig::setParameters(const std::map<string,string>& my_keys_map){
 }
 
 void ODScanConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -96,7 +96,7 @@ void ODScanConfig::prepareWrite()
 }
 
 void ODScanConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -129,7 +129,7 @@ void ODScanConfig::writeDB()
 
 
 void ODScanConfig::fetchData(ODScanConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -163,7 +163,7 @@ void ODScanConfig::fetchData(ODScanConfig * result)
   }
 }
 
-int ODScanConfig::fetchID()    throw(std::runtime_error)
+int ODScanConfig::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODScanCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODScanCycle.cc
@@ -24,7 +24,7 @@ ODScanCycle::~ODScanCycle()
 
 
 void ODScanCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODScanCycle::prepareWrite()
 }
 
 
-void ODScanCycle::writeDB()  throw(std::runtime_error)
+void ODScanCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODScanCycle::clear(){
 
 
 int ODScanCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODScanCycle::fetchID()
 
 
 void ODScanCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODScanCycle::setByID(int id)
 
 
 void ODScanCycle::fetchData(ODScanCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODScanCycle::fetchData(ODScanCycle * result)
 }
 
 void ODScanCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODTCCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCConfig.cc
@@ -35,7 +35,7 @@ ODTCCConfig::~ODTCCConfig()
 {
 }
 
-int ODTCCConfig::fetchNextId()  throw(std::runtime_error) {
+int ODTCCConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -79,7 +79,7 @@ void ODTCCConfig::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODTCCConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -135,7 +135,7 @@ void ODTCCConfig::prepareWrite()
 }
 
 void ODTCCConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"updating the clob 2"<<std::endl;
@@ -178,7 +178,7 @@ void ODTCCConfig::writeDB()
 
 
 void ODTCCConfig::fetchData(ODTCCConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -253,7 +253,7 @@ void ODTCCConfig::fetchData(ODTCCConfig * result)
 
 
 
-int ODTCCConfig::fetchID()    throw(std::runtime_error)
+int ODTCCConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTCCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCCycle.cc
@@ -24,7 +24,7 @@ ODTCCCycle::~ODTCCCycle()
 
 
 void ODTCCCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODTCCCycle::prepareWrite()
 }
 
 
-void ODTCCCycle::writeDB()  throw(std::runtime_error)
+void ODTCCCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODTCCCycle::clear(){
 
 
 int ODTCCCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODTCCCycle::fetchID()
 
 
 void ODTCCCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODTCCCycle::setByID(int id)
 
 
 void ODTCCCycle::fetchData(ODTCCCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODTCCCycle::fetchData(ODTCCCycle * result)
 }
 
 void ODTCCCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODTCCEEConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCEEConfig.cc
@@ -36,7 +36,7 @@ ODTCCEEConfig::~ODTCCEEConfig()
 {
 }
 
-int ODTCCEEConfig::fetchNextId()  throw(std::runtime_error) {
+int ODTCCEEConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -85,7 +85,7 @@ void ODTCCEEConfig::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODTCCEEConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -143,7 +143,7 @@ void ODTCCEEConfig::prepareWrite()
 }
 
 void ODTCCEEConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"updating the clob 2"<<std::endl;
@@ -186,7 +186,7 @@ void ODTCCEEConfig::writeDB()
 
 
 void ODTCCEEConfig::fetchData(ODTCCEEConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -262,7 +262,7 @@ void ODTCCEEConfig::fetchData(ODTCCEEConfig * result)
 
 
 
-int ODTCCEEConfig::fetchID()    throw(std::runtime_error)
+int ODTCCEEConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTCCEECycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCEECycle.cc
@@ -24,7 +24,7 @@ ODTCCEECycle::~ODTCCEECycle()
 
 
 void ODTCCEECycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODTCCEECycle::prepareWrite()
 }
 
 
-void ODTCCEECycle::writeDB()  throw(std::runtime_error)
+void ODTCCEECycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODTCCEECycle::clear(){
 
 
 int ODTCCEECycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODTCCEECycle::fetchID()
 
 
 void ODTCCEECycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODTCCEECycle::setByID(int id)
 
 
 void ODTCCEECycle::fetchData(ODTCCEECycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODTCCEECycle::fetchData(ODTCCEECycle * result)
 }
 
 void ODTCCEECycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODTTCFConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCFConfig.cc
@@ -31,7 +31,7 @@ ODTTCFConfig::~ODTTCFConfig()
 {
 }
 
-int ODTTCFConfig::fetchNextId()  throw(std::runtime_error) {
+int ODTTCFConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -58,7 +58,7 @@ int ODTTCFConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODTTCFConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   int next_id=fetchNextId();
@@ -102,7 +102,7 @@ void ODTTCFConfig::prepareWrite()
 }
 
 void ODTTCFConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"updating the clob 2"<<std::endl;
@@ -137,7 +137,7 @@ void ODTTCFConfig::writeDB()
 
 
 void ODTTCFConfig::fetchData(ODTTCFConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -177,7 +177,7 @@ void ODTTCFConfig::fetchData(ODTTCFConfig * result)
 
 
 
-int ODTTCFConfig::fetchID()    throw(std::runtime_error)
+int ODTTCFConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTTCFCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCFCycle.cc
@@ -24,7 +24,7 @@ ODTTCFCycle::~ODTTCFCycle()
 
 
 void ODTTCFCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODTTCFCycle::prepareWrite()
 }
 
 
-void ODTTCFCycle::writeDB()  throw(std::runtime_error)
+void ODTTCFCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODTTCFCycle::clear(){
 
 
 int ODTTCFCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODTTCFCycle::fetchID()
 
 
 void ODTTCFCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODTTCFCycle::setByID(int id)
 
 
 void ODTTCFCycle::fetchData(ODTTCFCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -156,7 +156,7 @@ void ODTTCFCycle::fetchData(ODTTCFCycle * result)
 }
 
 void ODTTCFCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODTTCciConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCciConfig.cc
@@ -40,7 +40,7 @@ ODTTCciConfig::~ODTTCciConfig()
 {
 }
 
-int ODTTCciConfig::fetchNextId()  throw(std::runtime_error) {
+int ODTTCciConfig::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -65,7 +65,7 @@ int ODTTCciConfig::fetchNextId()  throw(std::runtime_error) {
 
 
 void ODTTCciConfig::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -161,7 +161,7 @@ void ODTTCciConfig::setParameters(const std::map<string,string>& my_keys_map){
 
 
 void ODTTCciConfig::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -205,7 +205,7 @@ void ODTTCciConfig::writeDB()
 
 
 void ODTTCciConfig::fetchData(ODTTCciConfig * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -259,7 +259,7 @@ void ODTTCciConfig::fetchData(ODTTCciConfig * result)
 
 
 
-int ODTTCciConfig::fetchID()    throw(std::runtime_error)
+int ODTTCciConfig::fetchID()    noexcept(false)
 {
   if (m_ID!=0) {
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTTCciCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCciCycle.cc
@@ -24,7 +24,7 @@ ODTTCciCycle::~ODTTCciCycle()
 
 
 void ODTTCciCycle::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -38,7 +38,7 @@ void ODTTCciCycle::prepareWrite()
 }
 
 
-void ODTTCciCycle::writeDB()  throw(std::runtime_error)
+void ODTTCciCycle::writeDB()  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void ODTTCciCycle::clear(){
 
 
 int ODTTCciCycle::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -102,7 +102,7 @@ int ODTTCciCycle::fetchID()
 
 
 void ODTTCciCycle::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -129,7 +129,7 @@ void ODTTCciCycle::setByID(int id)
 
 
 void ODTTCciCycle::fetchData(ODTTCciCycle * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -157,7 +157,7 @@ void ODTTCciCycle::fetchData(ODTTCciCycle * result)
 
 
 void ODTTCciCycle::insertConfig()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   try {
 

--- a/OnlineDB/EcalCondDB/src/ODTowersToByPassDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODTowersToByPassDat.cc
@@ -32,7 +32,7 @@ ODTowersToByPassDat::~ODTowersToByPassDat()
 
 
 void ODTowersToByPassDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void ODTowersToByPassDat::prepareWrite()
 
 
 void ODTowersToByPassDat::writeDB(const ODTowersToByPassDat* item, ODTowersToByPassInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -69,7 +69,7 @@ void ODTowersToByPassDat::writeDB(const ODTowersToByPassDat* item, ODTowersToByP
 
 
 void ODTowersToByPassDat::fetchData(std::vector< ODTowersToByPassDat >* p, ODTowersToByPassInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -108,7 +108,7 @@ void ODTowersToByPassDat::fetchData(std::vector< ODTowersToByPassDat >* p, ODTow
 //  ************************************************************************   // 
 
 void ODTowersToByPassDat::writeArrayDB(const std::vector< ODTowersToByPassDat >& data, ODTowersToByPassInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODTowersToByPassInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODTowersToByPassInfo.cc
@@ -33,7 +33,7 @@ ODTowersToByPassInfo::~ODTowersToByPassInfo()
 
 
 
-int ODTowersToByPassInfo::fetchNextId()  throw(std::runtime_error) {
+int ODTowersToByPassInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODTowersToByPassInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODTowersToByPassInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void ODTowersToByPassInfo::setParameters(const std::map<string,string>& my_keys_
 }
 
 void ODTowersToByPassInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void ODTowersToByPassInfo::writeDB()
 
 
 void ODTowersToByPassInfo::fetchData(ODTowersToByPassInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -180,7 +180,7 @@ void ODTowersToByPassInfo::fetchData(ODTowersToByPassInfo * result)
   }
 }
 
-int ODTowersToByPassInfo::fetchID()    throw(std::runtime_error)
+int ODTowersToByPassInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODVfeToRejectDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODVfeToRejectDat.cc
@@ -32,7 +32,7 @@ ODVfeToRejectDat::~ODVfeToRejectDat()
 
 
 void ODVfeToRejectDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void ODVfeToRejectDat::prepareWrite()
 
 
 void ODVfeToRejectDat::writeDB(const ODVfeToRejectDat* item, ODVfeToRejectInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -69,7 +69,7 @@ void ODVfeToRejectDat::writeDB(const ODVfeToRejectDat* item, ODVfeToRejectInfo* 
 
 
 void ODVfeToRejectDat::fetchData(std::vector< ODVfeToRejectDat >* p, ODVfeToRejectInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -108,7 +108,7 @@ void ODVfeToRejectDat::fetchData(std::vector< ODVfeToRejectDat >* p, ODVfeToReje
 //  ************************************************************************   // 
 
 void ODVfeToRejectDat::writeArrayDB(const std::vector< ODVfeToRejectDat >& data, ODVfeToRejectInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODVfeToRejectInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODVfeToRejectInfo.cc
@@ -33,7 +33,7 @@ ODVfeToRejectInfo::~ODVfeToRejectInfo()
 
 
 
-int ODVfeToRejectInfo::fetchNextId()  throw(std::runtime_error) {
+int ODVfeToRejectInfo::fetchNextId()  noexcept(false) {
 
   int result=0;
   try {
@@ -56,7 +56,7 @@ int ODVfeToRejectInfo::fetchNextId()  throw(std::runtime_error) {
 }
 
 void ODVfeToRejectInfo::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -95,7 +95,7 @@ void ODVfeToRejectInfo::setParameters(const std::map<string,string>& my_keys_map
 }
 
 void ODVfeToRejectInfo::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -128,7 +128,7 @@ void ODVfeToRejectInfo::writeDB()
 
 
 void ODVfeToRejectInfo::fetchData(ODVfeToRejectInfo * result)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   result->clear();
@@ -180,7 +180,7 @@ void ODVfeToRejectInfo::fetchData(ODVfeToRejectInfo * result)
   }
 }
 
-int ODVfeToRejectInfo::fetchID()    throw(std::runtime_error)
+int ODVfeToRejectInfo::fetchID()    noexcept(false)
 {
   // Return from memory if available
   if (m_ID!=0) {

--- a/OnlineDB/EcalCondDB/src/ODWeightsDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODWeightsDat.cc
@@ -42,7 +42,7 @@ void ODWeightsDat::clear() {
 
 
 void ODWeightsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -58,7 +58,7 @@ void ODWeightsDat::prepareWrite()
 
 
 void ODWeightsDat::writeDB(const ODWeightsDat* item, ODFEWeightsInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -85,7 +85,7 @@ void ODWeightsDat::writeDB(const ODWeightsDat* item, ODFEWeightsInfo* iov )
 
 
 void ODWeightsDat::fetchData(std::vector< ODWeightsDat >* p, ODFEWeightsInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -133,7 +133,7 @@ void ODWeightsDat::fetchData(std::vector< ODWeightsDat >* p, ODFEWeightsInfo* io
 }
 
 void ODWeightsDat::fetchData(ODWeightsDat * p)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -165,7 +165,7 @@ void ODWeightsDat::fetchData(ODWeightsDat * p)
 //  ************************************************************************   // 
 
 void ODWeightsDat::writeArrayDB(const std::vector< ODWeightsDat >& data, ODFEWeightsInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/ODWeightsSamplesDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODWeightsSamplesDat.cc
@@ -31,7 +31,7 @@ void ODWeightsSamplesDat::clear() {
 }
 
 void ODWeightsSamplesDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void ODWeightsSamplesDat::prepareWrite()
 
 
 void ODWeightsSamplesDat::writeDB(const ODWeightsSamplesDat* item, ODFEWeightsInfo* iov )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -66,7 +66,7 @@ void ODWeightsSamplesDat::writeDB(const ODWeightsSamplesDat* item, ODFEWeightsIn
 
 
 void ODWeightsSamplesDat::fetchData(std::vector< ODWeightsSamplesDat >* p, ODFEWeightsInfo* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -101,7 +101,7 @@ void ODWeightsSamplesDat::fetchData(std::vector< ODWeightsSamplesDat >* p, ODFEW
 
 
 void ODWeightsSamplesDat::fetchData(ODWeightsSamplesDat * p)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -124,7 +124,7 @@ void ODWeightsSamplesDat::fetchData(ODWeightsSamplesDat * p)
 //  ************************************************************************   // 
 
 void ODWeightsSamplesDat::writeArrayDB(const std::vector< ODWeightsSamplesDat >& data, ODFEWeightsInfo* iov)
-    throw(std::runtime_error)
+    noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/RunCommentDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunCommentDat.cc
@@ -32,7 +32,7 @@ RunCommentDat::~RunCommentDat()
 
 
 void RunCommentDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -50,7 +50,7 @@ void RunCommentDat::prepareWrite()
 
 
 void RunCommentDat::writeDB(const EcalLogicID* ecid, const RunCommentDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void RunCommentDat::writeDB(const EcalLogicID* ecid, const RunCommentDat* item, 
 
 
 void RunCommentDat::fetchData(map< EcalLogicID, RunCommentDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunConfigDat.cc
@@ -28,7 +28,7 @@ RunConfigDat::~RunConfigDat()
 
 
 void RunConfigDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void RunConfigDat::prepareWrite()
 
 
 void RunConfigDat::writeDB(const EcalLogicID* ecid, const RunConfigDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void RunConfigDat::writeDB(const EcalLogicID* ecid, const RunConfigDat* item, Ru
 
 
 void RunConfigDat::fetchData(map< EcalLogicID, RunConfigDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
@@ -26,7 +26,7 @@ RunCrystalErrorsDat::~RunCrystalErrorsDat()
 
 
 void RunCrystalErrorsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void RunCrystalErrorsDat::prepareWrite()
 
 
 void RunCrystalErrorsDat::writeDB(const EcalLogicID* ecid, const RunCrystalErrorsDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -69,7 +69,7 @@ void RunCrystalErrorsDat::writeDB(const EcalLogicID* ecid, const RunCrystalError
 
 
 void RunCrystalErrorsDat::fetchData(map< EcalLogicID, RunCrystalErrorsDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
@@ -34,7 +34,7 @@ RunDCSHVDat::~RunDCSHVDat()
 
 
 void RunDCSHVDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -43,14 +43,14 @@ void RunDCSHVDat::prepareWrite()
 
 
 void RunDCSHVDat::writeDB(const EcalLogicID* ecid, const RunDCSHVDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 }
 
 
 
 void RunDCSHVDat::fetchData(map< EcalLogicID, RunDCSHVDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchLastData(fillMap);
 
@@ -353,7 +353,7 @@ void  RunDCSHVDat::setStatusForEndcaps(RunDCSHVDat &dat, const Tm& sinceTm) {
 }
 
 void RunDCSHVDat::fetchLastData(map< EcalLogicID, RunDCSHVDat >* fillMap )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -379,7 +379,7 @@ void RunDCSHVDat::fetchLastData(map< EcalLogicID, RunDCSHVDat >* fillMap )
 }
 
 void RunDCSHVDat::fetchHistoricalData(std::list< std::pair<Tm, std::map< EcalLogicID, RunDCSHVDat > > >* fillMap, const Tm& timeStart  )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
@@ -30,7 +30,7 @@ RunDCSLVDat::~RunDCSLVDat()
 
 
 void RunDCSLVDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -39,14 +39,14 @@ void RunDCSLVDat::prepareWrite()
 
 
 void RunDCSLVDat::writeDB(const EcalLogicID* ecid, const RunDCSLVDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 }
 
 
 
 void RunDCSLVDat::fetchData(map< EcalLogicID, RunDCSLVDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchLastData(fillMap);
 
@@ -170,7 +170,7 @@ void  RunDCSLVDat::setStatusForEndcaps(RunDCSLVDat &dat, const Tm& sinceTm) {
 }
 
 void RunDCSLVDat::fetchLastData(map< EcalLogicID, RunDCSLVDat >* fillMap )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
@@ -44,7 +44,7 @@ Tm RunDCSMagnetDat::getTime() const
 
 
 void RunDCSMagnetDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -53,14 +53,14 @@ void RunDCSMagnetDat::prepareWrite()
 
 
 void RunDCSMagnetDat::writeDB(const EcalLogicID* ecid, const RunDCSMagnetDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 }
 
 
 
 void RunDCSMagnetDat::fetchData(map< EcalLogicID, RunDCSMagnetDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   std::cout<<"going to call fetchLastData"<<std::endl;
@@ -143,7 +143,7 @@ int  RunDCSMagnetDat::nowMicroseconds() {
 
 
 void RunDCSMagnetDat::fetchLastData(map< EcalLogicID, RunDCSMagnetDat >* fillMap )
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 

--- a/OnlineDB/EcalCondDB/src/RunDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDat.cc
@@ -25,7 +25,7 @@ RunDat::~RunDat()
 
 
 void RunDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -43,7 +43,7 @@ void RunDat::prepareWrite()
 
 
 void RunDat::writeDB(const EcalLogicID* ecid, const RunDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -68,7 +68,7 @@ void RunDat::writeDB(const EcalLogicID* ecid, const RunDat* item, RunIOV* iov)
 
 
 void RunDat::fetchData(map< EcalLogicID, RunDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunFEConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunFEConfigDat.cc
@@ -28,7 +28,7 @@ RunFEConfigDat::~RunFEConfigDat()
 
 
 void RunFEConfigDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void RunFEConfigDat::prepareWrite()
 
 
 void RunFEConfigDat::writeDB(const EcalLogicID* ecid, const RunFEConfigDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -72,7 +72,7 @@ void RunFEConfigDat::writeDB(const EcalLogicID* ecid, const RunFEConfigDat* item
 
 
 void RunFEConfigDat::fetchData(map< EcalLogicID, RunFEConfigDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunH4TablePositionDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunH4TablePositionDat.cc
@@ -30,7 +30,7 @@ RunH4TablePositionDat::~RunH4TablePositionDat()
 
 
 void RunH4TablePositionDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -48,7 +48,7 @@ void RunH4TablePositionDat::prepareWrite()
 
 
 void RunH4TablePositionDat::writeDB(const EcalLogicID* ecid, const RunH4TablePositionDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -76,7 +76,7 @@ void RunH4TablePositionDat::writeDB(const EcalLogicID* ecid, const RunH4TablePos
 
 
 void RunH4TablePositionDat::fetchData(map< EcalLogicID, RunH4TablePositionDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/RunIOV.cc
@@ -101,7 +101,7 @@ RunTag RunIOV::getRunTag() const
 
 
 int RunIOV::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -150,7 +150,7 @@ int RunIOV::fetchID()
 
 
 void RunIOV::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -188,7 +188,7 @@ void RunIOV::setByID(int id)
 
 
 int RunIOV::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -238,7 +238,7 @@ int RunIOV::writeDB()
 
 
 int RunIOV::updateEndTimeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -282,7 +282,7 @@ int RunIOV::updateEndTimeDB()
 }
 
 int RunIOV::fetchIDByRunAndTag()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return from memory if available
   if (m_ID) {
@@ -328,7 +328,7 @@ int RunIOV::fetchIDByRunAndTag()
 
 
 int RunIOV::updateStartTimeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -374,7 +374,7 @@ int RunIOV::updateStartTimeDB()
 
 
 void RunIOV::setByRun(RunTag* tag, run_t run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -415,7 +415,7 @@ void RunIOV::setByRun(RunTag* tag, run_t run)
 }
 
 void RunIOV::setByTime(std::string location, const Tm &t) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
    
@@ -456,7 +456,7 @@ void RunIOV::setByTime(std::string location, const Tm &t)
 }
 
 void RunIOV::setByRun(std::string location, run_t run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
    
@@ -494,7 +494,7 @@ void RunIOV::setByRun(std::string location, run_t run)
 
 
 void RunIOV::setByRecentData(std::string dataTable, RunTag* tag, run_t run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
    this->checkConnection();
 
@@ -544,7 +544,7 @@ void RunIOV::setByRecentData(std::string dataTable, RunTag* tag, run_t run)
 
 
 void RunIOV::setByRecentData(std::string dataTable, std::string location, run_t run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
    

--- a/OnlineDB/EcalCondDB/src/RunLaserRunDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunLaserRunDat.cc
@@ -26,7 +26,7 @@ RunLaserRunDat::~RunLaserRunDat()
 
 
 void RunLaserRunDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -44,7 +44,7 @@ void RunLaserRunDat::prepareWrite()
 
 
 void RunLaserRunDat::writeDB(const EcalLogicID* ecid, const RunLaserRunDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void RunLaserRunDat::writeDB(const EcalLogicID* ecid, const RunLaserRunDat* item
 
 
 void RunLaserRunDat::fetchData(map< EcalLogicID, RunLaserRunDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunList.cc
+++ b/OnlineDB/EcalCondDB/src/RunList.cc
@@ -38,44 +38,44 @@ RunTag RunList::getRunTag() const
 }
 
 void RunList::fetchNonEmptyRuns() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(-1, -1, true, false); 
 }
 
 void RunList::fetchNonEmptyGlobalRuns() 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(-1, -1, false, true); 
 }
 
 void RunList::fetchNonEmptyRuns(int min_run, int max_run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(min_run, max_run, true, false); 
 }
 
 void RunList::fetchNonEmptyGlobalRuns(int min_run, int max_run) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(min_run, max_run, false, true); 
 }
 
 void RunList::fetchRuns()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(-1, -1);
 }
 
 void RunList::fetchRuns(int min_run, int max_run)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   fetchRuns(min_run, max_run, false, false);
 }
 
 void RunList::fetchRuns(int min_run, int max_run, bool withTriggers,
 			bool withGlobalTriggers)
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   /*
@@ -189,7 +189,7 @@ void RunList::fetchRuns(int min_run, int max_run, bool withTriggers,
 }
 
 void RunList::fetchLastNRuns( int max_run, int n_runs  )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   // fetch the last n_runs that come just before max_run (including max_run)
@@ -263,7 +263,7 @@ void RunList::fetchLastNRuns( int max_run, int n_runs  )
 
 
 void RunList::fetchRunsByLocation (int min_run, int max_run, const LocationDef& locDef )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();
@@ -352,7 +352,7 @@ void RunList::fetchRunsByLocation (int min_run, int max_run, const LocationDef& 
 }
 
 void RunList::fetchGlobalRunsByLocation (int min_run, int max_run, const LocationDef& locDef )
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
   this->checkConnection();

--- a/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
@@ -27,7 +27,7 @@ RunMemChErrorsDat::~RunMemChErrorsDat()
 
 
 void RunMemChErrorsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void RunMemChErrorsDat::prepareWrite()
 
 
 void RunMemChErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemChErrorsDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void RunMemChErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemChErrorsDat
 
 
 void RunMemChErrorsDat::fetchData(map< EcalLogicID, RunMemChErrorsDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
@@ -28,7 +28,7 @@ RunMemTTErrorsDat::~RunMemTTErrorsDat()
 
 
 void RunMemTTErrorsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void RunMemTTErrorsDat::prepareWrite()
 
 
 void RunMemTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemTTErrorsDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -71,7 +71,7 @@ void RunMemTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemTTErrorsDat
 
 
 void RunMemTTErrorsDat::fetchData(map< EcalLogicID, RunMemTTErrorsDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunModeDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunModeDef.cc
@@ -44,7 +44,7 @@ void RunModeDef::setRunMode(string runmode)
 
   
 int RunModeDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -78,7 +78,7 @@ int RunModeDef::fetchID()
 
 
 void RunModeDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -104,7 +104,7 @@ void RunModeDef::setByID(int id)
 
 
 void RunModeDef::fetchAllDefs( std::vector<RunModeDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {

--- a/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
@@ -28,7 +28,7 @@ RunPNErrorsDat::~RunPNErrorsDat()
 
 
 void RunPNErrorsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void RunPNErrorsDat::prepareWrite()
 
 
 void RunPNErrorsDat::writeDB(const EcalLogicID* ecid, const RunPNErrorsDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -71,7 +71,7 @@ void RunPNErrorsDat::writeDB(const EcalLogicID* ecid, const RunPNErrorsDat* item
 
 
 void RunPNErrorsDat::fetchData(map< EcalLogicID, RunPNErrorsDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunPTMTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunPTMTempDat.cc
@@ -27,7 +27,7 @@ RunPTMTempDat::~RunPTMTempDat()
 
 
 void RunPTMTempDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -45,7 +45,7 @@ void RunPTMTempDat::prepareWrite()
 
 
 void RunPTMTempDat::writeDB(const EcalLogicID* ecid, const RunPTMTempDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -70,7 +70,7 @@ void RunPTMTempDat::writeDB(const EcalLogicID* ecid, const RunPTMTempDat* item, 
 
 
 void RunPTMTempDat::fetchData(map< EcalLogicID, RunPTMTempDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunSeqDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunSeqDef.cc
@@ -42,7 +42,7 @@ void RunSeqDef::setRunTypeDef(const RunTypeDef& runTypeDef)
 
   
 int RunSeqDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -84,7 +84,7 @@ int RunSeqDef::fetchID()
 
 
 void RunSeqDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -116,7 +116,7 @@ void RunSeqDef::setByID(int id)
 
 
 void RunSeqDef::fetchAllDefs( std::vector<RunSeqDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {
@@ -137,7 +137,7 @@ void RunSeqDef::fetchAllDefs( std::vector<RunSeqDef>* fillVec)
 }
 
 int RunSeqDef::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if this data is already in the DB
   try {

--- a/OnlineDB/EcalCondDB/src/RunTPGConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunTPGConfigDat.cc
@@ -28,7 +28,7 @@ RunTPGConfigDat::~RunTPGConfigDat()
 
 
 void RunTPGConfigDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -46,7 +46,7 @@ void RunTPGConfigDat::prepareWrite()
 
 
 void RunTPGConfigDat::writeDB(const EcalLogicID* ecid, const RunTPGConfigDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -73,7 +73,7 @@ void RunTPGConfigDat::writeDB(const EcalLogicID* ecid, const RunTPGConfigDat* it
 
 
 void RunTPGConfigDat::fetchData(map< EcalLogicID, RunTPGConfigDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
@@ -28,7 +28,7 @@ RunTTErrorsDat::~RunTTErrorsDat()
 
 
 void RunTTErrorsDat::prepareWrite()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -47,7 +47,7 @@ void RunTTErrorsDat::prepareWrite()
 
 
 void RunTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunTTErrorsDat* item, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   this->checkPrepare();
@@ -71,7 +71,7 @@ void RunTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunTTErrorsDat* item
 
 
 void RunTTErrorsDat::fetchData(map< EcalLogicID, RunTTErrorsDat >* fillMap, RunIOV* iov)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   fillMap->clear();

--- a/OnlineDB/EcalCondDB/src/RunTag.cc
+++ b/OnlineDB/EcalCondDB/src/RunTag.cc
@@ -78,7 +78,7 @@ void RunTag::setRunTypeDef(const RunTypeDef& runTypeDef)
 
 
 int RunTag::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
 
 
@@ -125,7 +125,7 @@ int RunTag::fetchID()
 
 
 void RunTag::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -160,7 +160,7 @@ void RunTag::setByID(int id)
 
 
 int RunTag::writeDB()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // see if this data is already in the DB
   if (this->fetchID()) { 
@@ -202,7 +202,7 @@ int RunTag::writeDB()
 
 
 void RunTag::fetchAllTags( std::vector<RunTag>* fillVec)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {
@@ -225,7 +225,7 @@ void RunTag::fetchAllTags( std::vector<RunTag>* fillVec)
 
 
 void RunTag::fetchParentIDs(int* locID, int* runTypeID)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // get the location
   m_locDef.setConnection(m_env, m_conn);

--- a/OnlineDB/EcalCondDB/src/RunTypeDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunTypeDef.cc
@@ -48,7 +48,7 @@ string RunTypeDef::getDescription() const
 
   
 int RunTypeDef::fetchID()
-  throw(std::runtime_error)
+  noexcept(false)
 {
   // Return def from memory if available
   if (m_ID) {
@@ -82,7 +82,7 @@ int RunTypeDef::fetchID()
 
 
 void RunTypeDef::setByID(int id) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
 
@@ -109,7 +109,7 @@ void RunTypeDef::setByID(int id)
 
 
 void RunTypeDef::fetchAllDefs( std::vector<RunTypeDef>* fillVec) 
-  throw(std::runtime_error)
+  noexcept(false)
 {
   this->checkConnection();
   try {

--- a/OnlineDB/EcalCondDB/src/Tm.cc
+++ b/OnlineDB/EcalCondDB/src/Tm.cc
@@ -191,7 +191,7 @@ void Tm::setToGMTime(time_t t)
 }
 
 void Tm::setToString(const string s)
-  throw(std::runtime_error)
+  noexcept(false)
 {
   sscanf(s.c_str(), "%04d-%02d-%02d %02d:%02d:%02d", 
 	 &m_tm.tm_year, &m_tm.tm_mon, &m_tm.tm_mday,


### PR DESCRIPTION
ISO C++17 no more supports dynamic exception specifications. Starting
C++11 noexcept and noexcept(expression) were introduced, where if
expression is false it means that function/method potentially can throw
something. Simply put, now you can mark function as not throwing
anything or potentially throwing something. Again, this was deprecated
in C++11 and finally removed in C++17 to my understanding.

This PR generates 8 errors while compiling it thus should be merged as-is
(even if logically there is nothing wrong with it).

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>