### PR TITLE
Replace throw dynamic exception specifiers with noexcept

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh
@@ -28,7 +28,7 @@ namespace hcal {
     ConfigurationDatabase(log4cplus::Logger logger);
 
     /** \brief Open the database, using the given accessor */
-    void open(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException);
+    void open(const std::string& accessor) noexcept(false);
 
     typedef xercesc::DOMDocument* ApplicationConfig;
 
@@ -36,16 +36,16 @@ namespace hcal {
     /** \brief Get the application configuration for the given item
         \note User must release all DOMDocuments
      */
-    ApplicationConfig getApplicationConfig(const std::string& tag, const std::string& classname, int instance) throw (hcal::exception::ConfigurationDatabaseException);
+    ApplicationConfig getApplicationConfig(const std::string& tag, const std::string& classname, int instance) noexcept(false);
 
     // Get the configuration document (whole)
-    std::string getConfigurationDocument(const std::string& tag) throw (hcal::exception::ConfigurationDatabaseException);
+    std::string getConfigurationDocument(const std::string& tag) noexcept(false);
 
     // Firmware-related
     /** \brief Retrieve the checksum for a given firmware version */
-    unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException);
+    unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false);
     /** \brief Retrieve the MCS file lines for a given firmware version */
-    void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException);
+    void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false);
 
     typedef enum FPGASelectionEnum {Bottom=0, Top=1} FPGASelection;
 
@@ -77,7 +77,7 @@ namespace hcal {
 	\param slot Slot number
 	\param LUTs Return map of the LUTs
      */
-    void getLUTs(const std::string& tag, int crate, int slot, std::map<LUTId, LUT>& LUTs) throw (hcal::exception::ConfigurationDatabaseException);
+    void getLUTs(const std::string& tag, int crate, int slot, std::map<LUTId, LUT>& LUTs) noexcept(false);
 
     typedef std::vector<unsigned char> MD5Fingerprint;
 
@@ -85,7 +85,7 @@ namespace hcal {
 	\param tag Tag name for this LUT setup
 	\param checksums Checksums (MD5)
     */
-    void getLUTChecksums(const std::string& tag, std::map<LUTId, MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException);
+    void getLUTChecksums(const std::string& tag, std::map<LUTId, MD5Fingerprint>& checksums) noexcept(false);
 
     struct PatternId : public FPGAId {
       bool operator<(const PatternId& a) const;
@@ -100,7 +100,7 @@ namespace hcal {
 	\param slot Slot number
 	\param patterns Return map of the patterns
     */
-    void getPatterns(const std::string& tag, int crate, int slot, std::map<PatternId, HTRPattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException);
+    void getPatterns(const std::string& tag, int crate, int slot, std::map<PatternId, HTRPattern>& patterns) noexcept(false);
 
     // ZS-related
     struct ZSChannelId : public FPGAId {
@@ -117,7 +117,7 @@ namespace hcal {
 	\param slot Slot number
 	\param patterns Return map of the thresholds
     */
-    void getZSThresholds(const std::string& tag, int crate, int slot, std::map<ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException);
+    void getZSThresholds(const std::string& tag, int crate, int slot, std::map<ZSChannelId, int>& thresholds) noexcept(false);
 
     struct HLXMasks{
       uint32_t occMask;
@@ -131,7 +131,7 @@ namespace hcal {
 	\param slot Slot number
 	\param patterns Return map of the masks
     */
-    void getHLXMasks(const std::string& tag, int crate, int slot, std::map<FPGAId, HLXMasks>& masks) throw (hcal::exception::ConfigurationDatabaseException);
+    void getHLXMasks(const std::string& tag, int crate, int slot, std::map<FPGAId, HLXMasks>& masks) noexcept(false);
 
 
     typedef enum RBXdatumTypeEnum {
@@ -176,7 +176,7 @@ namespace hcal {
     void getRBXdata(const std::string& tag,
 		    const std::string& rbx,
 		    RBXdatumType dtype,
-		    std::map<RBXdatumId, RBXdatum>& RBXdata) throw (hcal::exception::ConfigurationDatabaseException);
+		    std::map<RBXdatumId, RBXdatum>& RBXdata) noexcept(false);
 
     typedef std::vector<unsigned char> RBXpattern;
 
@@ -187,7 +187,7 @@ namespace hcal {
      */
     void getRBXpatterns(const std::string& tag,
 			const std::string& rbx,
-			std::map<RBXdatumId, RBXpattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException);
+			std::map<RBXdatumId, RBXpattern>& patterns) noexcept(false);
 
     /** \brief Close the database */
     void close();

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh
@@ -35,25 +35,25 @@ namespace hcal {
     /** \brief Used by the Application to determine which implementation to use for a given accessor */
     virtual bool canHandleMethod(const std::string& method) const = 0;   
     /** \brief Connect to the database using the given accessor */
-    virtual void connect(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException) = 0;
+    virtual void connect(const std::string& accessor) noexcept(false) = 0;
     /** \brief Disconnect from the database */
     virtual void disconnect() = 0;
 
     /* Various requests (default for all is to throw an exception indicating that no implementation is available. */
-    virtual std::vector<std::string> getValidTags() throw (hcal::exception::ConfigurationDatabaseException);
-    virtual ConfigurationDatabase::ApplicationConfig getApplicationConfig(const std::string& tag, const std::string& classname, int instance) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual std::string getConfigurationDocument(const std::string& tag) throw (hcal::exception::ConfigurationDatabaseException);
+    virtual std::vector<std::string> getValidTags() noexcept(false);
+    virtual ConfigurationDatabase::ApplicationConfig getApplicationConfig(const std::string& tag, const std::string& classname, int instance) noexcept(false);
+    virtual std::string getConfigurationDocument(const std::string& tag) noexcept(false);
     /** \brief Retrieve the checksum for a given firmware version */
-    virtual unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException);
+    virtual unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false);
     /** \brief Retrieve the MCS file lines for a given firmware version */
-    virtual void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getLUTs(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getLUTChecksums(const std::string& tag, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getPatterns(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::PatternId, ConfigurationDatabase::HTRPattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getZSThresholds(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getHLXMasks(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>& masks) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getRBXdata(const std::string& tag, const std::string& rbx, ConfigurationDatabase::RBXdatumType dtype, std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXdatum>& RBXdata) throw (hcal::exception::ConfigurationDatabaseException);
-    virtual void getRBXpatterns(const std::string& tag, const std::string& rbx,	std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXpattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException);
+    virtual void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false);
+    virtual void getLUTs(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::LUT >& LUTs) noexcept(false);
+    virtual void getLUTChecksums(const std::string& tag, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::MD5Fingerprint>& checksums) noexcept(false);
+    virtual void getPatterns(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::PatternId, ConfigurationDatabase::HTRPattern>& patterns) noexcept(false);
+    virtual void getZSThresholds(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::ZSChannelId, int>& thresholds) noexcept(false);
+    virtual void getHLXMasks(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>& masks) noexcept(false);
+    virtual void getRBXdata(const std::string& tag, const std::string& rbx, ConfigurationDatabase::RBXdatumType dtype, std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXdatum>& RBXdata) noexcept(false);
+    virtual void getRBXpatterns(const std::string& tag, const std::string& rbx,	std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXpattern>& patterns) noexcept(false);
 
     // added by Gena Kukartsev
     virtual oracle::occi::Connection * getConnection( void );

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplOracle.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplOracle.hh
@@ -24,34 +24,34 @@ class ConfigurationDatabaseImplOracle: public hcal::ConfigurationDatabaseImpl {
 		ConfigurationDatabaseImplOracle();
 		virtual ~ConfigurationDatabaseImplOracle();
 		virtual bool canHandleMethod(const std::string& method) const;
-		virtual void connect(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException);
+		virtual void connect(const std::string& accessor) noexcept(false);
 		virtual void disconnect();
 	
 		virtual void getLUTs(const std::string& tag, int crate, int slot,  
 			std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) 
-							throw (hcal::exception::ConfigurationDatabaseException);
+							noexcept(false);
 
 		virtual void getLUTChecksums(const std::string& tag, 
 			std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) 
-							throw (hcal::exception::ConfigurationDatabaseException);
+							noexcept(false);
 
 		virtual void getPatterns(const std::string& tag, int crate, int slot, 
 			std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) 
-							throw (hcal::exception::ConfigurationDatabaseException);
+							noexcept(false);
 
 		virtual void getRBXdata(const std::string& tag, const std::string& rbx,
                                         hcal::ConfigurationDatabase::RBXdatumType dtype,
                                         std::map<hcal::ConfigurationDatabase::RBXdatumId, hcal::ConfigurationDatabase::RBXdatum>& RBXdata)
-                                                        throw (hcal::exception::ConfigurationDatabaseException);
+                                                        noexcept(false);
 
 	        virtual void getZSThresholds(const std::string& tag, int crate, int slot,
                                         std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds)
-                                        throw (hcal::exception::ConfigurationDatabaseException);
+                                        noexcept(false);
 
 	        virtual void getHLXMasks(const std::string& tag, int crate, int slot,
                                         std::map<hcal::ConfigurationDatabase::FPGAId,
                                                         hcal::ConfigurationDatabase::HLXMasks>& masks)
-                                        throw (hcal::exception::ConfigurationDatabaseException);
+                                        noexcept(false);
 
   // added by Gena Kukartsev
   virtual oracle::occi::Connection * getConnection( void );
@@ -87,12 +87,12 @@ class ConfigurationDatabaseImplOracle: public hcal::ConfigurationDatabaseImpl {
 #endif
 
   		void getLUTs_real(const std::string& tag, int crate, std::map<hcal::ConfigurationDatabase::LUTId, 
-				hcal::ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException);
+				hcal::ConfigurationDatabase::LUT >& LUTs) noexcept(false);
   		void getPatterns_real(const std::string& tag, int crate, std::map<hcal::ConfigurationDatabase::PatternId, 
-				hcal::ConfigurationDatabase::HTRPattern >& patterns) throw (hcal::exception::ConfigurationDatabaseException);
+				hcal::ConfigurationDatabase::HTRPattern >& patterns) noexcept(false);
                 void getHLXMasks_real(const std::string& tag, int crate,
                                 std::map<hcal::ConfigurationDatabase::FPGAId, hcal::ConfigurationDatabase::HLXMasks>& masks)
-                                                throw (hcal::exception::ConfigurationDatabaseException);
+                                                noexcept(false);
 
 		struct LUTCache {
 		    void clear() {

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplXMLFile.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplXMLFile.hh
@@ -14,16 +14,16 @@ public:
   ConfigurationDatabaseImplXMLFile();
   virtual ~ConfigurationDatabaseImplXMLFile();
   virtual bool canHandleMethod(const std::string& method) const;
-  virtual void connect(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException);
+  virtual void connect(const std::string& accessor) noexcept(false);
   virtual void disconnect();
 
-  virtual unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException);
-  virtual void getZSThresholds(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException);
-  virtual void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException);
+  virtual unsigned int getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false);
+  virtual void getZSThresholds(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds) noexcept(false);
+  virtual void getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false);
   // maximally simple implementation
-  virtual void getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException);
-  virtual void getLUTChecksums(const std::string& tag, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException);
-  virtual void getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) throw (hcal::exception::ConfigurationDatabaseException);
+  virtual void getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) noexcept(false);
+  virtual void getLUTChecksums(const std::string& tag, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) noexcept(false);
+  virtual void getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) noexcept(false);
 
   // added by Gena Kukartsev
   //virtual oracle::occi::Connection * getConnection( void );

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseStandardXMLParser.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseStandardXMLParser.hh
@@ -14,14 +14,14 @@
 class ConfigurationDatabaseStandardXMLParser {
 public:
   ConfigurationDatabaseStandardXMLParser();
-  void parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) throw (hcal::exception::ConfigurationDatabaseException);
+  void parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) noexcept(false);
   struct Item {
     std::map<std::string,std::string> parameters;
     std::vector<std::string> items;
     std::string encoding;
     std::vector<unsigned int> convert() const;
   };
-  void parseMultiple(const std::string& xmlDocument, std::list<Item>& items) throw (hcal::exception::ConfigurationDatabaseException);
+  void parseMultiple(const std::string& xmlDocument, std::list<Item>& items) noexcept(false);
 private:
   xercesc::SAX2XMLReader* m_parser;
 };

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabase.cc
@@ -16,7 +16,7 @@ namespace hcal {
     m_implementation=0;
   }
 
-  void ConfigurationDatabase::open(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabase::open(const std::string& accessor) noexcept(false) {
     if (m_implementationOptions.empty()) {
       std::vector<hcal::AbstractPluginFactory*> facts;
       hcal::PluginManager::getFactories("hcal::ConfigurationDatabaseImpl",facts);
@@ -49,7 +49,7 @@ namespace hcal {
     if (m_implementation!=0) m_implementation->disconnect();
   }
 
-  unsigned int ConfigurationDatabase::getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException) {
+  unsigned int ConfigurationDatabase::getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false) {
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
     }
@@ -57,7 +57,7 @@ namespace hcal {
     return m_implementation->getFirmwareChecksum(board,version);
   }
 
-  ConfigurationDatabase::ApplicationConfig ConfigurationDatabase::getApplicationConfig(const std::string& tag, const std::string& classname, int instance) throw (hcal::exception::ConfigurationDatabaseException) {
+  ConfigurationDatabase::ApplicationConfig ConfigurationDatabase::getApplicationConfig(const std::string& tag, const std::string& classname, int instance) noexcept(false) {
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
     }
@@ -66,14 +66,14 @@ namespace hcal {
   }
 
 
-  std::string ConfigurationDatabase::getConfigurationDocument(const std::string& tag) throw (hcal::exception::ConfigurationDatabaseException) {
+  std::string ConfigurationDatabase::getConfigurationDocument(const std::string& tag) noexcept(false) {
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
     }
     return m_implementation->getConfigurationDocument(tag);
   }
 
-  void ConfigurationDatabase::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabase::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false) {
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
     }
@@ -82,7 +82,7 @@ namespace hcal {
 
   }
 
-  void ConfigurationDatabase::getLUTs(const std::string& tag, int crate, int slot, std::map<LUTId, LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabase::getLUTs(const std::string& tag, int crate, int slot, std::map<LUTId, LUT >& LUTs) noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
@@ -97,7 +97,7 @@ namespace hcal {
     }
   }
 
-  void ConfigurationDatabase::getLUTChecksums(const std::string& tag, std::map<LUTId, MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabase::getLUTChecksums(const std::string& tag, std::map<LUTId, MD5Fingerprint>& checksums) noexcept(false) {
     checksums.clear();
 
     if (m_implementation==0) {
@@ -107,7 +107,7 @@ namespace hcal {
     m_implementation->getLUTChecksums(tag, checksums);
   }
 
-  void ConfigurationDatabase::getPatterns(const std::string& tag, int crate, int slot, std::map<PatternId, HTRPattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabase::getPatterns(const std::string& tag, int crate, int slot, std::map<PatternId, HTRPattern>& patterns) noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
@@ -125,7 +125,7 @@ namespace hcal {
 					 const std::string& rbx,
 					 RBXdatumType dtype,
 					 std::map<RBXdatumId, RBXdatum>& RBXdata)
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
@@ -137,7 +137,7 @@ namespace hcal {
   void ConfigurationDatabase::getRBXpatterns(const std::string& tag,
 					     const std::string& rbx,
 					     std::map<RBXdatumId, RBXpattern>& patterns)
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
@@ -147,7 +147,7 @@ namespace hcal {
   }
 
   void ConfigurationDatabase::getZSThresholds(const std::string& tag, int crate, int slot, std::map<ZSChannelId, int>& thresholds)
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");
@@ -157,7 +157,7 @@ namespace hcal {
   }
 
   void ConfigurationDatabase::getHLXMasks(const std::string& tag, int crate, int slot, std::map<FPGAId, HLXMasks>& m)
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
 
     if (m_implementation==0) {
       XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database connection not open");

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImpl.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImpl.cc
@@ -70,50 +70,50 @@ ConfigurationDatabaseImpl::ConfigurationDatabaseImpl() : m_logger(&std::cout) {
     }
   }
 
-  std::vector<std::string> ConfigurationDatabaseImpl::getValidTags() throw (hcal::exception::ConfigurationDatabaseException) {
+  std::vector<std::string> ConfigurationDatabaseImpl::getValidTags() noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  ConfigurationDatabase::ApplicationConfig ConfigurationDatabaseImpl::getApplicationConfig(const std::string& tag, const std::string& classname, int instance) throw (hcal::exception::ConfigurationDatabaseException) {
-    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
-  }
-
-  std::string ConfigurationDatabaseImpl::getConfigurationDocument(const std::string& tag) throw (hcal::exception::ConfigurationDatabaseException) {
+  ConfigurationDatabase::ApplicationConfig ConfigurationDatabaseImpl::getApplicationConfig(const std::string& tag, const std::string& classname, int instance) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
 
-  unsigned int ConfigurationDatabaseImpl::getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException) {
+  std::string ConfigurationDatabaseImpl::getConfigurationDocument(const std::string& tag) noexcept(false) {
+    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
+  }
+
+  unsigned int ConfigurationDatabaseImpl::getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
   
-  void ConfigurationDatabaseImpl::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  void ConfigurationDatabaseImpl::getLUTs(const std::string& tag,int crate, int slot, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getLUTs(const std::string& tag,int crate, int slot, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::LUT >& LUTs) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  void ConfigurationDatabaseImpl::getLUTChecksums(const std::string& tag, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getLUTChecksums(const std::string& tag, std::map<ConfigurationDatabase::LUTId, ConfigurationDatabase::MD5Fingerprint>& checksums) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  void ConfigurationDatabaseImpl::getPatterns(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::PatternId, ConfigurationDatabase::HTRPattern>& patterns) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getPatterns(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::PatternId, ConfigurationDatabase::HTRPattern>& patterns) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  void ConfigurationDatabaseImpl::getZSThresholds(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getZSThresholds(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::ZSChannelId, int>& thresholds) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
-  void ConfigurationDatabaseImpl::getHLXMasks(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>& masks) throw (hcal::exception::ConfigurationDatabaseException) {
+  void ConfigurationDatabaseImpl::getHLXMasks(const std::string& tag, int crate, int slot, std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>& masks) noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
   void ConfigurationDatabaseImpl::getRBXdata(const std::string& tag,
 					     const std::string& rbx,
 					     ConfigurationDatabase::RBXdatumType dtype,
 					     std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXdatum>& RBXdata) 
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
   void ConfigurationDatabaseImpl::getRBXpatterns(const std::string& tag,
 						 const std::string& rbx,
 						 std::map<ConfigurationDatabase::RBXdatumId, ConfigurationDatabase::RBXpattern>& patterns)
-    throw (hcal::exception::ConfigurationDatabaseException) {
+    noexcept(false) {
     XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Not implemented");
   }
 

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
@@ -30,7 +30,7 @@ ConfigurationDatabaseImplOracle::~ConfigurationDatabaseImplOracle() {
 
 }
 
-void ConfigurationDatabaseImplOracle::connect(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplOracle::connect(const std::string& accessor) noexcept(false) {
   std::map<std::string,std::string> params;
   std::string user, host, method, db, port,password;
   ConfigurationDatabaseImpl::parseAccessor(accessor,method,host,port,user,db,params);
@@ -88,7 +88,7 @@ inline static int cvtChar(int c) {
 
 void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag,
 		std::map<hcal::ConfigurationDatabase::LUTId,
-		hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException) {
+		hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) noexcept(false) {
 
 	if (env_ == NULL || conn_ == NULL) XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database is not open");
   	checksums.clear();
@@ -141,7 +141,7 @@ void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag,
 
 }
 
-void ConfigurationDatabaseImplOracle::getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplOracle::getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) noexcept(false) {
   if (m_lutCache.crate!=crate || m_lutCache.tag!=tag) {
     m_lutCache.clear();
     getLUTs_real(tag,crate,m_lutCache.luts);
@@ -160,7 +160,7 @@ void ConfigurationDatabaseImplOracle::getLUTs(const std::string& tag, int crate,
 
 void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int crate,
 			std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs)
-								throw (hcal::exception::ConfigurationDatabaseException)
+								noexcept(false)
 {
 
    try {
@@ -225,7 +225,7 @@ void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int c
 
 }
 
-void ConfigurationDatabaseImplOracle::getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplOracle::getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) noexcept(false) {
   if (m_patternCache.crate!=crate || m_patternCache.tag!=tag) {
     m_patternCache.clear();
     getPatterns_real(tag,crate,m_patternCache.patterns);
@@ -243,7 +243,7 @@ void ConfigurationDatabaseImplOracle::getPatterns(const std::string& tag, int cr
 
 void ConfigurationDatabaseImplOracle::getPatterns_real(const std::string& tag, int crate,
 			std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns)
-							throw (hcal::exception::ConfigurationDatabaseException) {
+							noexcept(false) {
    try {
         //Lets run the SQl Query
         Statement* stmt = conn_->createStatement();
@@ -297,7 +297,7 @@ void ConfigurationDatabaseImplOracle::getPatterns_real(const std::string& tag, i
 void ConfigurationDatabaseImplOracle::getRBXdata(const std::string& tag, const std::string& rbx,
                         hcal::ConfigurationDatabase::RBXdatumType dtype,
                         std::map<ConfigurationDatabase::RBXdatumId, hcal::ConfigurationDatabase::RBXdatum>& RBXdata)
-                        throw (hcal::exception::ConfigurationDatabaseException) {
+                        noexcept(false) {
 
         RBXdata.clear();
 
@@ -404,7 +404,7 @@ void ConfigurationDatabaseImplOracle::getRBXdata(const std::string& tag, const s
 
 void ConfigurationDatabaseImplOracle::getZSThresholds(const std::string& tag, int crate, int slot,
                 std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds)
-                throw (hcal::exception::ConfigurationDatabaseException) {
+                noexcept(false) {
 
    try {
         //Lets run the SQl Query
@@ -447,7 +447,7 @@ void ConfigurationDatabaseImplOracle::getZSThresholds(const std::string& tag, in
 
 void ConfigurationDatabaseImplOracle::getHLXMasks(const std::string& tag, int crate, int slot,
                         std::map<hcal::ConfigurationDatabase::FPGAId, hcal::ConfigurationDatabase::HLXMasks>& masks)
-                                        throw (hcal::exception::ConfigurationDatabaseException) {
+                                        noexcept(false) {
   if (m_hlxMaskCache.crate!=crate || m_hlxMaskCache.tag!=tag) {
     m_hlxMaskCache.clear();
     getHLXMasks_real(tag,crate,m_hlxMaskCache.masks);
@@ -466,7 +466,7 @@ void ConfigurationDatabaseImplOracle::getHLXMasks(const std::string& tag, int cr
 
 void ConfigurationDatabaseImplOracle::getHLXMasks_real(const std::string& tag, int crate,
                 std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>& masks)
-                throw (hcal::exception::ConfigurationDatabaseException) {
+                noexcept(false) {
    try {
         //Lets run the SQl Query
         Statement* stmt = conn_->createStatement();

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplXMLFile.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplXMLFile.cc
@@ -16,7 +16,7 @@ ConfigurationDatabaseImplXMLFile::~ConfigurationDatabaseImplXMLFile() {
 }
 bool ConfigurationDatabaseImplXMLFile::canHandleMethod(const std::string& method) const { return method=="xmlfile"; }
 
-void ConfigurationDatabaseImplXMLFile::connect(const std::string& accessor) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::connect(const std::string& accessor) noexcept(false) {
   // open file and copy into a string
   std::string theFile=accessor;
   std::string::size_type i=theFile.find("://");
@@ -130,7 +130,7 @@ std::map<std::string, std::string> ConfigurationDatabaseImplXMLFile::parseWhere(
 }
 
 /*
-hcal::ConfigurationDatabaseIterator* ConfigurationDatabaseImplXMLFile::query(const std::string& sector, const std::string& draftSelect, const std::string& draftWhere) throw (hcal::exception::ConfigurationDatabaseException) { 
+hcal::ConfigurationDatabaseIterator* ConfigurationDatabaseImplXMLFile::query(const std::string& sector, const std::string& draftSelect, const std::string& draftWhere) noexcept(false) { 
 
   std::map<std::string,std::string> whereMap=parseWhere(draftWhere);
   if (sector=="PATTERN") whereMap["PATTERN_SPEC_NAME"]=whereMap["TAG"];
@@ -144,11 +144,11 @@ hcal::ConfigurationDatabaseIterator* ConfigurationDatabaseImplXMLFile::query(con
 }
 */
 
-unsigned int ConfigurationDatabaseImplXMLFile::getFirmwareChecksum(const std::string& board, unsigned int version) throw (hcal::exception::ConfigurationDatabaseException) {
+unsigned int ConfigurationDatabaseImplXMLFile::getFirmwareChecksum(const std::string& board, unsigned int version) noexcept(false) {
   XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Unsupported");
 }
 
-void ConfigurationDatabaseImplXMLFile::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) noexcept(false) {
 
   std::string key=::toolbox::toString("%s:%x",board.c_str(),version);
 
@@ -165,11 +165,11 @@ void ConfigurationDatabaseImplXMLFile::getFirmwareMCS(const std::string& board, 
 
 }
 
-void ConfigurationDatabaseImplXMLFile::getLUTChecksums(const std::string& tag, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::getLUTChecksums(const std::string& tag, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) noexcept(false) {
   XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Unsupported");
 }
 
-void ConfigurationDatabaseImplXMLFile::getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::getLUTs(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) noexcept(false) {
   LUTs.clear();
 
   for (int tb=0; tb<=1; tb++) 
@@ -233,7 +233,7 @@ void ConfigurationDatabaseImplXMLFile::getLUTs(const std::string& tag, int crate
       }
 }
 
-void ConfigurationDatabaseImplXMLFile::getZSThresholds(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::getZSThresholds(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds) noexcept(false) {
   thresholds.clear();
   for (int tb=0; tb<=1; tb++) {
 
@@ -265,7 +265,7 @@ void ConfigurationDatabaseImplXMLFile::getZSThresholds(const std::string& tag, i
   }
 }
 
-void ConfigurationDatabaseImplXMLFile::getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseImplXMLFile::getPatterns(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) noexcept(false) {
   patterns.clear();
   for (int tb=0; tb<=1; tb++) 
     for (int fiber=1; fiber<=8; fiber++) {

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseStandardXMLParser.cc
@@ -172,7 +172,7 @@ XERCES_CPP_NAMESPACE_USE
     }
   }
 
-void ConfigurationDatabaseStandardXMLParser::parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseStandardXMLParser::parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) noexcept(false) {
   // uses XERCES SAX2 parser
   std::list<Item> theItems;
   ConfigurationDBHandler handler(theItems);
@@ -201,7 +201,7 @@ void ConfigurationDatabaseStandardXMLParser::parse(const std::string& xmlDocumen
 
 
 
-void ConfigurationDatabaseStandardXMLParser::parseMultiple(const std::string& xmlDocument, std::list<Item>& items) throw (hcal::exception::ConfigurationDatabaseException) {
+void ConfigurationDatabaseStandardXMLParser::parseMultiple(const std::string& xmlDocument, std::list<Item>& items) noexcept(false) {
   // uses XERCES SAX2 parser
   ConfigurationDBHandler handler(items);
     


### PR DESCRIPTION
Dynamic exceptions were deprecated in C++11, one should use noexcept /
noexcept(expression) instead.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>