### PR TITLE
Added ability to import framework into python

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -82,7 +82,7 @@ namespace edm {
                    std::vector<std::string> const& defaultServices,
                    std::vector<std::string> const& forcedServices = std::vector<std::string>());
 
-    EventProcessor(std::shared_ptr<ProcessDesc>& processDesc,
+    EventProcessor(std::shared_ptr<ProcessDesc> processDesc,
                    ServiceToken const& token,
                    serviceregistry::ServiceLegacy legacy);
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -311,7 +311,7 @@ namespace edm {
     init(processDesc, ServiceToken(), serviceregistry::kOverlapIsError);
   }
 
-  EventProcessor::EventProcessor(std::shared_ptr<ProcessDesc>& processDesc,
+  EventProcessor::EventProcessor(std::shared_ptr<ProcessDesc> processDesc,
                                  ServiceToken const& token,
                                  serviceregistry::ServiceLegacy legacy) :
     actReg_(),

--- a/FWCore/PythonFramework/BuildFile.xml
+++ b/FWCore/PythonFramework/BuildFile.xml
@@ -1,0 +1,7 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PythonParameterSet"/>
+<use   name="boost"/>
+<use   name="boost_python"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/FWCore/PythonFramework/interface/PythonEventProcessor.h
+++ b/FWCore/PythonFramework/interface/PythonEventProcessor.h
@@ -1,0 +1,71 @@
+#ifndef FWCore_PythonFramework_PythonEventProcessor_h
+#define FWCore_PythonFramework_PythonEventProcessor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/PythonFramework
+// Class  :     PythonEventProcessor
+// 
+/**\class PythonEventProcessor PythonEventProcessor.h "PythonEventProcessor.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris D Jones
+//         Created:  Fri, 20 Jan 2017 16:36:33 GMT
+//
+
+// system include files
+#include "FWCore/Framework/interface/EventProcessor.h"
+
+// user include files
+
+// forward declarations
+class PythonProcessDesc;
+
+class PythonEventProcessor
+{
+
+   public:
+      PythonEventProcessor(PythonProcessDesc const&);
+      ~PythonEventProcessor();
+      // ---------- const member functions ---------------------
+      /// Return the number of events this EventProcessor has tried to process
+      /// (inclues both successes and failures, including failures due
+      /// to exceptions during processing).
+      int totalEvents() const {
+         return processor_.totalEvents();
+      }
+
+      /// Return the number of events processed by this EventProcessor
+      /// which have been passed by one or more trigger paths.
+      int totalEventsPassed() const {
+         return processor_.totalEventsPassed();
+      }
+
+      /// Return the number of events that have not passed any trigger.
+      /// (N.B. totalEventsFailed() + totalEventsPassed() == totalEvents()
+      int totalEventsFailed() const {
+         return processor_.totalEventsFailed();
+      }
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+      void run();
+
+   private:
+      PythonEventProcessor(const PythonEventProcessor&) = delete; // stop default
+
+      const PythonEventProcessor& operator=(const PythonEventProcessor&) = delete; // stop default
+
+      // ---------- member data --------------------------------
+      int forcePluginSetupFirst_;
+      edm::EventProcessor processor_;
+};
+
+
+#endif

--- a/FWCore/PythonFramework/python/CmsRun.py
+++ b/FWCore/PythonFramework/python/CmsRun.py
@@ -1,0 +1,45 @@
+import libFWCorePythonFramework as _pf
+import libFWCorePythonParameterSet as _pp
+
+class CmsRun(object):
+  def __init__(self,process):
+    """Uses a cms.Process to setup an edm::EventProcessor
+    """
+    procDesc = _pp.ProcessDesc()
+    process.fillProcessDesc(procDesc.pset())
+    self._cppProcessor = _pf.PythonEventProcessor(procDesc)
+  def run(self):
+    """Process all the events
+    """
+    self._cppProcessor.run()
+
+  def totalEvents(self):
+    return self._cppProcessor.totalEvents()
+  def totalEventsPassed(self):
+    return self._cppProcessor.totalEventsPassed()    
+  def totalEventsFailed(self):
+    return self._cppProcessor.totalEventsFailed()
+
+if __name__ == "__main__":
+  
+  import unittest
+  class testCmsRun(unittest.TestCase):
+    def testFiltering(self):
+      import FWCore.ParameterSet.Config as cms
+      process = cms.Process("Test")
+      process.source = cms.Source("EmptySource")
+      nEvents=10
+      process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(nEvents))
+      process.scale = cms.EDFilter("Prescaler",prescaleFactor = cms.int32(1), prescaleOffset = cms.int32(0))
+      process.p = cms.Path(process.scale)
+      filterResults = ((10,0),(5,5),(3,7))
+      for x in [1,2,3]:
+        process.scale.prescaleFactor = x
+        e = CmsRun(process)
+        e.run()
+        self.assertEqual(e.totalEvents(),nEvents)
+        self.assertEqual(e.totalEventsPassed(),filterResults[x-1][0])
+        self.assertEqual(e.totalEventsFailed(),filterResults[x-1][1])
+        del e
+
+  unittest.main()

--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+//
+// Package:     Subsystem/Package
+// Class  :     PythonEventProcessor
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  root
+//         Created:  Fri, 20 Jan 2017 16:36:41 GMT
+//
+
+// system include files
+#include <mutex>
+
+// user include files
+#include "FWCore/PythonFramework/interface/PythonEventProcessor.h"
+#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+
+namespace {
+   std::once_flag pluginFlag;
+   int setupPluginSystem() {
+      std::call_once(pluginFlag, []() {
+         edmplugin::PluginManager::configure(edmplugin::standard::config());
+         });
+      return 0;
+   }
+}
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+PythonEventProcessor::PythonEventProcessor(PythonProcessDesc const& iDesc)
+: forcePluginSetupFirst_(setupPluginSystem())
+  ,processor_(iDesc.processDesc(),edm::ServiceToken(),edm::serviceregistry::kOverlapIsError)
+{
+}
+
+PythonEventProcessor::~PythonEventProcessor()
+{
+   try {
+      processor_.endJob();
+   }catch(...) {
+      
+   }
+}
+
+void
+PythonEventProcessor::run()
+{
+   (void) processor_.runToCompletion();
+}

--- a/FWCore/PythonFramework/src/PythonModule.cc
+++ b/FWCore/PythonFramework/src/PythonModule.cc
@@ -1,0 +1,36 @@
+#ifndef FWCore_PythonFramework_PythonModule_h
+#define FWCore_PythonFramework_PythonModule_h
+
+#include "FWCore/PythonParameterSet/interface/BoostPython.h"
+#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
+
+#include "FWCore/PythonFramework/interface/PythonEventProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// This is to give some special handling to cms::Exceptions thrown
+// in C++ code called by python. Only at the very top level do
+// we need the exception message returned by the function "what".
+// We only need the central message here as this will get converted
+// back into a cms::Exception again when control rises back into
+// the C++ code.  If necessary it would probably be possible to
+// improve these messages even more by adding something in the python
+// to add module type and label context to the messages being caught
+// here. At this point we did not think it worth the time to implement.
+namespace {
+  void translator(cms::Exception const& ex) {
+    PyErr_SetString(PyExc_RuntimeError, ex.message().c_str());
+  }
+}
+
+BOOST_PYTHON_MODULE(libFWCorePythonFramework)
+{
+  boost::python::register_exception_translator<cms::Exception>(translator);
+
+  boost::python::class_<PythonEventProcessor, boost::noncopyable>("PythonEventProcessor", boost::python::init<PythonProcessDesc const&>())
+    .def("run", &PythonEventProcessor::run)
+    .def("totalEvents", &PythonEventProcessor::totalEvents)
+    .def("totalEventsPassed", &PythonEventProcessor::totalEventsPassed)
+    .def("totalEventsFailed", &PythonEventProcessor::totalEventsFailed)
+  ;
+}
+#endif

--- a/FWCore/PythonFramework/test/BuildFile.xml
+++ b/FWCore/PythonFramework/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<bin file="TestFWCorePythonFrameworkDriver.cpp"> 
+  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/PythonFramework/test runPythonTests.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+

--- a/FWCore/PythonFramework/test/TestFWCorePythonFrameworkDriver.cpp
+++ b/FWCore/PythonFramework/test/TestFWCorePythonFrameworkDriver.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/FWCore/PythonFramework/test/runPythonTests.sh
+++ b/FWCore/PythonFramework/test/runPythonTests.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+for file in ${CMSSW_BASE}/src/FWCore/PythonFramework/python/*.py
+do
+  bn=`basename $file`
+  if [ "$bn" != "__init__.py" ]; then
+     python "$file" || die "unit tests for $bn failed" $?
+  fi
+done

--- a/FWCore/PythonParameterSet/interface/PythonProcessDesc.h
+++ b/FWCore/PythonParameterSet/interface/PythonProcessDesc.h
@@ -30,14 +30,16 @@ public:
 
   PythonParameterSet newPSet() const {return PythonParameterSet();}
 
+  PythonParameterSet& pset() { return theProcessPSet;}
+  
   std::string dump() const;
 
   // makes a new (copy) of the ParameterSet
-  std::shared_ptr<edm::ParameterSet> parameterSet();
+  std::shared_ptr<edm::ParameterSet> parameterSet() const;
 
   // makes a new (copy) of a ProcessDesc
   // For backward compatibility only.  Remove when no longer needed.
-  std::shared_ptr<edm::ProcessDesc> processDesc();
+  std::shared_ptr<edm::ProcessDesc> processDesc() const;
 
 private:
   void prepareToRead();

--- a/FWCore/PythonParameterSet/src/PythonModule.h
+++ b/FWCore/PythonParameterSet/src/PythonModule.h
@@ -152,6 +152,7 @@ BOOST_PYTHON_MODULE(libFWCorePythonParameterSet)
   boost::python::class_<PythonProcessDesc>("ProcessDesc", boost::python::init<>())
     .def(boost::python::init<std::string>())
     .def("newPSet", &PythonProcessDesc::newPSet)
+  .def("pset", &PythonProcessDesc::pset, boost::python::return_value_policy<boost::python::reference_existing_object>())
     .def("dump", &PythonProcessDesc::dump)
   ;
 }

--- a/FWCore/PythonParameterSet/src/PythonProcessDesc.cc
+++ b/FWCore/PythonParameterSet/src/PythonProcessDesc.cc
@@ -83,7 +83,7 @@ void PythonProcessDesc::readString(std::string const& pyConfig) {
                         theMainNamespace.ptr()));
 }
 
-std::shared_ptr<edm::ParameterSet> PythonProcessDesc::parameterSet() {
+std::shared_ptr<edm::ParameterSet> PythonProcessDesc::parameterSet() const {
   return std::make_shared<edm::ParameterSet>(theProcessPSet.pset());
 }
 
@@ -94,6 +94,6 @@ std::string PythonProcessDesc::dump() const {
 }
 
 // For backward compatibility only.  Remove when no longer used.
-std::shared_ptr<edm::ProcessDesc> PythonProcessDesc::processDesc() {
+std::shared_ptr<edm::ProcessDesc> PythonProcessDesc::processDesc() const {
   return std::make_shared<edm::ProcessDesc>(parameterSet());
 }


### PR DESCRIPTION
One can now create a CmsRun object in python, by passing it an
instance of cms.Process, and then run it. The CmsRun python
class instantiates a full version of the C++ framework.

CmsRun can be imported via
`from FWCore.PythonFramework.CmsRun import CmsRun`