### PR TITLE
Make HCAL TP LUT generation for Phase2 more robust.

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -239,10 +239,12 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
   }
 
   for (const auto& id: metadata->getAllChannels()) {
-     HcalDetId cell(id);
-     if (!topo_->valid(cell))
+     if (not (id.det() == DetId::Hcal and topo_->valid(id)))
         continue;
+     HcalDetId cell(id);
      HcalSubdetector subdet = cell.subdet();
+     if (subdet != HcalBarrel and subdet != HcalEndcap and subdet != HcalForward)
+        continue;
 
      const HcalQIECoder* channelCoder = conditions.getHcalCoder (cell);
      const HcalQIEShape* shape = conditions.getHcalShape(cell);


### PR DESCRIPTION
The current code crashes for Phase2.  Instead of generating all possible
DetIds and testing which ones are allowed, it is a lot cleaner to just
iterate over the produced metadata ids.