### PR TITLE
Use static_cast to call explicitly conversion operator on TString

### DIFF
--- a/PhysicsTools/RecoUtils/plugins/TriggerVariables.h
+++ b/PhysicsTools/RecoUtils/plugins/TriggerVariables.h
@@ -66,7 +66,7 @@ class HLTBitComputer : public VariableComputer {
     for (unsigned int iT=0;iT!=validTriggerNames_.size();++iT){
       TString tname(validTriggerNames_[iT]);
       tname.ReplaceAll("HLT_","");//remove the "HLT_" prefix
-      declare(std::string(tname), iC);
+      declare(std::string(static_cast<const char *>(tname)), iC);
     }
   }
     ~HLTBitComputer(){}
@@ -80,7 +80,7 @@ class HLTBitComputer : public VariableComputer {
 	TString tname(validTriggerNames_[iT]);
 	tname.ReplaceAll("HLT_","");
 	double r=trh->accept(triggerNames.triggerIndex(validTriggerNames_[iT]));
-	assign(std::string(tname),r);
+	assign(std::string(static_cast<const char *>(tname)),r);
       }
 
     }


### PR DESCRIPTION
TString in ROOT support std::string_view which was added into C++17
standard and CMSSW since GCC 6 is compiled with C++17. GCC 7 will
provide a ful C++17 language support and most of C++ standard library.

TString defines two conversion operators, one for const char * and one
for std::string_view. The std::string can be constructor by both of them
thus causing compiler to error on it.

Use static_cast to explicitly select conversion operator which would be
compatible with previous C++ standards.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>