### PR TITLE
Back to use PXB layer combination 134 and 124 for triplets (phase2 tracking)

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -35,7 +35,7 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 trackingPhase2PU140.toModify(highPtTripletStepSeedLayers,
 # combination with gap removed as only source of fakes in current geometry (kept for doc) 
     layerList = ['BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
-#                 'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                 'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
                  'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
                  'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
                  'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',


### PR DESCRIPTION
The validation between pre1 and pre2 shows some inefficiency in the barrel region for single mu w/o PU0. This has been presented [here](https://indico.cern.ch/event/602715/contributions/2431422/attachments/1397106/2131423/EricaBrondolin_20170118_ValidationD4.pdf). In order to recover it, two of the Pixel barrel layer combination have been re-introduced. Here are the results for eff/fake on a ttbar saple w/o PU: baseline (blue), +PR (red)
![screenshot from 2017-01-20 13 53 50](https://cloud.githubusercontent.com/assets/5331004/22150387/1e3133c4-df19-11e6-9161-d16ba9a433a2.png)
These two layer combination were considered redundant and eliminated in order to speed up the tracking process. A deep validation showed that the effect of removing them was not negligible due to a pixel local reconstruction inefficiency which is under investigation.

@atricomi @suchandradutta @delaere if you have any more information on the local reconstruction, please comment this PR.