### PR TITLE
Use static_cast to call explicitly conversion operator on TString

### DIFF
--- a/Fireworks/Core/src/FWGeometry.cc
+++ b/Fireworks/Core/src/FWGeometry.cc
@@ -37,7 +37,7 @@ FWGeometry::findFile( const char* fileName )
        {
            TObjString* path = (TObjString*)tokens->At( i );
            searchPath += ":";
-           searchPath += path->GetString();
+           searchPath += static_cast<const char *>(path->GetString());
            if (gSystem->Getenv("CMSSW_VERSION"))
                searchPath += "/Fireworks/Geometry/data/";
        }


### PR DESCRIPTION
TString in ROOT support std::string_view which was added into C++17
standard and CMSSW since GCC 6 is compiled with C++17. GCC 7 will
provide a ful C++17 language support and most of C++ standard library.

TString defines two conversion operators, one for const char * and one
for std::string_view. The std::string can be constructor by both of them
thus causing compiler to error on it.

Use static_cast to explicitly select conversion operator which would be
compatible with previous C++ standards.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>