### PR TITLE
Pr90x L1T Stage2 for Phase2

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -239,10 +239,12 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
   }
 
   for (const auto& id: metadata->getAllChannels()) {
-     HcalDetId cell(id);
-     if (!topo_->valid(cell))
+     if (not (id.det() == DetId::Hcal and topo_->valid(id)))
         continue;
+     HcalDetId cell(id);
      HcalSubdetector subdet = cell.subdet();
+     if (subdet != HcalBarrel and subdet != HcalEndcap and subdet != HcalForward)
+        continue;
 
      const HcalQIECoder* channelCoder = conditions.getHcalCoder (cell);
      const HcalQIEShape* shape = conditions.getHcalShape(cell);

--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -15,11 +15,12 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("caloStage2Raw")) )
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gmtStage2Raw")) )
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gtStage2Raw")) )
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 #
 # Legacy Trigger:
 #
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
+if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TDigiToRaw Sequence configured for Run1 (Legacy) trigger. "
     # legacy L1 packages:
     from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
@@ -40,7 +41,7 @@ if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
+if stage1L1Trigger.isChosen() and not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TDigiToRaw Sequence configured for Stage-1 (2015) trigger. "    
     # legacy L1 packers, still in use for 2015:
     from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
@@ -65,7 +66,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TDigiToRaw Sequence configured for Stage-2 (2016) trigger. "
     from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import *
     from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import *

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -69,6 +69,7 @@ def unpack_stage2():
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
     print "L1TRawToDigi Sequence configured for Run1 (Legacy) trigger. "
     unpack_legacy()
@@ -77,7 +78,7 @@ if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
+if stage1L1Trigger.isChosen() and not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TRawToDigi Sequence configured for Stage-1 (2015) trigger. "    
     unpack_stage1()
     L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1)
@@ -85,7 +86,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 #
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TRawToDigi Sequence configured for Stage-2 (2016) trigger. "    
     unpack_stage1()
     unpack_stage2()

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -70,7 +70,7 @@ def unpack_stage2():
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
+if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TRawToDigi Sequence configured for Run1 (Legacy) trigger. "
     unpack_legacy()
     L1TRawToDigi = cms.Sequence(L1TRawToDigi_Legacy);

--- a/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
+++ b/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
@@ -26,7 +26,7 @@ import SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi
 simCastorTechTrigDigis = SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi.simCastorTTRecord.clone()
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
+if not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     SimL1TechnicalTriggers = cms.Sequence( 
         simBscDigis + 
         simRpcTechTrigDigis + 

--- a/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
+++ b/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
@@ -26,6 +26,7 @@ import SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi
 simCastorTechTrigDigis = SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi.simCastorTTRecord.clone()
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 if not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     SimL1TechnicalTriggers = cms.Sequence( 
         simBscDigis + 

--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -15,6 +15,7 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 #    print "L1TCalorimeter conditions configured for Run1 (Legacy) trigger. "
 # 
@@ -36,7 +37,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     if pA_2016.isChosen():
         print "L1TCalorimeter Conditions configured for Stage-2 (2016 pA) trigger. "
         from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_HI_cfi import *    

--- a/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
@@ -5,7 +5,8 @@ import FWCore.ParameterSet.Config as cms
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TCalorimeter Sequence configured for Run1 (Legacy) trigger. "
 # -  RCT (Regional Calorimeter Trigger) emulator
     import L1Trigger.RegionalCaloTrigger.rctDigis_cfi
@@ -41,7 +42,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TCalorimeter Sequence configured for Stage-2 (2016) trigger. "
     # select one of the following two options:
     # - layer1 from L1Trigger/L1TCalorimeter package

--- a/L1Trigger/L1TGlobal/python/hackConditions_cff.py
+++ b/L1Trigger/L1TGlobal/python/hackConditions_cff.py
@@ -15,6 +15,7 @@ import FWCore.ParameterSet.Config as cms
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 #    print "L1TGlobal conditions configured for Run1 (Legacy) trigger. "
 # 
@@ -28,7 +29,7 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TGlobal Conditions configured for Stage-2 (2016) trigger. "
     from L1Trigger.L1TGlobal.StableParameters_cff import *
 #    from L1Trigger.L1TGlobal.GlobalParameters_cff import *

--- a/L1Trigger/L1TGlobal/python/simDigis_cff.py
+++ b/L1Trigger/L1TGlobal/python/simDigis_cff.py
@@ -8,7 +8,8 @@ import FWCore.ParameterSet.Config as cms
 # Legacy Trigger:
 #
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+if not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TGlobal Sequence configured for Legacy trigger (Run1 and Run 2015). "
 #
 # -  Global Trigger emulator
@@ -28,7 +29,7 @@ if not (stage2L1Trigger.isChosen()):
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
 #
 # -  Global Trigger emulator
 #

--- a/L1Trigger/L1TMuon/python/hackConditions_cff.py
+++ b/L1Trigger/L1TMuon/python/hackConditions_cff.py
@@ -11,6 +11,7 @@ import FWCore.ParameterSet.Config as cms
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 #    print "L1TMuon conditions configured for Run1 (Legacy) trigger. "
 # 
@@ -24,7 +25,7 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TMuon Conditions configured for Stage-2 (2016) trigger. "
     from L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff import *
     from L1Trigger.L1TMuonOverlap.fakeOmtfParams_cff import *

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 #
 # Legacy L1 Muon modules still running in 2016 trigger:
 #
@@ -24,9 +26,8 @@ SimL1TMuonCommon = cms.Sequence(simDtTriggerPrimitiveDigis + simCscTriggerPrimit
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
-    print "L1TMuon Sequence configured for Legacy trigger (Run1 and Run 2015). "
+if not (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
+    print "L1TMuon Sequence configured for Legacy trigger (Run1 and Run 2015)."
 #
 # - CSC Track Finder emulator
 #
@@ -68,7 +69,7 @@ if not (stage2L1Trigger.isChosen()):
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
+if (stage2L1Trigger.isChosen() or phase2_common.isChosen()):
     print "L1TMuon Sequence configured for Stage-2 (2016) trigger. "
     from L1Trigger.L1TMuonBarrel.simTwinMuxDigis_cfi import *
     from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *

--- a/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
@@ -23,5 +23,5 @@ L1NtupleRAW = cms.Sequence(
 
 #  do not have l1t::CaloTowerBxCollection in Stage1 
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-_stage1_L1NTupleRAW = L1NtupleRaw.copyAndExclude([l1CaloTowerTree,l1UpgradeTfMuonTree])
-stage1L1Trigger.toReplaceWith(L1NtupleRaw,_stage1_L1NTupleRAW)
+_stage1_L1NTupleRAW = L1NtupleRAW.copyAndExclude([l1CaloTowerTree,l1UpgradeTfMuonTree])
+stage1L1Trigger.toReplaceWith(L1NtupleRAW,_stage1_L1NTupleRAW)

--- a/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
@@ -9,7 +9,8 @@ hcalDigiSequence = cms.Sequence(simHcalTriggerPrimitiveDigis
                                 +simHcalDigis
                                 *simHcalTTPDigis)
 
-_phase2_hcalDigiSequence = hcalDigiSequence.copyAndExclude([simHcalTriggerPrimitiveDigis,simHcalTTPDigis])
+#_phase2_hcalDigiSequence = hcalDigiSequence.copyAndExclude([simHcalTriggerPrimitiveDigis,simHcalTTPDigis])
+#_phase2_hcalDigiSequence = hcalDigiSequence.copyAndExclude([simHcalTTPDigis])
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hcalDigiSequence, _phase2_hcalDigiSequence )
+#from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+#phase2_hcal.toReplaceWith( hcalDigiSequence, _phase2_hcalDigiSequence )


### PR DESCRIPTION
PR 90x for change in configuration to use L1T Stage2 (as opposed to L1T Legacy) in Phase2 era.
This PR also includes (needed to pass tests) https://github.com/cms-sw/cmssw/pull/17260 which fixed crashes in HCAL TPs for Phase2 

This PR is needed for Phase2 MC Production.

Details:
  - Use phase2_common era modifier to 
    - switch in L1T configuration to use Stage2 
    - configure conditions of L1T Muon, Calorimeter, and Global (as in Stage2)
    - configure L1T RAW2DIGI and DIGI2RAW to use Stage2 products
  - Include back in  simHcalTrigPrimitiveDigis and simHcalTTPDigis into hcalDigiSequence