### PR TITLE
Clean Clang warnings regarding hiding overloaded virtual functions

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
@@ -28,7 +28,7 @@ namespace pos{
     PixelCalibBase();
     virtual ~PixelCalibBase();
     virtual std::string mode() const {return mode_;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
+    virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelFEDTestDAC.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelFEDTestDAC.h
@@ -31,7 +31,7 @@ namespace pos{
   public:
     PixelFEDTestDAC(std::string filename);
     PixelFEDTestDAC(std::vector< std::vector<std::string> > &);
-    std::string mode() {return mode_;}
+    std::string mode() const {return mode_;}
     std::vector<unsigned int> dacs() {return dacs_;}
     virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 


### PR DESCRIPTION
Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>