### PR TITLE
edm::View<reco::Track> instead of reco::TrackCollection in DQM/TrackingMonitor

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -81,8 +81,8 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
 	edm::EDGetTokenT<reco::VertexCollection> pvSrcToken_;
 
-	edm::EDGetTokenT<reco::TrackCollection> allTrackToken_;
-	edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+	edm::EDGetTokenT<edm::View<reco::Track> > allTrackToken_;
+	edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
 

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -109,8 +109,8 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   edm::InputTag trackProducer    = conf_.getParameter<edm::InputTag>("TrackProducer");
   edm::InputTag tcProducer       = conf_.getParameter<edm::InputTag>("TCProducer");
   edm::InputTag seedProducer     = conf_.getParameter<edm::InputTag>("SeedProducer");
-  allTrackToken_       = consumes<reco::TrackCollection>(alltrackProducer);
-  trackToken_          = consumes<reco::TrackCollection>(trackProducer);
+  allTrackToken_       = consumes<edm::View<reco::Track> >(alltrackProducer);
+  trackToken_          = consumes<edm::View<reco::Track> >(trackProducer);
   trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer); 
   seedToken_           = consumes<edm::View<TrajectorySeed> >(seedProducer);
 
@@ -675,15 +675,16 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       NumberEventsOfVsBX->Fill(bx);
 
     // get the track collection
-    edm::Handle<reco::TrackCollection> trackHandle;
+    edm::Handle<edm::View<reco::Track> > trackHandle;
     iEvent.getByToken(trackToken_, trackHandle);
 
     int numberOfTracks_den = 0;
-    edm::Handle<reco::TrackCollection> allTrackHandle;
+    edm::Handle<edm::View<reco::Track> > allTrackHandle;
     iEvent.getByToken(allTrackToken_,allTrackHandle);
     if (allTrackHandle.isValid()) {
-      for (reco::TrackCollection::const_iterator track = allTrackHandle->begin();
-	   track!=allTrackHandle->end(); ++track) {
+      for ( edm::View<reco::Track>::const_iterator track = allTrackHandle->begin();
+	    track != allTrackHandle->end(); ++track ) {
+
 	if ( denSelection_(*track) )
 	  numberOfTracks_den++;
       }
@@ -707,15 +708,15 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       int numberOfTracks_num = 0;
       int numberOfTracks_pv0 = 0;
 
-      reco::TrackCollection trackCollection = *trackHandle;
+      const edm::View<reco::Track>& trackCollection = *trackHandle;
       // calculate the mean # rechits and layers
       int totalRecHits = 0, totalLayers = 0;
 
       theTrackAnalyzer->setNumberOfGoodVertices(iEvent);
       theTrackAnalyzer->setBX(iEvent);
       theTrackAnalyzer->setLumi(iEvent,iSetup);
-      for (reco::TrackCollection::const_iterator track = trackCollection.begin();
-	   track!=trackCollection.end(); ++track) {
+      for ( edm::View<reco::Track>::const_iterator track = trackHandle->begin();
+	    track != trackHandle->end(); ++track ) {
 	
 	if ( doPlotsVsBX_ || doAllPlots )
 	  NumberOfRecHitsPerTrackVsBX->Fill(bx,track->numberOfValidHits());
@@ -901,8 +902,9 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	    if (totalNumGoodPV>1) NumberOfTracksVsPUPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
 	    NumberOfPVtxVsGoodPVtx          -> Fill(float(totalNumGoodPV),pvHandle->size());
 
-	    for (reco::TrackCollection::const_iterator track = trackCollection.begin();
-		 track!=trackCollection.end(); ++track) {
+	    for ( edm::View<reco::Track>::const_iterator track = trackHandle->begin();
+		  track != trackHandle->end(); ++track ) {
+
 	      NumberOfRecHitsPerTrackVsGoodPVtx -> Fill(float(totalNumGoodPV), track->numberOfValidHits());
 	    }
 

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -715,9 +715,9 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       theTrackAnalyzer->setNumberOfGoodVertices(iEvent);
       theTrackAnalyzer->setBX(iEvent);
       theTrackAnalyzer->setLumi(iEvent,iSetup);
-      for ( edm::View<reco::Track>::const_iterator track = trackHandle->begin();
-	    track != trackHandle->end(); ++track ) {
-	
+      for ( edm::View<reco::Track>::const_iterator track = trackCollection.begin();
+	    track != trackCollection.end(); ++track ) {
+
 	if ( doPlotsVsBX_ || doAllPlots )
 	  NumberOfRecHitsPerTrackVsBX->Fill(bx,track->numberOfValidHits());
 	if ( numSelection_(*track) ) {
@@ -902,8 +902,8 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	    if (totalNumGoodPV>1) NumberOfTracksVsPUPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
 	    NumberOfPVtxVsGoodPVtx          -> Fill(float(totalNumGoodPV),pvHandle->size());
 
-	    for ( edm::View<reco::Track>::const_iterator track = trackHandle->begin();
-		  track != trackHandle->end(); ++track ) {
+	    for ( edm::View<reco::Track>::const_iterator track = trackCollection.begin();
+		  track != trackCollection.end(); ++track ) {
 
 	      NumberOfRecHitsPerTrackVsGoodPVtx -> Fill(float(totalNumGoodPV), track->numberOfValidHits());
 	    }


### PR DESCRIPTION
in order to be able to monitor reco::GsfTrack by using the already well advanced DQM/TrackMonitor
the reco::TrackCollection has been changed into edm::View<reco::Track>

code changes have been tested by running
`runTheMatrix -l limited`
and all workflows seem fine

in addition, we have --finally-- (filled) distributions for hltGsfTracks
<img width="826" alt="hltgsftracks" src="https://cloud.githubusercontent.com/assets/4946419/22145665/a789b2e8-df02-11e6-8a3e-3a0e7901dbda.png">

@rovere @VinInn @gpasztor @dmitrijus @vanbesien 
