### PR TITLE
Pass thread count to gridpack run scripts.

### DIFF
--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -66,7 +66,7 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
-      void doPreallocate(PreallocationConfiguration const&) {}
+      void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
 
@@ -103,6 +103,7 @@ namespace edm {
 
       virtual void preForkReleaseResources() {}
       virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      virtual void preallocThreads(unsigned int) {}
 
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -77,6 +78,12 @@ namespace edm {
       this->endJob();
     }
     
+    void
+    EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
+      auto const nThreads = iPrealloc.numberOfThreads();
+      preallocThreads(nThreads);
+    }
+   
     void
     EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {

--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
@@ -33,6 +33,8 @@ echo "%MSG-POWHEG number of events requested = $nevt"
 rnum=${6}
 echo "%MSG-POWHEG random seed used for the run = $rnum"
 
+ncpu=${7}
+echo "%MSG-POWHEG thread count requested = $ncpu (ignored)"
 
 seed=$rnum
 file="events"

--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
@@ -45,6 +45,8 @@ echo "%MSG-POWHEG number of events requested = $nevt"
 rnum=${10}
 echo "%MSG-POWHEG random seed used for the run = $rnum"
 
+ncpu=${11}
+echo "%MSG-POWHEG thread count requested = $ncpu (ignored)"
 
 seed=$rnum
 file="events"

--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
@@ -23,6 +23,9 @@ echo "%MSG-MG5 number of events requested = $nevt"
 rnum=${4}
 echo "%MSG-MG5 random seed used for the run = $rnum"
 
+ncpu=${5}
+echo "%MSG-MG5 thread count requested = $ncpu"
+
 LHEWORKDIR=`pwd`
 
 if [[ -d lheevent ]]
@@ -39,8 +42,8 @@ fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}
 #check the structure of the tarball
 tar xaf ${name} ; rm -f ${name} ;
 
-#generate events (call for 1 core always for now until hooks to set number of cores are implemented upstream)
-./runcmsgrid.sh $nevt $rnum 1
+#generate events
+./runcmsgrid.sh $nevt $rnum $ncpu
 
 mv cmsgrid_final.lhe $LHEWORKDIR/
 

--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -23,6 +23,9 @@ echo "%MSG-MG5 number of events requested = $nevt"
 rnum=${3}
 echo "%MSG-MG5 random seed used for the run = $rnum"
 
+ncpu=${4}
+echo "%MSG-MG5 thread count requested = $ncpu"
+
 LHEWORKDIR=`pwd`
 
 if [[ -d lheevent ]]
@@ -36,8 +39,8 @@ mkdir lheevent; cd lheevent
 #untar the tarball directly from cvmfs
 tar -xaf ${path} 
 
-#generate events (call for 1 core always for now until hooks to set number of cores are implemented upstream)
-./runcmsgrid.sh $nevt $rnum 1
+#generate events
+./runcmsgrid.sh $nevt $rnum $ncpu
 
 mv cmsgrid_final.lhe $LHEWORKDIR/
 

--- a/GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh
+++ b/GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh
@@ -40,6 +40,9 @@ echo "%MSG-MG5 number of events requested = $nevt"
 rnum=${12}
 echo "%MSG-MG5 random seed used for the run = $rnum"
 
+ncpu=${13}
+echo "%MSG-MG5 thread count requested = $ncpu (ignored)"
+
 # retrieve the wanted gridpack from the official repository 
 fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}_gridpack.tar.gz 
 

--- a/GeneratorInterface/LHEInterface/data/run_madgraph_tarball.sh
+++ b/GeneratorInterface/LHEInterface/data/run_madgraph_tarball.sh
@@ -40,6 +40,8 @@ echo "%MSG-MG5 number of events requested = $nevt"
 rnum=${12}
 echo "%MSG-MG5 random seed used for the run = $rnum"
 
+ncpu=${13}
+echo "%MSG-MG5 thread count requested = $ncpu (ignored)"
 
 if [[ -d madevent ]]
     then

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -75,6 +75,7 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
   virtual void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
   virtual void endRunProduce(edm::Run&, edm::EventSetup const&) override;
+  virtual void preallocThreads(unsigned int) override;
 
   int closeDescriptors(int preserve);
   void executeScript();
@@ -88,6 +89,7 @@ private:
   std::vector<std::string> args_;
   uint32_t npars_;
   uint32_t nEvents_;
+  unsigned int nThreads_{1};
   std::string outputContents_;
 
   std::auto_ptr<lhef::LHEReader>		reader_;
@@ -146,6 +148,13 @@ ExternalLHEProducer::~ExternalLHEProducer()
 //
 // member functions
 //
+
+// ------------ method called with number of threads in job --
+void
+ExternalLHEProducer::preallocThreads(unsigned int iThreads)
+{
+  nThreads_ = iThreads;
+}
 
 // ------------ method called to produce the data  ------------
 void
@@ -230,6 +239,8 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
   std::ostringstream randomStream;
   randomStream << rng->mySeed(); 
   args_.push_back(randomStream.str());
+
+  args_.emplace_back(std::to_string(nThreads_));
 
   for ( unsigned int iArg = 0; iArg < args_.size() ; iArg++ ) {
     LogDebug("LHEInputArgs") << "arg [" << iArg << "] = " << args_[iArg];


### PR DESCRIPTION
Altered the `ExternalLHEProducer` to pass information from the `cmsRun` process to the script that launches the generators.  This requires a small change to `EDProducerBase` so producers are informed of the number of threads in the current configuration.

Generators that are ready to run multi-process / multi-threaded will use this extra argument; otherwise, this is ignored.

@bendavid - does this reflect what we were discussing in email?  Anything I missed?  Do you have a suggested `cmsDriver` command I could run to validate?  I'm afraid I don't have deep knowledge on the generators...

@sextonkennedy - this is a follow-up from our discussion in December with @Dr15Jones; Josh had suggested that the most expedient route would be for me to attempt the changes.