### PR TITLE
ME0ReDigitizer not using roll==0 to distinguish between M1 and M2 geometry

### DIFF
--- a/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
@@ -95,8 +95,7 @@ int ME0NumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
     region =-1;
   layer   = num.getBaseNo(theLayerLevel)+1;
   chamber = num.getBaseNo(theSectorLevel) + 1;
-  if(theNEtaPart==1)  roll = 0;
-  else                roll = num.getBaseNo(theRollLevel)+1;
+  roll = num.getBaseNo(theRollLevel)+1;
 
   // collect all info
   

--- a/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
@@ -95,7 +95,8 @@ int ME0NumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
     region =-1;
   layer   = num.getBaseNo(theLayerLevel)+1;
   chamber = num.getBaseNo(theSectorLevel) + 1;
-  roll = num.getBaseNo(theRollLevel)+1;
+  if(theNEtaPart==1)  roll = 0;
+  else                roll = num.getBaseNo(theRollLevel)+1;
 
   // collect all info
   

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -79,6 +79,7 @@ void ME0ReDigiProducer::beginRun(const edm::Run&, const edm::EventSetup& eventSe
       << "ME0DetId " << detId << " central TOF " << centralTOF << std::endl;
   }
   nPartitions_ = centralTOF_.size()/6;
+  LogDebug("ME0ReDigiProducer")<<" Number of partitions "<<nPartitions_<<std::endl;
 }
 
 
@@ -147,7 +148,6 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
       // arrival time in ns
       //const float t0(centralTOF_[ nPartitions_ * (detId.layer() -1) + detId.roll() - 1 ]);
       int index = nPartitions_ * (detId.layer() -1) + detId.roll() - 1;
-      if(detId.roll() == 0) index = nPartitions_ * (detId.layer() -1) + detId.roll();
       edm::LogVerbatim("ME0ReDigiProducer")
 	<<"size "<<centralTOF_.size()<<" nPartitions "<<nPartitions_<<" layer "<<detId.layer()<<" roll "<<detId.roll()<<" index "<<index<<std::endl;
       
@@ -182,7 +182,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
       const float oldR(oldGP.perp());
 
       float newR = oldR;
-      if (me0Digi.prompt() and smearRadial_  and detId.roll() > 0)
+      if (me0Digi.prompt() and smearRadial_  and nPartitions_  > 1)
 	newR = CLHEP::RandGaussQ::shoot(engine, oldR, radialResolution_);
       
       // calculate the new position in local coordinates
@@ -240,7 +240,7 @@ void ME0ReDigiProducer::buildDigis(const ME0DigiPreRecoCollection & input_digis,
       
       float newY(newLP.y());
       // new hit has y coordinate in the center of the roll when using discretizeY
-      if (discretizeY_ and detId.roll() > 0) newY = 0;
+      if (discretizeY_ and nPartitions_ > 1) newY = 0;
       edm::LogVerbatim("ME0ReDigiProducer")
 	<< "\tnew Y " << newY << std::endl;
 


### PR DESCRIPTION
This PR provides a bugfix for PR #17175. The inclusion of a request to change the numbering starting from 1 broke the ME0Digi chain and resulted in bad rechits. 