### PR TITLE
Sync AOD and MiniAOD PU ID

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -468,7 +468,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 					if (isVtx0) {
 					    if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit) inVtx0 = true;
 					    if (lPack->fromPV(vtx_i) == 0) inVtxOther = true;
-					    dZ0 = lPack->dz(vtx_i);
+					    dZ0 = lPack->dz(iv.position());
 					}
 
 					if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {


### PR DESCRIPTION
For forward tracks (e.g. eta>2) the beta variable used in the pileup jet ID was not in sync when running on AOD and MiniAOD. Adapted the MiniAOD accordingly and checked with 3 event printouts with ~20 jets that they are in sync after this change.