### PR TITLE
Add dtors with noexcept(false) to match C++ requirements

### DIFF
--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -91,6 +91,7 @@ namespace edm {
         RunCacheHolder() = default;
         RunCacheHolder( RunCacheHolder<T,C> const&) = delete;
         RunCacheHolder<T,C>& operator=(RunCacheHolder<T,C> const&) = delete;
+        ~RunCacheHolder() noexcept(false) {};
       protected:
         C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
       private:
@@ -114,6 +115,7 @@ namespace edm {
         LuminosityBlockCacheHolder() = default;
         LuminosityBlockCacheHolder( LuminosityBlockCacheHolder<T,C> const&) = delete;
         LuminosityBlockCacheHolder<T,C>& operator=(LuminosityBlockCacheHolder<T,C> const&) = delete;
+        ~LuminosityBlockCacheHolder() noexcept(false) {};
       protected:
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return cache_.get(); }
       private:
@@ -139,6 +141,7 @@ namespace edm {
         RunSummaryCacheHolder() = default;
         RunSummaryCacheHolder( RunSummaryCacheHolder<T,C> const&) = delete;
         RunSummaryCacheHolder<T,C>& operator=(RunSummaryCacheHolder<T,C> const&) = delete;
+        ~RunSummaryCacheHolder() noexcept(false) {};
       private:
         friend class EndRunSummaryProducer<T,C>;
         void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) override final {
@@ -170,6 +173,7 @@ namespace edm {
         LuminosityBlockSummaryCacheHolder() = default;
         LuminosityBlockSummaryCacheHolder( LuminosityBlockSummaryCacheHolder<T,C> const&) = delete;
         LuminosityBlockSummaryCacheHolder<T,C>& operator=(LuminosityBlockSummaryCacheHolder<T,C> const&) = delete;
+        ~LuminosityBlockSummaryCacheHolder() noexcept(false) {};
       private:
         friend class EndLuminosityBlockSummaryProducer<T,C>;
         
@@ -201,6 +205,7 @@ namespace edm {
         BeginRunProducer() = default;
         BeginRunProducer( BeginRunProducer const&) = delete;
         BeginRunProducer& operator=(BeginRunProducer const&) = delete;
+        ~BeginRunProducer() noexcept(false) {};
         
       private:
         void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
@@ -214,6 +219,7 @@ namespace edm {
         EndRunProducer() = default;
         EndRunProducer( EndRunProducer const&) = delete;
         EndRunProducer& operator=(EndRunProducer const&) = delete;
+        ~EndRunProducer() noexcept(false) {};
         
       private:
         
@@ -228,6 +234,7 @@ namespace edm {
         EndRunSummaryProducer() = default;
         EndRunSummaryProducer( EndRunSummaryProducer const&) = delete;
         EndRunSummaryProducer& operator=(EndRunSummaryProducer const&) = delete;
+        ~EndRunSummaryProducer() noexcept(false) {};
         
       private:
         
@@ -244,6 +251,7 @@ namespace edm {
         BeginLuminosityBlockProducer() = default;
         BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
         BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
+        ~BeginLuminosityBlockProducer() noexcept(false) {};
         
       private:
         void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
@@ -256,6 +264,7 @@ namespace edm {
         EndLuminosityBlockProducer() = default;
         EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
         EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
+        ~EndLuminosityBlockProducer() noexcept(false) {};
         
       private:
         void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
@@ -268,6 +277,7 @@ namespace edm {
         EndLuminosityBlockSummaryProducer() = default;
         EndLuminosityBlockSummaryProducer( EndLuminosityBlockSummaryProducer const&) = delete;
         EndLuminosityBlockSummaryProducer& operator=(EndLuminosityBlockSummaryProducer const&) = delete;
+        ~EndLuminosityBlockSummaryProducer() noexcept(false) {};
         
       private:
         void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final {

--- a/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
@@ -36,6 +36,7 @@ namespace edm {
         InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         InputFileWatcher(InputFileWatcher const&) = delete;
         InputFileWatcher& operator=(InputFileWatcher const&) = delete;
+        ~InputFileWatcher() noexcept(false) {};
         
       private:
         void doRespondToOpenInputFile_(FileBlock const&) override final;

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -58,6 +58,7 @@ namespace edm {
             RunWatcher() = default;
             RunWatcher(RunWatcher const&) = delete;
             RunWatcher& operator=(RunWatcher const&) = delete;
+            ~RunWatcher() noexcept(false) {};
             
          private:
             void doBeginRun_(Run const& rp, EventSetup const& c) override final;
@@ -74,6 +75,7 @@ namespace edm {
             LuminosityBlockWatcher() = default;
             LuminosityBlockWatcher(LuminosityBlockWatcher const&) = delete;
             LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
+            ~LuminosityBlockWatcher() noexcept(false) {};
             
          private:
             void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final;
@@ -89,6 +91,7 @@ namespace edm {
             BeginRunProducer() = default;
             BeginRunProducer( BeginRunProducer const&) = delete;
             BeginRunProducer& operator=(BeginRunProducer const&) = delete;
+            ~BeginRunProducer() noexcept(false) {};
             
          private:
             void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
@@ -102,6 +105,7 @@ namespace edm {
             EndRunProducer() = default;
             EndRunProducer( EndRunProducer const&) = delete;
             EndRunProducer& operator=(EndRunProducer const&) = delete;
+            ~EndRunProducer() noexcept(false) {};
             
          private:
             
@@ -116,6 +120,7 @@ namespace edm {
             BeginLuminosityBlockProducer() = default;
             BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
             BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
+            ~BeginLuminosityBlockProducer() noexcept(false) {};
             
          private:
             void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) override final;
@@ -129,6 +134,7 @@ namespace edm {
             EndLuminosityBlockProducer() = default;
             EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
             EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
+            ~EndLuminosityBlockProducer() noexcept(false) {};
             
          private:
             void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) override final;

--- a/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
@@ -39,6 +39,7 @@ namespace edm {
         RunWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet){}
         RunWatcher(RunWatcher const&) = delete;
         RunWatcher& operator=(RunWatcher const&) = delete;
+        ~RunWatcher() noexcept(false) {};
         
       private:
         virtual void doBeginRun_(RunForOutput const& r) override final;
@@ -53,6 +54,7 @@ namespace edm {
         LuminosityBlockWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         LuminosityBlockWatcher(LuminosityBlockWatcher const&) = delete;
         LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
+        ~LuminosityBlockWatcher() noexcept(false) {};
         
       private:
         virtual void doBeginLuminosityBlock_(LuminosityBlockForOutput const& lb) override final;
@@ -67,6 +69,7 @@ namespace edm {
         InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         InputFileWatcher(InputFileWatcher const&) = delete;
         InputFileWatcher& operator=(InputFileWatcher const&) = delete;
+        ~InputFileWatcher() noexcept(false) {};
         
       private:
         void doRespondToOpenInputFile_(FileBlock const&) override final;


### PR DESCRIPTION
Compiler generated default dtor is noexcept(true) (i.e. not throwing),
but these classes are used as base classes where parent class dtor is
marked as noexcept(false) (i.e. throwing). This is not allowed.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>