### PR TITLE
Add back call to consumes within loop in the MixingModule.

### DIFF
--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -219,6 +219,7 @@ namespace edm {
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
+	consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
         std::unique_ptr<DigiAccumulatorMixMod> accumulator = std::unique_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -219,7 +219,9 @@ namespace edm {
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
-	consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
+	if(pset.existsAs<edm::InputTag>("HepMCProductLabel")) {
+	  consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
+	}
         std::unique_ptr<DigiAccumulatorMixMod> accumulator = std::unique_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {


### PR DESCRIPTION
This fix adds back a call to consumes in a loop, that is able to load the correct inputs.
This is needed by the TSG-STEAM group in the context of MC Trigger Rate Studies.

Backport in 81X of PR #17262 