### PR TITLE
Update the `GeneratorFilter` template class for new calling API.

### DIFF
--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -66,7 +66,7 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
-      void doPreallocate(PreallocationConfiguration const&) {}
+      void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
       
@@ -103,6 +103,7 @@ namespace edm {
 
       virtual void preForkReleaseResources() {}
       virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      virtual void preallocThreads(unsigned int) {}
 
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -79,6 +80,12 @@ namespace edm {
       this->endJob();
     }
     
+    void
+    EDFilterBase::doPreallocate(PreallocationConfiguration const&iPrealloc) {
+      auto const nThreads = iPrealloc.numberOfThreads();
+      preallocThreads(nThreads);
+    }
+
     void
     EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) {

--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -78,7 +78,7 @@ namespace gen {
     const std::string &gridpackPath() const { return gridpackPaths_[std::max(randomIndex_,0)]; }
     
     void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
-    void generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
+    void generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine, unsigned int ncpu);
     void cleanLHE();
 
   protected:

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -59,12 +59,14 @@ namespace edm
     virtual void beginLuminosityBlockProduce(LuminosityBlock&, EventSetup const&) override;
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
     virtual void endLuminosityBlockProduce(LuminosityBlock &, EventSetup const&) override;
+    virtual void preallocThreads(unsigned int iThreads) override;
 
   private:
     Hadronizer            hadronizer_;
     //gen::ExternalDecayDriver* decayer_;
     Decayer*              decayer_;
     unsigned int          nEventsInLumiBlock_;
+    unsigned int          nThreads_{1};
   };
 
   //------------------------------------------------------------------------
@@ -121,6 +123,12 @@ namespace edm
   template <class HAD, class DEC>
   GeneratorFilter<HAD, DEC>::~GeneratorFilter()
   { if ( decayer_ ) delete decayer_;}
+
+  template <class HAD, class DEC>
+  void
+  GeneratorFilter<HAD, DEC>::preallocThreads(unsigned int iThreads) {
+    nThreads_ = iThreads;
+  }
 
   template <class HAD, class DEC>
   bool
@@ -236,7 +244,7 @@ namespace edm
     RandomEngineSentry<DEC> randomEngineSentryDecay(decayer_, lumi.index());
 
     hadronizer_.randomizeIndex(lumi,randomEngineSentry.randomEngine());
-    hadronizer_.generateLHE(lumi,randomEngineSentry.randomEngine());
+    hadronizer_.generateLHE(lumi,randomEngineSentry.randomEngine(), nThreads_);
     
     if ( !hadronizer_.readSettings(0) )
        throw edm::Exception(errors::Configuration) 

--- a/GeneratorInterface/Core/src/BaseHadronizer.cc
+++ b/GeneratorInterface/Core/src/BaseHadronizer.cc
@@ -75,7 +75,7 @@ const std::vector<std::string> BaseHadronizer::theSharedResources;
     }
   }
   
-  void BaseHadronizer::generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine) {
+  void BaseHadronizer::generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine, unsigned int ncpu) {
         
     if (gridpackPath().empty()) {
       return;
@@ -100,16 +100,20 @@ const std::vector<std::string> BaseHadronizer::theSharedResources;
     
     std::ostringstream randomStream;
     randomStream << seedval;
+
+    std::string ncpu_str = std::to_string(ncpu);
    
     edm::FileInPath script("GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh");
     const char *outfilename = "cmsgrid_final.lhe";
-    
-    char *args[5];
+
+    static const int arg_count = 6;
+    char *args[arg_count];
     args[0] = strdup(script.fullPath().c_str());
     args[1] = strdup(gridpackPath().c_str());
     args[2] = strdup(nevStream.str().c_str());
     args[3] = strdup(randomStream.str().c_str());
-    args[4] = NULL;
+    args[4] = strdup(ncpu_str.c_str());
+    args[5] = NULL;
     
     pid_t pid = fork();
 
@@ -138,7 +142,7 @@ const std::vector<std::string> BaseHadronizer::theSharedResources;
 
     lheFile_ = outfilename;
     
-    for (int iarg=0; iarg<4; ++iarg) {
+    for (int iarg=0; iarg<(arg_count-1); ++iarg) {
       delete[] args[iarg];
     }
     


### PR DESCRIPTION
First round of improvements to allow multicore invocation of the generators missed this interface.

This was suggested by @bendavid but @davidlange6 merged the PR before my dev host finished compiling :/

@bendavid - the `cmsDriver` command you suggested failed (seems to simply be a difference between 7_1 and 9_0); have another suggested one to try?