### PR TITLE
TIB Rail Bottom Overlap Bugfix

### DIFF
--- a/Geometry/TrackerCommonData/data/v2/tob.xml
+++ b/Geometry/TrackerCommonData/data/v2/tob.xml
@@ -14,7 +14,7 @@
 		<Constant name="StiffenerR" value="0.400*cm"/>
 		<Constant name="RailTopDy" value="8.5*mm"/>
 		<Constant name="RailBottomDy" value="15*mm"/>
-		<Constant name="RailDx" value="4.3*mm"/>
+		<Constant name="RailDx" value="3.75*mm"/>
 		<Constant name="RailL" value="1.100*m"/>
 		<Constant name="RailInX" value="54.433*cm"/>
 		<Constant name="StiffenerY" value="2.700*cm"/>
@@ -574,12 +574,12 @@
 		<PosPart copyNumber="1">
 			<rParent name="tob:TOB"/>
 			<rChild name="tob:TIBRailBottom"/>
-			<Translation x="[RailInX]" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
+			<Translation x="[RailInX]-0.13*cm" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
 		</PosPart>
 		<PosPart copyNumber="2">
 			<rParent name="tob:TOB"/>
 			<rChild name="tob:TIBRailBottom"/>
-			<Translation x="-[RailInX]" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
+			<Translation x="-[RailInX]+0.13*cm" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
 		</PosPart>
 		<PosPart copyNumber="1">
 			<rParent name="tob:TOB"/>


### PR DESCRIPTION
* Remove overlap by making the rail 1.1 mm thinner and moving it by ~ 1 mm

![screenshot 2017-01-24 16 32 03](https://cloud.githubusercontent.com/assets/1390682/22287190/18c1dcf4-e2f2-11e6-8af9-91f96bbd896a.png)

<img width="859" alt="screen shot 2017-01-24 at 17 41 27" src="https://cloud.githubusercontent.com/assets/1390682/22256858/5cf67088-e25c-11e6-8a63-55c977c47f82.png">
