### PR TITLE
Fixed python module name for C++ callable code

### DIFF
--- a/FWCore/PythonParameterSet/src/PythonModule.h
+++ b/FWCore/PythonParameterSet/src/PythonModule.h
@@ -31,7 +31,7 @@ namespace {
   }
 }
 
-BOOST_PYTHON_MODULE(libFWCoreParameterSet)
+BOOST_PYTHON_MODULE(libFWCorePythonParameterSet)
 {
   boost::python::register_exception_translator<cms::Exception>(translator);
 

--- a/FWCore/PythonParameterSet/src/initializeModule.cc
+++ b/FWCore/PythonParameterSet/src/initializeModule.cc
@@ -25,8 +25,8 @@ static bool s_initialized = false;
 namespace edm {
    namespace python {
       void initializeModule() {
-         char *libFWCoreParameterSet = const_cast<char *>("libFWCoreParameterSet");
-         PyImport_AppendInittab(libFWCoreParameterSet, &initlibFWCoreParameterSet );
+         char *libFWCoreParameterSet = const_cast<char *>("libFWCorePythonParameterSet");
+         PyImport_AppendInittab(libFWCoreParameterSet, &initlibFWCorePythonParameterSet );
          Py_Initialize();
          if(!s_initialized)
          {


### PR DESCRIPTION
The proper module name should be libFWCorePythonParameterSet to
match the name of the shared library.