### PR TITLE
Replace buf/sprintf to std::to_string

### DIFF
--- a/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.cc
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <algorithm>
 #include <cstdio>
+#include <string>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
@@ -275,7 +276,6 @@ void DDTECModuleAlgo::execute(DDCompactView& cpv) {
   std::string name;
   std::string tag("Rphi");
   if (isStereo) tag = "Stereo";
-  char buf[5]; //for string operations
   //usefull constants
   const double topFrameEndZ = 0.5 * (-waferPosition + fullHeight) + pitchHeight + hybridHeight - topFrameHeight;
   DDName  parentName = parent().name(); 
@@ -374,8 +374,7 @@ void DDTECModuleAlgo::execute(DDCompactView& cpv) {
 
   //Supplies Box(es)
   for (int i= 0; i < (int)(siFrSuppBoxWidth.size());i++){
-    sprintf(buf,"%i",i);
-    name    = idName + "SuppliesBox"+buf;
+    name    = idName + "SuppliesBox" + std::to_string(i);
     matname = DDName(DDSplit(siFrSuppBoxMat).first, DDSplit(siFrSuppBoxMat).second);
     matter  = DDMaterial(matname);
     
@@ -595,9 +594,7 @@ void DDTECModuleAlgo::execute(DDCompactView& cpv) {
   
   //Si - Reencorcement
   for (int i= 0; i < (int)(siReenforceWidth.size());i++){
-    char buf[5];
-    sprintf(buf,"%i",i);
-    name    = idName + "SiReenforce"+buf;
+    name    = idName + "SiReenforce" + std::to_string(i);
     matname = DDName(DDSplit(siReenforceMat).first, DDSplit(siReenforceMat).second);
     matter  = DDMaterial(matname);
     


### PR DESCRIPTION
According to compiler (GCC 7) we need at least 11 bytes in the buffer.
Replace buf + sprintf (unsafe) with std::to_string.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>